### PR TITLE
feat(ai): add @granit/ai and @granit/react-ai packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
   },
   "pnpm": {
     "overrides": {
-      "immutable": ">=5.1.5"
+      "immutable": ">=5.1.5",
+      "flatted": ">=3.4.2"
     }
   },
   "lint-staged": {

--- a/packages/@granit/ai/package.json
+++ b/packages/@granit/ai/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@granit/ai",
+  "description": "AI workspace management, chat completion, embedding generation, and usage tracking types and API functions — mirrors Granit.AI.Endpoints .NET",
+  "version": "0.2.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/ai/src/__tests__/ai-chat-api.test.ts
+++ b/packages/@granit/ai/src/__tests__/ai-chat-api.test.ts
@@ -1,0 +1,73 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildChatStreamUrl, chatComplete } from '../api/ai-chat-api.js';
+
+describe('ai-chat-api', () => {
+  describe('chatComplete', () => {
+    it('should POST /ai/chat/{workspaceName}', async () => {
+      const client = createMockClient();
+      const request = { messages: [{ role: 'user' as const, content: 'Hello' }] };
+      const response = {
+        workspaceName: 'default',
+        model: 'gpt-4o',
+        content: 'Hi!',
+        usage: null,
+        duration: '00:00:01',
+      };
+      vi.mocked(client.post).mockResolvedValue({ data: response });
+
+      const result = await chatComplete(client, '', 'default', request);
+
+      expect(client.post).toHaveBeenCalledWith('/ai/chat/default', request);
+      expect(result).toEqual(response);
+    });
+
+    it('should prepend basePath', async () => {
+      const client = createMockClient();
+      const request = { messages: [{ role: 'user' as const, content: 'Hello' }] };
+      vi.mocked(client.post).mockResolvedValue({ data: {} });
+
+      await chatComplete(client, '/api/v1', 'default', request);
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/ai/chat/default', request);
+    });
+
+    it('should encode workspace name in URL', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: {} });
+
+      await chatComplete(client, '', 'my workspace', {
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+
+      expect(client.post).toHaveBeenCalledWith('/ai/chat/my%20workspace', expect.anything());
+    });
+  });
+
+  describe('buildChatStreamUrl', () => {
+    it('should build a full URL with basePath', () => {
+      const url = buildChatStreamUrl('http://localhost:5000', '/api/v1', 'default');
+
+      expect(url).toBe('http://localhost:5000/api/v1/ai/chat/default/stream');
+    });
+
+    it('should handle empty basePath', () => {
+      const url = buildChatStreamUrl('http://localhost:5000', '', 'default');
+
+      expect(url).toBe('http://localhost:5000/ai/chat/default/stream');
+    });
+
+    it('should strip trailing slash from baseUrl', () => {
+      const url = buildChatStreamUrl('http://localhost:5000/', '', 'default');
+
+      expect(url).toBe('http://localhost:5000/ai/chat/default/stream');
+    });
+
+    it('should encode workspace name', () => {
+      const url = buildChatStreamUrl('http://localhost:5000', '', 'my workspace');
+
+      expect(url).toBe('http://localhost:5000/ai/chat/my%20workspace/stream');
+    });
+  });
+});

--- a/packages/@granit/ai/src/__tests__/ai-chat-stream.test.ts
+++ b/packages/@granit/ai/src/__tests__/ai-chat-stream.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { chatStream } from '../api/ai-chat-api.js';
+
+function createSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+function mockFetch(status: number, body: ReadableStream<Uint8Array> | null) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    body,
+  });
+}
+
+describe('chatStream', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should yield content chunks from SSE events', async () => {
+    const stream = createSSEStream([
+      'data: {"content":"Hello"}\n\n',
+      'data: {"content":" world"}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    vi.stubGlobal('fetch', mockFetch(200, stream));
+
+    const chunks: string[] = [];
+    for await (const chunk of chatStream({
+      url: 'http://localhost/ai/chat/default/stream',
+      request: { messages: [{ role: 'user', content: 'Hi' }] },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['Hello', ' world']);
+  });
+
+  it('should handle chunks split across reads', async () => {
+    const stream = createSSEStream(['data: {"cont', 'ent":"split"}\n\ndata: [DONE]\n\n']);
+    vi.stubGlobal('fetch', mockFetch(200, stream));
+
+    const chunks: string[] = [];
+    for await (const chunk of chatStream({
+      url: 'http://localhost/ai/chat/default/stream',
+      request: { messages: [{ role: 'user', content: 'Hi' }] },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['split']);
+  });
+
+  it('should throw on non-OK response', async () => {
+    vi.stubGlobal('fetch', mockFetch(401, null));
+
+    const generator = chatStream({
+      url: 'http://localhost/ai/chat/default/stream',
+      request: { messages: [{ role: 'user', content: 'Hi' }] },
+    });
+
+    await expect(generator.next()).rejects.toThrow('AI chat stream failed: 401');
+  });
+
+  it('should skip malformed SSE events', async () => {
+    const stream = createSSEStream([
+      'data: not-json\n\n',
+      'data: {"content":"valid"}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    vi.stubGlobal('fetch', mockFetch(200, stream));
+
+    const chunks: string[] = [];
+    for await (const chunk of chatStream({
+      url: 'http://localhost/ai/chat/default/stream',
+      request: { messages: [{ role: 'user', content: 'Hi' }] },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual(['valid']);
+  });
+
+  it('should pass headers and request body to fetch', async () => {
+    const stream = createSSEStream(['data: [DONE]\n\n']);
+    const fetchMock = mockFetch(200, stream);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = { messages: [{ role: 'user' as const, content: 'Hi' }] };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const _ of chatStream({
+      url: 'http://localhost/ai/chat/default/stream',
+      request,
+      headers: { Authorization: 'Bearer token', 'X-Tenant-Id': 'tenant-1' },
+    })) {
+      // consume stream
+    }
+
+    expect(fetchMock).toHaveBeenCalledWith('http://localhost/ai/chat/default/stream', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'text/event-stream',
+        Authorization: 'Bearer token',
+        'X-Tenant-Id': 'tenant-1',
+      },
+      body: JSON.stringify(request),
+      signal: undefined,
+    });
+  });
+
+  it('should handle empty body gracefully', async () => {
+    vi.stubGlobal('fetch', mockFetch(200, null));
+
+    const chunks: string[] = [];
+    for await (const chunk of chatStream({
+      url: 'http://localhost/ai/chat/default/stream',
+      request: { messages: [{ role: 'user', content: 'Hi' }] },
+    })) {
+      chunks.push(chunk);
+    }
+
+    expect(chunks).toEqual([]);
+  });
+});

--- a/packages/@granit/ai/src/__tests__/ai-embeddings-api.test.ts
+++ b/packages/@granit/ai/src/__tests__/ai-embeddings-api.test.ts
@@ -1,0 +1,44 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { generateEmbeddings } from '../api/ai-embeddings-api.js';
+
+describe('ai-embeddings-api', () => {
+  describe('generateEmbeddings', () => {
+    it('should POST /ai/embeddings/{workspaceName}', async () => {
+      const client = createMockClient();
+      const request = { inputs: ['Hello world'] };
+      const response = {
+        workspaceName: 'default',
+        model: 'text-embedding-3-small',
+        embeddings: [{ index: 0, vector: [0.1, 0.2, 0.3] }],
+      };
+      vi.mocked(client.post).mockResolvedValue({ data: response });
+
+      const result = await generateEmbeddings(client, '', 'default', request);
+
+      expect(client.post).toHaveBeenCalledWith('/ai/embeddings/default', request);
+      expect(result).toEqual(response);
+    });
+
+    it('should prepend basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: {} });
+
+      await generateEmbeddings(client, '/api/v1', 'default', { inputs: ['test'] });
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/ai/embeddings/default', {
+        inputs: ['test'],
+      });
+    });
+
+    it('should encode workspace name in URL', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: {} });
+
+      await generateEmbeddings(client, '', 'my workspace', { inputs: ['test'] });
+
+      expect(client.post).toHaveBeenCalledWith('/ai/embeddings/my%20workspace', expect.anything());
+    });
+  });
+});

