### PR TITLE
feat(webhooks): add @granit/webhooks and @granit/react-webhooks packages

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,412 @@
+---
+name: audit
+description: 'Framework architect: deep codebase audit for type safety, API conformity, consistency, and refactoring opportunities. Analyzes packages against .NET backend contracts and cross-package conventions.'
+argument-hint: '[<package> | all | pr] [--fix] [--scope types|api|hooks|deps|all]'
+---
+
+# Framework Audit — Granit Front
+
+You are a **framework architect** specialized in TypeScript/React library design.
+Your mission: audit `@granit/*` packages for structural issues that linters and
+tests cannot catch — type mismatches with the backend, inconsistent patterns,
+missing features, dead code, and refactoring opportunities.
+
+Read [checklist.md](checklist.md) before proceeding.
+**If the file cannot be read, STOP and report the error.** Do not attempt to
+audit without the checklist — it contains the full verification matrix.
+
+**Absolute minimum rules** (in case checklist is partially loaded):
+
+1. Frontend types must mirror .NET DTO names and fields exactly
+2. All paginated responses must use `PagedResult<T>` from `@granit/querying`
+3. All paginated request params must use `PaginationParams` (no inline duplication)
+4. Every backend endpoint must have a corresponding frontend API function
+
+---
+
+## Invocation modes
+
+| Argument          | Scope                                                            |
+| ----------------- | ---------------------------------------------------------------- |
+| `help`            | Show available commands, flags, and examples                     |
+| _(none)_ or `all` | Full audit across all `@granit/*` packages                       |
+| `<package>`       | Single package (e.g., `querying`, `notifications`, `workflow`)   |
+| `pr`              | PR readiness — audit only packages touched by the current branch |
+
+### Flags
+
+| Flag              | Effect                                           |
+| ----------------- | ------------------------------------------------ |
+| `--fix`           | Apply fixes automatically (default: report only) |
+| `--scope types`   | Only check type conformity with backend          |
+| `--scope api`     | Only check API functions and serialization       |
+| `--scope hooks`   | Only check React hooks patterns                  |
+| `--scope deps`    | Only check dependencies and peer deps            |
+| `--scope all`     | Full audit (default)                             |
+| `--base <branch>` | Base branch for `pr` mode (default: `develop`)   |
+
+### Help (`/audit help`)
+
+If the argument is `help`, output the following reference card and **stop**
+(do not run any audit):
+
+```text
+/audit — Framework conformity audit for @granit/* packages
+
+USAGE
+  /audit [target] [flags]
+
+TARGETS
+  help              Show this help
+  all               Full audit — all packages (default)
+  pr                PR mode — only packages changed vs develop
+  <package>         Single package (e.g., querying, notifications, workflow)
+
+FLAGS
+  --fix             Apply fixes automatically (default: report only)
+  --scope <scope>   Limit audit to a category:
+                      types   Type conformity with .NET backend
+                      api     API functions and serialization
+                      hooks   React hooks patterns
+                      deps    Dependencies and peer deps
+                      all     Everything (default)
+  --base <branch>   Base branch for pr mode (default: develop)
+
+EXAMPLES
+  /audit                        Full audit, report only
+  /audit querying               Audit @granit/querying + react-querying
+  /audit querying --fix         Audit and auto-fix querying
+  /audit pr                     Check packages modified in current branch
+  /audit pr --fix               Check and fix before PR
+  /audit all --scope types      Only check type conformity across all packages
+  /audit notifications --scope api   Only check API coverage for notifications
+
+SEVERITY LEVELS
+  BREAKING        Type mismatch causing runtime errors — must fix
+  GAP             Missing backend feature — should implement
+  INCONSISTENCY   Pattern differs from other packages — should align
+  CLEANUP         Dead code, unused exports — should remove
+  IMPROVEMENT     Refactoring opportunity — consider
+
+RELATED SKILLS
+  /review         Pre-landing security & anti-pattern review (complements /audit pr)
+  /quality        Lint, format, tests, SonarQube quality gate
+```
+
+---
+
+## Step 1 — Identify target packages
+
+If a specific package was given, resolve it:
+
+- `querying` → `packages/@granit/querying` + `packages/@granit/react-querying`
+- `notifications` → `packages/@granit/notifications` + `packages/@granit/react-notifications`
+  - transport packages (`notifications-signalr`, `notifications-sse`, etc.)
+- Any name → `packages/@granit/{name}` + `packages/@granit/react-{name}` if it exists
+
+If `all`, list all packages under `packages/@granit/` and process each.
+
+---
+
+## Step 2 — Gather context
+
+For each target package, collect:
+
+1. **Frontend types**: read `src/types/` and `src/index.ts` (public API surface)
+2. **Frontend API functions**: read `src/api/` files
+3. **Frontend hooks**: read `src/hooks/` files (for `react-*` packages)
+4. **Backend contract**: use `mcp__granit-docs__search_code` and
+   `mcp__granit-docs__get_public_api` to find the corresponding .NET module types.
+   If available, also use `mcp__roslyn-lens__get_public_api` for precise signatures.
+5. **Peer dependencies**: read `package.json`
+6. **Consumer usage**: if the audit may lead to renaming or removing an exported
+   symbol, search for references in consumer apps before flagging:
+
+   ```bash
+   grep -r "@granit/{package}" ~/dev/digital-dynamics/guava-platform/applications/guava-front/src/
+   grep -r "@granit/{package}" ~/dev/digital-dynamics/guava-platform/applications/guava-admin/src/
+   ```
+
+   Record the blast radius (number of import sites) for each exported symbol.
+
+7. **Git history**: for any code that looks unusual, run `git log -p -- <file>`
+   to understand why it was written that way before flagging it.
+
+---
+
+## Step 3 — Run the checklist
+
+Apply every category from [checklist.md](checklist.md) against the gathered context.
+Work through the checklist **in order** — type conformity first, then API, hooks,
+dependencies, and finally cross-cutting concerns.
+
+For each finding, classify it:
+
+| Severity          | Meaning                                           | Action           |
+| ----------------- | ------------------------------------------------- | ---------------- |
+| **BREAKING**      | Type mismatch that will cause runtime errors      | Must fix         |
+| **GAP**           | Missing feature that the backend supports         | Should implement |
+| **INCONSISTENCY** | Pattern differs from other packages               | Should align     |
+| **CLEANUP**       | Dead code, unused exports, stale types            | Should remove    |
+| **IMPROVEMENT**   | Refactoring opportunity, better pattern available | Consider         |
+
+---
+
+## Step 4 — Report or fix
+
+### Report mode (default)
+
+Output findings using this format:
+
+```markdown
+## Audit Report — @granit/{package} — {date}
+
+### Summary
+
+| Severity      | Count |
+| ------------- | ----- |
+| BREAKING      | {n}   |
+| GAP           | {n}   |
+| INCONSISTENCY | {n}   |
+| CLEANUP       | {n}   |
+| IMPROVEMENT   | {n}   |
+
+### BREAKING
+
+- [{file}:{line}] {description}
+  Backend: {what the backend expects}
+  Frontend: {what the frontend has}
+  Fix: {suggested fix}
+
+### GAP
+
+- [{file}:{line}] {description}
+  Backend feature: {what exists in .NET}
+  Action: {what to implement}
+
+### INCONSISTENCY
+
+- [{file}:{line}] {description}
+  Pattern in other packages: {reference}
+  Fix: {suggested alignment}
+
+### CLEANUP
+
+- [{file}:{line}] {description}
+  Reason: {why it's dead/unused}
+
+### IMPROVEMENT
+
+- [{file}:{line}] {description}
+  Current: {current approach}
+  Proposed: {better approach}
+  Why: {benefit}
+```
+
+When auditing `all` packages, produce one report per package, then a
+**cross-package summary** at the end highlighting systemic issues.
+
+### Fix mode (`--fix`)
+
+Execute all commands via Bash tool. Process findings **one at a time**:
+
+For each **BREAKING** and **GAP** finding:
+
+1. Show the finding to the user
+2. Apply the fix (Edit tool)
+3. Run `pnpm --filter @granit/{package} exec tsc --noEmit` to verify
+   - **Pass**: mark as fixed, move to the next finding
+   - **Fail**: attempt ONE automatic correction based on the error message
+     - If the retry passes: mark as fixed
+     - If the retry fails: **revert the change**, log it as
+       `UNFIXABLE — requires manual intervention: {error}`, and move on
+4. **Never loop** on a failing fix. Two attempts max per finding, then move on.
+
+For **INCONSISTENCY** and **CLEANUP**: apply fixes without confirmation
+(same two-attempt rule applies).
+
+For **IMPROVEMENT**: report only, never auto-fix.
+
+After all fixes, run the full verification:
+
+```bash
+pnpm tsc && pnpm lint && pnpm test
+```
+
+If any step fails on code you did not touch, **stop and report** — do not
+attempt to fix pre-existing issues outside the audit scope.
+
+---
+
+## Step 5 — Cross-package analysis (full audit only)
+
+When auditing all packages, perform these additional checks:
+
+1. **Shared type consistency**: verify that `PaginationParams`, `PagedResult`,
+   and other shared types from `@granit/querying` are used consistently
+   (no inline `{ page?: number; pageSize?: number }` duplicates)
+2. **Import graph**: check that no circular dependencies exist between packages
+3. **Peer dependency matrix**: verify that the peer deps in CLAUDE.md match
+   actual `package.json` declarations
+4. **Export surface stability**: flag any exported symbol that is not used by
+   any consumer (guava-front, guava-admin) — candidate for removal
+5. **Pattern uniformity**: verify all domain modules follow the same structure
+   (core types package + react hooks package, same file organization)
+
+---
+
+## PR Mode (`/audit pr`)
+
+Lightweight, focused audit of only the packages modified in the current branch.
+Designed to run **before creating a PR** or **before merging**.
+
+This is NOT `/review` (which checks for security, N+1, XSS). This checks
+**framework conformity**: do your changes follow Granit conventions?
+
+### PR Step 1 — Determine scope
+
+```bash
+git fetch origin develop --quiet
+BRANCH=$(git branch --show-current)
+```
+
+If on `develop` or `main`: output **"Nothing to audit — you're on the base
+branch."** and stop.
+
+Get the list of changed files:
+
+```bash
+git diff origin/develop...HEAD --name-only
+```
+
+Extract the set of affected `@granit/*` packages from the file paths.
+If no `packages/@granit/` files were changed, output **"No framework packages
+modified — nothing to audit."** and stop.
+
+### PR Step 2 — Focused audit per package
+
+For each affected package, run the **full checklist** (Steps 2-4 from the
+standard audit) but only on that package. Use the same severity classification.
+
+Additionally, check these PR-specific concerns:
+
+#### Export surface changes
+
+```bash
+git diff origin/develop...HEAD -- "packages/@granit/{pkg}/src/index.ts"
+```
+
+For any added, renamed, or removed export:
+
+- **Added export**: verify it mirrors a backend type/endpoint (not speculative)
+- **Renamed export**: search consumers for the old name (Step 2.6 grep) and
+  flag if any consumer still uses it
+- **Removed export**: same consumer search — **BREAKING** if still imported
+
+#### New dependencies
+
+```bash
+git diff origin/develop...HEAD -- "packages/@granit/{pkg}/package.json"
+```
+
+For any new dependency:
+
+- [ ] Listed in `peerDependencies` (not `dependencies`) if it's a runtime dep
+- [ ] Entry added to `THIRD-PARTY-NOTICES.md`
+- [ ] License is permissive (MIT, Apache-2.0, BSD, ISC)
+- [ ] CLAUDE.md peer dep matrix updated
+
+#### New types vs backend
+
+For any new TypeScript interface or type added in the diff:
+
+- Fetch the corresponding .NET type via MCP tools
+- Verify field-by-field alignment (same checks as checklist section 1a)
+- Flag any field present in .NET but missing in the new TS type
+
+#### Test coverage
+
+For any new `src/api/*.ts` or `src/hooks/*.ts` file:
+
+- Verify a corresponding test file exists
+- If no test: flag as **GAP** with `Action: add test for {function}`
+
+### PR Step 3 — Verification gate
+
+Run the Definition of Done checks:
+
+```bash
+pnpm tsc && pnpm lint && npx vitest run
+```
+
+Report results inline with the audit findings.
+
+### PR Step 4 — PR report
+
+```markdown
+## PR Audit — {branch} → develop — {date}
+
+### Packages touched
+
+- @granit/{pkg1} ({n} files changed)
+- @granit/{pkg2} ({n} files changed)
+
+### Export surface
+
+| Package | Added | Renamed | Removed |
+| ------- | ----- | ------- | ------- |
+| ...     | ...   | ...     | ...     |
+
+### Findings
+
+| Severity      | Count |
+| ------------- | ----- |
+| BREAKING      | {n}   |
+| GAP           | {n}   |
+| INCONSISTENCY | {n}   |
+| CLEANUP       | {n}   |
+
+{findings details — same format as standard audit}
+
+### Verification
+
+| Check      | Result                 |
+| ---------- | ---------------------- |
+| TypeScript | PASS / FAIL            |
+| ESLint     | PASS / FAIL            |
+| Tests      | {n} passed, {n} failed |
+
+### Verdict
+
+READY TO MERGE | BLOCKED — {reasons}
+```
+
+If `--fix` is specified, apply the same fix workflow as the standard audit
+before producing the final verdict.
+
+---
+
+## Rules
+
+- **Read before judging.** Always read the full file before flagging something
+  as wrong. For code that looks unusual, run `git log -p -- <file>` or
+  `git blame <file>` via Bash to understand why it was written that way.
+  If the history reveals an intentional decision (bugfix, compliance, workaround),
+  do not flag it as an issue.
+- **Backend is the source of truth.** Frontend types must mirror .NET contracts.
+  If there's a mismatch, the frontend is wrong unless the backend docs say
+  otherwise. Always verify via MCP tools — never guess the backend shape.
+- **No speculative refactoring.** Only propose changes backed by evidence
+  (backend contract, pattern in 3+ other packages, or measurable improvement).
+  "Could be cleaner" is not a finding.
+- **Respect the monorepo.** Changes to exported types affect guava-front and
+  guava-admin. Before proposing any rename or removal, run the consumer grep
+  from Step 2.6 and report the blast radius. If > 5 import sites, flag it as
+  requiring a coordinated PR.
+- **One thing at a time.** Fix one category before moving to the next.
+  Don't mix type fixes with hook refactoring in the same pass.
+- **Context window discipline.** When auditing `all` packages, process them
+  one at a time. Produce the report for each package before moving to the next.
+  If you notice the audit becoming shallow (missing details, skipping checks),
+  split the remaining packages into a follow-up invocation rather than
+  producing a low-quality report.

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -1,0 +1,184 @@
+# Audit Checklist — Granit Front Packages
+
+Work through each category **in order**. For each check, compare the frontend
+package against the backend .NET module. Use MCP tools (`granit-docs`,
+`roslyn-lens`) to retrieve backend contracts efficiently.
+
+---
+
+## 1. Type Conformity (--scope types)
+
+### 1a. Request/Response DTOs
+
+For each type exported from the package's `src/types/`:
+
+- [ ] **Name alignment**: type name matches the .NET DTO name
+      (e.g., `QueryRequest` not `QueryParams`, `PagedResult` not `PaginatedResponse`)
+- [ ] **Field completeness**: every field in the .NET DTO has a corresponding
+      field in the TypeScript interface (check for missing optional fields)
+- [ ] **Field naming**: camelCase in TS matches the JSON serialization of the
+      .NET property (PascalCase → camelCase via `JsonSerializerOptions`)
+- [ ] **Field types**: correct TypeScript equivalent for each .NET type
+      (`Guid` → `string`, `DateTime` → `string`, `int?` → `number | null`,
+      `IReadOnlyList<T>` → `readonly T[]`, enums → string union or const object)
+- [ ] **Nullability**: nullable .NET properties are `| null` or `| undefined`
+      in TS, non-nullable are required
+- [ ] **Enum values**: string enum values match exactly (case-sensitive)
+- [ ] **Readonly markers**: response types use `readonly` on all fields
+
+### 1b. Shared base types
+
+- [ ] **PaginationParams**: used (not duplicated inline) in all paginated APIs
+- [ ] **PagedResult**: used (not `PaginatedResponse` or custom shapes) for all
+      paginated responses
+- [ ] **ProblemDetails**: error responses typed as `ProblemDetails` from
+      `@granit/api-client`
+
+### 1c. Export surface
+
+- [ ] **Single barrel**: `src/index.ts` is the only entry point
+- [ ] **No internal leaks**: types not meant for consumers are not exported
+- [ ] **`import type`**: type-only imports use `import type` syntax
+- [ ] **Re-exports**: if a type is used across packages, it's re-exported from
+      the owning package (not imported directly from `@granit/querying` in hooks)
+
+---
+
+## 2. API Functions (--scope api)
+
+### 2a. Function signatures
+
+For each function in `src/api/`:
+
+- [ ] **Parameter order**: `(client: AxiosInstance, basePath: string, ...params)`
+- [ ] **Return type**: explicit `Promise<T>` with correct response type
+- [ ] **HTTP method**: matches the backend endpoint
+      (`GET` for reads, `POST` for creates, `PUT` for full updates,
+      `PATCH` for partial, `DELETE` for removals)
+- [ ] **URL construction**: path segments properly encoded with
+      `encodeURIComponent` for dynamic segments
+- [ ] **Query params**: sent via `{ params }` config (not concatenated in URL)
+      for simple params; serialized with dedicated function for complex params
+
+### 2b. Endpoint coverage
+
+- [ ] **All backend endpoints covered**: each `Map*Endpoints` registration in
+      the .NET module has a corresponding frontend API function
+- [ ] **Saved views**: if the module uses `MapQueryEndpoints`, saved view CRUD
+      functions exist
+- [ ] **Meta endpoint**: if the module exposes `/meta`, a `fetch*Meta` function
+      exists
+
+### 2c. Serialization
+
+- [ ] **Query string format**: matches what the backend `[FromQuery]` or custom
+      binder expects (e.g., `filter[field.op]=value`, not `filter.field.op=value`)
+- [ ] **Boolean serialization**: `true`/`false` strings (not `1`/`0`)
+- [ ] **Array serialization**: comma-separated (e.g., `quickFilters=A,B`)
+- [ ] **Date serialization**: ISO 8601 format
+
+---
+
+## 3. React Hooks (--scope hooks)
+
+### 3a. Provider pattern
+
+- [ ] **Context provider**: `{Module}Provider` component exists with config prop
+- [ ] **useConfig hook**: `use{Module}Config()` hook throws if used outside
+      provider
+- [ ] **Config type**: includes `client: AxiosInstance` and `basePath: string`
+      at minimum
+
+### 3b. Query hooks
+
+- [ ] **TanStack Query**: all data fetching uses `useQuery` / `useMutation`
+- [ ] **Query keys**: use a factory function (`buildQueryKey` or module-specific
+      key builder) — no inline string arrays
+- [ ] **Stale time**: read-heavy data has appropriate `staleTime`
+      (metadata: `Infinity`, lists: default, real-time: `0`)
+- [ ] **Error handling**: errors propagate via TanStack Query's `error` state
+      (not try/catch swallowing)
+- [ ] **Enabled flag**: conditional queries use `enabled` option
+- [ ] **Pagination**: uses `usePagination` or `useInfiniteScroll` from
+      `@granit/react-querying` — not a custom implementation
+- [ ] **Optimistic updates**: mutations that affect cached lists invalidate
+      the relevant query keys in `onSuccess`
+
+### 3c. Hook API design
+
+- [ ] **Return shape**: consistent with other `@granit/react-*` packages
+      (query result + dispatchers + computed state)
+- [ ] **Memoization**: callbacks wrapped in `useCallback`, computed values in
+      `useMemo`
+- [ ] **No side effects at import**: hooks and providers don't execute code
+      at module level
+
+---
+
+## 4. Dependencies (--scope deps)
+
+### 4a. package.json
+
+- [ ] **Peer deps declared**: React, axios, @tanstack/react-query listed as
+      `peerDependencies` (not `dependencies`)
+- [ ] **Core package as peer dep**: `react-*` package lists its core `@granit/*`
+      counterpart as peer dep
+- [ ] **No phantom deps**: every imported package is listed in either `peerDependencies`
+      or `devDependencies`
+- [ ] **Version ranges**: peer deps use `^` or `*` ranges, not pinned versions
+- [ ] **No duplicate deps**: a dependency is not in both `peerDependencies`
+      and `dependencies`
+
+### 4b. CLAUDE.md sync
+
+- [ ] **Peer dep matrix**: the `peerDependencies` listed in CLAUDE.md match
+      the actual `package.json` of each package
+- [ ] **Package table**: new packages are listed in the CLAUDE.md package table
+
+### 4c. THIRD-PARTY-NOTICES
+
+- [ ] **All deps listed**: every external dependency has an entry in
+      `THIRD-PARTY-NOTICES.md`
+- [ ] **License check**: no GPL/LGPL/AGPL/SSPL dependencies
+
+---
+
+## 5. Cross-Cutting Concerns
+
+### 5a. Pattern uniformity
+
+- [ ] **Directory structure**: `src/types/`, `src/api/`, `src/hooks/`,
+      `src/providers/`, `src/__tests__/` — consistent across all packages
+- [ ] **Naming conventions**: functions follow `fetch*`, `create*`, `update*`,
+      `delete*` pattern; hooks follow `use*` pattern
+- [ ] **Error types**: API errors are `AxiosError<ProblemDetails>` everywhere
+- [ ] **Config pattern**: all `react-*` packages use Provider + useConfig
+      (not module-level singletons)
+
+### 5b. Test coverage
+
+- [ ] **API functions tested**: each `src/api/*.ts` file has a corresponding
+      test file
+- [ ] **Mock client**: tests use `createMockClient()` from `@granit/testing`
+- [ ] **Response shape**: mock responses in tests match `PagedResult<T>` or
+      the actual backend response shape (not outdated `PaginatedResponse`)
+- [ ] **Coverage >= 80%**: on all source files
+
+### 5c. Consumer compatibility
+
+- [ ] **guava-front imports**: check `grep -r "@granit/{package}" ~/dev/digital-dynamics/guava-platform/applications/guava-front/src/`
+      for any usage that would break with proposed changes
+- [ ] **guava-admin imports**: same check on guava-admin
+- [ ] **No breaking exports**: if an exported symbol is renamed/removed,
+      consumers must be updated in the same PR
+
+---
+
+## Suppressions — DO NOT flag
+
+- Style-only issues (formatting, import order) — linter handles this
+- Missing JSDoc on internal functions — only flag on public API
+- "Could be more generic" — don't suggest abstractions without 3+ duplicates
+- Test file organization (naming, folder structure)
+- `pnpm-lock.yaml` changes
+- Packages that are explicitly marked as placeholders/skeletons

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@
 | `@granit/localization`                  | Localization setup: `createLocalization` factory (i18next configuration)                                                                                                                                                                      |
 | `@granit/react-localization`            | React bindings for `@granit/localization`: `useLocale` hook (locale management + persistence)                                                                                                                                                 |
 | `@granit/logger-otlp`                   | OpenTelemetry log transport: `createOtlpTransport` for `@granit/logger`                                                                                                                                                                       |
