### PR TITLE
fix: SonarCloud code smells, coverage 80%+, rename build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,9 @@ env:
 
 jobs:
   # ---------------------------------------------------------------------------
-  # QUALITY + TEST (single job — avoids node_modules artifact transfer)
+  # BUILD + TEST (single job — avoids node_modules artifact transfer)
   # ---------------------------------------------------------------------------
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -105,7 +105,7 @@ jobs:
   # ANALYSIS
   # ---------------------------------------------------------------------------
   sonarcloud:
-    needs: build
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     continue-on-error: true
@@ -160,7 +160,7 @@ jobs:
   # BUILD (tsup — develop/main/tags only)
   # ---------------------------------------------------------------------------
   pack:
-    needs: build
+    needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v')
     steps:


### PR DESCRIPTION
## Summary

- Fix SonarCloud code smells: `window` → `globalThis`, merge duplicate imports, default params, React patterns
- Add tests to meet 80% branch coverage threshold (76.38% → 81.48%)
- Rename `build` job to `build-and-test` for clarity
- Pin all GitHub Actions to full commit SHAs (supply chain security)

## Test plan

- [x] `pnpm lint` passes (0 errors, 0 warnings)
- [x] `pnpm tsc` passes
- [x] `pnpm test:coverage --run` passes (81.48% branches >= 80%)
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)