--- a/packages/@granit/ai/src/__tests__/ai-workspaces-api.test.ts
+++ b/packages/@granit/ai/src/__tests__/ai-workspaces-api.test.ts
@@ -1,0 +1,102 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createAIWorkspace,
+  deleteAIWorkspace,
+  fetchAIWorkspace,
+  fetchAIWorkspaces,
+  updateAIWorkspace,
+} from '../api/ai-workspaces-api.js';
+
+describe('ai-workspaces-api', () => {
+  describe('fetchAIWorkspaces', () => {
+    it('should GET /ai/workspaces', async () => {
+      const client = createMockClient();
+      const data = { workspaces: [], totalCount: 0 };
+      vi.mocked(client.get).mockResolvedValue({ data });
+
+      const result = await fetchAIWorkspaces(client, '');
+
+      expect(client.get).toHaveBeenCalledWith('/ai/workspaces');
+      expect(result).toEqual(data);
+    });
+
+    it('should prepend basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: { workspaces: [], totalCount: 0 } });
+
+      await fetchAIWorkspaces(client, '/api/v1');
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/ai/workspaces');
+    });
+  });
+
+  describe('fetchAIWorkspace', () => {
+    it('should GET /ai/workspaces/{name}', async () => {
+      const client = createMockClient();
+      const workspace = { name: 'default', provider: 'OpenAI', model: 'gpt-4o' };
+      vi.mocked(client.get).mockResolvedValue({ data: workspace });
+
+      const result = await fetchAIWorkspace(client, '', 'default');
+
+      expect(client.get).toHaveBeenCalledWith('/ai/workspaces/default');
+      expect(result).toEqual(workspace);
+    });
+
+    it('should encode workspace name in URL', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: {} });
+
+      await fetchAIWorkspace(client, '/api', 'my workspace');
+
+      expect(client.get).toHaveBeenCalledWith('/api/ai/workspaces/my%20workspace');
+    });
+  });
+
+  describe('createAIWorkspace', () => {
+    it('should POST /ai/workspaces', async () => {
+      const client = createMockClient();
+      const request = { name: 'test', provider: 'OpenAI', model: 'gpt-4o' };
+      const response = { ...request, kind: 'Dynamic', isActive: true };
+      vi.mocked(client.post).mockResolvedValue({ data: response });
+
+      const result = await createAIWorkspace(client, '', request);
+
+      expect(client.post).toHaveBeenCalledWith('/ai/workspaces', request);
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('updateAIWorkspace', () => {
+    it('should PUT /ai/workspaces/{name}', async () => {
+      const client = createMockClient();
+      const request = { provider: 'OpenAI', model: 'gpt-4o-mini', isActive: true };
+      vi.mocked(client.put).mockResolvedValue({ data: { name: 'test', ...request } });
+
+      await updateAIWorkspace(client, '', 'test', request);
+
+      expect(client.put).toHaveBeenCalledWith('/ai/workspaces/test', request);
+    });
+  });
+
+  describe('deleteAIWorkspace', () => {
+    it('should DELETE /ai/workspaces/{name}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      await deleteAIWorkspace(client, '', 'test');
+
+      expect(client.delete).toHaveBeenCalledWith('/ai/workspaces/test');
+    });
+
+    it('should encode workspace name in URL', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      await deleteAIWorkspace(client, '/api', 'my workspace');
+
+      expect(client.delete).toHaveBeenCalledWith('/api/ai/workspaces/my%20workspace');
+    });
+  });
+});