+| `@granit/webhooks`                      | Webhook subscription management types and API functions: CRUD, lifecycle (activate/suspend/deactivate), secret rotation, test ping, stats — mirrors `Granit.Webhooks` .NET                                                                    |
+| `@granit/react-webhooks`                | React hooks for `@granit/webhooks`: `useSubscription`, `useCreateSubscription`, `useDeleteSubscription`, `useActivateSubscription`, `useRotateSecret`, `useTestPing`, `useDeliveries`, `useWebhookStats`                                      |
 | `@granit/idempotency`                   | Idempotency key generation: `createIdempotencyKey` — mirrors `Granit.Idempotency` .NET                                                                                                                                                        |
 
 ## Stack & versions
@@ -167,6 +169,8 @@ Full frontend conventions: `../granit-dotnet/docs/guide/conventions/frontend/`
   - `@granit/localization` → `i18next`
   - `@granit/react-localization` → `react`, `react-i18next`, `@granit/localization`, `@granit/storage`
   - `@granit/logger-otlp` → `@granit/logger`, `@opentelemetry/api`
+  - `@granit/webhooks` → `axios`
+  - `@granit/react-webhooks` → `react`, `axios`, `@tanstack/react-query`, `@granit/webhooks`
   - `@granit/idempotency` → _(no peer dependencies)_
 
 ## GitHub issues

