### PR TITLE
feat(workflow,querying): backend impact — workflow transitions + query validation

### DIFF
--- a/packages/@granit/querying/src/__tests__/query-param-serializer.test.ts
+++ b/packages/@granit/querying/src/__tests__/query-param-serializer.test.ts
@@ -84,6 +84,25 @@ describe('serializeQueryRequest', () => {
     expect(serializeQueryRequest({})).not.toContain('skipTotalCount');
   });
 
+  it('clamps page=0 to page=1 via validation', () => {
+    const result = serializeQueryRequest({ page: 0 });
+    const params = new URLSearchParams(result);
+    expect(params.get('page')).toBe('1');
+  });
+
+  it('clamps pageSize=1000 to pageSize=500 via validation', () => {
+    const result = serializeQueryRequest({ pageSize: 1000 });
+    const params = new URLSearchParams(result);
+    expect(params.get('pageSize')).toBe('500');
+  });
+
+  it('excludes page when both page and cursor are set (cursor wins)', () => {
+    const result = serializeQueryRequest({ page: 3, cursor: 'abc123' });
+    const params = new URLSearchParams(result);
+    expect(params.get('cursor')).toBe('abc123');
+    expect(params.has('page')).toBe(false);
+  });
+
   it('serializes a full query', () => {
     const params: QueryRequest = {
       page: 1,

--- a/packages/@granit/querying/src/__tests__/validate-query-request.test.ts
+++ b/packages/@granit/querying/src/__tests__/validate-query-request.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+
+import { QUERY_LIMITS } from '../validation/query-limits.js';
+import { validateQueryRequest } from '../validation/validate-query-request.js';
+
+import type { FilterEntry, QueryRequest } from '../types/query-params.js';
+
+describe('validateQueryRequest', () => {
+  it('returns params unchanged when all within limits', () => {
+    const params: QueryRequest = { page: 1, pageSize: 20, search: 'hello' };
+    expect(validateQueryRequest(params)).toEqual(params);
+  });
+
+  it('handles empty params', () => {
+    expect(validateQueryRequest({})).toEqual({});
+  });
+
+  it('clamps page to minimum 1', () => {
+    expect(validateQueryRequest({ page: 0 }).page).toBe(1);
+    expect(validateQueryRequest({ page: -5 }).page).toBe(1);
+    expect(validateQueryRequest({ page: 1 }).page).toBe(1);
+    expect(validateQueryRequest({ page: 100 }).page).toBe(100);
+  });
+
+  it('clamps pageSize to [1, 500]', () => {
+    expect(validateQueryRequest({ pageSize: 0 }).pageSize).toBe(1);
+    expect(validateQueryRequest({ pageSize: -1 }).pageSize).toBe(1);
+    expect(validateQueryRequest({ pageSize: 1000 }).pageSize).toBe(500);
+    expect(validateQueryRequest({ pageSize: 250 }).pageSize).toBe(250);
+  });
+
+  it('truncates search to 500 characters', () => {
+    const longSearch = 'a'.repeat(600);
+    const result = validateQueryRequest({ search: longSearch });
+    expect(result.search).toHaveLength(QUERY_LIMITS.SEARCH_MAX_LENGTH);
+  });
+
+  it('truncates cursor to 2000 characters', () => {
+    const longCursor = 'x'.repeat(3000);
+    const result = validateQueryRequest({ cursor: longCursor });
+    expect(result.cursor).toHaveLength(QUERY_LIMITS.CURSOR_MAX_LENGTH);
+  });
+
+  it('truncates groupBy to 200 characters', () => {
+    const longGroupBy = 'g'.repeat(300);
+    const result = validateQueryRequest({ groupBy: longGroupBy });
+    expect(result.groupBy).toHaveLength(QUERY_LIMITS.GROUP_BY_MAX_LENGTH);
+  });
+
+  it('slices filters to max 50 entries', () => {
+    const filters: FilterEntry[] = Array.from({ length: 60 }, (_, i) => ({
+      field: `field${i}`,
+      operator: 'Eq' as const,
+      value: `val${i}`,
+    }));
+    const result = validateQueryRequest({ filters });
+    expect(result.filters).toHaveLength(QUERY_LIMITS.FILTERS_MAX_COUNT);
+  });
+
+  it('slices quickFilters to max 20 entries', () => {
+    const quickFilters = Array.from({ length: 25 }, (_, i) => `filter${i}`);
+    const result = validateQueryRequest({ quickFilters });
+    expect(result.quickFilters).toHaveLength(QUERY_LIMITS.QUICK_FILTERS_MAX_COUNT);
+  });
+
+  it('slices presets to max 20 entries', () => {
+    const presets: Record<string, string[]> = {};
+    for (let i = 0; i < 25; i++) {
+      presets[`group${i}`] = [`preset${i}`];
+    }
+    const result = validateQueryRequest({ presets });
+    expect(Object.keys(result.presets!)).toHaveLength(QUERY_LIMITS.PRESETS_MAX_ENTRIES);
+  });
+
+  it('drops trailing sort entries when serialized length exceeds 500', () => {
+    const sort = Array.from({ length: 100 }, (_, i) => ({
+      field: `veryLongFieldNameForTesting${i}`,
+      direction: 'asc' as const,
+    }));
+    const result = validateQueryRequest({ sort });
+    const serialized = result
+      .sort!.map((s) => (s.direction === 'desc' ? `-${s.field}` : s.field))
+      .join(',');
+    expect(serialized.length).toBeLessThanOrEqual(QUERY_LIMITS.SORT_MAX_LENGTH);
+    expect(result.sort!.length).toBeLessThan(sort.length);
+  });
+
+  it('keeps sort unchanged when within limit', () => {
+    const sort = [
+      { field: 'createdAt', direction: 'desc' as const },
+      { field: 'name', direction: 'asc' as const },
+    ];
+    const result = validateQueryRequest({ sort });
+    expect(result.sort).toEqual(sort);
+  });
+
+  it('removes page when cursor is also set (cursor wins)', () => {
+    const result = validateQueryRequest({ page: 3, cursor: 'abc' });
+    expect(result.page).toBeUndefined();
+    expect(result.cursor).toBe('abc');
+  });
+
+  it('preserves page when cursor is not set', () => {
+    const result = validateQueryRequest({ page: 5 });
+    expect(result.page).toBe(5);
+  });
+
+  it('preserves cursor when page is not set', () => {
+    const result = validateQueryRequest({ cursor: 'abc' });
+    expect(result.cursor).toBe('abc');
+    expect(result.page).toBeUndefined();
+  });
+
+  it('does not modify arrays within limits', () => {
+    const filters: FilterEntry[] = [{ field: 'status', operator: 'Eq', value: 'active' }];
+    const result = validateQueryRequest({ filters });
+    expect(result.filters).toEqual(filters);
+  });
+});

--- a/packages/@granit/querying/src/api/query-param-serializer.ts
+++ b/packages/@granit/querying/src/api/query-param-serializer.ts
@@ -2,6 +2,8 @@
 // Query param serializer — QueryRequest → URL search string
 // ---------------------------------------------------------------------------
 
+import { validateQueryRequest } from '../validation/validate-query-request.js';
+
 import type { QueryRequest } from '../types/query-params.js';
 
 /**
@@ -55,10 +57,11 @@ function serializeSortAndPresets(entries: [string, string][], params: QueryReque
 }
 
 export function serializeQueryRequest(params: QueryRequest): string {
+  const validated = validateQueryRequest(params);
   const entries: [string, string][] = [];
-  serializeScalarParams(entries, params);
-  serializeFilters(entries, params);
-  serializeSortAndPresets(entries, params);
+  serializeScalarParams(entries, validated);
+  serializeFilters(entries, validated);
+  serializeSortAndPresets(entries, validated);
   return new URLSearchParams(entries).toString();
 }
 

--- a/packages/@granit/querying/src/index.ts
+++ b/packages/@granit/querying/src/index.ts
@@ -49,6 +49,10 @@ export {
   inferOperators,
 } from './utils/filter-operators.js';
 
+// Validation
+export { QUERY_LIMITS } from './validation/query-limits.js';
+export { validateQueryRequest } from './validation/validate-query-request.js';
+
 // API
 export { fetchGrouped, fetchPage, fetchQueryMeta } from './api/query-api.js';
 export { parseQueryRequest, serializeQueryRequest } from './api/query-param-serializer.js';

--- a/packages/@granit/querying/src/validation/query-limits.ts
+++ b/packages/@granit/querying/src/validation/query-limits.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// Server-enforced validation limits for QueryRequest parameters
+// ---------------------------------------------------------------------------
+
+/** Validation limits enforced by Granit Querying endpoints (422 on violation). */
+export const QUERY_LIMITS = {
+  PAGE_MIN: 1,
+  PAGE_SIZE_MIN: 1,
+  PAGE_SIZE_MAX: 500,
+  SEARCH_MAX_LENGTH: 500,
+  SORT_MAX_LENGTH: 500,
+  CURSOR_MAX_LENGTH: 2000,
+  GROUP_BY_MAX_LENGTH: 200,
+  FILTERS_MAX_COUNT: 50,
+  QUICK_FILTERS_MAX_COUNT: 20,
+  PRESETS_MAX_ENTRIES: 20,
+} as const;

--- a/packages/@granit/querying/src/validation/validate-query-request.ts
+++ b/packages/@granit/querying/src/validation/validate-query-request.ts
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------
+// QueryRequest validation — clamp/truncate to server-enforced limits
+// ---------------------------------------------------------------------------
+
+import { QUERY_LIMITS } from './query-limits.js';
+
+import type { QueryRequest, SortEntry } from '../types/query-params.js';
+
+/**
+ * Serialize sort entries to the comma-separated format used by the backend.
+ * Duplicated from the serializer to avoid circular imports.
+ */
+function serializeSortString(sort: readonly SortEntry[]): string {
+  return sort.map((s) => (s.direction === 'desc' ? `-${s.field}` : s.field)).join(',');
+}
+
+/**
+ * Validate and clamp a QueryRequest to server-enforced limits.
+ *
+ * - Clamps page >= 1, pageSize to [1, 500]
+ * - Truncates search, cursor, groupBy to max length
+ * - Slices filters, quickFilters to max count
+ * - Keeps first 20 preset entries
+ * - Drops trailing sort entries when serialized length exceeds 500
+ * - Enforces page/cursor mutual exclusion: cursor wins when both are set
+ */
+export function validateQueryRequest(params: QueryRequest): QueryRequest {
+  const result: Record<string, unknown> = { ...params };
+
+  // Page / cursor mutual exclusion — cursor wins
+  if (params.cursor && params.page != null) {
+    delete result.page;
+  }
+
+  // Page clamping
+  if (result.page != null) {
+    result.page = Math.max(QUERY_LIMITS.PAGE_MIN, result.page as number);
+  }
+
+  // PageSize clamping
+  if (params.pageSize != null) {
+    result.pageSize = Math.min(
+      QUERY_LIMITS.PAGE_SIZE_MAX,
+      Math.max(QUERY_LIMITS.PAGE_SIZE_MIN, params.pageSize)
+    );
+  }
+
+  // String truncation
+  if (params.search) {
+    result.search = params.search.slice(0, QUERY_LIMITS.SEARCH_MAX_LENGTH);
+  }
+  if (params.cursor) {
+    result.cursor = params.cursor.slice(0, QUERY_LIMITS.CURSOR_MAX_LENGTH);
+  }
+  if (params.groupBy) {
+    result.groupBy = params.groupBy.slice(0, QUERY_LIMITS.GROUP_BY_MAX_LENGTH);
+  }
+
+  // Array slicing
+  if (params.filters && params.filters.length > QUERY_LIMITS.FILTERS_MAX_COUNT) {
+    result.filters = params.filters.slice(0, QUERY_LIMITS.FILTERS_MAX_COUNT);
+  }
+  if (params.quickFilters && params.quickFilters.length > QUERY_LIMITS.QUICK_FILTERS_MAX_COUNT) {
+    result.quickFilters = params.quickFilters.slice(0, QUERY_LIMITS.QUICK_FILTERS_MAX_COUNT);
+  }
+
+  // Presets: keep first N entries
+  if (params.presets) {
+    const entries = Object.entries(params.presets);
+    if (entries.length > QUERY_LIMITS.PRESETS_MAX_ENTRIES) {
+      result.presets = Object.fromEntries(entries.slice(0, QUERY_LIMITS.PRESETS_MAX_ENTRIES));
+    }
+  }
+
+  // Sort: drop trailing entries until serialized length fits
+  if (params.sort && params.sort.length > 0) {
+    let sort = [...params.sort];
+    while (sort.length > 0 && serializeSortString(sort).length > QUERY_LIMITS.SORT_MAX_LENGTH) {
+      sort = sort.slice(0, -1);
+    }
+    result.sort = sort;
+  }
+
+  return result as QueryRequest;
+}

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
@@ -46,6 +46,57 @@ export interface UseBlobUploadReturn {
   readonly reset: () => void;
 }
 
+interface XhrUploadParams {
+  readonly url: string;
+  readonly method: string;
+  readonly headers: Record<string, string>;
+  readonly body: File;
+  readonly onProgress?: (percent: number) => void;
+}
+
+function uploadViaXhr(
+  params: XhrUploadParams,
+  abortRef: React.RefObject<XMLHttpRequest | null>
+): Promise<void> {
+  const { url, method, headers, body, onProgress } = params;
+
+  return new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    abortRef.current = xhr;
+
+    xhr.upload.addEventListener('progress', (event) => {
+      if (event.lengthComputable) {
+        onProgress?.(Math.round((event.loaded / event.total) * 100));
+      }
+    });
+
+    xhr.addEventListener('load', () => {
+      abortRef.current = null;
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve();
+      } else {
+        reject(new Error(`Upload failed with status ${xhr.status}`));
+      }
+    });
+
+    xhr.addEventListener('error', () => {
+      abortRef.current = null;
+      reject(new Error('Upload failed: network error'));
+    });
+
+    xhr.addEventListener('abort', () => {
+      abortRef.current = null;
+      reject(new Error('Upload aborted'));
+    });
+
+    xhr.open(method, url);
+    for (const [key, value] of Object.entries(headers)) {
+      xhr.setRequestHeader(key, value);
+    }
+    xhr.send(body);
+  });
+}
+
 const IDLE_STATE: BlobUploadState = {
   phase: 'idle',
   progress: 0,
@@ -112,45 +163,19 @@ export function useBlobUpload(options: BlobStorageOptions): UseBlobUploadReturn 
         setState((prev) => ({ ...prev, phase: 'uploading', blobId: ticket.blobId }));
 
         // Step 2: Upload file to pre-signed URL via XMLHttpRequest (for progress)
-        await new Promise<void>((resolve, reject) => {
-          const xhr = new XMLHttpRequest();
-          abortRef.current = xhr;
-
-          xhr.upload.addEventListener('progress', (event) => {
-            if (event.lengthComputable) {
-              const percent = Math.round((event.loaded / event.total) * 100);
+        await uploadViaXhr(
+          {
+            url: ticket.uploadUrl,
+            method: ticket.httpMethod,
+            headers: ticket.requiredHeaders,
+            body: file,
+            onProgress: (percent) => {
               setState((prev) => ({ ...prev, progress: percent }));
               onProgress?.(percent);
-            }
-          });
-
-          xhr.addEventListener('load', () => {
-            abortRef.current = null;
-            if (xhr.status >= 200 && xhr.status < 300) {
-              resolve();
-            } else {
-              reject(new Error(`Upload failed with status ${xhr.status}`));
-            }
-          });
-
-          xhr.addEventListener('error', () => {
-            abortRef.current = null;
-            reject(new Error('Upload failed: network error'));
-          });
-
-          xhr.addEventListener('abort', () => {
-            abortRef.current = null;
-            reject(new Error('Upload aborted'));
-          });
-
-          xhr.open(ticket.httpMethod, ticket.uploadUrl);
-
-          for (const [key, value] of Object.entries(ticket.requiredHeaders)) {
-            xhr.setRequestHeader(key, value);
-          }
-
-          xhr.send(file);
-        });
+            },
+          },
+          abortRef
+        );
 
         // Step 3: Confirm upload
         setState((prev) => ({ ...prev, phase: 'confirming', progress: 100 }));

--- a/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useOptimistic, useRef, useState, useTransition 
 import { useNotificationContext } from '../providers/notification-provider.js';
 
 import type { NotificationChannel, NotificationPreferenceDto } from '@granit/notifications';
+import type { AxiosInstance } from 'axios';
 
 export interface UseNotificationPreferencesReturn {
   preferences: NotificationPreferenceDto[];
@@ -18,6 +19,31 @@ type OptimisticAction = {
   notificationType: string;
   updated: NotificationPreferenceDto;
 };
+
+async function savePreference(
+  apiClient: AxiosInstance,
+  basePath: string,
+  notificationType: string,
+  updated: NotificationPreferenceDto,
+  mountedRef: React.RefObject<boolean>,
+  setPreferences: React.Dispatch<React.SetStateAction<NotificationPreferenceDto[]>>,
+  setError: React.Dispatch<React.SetStateAction<Error | null>>
+): Promise<void> {
+  try {
+    const saved = await updatePreference(apiClient, basePath, updated);
+    if (mountedRef.current) {
+      setPreferences((prev) =>
+        prev.map((p) => (p.notificationType === notificationType ? saved : p))
+      );
+    }
+  } catch (err) {
+    // No manual rollback — useOptimistic reverts automatically when the
+    // transition ends and setPreferences was not called with a new value.
+    if (mountedRef.current) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+}
 
 /**
  * CRUD hook for notification preferences (type x channel matrix).
@@ -78,21 +104,15 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
 
       startTransition(async () => {
         applyOptimistic({ notificationType, updated });
-
-        try {
-          const saved = await updatePreference(config.apiClient, basePath, updated);
-          if (mountedRef.current) {
-            setPreferences((prev) =>
-              prev.map((p) => (p.notificationType === notificationType ? saved : p))
-            );
-          }
-        } catch (err) {
-          // No manual rollback — useOptimistic reverts automatically when the
-          // transition ends and setPreferences was not called with a new value.
-          if (mountedRef.current) {
-            setError(err instanceof Error ? err : new Error(String(err)));
-          }
-        }
+        await savePreference(
+          config.apiClient,
+          basePath,
+          notificationType,
+          updated,
+          mountedRef,
+          setPreferences,
+          setError
+        );
       });
     },
     [config.apiClient, basePath, preferences, applyOptimistic]

--- a/packages/@granit/react-workflow/src/__tests__/use-execute-transition.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-execute-transition.test.ts
@@ -1,0 +1,139 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useExecuteTransition } from '../hooks/use-execute-transition.js';
+
+import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
+
+import type { TransitionResultDto } from '@granit/workflow';
+
+describe('useExecuteTransition', () => {
+  it('should execute a transition successfully', async () => {
+    const client = createMockClient();
+    const transitionResult: TransitionResultDto = {
+      succeeded: true,
+      resultingState: 'Published',
+      outcome: 'Completed',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(transitionResult));
+    const onSuccess = vi.fn();
+
+    const { result } = renderHook(() => useExecuteTransition({ onSuccess }), {
+      wrapper: createWrapper(client),
+    });
+
+    let returned: TransitionResultDto | null = null;
+    await act(async () => {
+      returned = await result.current.transition('Draft', 'Published', 'Approved');
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/workflow/transitions',
+      { targetState: 'Published', comment: 'Approved' },
+      { params: { currentState: 'Draft' } }
+    );
+    expect(returned).toEqual(transitionResult);
+    expect(result.current.result).toEqual(transitionResult);
+    expect(onSuccess).toHaveBeenCalledWith(transitionResult);
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should handle transition error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Forbidden'));
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useExecuteTransition({ onError }), {
+      wrapper: createWrapper(client),
+    });
+
+    let returned: TransitionResultDto | null = null;
+    await act(async () => {
+      returned = await result.current.transition('Draft', 'Published');
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error?.message).toBe('Forbidden');
+    expect(onError).toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should set loading state during transition', async () => {
+    const client = createMockClient();
+    let resolvePost!: (value: unknown) => void;
+    vi.mocked(client.post).mockReturnValue(
+      new Promise((resolve) => {
+        resolvePost = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useExecuteTransition(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.loading).toBe(false);
+
+    let promise: Promise<unknown>;
+    act(() => {
+      promise = result.current.transition('Draft', 'Published');
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(true));
+
+    await act(async () => {
+      resolvePost(
+        axiosResponse({
+          succeeded: true,
+          resultingState: 'Published',
+          outcome: 'Completed',
+        })
+      );
+      await promise!;
+    });
+
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should wrap non-Error thrown values', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue('string error');
+    const onError = vi.fn();
+
+    const { result } = renderHook(() => useExecuteTransition({ onError }), {
+      wrapper: createWrapper(client),
+    });
+
+    let returned: TransitionResultDto | null = null;
+    await act(async () => {
+      returned = await result.current.transition('Draft', 'Published');
+    });
+
+    expect(returned).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('string error');
+    expect(onError).toHaveBeenCalledWith(expect.any(Error));
+    expect(result.current.loading).toBe(false);
+  });
+
+  it('should handle approval-requested outcome', async () => {
+    const client = createMockClient();
+    const transitionResult: TransitionResultDto = {
+      succeeded: true,
+      resultingState: 'PendingReview',
+      outcome: 'ApprovalRequested',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(transitionResult));
+
+    const { result } = renderHook(() => useExecuteTransition(), {
+      wrapper: createWrapper(client),
+    });
+
+    let returned: TransitionResultDto | null = null;
+    await act(async () => {
+      returned = await result.current.transition('Draft', 'Published');
+    });
+
+    expect(returned!.outcome).toBe('ApprovalRequested');
+    expect(returned!.resultingState).toBe('PendingReview');
+  });
+});

--- a/packages/@granit/react-workflow/src/__tests__/use-transitions.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-transitions.test.ts
@@ -1,0 +1,144 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useTransitions } from '../hooks/use-transitions.js';
+
+import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
+
+import type { WorkflowStatusDto } from '@granit/workflow';
+
+describe('useTransitions', () => {
+  it('should load transitions on mount', async () => {
+    const client = createMockClient();
+    const status: WorkflowStatusDto = {
+      currentState: 'Draft',
+      availableTransitions: [
+        { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
+        { targetState: 'Archived', name: 'Archiver', allowed: false, requiresApproval: true },
+      ],
+    };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(status));
+
+    const { result } = renderHook(() => useTransitions({ currentState: 'Draft' }), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.transitions).toHaveLength(2);
+    expect(result.current.transitions[0].name).toBe('Publier');
+    expect(result.current.transitions[1].requiresApproval).toBe(true);
+  });
+
+  it('should set error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useTransitions({ currentState: 'Draft' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.transitions).toHaveLength(0);
+  });
+
+  it('should wrap non-Error thrown values', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue('string error');
+
+    const { result } = renderHook(() => useTransitions({ currentState: 'Draft' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBe('string error');
+  });
+
+  it('should discard results when unmounted during fetch', async () => {
+    const client = createMockClient();
+    let resolveGet!: (value: unknown) => void;
+    vi.mocked(client.get).mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      })
+    );
+
+    const { result, unmount } = renderHook(() => useTransitions({ currentState: 'Draft' }), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.loading).toBe(true);
+
+    unmount();
+
+    await act(async () => {
+      resolveGet(
+        axiosResponse({
+          currentState: 'Draft',
+          availableTransitions: [],
+        })
+      );
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('should discard errors when unmounted during fetch', async () => {
+    const client = createMockClient();
+    let rejectGet!: (reason: unknown) => void;
+    vi.mocked(client.get).mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectGet = reject;
+      })
+    );
+
+    const { unmount } = renderHook(() => useTransitions({ currentState: 'Draft' }), {
+      wrapper: createWrapper(client),
+    });
+
+    unmount();
+
+    await act(async () => {
+      rejectGet(new Error('Late error'));
+    });
+
+    expect(true).toBe(true);
+  });
+
+  it('should refetch when refetch is called', async () => {
+    const client = createMockClient();
+    const status1: WorkflowStatusDto = {
+      currentState: 'Draft',
+      availableTransitions: [
+        { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
+      ],
+    };
+    const status2: WorkflowStatusDto = {
+      currentState: 'Draft',
+      availableTransitions: [
+        { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
+        { targetState: 'Archived', name: 'Archiver', allowed: true, requiresApproval: false },
+      ],
+    };
+    vi.mocked(client.get)
+      .mockResolvedValueOnce(axiosResponse(status1))
+      .mockResolvedValueOnce(axiosResponse(status2));
+
+    const { result } = renderHook(() => useTransitions({ currentState: 'Draft' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.transitions).toHaveLength(1);
+
+    await result.current.refetch();
+
+    await waitFor(() => expect(result.current.transitions).toHaveLength(2));
+  });
+});

--- a/packages/@granit/react-workflow/src/hooks/use-execute-transition.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-execute-transition.ts
@@ -1,0 +1,67 @@
+import { createLogger } from '@granit/logger';
+import { executeStateMachineTransition } from '@granit/workflow';
+import { useCallback, useState } from 'react';
+
+import { useWorkflowConfig } from '../providers/workflow-provider.js';
+
+import type { TransitionResultDto } from '@granit/workflow';
+
+const logger = createLogger('workflow:execute-transition');
+
+export interface UseExecuteTransitionOptions {
+  onSuccess?: (result: TransitionResultDto) => void;
+  onError?: (error: Error) => void;
+}
+
+export interface UseExecuteTransitionReturn {
+  transition: (
+    currentState: string,
+    targetState: string,
+    comment?: string
+  ) => Promise<TransitionResultDto | null>;
+  loading: boolean;
+  result: TransitionResultDto | null;
+  error: Error | null;
+}
+
+export function useExecuteTransition(
+  options?: UseExecuteTransitionOptions
+): UseExecuteTransitionReturn {
+  const { apiClient, basePath } = useWorkflowConfig();
+
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<TransitionResultDto | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+
+  const transition = useCallback(
+    async (
+      currentState: string,
+      targetState: string,
+      comment?: string
+    ): Promise<TransitionResultDto | null> => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const data = await executeStateMachineTransition(apiClient, basePath, currentState, {
+          targetState,
+          comment,
+        });
+        setResult(data);
+        options?.onSuccess?.(data);
+        return data;
+      } catch (err) {
+        const wrapped = err instanceof Error ? err : new Error(String(err));
+        logger.error('Failed to execute transition', wrapped);
+        setError(wrapped);
+        options?.onError?.(wrapped);
+        return null;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [apiClient, basePath, options?.onSuccess, options?.onError]
+  );
+
+  return { transition, loading, result, error };
+}

--- a/packages/@granit/react-workflow/src/hooks/use-transitions.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-transitions.ts
@@ -1,0 +1,66 @@
+import { createLogger } from '@granit/logger';
+import { fetchTransitions } from '@granit/workflow';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useWorkflowConfig } from '../providers/workflow-provider.js';
+
+import type { TransitionDto } from '@granit/workflow';
+
+const logger = createLogger('workflow:transitions');
+
+export interface UseTransitionsOptions {
+  currentState: string;
+}
+
+export interface UseTransitionsReturn {
+  transitions: TransitionDto[];
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export function useTransitions({ currentState }: UseTransitionsOptions): UseTransitionsReturn {
+  const { apiClient, basePath } = useWorkflowConfig();
+
+  const [transitions, setTransitions] = useState<TransitionDto[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const refetch = useCallback(async () => {
+    abortRef.current?.abort();
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const status = await fetchTransitions(apiClient, basePath, currentState);
+
+      if (!controller.signal.aborted) {
+        setTransitions(status.availableTransitions);
+      }
+    } catch (err) {
+      if (!controller.signal.aborted) {
+        const wrapped = err instanceof Error ? err : new Error(String(err));
+        logger.error('Failed to fetch transitions', wrapped);
+        setError(wrapped);
+      }
+    } finally {
+      if (!controller.signal.aborted) {
+        setLoading(false);
+      }
+    }
+  }, [apiClient, basePath, currentState]);
+
+  useEffect(() => {
+    refetch().catch(() => {});
+    return () => {
+      abortRef.current?.abort();
+    };
+  }, [refetch]);
+
+  return { transitions, loading, error, refetch };
+}

--- a/packages/@granit/react-workflow/src/index.ts
+++ b/packages/@granit/react-workflow/src/index.ts
@@ -7,6 +7,15 @@ export { useWorkflowConfig, WorkflowProvider } from './providers/workflow-provid
 export type { WorkflowProviderProps } from './providers/workflow-provider.js';
 
 // Hooks
+export { useExecuteTransition } from './hooks/use-execute-transition.js';
+export type {
+  UseExecuteTransitionOptions,
+  UseExecuteTransitionReturn,
+} from './hooks/use-execute-transition.js';
+
+export { useTransitions } from './hooks/use-transitions.js';
+export type { UseTransitionsOptions, UseTransitionsReturn } from './hooks/use-transitions.js';
+
 export { useWorkflowHistory } from './hooks/use-workflow-history.js';
 export type {
   UseWorkflowHistoryOptions,

--- a/packages/@granit/workflow/src/__tests__/api.test.ts
+++ b/packages/@granit/workflow/src/__tests__/api.test.ts
@@ -1,7 +1,13 @@
 import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 
-import { executeTransition, fetchHistory, fetchStatus } from '../api/workflow-api.js';
+import {
+  executeStateMachineTransition,
+  executeTransition,
+  fetchHistory,
+  fetchStatus,
+  fetchTransitions,
+} from '../api/workflow-api.js';
 
 import type {
   TransitionHistoryDto,
@@ -72,6 +78,47 @@ describe('workflow api', () => {
       params: {},
     });
     expect(result).toEqual({ items: historyItems, totalCount: 1, nextCursor: null });
+  });
+
+  it('should call GET with query param for fetchTransitions', async () => {
+    const client = createMockClient();
+    const status: WorkflowStatusDto = {
+      currentState: 'Draft',
+      availableTransitions: [
+        { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
+        { targetState: 'Archived', name: 'Archiver', allowed: false, requiresApproval: true },
+      ],
+    };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(status));
+
+    const result = await fetchTransitions(client, basePath, 'Draft');
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/workflow/transitions', {
+      params: { currentState: 'Draft' },
+    });
+    expect(result).toEqual(status);
+  });
+
+  it('should call POST with query param and body for executeStateMachineTransition', async () => {
+    const client = createMockClient();
+    const transitionResult: TransitionResultDto = {
+      succeeded: true,
+      resultingState: 'Published',
+      outcome: 'Completed',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(transitionResult));
+
+    const result = await executeStateMachineTransition(client, basePath, 'Draft', {
+      targetState: 'Published',
+      comment: 'Approved by medical director.',
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/workflow/transitions',
+      { targetState: 'Published', comment: 'Approved by medical director.' },
+      { params: { currentState: 'Draft' } }
+    );
+    expect(result).toEqual(transitionResult);
   });
 
   it('should pass pagination params to fetchHistory when provided', async () => {

--- a/packages/@granit/workflow/src/api/workflow-api.ts
+++ b/packages/@granit/workflow/src/api/workflow-api.ts
@@ -45,6 +45,31 @@ export async function executeTransition(
   return data;
 }
 
+/** Fetch available transitions for a given state (state-machine level, no entity context). */
+export async function fetchTransitions(
+  client: AxiosInstance,
+  basePath: string,
+  currentState: string
+): Promise<WorkflowStatusDto> {
+  const { data } = await client.get<WorkflowStatusDto>(`${basePath}/transitions`, {
+    params: { currentState },
+  });
+  return data;
+}
+
+/** Execute a state-machine transition (no entity context). */
+export async function executeStateMachineTransition(
+  client: AxiosInstance,
+  basePath: string,
+  currentState: string,
+  request: TransitionRequestDto
+): Promise<TransitionResultDto> {
+  const { data } = await client.post<TransitionResultDto>(`${basePath}/transitions`, request, {
+    params: { currentState },
+  });
+  return data;
+}
+
 /** Response shape for the paginated workflow history endpoint. */
 export type WorkflowHistoryPage = PagedResult<TransitionHistoryDto>;
 

--- a/packages/@granit/workflow/src/index.ts
+++ b/packages/@granit/workflow/src/index.ts
@@ -18,5 +18,11 @@ export type {
 } from './types/index.js';
 
 // API
-export { executeTransition, fetchHistory, fetchStatus } from './api/workflow-api.js';
+export {
+  executeStateMachineTransition,
+  executeTransition,
+  fetchHistory,
+  fetchStatus,
+  fetchTransitions,
+} from './api/workflow-api.js';
 export type { WorkflowHistoryPage } from './api/workflow-api.js';


### PR DESCRIPTION
## Summary

- **Workflow**: add `fetchTransitions` / `executeStateMachineTransition` API functions and `useTransitions` / `useExecuteTransition` React hooks for the new state-machine level transition endpoints (`GET/POST /transitions?currentState=`)
- **Querying**: add `QUERY_LIMITS` constants and `validateQueryRequest()` function integrated into `serializeQueryRequest` to prevent 422 rejections from new server-side validation (page ≥ 1, pageSize 1–500, search ≤ 500 chars, cursor/page mutual exclusion, etc.)
- **Refactor**: reduce nesting depth in `useBlobUpload` and `useNotificationPreferences` (SonarQube brain-overload)

## Test plan

- [x] `pnpm tsc` — passes
- [x] `pnpm lint` — passes (0 warnings)
- [x] `pnpm --filter @granit/workflow test` — passes (6 tests)
- [x] `pnpm --filter @granit/react-workflow test` — passes (new hook tests)
- [x] `pnpm --filter @granit/querying test` — passes (validation + serializer integration tests)
- [x] `pnpm --filter @granit/react-blob-storage test` — passes (14 test files)
- [x] `pnpm --filter @granit/react-notifications test` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)