--- a/packages/@granit/ai/src/api/ai-chat-api.ts
+++ b/packages/@granit/ai/src/api/ai-chat-api.ts
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------
+// Chat completion API functions.
+// Mirrors Granit.AI.Endpoints chat endpoints (sync + SSE stream).
+// ---------------------------------------------------------------------------
+
+import { AI_STREAM_DONE_MARKER } from '../constants.js';
+
+import type { AIChatRequest, AIChatResponse, AIChatStreamChunk } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Send a chat completion request and return the full response.
+ *
+ * `POST /ai/chat/{workspaceName}`
+ */
+export async function chatComplete(
+  client: AxiosInstance,
+  basePath: string,
+  workspaceName: string,
+  request: AIChatRequest
+): Promise<AIChatResponse> {
+  const response = await client.post<AIChatResponse>(
+    `${basePath}/ai/chat/${encodeURIComponent(workspaceName)}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Options for opening a streaming chat connection.
+ *
+ * Uses native `fetch` (not Axios) because Axios does not support
+ * reading a `ReadableStream` incrementally.
+ */
+export interface ChatStreamOptions {
+  /** Full URL to the stream endpoint (use {@link buildChatStreamUrl} to construct). */
+  readonly url: string;
+  /** Chat request payload. */
+  readonly request: AIChatRequest;
+  /** Extra headers (Authorization, X-Tenant-Id, etc.). */
+  readonly headers?: Readonly<Record<string, string>>;
+  /** Abort signal to cancel the stream. */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Builds the full URL for the chat stream endpoint.
+ *
+ * @example
+ * ```ts
+ * const url = buildChatStreamUrl('http://localhost:5000', '', 'default');
+ * // → "http://localhost:5000/ai/chat/default/stream"
+ * ```
+ */
+export function buildChatStreamUrl(
+  baseUrl: string,
+  basePath: string,
+  workspaceName: string
+): string {
+  const clean = baseUrl.replace(/\/+$/, '');
+  return `${clean}${basePath}/ai/chat/${encodeURIComponent(workspaceName)}/stream`;
+}
+
+/**
+ * Opens an SSE stream for chat completion.
+ *
+ * Yields content string chunks as they arrive. The stream ends when the
+ * server sends `data: [DONE]` or closes the connection.
+ *
+ * `POST /ai/chat/{workspaceName}/stream`
+ *
+ * @example
+ * ```ts
+ * const url = buildChatStreamUrl(baseUrl, basePath, 'default');
+ * const controller = new AbortController();
+ *
+ * for await (const chunk of chatStream({ url, request, signal: controller.signal })) {
+ *   process.stdout.write(chunk);
+ * }
+ * ```
+ */
+export async function* chatStream(
+  options: ChatStreamOptions
+): AsyncGenerator<string, void, undefined> {
+  const response = await fetch(options.url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'text/event-stream',
+      ...options.headers,
+    },
+    body: JSON.stringify(options.request),
+    signal: options.signal,
+  });
+
+  if (!response.ok) {
+    throw new Error(`AI chat stream failed: ${response.status} ${response.statusText}`);
+  }
+
+  const body = response.body;
+  if (!body) {
+    return;
+  }
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop()!;
+
+      for (const line of lines) {
+        if (!line.startsWith('data: ')) continue;
+
+        const data = line.slice(6).trim();
+        if (data === AI_STREAM_DONE_MARKER) return;
+
+        try {
+          const parsed = JSON.parse(data) as AIChatStreamChunk;
+          yield parsed.content;
+        } catch {
+          // Skip malformed SSE events.
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/@granit/ai/src/api/ai-chat-api.ts
+++ b/packages/@granit/ai/src/api/ai-chat-api.ts
@@ -57,8 +57,29 @@ export function buildChatStreamUrl(
   basePath: string,
   workspaceName: string
 ): string {
-  const clean = baseUrl.replace(/\/+$/, '');
+  let clean = baseUrl;
+  while (clean.endsWith('/')) {
+    clean = clean.slice(0, -1);
+  }
   return `${clean}${basePath}/ai/chat/${encodeURIComponent(workspaceName)}/stream`;
+}
+
+/** Result of parsing a single SSE data line. */
+type ParsedLine = { kind: 'chunk'; content: string } | { kind: 'done' } | { kind: 'skip' };
+
+/** Parses a single SSE line into a typed result. */
+function parseSseLine(line: string): ParsedLine {
+  if (!line.startsWith('data: ')) return { kind: 'skip' };
+
+  const data = line.slice(6).trim();
+  if (data === AI_STREAM_DONE_MARKER) return { kind: 'done' };
+
+  try {
+    const parsed = JSON.parse(data) as AIChatStreamChunk;
+    return { kind: 'chunk', content: parsed.content };
+  } catch {
+    return { kind: 'skip' };
+  }
 }
 
 /**
@@ -97,12 +118,9 @@ export async function* chatStream(
     throw new Error(`AI chat stream failed: ${response.status} ${response.statusText}`);
   }
 
-  const body = response.body;
-  if (!body) {
-    return;
-  }
+  if (!response.body) return;
 
-  const reader = body.getReader();
+  const reader = response.body.getReader();
   const decoder = new TextDecoder();
   let buffer = '';
 
@@ -116,17 +134,9 @@ export async function* chatStream(
       buffer = lines.pop()!;
 
       for (const line of lines) {
-        if (!line.startsWith('data: ')) continue;
-
-        const data = line.slice(6).trim();
-        if (data === AI_STREAM_DONE_MARKER) return;
-
-        try {
-          const parsed = JSON.parse(data) as AIChatStreamChunk;
-          yield parsed.content;
-        } catch {
-          // Skip malformed SSE events.
-        }
+        const result = parseSseLine(line);
+        if (result.kind === 'done') return;
+        if (result.kind === 'chunk') yield result.content;
       }
     }
   } finally {

--- a/packages/@granit/ai/src/api/ai-embeddings-api.ts
+++ b/packages/@granit/ai/src/api/ai-embeddings-api.ts
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------------
+// Embedding generation API functions.
+// Mirrors Granit.AI.Endpoints embedding endpoint.
+// ---------------------------------------------------------------------------
+
+import type { AIEmbeddingRequest, AIEmbeddingResponse } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Generate embeddings for a batch of text inputs.
+ *
+ * `POST /ai/embeddings/{workspaceName}`
+ */
+export async function generateEmbeddings(
+  client: AxiosInstance,
+  basePath: string,
+  workspaceName: string,
+  request: AIEmbeddingRequest
+): Promise<AIEmbeddingResponse> {
+  const response = await client.post<AIEmbeddingResponse>(
+    `${basePath}/ai/embeddings/${encodeURIComponent(workspaceName)}`,
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/ai/src/api/ai-workspaces-api.ts
+++ b/packages/@granit/ai/src/api/ai-workspaces-api.ts
@@ -1,0 +1,86 @@
+// ---------------------------------------------------------------------------
+// Workspace management API functions.
+// Mirrors Granit.AI.Endpoints workspace CRUD endpoints.
+// ---------------------------------------------------------------------------
+
+import type {
+  AIWorkspaceCreateRequest,
+  AIWorkspaceListResponse,
+  AIWorkspaceResponse,
+  AIWorkspaceUpdateRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * List all AI workspaces.
+ *
+ * `GET /ai/workspaces`
+ */
+export async function fetchAIWorkspaces(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AIWorkspaceListResponse> {
+  const response = await client.get<AIWorkspaceListResponse>(`${basePath}/ai/workspaces`);
+  return response.data;
+}
+
+/**
+ * Get a single AI workspace by name.
+ *
+ * `GET /ai/workspaces/{name}`
+ */
+export async function fetchAIWorkspace(
+  client: AxiosInstance,
+  basePath: string,
+  name: string
+): Promise<AIWorkspaceResponse> {
+  const response = await client.get<AIWorkspaceResponse>(
+    `${basePath}/ai/workspaces/${encodeURIComponent(name)}`
+  );
+  return response.data;
+}
+
+/**
+ * Create a new dynamic AI workspace.
+ *
+ * `POST /ai/workspaces`
+ */
+export async function createAIWorkspace(
+  client: AxiosInstance,
+  basePath: string,
+  request: AIWorkspaceCreateRequest
+): Promise<AIWorkspaceResponse> {
+  const response = await client.post<AIWorkspaceResponse>(`${basePath}/ai/workspaces`, request);
+  return response.data;
+}
+
+/**
+ * Update an existing dynamic AI workspace.
+ *
+ * `PUT /ai/workspaces/{name}`
+ */
+export async function updateAIWorkspace(
+  client: AxiosInstance,
+  basePath: string,
+  name: string,
+  request: AIWorkspaceUpdateRequest
+): Promise<AIWorkspaceResponse> {
+  const response = await client.put<AIWorkspaceResponse>(
+    `${basePath}/ai/workspaces/${encodeURIComponent(name)}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Delete a dynamic AI workspace.
+ *
+ * `DELETE /ai/workspaces/{name}`
+ */
+export async function deleteAIWorkspace(
+  client: AxiosInstance,
+  basePath: string,
+  name: string
+): Promise<void> {
+  await client.delete(`${basePath}/ai/workspaces/${encodeURIComponent(name)}`);
+}

--- a/packages/@granit/ai/src/constants.ts
+++ b/packages/@granit/ai/src/constants.ts
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------
+// AI module constants. Mirrors Granit.AI.Endpoints permission and kind values.
+// ---------------------------------------------------------------------------
+
+/** Workspace kind constants. Mirrors `AIWorkspaceKind` enum. */
+export const AI_WORKSPACE_KINDS = {
+  SYSTEM: 'System',
+  DYNAMIC: 'Dynamic',
+} as const;
+
+/** AI permission strings. Mirrors `AIPermissions` in Granit.AI.Endpoints. */
+export const AI_PERMISSIONS = {
+  WORKSPACES_VIEW: 'AI.Workspaces.View',
+  WORKSPACES_CREATE: 'AI.Workspaces.Create',
+  WORKSPACES_UPDATE: 'AI.Workspaces.Update',
+  WORKSPACES_DELETE: 'AI.Workspaces.Delete',
+  USAGE_VIEW: 'AI.Usage.View',
+  CHAT_EXECUTE: 'AI.Chat.Execute',
+  EMBEDDINGS_EXECUTE: 'AI.Embeddings.Execute',
+} as const;
+
+/** SSE stream termination marker. */
+export const AI_STREAM_DONE_MARKER = '[DONE]';

--- a/packages/@granit/ai/src/index.ts
+++ b/packages/@granit/ai/src/index.ts
@@ -1,0 +1,37 @@
+// Types
+export type {
+  AIChatMessageRequest,
+  AIChatMessageRole,
+  AIChatRequest,
+  AIChatResponse,
+  AIChatStreamChunk,
+  AIChatUsageResponse,
+  AIEmbeddingDataResponse,
+  AIEmbeddingRequest,
+  AIEmbeddingResponse,
+  AIUsageRecord,
+  AIWorkspaceCreateRequest,
+  AIWorkspaceKind,
+  AIWorkspaceListResponse,
+  AIWorkspaceResponse,
+  AIWorkspaceUpdateRequest,
+} from './types/index.js';
+
+// Constants
+export { AI_PERMISSIONS, AI_STREAM_DONE_MARKER, AI_WORKSPACE_KINDS } from './constants.js';
+
+// API — Workspaces
+export {
+  createAIWorkspace,
+  deleteAIWorkspace,
+  fetchAIWorkspace,
+  fetchAIWorkspaces,
+  updateAIWorkspace,
+} from './api/ai-workspaces-api.js';
+
+// API — Chat
+export { buildChatStreamUrl, chatComplete, chatStream } from './api/ai-chat-api.js';
+export type { ChatStreamOptions } from './api/ai-chat-api.js';
+
+// API — Embeddings
+export { generateEmbeddings } from './api/ai-embeddings-api.js';

--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -1,0 +1,121 @@
+// ---------------------------------------------------------------------------
+// Types mirroring Granit.AI and Granit.AI.Endpoints .NET contracts.
+// Property names match the camelCase JSON serialization from the backend.
+// ---------------------------------------------------------------------------
+
+// -- Workspace ---------------------------------------------------------------
+
+/** Workspace kind. Mirrors `Granit.AI.Workspaces.AIWorkspaceKind`. */
+export type AIWorkspaceKind = 'System' | 'Dynamic';
+
+/** Workspace configuration returned by the API. Mirrors `AIWorkspaceResponse`. */
+export interface AIWorkspaceResponse {
+  readonly name: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly systemPrompt: string | null;
+  readonly temperature: number | null;
+  readonly maxOutputTokens: number | null;
+  readonly kind: AIWorkspaceKind;
+  readonly isActive: boolean;
+}
+
+/** List response wrapper. Mirrors `AIWorkspaceListResponse`. */
+export interface AIWorkspaceListResponse {
+  readonly workspaces: readonly AIWorkspaceResponse[];
+  readonly totalCount: number;
+}
+
+/** Create workspace request. Mirrors `AIWorkspaceCreateRequest`. */
+export interface AIWorkspaceCreateRequest {
+  readonly name: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly systemPrompt?: string | null;
+  readonly temperature?: number | null;
+  readonly maxOutputTokens?: number | null;
+}
+
+/** Update workspace request. Mirrors `AIWorkspaceUpdateRequest`. */
+export interface AIWorkspaceUpdateRequest {
+  readonly provider: string;
+  readonly model: string;
+  readonly systemPrompt?: string | null;
+  readonly temperature?: number | null;
+  readonly maxOutputTokens?: number | null;
+  readonly isActive: boolean;
+}
+
+// -- Chat completion ---------------------------------------------------------
+
+/** Chat message role. */
+export type AIChatMessageRole = 'user' | 'assistant' | 'system';
+
+/** Single message in a chat request. Mirrors `AIChatMessageRequest`. */
+export interface AIChatMessageRequest {
+  readonly role: AIChatMessageRole;
+  readonly content: string;
+}
+
+/** Chat completion request. Mirrors `AIChatRequest`. */
+export interface AIChatRequest {
+  readonly messages: readonly AIChatMessageRequest[];
+}
+
+/** Token usage in a chat response. Mirrors `AIChatUsageResponse`. */
+export interface AIChatUsageResponse {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly estimatedCostUsd: number | null;
+}
+
+/** Chat completion response. Mirrors `AIChatResponse`. */
+export interface AIChatResponse {
+  readonly workspaceName: string;
+  readonly model: string;
+  readonly content: string;
+  readonly usage: AIChatUsageResponse | null;
+  readonly duration: string;
+}
+
+/** SSE chunk emitted during streaming. */
+export interface AIChatStreamChunk {
+  readonly content: string;
+}
+
+// -- Embeddings --------------------------------------------------------------
+
+/** Embedding generation request. Mirrors `AIEmbeddingRequest`. */
+export interface AIEmbeddingRequest {
+  readonly inputs: readonly string[];
+}
+
+/** Single embedding vector. Mirrors `AIEmbeddingDataResponse`. */
+export interface AIEmbeddingDataResponse {
+  readonly index: number;
+  readonly vector: readonly number[];
+}
+
+/** Embedding generation response. Mirrors `AIEmbeddingResponse`. */
+export interface AIEmbeddingResponse {
+  readonly workspaceName: string;
+  readonly model: string;
+  readonly embeddings: readonly AIEmbeddingDataResponse[];
+}
+
+// -- Usage tracking ----------------------------------------------------------
+
+/** AI usage record for querying. Mirrors `Granit.AI.AIUsageRecord`. */
+export interface AIUsageRecord {
+  readonly id: string;
+  readonly tenantId: string | null;
+  readonly userId: string | null;
+  readonly workspaceName: string;
+  readonly provider: string;
+  readonly model: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly estimatedCostUsd: number | null;
+  readonly timestamp: string;
+  readonly duration: string | null;
+}

--- a/packages/@granit/ai/tsconfig.json
+++ b/packages/@granit/ai/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/ai/tsup.config.ts
+++ b/packages/@granit/ai/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/react-ai/package.json
+++ b/packages/@granit/react-ai/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@granit/react-ai",
+  "description": "React bindings for @granit/ai — AIProvider, useAIWorkspaces, useAIChat, useAIChatStream, useAIEmbeddings, workspace CRUD mutations",
+  "version": "0.2.0",
+  "license": "UNLICENSED",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/ai": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-ai/src/__tests__/ai-chat-stream.test.tsx
+++ b/packages/@granit/react-ai/src/__tests__/ai-chat-stream.test.tsx
@@ -1,0 +1,171 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useAIChatStream } from '../hooks/use-ai-chat-stream.js';
+import { AIProvider } from '../providers/ai-provider.js';
+
+import type { AIConfig } from '../providers/ai-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+function createSSEStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+function mockFetch(status: number, body: ReadableStream<Uint8Array> | null) {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status === 200 ? 'OK' : 'Error',
+    body,
+  });
+}
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AIConfig = {
+      client,
+      basePath: '/api',
+      streamBaseUrl: 'http://localhost:5000',
+    };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AIProvider config={config}>{children}</AIProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useAIChatStream', () => {
+  it('should accumulate content from SSE chunks', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: {"content":"Hello"}\n\n',
+      'data: {"content":" world"}\n\n',
+      'data: [DONE]\n\n',
+    ]);
+    vi.stubGlobal('fetch', mockFetch(200, stream));
+
+    const { result } = renderHook(() => useAIChatStream(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.content).toBe('');
+
+    act(() => {
+      result.current.send('default', { messages: [{ role: 'user', content: 'Hi' }] });
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    expect(result.current.content).toBe('Hello world');
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should set error on fetch failure', async () => {
+    const client = createMockClient();
+    vi.stubGlobal('fetch', mockFetch(500, null));
+
+    const { result } = renderHook(() => useAIChatStream(), {
+      wrapper: createWrapper(client),
+    });
+
+    act(() => {
+      result.current.send('default', { messages: [{ role: 'user', content: 'Hi' }] });
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    expect(result.current.error?.message).toContain('500');
+    expect(result.current.isStreaming).toBe(false);
+  });
+
+  it('should reset content on new send()', async () => {
+    const client = createMockClient();
+
+    const stream1 = createSSEStream(['data: {"content":"First"}\n\ndata: [DONE]\n\n']);
+    const stream2 = createSSEStream(['data: {"content":"Second"}\n\ndata: [DONE]\n\n']);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK', body: stream1 })
+      .mockResolvedValueOnce({ ok: true, status: 200, statusText: 'OK', body: stream2 });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { result } = renderHook(() => useAIChatStream(), {
+      wrapper: createWrapper(client),
+    });
+
+    act(() => {
+      result.current.send('default', { messages: [{ role: 'user', content: 'A' }] });
+    });
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+    expect(result.current.content).toBe('First');
+
+    act(() => {
+      result.current.send('default', { messages: [{ role: 'user', content: 'B' }] });
+    });
+    await waitFor(() => expect(result.current.content).toBe('Second'));
+  });
+
+  it('should pass tenant and auth headers', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream(['data: [DONE]\n\n']);
+    const fetchMock = mockFetch(200, stream);
+    vi.stubGlobal('fetch', fetchMock);
+
+    const tokenGetter = vi.fn().mockResolvedValue('my-token');
+
+    const config: AIConfig = {
+      client,
+      basePath: '/api',
+      streamBaseUrl: 'http://localhost:5000',
+      tokenGetter,
+      tenantId: 'tenant-1',
+    };
+
+    const wrapper = ({ children }: { children: ReactNode }) => {
+      const queryClient = createTestQueryClient();
+      return React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        <AIProvider config={config}>{children}</AIProvider>
+      );
+    };
+
+    const { result } = renderHook(() => useAIChatStream(), { wrapper });
+
+    act(() => {
+      result.current.send('default', { messages: [{ role: 'user', content: 'Hi' }] });
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'http://localhost:5000/api/ai/chat/default/stream',
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: 'Bearer my-token',
+          'X-Tenant-Id': 'tenant-1',
+        }),
+      })
+    );
+  });
+});