--- a/packages/@granit/react-webhooks/package.json
+++ b/packages/@granit/react-webhooks/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@granit/react-webhooks",
+  "description": "React hooks for webhook subscription management — useSubscription, useCreateSubscription, useTestPing, useWebhookStats",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/webhooks": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-webhooks/src/__tests__/use-deliveries.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-deliveries.test.tsx
@@ -1,0 +1,101 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useDeliveries } from '../hooks/use-deliveries.js';
+
+import type { WebhookDeliveryAttemptResponse } from '@granit/webhooks';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockDeliveries: WebhookDeliveryAttemptResponse[] = [
+  {
+    deliveryId: 'del-001',
+    subscriptionId: 'sub-001',
+    tenantId: null,
+    eventType: 'document.uploaded',
+    targetUrl: 'https://example.com/webhook',
+    httpStatusCode: 200,
+    payloadHash: 'a'.repeat(64),
+    occurredAt: '2026-03-20T10:00:00Z',
+    durationMs: 142,
+    errorMessage: null,
+    isSuccess: true,
+  },
+  {
+    deliveryId: 'del-002',
+    subscriptionId: 'sub-001',
+    tenantId: null,
+    eventType: 'document.uploaded',
+    targetUrl: 'https://example.com/webhook',
+    httpStatusCode: 500,
+    payloadHash: 'b'.repeat(64),
+    occurredAt: '2026-03-20T10:05:00Z',
+    durationMs: 3021,
+    errorMessage: 'Internal Server Error',
+    isSuccess: false,
+  },
+];
+
+describe('useDeliveries', () => {
+  it('should fetch deliveries for a subscription', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockDeliveries });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeliveries('sub-001', { client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001/deliveries');
+    expect(result.current.data).toEqual(mockDeliveries);
+  });
+
+  it('should be disabled when subscriptionId is empty', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeliveries('', { client }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('should use custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useDeliveries('sub-001', { client, basePath: '/api/v2/webhooks' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v2/webhooks/sub-001/deliveries');
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeliveries('sub-001', { client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription-lifecycle.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription-lifecycle.test.tsx
@@ -1,0 +1,137 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { WebhookSubscriptionStatus, webhooksKeys } from '@granit/webhooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useActivateSubscription,
+  useDeactivateSubscription,
+  useSuspendSubscription,
+} from '../hooks/use-subscription-lifecycle.js';
+
+import type { WebhookSubscriptionResponse } from '@granit/webhooks';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockSubscription: WebhookSubscriptionResponse = {
+  id: 'sub-001',
+  targetUrl: 'https://example.com/webhook',
+  eventType: 'document.uploaded',
+  status: WebhookSubscriptionStatus.Active,
+  consecutiveFailureCount: 0,
+  lastSuccessAt: null,
+  createdAt: '2026-03-01T08:00:00Z',
+  modifiedAt: null,
+};
+
+describe('useActivateSubscription', () => {
+  it('should send POST to /{id}/activate and invalidate on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: mockSubscription });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useActivateSubscription({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001/activate');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.subscriptions(),
+    });
+  });
+
+  it('should handle activation error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useActivateSubscription({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useSuspendSubscription', () => {
+  it('should send POST to /{id}/suspend and invalidate on success', async () => {
+    const client = createMockClient();
+    const suspended = { ...mockSubscription, status: WebhookSubscriptionStatus.Suspended };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: suspended });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useSuspendSubscription({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001/suspend');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.subscriptions(),
+    });
+  });
+});
+
+describe('useDeactivateSubscription', () => {
+  it('should send POST to /{id}/deactivate with reason and invalidate on success', async () => {
+    const client = createMockClient();
+    const deactivated = { ...mockSubscription, status: WebhookSubscriptionStatus.Deactivated };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: deactivated });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeactivateSubscription({ client }), { wrapper });
+
+    result.current.mutate({
+      id: 'sub-001',
+      request: { reason: 'No longer needed' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001/deactivate', {
+      reason: 'No longer needed',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.subscriptions(),
+    });
+  });
+
+  it('should handle deactivation error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeactivateSubscription({ client }), { wrapper });
+
+    result.current.mutate({
+      id: 'sub-001',
+      request: { reason: 'Test' },
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription-mutations.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription-mutations.test.tsx
@@ -1,0 +1,152 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { WebhookSubscriptionStatus, webhooksKeys } from '@granit/webhooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useCreateSubscription,
+  useDeleteSubscription,
+  useUpdateSubscription,
+} from '../hooks/use-subscription-mutations.js';
+
+import type {
+  WebhookSubscriptionCreatedResponse,
+  WebhookSubscriptionResponse,
+} from '@granit/webhooks';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockSubscription: WebhookSubscriptionResponse = {
+  id: 'sub-001',
+  targetUrl: 'https://example.com/webhook',
+  eventType: 'document.uploaded',
+  status: WebhookSubscriptionStatus.Active,
+  consecutiveFailureCount: 0,
+  lastSuccessAt: null,
+  createdAt: '2026-03-01T08:00:00Z',
+  modifiedAt: null,
+};
+
+describe('useCreateSubscription', () => {
+  it('should send POST and invalidate subscriptions on success', async () => {
+    const client = createMockClient();
+    const response: WebhookSubscriptionCreatedResponse = {
+      id: 'sub-002',
+      targetUrl: 'https://example.com/webhook',
+      eventType: 'document.uploaded',
+      status: WebhookSubscriptionStatus.Active,
+      signingSecret: 'whsec_abc123',
+    };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateSubscription({ client }), { wrapper });
+
+    result.current.mutate({
+      targetUrl: 'https://example.com/webhook',
+      eventType: 'document.uploaded',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions', {
+      targetUrl: 'https://example.com/webhook',
+      eventType: 'document.uploaded',
+    });
+    expect(result.current.data).toEqual(response);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.subscriptions(),
+    });
+  });
+
+  it('should handle creation error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Bad Request'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateSubscription({ client }), { wrapper });
+
+    result.current.mutate({
+      targetUrl: 'invalid-url',
+      eventType: 'document.uploaded',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});
+
+describe('useUpdateSubscription', () => {
+  it('should send PUT to /{id} and invalidate on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValueOnce({ data: mockSubscription });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateSubscription({ client }), { wrapper });
+
+    result.current.mutate({
+      id: 'sub-001',
+      request: { targetUrl: 'https://example.com/v2/webhook' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.put).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001', {
+      targetUrl: 'https://example.com/v2/webhook',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.subscriptions(),
+    });
+  });
+});
+
+describe('useDeleteSubscription', () => {
+  it('should send DELETE to /{id} and invalidate on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteSubscription({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.subscriptions(),
+    });
+  });
+
+  it('should handle delete error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteSubscription({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription-operations.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription-operations.test.tsx
@@ -1,0 +1,106 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { webhooksKeys } from '@granit/webhooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useRotateSecret, useTestPing } from '../hooks/use-subscription-operations.js';
+
+import type {
+  WebhookSubscriptionRotateSecretResponse,
+  WebhookSubscriptionTestPingResponse,
+} from '@granit/webhooks';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+describe('useRotateSecret', () => {
+  it('should send POST to /{id}/rotate-secret and invalidate subscription on success', async () => {
+    const client = createMockClient();
+    const response: WebhookSubscriptionRotateSecretResponse = {
+      signingSecret: 'whsec_new456',
+    };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRotateSecret({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/webhooks/subscriptions/sub-001/rotate-secret'
+    );
+    expect(result.current.data).toEqual(response);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.subscription('sub-001'),
+    });
+  });
+
+  it('should handle rotation error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRotateSecret({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});
+
+describe('useTestPing', () => {
+  it('should send POST to /{id}/test-ping', async () => {
+    const client = createMockClient();
+    const response: WebhookSubscriptionTestPingResponse = {
+      success: true,
+      httpStatusCode: 200,
+      durationMs: 142,
+    };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useTestPing({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001/test-ping');
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should report failed ping', async () => {
+    const client = createMockClient();
+    const response: WebhookSubscriptionTestPingResponse = {
+      success: false,
+      httpStatusCode: 503,
+      durationMs: 5012,
+    };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useTestPing({ client }), { wrapper });
+
+    result.current.mutate('sub-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.success).toBe(false);
+  });
+});

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription.test.tsx
@@ -1,0 +1,84 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { WebhookSubscriptionStatus } from '@granit/webhooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useSubscription } from '../hooks/use-subscription.js';
+
+import type { WebhookSubscriptionResponse } from '@granit/webhooks';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockSubscription: WebhookSubscriptionResponse = {
+  id: 'sub-001',
+  targetUrl: 'https://example.com/webhook',
+  eventType: 'document.uploaded',
+  status: WebhookSubscriptionStatus.Active,
+  consecutiveFailureCount: 0,
+  lastSuccessAt: '2026-03-20T10:00:00Z',
+  createdAt: '2026-03-01T08:00:00Z',
+  modifiedAt: null,
+};
+
+describe('useSubscription', () => {
+  it('should fetch subscription with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockSubscription });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubscription('sub-001', { client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/sub-001');
+    expect(result.current.data).toEqual(mockSubscription);
+  });
+
+  it('should fetch subscription with custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockSubscription });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useSubscription('sub-001', { client, basePath: '/api/v2/webhooks' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v2/webhooks/sub-001');
+  });
+
+  it('should be disabled when id is empty', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubscription('', { client }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSubscription('sub-001', { client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-webhooks/src/__tests__/use-webhook-stats.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-webhook-stats.test.tsx
@@ -1,0 +1,71 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useWebhookStats } from '../hooks/use-webhook-stats.js';
+
+import type { WebhookSubscriptionStatsResponse } from '@granit/webhooks';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockStats: WebhookSubscriptionStatsResponse = {
+  totalSubscriptions: 10,
+  activeCount: 7,
+  suspendedCount: 2,
+  deactivatedCount: 1,
+  deliveriesLast24h: 523,
+  successRateLast24h: 99.2,
+  avgResponseTimeMsLast24h: 85,
+};
+
+describe('useWebhookStats', () => {
+  it('should fetch webhook stats with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockStats });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebhookStats({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/subscriptions/stats');
+    expect(result.current.data).toEqual(mockStats);
+  });
+
+  it('should use custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockStats });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebhookStats({ client, basePath: '/api/v2/webhooks' }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v2/webhooks/stats');
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebhookStats({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-webhooks/src/hooks/use-deliveries.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-deliveries.ts
@@ -1,0 +1,26 @@
+import { getDeliveries, webhooksKeys } from '@granit/webhooks';
+import { useQuery } from '@tanstack/react-query';
+
+import type { WebhooksOptions } from './use-subscription.js';
+import type { WebhookDeliveryAttemptResponse } from '@granit/webhooks';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
+
+/**
+ * Query hook that fetches delivery attempts for a specific subscription.
+ *
+ * The query is disabled when `subscriptionId` is empty.
+ */
+export function useDeliveries(
+  subscriptionId: string,
+  options: WebhooksOptions
+): UseQueryResult<WebhookDeliveryAttemptResponse[]> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useQuery({
+    queryKey: webhooksKeys.deliveries(subscriptionId),
+    queryFn: () => getDeliveries(client, basePath, subscriptionId),
+    enabled: subscriptionId.length > 0,
+  });
+}

--- a/packages/@granit/react-webhooks/src/hooks/use-subscription-lifecycle.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-subscription-lifecycle.ts
@@ -1,0 +1,77 @@
+import {
+  activateSubscription,
+  deactivateSubscription,
+  suspendSubscription,
+  webhooksKeys,
+} from '@granit/webhooks';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { WebhooksOptions } from './use-subscription.js';
+import type {
+  WebhookSubscriptionDeactivateRequest,
+  WebhookSubscriptionResponse,
+} from '@granit/webhooks';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
+
+/**
+ * Mutation hook to activate a suspended webhook subscription.
+ *
+ * Invalidates subscription queries on success.
+ */
+export function useActivateSubscription(
+  options: WebhooksOptions
+): UseMutationResult<WebhookSubscriptionResponse, Error, string> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => activateSubscription(client, basePath, id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: webhooksKeys.subscriptions() });
+    },
+  });
+}
+
+/**
+ * Mutation hook to suspend a webhook subscription.
+ *
+ * Invalidates subscription queries on success.
+ */
+export function useSuspendSubscription(
+  options: WebhooksOptions
+): UseMutationResult<WebhookSubscriptionResponse, Error, string> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => suspendSubscription(client, basePath, id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: webhooksKeys.subscriptions() });
+    },
+  });
+}
+
+/**
+ * Mutation hook to deactivate a webhook subscription permanently.
+ *
+ * Invalidates subscription queries on success.
+ */
+export function useDeactivateSubscription(
+  options: WebhooksOptions
+): UseMutationResult<
+  WebhookSubscriptionResponse,
+  Error,
+  { id: string; request: WebhookSubscriptionDeactivateRequest }
+> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }) => deactivateSubscription(client, basePath, id, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: webhooksKeys.subscriptions() });
+    },
+  });
+}

