### PR TITLE
feat(blob-storage): add @granit/blob-storage and @granit/react-blob-storage packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,8 @@
 | `@granit/logger`                        | Configurable logger factory (`createLogger(prefix)`)                                                                                                                                                                                          |
 | `@granit/utils`                         | Shared utilities (`cn`, `formatDate`, `formatNumber`, …)                                                                                                                                                                                      |
 | `@granit/api-client`                    | Axios factory (`createApiClient`, `setTokenGetter`), shared response types (`PaginatedResponse`, `ProblemDetails`)                                                                                                                            |
+| `@granit/blob-storage`                  | Blob storage types and API functions: `initiateUpload`, `confirmUpload`, `getDownloadUrl`, `deleteBlob`, `getBlob`, `cleanupOrphans` — mirrors `Granit.BlobStorage` .NET contract                                                             |
+| `@granit/react-blob-storage`            | React hooks for `@granit/blob-storage`: `useBlob`, `useInitiateUpload`, `useConfirmUpload`, `useDeleteBlob`, `useDownloadUrl`, `useCleanupOrphans`, `useBlobUpload` (orchestration)                                                           |
 | `@granit/authentication`                | Keycloak/OIDC authentication types: `BaseAuthContextType`, `KeycloakUserInfo`, `KeycloakCoreConfig`, `LoginOptions`, `LogoutOptions` — mirrors `Granit.Authentication` .NET                                                                   |
 | `@granit/react-authentication`          | React bindings for `@granit/authentication`: `useKeycloakInit`, `createAuthContext`, `createMockProvider`                                                                                                                                     |
 | `@granit/authorization`                 | Permission/role authorization types: `PermissionsResponse`, `PermissionDefinitionDto`, `PermissionGroupDto`, `PermissionGrantDto` — mirrors `Granit.Authorization` .NET                                                                       |
@@ -117,6 +119,8 @@ Full frontend conventions: `../granit-dotnet/docs/guide/conventions/frontend/`
 - **Peer dep matrix** (actual `peerDependencies` from each `package.json`):
   - `@granit/utils` → `clsx`, `tailwind-merge`, `date-fns`
   - `@granit/api-client` → `axios`
+  - `@granit/blob-storage` → `axios`
+  - `@granit/react-blob-storage` → `react`, `axios`, `@tanstack/react-query`, `@granit/blob-storage`
   - `@granit/authentication` → `keycloak-js`
   - `@granit/react-authentication` → `react`, `keycloak-js`, `@granit/api-client`, `@granit/authentication`
   - `@granit/authorization` → `axios`