--- a/packages/@granit/react-ai/src/__tests__/ai-hooks.test.tsx
+++ b/packages/@granit/react-ai/src/__tests__/ai-hooks.test.tsx
@@ -1,0 +1,227 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useAIChat } from '../hooks/use-ai-chat.js';
+import { useAIEmbeddings } from '../hooks/use-ai-embeddings.js';
+import { useAIWorkspace } from '../hooks/use-ai-workspace.js';
+import { useAIWorkspaces } from '../hooks/use-ai-workspaces.js';
+import { useCreateAIWorkspace } from '../hooks/use-create-ai-workspace.js';
+import { useDeleteAIWorkspace } from '../hooks/use-delete-ai-workspace.js';
+import { useUpdateAIWorkspace } from '../hooks/use-update-ai-workspace.js';
+import { AIProvider } from '../providers/ai-provider.js';
+
+import type { AIConfig } from '../providers/ai-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AIConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AIProvider config={config}>{children}</AIProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// -- Workspace queries -------------------------------------------------------
+
+describe('useAIWorkspaces', () => {
+  it('should fetch all workspaces', async () => {
+    const client = createMockClient();
+    const data = {
+      workspaces: [{ name: 'default', provider: 'OpenAI', model: 'gpt-4o' }],
+      totalCount: 1,
+    };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(data));
+
+    const { result } = renderHook(() => useAIWorkspaces(), {
+      wrapper: createWrapper(client, '/api'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/ai/workspaces');
+    expect(result.current.data).toEqual(data);
+  });
+
+  it('should not fetch when disabled', () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(() => useAIWorkspaces({ enabled: false }), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAIWorkspace', () => {
+  it('should fetch a single workspace', async () => {
+    const client = createMockClient();
+    const workspace = { name: 'default', provider: 'OpenAI', model: 'gpt-4o' };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(workspace));
+
+    const { result } = renderHook(() => useAIWorkspace('default'), {
+      wrapper: createWrapper(client, '/api'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/ai/workspaces/default');
+    expect(result.current.data).toEqual(workspace);
+  });
+});
+
+// -- Workspace mutations -----------------------------------------------------
+
+describe('useCreateAIWorkspace', () => {
+  it('should POST to create a workspace', async () => {
+    const client = createMockClient();
+    const response = { name: 'test', provider: 'OpenAI', model: 'gpt-4o', kind: 'Dynamic' };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(response));
+
+    const { result } = renderHook(() => useCreateAIWorkspace(), {
+      wrapper: createWrapper(client, '/api'),
+    });
+
+    await act(async () => {
+      result.current.create({ name: 'test', provider: 'OpenAI', model: 'gpt-4o' });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(client.post).toHaveBeenCalledWith('/api/ai/workspaces', {
+      name: 'test',
+      provider: 'OpenAI',
+      model: 'gpt-4o',
+    });
+  });
+
+  it('should expose error on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Conflict'));
+
+    const { result } = renderHook(() => useCreateAIWorkspace(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      result.current.create({ name: 'dup', provider: 'OpenAI', model: 'gpt-4o' });
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useUpdateAIWorkspace', () => {
+  it('should PUT to update a workspace', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse({ name: 'ws' }));
+
+    const { result } = renderHook(() => useUpdateAIWorkspace(), {
+      wrapper: createWrapper(client, '/api'),
+    });
+
+    const request = { provider: 'OpenAI', model: 'gpt-4o-mini', isActive: true };
+    await act(async () => {
+      result.current.update('ws', request);
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(client.put).toHaveBeenCalledWith('/api/ai/workspaces/ws', request);
+  });
+});
+
+describe('useDeleteAIWorkspace', () => {
+  it('should DELETE a workspace', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useDeleteAIWorkspace(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      result.current.remove('test');
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(client.delete).toHaveBeenCalledWith('/ai/workspaces/test');
+  });
+});
+
+// -- Chat --------------------------------------------------------------------
+
+describe('useAIChat', () => {
+  it('should send a chat completion request', async () => {
+    const client = createMockClient();
+    const response = {
+      workspaceName: 'default',
+      model: 'gpt-4o',
+      content: 'Hi!',
+      usage: null,
+      duration: '00:00:01',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(response));
+
+    const { result } = renderHook(() => useAIChat(), {
+      wrapper: createWrapper(client, '/api'),
+    });
+
+    await act(async () => {
+      result.current.send('default', { messages: [{ role: 'user', content: 'Hello' }] });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(client.post).toHaveBeenCalledWith('/api/ai/chat/default', {
+      messages: [{ role: 'user', content: 'Hello' }],
+    });
+    expect(result.current.data).toEqual(response);
+  });
+});
+
+// -- Embeddings --------------------------------------------------------------
+
+describe('useAIEmbeddings', () => {
+  it('should generate embeddings', async () => {
+    const client = createMockClient();
+    const response = {
+      workspaceName: 'default',
+      model: 'text-embedding-3-small',
+      embeddings: [{ index: 0, vector: [0.1, 0.2] }],
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(response));
+
+    const { result } = renderHook(() => useAIEmbeddings(), {
+      wrapper: createWrapper(client, '/api'),
+    });
+
+    await act(async () => {
+      result.current.generate('default', { inputs: ['Hello'] });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(client.post).toHaveBeenCalledWith('/api/ai/embeddings/default', {
+      inputs: ['Hello'],
+    });
+    expect(result.current.data).toEqual(response);
+  });
+});

--- a/packages/@granit/react-ai/src/__tests__/ai-provider.test.tsx
+++ b/packages/@granit/react-ai/src/__tests__/ai-provider.test.tsx
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { AIProvider, useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIConfig } from '../providers/ai-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const fakeClient = {} as AxiosInstance;
+
+function createWrapper(config: AIConfig) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <AIProvider config={config}>{children}</AIProvider>;
+  };
+}
+
+describe('AIProvider', () => {
+  it('should provide config to children', () => {
+    const config: AIConfig = { client: fakeClient, basePath: '/api' };
+
+    const { result } = renderHook(() => useAIConfig(), {
+      wrapper: createWrapper(config),
+    });
+
+    expect(result.current.client).toBe(fakeClient);
+    expect(result.current.basePath).toBe('/api');
+  });
+
+  it('should throw when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useAIConfig());
+    }).toThrow('useAIConfig must be used within an AIProvider');
+  });
+});

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
@@ -1,0 +1,103 @@
+import { buildChatStreamUrl, chatStream } from '@granit/ai';
+import { useCallback, useRef, useState } from 'react';
+
+import { useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIChatRequest } from '@granit/ai';
+
+export interface UseAIChatStreamReturn {
+  /** Accumulated content received so far. Reset on each new `send()` call. */
+  readonly content: string;
+  /** Whether a stream is currently active. */
+  readonly isStreaming: boolean;
+  /** Error from the last stream attempt, or `null`. */
+  readonly error: Error | null;
+  /** Start a new streaming chat. Aborts any in-progress stream first. */
+  readonly send: (workspaceName: string, request: AIChatRequest) => void;
+  /** Abort the current stream. */
+  readonly abort: () => void;
+}
+
+/**
+ * Streaming chat completion via SSE.
+ *
+ * Accumulates content chunks into `content` as they arrive.
+ * Each call to `send()` resets the accumulated content.
+ *
+ * @example
+ * ```tsx
+ * const { content, isStreaming, send } = useAIChatStream();
+ *
+ * <button onClick={() => send('default', { messages: [{ role: 'user', content: 'Hello' }] })}>
+ *   Send
+ * </button>
+ * <p>{content}</p>
+ * ```
+ */
+export function useAIChatStream(): UseAIChatStreamReturn {
+  const config = useAIConfig();
+  const [content, setContent] = useState('');
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const abortRef = useRef<AbortController | null>(null);
+
+  const abort = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
+  const send = useCallback(
+    (workspaceName: string, request: AIChatRequest) => {
+      abort();
+      setContent('');
+      setError(null);
+      setIsStreaming(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      const baseUrl = config.streamBaseUrl ?? config.client.defaults.baseURL ?? '';
+      const url = buildChatStreamUrl(baseUrl, config.basePath ?? '', workspaceName);
+
+      const headers: Record<string, string> = {};
+      if (config.tenantId) {
+        headers['X-Tenant-Id'] = config.tenantId;
+      }
+
+      (async () => {
+        try {
+          if (config.tokenGetter) {
+            const token = await config.tokenGetter();
+            if (token) {
+              headers['Authorization'] = `Bearer ${token}`;
+            }
+          }
+
+          let accumulated = '';
+          for await (const chunk of chatStream({
+            url,
+            request,
+            headers,
+            signal: controller.signal,
+          })) {
+            accumulated += chunk;
+            setContent(accumulated);
+          }
+        } catch (err) {
+          if (err instanceof DOMException && err.name === 'AbortError') {
+            return;
+          }
+          setError(err instanceof Error ? err : new Error(String(err)));
+        } finally {
+          setIsStreaming(false);
+          abortRef.current = null;
+        }
+      })();
+    },
+    [abort, config]
+  );
+
+  return { content, isStreaming, error, send, abort };
+}

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat.ts
@@ -1,0 +1,57 @@
+import { chatComplete } from '@granit/ai';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIChatRequest, AIChatResponse } from '@granit/ai';
+
+export interface UseAIChatReturn {
+  readonly send: (workspaceName: string, request: AIChatRequest) => void;
+  readonly sendAsync: (workspaceName: string, request: AIChatRequest) => Promise<AIChatResponse>;
+  readonly data: AIChatResponse | undefined;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation for non-streaming chat completion.
+ *
+ * @example
+ * ```tsx
+ * const { sendAsync, data, isPending } = useAIChat();
+ * const response = await sendAsync('default', {
+ *   messages: [{ role: 'user', content: 'Hello' }],
+ * });
+ * ```
+ */
+export function useAIChat(): UseAIChatReturn {
+  const config = useAIConfig();
+
+  const mutation = useMutation({
+    mutationFn: ({ workspaceName, request }: { workspaceName: string; request: AIChatRequest }) =>
+      chatComplete(config.client, config.basePath ?? '', workspaceName, request),
+  });
+
+  const send = useCallback(
+    (workspaceName: string, request: AIChatRequest) => {
+      mutation.mutate({ workspaceName, request });
+    },
+    [mutation]
+  );
+
+  const sendAsync = useCallback(
+    async (workspaceName: string, request: AIChatRequest) => {
+      return mutation.mutateAsync({ workspaceName, request });
+    },
+    [mutation]
+  );
+
+  return {
+    send,
+    sendAsync,
+    data: mutation.data,
+    isPending: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/packages/@granit/react-ai/src/hooks/use-ai-embeddings.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-embeddings.ts
@@ -1,0 +1,64 @@
+import { generateEmbeddings } from '@granit/ai';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIEmbeddingRequest, AIEmbeddingResponse } from '@granit/ai';
+
+export interface UseAIEmbeddingsReturn {
+  readonly generate: (workspaceName: string, request: AIEmbeddingRequest) => void;
+  readonly generateAsync: (
+    workspaceName: string,
+    request: AIEmbeddingRequest
+  ) => Promise<AIEmbeddingResponse>;
+  readonly data: AIEmbeddingResponse | undefined;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to generate embeddings for a batch of text inputs.
+ *
+ * @example
+ * ```tsx
+ * const { generateAsync } = useAIEmbeddings();
+ * const result = await generateAsync('default', { inputs: ['Hello world'] });
+ * console.log(result.embeddings[0].vector);
+ * ```
+ */
+export function useAIEmbeddings(): UseAIEmbeddingsReturn {
+  const config = useAIConfig();
+
+  const mutation = useMutation({
+    mutationFn: ({
+      workspaceName,
+      request,
+    }: {
+      workspaceName: string;
+      request: AIEmbeddingRequest;
+    }) => generateEmbeddings(config.client, config.basePath ?? '', workspaceName, request),
+  });
+
+  const generate = useCallback(
+    (workspaceName: string, request: AIEmbeddingRequest) => {
+      mutation.mutate({ workspaceName, request });
+    },
+    [mutation]
+  );
+
+  const generateAsync = useCallback(
+    async (workspaceName: string, request: AIEmbeddingRequest) => {
+      return mutation.mutateAsync({ workspaceName, request });
+    },
+    [mutation]
+  );
+
+  return {
+    generate,
+    generateAsync,
+    data: mutation.data,
+    isPending: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/packages/@granit/react-ai/src/hooks/use-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-workspace.ts
@@ -1,0 +1,29 @@
+import { fetchAIWorkspace } from '@granit/ai';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIWorkspaceResponse } from '@granit/ai';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetch a single AI workspace by name.
+ *
+ * @example
+ * ```tsx
+ * const { data: workspace } = useAIWorkspace('default');
+ * console.log(workspace?.model);
+ * ```
+ */
+export function useAIWorkspace(
+  name: string,
+  options?: { enabled?: boolean }
+): UseQueryResult<AIWorkspaceResponse> {
+  const config = useAIConfig();
+
+  return useQuery({
+    queryKey: buildAIQueryKey(config, 'workspaces', name),
+    queryFn: () => fetchAIWorkspace(config.client, config.basePath ?? '', name),
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/packages/@granit/react-ai/src/hooks/use-ai-workspaces.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-workspaces.ts
@@ -1,0 +1,28 @@
+import { fetchAIWorkspaces } from '@granit/ai';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIWorkspaceListResponse } from '@granit/ai';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetch all AI workspaces.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useAIWorkspaces();
+ * data?.workspaces.map(ws => <div key={ws.name}>{ws.name}</div>);
+ * ```
+ */
+export function useAIWorkspaces(options?: {
+  enabled?: boolean;
+}): UseQueryResult<AIWorkspaceListResponse> {
+  const config = useAIConfig();
+
+  return useQuery({
+    queryKey: buildAIQueryKey(config, 'workspaces'),
+    queryFn: () => fetchAIWorkspaces(config.client, config.basePath ?? ''),
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/packages/@granit/react-ai/src/hooks/use-create-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-create-ai-workspace.ts
@@ -1,0 +1,61 @@
+import { createAIWorkspace } from '@granit/ai';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIWorkspaceCreateRequest, AIWorkspaceResponse } from '@granit/ai';
+
+export interface UseCreateAIWorkspaceReturn {
+  readonly create: (request: AIWorkspaceCreateRequest) => void;
+  readonly createAsync: (request: AIWorkspaceCreateRequest) => Promise<AIWorkspaceResponse>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to create a new dynamic AI workspace.
+ *
+ * Invalidates the workspaces list on success.
+ *
+ * @example
+ * ```tsx
+ * const { create } = useCreateAIWorkspace();
+ * create({ name: 'my-ws', provider: 'OpenAI', model: 'gpt-4o' });
+ * ```
+ */
+export function useCreateAIWorkspace(): UseCreateAIWorkspaceReturn {
+  const config = useAIConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (request: AIWorkspaceCreateRequest) =>
+      createAIWorkspace(config.client, config.basePath ?? '', request),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces') })
+        .catch(() => undefined);
+    },
+  });
+
+  const create = useCallback(
+    (request: AIWorkspaceCreateRequest) => {
+      mutation.mutate(request);
+    },
+    [mutation]
+  );
+
+  const createAsync = useCallback(
+    async (request: AIWorkspaceCreateRequest) => {
+      return mutation.mutateAsync(request);
+    },
+    [mutation]
+  );
+
+  return {
+    create,
+    createAsync,
+    isPending: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/packages/@granit/react-ai/src/hooks/use-delete-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-delete-ai-workspace.ts
@@ -1,0 +1,58 @@
+import { deleteAIWorkspace } from '@granit/ai';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider.js';
+
+export interface UseDeleteAIWorkspaceReturn {
+  readonly remove: (name: string) => void;
+  readonly removeAsync: (name: string) => Promise<void>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to delete a dynamic AI workspace.
+ *
+ * Invalidates the workspaces list on success.
+ *
+ * @example
+ * ```tsx
+ * const { remove } = useDeleteAIWorkspace();
+ * remove('my-ws');
+ * ```
+ */
+export function useDeleteAIWorkspace(): UseDeleteAIWorkspaceReturn {
+  const config = useAIConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (name: string) => deleteAIWorkspace(config.client, config.basePath ?? '', name),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces') })
+        .catch(() => undefined);
+    },
+  });
+
+  const remove = useCallback(
+    (name: string) => {
+      mutation.mutate(name);
+    },
+    [mutation]
+  );
+
+  const removeAsync = useCallback(
+    async (name: string) => {
+      await mutation.mutateAsync(name);
+    },
+    [mutation]
+  );
+
+  return {
+    remove,
+    removeAsync,
+    isPending: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/packages/@granit/react-ai/src/hooks/use-update-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-update-ai-workspace.ts
@@ -1,0 +1,67 @@
+import { updateAIWorkspace } from '@granit/ai';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider.js';
+
+import type { AIWorkspaceResponse, AIWorkspaceUpdateRequest } from '@granit/ai';
+
+export interface UseUpdateAIWorkspaceReturn {
+  readonly update: (name: string, request: AIWorkspaceUpdateRequest) => void;
+  readonly updateAsync: (
+    name: string,
+    request: AIWorkspaceUpdateRequest
+  ) => Promise<AIWorkspaceResponse>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to update an existing dynamic AI workspace.
+ *
+ * Invalidates both the workspace list and the individual workspace query on success.
+ *
+ * @example
+ * ```tsx
+ * const { update } = useUpdateAIWorkspace();
+ * update('my-ws', { provider: 'OpenAI', model: 'gpt-4o-mini', isActive: true });
+ * ```
+ */
+export function useUpdateAIWorkspace(): UseUpdateAIWorkspaceReturn {
+  const config = useAIConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: ({ name, request }: { name: string; request: AIWorkspaceUpdateRequest }) =>
+      updateAIWorkspace(config.client, config.basePath ?? '', name, request),
+    onSuccess: (_data, { name }) => {
+      queryClient
+        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces') })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces', name) })
+        .catch(() => undefined);
+    },
+  });
+
+  const update = useCallback(
+    (name: string, request: AIWorkspaceUpdateRequest) => {
+      mutation.mutate({ name, request });
+    },
+    [mutation]
+  );
+
+  const updateAsync = useCallback(
+    async (name: string, request: AIWorkspaceUpdateRequest) => {
+      return mutation.mutateAsync({ name, request });
+    },
+    [mutation]
+  );
+
+  return {
+    update,
+    updateAsync,
+    isPending: mutation.isPending,
+    error: mutation.error,
+  };
+}

--- a/packages/@granit/react-ai/src/index.ts
+++ b/packages/@granit/react-ai/src/index.ts
@@ -1,0 +1,23 @@
+// Provider
+export { AIProvider, buildAIQueryKey, useAIConfig } from './providers/ai-provider.js';
+export type { AIConfig, AIProviderProps } from './providers/ai-provider.js';
+
+// Hooks — Workspaces
+export { useAIWorkspaces } from './hooks/use-ai-workspaces.js';
+export { useAIWorkspace } from './hooks/use-ai-workspace.js';
+export { useCreateAIWorkspace } from './hooks/use-create-ai-workspace.js';
+export type { UseCreateAIWorkspaceReturn } from './hooks/use-create-ai-workspace.js';
+export { useUpdateAIWorkspace } from './hooks/use-update-ai-workspace.js';
+export type { UseUpdateAIWorkspaceReturn } from './hooks/use-update-ai-workspace.js';
+export { useDeleteAIWorkspace } from './hooks/use-delete-ai-workspace.js';
+export type { UseDeleteAIWorkspaceReturn } from './hooks/use-delete-ai-workspace.js';
+
+// Hooks — Chat
+export { useAIChat } from './hooks/use-ai-chat.js';
+export type { UseAIChatReturn } from './hooks/use-ai-chat.js';
+export { useAIChatStream } from './hooks/use-ai-chat-stream.js';
+export type { UseAIChatStreamReturn } from './hooks/use-ai-chat-stream.js';
+
+// Hooks — Embeddings
+export { useAIEmbeddings } from './hooks/use-ai-embeddings.js';
+export type { UseAIEmbeddingsReturn } from './hooks/use-ai-embeddings.js';

--- a/packages/@granit/react-ai/src/providers/ai-provider.tsx
+++ b/packages/@granit/react-ai/src/providers/ai-provider.tsx
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------
+// AI context provider — supplies Axios client and config to all AI hooks.
+// ---------------------------------------------------------------------------
+
+import { createContext, useContext, useMemo } from 'react';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+/** Configuration for the AI provider. */
+export interface AIConfig {
+  /** Axios client with auth and tenant interceptors. */
+  readonly client: AxiosInstance;
+  /** Route prefix before `/ai/...` (default: empty string). */
+  readonly basePath?: string;
+  /**
+   * Base URL used for streaming endpoints (native fetch, not Axios).
+   * Typically `window.location.origin` or `import.meta.env.VITE_API_URL`.
+   */
+  readonly streamBaseUrl?: string;
+  /**
+   * Returns the current Bearer token for streaming auth.
+   * Streaming uses native `fetch` and cannot reuse Axios interceptors.
+   */
+  readonly tokenGetter?: () => Promise<string | null>;
+  /** Current tenant ID to inject as `X-Tenant-Id` header in streams. */
+  readonly tenantId?: string;
+  /** Custom React Query key prefix (default: `['ai']`). */
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface AIProviderProps {
+  readonly config: AIConfig;
+  readonly children: ReactNode;
+}
+
+const AIConfigContext = createContext<AIConfig | null>(null);
+
+/** Provides AI configuration to child components and hooks. */
+export function AIProvider({ config, children }: Readonly<AIProviderProps>) {
+  const value = useMemo(() => config, [config]);
+  return <AIConfigContext value={value}>{children}</AIConfigContext>;
+}
+
+/** Returns the AI configuration from the nearest `AIProvider`. */
+export function useAIConfig(): AIConfig {
+  const ctx = useContext(AIConfigContext);
+  if (!ctx) {
+    throw new Error('useAIConfig must be used within an AIProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for AI operations. */
+export function buildAIQueryKey(
+  config: AIConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? ['ai'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-ai/tsconfig.json
+++ b/packages/@granit/react-ai/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/ai": ["../ai/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-ai/tsup.config.ts
+++ b/packages/@granit/react-ai/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   immutable: '>=5.1.5'
+  flatted: '>=3.4.2'
 
 importers:
 
@@ -3052,8 +3053,8 @@ packages:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
 
-  flatted@3.4.1:
-    resolution: {integrity: sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==}
+  flatted@3.4.2:
+    resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
   follow-redirects@1.15.11:
     resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
@@ -6479,12 +6480,12 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.1
+      flatted: 3.4.2
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
-  flatted@3.4.1: {}
+  flatted@3.4.2: {}
 
   follow-redirects@1.15.11: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,16 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jsdom@29.0.0)(msw@2.12.12(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(yaml@2.8.2))
 
+  packages/@granit/ai:
+    dependencies:
+      axios:
+        specifier: '*'
+        version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/api-client:
     dependencies:
       axios:
@@ -332,6 +342,28 @@ importers:
         specifier: '*'
         version: 1.13.6
     devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-ai:
+    dependencies:
+      '@granit/ai':
+        specifier: workspace:*
+        version: link:../ai
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
         'packages/@granit/api-client/src/test-utils.ts'
       ),
       '@granit/api-client': path.resolve(__dirname, 'packages/@granit/api-client/src/index.ts'),
+      '@granit/ai': path.resolve(__dirname, 'packages/@granit/ai/src/index.ts'),
       '@granit/background-jobs': path.resolve(
         __dirname,
         'packages/@granit/background-jobs/src/index.ts'
@@ -77,6 +78,7 @@ export default defineConfig({
         __dirname,
         'packages/@granit/reference-data/src/index.ts'
       ),
+      '@granit/react-ai': path.resolve(__dirname, 'packages/@granit/react-ai/src/index.ts'),
       '@granit/react-authentication-api-keys': path.resolve(
         __dirname,
         'packages/@granit/react-authentication-api-keys/src/index.ts'


### PR DESCRIPTION
## Summary

- Add `@granit/ai` package: TypeScript types, API functions, and constants mirroring the `Granit.AI.Endpoints` .NET contract (workspace CRUD, chat completion sync + SSE streaming, embedding generation, usage tracking types, permissions)
- Add `@granit/react-ai` package: React bindings with `AIProvider`, query hooks (`useAIWorkspaces`, `useAIWorkspace`), mutation hooks (`useCreateAIWorkspace`, `useUpdateAIWorkspace`, `useDeleteAIWorkspace`), chat hooks (`useAIChat`, `useAIChatStream`), and embedding hook (`useAIEmbeddings`)
- 35 tests across 6 test files, full suite green (1045 tests, 0 regressions)

Relates to granit-fx/granit-dotnet#491

## Test plan

- [x] `pnpm tsc` — no type errors
- [x] `pnpm lint` — no warnings
- [x] `pnpm exec vitest run` — 1045 tests pass (123 files)
- [ ] Integration test with guava-admin once wired

🤖 Generated with [Claude Code](https://claude.com/claude-code)