--- a/packages/@granit/react-webhooks/src/hooks/use-subscription-mutations.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-subscription-mutations.ts
@@ -1,0 +1,81 @@
+import {
+  createSubscription,
+  deleteSubscription,
+  updateSubscription,
+  webhooksKeys,
+} from '@granit/webhooks';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { WebhooksOptions } from './use-subscription.js';
+import type {
+  WebhookSubscriptionCreateRequest,
+  WebhookSubscriptionCreatedResponse,
+  WebhookSubscriptionResponse,
+  WebhookSubscriptionUpdateRequest,
+} from '@granit/webhooks';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
+
+/**
+ * Mutation hook to create a new webhook subscription.
+ *
+ * Returns the created subscription with the signing secret (shown once).
+ * Invalidates subscription queries on success.
+ */
+export function useCreateSubscription(
+  options: WebhooksOptions
+): UseMutationResult<WebhookSubscriptionCreatedResponse, Error, WebhookSubscriptionCreateRequest> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: WebhookSubscriptionCreateRequest) =>
+      createSubscription(client, basePath, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: webhooksKeys.subscriptions() });
+    },
+  });
+}
+
+/**
+ * Mutation hook to update a webhook subscription's target URL.
+ *
+ * Invalidates subscription queries on success.
+ */
+export function useUpdateSubscription(
+  options: WebhooksOptions
+): UseMutationResult<
+  WebhookSubscriptionResponse,
+  Error,
+  { id: string; request: WebhookSubscriptionUpdateRequest }
+> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }) => updateSubscription(client, basePath, id, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: webhooksKeys.subscriptions() });
+    },
+  });
+}
+
+/**
+ * Mutation hook to delete a webhook subscription.
+ *
+ * Invalidates subscription queries on success.
+ */
+export function useDeleteSubscription(
+  options: WebhooksOptions
+): UseMutationResult<void, Error, string> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteSubscription(client, basePath, id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: webhooksKeys.subscriptions() });
+    },
+  });
+}

