### PR TITLE
feat(background-jobs): align with .NET PagedResult pagination contract

### DIFF
--- a/packages/@granit/background-jobs/package.json
+++ b/packages/@granit/background-jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/background-jobs",
   "description": "Background job status types — mirrors Granit.BackgroundJobs .NET contract",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -12,6 +12,10 @@
   ],
   "scripts": {
     "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/querying": "workspace:*",
+    "axios": "*"
   },
   "devDependencies": {
     "@granit/testing": "workspace:*"

--- a/packages/@granit/background-jobs/src/__tests__/background-jobs-api.test.ts
+++ b/packages/@granit/background-jobs/src/__tests__/background-jobs-api.test.ts
@@ -1,30 +1,63 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { fetchBackgroundJob } from '../api/background-jobs-api.js';
+import { fetchBackgroundJob, fetchBackgroundJobs } from '../api/background-jobs-api.js';
 
 import type { BackgroundJobStatus } from '../types/index.js';
+import type { PagedResult } from '@granit/querying';
 
 const BASE = '/api/v1/background-jobs';
 
-describe('background-jobs-api', () => {
-  it('fetchBackgroundJob calls GET /{name}', async () => {
+const mockJob: BackgroundJobStatus = {
+  jobName: 'SendEmails',
+  cronExpression: '0 */5 * * *',
+  isEnabled: true,
+  lastExecutedAt: '2026-03-17T10:00:00Z',
+  nextExecutionAt: '2026-03-17T10:05:00Z',
+  consecutiveFailures: 0,
+  deadLetterCount: 0,
+  lastError: null,
+};
+
+describe('fetchBackgroundJobs', () => {
+  it('calls GET basePath without params', async () => {
     const client = createMockClient();
-    const job: BackgroundJobStatus = {
-      jobName: 'SendEmails',
-      cronExpression: '0 */5 * * *',
-      isEnabled: true,
-      lastExecutedAt: '2026-03-17T10:00:00Z',
-      nextExecutionAt: '2026-03-17T10:05:00Z',
-      consecutiveFailures: 0,
-      deadLetterCount: 0,
-      lastError: null,
+    const page: PagedResult<BackgroundJobStatus> = {
+      items: [mockJob],
+      totalCount: 1,
+      hasMore: false,
     };
-    vi.mocked(client.get).mockResolvedValueOnce({ data: job });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: page });
+
+    const result = await fetchBackgroundJobs(client, BASE);
+    expect(client.get).toHaveBeenCalledWith(BASE, { params: undefined });
+    expect(result).toEqual(page);
+  });
+
+  it('passes pagination params to the request', async () => {
+    const client = createMockClient();
+    const page: PagedResult<BackgroundJobStatus> = {
+      items: [mockJob],
+      totalCount: 5,
+      hasMore: true,
+    };
+    vi.mocked(client.get).mockResolvedValueOnce({ data: page });
+
+    const result = await fetchBackgroundJobs(client, BASE, { page: 2, pageSize: 10 });
+    expect(client.get).toHaveBeenCalledWith(BASE, { params: { page: 2, pageSize: 10 } });
+    expect(result.totalCount).toBe(5);
+    expect(result.hasMore).toBe(true);
+  });
+});
+
+describe('fetchBackgroundJob', () => {
+  it('calls GET /{name}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockJob });
 
     const result = await fetchBackgroundJob(client, BASE, 'SendEmails');
     expect(client.get).toHaveBeenCalledWith(`${BASE}/SendEmails`);
-    expect(result).toEqual(job);
+    expect(result).toEqual(mockJob);
   });
 
   it('encodes job name with special characters', async () => {

--- a/packages/@granit/background-jobs/src/__tests__/background-jobs-types.test.ts
+++ b/packages/@granit/background-jobs/src/__tests__/background-jobs-types.test.ts
@@ -1,8 +1,20 @@
 import { describe, expectTypeOf, it } from 'vitest';
 
-import type { BackgroundJobStatus } from '../index.js';
+import type { BackgroundJobListParams, BackgroundJobStatus } from '../index.js';
 
 describe('@granit/background-jobs types', () => {
+  describe('BackgroundJobListParams', () => {
+    it('should have optional page field', () => {
+      expectTypeOf<BackgroundJobListParams>().toHaveProperty('page');
+      expectTypeOf<BackgroundJobListParams['page']>().toEqualTypeOf<number | undefined>();
+    });
+
+    it('should have optional pageSize field', () => {
+      expectTypeOf<BackgroundJobListParams>().toHaveProperty('pageSize');
+      expectTypeOf<BackgroundJobListParams['pageSize']>().toEqualTypeOf<number | undefined>();
+    });
+  });
+
   describe('BackgroundJobStatus', () => {
     it('should have job identification fields', () => {
       expectTypeOf<BackgroundJobStatus>().toHaveProperty('jobName');

--- a/packages/@granit/background-jobs/src/api/background-jobs-api.ts
+++ b/packages/@granit/background-jobs/src/api/background-jobs-api.ts
@@ -1,5 +1,20 @@
-import type { BackgroundJobStatus } from '../types/index.js';
+import type { BackgroundJobListParams, BackgroundJobStatus } from '../types/index.js';
+import type { PagedResult } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
+
+/**
+ * Fetch a paginated list of all background jobs.
+ *
+ * `GET {basePath}?page=&pageSize=`
+ */
+export async function fetchBackgroundJobs(
+  client: AxiosInstance,
+  basePath: string,
+  params?: BackgroundJobListParams
+): Promise<PagedResult<BackgroundJobStatus>> {
+  const { data } = await client.get<PagedResult<BackgroundJobStatus>>(basePath, { params });
+  return data;
+}
 
 /**
  * Fetch the status of a specific background job by name.

--- a/packages/@granit/background-jobs/src/index.ts
+++ b/packages/@granit/background-jobs/src/index.ts
@@ -1,5 +1,5 @@
 // Types
-export type { BackgroundJobStatus } from './types/index.js';
+export type { BackgroundJobListParams, BackgroundJobStatus } from './types/index.js';
 
 // API
-export { fetchBackgroundJob } from './api/background-jobs-api.js';
+export { fetchBackgroundJob, fetchBackgroundJobs } from './api/background-jobs-api.js';

--- a/packages/@granit/background-jobs/src/types/background-job-list-params.ts
+++ b/packages/@granit/background-jobs/src/types/background-job-list-params.ts
@@ -1,0 +1,5 @@
+/** Pagination parameters for listing background jobs. Mirrors .NET query params. */
+export interface BackgroundJobListParams {
+  readonly page?: number;
+  readonly pageSize?: number;
+}

--- a/packages/@granit/background-jobs/src/types/index.ts
+++ b/packages/@granit/background-jobs/src/types/index.ts
@@ -1,3 +1,5 @@
+export type { BackgroundJobListParams } from './background-job-list-params.js';
+
 /** Status of a background job. Mirrors Granit.BackgroundJobs.BackgroundJobStatus .NET. */
 export interface BackgroundJobStatus {
   readonly jobName: string;

--- a/packages/@granit/querying/package.json
+++ b/packages/@granit/querying/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/querying",
   "description": "Headless data grid hooks with TanStack Query integration",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/querying/src/types/query-results.ts
+++ b/packages/@granit/querying/src/types/query-results.ts
@@ -6,6 +6,8 @@
 export interface PagedResult<T> {
   readonly items: readonly T[];
   readonly totalCount: number;
+  /** Whether more pages exist beyond the current one. */
+  readonly hasMore?: boolean;
   /** Opaque cursor for next page (only for keyset pagination). */
   readonly nextCursor?: string;
 }

--- a/packages/@granit/react-background-jobs/package.json
+++ b/packages/@granit/react-background-jobs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-background-jobs",
   "description": "React hooks for background job monitoring — useBackgroundJobs, usePauseJob, useResumeJob, useTriggerJob",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -15,6 +15,7 @@
   },
   "peerDependencies": {
     "@granit/background-jobs": "workspace:*",
+    "@granit/querying": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "axios": "*",
     "react": "^19.0.0"

--- a/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
@@ -14,6 +14,7 @@ import {
 } from '../hooks/use-background-jobs.js';
 
 import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { PagedResult } from '@granit/querying';
 
 function createWrapper() {
   const queryClient = createTestQueryClient();
@@ -36,9 +37,23 @@ const mockJob: BackgroundJobStatus = {
   lastError: null,
 };
 
+const mockPage: PagedResult<BackgroundJobStatus> = {
+  items: [mockJob],
+  totalCount: 1,
+  hasMore: false,
+};
+
 describe('backgroundJobKeys', () => {
-  it('should produce stable list key', () => {
-    expect(backgroundJobKeys.list()).toEqual(['background-jobs', 'list']);
+  it('should produce stable list key without params', () => {
+    expect(backgroundJobKeys.list()).toEqual(['background-jobs', 'list', {}]);
+  });
+
+  it('should produce stable list key with params', () => {
+    expect(backgroundJobKeys.list({ page: 2, pageSize: 10 })).toEqual([
+      'background-jobs',
+      'list',
+      { page: 2, pageSize: 10 },
+    ]);
   });
 
   it('should produce stable job key', () => {
@@ -49,20 +64,20 @@ describe('backgroundJobKeys', () => {
 describe('useBackgroundJobs', () => {
   it('should fetch jobs with default basePath', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [mockJob] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockPage });
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useBackgroundJobs({ client }), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs');
-    expect(result.current.data).toEqual([mockJob]);
+    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs', { params: undefined });
+    expect(result.current.data).toEqual(mockPage);
   });
 
   it('should fetch jobs with custom basePath', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [mockJob] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockPage });
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useBackgroundJobs({ client, basePath: '/api/v2/jobs' }), {
@@ -71,7 +86,24 @@ describe('useBackgroundJobs', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/jobs');
+    expect(client.get).toHaveBeenCalledWith('/api/v2/jobs', { params: undefined });
+  });
+
+  it('should pass pagination params to the request', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockPage });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useBackgroundJobs({ client, params: { page: 2, pageSize: 10 } }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs', {
+      params: { page: 2, pageSize: 10 },
+    });
   });
 
   it('should handle fetch error', async () => {
@@ -103,7 +135,7 @@ describe('usePauseJob', () => {
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/InvoiceSync/pause');
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: backgroundJobKeys.list(),
+      queryKey: backgroundJobKeys.all,
     });
   });
 
@@ -154,7 +186,7 @@ describe('useResumeJob', () => {
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/InvoiceSync/resume');
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: backgroundJobKeys.list(),
+      queryKey: backgroundJobKeys.all,
     });
   });
 
@@ -205,7 +237,7 @@ describe('useTriggerJob', () => {
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/InvoiceSync/trigger');
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: backgroundJobKeys.list(),
+      queryKey: backgroundJobKeys.all,
     });
   });
 

--- a/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
+++ b/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
@@ -1,6 +1,8 @@
+import { fetchBackgroundJobs } from '@granit/background-jobs';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { BackgroundJobListParams, BackgroundJobStatus } from '@granit/background-jobs';
+import type { PagedResult } from '@granit/querying';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 import type { AxiosInstance } from 'axios';
 
@@ -12,36 +14,37 @@ export interface BackgroundJobsOptions {
   readonly client: AxiosInstance;
   /** Base URL for the background-jobs API. Defaults to `/api/v1/background-jobs`. */
   readonly basePath?: string;
+  /** Pagination parameters for the list endpoint. */
+  readonly params?: BackgroundJobListParams;
 }
 
 /** Query key factory for background jobs queries. */
 export const backgroundJobKeys = {
   all: ['background-jobs'] as const,
-  list: () => [...backgroundJobKeys.all, 'list'] as const,
+  list: (params?: BackgroundJobListParams) =>
+    [...backgroundJobKeys.all, 'list', params ?? {}] as const,
   job: (name: string) => [...backgroundJobKeys.all, 'job', name] as const,
 };
 
 /**
- * Query hook that fetches the list of all background jobs with their current status.
+ * Query hook that fetches a paginated list of all background jobs with their current status.
  *
  * Polls every 15 seconds to reflect live scheduler state.
  *
  * @example
  * ```tsx
- * const { data: jobs } = useBackgroundJobs({ client: api });
+ * const { data } = useBackgroundJobs({ client: api });
+ * // data.items, data.totalCount, data.hasMore
  * ```
  */
 export function useBackgroundJobs(
   options: BackgroundJobsOptions
-): UseQueryResult<readonly BackgroundJobStatus[]> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+): UseQueryResult<PagedResult<BackgroundJobStatus>> {
+  const { client, basePath = DEFAULT_BASE_PATH, params } = options;
 
   return useQuery({
-    queryKey: backgroundJobKeys.list(),
-    queryFn: async () => {
-      const response = await client.get<readonly BackgroundJobStatus[]>(basePath);
-      return response.data;
-    },
+    queryKey: backgroundJobKeys.list(params),
+    queryFn: () => fetchBackgroundJobs(client, basePath, params),
     refetchInterval: 15_000,
   });
 }
@@ -98,7 +101,7 @@ export function usePauseJob(
       await client.post(`${basePath}/${encodeURIComponent(jobName)}/pause`);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.list() });
+      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
     },
   });
 }
@@ -125,7 +128,7 @@ export function useResumeJob(
       await client.post(`${basePath}/${encodeURIComponent(jobName)}/resume`);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.list() });
+      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
     },
   });
 }
@@ -152,7 +155,7 @@ export function useTriggerJob(
       await client.post(`${basePath}/${encodeURIComponent(jobName)}/trigger`);
     },
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.list() });
+      await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
     },
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -194,6 +194,23 @@ importers:
         version: 1.13.6
 
   packages/@granit/background-jobs:
+    dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
+      axios:
+        specifier: '*'
+        version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/blob-storage:
+    dependencies:
+      axios:
+        specifier: '*'
+        version: 1.13.6
     devDependencies:
       '@granit/testing':
         specifier: workspace:*
@@ -422,6 +439,31 @@ importers:
       '@granit/background-jobs':
         specifier: workspace:*
         version: link:../background-jobs
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-blob-storage:
+    dependencies:
+      '@granit/blob-storage':
+        specifier: workspace:*
+        version: link:../blob-storage
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.21(react@19.2.4)


### PR DESCRIPTION
## Summary

- Add `hasMore?: boolean` to `PagedResult<T>` in `@granit/querying` (aligns with .NET)
- Add `BackgroundJobListParams` type and `fetchBackgroundJobs` API function to `@granit/background-jobs`
- Update `useBackgroundJobs` hook to return `PagedResult<BackgroundJobStatus>` with pagination params
- Broaden mutation cache invalidation to `backgroundJobKeys.all`
- Version bumps: `@granit/querying`, `@granit/background-jobs`, `@granit/react-background-jobs` → 0.3.0

Closes #86, #87, #88, #89, #93, #94, #97, #99, #100

## Test plan

- [ ] `pnpm --filter @granit/background-jobs test --run` — all tests pass
- [ ] `pnpm --filter @granit/react-background-jobs test --run` — all tests pass
- [ ] `pnpm tsc` — TypeScript clean on affected packages
- [ ] No lint errors on modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)