### PR TITLE
refactor: unify shared types, fix dependencies, improve tests

### DIFF
--- a/packages/@granit/audit-log/package.json
+++ b/packages/@granit/audit-log/package.json
@@ -17,6 +17,7 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/querying": "workspace:*",
     "axios": "*"
   },
   "publishConfig": {

--- a/packages/@granit/audit-log/src/types/index.ts
+++ b/packages/@granit/audit-log/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { PagedResult, PaginationParams } from '@granit/querying';
+
 // ---------------------------------------------------------------------------
 // Audit log types — mirrors Granit.AuditLog .NET contracts
 // ---------------------------------------------------------------------------
@@ -64,9 +66,7 @@ export type AuditLogEntryDetail = {
 };
 
 /** Query parameters for listing audit log entries. */
-export type AuditLogListParams = {
-  readonly page?: number;
-  readonly pageSize?: number;
+export type AuditLogListParams = PaginationParams & {
   readonly userId?: string;
   readonly entityType?: string;
   readonly entityId?: string;
@@ -76,9 +76,4 @@ export type AuditLogListParams = {
 };
 
 /** Paginated response for audit log entries. */
-export type AuditLogPage = {
-  readonly items: readonly AuditLogEntry[];
-  readonly totalCount: number | null;
-  readonly hasMore: boolean;
-  readonly nextCursor: string | null;
-};
+export type AuditLogPage = PagedResult<AuditLogEntry>;

--- a/packages/@granit/background-jobs/src/types/background-job-list-params.ts
+++ b/packages/@granit/background-jobs/src/types/background-job-list-params.ts
@@ -1,5 +1,4 @@
+import type { PaginationParams } from '@granit/querying';
+
 /** Pagination parameters for listing background jobs. Mirrors .NET query params. */
-export interface BackgroundJobListParams {
-  readonly page?: number;
-  readonly pageSize?: number;
-}
+export type BackgroundJobListParams = PaginationParams;

--- a/packages/@granit/data-exchange/package.json
+++ b/packages/@granit/data-exchange/package.json
@@ -17,6 +17,8 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/querying": "workspace:*",
     "@granit/utils": "workspace:*",
     "axios": "*"
   },

--- a/packages/@granit/data-exchange/src/export/api/export-api.ts
+++ b/packages/@granit/data-exchange/src/export/api/export-api.ts
@@ -3,22 +3,14 @@ import type {
   ExportFieldDescriptor,
 } from '../types/export-definition.js';
 import type { CreateExportJobRequest, ExportJobResponse } from '../types/export-job.js';
+import type { PaginatedResponse } from '@granit/api-client';
+import type { PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
-/** Paginated response envelope. Mirrors `@granit/api-client` PaginatedResponse. */
-interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
 /** Query parameters for listing export jobs. */
-export interface ExportJobListParams {
+export type ExportJobListParams = PaginationParams & {
   readonly status?: string;
-  readonly page?: number;
-  readonly pageSize?: number;
-}
+};
 
 /**
  * Fetches all registered export definitions.

--- a/packages/@granit/data-exchange/src/import/api/import-api.ts
+++ b/packages/@granit/data-exchange/src/import/api/import-api.ts
@@ -1,22 +1,14 @@
 import type { ImportJobResponse } from '../types/import-job.js';
 import type { ConfirmMappingsRequest, ImportPreviewResponse } from '../types/import-preview.js';
 import type { ImportReportResponse } from '../types/import-report.js';
+import type { PaginatedResponse } from '@granit/api-client';
+import type { PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
-/** Paginated response envelope. Mirrors `@granit/api-client` PaginatedResponse. */
-interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
 /** Query parameters for listing import jobs. */
-export interface ImportJobListParams {
+export type ImportJobListParams = PaginationParams & {
   readonly status?: string;
-  readonly page?: number;
-  readonly pageSize?: number;
-}
+};
 
 /**
  * Uploads a file and creates a new import job.

--- a/packages/@granit/identity/package.json
+++ b/packages/@granit/identity/package.json
@@ -17,6 +17,7 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/querying": "workspace:*",
     "axios": "*"
   },
   "publishConfig": {

--- a/packages/@granit/identity/src/types/identity-user.ts
+++ b/packages/@granit/identity/src/types/identity-user.ts
@@ -1,3 +1,5 @@
+import type { PagedResult, PaginationParams } from '@granit/querying';
+
 /** Cached identity user — mirrors Granit.Identity.IdentityUser .NET record. */
 export type IdentityUser = {
   readonly id: string;
@@ -9,10 +11,8 @@ export type IdentityUser = {
   readonly attributes: Readonly<Record<string, string>> | null;
 };
 
-export type IdentityUserListParams = {
+export type IdentityUserListParams = PaginationParams & {
   readonly search?: string;
-  readonly page?: number;
-  readonly pageSize?: number;
 };
 
 export type IdentityUserCacheStats = {
@@ -30,10 +30,5 @@ export type IdentityUserCacheSyncStaleResult = {
   readonly refreshedCount: number;
 };
 
-/** Paginated response for identity user listing — mirrors Granit.Querying.PagedResult. */
-export type IdentityUserPage = {
-  readonly items: readonly IdentityUser[];
-  readonly totalCount: number | null;
-  readonly hasMore: boolean;
-  readonly nextCursor: string | null;
-};
+/** Paginated response for identity user listing. */
+export type IdentityUserPage = PagedResult<IdentityUser>;

--- a/packages/@granit/notifications/package.json
+++ b/packages/@granit/notifications/package.json
@@ -17,6 +17,7 @@
     "@granit/api-client": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/querying": "workspace:*",
     "axios": "*"
   },
   "publishConfig": {

--- a/packages/@granit/notifications/src/types/index.ts
+++ b/packages/@granit/notifications/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { PagedResult } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
@@ -18,13 +19,9 @@ export interface NotificationDto {
   readAt: string | null;
 }
 
-export interface NotificationPageDto {
-  items: NotificationDto[];
-  totalCount: number;
-  /** Opaque cursor for next page (always null for offset pagination). */
-  nextCursor: string | null;
-  unreadCount: number;
-}
+export type NotificationPageDto = PagedResult<NotificationDto> & {
+  readonly unreadCount: number;
+};
 
 // ---------------------------------------------------------------------------
 // Activity feed
@@ -40,12 +37,7 @@ export interface ActivityFeedEntryDto {
   userDisplayName: string | null;
 }
 
-export interface ActivityFeedPageDto {
-  items: ActivityFeedEntryDto[];
-  totalCount: number;
-  /** Opaque cursor for next page (always null for offset pagination). */
-  nextCursor: string | null;
-}
+export type ActivityFeedPageDto = PagedResult<ActivityFeedEntryDto>;
 
 // ---------------------------------------------------------------------------
 // Channels — extensible string type with well-known constants

--- a/packages/@granit/querying/src/__tests__/query-param-serializer.test.ts
+++ b/packages/@granit/querying/src/__tests__/query-param-serializer.test.ts
@@ -1,32 +1,32 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseQueryParams, serializeQueryParams } from '../api/query-param-serializer.js';
+import { parseQueryRequest, serializeQueryRequest } from '../api/query-param-serializer.js';
 
-import type { QueryParams } from '../types/query-params.js';
+import type { QueryRequest } from '../types/query-params.js';
 
-describe('serializeQueryParams', () => {
+describe('serializeQueryRequest', () => {
   it('serializes empty params to empty string', () => {
-    expect(serializeQueryParams({})).toBe('');
+    expect(serializeQueryRequest({})).toBe('');
   });
 
   it('serializes page and pageSize', () => {
-    const result = serializeQueryParams({ page: 2, pageSize: 50 });
+    const result = serializeQueryRequest({ page: 2, pageSize: 50 });
     expect(result).toContain('page=2');
     expect(result).toContain('pageSize=50');
   });
 
   it('serializes search', () => {
-    const result = serializeQueryParams({ search: 'Dupont' });
+    const result = serializeQueryRequest({ search: 'Dupont' });
     expect(result).toContain('search=Dupont');
   });
 
   it('serializes cursor', () => {
-    const result = serializeQueryParams({ cursor: 'abc123' });
+    const result = serializeQueryRequest({ cursor: 'abc123' });
     expect(result).toContain('cursor=abc123');
   });
 
   it('serializes filters with field.operator syntax', () => {
-    const result = serializeQueryParams({
+    const result = serializeQueryRequest({
       filters: [
         { field: 'status', operator: 'Eq', value: 'active' },
         { field: 'age', operator: 'Gte', value: '18' },
@@ -38,7 +38,7 @@ describe('serializeQueryParams', () => {
   });
 
   it('serializes sort with descending prefix', () => {
-    const result = serializeQueryParams({
+    const result = serializeQueryRequest({
       sort: [
         { field: 'createdAt', direction: 'desc' },
         { field: 'lastName', direction: 'asc' },
@@ -48,7 +48,7 @@ describe('serializeQueryParams', () => {
   });
 
   it('serializes presets by group', () => {
-    const result = serializeQueryParams({
+    const result = serializeQueryRequest({
       presets: { status: ['Active', 'Pending'] },
     });
     const params = new URLSearchParams(result);
@@ -56,26 +56,36 @@ describe('serializeQueryParams', () => {
   });
 
   it('skips empty preset groups', () => {
-    const result = serializeQueryParams({
+    const result = serializeQueryRequest({
       presets: { status: [] },
     });
     expect(result).not.toContain('presets');
   });
 
   it('serializes quickFilters as comma-separated', () => {
-    const result = serializeQueryParams({
+    const result = serializeQueryRequest({
       quickFilters: ['MyItems', 'Unread'],
     });
     expect(result).toContain('quickFilters=MyItems%2CUnread');
   });
 
   it('serializes groupBy', () => {
-    const result = serializeQueryParams({ groupBy: 'status' });
+    const result = serializeQueryRequest({ groupBy: 'status' });
     expect(result).toContain('groupBy=status');
   });
 
+  it('serializes skipTotalCount when true', () => {
+    const result = serializeQueryRequest({ skipTotalCount: true });
+    expect(result).toContain('skipTotalCount=true');
+  });
+
+  it('omits skipTotalCount when false or undefined', () => {
+    expect(serializeQueryRequest({ skipTotalCount: false })).not.toContain('skipTotalCount');
+    expect(serializeQueryRequest({})).not.toContain('skipTotalCount');
+  });
+
   it('serializes a full query', () => {
-    const params: QueryParams = {
+    const params: QueryRequest = {
       page: 1,
       pageSize: 20,
       search: 'test',
@@ -85,7 +95,7 @@ describe('serializeQueryParams', () => {
       quickFilters: ['MyItems'],
       groupBy: 'status',
     };
-    const result = serializeQueryParams(params);
+    const result = serializeQueryRequest(params);
     const urlParams = new URLSearchParams(result);
     expect(urlParams.get('page')).toBe('1');
     expect(urlParams.get('pageSize')).toBe('20');
@@ -98,30 +108,30 @@ describe('serializeQueryParams', () => {
   });
 });
 
-describe('parseQueryParams', () => {
+describe('parseQueryRequest', () => {
   it('parses empty string', () => {
-    const result = parseQueryParams('');
+    const result = parseQueryRequest('');
     expect(result).toEqual({});
   });
 
   it('parses page and pageSize', () => {
-    const result = parseQueryParams('page=2&pageSize=50');
+    const result = parseQueryRequest('page=2&pageSize=50');
     expect(result.page).toBe(2);
     expect(result.pageSize).toBe(50);
   });
 
   it('parses search', () => {
-    const result = parseQueryParams('search=Dupont');
+    const result = parseQueryRequest('search=Dupont');
     expect(result.search).toBe('Dupont');
   });
 
   it('parses cursor', () => {
-    const result = parseQueryParams('cursor=abc123');
+    const result = parseQueryRequest('cursor=abc123');
     expect(result.cursor).toBe('abc123');
   });
 
   it('parses filters', () => {
-    const result = parseQueryParams('filter[status.Eq]=active&filter[age.Gte]=18');
+    const result = parseQueryRequest('filter[status.Eq]=active&filter[age.Gte]=18');
     expect(result.filters).toEqual([
       { field: 'status', operator: 'Eq', value: 'active' },
       { field: 'age', operator: 'Gte', value: '18' },
@@ -129,7 +139,7 @@ describe('parseQueryParams', () => {
   });
 
   it('parses sort with descending prefix', () => {
-    const result = parseQueryParams('sort=-createdAt,lastName');
+    const result = parseQueryRequest('sort=-createdAt,lastName');
     expect(result.sort).toEqual([
       { field: 'createdAt', direction: 'desc' },
       { field: 'lastName', direction: 'asc' },
@@ -137,22 +147,32 @@ describe('parseQueryParams', () => {
   });
 
   it('parses presets', () => {
-    const result = parseQueryParams('presets[status]=Active,Pending');
+    const result = parseQueryRequest('presets[status]=Active,Pending');
     expect(result.presets).toEqual({ status: ['Active', 'Pending'] });
   });
 
   it('parses quickFilters', () => {
-    const result = parseQueryParams('quickFilters=MyItems,Unread');
+    const result = parseQueryRequest('quickFilters=MyItems,Unread');
     expect(result.quickFilters).toEqual(['MyItems', 'Unread']);
   });
 
   it('parses groupBy', () => {
-    const result = parseQueryParams('groupBy=status');
+    const result = parseQueryRequest('groupBy=status');
     expect(result.groupBy).toBe('status');
   });
 
+  it('parses skipTotalCount', () => {
+    const result = parseQueryRequest('skipTotalCount=true');
+    expect(result.skipTotalCount).toBe(true);
+  });
+
+  it('ignores skipTotalCount when not true', () => {
+    const result = parseQueryRequest('skipTotalCount=false');
+    expect(result.skipTotalCount).toBeUndefined();
+  });
+
   it('round-trips a full query', () => {
-    const original: QueryParams = {
+    const original: QueryRequest = {
       page: 1,
       pageSize: 20,
       search: 'test',
@@ -162,8 +182,8 @@ describe('parseQueryParams', () => {
       quickFilters: ['MyItems'],
       groupBy: 'status',
     };
-    const serialized = serializeQueryParams(original);
-    const parsed = parseQueryParams(serialized);
+    const serialized = serializeQueryRequest(original);
+    const parsed = parseQueryRequest(serialized);
     expect(parsed.page).toBe(original.page);
     expect(parsed.pageSize).toBe(original.pageSize);
     expect(parsed.search).toBe(original.search);

--- a/packages/@granit/querying/src/api/query-api.ts
+++ b/packages/@granit/querying/src/api/query-api.ts
@@ -2,10 +2,10 @@
 // Query API — data fetching functions
 // ---------------------------------------------------------------------------
 
-import { serializeQueryParams } from './query-param-serializer.js';
+import { serializeQueryRequest } from './query-param-serializer.js';
 
 import type { QueryMetadata } from '../types/query-metadata.js';
-import type { QueryParams } from '../types/query-params.js';
+import type { QueryRequest } from '../types/query-params.js';
 import type { GroupedResult, PagedResult } from '../types/query-results.js';
 import type { AxiosInstance } from 'axios';
 
@@ -14,14 +14,14 @@ import type { AxiosInstance } from 'axios';
  *
  * @param client - Axios instance (from @granit/api-client)
  * @param basePath - API base path (e.g. "/api/v1/patients")
- * @param params - Query parameters
+ * @param request - Query request parameters
  */
 export async function fetchPage<T>(
   client: AxiosInstance,
   basePath: string,
-  params: QueryParams
+  request: QueryRequest
 ): Promise<PagedResult<T>> {
-  const qs = serializeQueryParams(params);
+  const qs = serializeQueryRequest(request);
   const url = qs ? `${basePath}?${qs}` : basePath;
   const response = await client.get<PagedResult<T>>(url);
   return response.data;
@@ -32,14 +32,14 @@ export async function fetchPage<T>(
  *
  * @param client - Axios instance (from @granit/api-client)
  * @param basePath - API base path (e.g. "/api/v1/patients")
- * @param params - Query parameters (must include groupBy)
+ * @param request - Query request parameters (must include groupBy)
  */
 export async function fetchGrouped<T>(
   client: AxiosInstance,
   basePath: string,
-  params: QueryParams
+  request: QueryRequest
 ): Promise<GroupedResult<T>> {
-  const qs = serializeQueryParams(params);
+  const qs = serializeQueryRequest(request);
   const url = qs ? `${basePath}?${qs}` : basePath;
   const response = await client.get<GroupedResult<T>>(url);
   return response.data;

--- a/packages/@granit/querying/src/api/query-param-serializer.ts
+++ b/packages/@granit/querying/src/api/query-param-serializer.ts
@@ -1,11 +1,11 @@
 // ---------------------------------------------------------------------------
-// Query param serializer — QueryParams → URL search string
+// Query param serializer — QueryRequest → URL search string
 // ---------------------------------------------------------------------------
 
-import type { QueryParams } from '../types/query-params.js';
+import type { QueryRequest } from '../types/query-params.js';
 
 /**
- * Serialize QueryParams to a URL search string (without leading '?').
+ * Serialize QueryRequest to a URL search string (without leading '?').
  *
  * Format:
  * ```
@@ -17,22 +17,23 @@ import type { QueryParams } from '../types/query-params.js';
  *   &groupBy=field
  * ```
  */
-function serializeScalarParams(entries: [string, string][], params: QueryParams): void {
+function serializeScalarParams(entries: [string, string][], params: QueryRequest): void {
   if (params.page != null) entries.push(['page', String(params.page)]);
   if (params.pageSize != null) entries.push(['pageSize', String(params.pageSize)]);
   if (params.cursor) entries.push(['cursor', params.cursor]);
   if (params.search) entries.push(['search', params.search]);
   if (params.groupBy) entries.push(['groupBy', params.groupBy]);
+  if (params.skipTotalCount) entries.push(['skipTotalCount', 'true']);
 }
 
-function serializeFilters(entries: [string, string][], params: QueryParams): void {
+function serializeFilters(entries: [string, string][], params: QueryRequest): void {
   if (!params.filters) return;
   for (const filter of params.filters) {
     entries.push([`filter[${filter.field}.${filter.operator}]`, filter.value]);
   }
 }
 
-function serializeSortAndPresets(entries: [string, string][], params: QueryParams): void {
+function serializeSortAndPresets(entries: [string, string][], params: QueryRequest): void {
   if (params.sort && params.sort.length > 0) {
     const sortStr = params.sort
       .map((s) => (s.direction === 'desc' ? `-${s.field}` : s.field))
@@ -53,7 +54,7 @@ function serializeSortAndPresets(entries: [string, string][], params: QueryParam
   }
 }
 
-export function serializeQueryParams(params: QueryParams): string {
+export function serializeQueryRequest(params: QueryRequest): string {
   const entries: [string, string][] = [];
   serializeScalarParams(entries, params);
   serializeFilters(entries, params);
@@ -62,11 +63,11 @@ export function serializeQueryParams(params: QueryParams): string {
 }
 
 /**
- * Parse a URL search string back into QueryParams.
+ * Parse a URL search string back into QueryRequest.
  *
- * Inverse of {@link serializeQueryParams}.
+ * Inverse of {@link serializeQueryRequest}.
  */
-export function parseQueryParams(search: string): QueryParams {
+export function parseQueryRequest(search: string): QueryRequest {
   const url = new URLSearchParams(search);
   const params: {
     page?: number;
@@ -78,6 +79,7 @@ export function parseQueryParams(search: string): QueryParams {
     presets?: Record<string, string[]>;
     quickFilters?: string[];
     groupBy?: string;
+    skipTotalCount?: boolean;
   } = {};
 
   const pageStr = url.get('page');
@@ -136,5 +138,8 @@ export function parseQueryParams(search: string): QueryParams {
   const groupBy = url.get('groupBy');
   if (groupBy) params.groupBy = groupBy;
 
-  return params as QueryParams;
+  const skipTotalCount = url.get('skipTotalCount');
+  if (skipTotalCount === 'true') params.skipTotalCount = true;
+
+  return params as QueryRequest;
 }

--- a/packages/@granit/querying/src/index.ts
+++ b/packages/@granit/querying/src/index.ts
@@ -12,6 +12,7 @@ export type {
   FilterGroupMeta,
   FilterOperator,
   FilterSuggestion,
+  PaginationParams,
   FilterSuggestionValue,
   FilterToken,
   FilterTokenType,
@@ -23,7 +24,7 @@ export type {
   PaginationMeta,
   PresetMeta,
   QueryMetadata,
-  QueryParams,
+  QueryRequest,
   QuickFilterMeta,
   SavedViewSummary,
   SmartFilterPhase,
@@ -50,7 +51,7 @@ export {
 
 // API
 export { fetchGrouped, fetchPage, fetchQueryMeta } from './api/query-api.js';
-export { parseQueryParams, serializeQueryParams } from './api/query-param-serializer.js';
+export { parseQueryRequest, serializeQueryRequest } from './api/query-param-serializer.js';
 export {
   createSavedView,
   deleteSavedView,

--- a/packages/@granit/querying/src/types/index.ts
+++ b/packages/@granit/querying/src/types/index.ts
@@ -5,7 +5,8 @@
 export type {
   FilterEntry,
   FilterOperator,
-  QueryParams,
+  PaginationParams,
+  QueryRequest,
   SortDirection,
   SortEntry,
 } from './query-params.js';

--- a/packages/@granit/querying/src/types/query-params.ts
+++ b/packages/@granit/querying/src/types/query-params.ts
@@ -2,6 +2,14 @@
 // Query parameters — mirrors Granit.Querying.QueryRequest (.NET)
 // ---------------------------------------------------------------------------
 
+/** Minimal pagination parameters shared across all domain modules. */
+export interface PaginationParams {
+  /** One-based page number. */
+  readonly page?: number;
+  /** Items per page. */
+  readonly pageSize?: number;
+}
+
 /**
  * Filter operators supported by Granit Querying.
  *
@@ -43,7 +51,7 @@ export interface SortEntry {
 }
 
 /**
- * Full query parameters sent to the backend.
+ * Full query request sent to the backend — mirrors `Granit.Querying.QueryRequest` (.NET).
  *
  * Serialized to query string format:
  * ```
@@ -53,13 +61,10 @@ export interface SortEntry {
  *  &presets[group]=name1,name2
  *  &quickFilters=Name1,Name2
  *  &groupBy=field
+ *  &skipTotalCount=true
  * ```
  */
-export interface QueryParams {
-  /** One-based page number. Mutually exclusive with cursor. */
-  readonly page?: number;
-  /** Items per page. Clamped to maxPageSize by backend. */
-  readonly pageSize?: number;
+export interface QueryRequest extends PaginationParams {
   /** Opaque cursor for keyset pagination (base64). Mutually exclusive with page. */
   readonly cursor?: string;
   /** Free-text search on global search properties. */
@@ -80,4 +85,10 @@ export interface QueryParams {
   readonly quickFilters?: readonly string[];
   /** Property name for grouping. When set, response is GroupedResult. */
   readonly groupBy?: string;
+  /**
+   * When true, omits the expensive COUNT(*) query.
+   * Useful for large datasets with cursor pagination where totalCount is not needed.
+   * When set, `PagedResult.totalCount` will be null.
+   */
+  readonly skipTotalCount?: boolean;
 }

--- a/packages/@granit/querying/src/types/query-results.ts
+++ b/packages/@granit/querying/src/types/query-results.ts
@@ -5,11 +5,11 @@
 /** Paginated query result (offset or cursor). */
 export interface PagedResult<T> {
   readonly items: readonly T[];
-  readonly totalCount: number;
+  readonly totalCount: number | null;
   /** Whether more pages exist beyond the current one. */
   readonly hasMore?: boolean;
   /** Opaque cursor for next page (only for keyset pagination). */
-  readonly nextCursor?: string;
+  readonly nextCursor?: string | null;
 }
 
 /** Grouped query result (when groupBy is specified). */

--- a/packages/@granit/react-audit-log/package.json
+++ b/packages/@granit/react-audit-log/package.json
@@ -14,7 +14,6 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@granit/audit-log": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/react-testing": "workspace:*"
   },

--- a/packages/@granit/react-data-exchange/package.json
+++ b/packages/@granit/react-data-exchange/package.json
@@ -14,6 +14,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/data-exchange": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",

--- a/packages/@granit/react-data-exchange/src/export/hooks/use-export-jobs.ts
+++ b/packages/@granit/react-data-exchange/src/export/hooks/use-export-jobs.ts
@@ -3,16 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildExportQueryKey, useExportConfig } from '../providers/export-provider.js';
 
+import type { PaginatedResponse } from '@granit/api-client';
 import type { ExportJobListParams, ExportJobResponse } from '@granit/data-exchange';
 import type { UseQueryResult } from '@tanstack/react-query';
-
-/** Paginated response envelope for export jobs. */
-interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
 
 /**
  * Query hook that fetches a paginated list of export jobs.

--- a/packages/@granit/react-data-exchange/src/import/hooks/use-import-jobs.ts
+++ b/packages/@granit/react-data-exchange/src/import/hooks/use-import-jobs.ts
@@ -3,16 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildImportQueryKey, useImportConfig } from '../providers/import-provider.js';
 
+import type { PaginatedResponse } from '@granit/api-client';
 import type { ImportJobListParams, ImportJobResponse } from '@granit/data-exchange';
 import type { UseQueryResult } from '@tanstack/react-query';
-
-/** Paginated response envelope for import jobs. */
-interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
 
 /**
  * Query hook that fetches a paginated list of import jobs.

--- a/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
@@ -15,7 +15,7 @@ export interface UseEntityActivityFeedOptions {
 
 export interface UseEntityActivityFeedReturn {
   entries: readonly ActivityFeedEntryDto[];
-  totalCount: number;
+  totalCount: number | null;
   loading: boolean;
   loadingMore: boolean;
   error: Error | null;

--- a/packages/@granit/react-notifications/src/hooks/use-notifications.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notifications.ts
@@ -13,7 +13,7 @@ export interface UseNotificationsOptions {
 
 export interface UseNotificationsReturn {
   notifications: readonly NotificationDto[];
-  totalCount: number;
+  totalCount: number | null;
   loading: boolean;
   loadingMore: boolean;
   error: Error | null;

--- a/packages/@granit/react-querying/src/hooks/use-infinite-scroll.ts
+++ b/packages/@granit/react-querying/src/hooks/use-infinite-scroll.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 /** Contract for the fetcher function (compatible with PagedResult). */
 export interface InfiniteScrollPage<T> {
   readonly items: readonly T[];
-  readonly totalCount: number;
+  readonly totalCount: number | null;
 }
 
 export interface UseInfiniteScrollOptions<T, P extends InfiniteScrollPage<T>> {
@@ -27,7 +27,7 @@ export interface UseInfiniteScrollReturn<T> {
   /** Direct setter for optimistic or local updates. */
   readonly setItems: React.Dispatch<React.SetStateAction<readonly T[]>>;
   /** Total number of items available on the server. */
-  readonly totalCount: number;
+  readonly totalCount: number | null;
   /** True during the initial fetch (first page). */
   readonly loading: boolean;
   /** True while loading additional pages (not the first). */
@@ -71,7 +71,7 @@ export function useInfiniteScroll<T, P extends InfiniteScrollPage<T> = InfiniteS
   const { fetcher, pageSize = DEFAULT_PAGE_SIZE, onSuccess, enabled = true } = options;
 
   const [items, setItems] = useState<readonly T[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
+  const [totalCount, setTotalCount] = useState<number | null>(0);
   const [loading, setLoading] = useState(enabled);
   const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -124,7 +124,7 @@ export function useInfiniteScroll<T, P extends InfiniteScrollPage<T> = InfiniteS
     fetchPage(1, false);
   }, [fetchPage]);
 
-  const hasMore = items.length < totalCount;
+  const hasMore = items.length < (totalCount ?? 0);
 
   return {
     items,

--- a/packages/@granit/react-querying/src/hooks/use-pagination.ts
+++ b/packages/@granit/react-querying/src/hooks/use-pagination.ts
@@ -7,7 +7,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 /** Contract for the fetcher function (compatible with PagedResult). */
 export interface PaginationPage<T> {
   readonly items: readonly T[];
-  readonly totalCount: number;
+  readonly totalCount: number | null;
 }
 
 export interface UsePaginationOptions<T, P extends PaginationPage<T>> {
@@ -27,7 +27,7 @@ export interface UsePaginationReturn<T> {
   /** Direct setter for optimistic or local updates. */
   readonly setItems: React.Dispatch<React.SetStateAction<readonly T[]>>;
   /** Total number of items across all pages. */
-  readonly totalCount: number;
+  readonly totalCount: number | null;
   /** True during the initial or page-change fetch. */
   readonly loading: boolean;
   /** Last fetch error, or null. */
@@ -73,13 +73,13 @@ export function usePagination<T, P extends PaginationPage<T> = PaginationPage<T>
   const { fetcher, pageSize = DEFAULT_PAGE_SIZE, onSuccess, enabled = true } = options;
 
   const [items, setItems] = useState<readonly T[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
+  const [totalCount, setTotalCount] = useState<number | null>(0);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
   const [page, setPage] = useState(1);
   const abortRef = useRef<AbortController | null>(null);
 
-  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+  const totalPages = Math.max(1, Math.ceil((totalCount ?? 0) / pageSize));
   const hasPreviousPage = page > 1;
   const hasNextPage = page < totalPages;
 

--- a/packages/@granit/react-querying/src/hooks/use-query-endpoint.ts
+++ b/packages/@granit/react-querying/src/hooks/use-query-endpoint.ts
@@ -12,7 +12,7 @@ import type {
   FilterEntry,
   GroupedResult,
   PagedResult,
-  QueryParams,
+  QueryRequest,
   SortEntry,
 } from '@granit/querying';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -34,12 +34,12 @@ type QueryAction =
   | { type: 'SET_QUICK_FILTERS'; quickFilters: readonly string[] }
   | { type: 'TOGGLE_QUICK_FILTER'; name: string }
   | { type: 'SET_GROUP_BY'; groupBy: string | undefined }
-  | { type: 'SET_PARAMS'; params: QueryParams }
+  | { type: 'SET_PARAMS'; params: QueryRequest }
   | { type: 'RESET' };
 
 interface QueryState {
-  readonly params: QueryParams;
-  readonly initialParams: QueryParams;
+  readonly params: QueryRequest;
+  readonly initialParams: QueryRequest;
 }
 
 /**
@@ -143,14 +143,14 @@ function queryReducer(state: QueryState, action: QueryAction): QueryState {
 
 export interface UseQueryEndpointOptions {
   /** Initial query parameters. */
-  readonly initialParams?: QueryParams;
+  readonly initialParams?: QueryRequest;
   /** Whether the query is enabled. Defaults to true. */
   readonly enabled?: boolean;
 }
 
 export interface UseQueryEndpointReturn<T> {
   /** Current query parameters. */
-  readonly params: QueryParams;
+  readonly params: QueryRequest;
   /** Query result for flat (paged) data. */
   readonly query: UseQueryResult<PagedResult<T>>;
   /** Query result for grouped data (when groupBy is set). */
@@ -170,7 +170,7 @@ export interface UseQueryEndpointReturn<T> {
   readonly setQuickFilters: (quickFilters: readonly string[]) => void;
   readonly toggleQuickFilter: (name: string) => void;
   readonly setGroupBy: (groupBy: string | undefined) => void;
-  readonly setParams: (params: QueryParams) => void;
+  readonly setParams: (params: QueryRequest) => void;
   readonly reset: () => void;
 }
 
@@ -178,7 +178,7 @@ export interface UseQueryEndpointReturn<T> {
 // Default initial params
 // ---------------------------------------------------------------------------
 
-const DEFAULT_PARAMS: QueryParams = { page: 1, pageSize: 20 };
+const DEFAULT_PARAMS: QueryRequest = { page: 1, pageSize: 20 };
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -275,7 +275,7 @@ export function useQueryEndpoint<T>(options?: UseQueryEndpointOptions): UseQuery
     []
   );
   const setParams = useCallback(
-    (p: QueryParams) => dispatch({ type: 'SET_PARAMS', params: p }),
+    (p: QueryRequest) => dispatch({ type: 'SET_PARAMS', params: p }),
     []
   );
   const reset = useCallback(() => dispatch({ type: 'RESET' }), []);

--- a/packages/@granit/react-templating/src/__tests__/hooks.test.tsx
+++ b/packages/@granit/react-templating/src/__tests__/hooks.test.tsx
@@ -1,14 +1,20 @@
+import { createTestQueryClient } from '@granit/react-testing';
 import { TemplateLifecycleStatus } from '@granit/templating';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useTemplateCategories } from '../hooks/use-template-categories.js';
-import { useTemplateHistory } from '../hooks/use-template-history.js';
+import {
+  useTemplateCategories,
+  useTemplateCategoryMutations,
+} from '../hooks/use-template-categories.js';
+import { useTemplateHistory, useTemplateRevision } from '../hooks/use-template-history.js';
 import { useTemplateMutations } from '../hooks/use-template-mutations.js';
-import { useTemplatePreview } from '../hooks/use-template-preview.js';
+import { useTemplateBinaryPreview, useTemplatePreview } from '../hooks/use-template-preview.js';
 import { useTemplateVariables } from '../hooks/use-template-variables.js';
 import { useTemplate } from '../hooks/use-template.js';
 import { useTemplates } from '../hooks/use-templates.js';
+import { TemplatingProvider } from '../providers/templating-provider.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
@@ -19,10 +25,33 @@ import type {
   TemplateHistory,
   TemplateListItem,
   TemplatePreviewResponse,
+  TemplateRevision,
   TemplateVariables,
 } from '@granit/templating';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Create a wrapper that exposes the QueryClient for cache invalidation assertions.
+ */
+function createWrapperWithQueryClient(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: Readonly<{ children: React.ReactNode }>) => (
+    <QueryClientProvider client={queryClient}>
+      <TemplatingProvider client={client}>{children}</TemplatingProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+// ---------------------------------------------------------------------------
+// useTemplates
+// ---------------------------------------------------------------------------
 
 describe('useTemplates', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should fetch templates list', async () => {
     const client = createMockClient();
     const response: PaginatedResponse<TemplateListItem> = {
@@ -64,9 +93,29 @@ describe('useTemplates', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     expect(client.get).toHaveBeenCalledWith('/api/v1/templates', { params });
   });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Network Error'));
+
+    const { result } = renderHook(() => useTemplates(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Network Error');
+  });
 });
 
+// ---------------------------------------------------------------------------
+// useTemplate
+// ---------------------------------------------------------------------------
+
 describe('useTemplate', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should fetch template detail', async () => {
     const client = createMockClient();
     const detail: TemplateDetail = {
@@ -99,9 +148,44 @@ describe('useTemplate', () => {
     expect(result.current.fetchStatus).toBe('idle');
     expect(client.get).not.toHaveBeenCalled();
   });
+
+  it('should pass culture param', async () => {
+    const client = createMockClient();
+    const detail: TemplateDetail = { name: 'Billing.Invoice', culture: 'fr-BE' };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(detail));
+
+    renderHook(() => useTemplate('Billing.Invoice', 'fr-BE'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice', {
+      params: { culture: 'fr-BE' },
+    });
+  });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Not Found'));
+
+    const { result } = renderHook(() => useTemplate('unknown'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Not Found');
+  });
 });
 
+// ---------------------------------------------------------------------------
+// useTemplateMutations
+// ---------------------------------------------------------------------------
+
 describe('useTemplateMutations', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should save draft and invalidate queries', async () => {
     const client = createMockClient();
     const detail: TemplateDetail = { name: 'Billing.Invoice' };
@@ -188,9 +272,156 @@ describe('useTemplateMutations', () => {
       content: '<p>Updated</p>',
     });
   });
+
+  it('should expose error state when saveDraft fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Conflict'));
+
+    const { result } = renderHook(() => useTemplateMutations(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.saveDraft.mutate({ name: 'Billing.Invoice', content: '<p>Hello</p>' });
+
+    await waitFor(() => expect(result.current.saveDraft.isError).toBe(true));
+    expect(result.current.saveDraft.error?.message).toBe('Conflict');
+  });
+
+  it('should expose error state when publish fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Forbidden'));
+
+    const { result } = renderHook(() => useTemplateMutations(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.publish.mutate({ name: 'Billing.Invoice' });
+
+    await waitFor(() => expect(result.current.publish.isError).toBe(true));
+    expect(result.current.publish.error?.message).toBe('Forbidden');
+  });
+
+  it('should invalidate cache after saveDraft succeeds', async () => {
+    const client = createMockClient();
+    const detail: TemplateDetail = { name: 'Billing.Invoice' };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(detail));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateMutations(), { wrapper });
+
+    result.current.saveDraft.mutate({ name: 'Billing.Invoice', content: '<p>Hello</p>' });
+
+    await waitFor(() => expect(result.current.saveDraft.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates'] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'detail', 'Billing.Invoice'] })
+    );
+  });
+
+  it('should invalidate cache after publish succeeds', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateMutations(), { wrapper });
+
+    result.current.publish.mutate({ name: 'Billing.Invoice' });
+
+    await waitFor(() => expect(result.current.publish.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates'] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'detail', 'Billing.Invoice'] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'history', 'Billing.Invoice'] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'lifecycle', 'Billing.Invoice'] })
+    );
+  });
+
+  it('should invalidate cache after unpublish succeeds', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateMutations(), { wrapper });
+
+    result.current.unpublish.mutate({ name: 'Billing.Invoice' });
+
+    await waitFor(() => expect(result.current.unpublish.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates'] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'detail', 'Billing.Invoice'] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'history', 'Billing.Invoice'] })
+    );
+  });
+
+  it('should invalidate cache after deleteDraft succeeds', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateMutations(), { wrapper });
+
+    result.current.deleteDraft.mutate({ name: 'Billing.Invoice' });
+
+    await waitFor(() => expect(result.current.deleteDraft.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates'] })
+    );
+  });
+
+  it('should invalidate cache after updateDraft succeeds', async () => {
+    const client = createMockClient();
+    const detail: TemplateDetail = { name: 'Billing.Invoice' };
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(detail));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateMutations(), { wrapper });
+
+    result.current.updateDraft.mutate({
+      name: 'Billing.Invoice',
+      request: { name: 'Billing.Invoice', content: '<p>Updated</p>' },
+    });
+
+    await waitFor(() => expect(result.current.updateDraft.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates'] })
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'detail', 'Billing.Invoice'] })
+    );
+  });
 });
 
+// ---------------------------------------------------------------------------
+// useTemplateHistory
+// ---------------------------------------------------------------------------
+
 describe('useTemplateHistory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should fetch history', async () => {
     const client = createMockClient();
     const history: TemplateHistory = {
@@ -208,9 +439,104 @@ describe('useTemplateHistory', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(history);
   });
+
+  it('should not fetch when name is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useTemplateHistory(''), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Server Error'));
+
+    const { result } = renderHook(() => useTemplateHistory('Billing.Invoice'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Server Error');
+  });
 });
 
+// ---------------------------------------------------------------------------
+// useTemplateRevision
+// ---------------------------------------------------------------------------
+
+describe('useTemplateRevision', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch a specific revision', async () => {
+    const client = createMockClient();
+    const revision: TemplateRevision = {
+      revisionId: 'rev-1',
+      content: '<p>Hello</p>',
+      mimeType: 'text/html',
+      status: TemplateLifecycleStatus.Published,
+      createdAt: '2026-03-01T10:00:00Z',
+      createdBy: 'admin',
+      publishedAt: '2026-03-02T10:00:00Z',
+      publishedBy: 'admin',
+    };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(revision));
+
+    const { result } = renderHook(() => useTemplateRevision('Billing.Invoice', 'rev-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(revision);
+    expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/history/rev-1');
+  });
+
+  it('should not fetch when name is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useTemplateRevision('', 'rev-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('should not fetch when revisionId is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useTemplateRevision('Billing.Invoice', ''), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Not Found'));
+
+    const { result } = renderHook(() => useTemplateRevision('Billing.Invoice', 'rev-999'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useTemplatePreview
+// ---------------------------------------------------------------------------
+
 describe('useTemplatePreview', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should preview template via mutation', async () => {
     const client = createMockClient();
     const response: TemplatePreviewResponse = {
@@ -229,9 +555,75 @@ describe('useTemplatePreview', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(response);
   });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Parse Error'));
+
+    const { result } = renderHook(() => useTemplatePreview(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ name: 'Billing.Invoice', request: { data: { title: 'Test' } } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Parse Error');
+  });
 });
 
+// ---------------------------------------------------------------------------
+// useTemplateBinaryPreview
+// ---------------------------------------------------------------------------
+
+describe('useTemplateBinaryPreview', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should preview template as binary via mutation', async () => {
+    const client = createMockClient();
+    const blob = new Blob(['pdf-content'], { type: 'application/pdf' });
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(blob));
+
+    const { result } = renderHook(() => useTemplateBinaryPreview(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ name: 'Billing.Invoice', request: { data: { total: 100 } } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeInstanceOf(Blob);
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/templates/Billing.Invoice/preview',
+      { data: { total: 100 } },
+      { responseType: 'blob' }
+    );
+  });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Render Failed'));
+
+    const { result } = renderHook(() => useTemplateBinaryPreview(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ name: 'Billing.Invoice', request: {} });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Render Failed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useTemplateVariables
+// ---------------------------------------------------------------------------
+
 describe('useTemplateVariables', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should fetch variables', async () => {
     const client = createMockClient();
     const variables: TemplateVariables = {
@@ -257,9 +649,29 @@ describe('useTemplateVariables', () => {
 
     expect(result.current.fetchStatus).toBe('idle');
   });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Server Error'));
+
+    const { result } = renderHook(() => useTemplateVariables('Billing.Invoice'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Server Error');
+  });
 });
 
+// ---------------------------------------------------------------------------
+// useTemplateCategories
+// ---------------------------------------------------------------------------
+
 describe('useTemplateCategories', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('should fetch categories', async () => {
     const client = createMockClient();
     const categories: TemplateCategory[] = [
@@ -273,5 +685,172 @@ describe('useTemplateCategories', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(categories);
+  });
+
+  it('should expose error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Forbidden'));
+
+    const { result } = renderHook(() => useTemplateCategories(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useTemplateCategoryMutations
+// ---------------------------------------------------------------------------
+
+describe('useTemplateCategoryMutations', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should create a category', async () => {
+    const client = createMockClient();
+    const created: TemplateCategory = {
+      id: 'cat-2',
+      name: 'Legal',
+      sortOrder: 2,
+      templateCount: 0,
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(created));
+
+    const { result } = renderHook(() => useTemplateCategoryMutations(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.create.mutate({ name: 'Legal', sortOrder: 2 });
+
+    await waitFor(() => expect(result.current.create.isSuccess).toBe(true));
+    expect(client.post).toHaveBeenCalledWith('/api/v1/templates/categories', {
+      name: 'Legal',
+      sortOrder: 2,
+    });
+    expect(result.current.create.data).toEqual(created);
+  });
+
+  it('should update a category', async () => {
+    const client = createMockClient();
+    const updated: TemplateCategory = {
+      id: 'cat-1',
+      name: 'Billing Updated',
+      sortOrder: 1,
+      templateCount: 5,
+    };
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(updated));
+
+    const { result } = renderHook(() => useTemplateCategoryMutations(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.update.mutate({
+      id: 'cat-1',
+      request: { name: 'Billing Updated', sortOrder: 1 },
+    });
+
+    await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+    expect(client.put).toHaveBeenCalledWith('/api/v1/templates/categories/cat-1', {
+      name: 'Billing Updated',
+      sortOrder: 1,
+    });
+    expect(result.current.update.data).toEqual(updated);
+  });
+
+  it('should delete a category', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useTemplateCategoryMutations(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.delete.mutate('cat-1');
+
+    await waitFor(() => expect(result.current.delete.isSuccess).toBe(true));
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/templates/categories/cat-1');
+  });
+
+  it('should expose error state when create fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Duplicate Name'));
+
+    const { result } = renderHook(() => useTemplateCategoryMutations(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.create.mutate({ name: 'Billing' });
+
+    await waitFor(() => expect(result.current.create.isError).toBe(true));
+    expect(result.current.create.error?.message).toBe('Duplicate Name');
+  });
+
+  it('should invalidate categories cache after create', async () => {
+    const client = createMockClient();
+    const created: TemplateCategory = {
+      id: 'cat-2',
+      name: 'Legal',
+      sortOrder: 2,
+      templateCount: 0,
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(created));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateCategoryMutations(), { wrapper });
+
+    result.current.create.mutate({ name: 'Legal' });
+
+    await waitFor(() => expect(result.current.create.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'categories'] })
+    );
+  });
+
+  it('should invalidate categories cache after update', async () => {
+    const client = createMockClient();
+    const updated: TemplateCategory = {
+      id: 'cat-1',
+      name: 'Billing v2',
+      sortOrder: 1,
+      templateCount: 5,
+    };
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(updated));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateCategoryMutations(), { wrapper });
+
+    result.current.update.mutate({
+      id: 'cat-1',
+      request: { name: 'Billing v2', sortOrder: 1 },
+    });
+
+    await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'categories'] })
+    );
+  });
+
+  it('should invalidate categories cache after delete', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTemplateCategoryMutations(), { wrapper });
+
+    result.current.delete.mutate('cat-1');
+
+    await waitFor(() => expect(result.current.delete.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ['templates', 'categories'] })
+    );
   });
 });

--- a/packages/@granit/react-timeline/src/hooks/use-timeline.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-timeline.ts
@@ -16,7 +16,7 @@ export interface UseTimelineOptions {
 
 export interface UseTimelineReturn {
   entries: readonly TimelineStreamEntry[];
-  totalCount: number;
+  totalCount: number | null;
   loading: boolean;
   loadingMore: boolean;
   error: Error | null;

--- a/packages/@granit/react-workflow/src/hooks/use-workflow-history.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-workflow-history.ts
@@ -15,7 +15,7 @@ export interface UseWorkflowHistoryOptions {
 }
 
 export interface UseWorkflowHistoryReturn {
-  history: TransitionHistoryDto[];
+  history: readonly TransitionHistoryDto[];
   loading: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
@@ -28,7 +28,7 @@ export function useWorkflowHistory({
 }: UseWorkflowHistoryOptions): UseWorkflowHistoryReturn {
   const { apiClient, basePath } = useWorkflowConfig();
 
-  const [history, setHistory] = useState<TransitionHistoryDto[]>([]);
+  const [history, setHistory] = useState<readonly TransitionHistoryDto[]>([]);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
 

--- a/packages/@granit/reference-data/package.json
+++ b/packages/@granit/reference-data/package.json
@@ -13,6 +13,9 @@
   "scripts": {
     "build": "tsup"
   },
+  "peerDependencies": {
+    "@granit/querying": "workspace:*"
+  },
   "publishConfig": {
     "exports": {
       ".": {

--- a/packages/@granit/reference-data/src/types/index.ts
+++ b/packages/@granit/reference-data/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { PaginationParams } from '@granit/querying';
+
 /** Country reference data entry. Mirrors Granit.ReferenceData.Country .NET. */
 export interface Country {
   readonly code: string;
@@ -21,12 +23,10 @@ export interface Country {
 }
 
 /** Parameters for listing countries. */
-export interface CountriesListParams {
+export type CountriesListParams = PaginationParams & {
   readonly search?: string;
-  readonly page?: number;
-  readonly pageSize?: number;
   readonly sortBy?: string;
   readonly desc?: boolean;
   readonly region?: string;
   readonly isActive?: boolean;
-}
+};

--- a/packages/@granit/templating/package.json
+++ b/packages/@granit/templating/package.json
@@ -17,6 +17,7 @@
     "@granit/api-client": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/querying": "workspace:*",
     "axios": "*"
   },
   "publishConfig": {

--- a/packages/@granit/templating/src/types/template-types.ts
+++ b/packages/@granit/templating/src/types/template-types.ts
@@ -1,3 +1,4 @@
+import type { PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 // ── Template lifecycle status (mirrors .NET Granit.Templating.Domain.TemplateLifecycleStatus) ──
@@ -59,9 +60,7 @@ export type TemplateListItem = {
   readonly hasPublishedVersion: boolean;
 };
 
-export type TemplateListParams = {
-  readonly page?: number;
-  readonly pageSize?: number;
+export type TemplateListParams = PaginationParams & {
   readonly search?: string;
   readonly status?: TemplateLifecycleStatusValue;
   readonly category?: string;

--- a/packages/@granit/timeline/package.json
+++ b/packages/@granit/timeline/package.json
@@ -18,6 +18,7 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/querying": "workspace:*",
     "axios": "*"
   },
   "publishConfig": {

--- a/packages/@granit/timeline/src/types/request.ts
+++ b/packages/@granit/timeline/src/types/request.ts
@@ -1,4 +1,5 @@
 import type { TimelineEntryTypeValue } from './entry-type.js';
+import type { PaginationParams } from '@granit/querying';
 
 // --- API request types ---
 
@@ -11,7 +12,4 @@ export interface CreateTimelineEntryRequest {
 
 // --- Pagination ---
 
-export interface TimelineQueryParams {
-  page?: number;
-  pageSize?: number;
-}
+export type TimelineQueryParams = PaginationParams;

--- a/packages/@granit/timeline/src/types/stream.ts
+++ b/packages/@granit/timeline/src/types/stream.ts
@@ -1,4 +1,5 @@
 import type { TimelineEntryTypeValue } from './entry-type.js';
+import type { PagedResult } from '@granit/querying';
 
 // --- API response types ---
 
@@ -15,9 +16,4 @@ export interface TimelineStreamEntry {
   attachmentBlobIds: string[];
 }
 
-export interface TimelineStreamPage {
-  items: TimelineStreamEntry[];
-  totalCount: number;
-  /** Opaque cursor for next page (always null for offset pagination). */
-  nextCursor: string | null;
-}
+export type TimelineStreamPage = PagedResult<TimelineStreamEntry>;

--- a/packages/@granit/workflow/package.json
+++ b/packages/@granit/workflow/package.json
@@ -17,6 +17,7 @@
     "@granit/api-client": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/querying": "workspace:*",
     "axios": "*"
   },
   "publishConfig": {

--- a/packages/@granit/workflow/src/api/workflow-api.ts
+++ b/packages/@granit/workflow/src/api/workflow-api.ts
@@ -4,6 +4,7 @@ import type {
   TransitionResultDto,
   WorkflowStatusDto,
 } from '../types/index.js';
+import type { PagedResult } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 function buildUrl(
@@ -45,11 +46,7 @@ export async function executeTransition(
 }
 
 /** Response shape for the paginated workflow history endpoint. */
-export interface WorkflowHistoryPage {
-  items: TransitionHistoryDto[];
-  totalCount: number;
-  nextCursor: string | null;
-}
+export type WorkflowHistoryPage = PagedResult<TransitionHistoryDto>;
 
 /** Fetch the transition history (HDS audit trail) for an entity. */
 export async function fetchHistory(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
 
   packages/@granit/audit-log:
     dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       axios:
         specifier: '*'
         version: 1.13.6
@@ -240,6 +243,12 @@ importers:
 
   packages/@granit/data-exchange:
     dependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
@@ -274,6 +283,9 @@ importers:
 
   packages/@granit/identity:
     dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       axios:
         specifier: '*'
         version: 1.13.6
@@ -303,6 +315,9 @@ importers:
 
   packages/@granit/notifications:
     dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       axios:
         specifier: '*'
         version: 1.13.6
@@ -388,6 +403,9 @@ importers:
 
   packages/@granit/react-audit-log:
     dependencies:
+      '@granit/audit-log':
+        specifier: workspace:*
+        version: link:../audit-log
       '@tanstack/react-query':
         specifier: ^5.0.0
         version: 5.90.21(react@19.2.4)
@@ -398,9 +416,6 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4
     devDependencies:
-      '@granit/audit-log':
-        specifier: workspace:*
-        version: link:../audit-log
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -525,6 +540,9 @@ importers:
 
   packages/@granit/react-data-exchange:
     dependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/data-exchange':
         specifier: workspace:*
         version: link:../data-exchange
@@ -907,7 +925,11 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
-  packages/@granit/reference-data: {}
+  packages/@granit/reference-data:
+    dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
 
   packages/@granit/settings:
     dependencies:
@@ -923,6 +945,9 @@ importers:
 
   packages/@granit/templating:
     dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       axios:
         specifier: '*'
         version: 1.13.6
@@ -942,6 +967,9 @@ importers:
 
   packages/@granit/timeline:
     dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       axios:
         specifier: '*'
         version: 1.13.6
@@ -973,6 +1001,9 @@ importers:
 
   packages/@granit/workflow:
     dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       axios:
         specifier: '*'
         version: 1.13.6

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
         'packages/@granit/api-client/src/test-utils.ts'
       ),
       '@granit/api-client': path.resolve(__dirname, 'packages/@granit/api-client/src/index.ts'),
+      '@granit/audit-log': path.resolve(__dirname, 'packages/@granit/audit-log/src/index.ts'),
       '@granit/ai': path.resolve(__dirname, 'packages/@granit/ai/src/index.ts'),
       '@granit/background-jobs': path.resolve(
         __dirname,
@@ -42,6 +43,7 @@ export default defineConfig({
         'packages/@granit/error-boundary/src/index.ts'
       ),
       '@granit/features': path.resolve(__dirname, 'packages/@granit/features/src/index.ts'),
+      '@granit/idempotency': path.resolve(__dirname, 'packages/@granit/idempotency/src/index.ts'),
       '@granit/identity': path.resolve(__dirname, 'packages/@granit/identity/src/index.ts'),
       '@granit/localization': path.resolve(__dirname, 'packages/@granit/localization/src/index.ts'),
       '@granit/logger': path.resolve(__dirname, 'packages/@granit/logger/src/index.ts'),
@@ -80,6 +82,10 @@ export default defineConfig({
         'packages/@granit/reference-data/src/index.ts'
       ),
       '@granit/react-ai': path.resolve(__dirname, 'packages/@granit/react-ai/src/index.ts'),
+      '@granit/react-audit-log': path.resolve(
+        __dirname,
+        'packages/@granit/react-audit-log/src/index.ts'
+      ),
       '@granit/react-authentication-api-keys': path.resolve(
         __dirname,
         'packages/@granit/react-authentication-api-keys/src/index.ts'
@@ -144,6 +150,10 @@ export default defineConfig({
         __dirname,
         'packages/@granit/react-querying/src/index.ts'
       ),
+      '@granit/react-templating': path.resolve(
+        __dirname,
+        'packages/@granit/react-templating/src/index.ts'
+      ),
       '@granit/react-testing': path.resolve(
         __dirname,
         'packages/@granit/react-testing/src/index.ts'
@@ -170,6 +180,7 @@ export default defineConfig({
       ),
       '@granit/settings': path.resolve(__dirname, 'packages/@granit/settings/src/index.ts'),
       '@granit/storage': path.resolve(__dirname, 'packages/@granit/storage/src/index.ts'),
+      '@granit/templating': path.resolve(__dirname, 'packages/@granit/templating/src/index.ts'),
       '@granit/testing': path.resolve(__dirname, 'packages/@granit/testing/src/index.ts'),
       '@granit/timeline': path.resolve(__dirname, 'packages/@granit/timeline/src/index.ts'),
       '@granit/tracing': path.resolve(__dirname, 'packages/@granit/tracing/src/index.ts'),


### PR DESCRIPTION
## Summary

- **Type deduplication**: Replace 4 duplicate `PaginatedResponse` and 6 duplicate `*Page` types with imports from `@granit/api-client` and `PagedResult<T>` aliases from `@granit/querying`
- **PaginationParams base type**: Create `PaginationParams` in `@granit/querying`, migrate 8 domain `*ListParams` types to extend it instead of redeclaring `page/pageSize`
- **PagedResult alignment**: Update `totalCount` to `number | null` matching .NET backend contracts, fix `usePagination` and `useInfiniteScroll` with `?? 0` guards
- **Dependency hygiene**: Add missing `@granit/querying` peerDep to 7 packages, fix double declaration in `react-audit-log`, add 5 missing vitest aliases
- **Cleanup**: Remove empty `validation`/`react-validation` skeleton directories
- **Tests**: Enrich `react-templating` test coverage (+32 tests for `useTemplateRevision`, `useTemplateBinaryPreview`, `useTemplateCategoryMutations`)

## Test plan

- [x] `pnpm tsc` — 0 errors
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm test --run` — 131 files, 1122 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)