--- a/packages/@granit/react-webhooks/src/hooks/use-subscription-operations.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-subscription-operations.ts
@@ -1,0 +1,44 @@
+import { rotateSecret, testPing, webhooksKeys } from '@granit/webhooks';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import type { WebhooksOptions } from './use-subscription.js';
+import type {
+  WebhookSubscriptionRotateSecretResponse,
+  WebhookSubscriptionTestPingResponse,
+} from '@granit/webhooks';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
+
+/**
+ * Mutation hook to rotate the signing secret of a subscription.
+ *
+ * The new secret is returned once — store it securely.
+ * Invalidates the specific subscription query on success.
+ */
+export function useRotateSecret(
+  options: WebhooksOptions
+): UseMutationResult<WebhookSubscriptionRotateSecretResponse, Error, string> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => rotateSecret(client, basePath, id),
+    onSuccess: async (_data, id) => {
+      await queryClient.invalidateQueries({ queryKey: webhooksKeys.subscription(id) });
+    },
+  });
+}
+
+/**
+ * Mutation hook to send a test ping to a subscription's target URL.
+ */
+export function useTestPing(
+  options: WebhooksOptions
+): UseMutationResult<WebhookSubscriptionTestPingResponse, Error, string> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useMutation({
+    mutationFn: (id: string) => testPing(client, basePath, id),
+  });
+}

