### PR TITLE
fix: add missing tsup.config.ts for blob-storage and webhooks packages

### DIFF
--- a/packages/@granit/blob-storage/tsup.config.ts
+++ b/packages/@granit/blob-storage/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/react-blob-storage/tsup.config.ts
+++ b/packages/@granit/react-blob-storage/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//, /^react/, /^@tanstack\//],
+});

--- a/packages/@granit/react-webhooks/tsup.config.ts
+++ b/packages/@granit/react-webhooks/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//, /^react/, /^@tanstack\//],
+});

--- a/packages/@granit/webhooks/tsup.config.ts
+++ b/packages/@granit/webhooks/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});


### PR DESCRIPTION
## Summary

- Add `tsup.config.ts` to `@granit/blob-storage`, `@granit/react-blob-storage`, `@granit/webhooks`, and `@granit/react-webhooks`
- These packages had `"build": "tsup"` in package.json but no tsup config file, causing CI build failures

## Test plan

- [x] `pnpm --filter @granit/blob-storage build` passes
- [x] `pnpm --filter @granit/react-blob-storage build` passes
- [x] `pnpm --filter @granit/webhooks build` passes
- [x] `pnpm --filter @granit/react-webhooks build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)