### PR TITLE
feat(diagnostics): add @granit/diagnostics and @granit/react-diagnostics packages

### DIFF
--- a/packages/@granit/diagnostics/package.json
+++ b/packages/@granit/diagnostics/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@granit/diagnostics",
+  "description": "Monitoring health types and API — mirrors Granit.Diagnostics .NET contract",
+  "version": "0.3.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/diagnostics/src/__tests__/diagnostics-api.test.ts
+++ b/packages/@granit/diagnostics/src/__tests__/diagnostics-api.test.ts
@@ -1,0 +1,79 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_DIAGNOSTICS_BASE_PATH, fetchMonitoringHealth } from '../api/diagnostics-api.js';
+
+import type { MonitoringHealthResponse } from '../types/index.js';
+
+const BASE = DEFAULT_DIAGNOSTICS_BASE_PATH;
+
+const mockResponse: MonitoringHealthResponse = {
+  services: [
+    {
+      id: 'postgresql',
+      name: 'Postgresql',
+      status: 'healthy',
+      responseTimeMs: 5.2,
+      description: 'Primary database cluster',
+      tags: ['readiness', 'startup'],
+    },
+  ],
+  checkedAt: '2026-03-20T12:00:00+00:00',
+};
+
+describe('fetchMonitoringHealth', () => {
+  it('calls GET {basePath}/health', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockResponse });
+
+    const result = await fetchMonitoringHealth(client, BASE);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/health`);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it('returns all services from the response', async () => {
+    const client = createMockClient();
+    const multiService: MonitoringHealthResponse = {
+      services: [
+        {
+          id: 'postgresql',
+          name: 'Postgresql',
+          status: 'healthy',
+          responseTimeMs: 5.2,
+          description: 'Primary database cluster',
+          tags: ['readiness', 'startup'],
+        },
+        {
+          id: 'redis',
+          name: 'Redis',
+          status: 'degraded',
+          responseTimeMs: 120.5,
+          description: null,
+          tags: ['readiness'],
+        },
+      ],
+      checkedAt: '2026-03-20T12:00:00+00:00',
+    };
+    vi.mocked(client.get).mockResolvedValueOnce({ data: multiService });
+
+    const result = await fetchMonitoringHealth(client, BASE);
+    expect(result.services).toHaveLength(2);
+    expect(result.services[0].status).toBe('healthy');
+    expect(result.services[1].status).toBe('degraded');
+  });
+
+  it('uses a custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockResponse });
+
+    await fetchMonitoringHealth(client, '/api/v2/diagnostics');
+    expect(client.get).toHaveBeenCalledWith('/api/v2/diagnostics/health');
+  });
+
+  it('propagates errors from the client', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValueOnce(new Error('Forbidden'));
+
+    await expect(fetchMonitoringHealth(client, BASE)).rejects.toThrow('Forbidden');
+  });
+});

--- a/packages/@granit/diagnostics/src/__tests__/diagnostics-types.test.ts
+++ b/packages/@granit/diagnostics/src/__tests__/diagnostics-types.test.ts
@@ -1,0 +1,54 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { MonitoringHealthResponse, ServiceHealth, ServiceStatus } from '../index.js';
+
+describe('@granit/diagnostics types', () => {
+  describe('ServiceStatus', () => {
+    it('should be a union of health states', () => {
+      expectTypeOf<ServiceStatus>().toEqualTypeOf<'healthy' | 'degraded' | 'down'>();
+    });
+  });
+
+  describe('ServiceHealth', () => {
+    it('should have identification fields', () => {
+      expectTypeOf<ServiceHealth>().toHaveProperty('id');
+      expectTypeOf<ServiceHealth['id']>().toBeString();
+      expectTypeOf<ServiceHealth>().toHaveProperty('name');
+      expectTypeOf<ServiceHealth['name']>().toBeString();
+    });
+
+    it('should have status field', () => {
+      expectTypeOf<ServiceHealth>().toHaveProperty('status');
+      expectTypeOf<ServiceHealth['status']>().toEqualTypeOf<ServiceStatus>();
+    });
+
+    it('should have nullable responseTimeMs', () => {
+      expectTypeOf<ServiceHealth>().toHaveProperty('responseTimeMs');
+      expectTypeOf<ServiceHealth['responseTimeMs']>().toEqualTypeOf<number | null>();
+    });
+
+    it('should have nullable description', () => {
+      expectTypeOf<ServiceHealth>().toHaveProperty('description');
+      expectTypeOf<ServiceHealth['description']>().toEqualTypeOf<string | null>();
+    });
+
+    it('should have readonly tags array', () => {
+      expectTypeOf<ServiceHealth>().toHaveProperty('tags');
+      expectTypeOf<ServiceHealth['tags']>().toEqualTypeOf<readonly string[]>();
+    });
+  });
+
+  describe('MonitoringHealthResponse', () => {
+    it('should have readonly services array', () => {
+      expectTypeOf<MonitoringHealthResponse>().toHaveProperty('services');
+      expectTypeOf<MonitoringHealthResponse['services']>().toEqualTypeOf<
+        readonly ServiceHealth[]
+      >();
+    });
+
+    it('should have checkedAt timestamp', () => {
+      expectTypeOf<MonitoringHealthResponse>().toHaveProperty('checkedAt');
+      expectTypeOf<MonitoringHealthResponse['checkedAt']>().toBeString();
+    });
+  });
+});

--- a/packages/@granit/diagnostics/src/api/diagnostics-api.ts
+++ b/packages/@granit/diagnostics/src/api/diagnostics-api.ts
@@ -1,0 +1,18 @@
+import type { MonitoringHealthResponse } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/** Default base path for the diagnostics API. */
+export const DEFAULT_DIAGNOSTICS_BASE_PATH = '/api/granit/diagnostics';
+
+/**
+ * Fetch the monitoring health status of all registered services.
+ *
+ * `GET {basePath}/health`
+ */
+export async function fetchMonitoringHealth(
+  client: AxiosInstance,
+  basePath: string
+): Promise<MonitoringHealthResponse> {
+  const { data } = await client.get<MonitoringHealthResponse>(`${basePath}/health`);
+  return data;
+}

--- a/packages/@granit/diagnostics/src/index.ts
+++ b/packages/@granit/diagnostics/src/index.ts
@@ -1,0 +1,5 @@
+// Types
+export type { MonitoringHealthResponse, ServiceHealth, ServiceStatus } from './types/index.js';
+
+// API
+export { DEFAULT_DIAGNOSTICS_BASE_PATH, fetchMonitoringHealth } from './api/diagnostics-api.js';

--- a/packages/@granit/diagnostics/src/types/index.ts
+++ b/packages/@granit/diagnostics/src/types/index.ts
@@ -1,0 +1,19 @@
+/** Health status of an individual service check. */
+export type ServiceStatus = 'healthy' | 'degraded' | 'down';
+
+/** Health information for a single monitored service. */
+export interface ServiceHealth {
+  readonly id: string;
+  readonly name: string;
+  readonly status: ServiceStatus;
+  readonly responseTimeMs: number | null;
+  readonly description: string | null;
+  readonly tags: readonly string[];
+}
+
+/** Response from the monitoring health endpoint. */
+export interface MonitoringHealthResponse {
+  readonly services: readonly ServiceHealth[];
+  /** ISO 8601 timestamp of when the health check was performed. */
+  readonly checkedAt: string;
+}

--- a/packages/@granit/diagnostics/tsconfig.json
+++ b/packages/@granit/diagnostics/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/diagnostics/tsup.config.ts
+++ b/packages/@granit/diagnostics/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/react-diagnostics/package.json
+++ b/packages/@granit/react-diagnostics/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@granit/react-diagnostics",
+  "description": "React hooks for monitoring health — useMonitoringHealth",
+  "version": "0.3.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/diagnostics": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
+++ b/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
@@ -1,0 +1,100 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { diagnosticsKeys, useMonitoringHealth } from '../hooks/use-monitoring-health.js';
+
+import type { MonitoringHealthResponse } from '@granit/diagnostics';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+const mockResponse: MonitoringHealthResponse = {
+  services: [
+    {
+      id: 'postgresql',
+      name: 'Postgresql',
+      status: 'healthy',
+      responseTimeMs: 5.2,
+      description: 'Primary database cluster',
+      tags: ['readiness', 'startup'],
+    },
+  ],
+  checkedAt: '2026-03-20T12:00:00+00:00',
+};
+
+describe('diagnosticsKeys', () => {
+  it('should produce stable all key', () => {
+    expect(diagnosticsKeys.all).toEqual(['diagnostics']);
+  });
+
+  it('should produce stable health key', () => {
+    expect(diagnosticsKeys.health()).toEqual(['diagnostics', 'health']);
+  });
+});
+
+describe('useMonitoringHealth', () => {
+  it('should fetch health with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockResponse });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMonitoringHealth({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/granit/diagnostics/health');
+    expect(result.current.data).toEqual(mockResponse);
+  });
+
+  it('should fetch health with custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockResponse });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useMonitoringHealth({ client, basePath: '/api/v2/diagnostics' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v2/diagnostics/health');
+  });
+
+  it('should return services from the response', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockResponse });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMonitoringHealth({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.services).toHaveLength(1);
+    expect(result.current.data?.services[0].id).toBe('postgresql');
+    expect(result.current.data?.checkedAt).toBe('2026-03-20T12:00:00+00:00');
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMonitoringHealth({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-diagnostics/src/hooks/use-monitoring-health.ts
+++ b/packages/@granit/react-diagnostics/src/hooks/use-monitoring-health.ts
@@ -1,0 +1,46 @@
+import { DEFAULT_DIAGNOSTICS_BASE_PATH, fetchMonitoringHealth } from '@granit/diagnostics';
+import { useQuery } from '@tanstack/react-query';
+
+import type { MonitoringHealthResponse } from '@granit/diagnostics';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+
+/** Query key factory for diagnostics queries. */
+export const diagnosticsKeys = {
+  all: ['diagnostics'] as const,
+  health: () => [...diagnosticsKeys.all, 'health'] as const,
+};
+
+/** Options accepted by the useMonitoringHealth hook. */
+export interface MonitoringHealthOptions {
+  /** Axios instance used for all requests. */
+  readonly client: AxiosInstance;
+  /** Base URL for the diagnostics API. Defaults to `/api/granit/diagnostics`. */
+  readonly basePath?: string;
+  /** Polling interval in milliseconds. Defaults to `30_000` (30 seconds). */
+  readonly refetchInterval?: number;
+}
+
+/**
+ * Query hook that fetches the monitoring health status of all registered services.
+ *
+ * Polls every 30 seconds by default to reflect live health state.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useMonitoringHealth({ client: api });
+ * // data.services, data.checkedAt
+ * ```
+ */
+export function useMonitoringHealth(
+  options: MonitoringHealthOptions
+): UseQueryResult<MonitoringHealthResponse> {
+  const { client, basePath = DEFAULT_DIAGNOSTICS_BASE_PATH, refetchInterval = 30_000 } = options;
+
+  return useQuery({
+    queryKey: diagnosticsKeys.health(),
+    queryFn: () => fetchMonitoringHealth(client, basePath),
+    staleTime: 30_000,
+    refetchInterval,
+  });
+}

--- a/packages/@granit/react-diagnostics/src/index.ts
+++ b/packages/@granit/react-diagnostics/src/index.ts
@@ -1,0 +1,5 @@
+// Hooks
+export { diagnosticsKeys, useMonitoringHealth } from './hooks/use-monitoring-health.js';
+
+// Types
+export type { MonitoringHealthOptions } from './hooks/use-monitoring-health.js';

--- a/packages/@granit/react-diagnostics/tsconfig.json
+++ b/packages/@granit/react-diagnostics/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/diagnostics": ["../diagnostics/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-diagnostics/tsup.config.ts
+++ b/packages/@granit/react-diagnostics/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,16 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/diagnostics:
+    dependencies:
+      axios:
+        specifier: '*'
+        version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/error-boundary: {}
 
   packages/@granit/features:
@@ -564,6 +574,28 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-diagnostics:
+    dependencies:
+      '@granit/diagnostics':
+        specifier: workspace:*
+        version: link:../diagnostics
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
     devDependencies:
       '@granit/react-testing':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- Add `@granit/diagnostics` package: types (`ServiceStatus`, `ServiceHealth`, `MonitoringHealthResponse`), API function (`fetchMonitoringHealth`), and `DEFAULT_DIAGNOSTICS_BASE_PATH` constant — mirrors `Granit.Diagnostics.Endpoints` .NET contract
- Add `@granit/react-diagnostics` package: `useMonitoringHealth` React Query hook with 30s polling, `diagnosticsKeys` query key factory
- Full test coverage: type-level tests, API mock tests, and React hook tests following `@granit/background-jobs` patterns

## Test plan

- [x] `pnpm lint` — clean (0 warnings)
- [x] `pnpm tsc` — clean (no errors)
- [x] `pnpm test --run` — 144 test files, 1209 tests passed
- [ ] Verify integration in guava-front/guava-admin with `link:` protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)