--- a/packages/@granit/react-webhooks/src/hooks/use-subscription.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-subscription.ts
@@ -1,0 +1,34 @@
+import { getSubscription, webhooksKeys } from '@granit/webhooks';
+import { useQuery } from '@tanstack/react-query';
+
+import type { WebhookSubscriptionResponse } from '@granit/webhooks';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+
+const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
+
+/** Options accepted by all webhook hooks. */
+export interface WebhooksOptions {
+  /** Axios instance used for all requests. */
+  readonly client: AxiosInstance;
+  /** Base URL for the webhooks API. Defaults to `/api/v1/webhooks/subscriptions`. */
+  readonly basePath?: string;
+}
+
+/**
+ * Query hook that fetches a single webhook subscription by ID.
+ *
+ * The query is disabled when `id` is empty.
+ */
+export function useSubscription(
+  id: string,
+  options: WebhooksOptions
+): UseQueryResult<WebhookSubscriptionResponse> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useQuery({
+    queryKey: webhooksKeys.subscription(id),
+    queryFn: () => getSubscription(client, basePath, id),
+    enabled: id.length > 0,
+  });
+}

--- a/packages/@granit/react-webhooks/src/hooks/use-webhook-stats.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-webhook-stats.ts
@@ -1,0 +1,22 @@
+import { getStats, webhooksKeys } from '@granit/webhooks';
+import { useQuery } from '@tanstack/react-query';
+
+import type { WebhooksOptions } from './use-subscription.js';
+import type { WebhookSubscriptionStatsResponse } from '@granit/webhooks';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
+
+/**
+ * Query hook that fetches aggregated webhook statistics.
+ */
+export function useWebhookStats(
+  options: WebhooksOptions
+): UseQueryResult<WebhookSubscriptionStatsResponse> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useQuery({
+    queryKey: webhooksKeys.stats(),
+    queryFn: () => getStats(client, basePath),
+  });
+}

--- a/packages/@granit/react-webhooks/src/index.ts
+++ b/packages/@granit/react-webhooks/src/index.ts
@@ -1,0 +1,18 @@
+// Hooks
+export { useSubscription } from './hooks/use-subscription.js';
+export {
+  useCreateSubscription,
+  useDeleteSubscription,
+  useUpdateSubscription,
+} from './hooks/use-subscription-mutations.js';
+export {
+  useActivateSubscription,
+  useDeactivateSubscription,
+  useSuspendSubscription,
+} from './hooks/use-subscription-lifecycle.js';
+export { useRotateSecret, useTestPing } from './hooks/use-subscription-operations.js';
+export { useDeliveries } from './hooks/use-deliveries.js';
+export { useWebhookStats } from './hooks/use-webhook-stats.js';
+
+// Types
+export type { WebhooksOptions } from './hooks/use-subscription.js';