--- a/packages/@granit/blob-storage/package.json
+++ b/packages/@granit/blob-storage/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@granit/blob-storage",
+  "description": "Blob storage types and API functions — mirrors Granit.BlobStorage .NET contract",
+  "version": "0.2.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/blob-storage/src/__tests__/blob-storage-api.test.ts
+++ b/packages/@granit/blob-storage/src/__tests__/blob-storage-api.test.ts
@@ -1,0 +1,197 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  cleanupOrphans,
+  confirmUpload,
+  deleteBlob,
+  getBlob,
+  getDownloadUrl,
+  initiateUpload,
+} from '../api/blob-storage-api.js';
+import { BlobStatus } from '../types/index.js';
+
+import type {
+  BlobCleanupOrphansResponse,
+  BlobConfirmUploadResponse,
+  BlobDescriptorResponse,
+  BlobDownloadUrlResponse,
+  BlobUploadInitiateResponse,
+} from '../types/index.js';
+
+const BASE = '/api/v1/blobs';
+
+describe('blob-storage-api', () => {
+  describe('initiateUpload', () => {
+    it('sends POST to /upload with request body', async () => {
+      const client = createMockClient();
+      const response: BlobUploadInitiateResponse = {
+        blobId: 'abc-123',
+        uploadUrl: 'https://s3.example.com/presigned',
+        httpMethod: 'PUT',
+        expiresAt: '2026-03-20T12:00:00Z',
+        requiredHeaders: { 'Content-Type': 'image/png' },
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await initiateUpload(client, BASE, {
+        containerName: 'medical-images',
+        fileName: 'scan.png',
+        contentType: 'image/png',
+        sizeBytes: 1024,
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/upload`, {
+        containerName: 'medical-images',
+        fileName: 'scan.png',
+        contentType: 'image/png',
+        sizeBytes: 1024,
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('confirmUpload', () => {
+    it('sends POST to /{id}/confirm', async () => {
+      const client = createMockClient();
+      const response: BlobConfirmUploadResponse = {
+        blobId: 'abc-123',
+        isValid: true,
+        status: BlobStatus.Valid,
+        verifiedContentType: 'image/png',
+        sizeBytes: 1024,
+        rejectionReason: null,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await confirmUpload(client, BASE, 'abc-123', {
+        containerName: 'medical-images',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/abc-123/confirm`, {
+        containerName: 'medical-images',
+      });
+      expect(result).toEqual(response);
+    });
+
+    it('encodes blob ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: {} });
+
+      await confirmUpload(client, BASE, 'id with spaces', {
+        containerName: 'docs',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/id%20with%20spaces/confirm`, {
+        containerName: 'docs',
+      });
+    });
+  });
+
+  describe('getDownloadUrl', () => {
+    it('sends POST to /{id}/download-url', async () => {
+      const client = createMockClient();
+      const response: BlobDownloadUrlResponse = {
+        downloadUrl: 'https://s3.example.com/download',
+        expiresAt: '2026-03-20T12:05:00Z',
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await getDownloadUrl(client, BASE, 'abc-123', {
+        containerName: 'medical-images',
+        fileName: 'report.pdf',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/abc-123/download-url`, {
+        containerName: 'medical-images',
+        fileName: 'report.pdf',
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('deleteBlob', () => {
+    it('sends DELETE to /{id} with body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteBlob(client, BASE, 'abc-123', {
+        containerName: 'medical-images',
+        deletionReason: 'RGPD Art. 17 erasure',
+      });
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/abc-123`, {
+        data: {
+          containerName: 'medical-images',
+          deletionReason: 'RGPD Art. 17 erasure',
+        },
+      });
+    });
+
+    it('sends DELETE without deletionReason when omitted', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteBlob(client, BASE, 'abc-123', {
+        containerName: 'docs',
+      });
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/abc-123`, {
+        data: { containerName: 'docs' },
+      });
+    });
+  });
+
+  describe('getBlob', () => {
+    it('sends GET to /{id} with containerName query param', async () => {
+      const client = createMockClient();
+      const descriptor: BlobDescriptorResponse = {
+        id: 'abc-123',
+        containerName: 'medical-images',
+        originalFileName: 'scan.png',
+        declaredContentType: 'image/png',
+        verifiedContentType: 'image/png',
+        declaredSizeBytes: 1024,
+        actualSizeBytes: 1020,
+        status: BlobStatus.Valid,
+        rejectionReason: null,
+        deletionReason: null,
+        createdAt: '2026-03-20T10:00:00Z',
+        validatedAt: '2026-03-20T10:00:05Z',
+        deletedAt: null,
+      };
+      vi.mocked(client.get).mockResolvedValueOnce({ data: descriptor });
+
+      const result = await getBlob(client, BASE, 'abc-123', 'medical-images');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/abc-123`, {
+        params: { containerName: 'medical-images' },
+      });
+      expect(result).toEqual(descriptor);
+    });
+
+    it('encodes blob ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: {} });
+
+      await getBlob(client, BASE, 'id/slash', 'docs');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/id%2Fslash`, {
+        params: { containerName: 'docs' },
+      });
+    });
+  });
+
+  describe('cleanupOrphans', () => {
+    it('sends POST to /cleanup-orphans', async () => {
+      const client = createMockClient();
+      const response: BlobCleanupOrphansResponse = { cleanedCount: 5 };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await cleanupOrphans(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/cleanup-orphans`);
+      expect(result).toEqual(response);
+    });
+  });
+});

--- a/packages/@granit/blob-storage/src/__tests__/blob-storage-types.test.ts
+++ b/packages/@granit/blob-storage/src/__tests__/blob-storage-types.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+
+import { BlobStatus } from '../types/index.js';
+
+describe('BlobStatus', () => {
+  it('should match .NET enum values', () => {
+    expect(BlobStatus.Pending).toBe(0);
+    expect(BlobStatus.Uploading).toBe(1);
+    expect(BlobStatus.Valid).toBe(2);
+    expect(BlobStatus.Rejected).toBe(3);
+    expect(BlobStatus.Deleted).toBe(4);
+  });
+
+  it('should have exactly 5 members', () => {
+    expect(Object.keys(BlobStatus)).toHaveLength(5);
+  });
+});

--- a/packages/@granit/blob-storage/src/api/blob-storage-api.ts
+++ b/packages/@granit/blob-storage/src/api/blob-storage-api.ts
@@ -1,0 +1,107 @@
+import type {
+  BlobCleanupOrphansResponse,
+  BlobConfirmUploadRequest,
+  BlobConfirmUploadResponse,
+  BlobDeleteRequest,
+  BlobDescriptorResponse,
+  BlobDownloadUrlRequest,
+  BlobDownloadUrlResponse,
+  BlobUploadInitiateRequest,
+  BlobUploadInitiateResponse,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Initiate a direct-to-cloud upload and get a pre-signed URL.
+ *
+ * `POST {basePath}/upload`
+ */
+export async function initiateUpload(
+  client: AxiosInstance,
+  basePath: string,
+  request: BlobUploadInitiateRequest
+): Promise<BlobUploadInitiateResponse> {
+  const { data } = await client.post<BlobUploadInitiateResponse>(`${basePath}/upload`, request);
+  return data;
+}
+
+/**
+ * Confirm a client-side upload — runs the server validation pipeline.
+ *
+ * `POST {basePath}/{id}/confirm`
+ */
+export async function confirmUpload(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: BlobConfirmUploadRequest
+): Promise<BlobConfirmUploadResponse> {
+  const { data } = await client.post<BlobConfirmUploadResponse>(
+    `${basePath}/${encodeURIComponent(id)}/confirm`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Generate a pre-signed download URL.
+ *
+ * `POST {basePath}/{id}/download-url`
+ */
+export async function getDownloadUrl(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: BlobDownloadUrlRequest
+): Promise<BlobDownloadUrlResponse> {
+  const { data } = await client.post<BlobDownloadUrlResponse>(
+    `${basePath}/${encodeURIComponent(id)}/download-url`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Delete a blob (crypto-shredding — audit record retained).
+ *
+ * `DELETE {basePath}/{id}`
+ */
+export async function deleteBlob(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: BlobDeleteRequest
+): Promise<void> {
+  await client.delete(`${basePath}/${encodeURIComponent(id)}`, { data: request });
+}
+
+/**
+ * Get a blob descriptor by ID.
+ *
+ * `GET {basePath}/{id}?containerName=...`
+ */
+export async function getBlob(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  containerName: string
+): Promise<BlobDescriptorResponse> {
+  const { data } = await client.get<BlobDescriptorResponse>(
+    `${basePath}/${encodeURIComponent(id)}`,
+    { params: { containerName } }
+  );
+  return data;
+}
+
+/**
+ * Clean up orphaned blobs stuck in Pending/Uploading state.
+ *
+ * `POST {basePath}/cleanup-orphans`
+ */
+export async function cleanupOrphans(
+  client: AxiosInstance,
+  basePath: string
+): Promise<BlobCleanupOrphansResponse> {
+  const { data } = await client.post<BlobCleanupOrphansResponse>(`${basePath}/cleanup-orphans`);
+  return data;
+}

--- a/packages/@granit/blob-storage/src/hooks/query-keys.ts
+++ b/packages/@granit/blob-storage/src/hooks/query-keys.ts
@@ -1,0 +1,7 @@
+/** Query key factory for blob storage queries. */
+export const blobStorageKeys = {
+  all: ['blob-storage'] as const,
+  blobs: () => [...blobStorageKeys.all, 'blob'] as const,
+  blob: (id: string, containerName: string) =>
+    [...blobStorageKeys.blobs(), id, containerName] as const,
+};

--- a/packages/@granit/blob-storage/src/index.ts
+++ b/packages/@granit/blob-storage/src/index.ts
@@ -1,0 +1,28 @@
+// Types
+export { BlobStatus } from './types/index.js';
+
+export type {
+  BlobCleanupOrphansResponse,
+  BlobConfirmUploadRequest,
+  BlobConfirmUploadResponse,
+  BlobDeleteRequest,
+  BlobDescriptorResponse,
+  BlobDownloadUrlRequest,
+  BlobDownloadUrlResponse,
+  BlobStatusValue,
+  BlobUploadInitiateRequest,
+  BlobUploadInitiateResponse,
+} from './types/index.js';
+
+// Query keys
+export { blobStorageKeys } from './hooks/query-keys.js';
+
+// API
+export {
+  cleanupOrphans,
+  confirmUpload,
+  deleteBlob,
+  getBlob,
+  getDownloadUrl,
+  initiateUpload,
+} from './api/blob-storage-api.js';

--- a/packages/@granit/blob-storage/src/types/index.ts
+++ b/packages/@granit/blob-storage/src/types/index.ts
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------------
+// Blob storage types — mirrors Granit.BlobStorage .NET contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Blob lifecycle status.
+ *
+ * Mirrors `Granit.BlobStorage.Domain.BlobStatus` (.NET).
+ */
+export const BlobStatus = {
+  Pending: 0,
+  Uploading: 1,
+  Valid: 2,
+  Rejected: 3,
+  Deleted: 4,
+} as const;
+
+export type BlobStatusValue = (typeof BlobStatus)[keyof typeof BlobStatus];
+
+// ── Upload initiation ───────────────────────────────────────────────────────
+
+/** Request body for `POST /upload`. */
+export interface BlobUploadInitiateRequest {
+  readonly containerName: string;
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly sizeBytes: number;
+}
+
+/** Response from `POST /upload` (201 Created). */
+export interface BlobUploadInitiateResponse {
+  readonly blobId: string;
+  readonly uploadUrl: string;
+  readonly httpMethod: string;
+  readonly expiresAt: string;
+  readonly requiredHeaders: Readonly<Record<string, string>>;
+}
+
+// ── Upload confirmation ─────────────────────────────────────────────────────
+
+/** Request body for `POST /{id}/confirm`. */
+export interface BlobConfirmUploadRequest {
+  readonly containerName: string;
+}
+
+/** Response from `POST /{id}/confirm`. */
+export interface BlobConfirmUploadResponse {
+  readonly blobId: string;
+  readonly isValid: boolean;
+  readonly status: BlobStatusValue;
+  readonly verifiedContentType: string | null;
+  readonly sizeBytes: number | null;
+  readonly rejectionReason: string | null;
+}
+
+// ── Download URL ────────────────────────────────────────────────────────────
+
+/** Request body for `POST /{id}/download-url`. */
+export interface BlobDownloadUrlRequest {
+  readonly containerName: string;
+  readonly fileName?: string;
+}
+
+/** Response from `POST /{id}/download-url`. */
+export interface BlobDownloadUrlResponse {
+  readonly downloadUrl: string;
+  readonly expiresAt: string;
+}
+
+// ── Delete ───────────────────────────────────────────────────────────────────
+
+/** Request body for `DELETE /{id}`. */
+export interface BlobDeleteRequest {
+  readonly containerName: string;
+  readonly deletionReason?: string;
+}
+
+// ── Descriptor ──────────────────────────────────────────────────────────────
+
+/** Full blob descriptor. Mirrors `BlobDescriptorResponse` (.NET). */
+export interface BlobDescriptorResponse {
+  readonly id: string;
+  readonly containerName: string;
+  readonly originalFileName: string;
+  readonly declaredContentType: string;
+  readonly verifiedContentType: string | null;
+  readonly declaredSizeBytes: number;
+  readonly actualSizeBytes: number | null;
+  readonly status: BlobStatusValue;
+  readonly rejectionReason: string | null;
+  readonly deletionReason: string | null;
+  readonly createdAt: string;
+  readonly validatedAt: string | null;
+  readonly deletedAt: string | null;
+}
+
+// ── Cleanup orphans ─────────────────────────────────────────────────────────
+
+/** Response from `POST /cleanup-orphans`. */
+export interface BlobCleanupOrphansResponse {
+  readonly cleanedCount: number;
+}

--- a/packages/@granit/blob-storage/tsconfig.json
+++ b/packages/@granit/blob-storage/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/react-blob-storage/package.json
+++ b/packages/@granit/react-blob-storage/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@granit/react-blob-storage",
+  "description": "React hooks for blob storage — useBlob, useInitiateUpload, useConfirmUpload, useBlobUpload, useDownloadUrl, useDeleteBlob",
+  "version": "0.2.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/blob-storage": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-cleanup.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-cleanup.test.tsx
@@ -1,0 +1,68 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useCleanupOrphans } from '../hooks/use-blob-cleanup.js';
+
+import type { BlobCleanupOrphansResponse } from '@granit/blob-storage';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+describe('useCleanupOrphans', () => {
+  it('should send POST to /cleanup-orphans', async () => {
+    const client = createMockClient();
+    const response: BlobCleanupOrphansResponse = { cleanedCount: 3 };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCleanupOrphans({ client }), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/cleanup-orphans');
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should use custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: { cleanedCount: 0 } });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCleanupOrphans({ client, basePath: '/api/v2/blobs' }), {
+      wrapper,
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v2/blobs/cleanup-orphans');
+  });
+
+  it('should handle error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCleanupOrphans({ client }), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-download.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-download.test.tsx
@@ -1,0 +1,86 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useDownloadUrl } from '../hooks/use-blob-download.js';
+
+import type { BlobDownloadUrlResponse } from '@granit/blob-storage';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+describe('useDownloadUrl', () => {
+  it('should send POST to /{id}/download-url', async () => {
+    const client = createMockClient();
+    const response: BlobDownloadUrlResponse = {
+      downloadUrl: 'https://s3.example.com/download',
+      expiresAt: '2026-03-20T12:05:00Z',
+    };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDownloadUrl({ client }), { wrapper });
+
+    result.current.mutate({
+      id: 'abc-123',
+      request: { containerName: 'docs', fileName: 'report.pdf' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/abc-123/download-url', {
+      containerName: 'docs',
+      fileName: 'report.pdf',
+    });
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should use custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: {} });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDownloadUrl({ client, basePath: '/api/v2/blobs' }), {
+      wrapper,
+    });
+
+    result.current.mutate({
+      id: 'abc-123',
+      request: { containerName: 'docs' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v2/blobs/abc-123/download-url',
+      expect.any(Object)
+    );
+  });
+
+  it('should handle error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDownloadUrl({ client }), { wrapper });
+
+    result.current.mutate({
+      id: 'abc-123',
+      request: { containerName: 'docs' },
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
@@ -1,0 +1,180 @@
+import { blobStorageKeys, BlobStatus } from '@granit/blob-storage';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useConfirmUpload, useDeleteBlob, useInitiateUpload } from '../hooks/use-blob-mutations.js';
+
+import type { BlobConfirmUploadResponse, BlobUploadInitiateResponse } from '@granit/blob-storage';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+describe('useInitiateUpload', () => {
+  it('should send POST to /upload', async () => {
+    const client = createMockClient();
+    const response: BlobUploadInitiateResponse = {
+      blobId: 'abc-123',
+      uploadUrl: 'https://s3.example.com/presigned',
+      httpMethod: 'PUT',
+      expiresAt: '2026-03-20T12:00:00Z',
+      requiredHeaders: { 'Content-Type': 'image/png' },
+    };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useInitiateUpload({ client }), { wrapper });
+
+    result.current.mutate({
+      containerName: 'docs',
+      fileName: 'report.pdf',
+      contentType: 'application/pdf',
+      sizeBytes: 4096,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/upload', {
+      containerName: 'docs',
+      fileName: 'report.pdf',
+      contentType: 'application/pdf',
+      sizeBytes: 4096,
+    });
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should use custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: {} });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useInitiateUpload({ client, basePath: '/api/v2/blobs' }), {
+      wrapper,
+    });
+
+    result.current.mutate({
+      containerName: 'docs',
+      fileName: 'file.txt',
+      contentType: 'text/plain',
+      sizeBytes: 100,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v2/blobs/upload', expect.any(Object));
+  });
+
+  it('should handle error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useInitiateUpload({ client }), { wrapper });
+
+    result.current.mutate({
+      containerName: 'docs',
+      fileName: 'file.txt',
+      contentType: 'text/plain',
+      sizeBytes: 100,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});
+
+describe('useConfirmUpload', () => {
+  it('should send POST to /{id}/confirm and invalidate on success', async () => {
+    const client = createMockClient();
+    const response: BlobConfirmUploadResponse = {
+      blobId: 'abc-123',
+      isValid: true,
+      status: BlobStatus.Valid,
+      verifiedContentType: 'image/png',
+      sizeBytes: 1024,
+      rejectionReason: null,
+    };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useConfirmUpload({ client }), { wrapper });
+
+    result.current.mutate({ id: 'abc-123', request: { containerName: 'docs' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/abc-123/confirm', {
+      containerName: 'docs',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: blobStorageKeys.blobs(),
+    });
+  });
+
+  it('should handle confirmation error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Bad Request'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useConfirmUpload({ client }), { wrapper });
+
+    result.current.mutate({ id: 'abc-123', request: { containerName: 'docs' } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});
+
+describe('useDeleteBlob', () => {
+  it('should send DELETE to /{id} and invalidate on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteBlob({ client }), { wrapper });
+
+    result.current.mutate({
+      id: 'abc-123',
+      request: { containerName: 'docs', deletionReason: 'RGPD Art. 17' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/blobs/abc-123', {
+      data: { containerName: 'docs', deletionReason: 'RGPD Art. 17' },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: blobStorageKeys.blobs(),
+    });
+  });
+
+  it('should handle delete error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteBlob({ client }), { wrapper });
+
+    result.current.mutate({ id: 'abc-123', request: { containerName: 'docs' } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
@@ -1,0 +1,224 @@
+import { BlobStatus } from '@granit/blob-storage';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useBlobUpload } from '../hooks/use-blob-upload.js';
+
+import type { BlobConfirmUploadResponse, BlobUploadInitiateResponse } from '@granit/blob-storage';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockTicket: BlobUploadInitiateResponse = {
+  blobId: 'blob-456',
+  uploadUrl: 'https://s3.example.com/presigned',
+  httpMethod: 'PUT',
+  expiresAt: '2026-03-20T12:00:00Z',
+  requiredHeaders: { 'Content-Type': 'image/png', 'x-amz-meta-tenant': 'tenant-1' },
+};
+
+const mockConfirmation: BlobConfirmUploadResponse = {
+  blobId: 'blob-456',
+  isValid: true,
+  status: BlobStatus.Valid,
+  verifiedContentType: 'image/png',
+  sizeBytes: 1024,
+  rejectionReason: null,
+};
+
+let xhrInstances: MockXHR[];
+
+class MockXHR {
+  status = 200;
+  readyState = 0;
+  uploadListeners: Record<string, (e: unknown) => void> = {};
+  listeners: Record<string, (e: unknown) => void> = {};
+  upload = {
+    addEventListener: (event: string, handler: (e: unknown) => void) => {
+      this.uploadListeners[event] = handler;
+    },
+  };
+  addEventListener = (event: string, handler: (e: unknown) => void) => {
+    this.listeners[event] = handler;
+  };
+  open = vi.fn();
+  setRequestHeader = vi.fn();
+  send = vi.fn();
+  abort = vi.fn();
+
+  constructor() {
+    xhrInstances.push(this);
+  }
+
+  simulateSuccess() {
+    this.listeners['load']?.({});
+  }
+
+  simulateError() {
+    this.listeners['error']?.({});
+  }
+}
+
+beforeEach(() => {
+  xhrInstances = [];
+  vi.stubGlobal('XMLHttpRequest', MockXHR);
+});
+
+describe('useBlobUpload', () => {
+  it('should start in idle state', () => {
+    const client = createMockClient();
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlobUpload({ client }), { wrapper });
+
+    expect(result.current.state.phase).toBe('idle');
+    expect(result.current.state.progress).toBe(0);
+    expect(result.current.state.blobId).toBeNull();
+    expect(result.current.state.result).toBeNull();
+    expect(result.current.state.error).toBeNull();
+  });
+
+  it('should complete the full upload flow', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post)
+      .mockResolvedValueOnce({ data: mockTicket })
+      .mockResolvedValueOnce({ data: mockConfirmation });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlobUpload({ client }), { wrapper });
+
+    const file = new File(['test content'], 'test.png', { type: 'image/png' });
+
+    let uploadPromise: Promise<BlobConfirmUploadResponse>;
+
+    await act(async () => {
+      uploadPromise = result.current.upload({ file, containerName: 'docs' });
+
+      // Wait for initiation POST to complete and XHR to be created
+      await waitFor(() => expect(xhrInstances).toHaveLength(1));
+    });
+
+    const xhr = xhrInstances[0]!;
+
+    expect(xhr.open).toHaveBeenCalledWith('PUT', 'https://s3.example.com/presigned');
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('Content-Type', 'image/png');
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith('x-amz-meta-tenant', 'tenant-1');
+    expect(xhr.send).toHaveBeenCalledWith(file);
+
+    // Simulate successful S3 upload + wait for confirm
+    await act(async () => {
+      xhr.simulateSuccess();
+      await uploadPromise!;
+    });
+
+    expect(result.current.state.phase).toBe('complete');
+    expect(result.current.state.blobId).toBe('blob-456');
+    expect(result.current.state.result).toEqual(mockConfirmation);
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/upload', {
+      containerName: 'docs',
+      fileName: 'test.png',
+      contentType: 'image/png',
+      sizeBytes: 12,
+    });
+  });
+
+  it('should handle initiation error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Unauthorized'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlobUpload({ client }), { wrapper });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await expect(result.current.upload({ file, containerName: 'docs' })).rejects.toThrow(
+        'Unauthorized'
+      );
+    });
+
+    expect(result.current.state.phase).toBe('error');
+    expect(result.current.state.error?.message).toBe('Unauthorized');
+  });
+
+  it('should handle XHR upload error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: mockTicket });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlobUpload({ client }), { wrapper });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+
+    let uploadPromise: Promise<BlobConfirmUploadResponse>;
+
+    await act(async () => {
+      uploadPromise = result.current.upload({ file, containerName: 'docs' });
+      await waitFor(() => expect(xhrInstances).toHaveLength(1));
+    });
+
+    await act(async () => {
+      xhrInstances[0]!.simulateError();
+      await expect(uploadPromise!).rejects.toThrow('network error');
+    });
+
+    expect(result.current.state.phase).toBe('error');
+  });
+
+  it('should reset state', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('fail'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlobUpload({ client }), { wrapper });
+
+    const file = new File(['x'], 'x.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await expect(result.current.upload({ file, containerName: 'docs' })).rejects.toThrow();
+    });
+
+    expect(result.current.state.phase).toBe('error');
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.state.phase).toBe('idle');
+    expect(result.current.state.progress).toBe(0);
+    expect(result.current.state.error).toBeNull();
+  });
+
+  it('should use application/octet-stream when file type is empty', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: mockTicket });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlobUpload({ client }), { wrapper });
+
+    const file = new File(['data'], 'unknown', { type: '' });
+
+    await act(async () => {
+      result.current.upload({ file, containerName: 'docs' });
+      await waitFor(() => expect(xhrInstances).toHaveLength(1));
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/upload', {
+      containerName: 'docs',
+      fileName: 'unknown',
+      contentType: 'application/octet-stream',
+      sizeBytes: 4,
+    });
+  });
+});

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
@@ -1,0 +1,105 @@
+import { BlobStatus } from '@granit/blob-storage';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useBlob } from '../hooks/use-blob.js';
+
+import type { BlobDescriptorResponse } from '@granit/blob-storage';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockDescriptor: BlobDescriptorResponse = {
+  id: 'abc-123',
+  containerName: 'medical-images',
+  originalFileName: 'scan.png',
+  declaredContentType: 'image/png',
+  verifiedContentType: 'image/png',
+  declaredSizeBytes: 1024,
+  actualSizeBytes: 1020,
+  status: BlobStatus.Valid,
+  rejectionReason: null,
+  deletionReason: null,
+  createdAt: '2026-03-20T10:00:00Z',
+  validatedAt: '2026-03-20T10:00:05Z',
+  deletedAt: null,
+};
+
+describe('useBlob', () => {
+  it('should fetch blob descriptor with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockDescriptor });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlob('abc-123', 'medical-images', { client }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/blobs/abc-123', {
+      params: { containerName: 'medical-images' },
+    });
+    expect(result.current.data).toEqual(mockDescriptor);
+  });
+
+  it('should fetch blob descriptor with custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockDescriptor });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useBlob('abc-123', 'docs', { client, basePath: '/api/v2/blobs' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v2/blobs/abc-123', {
+      params: { containerName: 'docs' },
+    });
+  });
+
+  it('should be disabled when id is empty', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlob('', 'docs', { client }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('should be disabled when containerName is empty', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlob('abc-123', '', { client }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useBlob('abc-123', 'docs', { client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
@@ -1,0 +1,29 @@
+import { cleanupOrphans } from '@granit/blob-storage';
+import { useMutation } from '@tanstack/react-query';
+
+import type { BlobStorageOptions } from './use-blob.js';
+import type { BlobCleanupOrphansResponse } from '@granit/blob-storage';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/blobs';
+
+/**
+ * Mutation hook to clean up orphaned blobs stuck in Pending/Uploading state.
+ *
+ * Sends `POST {basePath}/cleanup-orphans`. Typically used by admin interfaces.
+ *
+ * @example
+ * ```tsx
+ * const { mutateAsync: cleanup } = useCleanupOrphans({ client: api });
+ * const { cleanedCount } = await cleanup();
+ * ```
+ */
+export function useCleanupOrphans(
+  options: BlobStorageOptions
+): UseMutationResult<BlobCleanupOrphansResponse, Error, void> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useMutation({
+    mutationFn: () => cleanupOrphans(client, basePath),
+  });
+}

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-download.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-download.ts
@@ -1,0 +1,35 @@
+import { getDownloadUrl } from '@granit/blob-storage';
+import { useMutation } from '@tanstack/react-query';
+
+import type { BlobStorageOptions } from './use-blob.js';
+import type { BlobDownloadUrlRequest, BlobDownloadUrlResponse } from '@granit/blob-storage';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/blobs';
+
+/**
+ * Mutation hook to generate a pre-signed download URL.
+ *
+ * This is a mutation (not a query) because download URLs are ephemeral
+ * pre-signed URLs that should not be cached.
+ *
+ * @example
+ * ```tsx
+ * const { mutateAsync: download } = useDownloadUrl({ client: api });
+ * const { downloadUrl } = await download({ id: 'abc-123', request: { containerName: 'docs' } });
+ * window.open(downloadUrl);
+ * ```
+ */
+export function useDownloadUrl(
+  options: BlobStorageOptions
+): UseMutationResult<
+  BlobDownloadUrlResponse,
+  Error,
+  { id: string; request: BlobDownloadUrlRequest }
+> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useMutation({
+    mutationFn: ({ id, request }) => getDownloadUrl(client, basePath, id, request),
+  });
+}

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
@@ -1,0 +1,91 @@
+import { blobStorageKeys, confirmUpload, deleteBlob, initiateUpload } from '@granit/blob-storage';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { BlobStorageOptions } from './use-blob.js';
+import type {
+  BlobConfirmUploadRequest,
+  BlobConfirmUploadResponse,
+  BlobDeleteRequest,
+  BlobUploadInitiateRequest,
+  BlobUploadInitiateResponse,
+} from '@granit/blob-storage';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/blobs';
+
+/**
+ * Mutation hook to initiate a direct-to-cloud upload.
+ *
+ * Sends `POST {basePath}/upload` and returns a pre-signed URL.
+ *
+ * @example
+ * ```tsx
+ * const { mutateAsync: initiate } = useInitiateUpload({ client: api });
+ * const ticket = await initiate({ containerName: 'docs', fileName: 'report.pdf', contentType: 'application/pdf', sizeBytes: 4096 });
+ * ```
+ */
+export function useInitiateUpload(
+  options: BlobStorageOptions
+): UseMutationResult<BlobUploadInitiateResponse, Error, BlobUploadInitiateRequest> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useMutation({
+    mutationFn: (request: BlobUploadInitiateRequest) => initiateUpload(client, basePath, request),
+  });
+}
+
+/**
+ * Mutation hook to confirm a client-side upload.
+ *
+ * Sends `POST {basePath}/{id}/confirm` and runs the server validation pipeline.
+ * Invalidates blob queries on success.
+ *
+ * @example
+ * ```tsx
+ * const { mutateAsync: confirm } = useConfirmUpload({ client: api });
+ * const result = await confirm({ id: 'abc-123', request: { containerName: 'docs' } });
+ * ```
+ */
+export function useConfirmUpload(
+  options: BlobStorageOptions
+): UseMutationResult<
+  BlobConfirmUploadResponse,
+  Error,
+  { id: string; request: BlobConfirmUploadRequest }
+> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }) => confirmUpload(client, basePath, id, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
+    },
+  });
+}
+
+/**
+ * Mutation hook to delete a blob (crypto-shredding).
+ *
+ * Sends `DELETE {basePath}/{id}` with the container name in the request body.
+ * Invalidates blob queries on success.
+ *
+ * @example
+ * ```tsx
+ * const { mutate: remove } = useDeleteBlob({ client: api });
+ * remove({ id: 'abc-123', request: { containerName: 'docs', deletionReason: 'RGPD Art. 17' } });
+ * ```
+ */
+export function useDeleteBlob(
+  options: BlobStorageOptions
+): UseMutationResult<void, Error, { id: string; request: BlobDeleteRequest }> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }) => deleteBlob(client, basePath, id, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
+    },
+  });
+}

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
@@ -1,0 +1,183 @@
+import { blobStorageKeys, confirmUpload, initiateUpload } from '@granit/blob-storage';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useRef, useState } from 'react';
+
+import type { BlobStorageOptions } from './use-blob.js';
+import type { BlobConfirmUploadResponse } from '@granit/blob-storage';
+
+const DEFAULT_BASE_PATH = '/api/v1/blobs';
+
+/** Upload progress phase. */
+export type BlobUploadPhase =
+  | 'idle'
+  | 'initiating'
+  | 'uploading'
+  | 'confirming'
+  | 'complete'
+  | 'error';
+
+/** Current state of the upload orchestration. */
+export interface BlobUploadState {
+  readonly phase: BlobUploadPhase;
+  /** Upload progress 0–100, only meaningful during `uploading` phase. */
+  readonly progress: number;
+  /** Blob ID assigned by the server after initiation. */
+  readonly blobId: string | null;
+  /** Confirmation result, available when phase is `complete`. */
+  readonly result: BlobConfirmUploadResponse | null;
+  /** Error, available when phase is `error`. */
+  readonly error: Error | null;
+}
+
+/** Parameters for starting an upload. */
+export interface BlobUploadParams {
+  readonly file: File;
+  readonly containerName: string;
+  readonly onProgress?: (percent: number) => void;
+}
+
+/** Return type of {@link useBlobUpload}. */
+export interface UseBlobUploadReturn {
+  /** Start the three-step upload flow (initiate → PUT → confirm). */
+  readonly upload: (params: BlobUploadParams) => Promise<BlobConfirmUploadResponse>;
+  /** Current upload state. */
+  readonly state: BlobUploadState;
+  /** Reset state back to idle. */
+  readonly reset: () => void;
+}
+
+const IDLE_STATE: BlobUploadState = {
+  phase: 'idle',
+  progress: 0,
+  blobId: null,
+  result: null,
+  error: null,
+};
+
+/**
+ * Orchestration hook for the full direct-to-cloud upload flow.
+ *
+ * 1. **Initiate**: `POST /upload` to get a pre-signed URL
+ * 2. **Upload**: `PUT` the file directly to the storage provider using the pre-signed URL
+ * 3. **Confirm**: `POST /{id}/confirm` to run the server validation pipeline
+ *
+ * The S3/Azure PUT uses `XMLHttpRequest` (not axios) because the pre-signed URL
+ * points to the storage provider, not the application API.
+ *
+ * @example
+ * ```tsx
+ * const { upload, state, reset } = useBlobUpload({ client: api });
+ *
+ * const handleFile = async (file: File) => {
+ *   const result = await upload({ file, containerName: 'documents' });
+ *   if (result.isValid) console.log('Upload validated:', result.blobId);
+ * };
+ * ```
+ */
+export function useBlobUpload(options: BlobStorageOptions): UseBlobUploadReturn {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+  const [state, setState] = useState<BlobUploadState>(IDLE_STATE);
+  const abortRef = useRef<XMLHttpRequest | null>(null);
+
+  const reset = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+    setState(IDLE_STATE);
+  }, []);
+
+  const upload = useCallback(
+    async (params: BlobUploadParams): Promise<BlobConfirmUploadResponse> => {
+      const { file, containerName, onProgress } = params;
+
+      try {
+        // Step 1: Initiate upload
+        setState({
+          phase: 'initiating',
+          progress: 0,
+          blobId: null,
+          result: null,
+          error: null,
+        });
+
+        const ticket = await initiateUpload(client, basePath, {
+          containerName,
+          fileName: file.name,
+          contentType: file.type || 'application/octet-stream',
+          sizeBytes: file.size,
+        });
+
+        setState((prev) => ({ ...prev, phase: 'uploading', blobId: ticket.blobId }));
+
+        // Step 2: Upload file to pre-signed URL via XMLHttpRequest (for progress)
+        await new Promise<void>((resolve, reject) => {
+          const xhr = new XMLHttpRequest();
+          abortRef.current = xhr;
+
+          xhr.upload.addEventListener('progress', (event) => {
+            if (event.lengthComputable) {
+              const percent = Math.round((event.loaded / event.total) * 100);
+              setState((prev) => ({ ...prev, progress: percent }));
+              onProgress?.(percent);
+            }
+          });
+
+          xhr.addEventListener('load', () => {
+            abortRef.current = null;
+            if (xhr.status >= 200 && xhr.status < 300) {
+              resolve();
+            } else {
+              reject(new Error(`Upload failed with status ${xhr.status}`));
+            }
+          });
+
+          xhr.addEventListener('error', () => {
+            abortRef.current = null;
+            reject(new Error('Upload failed: network error'));
+          });
+
+          xhr.addEventListener('abort', () => {
+            abortRef.current = null;
+            reject(new Error('Upload aborted'));
+          });
+
+          xhr.open(ticket.httpMethod, ticket.uploadUrl);
+
+          for (const [key, value] of Object.entries(ticket.requiredHeaders)) {
+            xhr.setRequestHeader(key, value);
+          }
+
+          xhr.send(file);
+        });
+
+        // Step 3: Confirm upload
+        setState((prev) => ({ ...prev, phase: 'confirming', progress: 100 }));
+
+        const confirmation = await confirmUpload(client, basePath, ticket.blobId, {
+          containerName,
+        });
+
+        setState({
+          phase: 'complete',
+          progress: 100,
+          blobId: ticket.blobId,
+          result: confirmation,
+          error: null,
+        });
+
+        await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
+
+        return confirmation;
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        setState((prev) => ({ ...prev, phase: 'error', error }));
+        throw error;
+      }
+    },
+    [client, basePath, queryClient]
+  );
+
+  return { upload, state, reset };
+}

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
@@ -1,0 +1,40 @@
+import { blobStorageKeys, getBlob } from '@granit/blob-storage';
+import { useQuery } from '@tanstack/react-query';
+
+import type { BlobDescriptorResponse } from '@granit/blob-storage';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+
+const DEFAULT_BASE_PATH = '/api/v1/blobs';
+
+/** Options accepted by all blob-storage hooks. */
+export interface BlobStorageOptions {
+  /** Axios instance used for all requests. */
+  readonly client: AxiosInstance;
+  /** Base URL for the blob-storage API. Defaults to `/api/v1/blobs`. */
+  readonly basePath?: string;
+}
+
+/**
+ * Query hook that fetches a single blob descriptor by ID.
+ *
+ * The query is disabled when `id` or `containerName` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: blob } = useBlob('abc-123', 'medical-images', { client: api });
+ * ```
+ */
+export function useBlob(
+  id: string,
+  containerName: string,
+  options: BlobStorageOptions
+): UseQueryResult<BlobDescriptorResponse> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useQuery({
+    queryKey: blobStorageKeys.blob(id, containerName),
+    queryFn: () => getBlob(client, basePath, id, containerName),
+    enabled: id.length > 0 && containerName.length > 0,
+  });
+}

--- a/packages/@granit/react-blob-storage/src/index.ts
+++ b/packages/@granit/react-blob-storage/src/index.ts
@@ -1,0 +1,14 @@
+// Hooks
+export { useBlob } from './hooks/use-blob.js';
+export { useConfirmUpload, useDeleteBlob, useInitiateUpload } from './hooks/use-blob-mutations.js';
+export { useDownloadUrl } from './hooks/use-blob-download.js';
+export { useCleanupOrphans } from './hooks/use-blob-cleanup.js';
+export { useBlobUpload } from './hooks/use-blob-upload.js';
+
+// Types
+export type { BlobStorageOptions } from './hooks/use-blob.js';
+export type {
+  BlobUploadParams,
+  BlobUploadPhase,
+  BlobUploadState,
+} from './hooks/use-blob-upload.js';

--- a/packages/@granit/react-blob-storage/tsconfig.json
+++ b/packages/@granit/react-blob-storage/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,16 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/blob-storage:
+    dependencies:
+      axios:
+        specifier: '*'
+        version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/cookies: {}
 
   packages/@granit/cookies-klaro:
@@ -475,6 +485,28 @@ importers:
       '@granit/querying':
         specifier: workspace:*
         version: link:../querying
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-blob-storage:
+    dependencies:
+      '@granit/blob-storage':
+        specifier: workspace:*
+        version: link:../blob-storage
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.21(react@19.2.4)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,16 +227,6 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
-  packages/@granit/blob-storage:
-    dependencies:
-      axios:
-        specifier: '*'
-        version: 1.13.6
-    devDependencies:
-      '@granit/testing':
-        specifier: workspace:*
-        version: link:../testing
-
   packages/@granit/cookies: {}
 
   packages/@granit/cookies-klaro:
@@ -485,28 +475,6 @@ importers:
       '@granit/querying':
         specifier: workspace:*
         version: link:../querying
-      '@tanstack/react-query':
-        specifier: ^5.0.0
-        version: 5.90.21(react@19.2.4)
-      axios:
-        specifier: '*'
-        version: 1.13.6
-      react:
-        specifier: ^19.0.0
-        version: 19.2.4
-    devDependencies:
-      '@granit/react-testing':
-        specifier: workspace:*
-        version: link:../react-testing
-      '@granit/testing':
-        specifier: workspace:*
-        version: link:../testing
-
-  packages/@granit/react-blob-storage:
-    dependencies:
-      '@granit/blob-storage':
-        specifier: workspace:*
-        version: link:../blob-storage
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.21(react@19.2.4)

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         __dirname,
         'packages/@granit/background-jobs/src/index.ts'
       ),
+      '@granit/blob-storage': path.resolve(__dirname, 'packages/@granit/blob-storage/src/index.ts'),
       '@granit/authentication-api-keys': path.resolve(
         __dirname,
         'packages/@granit/authentication-api-keys/src/index.ts'
@@ -86,6 +87,10 @@ export default defineConfig({
       '@granit/react-background-jobs': path.resolve(
         __dirname,
         'packages/@granit/react-background-jobs/src/index.ts'
+      ),
+      '@granit/react-blob-storage': path.resolve(
+        __dirname,
+        'packages/@granit/react-blob-storage/src/index.ts'
       ),
       '@granit/react-authentication': path.resolve(
         __dirname,


### PR DESCRIPTION
## Summary

- Add `@granit/blob-storage` package: types, API functions, and query keys mirroring `Granit.BlobStorage.Endpoints` .NET contract
- Add `@granit/react-blob-storage` package: 7 React hooks including `useBlobUpload` orchestration for the direct-to-cloud upload flow (initiate → presigned PUT to S3/Azure → confirm)
- Register vitest aliases and update `CLAUDE.md` package table + peer dep matrix

## Details

### `@granit/blob-storage` (core)
- `BlobStatus` const enum (Pending, Uploading, Valid, Rejected, Deleted)
- 9 DTO types mirroring .NET contract
- 6 API functions: `initiateUpload`, `confirmUpload`, `getDownloadUrl`, `deleteBlob`, `getBlob`, `cleanupOrphans`
- Query key factory (`blobStorageKeys`)

### `@granit/react-blob-storage` (React)
- `useBlob` — query hook for blob descriptors
- `useInitiateUpload`, `useConfirmUpload`, `useDeleteBlob` — mutations with cache invalidation
- `useDownloadUrl` — mutation for ephemeral presigned download URLs
- `useCleanupOrphans` — admin mutation
- `useBlobUpload` — orchestration hook with state machine (`idle → initiating → uploading → confirming → complete | error`), XHR progress tracking, and abort support

List/query uses `QueryProvider` + `useQueryEndpoint<BlobDescriptorResponse>` from `@granit/react-querying`.

Closes #90, #91, #92, #95, #96, #98
Relates to Epic #103, Features #101, #102

## Test plan

- [x] 11 core package tests (types + API functions)
- [x] 24 React hook tests (query, mutations, download, cleanup, upload orchestration)
- [x] `pnpm tsc` passes
- [x] `pnpm lint` passes (--max-warnings 0)
- [x] Pre-commit hooks pass (prettier, eslint, markdownlint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)