### PR TITLE
refactor: align pagination types with backend PagedResult contract

### DIFF
--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -15,6 +15,12 @@ export interface ApiClientConfig {
 // Generic response types (REST APIs)
 // ---------------------------------------------------------------------------
 
+/**
+ * @deprecated Use `PagedResult<T>` from `@granit/querying` instead.
+ * This type does not match the backend `PagedResult<T>` contract
+ * (uses `total` instead of `totalCount`, includes `page`/`pageSize`
+ * which are request params, not response fields).
+ */
 export interface PaginatedResponse<T> {
   items: T[];
   total: number;

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -15,19 +15,6 @@ export interface ApiClientConfig {
 // Generic response types (REST APIs)
 // ---------------------------------------------------------------------------
 
-/**
- * @deprecated Use `PagedResult<T>` from `@granit/querying` instead.
- * This type does not match the backend `PagedResult<T>` contract
- * (uses `total` instead of `totalCount`, includes `page`/`pageSize`
- * which are request params, not response fields).
- */
-export interface PaginatedResponse<T> {
-  items: T[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
-
 // RFC 7807 Problem Details — standard error format from Granit .NET backend.
 // See: Granit.ExceptionHandling (400 BusinessException, 404 NotFoundException,
 // 403 ForbiddenException, 409 ConflictException, 422 ValidationException, 500).

--- a/packages/@granit/data-exchange/src/export/api/export-api.ts
+++ b/packages/@granit/data-exchange/src/export/api/export-api.ts
@@ -3,8 +3,7 @@ import type {
   ExportFieldDescriptor,
 } from '../types/export-definition.js';
 import type { CreateExportJobRequest, ExportJobResponse } from '../types/export-job.js';
-import type { PaginatedResponse } from '@granit/api-client';
-import type { PaginationParams } from '@granit/querying';
+import type { PagedResult, PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 /** Query parameters for listing export jobs. */
@@ -80,8 +79,8 @@ export async function fetchExportJobs(
   client: AxiosInstance,
   basePath: string,
   params?: ExportJobListParams
-): Promise<PaginatedResponse<ExportJobResponse>> {
-  const response = await client.get<PaginatedResponse<ExportJobResponse>>(`${basePath}/jobs`, {
+): Promise<PagedResult<ExportJobResponse>> {
+  const response = await client.get<PagedResult<ExportJobResponse>>(`${basePath}/jobs`, {
     params,
   });
   return response.data;

--- a/packages/@granit/data-exchange/src/import/api/import-api.ts
+++ b/packages/@granit/data-exchange/src/import/api/import-api.ts
@@ -1,8 +1,7 @@
 import type { ImportJobResponse } from '../types/import-job.js';
 import type { ConfirmMappingsRequest, ImportPreviewResponse } from '../types/import-preview.js';
 import type { ImportReportResponse } from '../types/import-report.js';
-import type { PaginatedResponse } from '@granit/api-client';
-import type { PaginationParams } from '@granit/querying';
+import type { PagedResult, PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 /** Query parameters for listing import jobs. */
@@ -141,8 +140,8 @@ export async function fetchImportJobs(
   client: AxiosInstance,
   basePath: string,
   params?: ImportJobListParams
-): Promise<PaginatedResponse<ImportJobResponse>> {
-  const response = await client.get<PaginatedResponse<ImportJobResponse>>(`${basePath}/jobs`, {
+): Promise<PagedResult<ImportJobResponse>> {
+  const response = await client.get<PagedResult<ImportJobResponse>>(`${basePath}/jobs`, {
     params,
   });
   return response.data;

--- a/packages/@granit/notifications/src/api/notification-api.ts
+++ b/packages/@granit/notifications/src/api/notification-api.ts
@@ -4,6 +4,7 @@ import type {
   NotificationPageDto,
   NotificationPreferenceDto,
 } from '../types/index.js';
+import type { PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 function buildUrl(basePath: string, ...segments: string[]): string {
@@ -17,7 +18,7 @@ function buildUrl(basePath: string, ...segments: string[]): string {
 export async function fetchNotifications(
   client: AxiosInstance,
   basePath: string,
-  params: { page?: number; pageSize?: number } = {}
+  params: PaginationParams = {}
 ): Promise<NotificationPageDto> {
   const { data } = await client.get<NotificationPageDto>(buildUrl(basePath, 'notifications'), {
     params,
@@ -60,7 +61,7 @@ export async function fetchEntityActivityFeed(
   basePath: string,
   entityType: string,
   entityId: string,
-  params: { page?: number; pageSize?: number } = {}
+  params: PaginationParams = {}
 ): Promise<ActivityFeedPageDto> {
   const { data } = await client.get<ActivityFeedPageDto>(
     buildUrl(basePath, 'activity-feed', entityType, entityId),

--- a/packages/@granit/react-data-exchange/package.json
+++ b/packages/@granit/react-data-exchange/package.json
@@ -16,6 +16,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/data-exchange": "workspace:*",
+    "@granit/querying": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "axios": "*",

--- a/packages/@granit/react-data-exchange/src/__tests__/export/use-export-jobs.test.tsx
+++ b/packages/@granit/react-data-exchange/src/__tests__/export/use-export-jobs.test.tsx
@@ -44,9 +44,7 @@ describe('useExportJobs', () => {
           completedAt: '2026-03-17T10:01:00Z',
         },
       ],
-      total: 1,
-      page: 1,
-      pageSize: 20,
+      totalCount: 1,
     };
     vi.spyOn(mockClient, 'get').mockResolvedValueOnce({ data: paginatedResponse });
 
@@ -56,7 +54,7 @@ describe('useExportJobs', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.items).toHaveLength(1);
-    expect(result.current.data?.total).toBe(1);
+    expect(result.current.data?.totalCount).toBe(1);
     expect(mockClient.get).toHaveBeenCalledWith('/api/v1/data-exchange/metadata/jobs', {
       params: undefined,
     });
@@ -64,7 +62,7 @@ describe('useExportJobs', () => {
 
   it('passes filtering params to the API', async () => {
     vi.spyOn(mockClient, 'get').mockResolvedValueOnce({
-      data: { items: [], total: 0, page: 1, pageSize: 10 },
+      data: { items: [], totalCount: 0 },
     });
 
     const { result } = renderHook(

--- a/packages/@granit/react-data-exchange/src/__tests__/import/use-import-jobs.test.tsx
+++ b/packages/@granit/react-data-exchange/src/__tests__/import/use-import-jobs.test.tsx
@@ -43,9 +43,7 @@ describe('useImportJobs', () => {
           completedAt: '2026-03-17T10:01:00Z',
         },
       ],
-      total: 1,
-      page: 1,
-      pageSize: 20,
+      totalCount: 1,
     };
     vi.spyOn(mockClient, 'get').mockResolvedValueOnce({ data: paginatedResponse });
 
@@ -55,7 +53,7 @@ describe('useImportJobs', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.items).toHaveLength(1);
-    expect(result.current.data?.total).toBe(1);
+    expect(result.current.data?.totalCount).toBe(1);
     expect(mockClient.get).toHaveBeenCalledWith('/api/v1/data-exchange/import/jobs', {
       params: undefined,
     });
@@ -63,7 +61,7 @@ describe('useImportJobs', () => {
 
   it('passes filtering params to the API', async () => {
     vi.spyOn(mockClient, 'get').mockResolvedValueOnce({
-      data: { items: [], total: 0, page: 1, pageSize: 10 },
+      data: { items: [], totalCount: 0 },
     });
 
     const { result } = renderHook(

--- a/packages/@granit/react-data-exchange/src/export/hooks/use-export-jobs.ts
+++ b/packages/@granit/react-data-exchange/src/export/hooks/use-export-jobs.ts
@@ -3,8 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildExportQueryKey, useExportConfig } from '../providers/export-provider.js';
 
-import type { PaginatedResponse } from '@granit/api-client';
 import type { ExportJobListParams, ExportJobResponse } from '@granit/data-exchange';
+import type { PagedResult } from '@granit/querying';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -19,7 +19,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
  */
 export function useExportJobs(
   params?: ExportJobListParams
-): UseQueryResult<PaginatedResponse<ExportJobResponse>> {
+): UseQueryResult<PagedResult<ExportJobResponse>> {
   const config = useExportConfig();
 
   return useQuery({

--- a/packages/@granit/react-data-exchange/src/import/hooks/use-import-jobs.ts
+++ b/packages/@granit/react-data-exchange/src/import/hooks/use-import-jobs.ts
@@ -3,8 +3,8 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildImportQueryKey, useImportConfig } from '../providers/import-provider.js';
 
-import type { PaginatedResponse } from '@granit/api-client';
 import type { ImportJobListParams, ImportJobResponse } from '@granit/data-exchange';
+import type { PagedResult } from '@granit/querying';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -19,7 +19,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
  */
 export function useImportJobs(
   params?: ImportJobListParams
-): UseQueryResult<PaginatedResponse<ImportJobResponse>> {
+): UseQueryResult<PagedResult<ImportJobResponse>> {
   const config = useImportConfig();
 
   return useQuery({

--- a/packages/@granit/react-templating/package.json
+++ b/packages/@granit/react-templating/package.json
@@ -15,6 +15,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/querying": "workspace:*",
     "@granit/templating": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/react-testing": "workspace:*"

--- a/packages/@granit/react-templating/src/__tests__/hooks.test.tsx
+++ b/packages/@granit/react-templating/src/__tests__/hooks.test.tsx
@@ -18,7 +18,7 @@ import { TemplatingProvider } from '../providers/templating-provider.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
-import type { PaginatedResponse } from '@granit/api-client';
+import type { PagedResult } from '@granit/querying';
 import type {
   TemplateCategory,
   TemplateDetail,
@@ -54,7 +54,7 @@ describe('useTemplates', () => {
 
   it('should fetch templates list', async () => {
     const client = createMockClient();
-    const response: PaginatedResponse<TemplateListItem> = {
+    const response: PagedResult<TemplateListItem> = {
       items: [
         {
           name: 'Billing.Invoice',
@@ -65,9 +65,7 @@ describe('useTemplates', () => {
           hasPublishedVersion: false,
         },
       ],
-      total: 1,
-      page: 1,
-      pageSize: 20,
+      totalCount: 1,
     };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 

--- a/packages/@granit/templating/src/__tests__/api.test.ts
+++ b/packages/@granit/templating/src/__tests__/api.test.ts
@@ -31,7 +31,7 @@ import type {
   TemplateRevision,
   TemplateVariables,
 } from '../types/index.js';
-import type { PaginatedResponse } from '@granit/api-client';
+import type { PagedResult } from '@granit/querying';
 
 const basePath = '/api/v1';
 
@@ -39,7 +39,7 @@ describe('templates-api', () => {
   describe('getTemplates', () => {
     it('should call GET /templates with params', async () => {
       const client = createMockClient();
-      const response: PaginatedResponse<TemplateListItem> = {
+      const response: PagedResult<TemplateListItem> = {
         items: [
           {
             name: 'Billing.Invoice',
@@ -50,9 +50,7 @@ describe('templates-api', () => {
             hasPublishedVersion: false,
           },
         ],
-        total: 1,
-        page: 1,
-        pageSize: 20,
+        totalCount: 1,
       };
       vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 
@@ -68,9 +66,7 @@ describe('templates-api', () => {
 
     it('should call GET /templates without params', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue(
-        axiosResponse({ items: [], total: 0, page: 1, pageSize: 20 })
-      );
+      vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [], totalCount: 0 }));
 
       await getTemplates(client, basePath);
 

--- a/packages/@granit/templating/src/api/templates-api.ts
+++ b/packages/@granit/templating/src/api/templates-api.ts
@@ -13,7 +13,7 @@ import type {
   TemplateVariables,
   UpdateTemplateCategoryRequest,
 } from '../types/index.js';
-import type { PaginatedResponse } from '@granit/api-client';
+import type { PagedResult, PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 function templateUrl(basePath: string, name: string, ...segments: string[]): string {
@@ -29,8 +29,8 @@ export async function getTemplates(
   client: AxiosInstance,
   basePath: string,
   params?: TemplateListParams
-): Promise<PaginatedResponse<TemplateListItem>> {
-  const { data } = await client.get<PaginatedResponse<TemplateListItem>>(`${basePath}/templates`, {
+): Promise<PagedResult<TemplateListItem>> {
+  const { data } = await client.get<PagedResult<TemplateListItem>>(`${basePath}/templates`, {
     params,
   });
   return data;
@@ -119,7 +119,7 @@ export async function getHistory(
   client: AxiosInstance,
   basePath: string,
   name: string,
-  params?: { culture?: string; page?: number; pageSize?: number }
+  params?: PaginationParams & { culture?: string }
 ): Promise<TemplateHistory> {
   const { data } = await client.get<TemplateHistory>(templateUrl(basePath, name, 'history'), {
     params,

--- a/packages/@granit/webhooks/package.json
+++ b/packages/@granit/webhooks/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@granit/webhooks",
+  "description": "Webhook subscription management types and API functions — mirrors Granit.Webhooks .NET contract",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/webhooks/src/index.ts
+++ b/packages/@granit/webhooks/src/index.ts
@@ -1,0 +1,2 @@
+// @granit/webhooks — placeholder (package not yet implemented)
+export {};

--- a/packages/@granit/webhooks/tsconfig.json
+++ b/packages/@granit/webhooks/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/workflow/src/api/workflow-api.ts
+++ b/packages/@granit/workflow/src/api/workflow-api.ts
@@ -4,7 +4,7 @@ import type {
   TransitionResultDto,
   WorkflowStatusDto,
 } from '../types/index.js';
-import type { PagedResult } from '@granit/querying';
+import type { PagedResult, PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 function buildUrl(
@@ -54,7 +54,7 @@ export async function fetchHistory(
   basePath: string,
   entityType: string,
   entityId: string,
-  params: { page?: number; pageSize?: number } = {}
+  params: PaginationParams = {}
 ): Promise<WorkflowHistoryPage> {
   const { data } = await client.get<WorkflowHistoryPage>(
     buildUrl(basePath, entityType, entityId, 'history'),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -816,6 +816,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1001,6 +1004,16 @@ importers:
       tailwind-merge:
         specifier: '*'
         version: 3.5.0
+
+  packages/@granit/webhooks:
+    dependencies:
+      axios:
+        specifier: '*'
+        version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
 
   packages/@granit/workflow:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,6 +546,9 @@ importers:
       '@granit/data-exchange':
         specifier: workspace:*
         version: link:../data-exchange
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils


### PR DESCRIPTION
## Summary

- **Replace `PaginatedResponse<T>` with `PagedResult<T>`** across data-exchange, templating, and react hooks — the old type had a different contract (`total` vs `totalCount`, included `page`/`pageSize` in response)
- **Use `PaginationParams`** from `@granit/querying` instead of inline `{ page?: number; pageSize?: number }` in notifications and workflow APIs
- **Remove dead `PaginatedResponse`** from `@granit/api-client` (all consumers migrated, guava-admin updated separately)
- **Add `@granit/webhooks` skeleton** (tsconfig + empty index.ts to unblock `pnpm tsc`)

### Affected packages

| Package | Change |
|---------|--------|
| `@granit/api-client` | Remove `PaginatedResponse` |
| `@granit/data-exchange` | `PaginatedResponse` → `PagedResult` |
| `@granit/react-data-exchange` | `PaginatedResponse` → `PagedResult`, add `@granit/querying` peer dep |
| `@granit/templating` | `PaginatedResponse` → `PagedResult`, inline params → `PaginationParams` |
| `@granit/react-templating` | Fix test to use `PagedResult` |
| `@granit/notifications` | Inline params → `PaginationParams` |
| `@granit/workflow` | Inline params → `PaginationParams` |
| `@granit/webhooks` | New skeleton package |

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 1122 tests passing
- [x] guava-admin updated and pushed separately (`feature/ai-module`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)