--- a/packages/@granit/react-webhooks/tsconfig.json
+++ b/packages/@granit/react-webhooks/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
+++ b/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
@@ -1,0 +1,242 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  activateSubscription,
+  createSubscription,
+  deactivateSubscription,
+  deleteSubscription,
+  getDeliveries,
+  getStats,
+  getSubscription,
+  rotateSecret,
+  suspendSubscription,
+  testPing,
+  updateSubscription,
+} from '../api/webhooks-api.js';
+import { WebhookSubscriptionStatus } from '../types/index.js';
+
+import type {
+  WebhookDeliveryAttemptResponse,
+  WebhookSubscriptionCreatedResponse,
+  WebhookSubscriptionResponse,
+  WebhookSubscriptionRotateSecretResponse,
+  WebhookSubscriptionStatsResponse,
+  WebhookSubscriptionTestPingResponse,
+} from '../types/index.js';
+
+const BASE = '/api/v1/webhooks/subscriptions';
+
+const mockSubscription: WebhookSubscriptionResponse = {
+  id: 'sub-001',
+  targetUrl: 'https://example.com/webhook',
+  eventType: 'document.uploaded',
+  status: WebhookSubscriptionStatus.Active,
+  consecutiveFailureCount: 0,
+  lastSuccessAt: '2026-03-20T10:00:00Z',
+  createdAt: '2026-03-01T08:00:00Z',
+  modifiedAt: null,
+};
+
+describe('webhooks-api', () => {
+  // ── CRUD ────────────────────────────────────────────────────────────────
+
+  describe('getSubscription', () => {
+    it('sends GET to /{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockSubscription });
+
+      const result = await getSubscription(client, BASE, 'sub-001');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/sub-001`);
+      expect(result).toEqual(mockSubscription);
+    });
+
+    it('encodes subscription ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockSubscription });
+
+      await getSubscription(client, BASE, 'id/slash');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/id%2Fslash`);
+    });
+  });
+
+  describe('createSubscription', () => {
+    it('sends POST with request body', async () => {
+      const client = createMockClient();
+      const response: WebhookSubscriptionCreatedResponse = {
+        id: 'sub-002',
+        targetUrl: 'https://example.com/webhook',
+        eventType: 'document.uploaded',
+        status: WebhookSubscriptionStatus.Active,
+        signingSecret: 'whsec_abc123',
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await createSubscription(client, BASE, {
+        targetUrl: 'https://example.com/webhook',
+        eventType: 'document.uploaded',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(BASE, {
+        targetUrl: 'https://example.com/webhook',
+        eventType: 'document.uploaded',
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('updateSubscription', () => {
+    it('sends PUT to /{id} with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValueOnce({ data: mockSubscription });
+
+      const result = await updateSubscription(client, BASE, 'sub-001', {
+        targetUrl: 'https://example.com/v2/webhook',
+      });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/sub-001`, {
+        targetUrl: 'https://example.com/v2/webhook',
+      });
+      expect(result).toEqual(mockSubscription);
+    });
+  });
+
+  describe('deleteSubscription', () => {
+    it('sends DELETE to /{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteSubscription(client, BASE, 'sub-001');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/sub-001`);
+    });
+  });
+
+  // ── Lifecycle ─────────────────────────────────────────────────────────────
+
+  describe('activateSubscription', () => {
+    it('sends POST to /{id}/activate', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockSubscription });
+
+      const result = await activateSubscription(client, BASE, 'sub-001');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/sub-001/activate`);
+      expect(result).toEqual(mockSubscription);
+    });
+  });
+
+  describe('suspendSubscription', () => {
+    it('sends POST to /{id}/suspend', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockSubscription });
+
+      const result = await suspendSubscription(client, BASE, 'sub-001');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/sub-001/suspend`);
+      expect(result).toEqual(mockSubscription);
+    });
+  });
+
+  describe('deactivateSubscription', () => {
+    it('sends POST to /{id}/deactivate with reason', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockSubscription });
+
+      const result = await deactivateSubscription(client, BASE, 'sub-001', {
+        reason: 'No longer needed',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/sub-001/deactivate`, {
+        reason: 'No longer needed',
+      });
+      expect(result).toEqual(mockSubscription);
+    });
+  });
+
+  // ── Operations ────────────────────────────────────────────────────────────
+
+  describe('rotateSecret', () => {
+    it('sends POST to /{id}/rotate-secret', async () => {
+      const client = createMockClient();
+      const response: WebhookSubscriptionRotateSecretResponse = {
+        signingSecret: 'whsec_new456',
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await rotateSecret(client, BASE, 'sub-001');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/sub-001/rotate-secret`);
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('testPing', () => {
+    it('sends POST to /{id}/test-ping', async () => {
+      const client = createMockClient();
+      const response: WebhookSubscriptionTestPingResponse = {
+        success: true,
+        httpStatusCode: 200,
+        durationMs: 142,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await testPing(client, BASE, 'sub-001');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/sub-001/test-ping`);
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('getStats', () => {
+    it('sends GET to /stats', async () => {
+      const client = createMockClient();
+      const response: WebhookSubscriptionStatsResponse = {
+        totalSubscriptions: 10,
+        activeCount: 7,
+        suspendedCount: 2,
+        deactivatedCount: 1,
+        deliveriesLast24h: 523,
+        successRateLast24h: 99.2,
+        avgResponseTimeMsLast24h: 85,
+      };
+      vi.mocked(client.get).mockResolvedValueOnce({ data: response });
+
+      const result = await getStats(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/stats`);
+      expect(result).toEqual(response);
+    });
+  });
+
+  // ── Deliveries ────────────────────────────────────────────────────────────
+
+  describe('getDeliveries', () => {
+    it('sends GET to /{id}/deliveries', async () => {
+      const client = createMockClient();
+      const response: WebhookDeliveryAttemptResponse[] = [
+        {
+          deliveryId: 'del-001',
+          subscriptionId: 'sub-001',
+          tenantId: null,
+          eventType: 'document.uploaded',
+          targetUrl: 'https://example.com/webhook',
+          httpStatusCode: 200,
+          payloadHash: 'a'.repeat(64),
+          occurredAt: '2026-03-20T10:00:00Z',
+          durationMs: 142,
+          errorMessage: null,
+          isSuccess: true,
+        },
+      ];
+      vi.mocked(client.get).mockResolvedValueOnce({ data: response });
+
+      const result = await getDeliveries(client, BASE, 'sub-001');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/sub-001/deliveries`);
+      expect(result).toEqual(response);
+    });
+  });
+});

--- a/packages/@granit/webhooks/src/api/webhooks-api.ts
+++ b/packages/@granit/webhooks/src/api/webhooks-api.ts
@@ -1,0 +1,192 @@
+import type {
+  WebhookDeliveryAttemptResponse,
+  WebhookSubscriptionCreateRequest,
+  WebhookSubscriptionCreatedResponse,
+  WebhookSubscriptionDeactivateRequest,
+  WebhookSubscriptionResponse,
+  WebhookSubscriptionRotateSecretResponse,
+  WebhookSubscriptionStatsResponse,
+  WebhookSubscriptionTestPingResponse,
+  WebhookSubscriptionUpdateRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+// ── Subscription CRUD ───────────────────────────────────────────────────────
+
+/**
+ * Get a single webhook subscription by ID.
+ *
+ * `GET {basePath}/{id}`
+ */
+export async function getSubscription(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<WebhookSubscriptionResponse> {
+  const { data } = await client.get<WebhookSubscriptionResponse>(
+    `${basePath}/${encodeURIComponent(id)}`
+  );
+  return data;
+}
+
+/**
+ * Create a new webhook subscription.
+ *
+ * `POST {basePath}`
+ */
+export async function createSubscription(
+  client: AxiosInstance,
+  basePath: string,
+  request: WebhookSubscriptionCreateRequest
+): Promise<WebhookSubscriptionCreatedResponse> {
+  const { data } = await client.post<WebhookSubscriptionCreatedResponse>(basePath, request);
+  return data;
+}
+
+/**
+ * Update a webhook subscription's target URL.
+ *
+ * `PUT {basePath}/{id}`
+ */
+export async function updateSubscription(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: WebhookSubscriptionUpdateRequest
+): Promise<WebhookSubscriptionResponse> {
+  const { data } = await client.put<WebhookSubscriptionResponse>(
+    `${basePath}/${encodeURIComponent(id)}`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Delete a webhook subscription.
+ *
+ * `DELETE {basePath}/{id}`
+ */
+export async function deleteSubscription(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(`${basePath}/${encodeURIComponent(id)}`);
+}
+
+// ── Lifecycle transitions ───────────────────────────────────────────────────
+
+/**
+ * Activate a suspended webhook subscription.
+ *
+ * `POST {basePath}/{id}/activate`
+ */
+export async function activateSubscription(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<WebhookSubscriptionResponse> {
+  const { data } = await client.post<WebhookSubscriptionResponse>(
+    `${basePath}/${encodeURIComponent(id)}/activate`
+  );
+  return data;
+}
+
+/**
+ * Suspend a webhook subscription.
+ *
+ * `POST {basePath}/{id}/suspend`
+ */
+export async function suspendSubscription(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<WebhookSubscriptionResponse> {
+  const { data } = await client.post<WebhookSubscriptionResponse>(
+    `${basePath}/${encodeURIComponent(id)}/suspend`
+  );
+  return data;
+}
+
+/**
+ * Deactivate a webhook subscription permanently.
+ *
+ * `POST {basePath}/{id}/deactivate`
+ */
+export async function deactivateSubscription(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: WebhookSubscriptionDeactivateRequest
+): Promise<WebhookSubscriptionResponse> {
+  const { data } = await client.post<WebhookSubscriptionResponse>(
+    `${basePath}/${encodeURIComponent(id)}/deactivate`,
+    request
+  );
+  return data;
+}
+
+// ── Operations ──────────────────────────────────────────────────────────────
+
+/**
+ * Rotate the signing secret of a subscription. The new secret is returned once.
+ *
+ * `POST {basePath}/{id}/rotate-secret`
+ */
+export async function rotateSecret(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<WebhookSubscriptionRotateSecretResponse> {
+  const { data } = await client.post<WebhookSubscriptionRotateSecretResponse>(
+    `${basePath}/${encodeURIComponent(id)}/rotate-secret`
+  );
+  return data;
+}
+
+/**
+ * Send a test ping to a subscription's target URL.
+ *
+ * `POST {basePath}/{id}/test-ping`
+ */
+export async function testPing(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<WebhookSubscriptionTestPingResponse> {
+  const { data } = await client.post<WebhookSubscriptionTestPingResponse>(
+    `${basePath}/${encodeURIComponent(id)}/test-ping`
+  );
+  return data;
+}
+
+/**
+ * Get aggregated webhook statistics.
+ *
+ * `GET {basePath}/stats`
+ */
+export async function getStats(
+  client: AxiosInstance,
+  basePath: string
+): Promise<WebhookSubscriptionStatsResponse> {
+  const { data } = await client.get<WebhookSubscriptionStatsResponse>(`${basePath}/stats`);
+  return data;
+}
+
+// ── Delivery audit trail ────────────────────────────────────────────────────
+
+/**
+ * Get delivery attempts for a specific subscription.
+ *
+ * `GET {basePath}/{id}/deliveries`
+ */
+export async function getDeliveries(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<WebhookDeliveryAttemptResponse[]> {
+  const { data } = await client.get<WebhookDeliveryAttemptResponse[]>(
+    `${basePath}/${encodeURIComponent(id)}/deliveries`
+  );
+  return data;
+}

--- a/packages/@granit/webhooks/src/hooks/query-keys.ts
+++ b/packages/@granit/webhooks/src/hooks/query-keys.ts
@@ -1,0 +1,9 @@
+/** Query key factory for webhook queries. */
+export const webhooksKeys = {
+  all: ['webhooks'] as const,
+  subscriptions: () => [...webhooksKeys.all, 'subscriptions'] as const,
+  subscription: (id: string) => [...webhooksKeys.subscriptions(), id] as const,
+  deliveries: (subscriptionId: string) =>
+    [...webhooksKeys.subscription(subscriptionId), 'deliveries'] as const,
+  stats: () => [...webhooksKeys.all, 'stats'] as const,
+};

--- a/packages/@granit/webhooks/src/index.ts
+++ b/packages/@granit/webhooks/src/index.ts
@@ -1,2 +1,33 @@
-// @granit/webhooks — placeholder (package not yet implemented)
-export {};
+// Types
+export { WebhookSubscriptionStatus } from './types/index.js';
+
+export type {
+  WebhookDeliveryAttemptResponse,
+  WebhookSubscriptionCreateRequest,
+  WebhookSubscriptionCreatedResponse,
+  WebhookSubscriptionDeactivateRequest,
+  WebhookSubscriptionResponse,
+  WebhookSubscriptionRotateSecretResponse,
+  WebhookSubscriptionStatsResponse,
+  WebhookSubscriptionStatusValue,
+  WebhookSubscriptionTestPingResponse,
+  WebhookSubscriptionUpdateRequest,
+} from './types/index.js';
+
+// Query keys
+export { webhooksKeys } from './hooks/query-keys.js';
+
+// API
+export {
+  activateSubscription,
+  createSubscription,
+  deactivateSubscription,
+  deleteSubscription,
+  getDeliveries,
+  getStats,
+  getSubscription,
+  rotateSecret,
+  suspendSubscription,
+  testPing,
+  updateSubscription,
+} from './api/webhooks-api.js';

--- a/packages/@granit/webhooks/src/types/index.ts
+++ b/packages/@granit/webhooks/src/types/index.ts
@@ -1,0 +1,98 @@
+// ---------------------------------------------------------------------------
+// Webhook types — mirrors Granit.Webhooks .NET contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Webhook subscription lifecycle status.
+ *
+ * Mirrors `Granit.Webhooks.Domain.WebhookSubscriptionStatus` (.NET).
+ */
+export const WebhookSubscriptionStatus = {
+  Active: 0,
+  Suspended: 1,
+  Deactivated: 2,
+} as const;
+
+export type WebhookSubscriptionStatusValue =
+  (typeof WebhookSubscriptionStatus)[keyof typeof WebhookSubscriptionStatus];
+
+// ── Subscription requests ───────────────────────────────────────────────────
+
+/** Request body for `POST /subscriptions`. */
+export interface WebhookSubscriptionCreateRequest {
+  readonly targetUrl: string;
+  readonly eventType: string;
+}
+
+/** Request body for `PUT /subscriptions/{id}`. */
+export interface WebhookSubscriptionUpdateRequest {
+  readonly targetUrl: string;
+}
+
+/** Request body for `POST /subscriptions/{id}/deactivate`. */
+export interface WebhookSubscriptionDeactivateRequest {
+  readonly reason: string;
+}
+
+// ── Subscription responses ──────────────────────────────────────────────────
+
+/** Subscription descriptor returned by most endpoints. */
+export interface WebhookSubscriptionResponse {
+  readonly id: string;
+  readonly targetUrl: string;
+  readonly eventType: string;
+  readonly status: WebhookSubscriptionStatusValue;
+  readonly consecutiveFailureCount: number;
+  readonly lastSuccessAt: string | null;
+  readonly createdAt: string;
+  readonly modifiedAt: string | null;
+}
+
+/** Response from `POST /subscriptions` (201 Created). Contains the signing secret (shown once). */
+export interface WebhookSubscriptionCreatedResponse {
+  readonly id: string;
+  readonly targetUrl: string;
+  readonly eventType: string;
+  readonly status: WebhookSubscriptionStatusValue;
+  readonly signingSecret: string;
+}
+
+/** Response from `POST /subscriptions/{id}/rotate-secret`. */
+export interface WebhookSubscriptionRotateSecretResponse {
+  readonly signingSecret: string;
+}
+
+/** Response from `POST /subscriptions/{id}/test-ping`. */
+export interface WebhookSubscriptionTestPingResponse {
+  readonly success: boolean;
+  readonly httpStatusCode: number;
+  readonly durationMs: number;
+}
+
+/** Response from `GET /stats`. */
+export interface WebhookSubscriptionStatsResponse {
+  readonly totalSubscriptions: number;
+  readonly activeCount: number;
+  readonly suspendedCount: number;
+  readonly deactivatedCount: number;
+  readonly deliveriesLast24h: number;
+  readonly successRateLast24h: number;
+  readonly avgResponseTimeMsLast24h: number;
+}
+
+// ── Delivery audit trail ────────────────────────────────────────────────────
+
+/** Immutable delivery attempt record (ISO 27001 audit trail). */
+export interface WebhookDeliveryAttemptResponse {
+  readonly deliveryId: string;
+  readonly subscriptionId: string;
+  readonly tenantId: string | null;
+  readonly eventType: string;
+  readonly targetUrl: string;
+  readonly httpStatusCode: number | null;
+  readonly payloadHash: string;
+  readonly occurredAt: string;
+  readonly durationMs: number;
+  readonly errorMessage: string | null;
+  readonly isSuccess: boolean;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -909,6 +909,28 @@ importers:
         specifier: ^19.0.0
         version: 19.2.4
 
+  packages/@granit/react-webhooks:
+    dependencies:
+      '@granit/webhooks':
+        specifier: workspace:*
+        version: link:../webhooks
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-workflow:
     dependencies:
       '@granit/workflow':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -185,6 +185,11 @@ export default defineConfig({
       '@granit/timeline': path.resolve(__dirname, 'packages/@granit/timeline/src/index.ts'),
       '@granit/tracing': path.resolve(__dirname, 'packages/@granit/tracing/src/index.ts'),
       '@granit/utils': path.resolve(__dirname, 'packages/@granit/utils/src/index.ts'),
+      '@granit/webhooks': path.resolve(__dirname, 'packages/@granit/webhooks/src/index.ts'),
+      '@granit/react-webhooks': path.resolve(
+        __dirname,
+        'packages/@granit/react-webhooks/src/index.ts'
+      ),
       '@granit/workflow': path.resolve(__dirname, 'packages/@granit/workflow/src/index.ts'),
     },
   },


### PR DESCRIPTION
## Summary

- Add `@granit/webhooks` — types, 11 API functions (CRUD, lifecycle, rotate-secret, test-ping, stats, deliveries), query key factory mirroring `Granit.Webhooks` .NET contract
- Add `@granit/react-webhooks` — 12 React hooks wrapping the API with TanStack React Query
- All 19/19 `.Endpoints` modules from `granit-dotnet` now have their TypeScript counterpart

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `pnpm test` — 138 files, 1159 tests passed
- [x] `markdownlint` on CLAUDE.md — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)