### PR TITLE
feat(identity): add identity provider endpoints and fix RGPD routes

### DIFF
--- a/packages/@granit/identity/src/__tests__/identity-provider-group-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-group-api.test.ts
@@ -1,0 +1,90 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  addUserToGroup,
+  fetchGroups,
+  fetchUserGroups,
+  removeUserFromGroup,
+} from '../api/identity-provider-group-api.js';
+
+import type { IdentityGroup } from '../types/index.js';
+
+const sampleGroup: IdentityGroup = {
+  id: 'group-1',
+  name: 'developers',
+  path: '/developers',
+  subGroups: [],
+};
+
+const basePath = '/identity/provider';
+
+describe('identity-provider-group-api', () => {
+  describe('fetchGroups', () => {
+    it('should GET {basePath}/groups', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleGroup]));
+
+      const result = await fetchGroups(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/groups`);
+      expect(result).toEqual([sampleGroup]);
+    });
+  });
+
+  describe('fetchUserGroups', () => {
+    it('should GET {basePath}/users/{userId}/groups', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleGroup]));
+
+      const result = await fetchUserGroups(client, basePath, 'user-1');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users/user-1/groups`);
+      expect(result).toEqual([sampleGroup]);
+    });
+
+    it('should encode userId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+      await fetchUserGroups(client, basePath, 'user/special@id');
+
+      expect(client.get).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}/groups`
+      );
+    });
+  });
+
+  describe('addUserToGroup', () => {
+    it('should PUT {basePath}/users/{userId}/groups/{groupId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+      await addUserToGroup(client, basePath, 'user-1', 'group-1');
+
+      expect(client.put).toHaveBeenCalledWith(`${basePath}/users/user-1/groups/group-1`);
+    });
+
+    it('should encode userId and groupId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+      await addUserToGroup(client, basePath, 'user/special@id', 'group/special@id');
+
+      expect(client.put).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}/groups/${encodeURIComponent('group/special@id')}`
+      );
+    });
+  });
+
+  describe('removeUserFromGroup', () => {
+    it('should DELETE {basePath}/users/{userId}/groups/{groupId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+      await removeUserFromGroup(client, basePath, 'user-1', 'group-1');
+
+      expect(client.delete).toHaveBeenCalledWith(`${basePath}/users/user-1/groups/group-1`);
+    });
+  });
+});

--- a/packages/@granit/identity/src/__tests__/identity-provider-password-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-password-api.test.ts
@@ -1,0 +1,74 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchPasswordChangedAt,
+  sendPasswordResetEmail,
+  setTemporaryPassword,
+} from '../api/identity-provider-password-api.js';
+
+import type { IdentityPasswordChangedAtResponse } from '../types/index.js';
+
+const basePath = '/identity/provider';
+
+describe('identity-provider-password-api', () => {
+  describe('fetchPasswordChangedAt', () => {
+    it('should GET {basePath}/users/{userId}/password/changed-at', async () => {
+      const client = createMockClient();
+      const response: IdentityPasswordChangedAtResponse = {
+        changedAt: '2026-03-15T08:00:00Z',
+      };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
+
+      const result = await fetchPasswordChangedAt(client, basePath, 'user-1');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users/user-1/password/changed-at`);
+      expect(result).toEqual(response);
+    });
+
+    it('should return null changedAt when password was never changed', async () => {
+      const client = createMockClient();
+      const response: IdentityPasswordChangedAtResponse = { changedAt: null };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
+
+      const result = await fetchPasswordChangedAt(client, basePath, 'user-1');
+
+      expect(result.changedAt).toBeNull();
+    });
+
+    it('should encode userId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse({ changedAt: null }));
+
+      await fetchPasswordChangedAt(client, basePath, 'user/special@id');
+
+      expect(client.get).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}/password/changed-at`
+      );
+    });
+  });
+
+  describe('sendPasswordResetEmail', () => {
+    it('should POST {basePath}/users/{userId}/password/reset-email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+      await sendPasswordResetEmail(client, basePath, 'user-1');
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/users/user-1/password/reset-email`);
+    });
+  });
+
+  describe('setTemporaryPassword', () => {
+    it('should POST {basePath}/users/{userId}/password/temporary with password body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+      await setTemporaryPassword(client, basePath, 'user-1', 'temp123!');
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/users/user-1/password/temporary`, {
+        password: 'temp123!',
+      });
+    });
+  });
+});

--- a/packages/@granit/identity/src/__tests__/identity-provider-role-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-role-api.test.ts
@@ -1,0 +1,113 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assignRole,
+  fetchRoleMembers,
+  fetchRoles,
+  fetchUserRoles,
+  removeRole,
+} from '../api/identity-provider-role-api.js';
+
+import type { IdentityRole, IdentityUser } from '../types/index.js';
+
+const sampleRole: IdentityRole = {
+  id: 'role-1',
+  name: 'admin',
+  description: 'Administrator role',
+};
+
+const sampleUser: IdentityUser = {
+  id: 'user-1',
+  username: 'jdoe',
+  email: 'jdoe@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  enabled: true,
+  attributes: null,
+};
+
+const basePath = '/identity/provider';
+
+describe('identity-provider-role-api', () => {
+  describe('fetchRoles', () => {
+    it('should GET {basePath}/roles', async () => {
+      const client = createMockClient();
+      const roles = [sampleRole];
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(roles));
+
+      const result = await fetchRoles(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/roles`);
+      expect(result).toEqual(roles);
+    });
+  });
+
+  describe('fetchRoleMembers', () => {
+    it('should GET {basePath}/roles/{roleName}/members', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleUser]));
+
+      const result = await fetchRoleMembers(client, basePath, 'admin');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/roles/admin/members`);
+      expect(result).toEqual([sampleUser]);
+    });
+
+    it('should encode roleName with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+      await fetchRoleMembers(client, basePath, 'role/special@name');
+
+      expect(client.get).toHaveBeenCalledWith(
+        `${basePath}/roles/${encodeURIComponent('role/special@name')}/members`
+      );
+    });
+  });
+
+  describe('fetchUserRoles', () => {
+    it('should GET {basePath}/users/{userId}/roles', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleRole]));
+
+      const result = await fetchUserRoles(client, basePath, 'user-1');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users/user-1/roles`);
+      expect(result).toEqual([sampleRole]);
+    });
+  });
+
+  describe('assignRole', () => {
+    it('should PUT {basePath}/users/{userId}/roles/{roleName}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+      await assignRole(client, basePath, 'user-1', 'admin');
+
+      expect(client.put).toHaveBeenCalledWith(`${basePath}/users/user-1/roles/admin`);
+    });
+
+    it('should encode userId and roleName with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+      await assignRole(client, basePath, 'user/special@id', 'role/special@name');
+
+      expect(client.put).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}/roles/${encodeURIComponent('role/special@name')}`
+      );
+    });
+  });
+
+  describe('removeRole', () => {
+    it('should DELETE {basePath}/users/{userId}/roles/{roleName}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+      await removeRole(client, basePath, 'user-1', 'admin');
+
+      expect(client.delete).toHaveBeenCalledWith(`${basePath}/users/user-1/roles/admin`);
+    });
+  });
+});

--- a/packages/@granit/identity/src/__tests__/identity-provider-session-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-session-api.test.ts
@@ -1,0 +1,104 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchUserDeviceActivity,
+  fetchUserSessions,
+  terminateAllSessions,
+  terminateSession,
+} from '../api/identity-provider-session-api.js';
+
+import type { IdentityDeviceActivity, IdentitySession } from '../types/index.js';
+
+const sampleSession: IdentitySession = {
+  sessionId: 'session-1',
+  ipAddress: '192.168.1.1',
+  startedAt: '2026-03-20T10:00:00Z',
+  lastAccess: '2026-03-20T12:00:00Z',
+  rememberMe: false,
+  clients: ['web-app'],
+};
+
+const sampleDeviceActivity: IdentityDeviceActivity = {
+  ipAddress: '192.168.1.1',
+  lastAccess: '2026-03-20T12:00:00Z',
+  device: 'Desktop',
+  os: 'Windows',
+  osVersion: '11',
+  browser: 'Chrome',
+  mobile: false,
+  current: true,
+  sessions: [sampleSession],
+};
+
+const basePath = '/identity/provider';
+
+describe('identity-provider-session-api', () => {
+  describe('fetchUserSessions', () => {
+    it('should GET {basePath}/users/{userId}/sessions', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleSession]));
+
+      const result = await fetchUserSessions(client, basePath, 'user-1');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users/user-1/sessions`);
+      expect(result).toEqual([sampleSession]);
+    });
+
+    it('should encode userId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+      await fetchUserSessions(client, basePath, 'user/special@id');
+
+      expect(client.get).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}/sessions`
+      );
+    });
+  });
+
+  describe('fetchUserDeviceActivity', () => {
+    it('should GET {basePath}/users/{userId}/devices', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleDeviceActivity]));
+
+      const result = await fetchUserDeviceActivity(client, basePath, 'user-1');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users/user-1/devices`);
+      expect(result).toEqual([sampleDeviceActivity]);
+    });
+  });
+
+  describe('terminateSession', () => {
+    it('should DELETE {basePath}/users/{userId}/sessions/{sessionId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+      await terminateSession(client, basePath, 'user-1', 'session-1');
+
+      expect(client.delete).toHaveBeenCalledWith(`${basePath}/users/user-1/sessions/session-1`);
+    });
+
+    it('should encode userId and sessionId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+      await terminateSession(client, basePath, 'user/special@id', 'session/special@id');
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}/sessions/${encodeURIComponent('session/special@id')}`
+      );
+    });
+  });
+
+  describe('terminateAllSessions', () => {
+    it('should DELETE {basePath}/users/{userId}/sessions', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+      await terminateAllSessions(client, basePath, 'user-1');
+
+      expect(client.delete).toHaveBeenCalledWith(`${basePath}/users/user-1/sessions`);
+    });
+  });
+});

--- a/packages/@granit/identity/src/__tests__/identity-provider-user-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-user-api.test.ts
@@ -1,0 +1,137 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createUser,
+  fetchProviderUser,
+  fetchProviderUsers,
+  setUserEnabled,
+  updateUser,
+} from '../api/identity-provider-user-api.js';
+
+import type { IdentityUser } from '../types/index.js';
+
+const sampleUser: IdentityUser = {
+  id: 'user-1',
+  username: 'jdoe',
+  email: 'jdoe@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  enabled: true,
+  attributes: null,
+};
+
+const basePath = '/identity/provider';
+
+describe('identity-provider-user-api', () => {
+  describe('fetchProviderUsers', () => {
+    it('should GET {basePath}/users without params', async () => {
+      const client = createMockClient();
+      const users = [sampleUser];
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(users));
+
+      const result = await fetchProviderUsers(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users`, { params: undefined });
+      expect(result).toEqual(users);
+    });
+
+    it('should GET {basePath}/users with search params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+      const params = { search: 'john', first: 0, max: 10 };
+      const result = await fetchProviderUsers(client, basePath, params);
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users`, { params });
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('fetchProviderUser', () => {
+    it('should GET {basePath}/users/{userId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleUser));
+
+      const result = await fetchProviderUser(client, basePath, 'user-1');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/users/user-1`);
+      expect(result).toEqual(sampleUser);
+    });
+
+    it('should encode userId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleUser));
+
+      await fetchProviderUser(client, basePath, 'user/special@id');
+
+      expect(client.get).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}`
+      );
+    });
+  });
+
+  describe('createUser', () => {
+    it('should POST {basePath}/users with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleUser));
+
+      const request = { username: 'jdoe', email: 'jdoe@example.com', enabled: true };
+      const result = await createUser(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/users`, request);
+      expect(result).toEqual(sampleUser);
+    });
+  });
+
+  describe('updateUser', () => {
+    it('should PUT {basePath}/users/{userId} with request body', async () => {
+      const client = createMockClient();
+      const updated = { ...sampleUser, email: 'new@example.com' };
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(updated));
+
+      const request = { email: 'new@example.com' };
+      const result = await updateUser(client, basePath, 'user-1', request);
+
+      expect(client.put).toHaveBeenCalledWith(`${basePath}/users/user-1`, request);
+      expect(result).toEqual(updated);
+    });
+
+    it('should encode userId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleUser));
+
+      await updateUser(client, basePath, 'user/special@id', { email: 'x@y.com' });
+
+      expect(client.put).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}`,
+        { email: 'x@y.com' }
+      );
+    });
+  });
+
+  describe('setUserEnabled', () => {
+    it('should PATCH {basePath}/users/{userId}/enabled', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
+
+      await setUserEnabled(client, basePath, 'user-1', false);
+
+      expect(client.patch).toHaveBeenCalledWith(`${basePath}/users/user-1/enabled`, {
+        enabled: false,
+      });
+    });
+
+    it('should encode userId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
+
+      await setUserEnabled(client, basePath, 'user/special@id', true);
+
+      expect(client.patch).toHaveBeenCalledWith(
+        `${basePath}/users/${encodeURIComponent('user/special@id')}/enabled`,
+        { enabled: true }
+      );
+    });
+  });
+});

--- a/packages/@granit/identity/src/__tests__/identity-user-cache-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-user-cache-api.test.ts
@@ -165,13 +165,13 @@ describe('identity-user-cache-api', () => {
   });
 
   describe('eraseUserCache', () => {
-    it('should DELETE {basePath}/{userId}/erase', async () => {
+    it('should DELETE {basePath}/{userId}', async () => {
       const client = createMockClient();
       vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
 
       await eraseUserCache(client, basePath, 'user-1');
 
-      expect(client.delete).toHaveBeenCalledWith(`${basePath}/user-1/erase`);
+      expect(client.delete).toHaveBeenCalledWith(`${basePath}/user-1`);
     });
 
     it('should encode userId with special characters', async () => {
@@ -181,28 +181,28 @@ describe('identity-user-cache-api', () => {
       await eraseUserCache(client, basePath, 'user/special@id');
 
       expect(client.delete).toHaveBeenCalledWith(
-        `${basePath}/${encodeURIComponent('user/special@id')}/erase`
+        `${basePath}/${encodeURIComponent('user/special@id')}`
       );
     });
   });
 
   describe('pseudonymizeUserCache', () => {
-    it('should POST {basePath}/{userId}/pseudonymize', async () => {
+    it('should PATCH {basePath}/{userId}/pseudonymize', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+      vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
 
       await pseudonymizeUserCache(client, basePath, 'user-1');
 
-      expect(client.post).toHaveBeenCalledWith(`${basePath}/user-1/pseudonymize`);
+      expect(client.patch).toHaveBeenCalledWith(`${basePath}/user-1/pseudonymize`);
     });
 
     it('should encode userId with special characters', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+      vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
 
       await pseudonymizeUserCache(client, basePath, 'user/special@id');
 
-      expect(client.post).toHaveBeenCalledWith(
+      expect(client.patch).toHaveBeenCalledWith(
         `${basePath}/${encodeURIComponent('user/special@id')}/pseudonymize`
       );
     });

--- a/packages/@granit/identity/src/api/identity-provider-group-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-group-api.ts
@@ -1,0 +1,63 @@
+import type { IdentityGroup } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * List all groups from the identity provider.
+ *
+ * `GET {basePath}/groups`
+ */
+export async function fetchGroups(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly IdentityGroup[]> {
+  const response = await client.get<readonly IdentityGroup[]>(`${basePath}/groups`);
+  return response.data;
+}
+
+/**
+ * List groups a user belongs to.
+ *
+ * `GET {basePath}/users/{userId}/groups`
+ */
+export async function fetchUserGroups(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<readonly IdentityGroup[]> {
+  const response = await client.get<readonly IdentityGroup[]>(
+    `${basePath}/users/${encodeURIComponent(userId)}/groups`
+  );
+  return response.data;
+}
+
+/**
+ * Add a user to a group (idempotent).
+ *
+ * `PUT {basePath}/users/{userId}/groups/{groupId}`
+ */
+export async function addUserToGroup(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  groupId: string
+): Promise<void> {
+  await client.put(
+    `${basePath}/users/${encodeURIComponent(userId)}/groups/${encodeURIComponent(groupId)}`
+  );
+}
+
+/**
+ * Remove a user from a group (idempotent).
+ *
+ * `DELETE {basePath}/users/{userId}/groups/{groupId}`
+ */
+export async function removeUserFromGroup(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  groupId: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/users/${encodeURIComponent(userId)}/groups/${encodeURIComponent(groupId)}`
+  );
+}

--- a/packages/@granit/identity/src/api/identity-provider-password-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-password-api.ts
@@ -1,0 +1,48 @@
+import type { IdentityPasswordChangedAtResponse } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Get the last password change timestamp for a user.
+ *
+ * `GET {basePath}/users/{userId}/password/changed-at`
+ */
+export async function fetchPasswordChangedAt(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<IdentityPasswordChangedAtResponse> {
+  const response = await client.get<IdentityPasswordChangedAtResponse>(
+    `${basePath}/users/${encodeURIComponent(userId)}/password/changed-at`
+  );
+  return response.data;
+}
+
+/**
+ * Send a password reset email to a user.
+ * May return 501 if `supportsNativePasswordResetEmail` is false.
+ *
+ * `POST {basePath}/users/{userId}/password/reset-email`
+ */
+export async function sendPasswordResetEmail(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<void> {
+  await client.post(`${basePath}/users/${encodeURIComponent(userId)}/password/reset-email`);
+}
+
+/**
+ * Set a temporary password for a user.
+ *
+ * `POST {basePath}/users/{userId}/password/temporary`
+ */
+export async function setTemporaryPassword(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  password: string
+): Promise<void> {
+  await client.post(`${basePath}/users/${encodeURIComponent(userId)}/password/temporary`, {
+    password,
+  });
+}

--- a/packages/@granit/identity/src/api/identity-provider-role-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-role-api.ts
@@ -1,0 +1,79 @@
+import type { IdentityRole, IdentityUser } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * List all roles from the identity provider.
+ *
+ * `GET {basePath}/roles`
+ */
+export async function fetchRoles(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly IdentityRole[]> {
+  const response = await client.get<readonly IdentityRole[]>(`${basePath}/roles`);
+  return response.data;
+}
+
+/**
+ * List members of a role from the identity provider.
+ *
+ * `GET {basePath}/roles/{roleName}/members`
+ */
+export async function fetchRoleMembers(
+  client: AxiosInstance,
+  basePath: string,
+  roleName: string
+): Promise<readonly IdentityUser[]> {
+  const response = await client.get<readonly IdentityUser[]>(
+    `${basePath}/roles/${encodeURIComponent(roleName)}/members`
+  );
+  return response.data;
+}
+
+/**
+ * List roles assigned to a user.
+ *
+ * `GET {basePath}/users/{userId}/roles`
+ */
+export async function fetchUserRoles(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<readonly IdentityRole[]> {
+  const response = await client.get<readonly IdentityRole[]>(
+    `${basePath}/users/${encodeURIComponent(userId)}/roles`
+  );
+  return response.data;
+}
+
+/**
+ * Assign a role to a user (idempotent).
+ *
+ * `PUT {basePath}/users/{userId}/roles/{roleName}`
+ */
+export async function assignRole(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  roleName: string
+): Promise<void> {
+  await client.put(
+    `${basePath}/users/${encodeURIComponent(userId)}/roles/${encodeURIComponent(roleName)}`
+  );
+}
+
+/**
+ * Remove a role from a user (idempotent).
+ *
+ * `DELETE {basePath}/users/{userId}/roles/{roleName}`
+ */
+export async function removeRole(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  roleName: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/users/${encodeURIComponent(userId)}/roles/${encodeURIComponent(roleName)}`
+  );
+}

--- a/packages/@granit/identity/src/api/identity-provider-session-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-session-api.ts
@@ -1,0 +1,63 @@
+import type { IdentityDeviceActivity, IdentitySession } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * List active sessions for a user.
+ *
+ * `GET {basePath}/users/{userId}/sessions`
+ */
+export async function fetchUserSessions(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<readonly IdentitySession[]> {
+  const response = await client.get<readonly IdentitySession[]>(
+    `${basePath}/users/${encodeURIComponent(userId)}/sessions`
+  );
+  return response.data;
+}
+
+/**
+ * List device activity for a user.
+ *
+ * `GET {basePath}/users/{userId}/devices`
+ */
+export async function fetchUserDeviceActivity(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<readonly IdentityDeviceActivity[]> {
+  const response = await client.get<readonly IdentityDeviceActivity[]>(
+    `${basePath}/users/${encodeURIComponent(userId)}/devices`
+  );
+  return response.data;
+}
+
+/**
+ * Terminate a specific session. May return 501 if `supportsIndividualSessionTermination` is false.
+ *
+ * `DELETE {basePath}/users/{userId}/sessions/{sessionId}`
+ */
+export async function terminateSession(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  sessionId: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/users/${encodeURIComponent(userId)}/sessions/${encodeURIComponent(sessionId)}`
+  );
+}
+
+/**
+ * Terminate all active sessions for a user.
+ *
+ * `DELETE {basePath}/users/{userId}/sessions`
+ */
+export async function terminateAllSessions(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<void> {
+  await client.delete(`${basePath}/users/${encodeURIComponent(userId)}/sessions`);
+}

--- a/packages/@granit/identity/src/api/identity-provider-user-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-user-api.ts
@@ -1,0 +1,89 @@
+import type {
+  IdentityUser,
+  IdentityUserCreateRequest,
+  IdentityUserUpdateRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+export type IdentityProviderUserListParams = {
+  readonly search?: string;
+  readonly first?: number;
+  readonly max?: number;
+};
+
+/**
+ * List/search users from the identity provider.
+ *
+ * `GET {basePath}/users`
+ */
+export async function fetchProviderUsers(
+  client: AxiosInstance,
+  basePath: string,
+  params?: IdentityProviderUserListParams
+): Promise<readonly IdentityUser[]> {
+  const response = await client.get<readonly IdentityUser[]>(`${basePath}/users`, { params });
+  return response.data;
+}
+
+/**
+ * Get a single user by ID from the identity provider.
+ *
+ * `GET {basePath}/users/{userId}`
+ */
+export async function fetchProviderUser(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<IdentityUser> {
+  const response = await client.get<IdentityUser>(
+    `${basePath}/users/${encodeURIComponent(userId)}`
+  );
+  return response.data;
+}
+
+/**
+ * Create a new user in the identity provider.
+ * May return 501 if `supportsUserCreation` is false.
+ *
+ * `POST {basePath}/users`
+ */
+export async function createUser(
+  client: AxiosInstance,
+  basePath: string,
+  request: IdentityUserCreateRequest
+): Promise<IdentityUser> {
+  const response = await client.post<IdentityUser>(`${basePath}/users`, request);
+  return response.data;
+}
+
+/**
+ * Update an existing user in the identity provider.
+ *
+ * `PUT {basePath}/users/{userId}`
+ */
+export async function updateUser(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  request: IdentityUserUpdateRequest
+): Promise<IdentityUser> {
+  const response = await client.put<IdentityUser>(
+    `${basePath}/users/${encodeURIComponent(userId)}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Enable or disable a user in the identity provider.
+ *
+ * `PATCH {basePath}/users/{userId}/enabled`
+ */
+export async function setUserEnabled(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  enabled: boolean
+): Promise<void> {
+  await client.patch(`${basePath}/users/${encodeURIComponent(userId)}/enabled`, { enabled });
+}

--- a/packages/@granit/identity/src/api/identity-user-cache-api.ts
+++ b/packages/@granit/identity/src/api/identity-user-cache-api.ts
@@ -105,25 +105,25 @@ export async function syncStaleUsers(
 /**
  * Erase a user's cached data (hard delete).
  *
- * `DELETE {basePath}/{userId}/erase`
+ * `DELETE {basePath}/{userId}`
  */
 export async function eraseUserCache(
   client: AxiosInstance,
   basePath: string,
   userId: string
 ): Promise<void> {
-  await client.delete(`${basePath}/${encodeURIComponent(userId)}/erase`);
+  await client.delete(`${basePath}/${encodeURIComponent(userId)}`);
 }
 
 /**
  * Pseudonymize a user's cached data (GDPR right to be forgotten).
  *
- * `POST {basePath}/{userId}/pseudonymize`
+ * `PATCH {basePath}/{userId}/pseudonymize`
  */
 export async function pseudonymizeUserCache(
   client: AxiosInstance,
   basePath: string,
   userId: string
 ): Promise<void> {
-  await client.post(`${basePath}/${encodeURIComponent(userId)}/pseudonymize`);
+  await client.patch(`${basePath}/${encodeURIComponent(userId)}/pseudonymize`);
 }

--- a/packages/@granit/identity/src/index.ts
+++ b/packages/@granit/identity/src/index.ts
@@ -8,8 +8,18 @@ export type {
   IdentityUserListParams,
   IdentityUserPage,
 } from './types/index.js';
+export type { IdentityRole } from './types/index.js';
+export type { IdentityGroup } from './types/index.js';
+export type { IdentityDeviceActivity, IdentitySession } from './types/index.js';
+export type { IdentityPasswordChangedAtResponse } from './types/index.js';
+export type {
+  IdentitySetTemporaryPasswordRequest,
+  IdentityUserCreateRequest,
+  IdentityUserSetEnabledRequest,
+  IdentityUserUpdateRequest,
+} from './types/index.js';
 
-// API
+// API — User cache
 export { fetchIdentityCapabilities } from './api/identity-capabilities-api.js';
 export {
   batchResolveUsers,
@@ -22,3 +32,37 @@ export {
   syncStaleUsers,
   syncUsers,
 } from './api/identity-user-cache-api.js';
+
+// API — Identity provider
+export type { IdentityProviderUserListParams } from './api/identity-provider-user-api.js';
+export {
+  createUser,
+  fetchProviderUser,
+  fetchProviderUsers,
+  setUserEnabled,
+  updateUser,
+} from './api/identity-provider-user-api.js';
+export {
+  assignRole,
+  fetchRoleMembers,
+  fetchRoles,
+  fetchUserRoles,
+  removeRole,
+} from './api/identity-provider-role-api.js';
+export {
+  addUserToGroup,
+  fetchGroups,
+  fetchUserGroups,
+  removeUserFromGroup,
+} from './api/identity-provider-group-api.js';
+export {
+  fetchUserDeviceActivity,
+  fetchUserSessions,
+  terminateAllSessions,
+  terminateSession,
+} from './api/identity-provider-session-api.js';
+export {
+  fetchPasswordChangedAt,
+  sendPasswordResetEmail,
+  setTemporaryPassword,
+} from './api/identity-provider-password-api.js';

--- a/packages/@granit/identity/src/types/identity-group.ts
+++ b/packages/@granit/identity/src/types/identity-group.ts
@@ -1,0 +1,7 @@
+/** Identity group from the identity provider — mirrors Granit.Identity.IdentityGroup .NET record. */
+export type IdentityGroup = {
+  readonly id: string;
+  readonly name: string;
+  readonly path: string | null;
+  readonly subGroups: readonly IdentityGroup[];
+};

--- a/packages/@granit/identity/src/types/identity-password.ts
+++ b/packages/@granit/identity/src/types/identity-password.ts
@@ -1,0 +1,4 @@
+/** Response from `GET /identity/provider/users/{userId}/password/changed-at`. */
+export type IdentityPasswordChangedAtResponse = {
+  readonly changedAt: string | null;
+};

--- a/packages/@granit/identity/src/types/identity-provider-requests.ts
+++ b/packages/@granit/identity/src/types/identity-provider-requests.ts
@@ -1,0 +1,27 @@
+/** Request body for `POST /identity/provider/users`. */
+export type IdentityUserCreateRequest = {
+  readonly username: string;
+  readonly email: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly enabled: boolean;
+  readonly temporaryPassword?: string;
+};
+
+/** Request body for `PUT /identity/provider/users/{userId}`. */
+export type IdentityUserUpdateRequest = {
+  readonly email?: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly attributes?: Readonly<Record<string, string | null>>;
+};
+
+/** Request body for `PATCH /identity/provider/users/{userId}/enabled`. */
+export type IdentityUserSetEnabledRequest = {
+  readonly enabled: boolean;
+};
+
+/** Request body for `POST /identity/provider/users/{userId}/password/temporary`. */
+export type IdentitySetTemporaryPasswordRequest = {
+  readonly password: string;
+};

--- a/packages/@granit/identity/src/types/identity-role.ts
+++ b/packages/@granit/identity/src/types/identity-role.ts
@@ -1,0 +1,6 @@
+/** Identity role from the identity provider — mirrors Granit.Identity.IdentityRole .NET record. */
+export type IdentityRole = {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string | null;
+};

--- a/packages/@granit/identity/src/types/identity-session.ts
+++ b/packages/@granit/identity/src/types/identity-session.ts
@@ -1,0 +1,22 @@
+/** Active session from the identity provider — mirrors Granit.Identity.IdentitySession .NET record. */
+export type IdentitySession = {
+  readonly sessionId: string;
+  readonly ipAddress: string | null;
+  readonly startedAt: string;
+  readonly lastAccess: string;
+  readonly rememberMe: boolean;
+  readonly clients: readonly string[];
+};
+
+/** Device activity from the identity provider — mirrors Granit.Identity.IdentityDeviceActivity .NET record. */
+export type IdentityDeviceActivity = {
+  readonly ipAddress: string | null;
+  readonly lastAccess: string;
+  readonly device: string | null;
+  readonly os: string | null;
+  readonly osVersion: string | null;
+  readonly browser: string | null;
+  readonly mobile: boolean;
+  readonly current: boolean;
+  readonly sessions: readonly IdentitySession[];
+};

--- a/packages/@granit/identity/src/types/index.ts
+++ b/packages/@granit/identity/src/types/index.ts
@@ -7,6 +7,17 @@ export type {
   IdentityUserPage,
 } from './identity-user.js';
 
+export type { IdentityRole } from './identity-role.js';
+export type { IdentityGroup } from './identity-group.js';
+export type { IdentityDeviceActivity, IdentitySession } from './identity-session.js';
+export type { IdentityPasswordChangedAtResponse } from './identity-password.js';
+export type {
+  IdentitySetTemporaryPasswordRequest,
+  IdentityUserCreateRequest,
+  IdentityUserSetEnabledRequest,
+  IdentityUserUpdateRequest,
+} from './identity-provider-requests.js';
+
 /** Response from `GET /identity/users/capabilities`. */
 export interface IdentityProviderCapabilities {
   /** Display name of the active identity provider (e.g. "Keycloak", "Entra ID"). */

--- a/packages/@granit/react-identity/src/__tests__/use-identity-groups.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-groups.test.tsx
@@ -1,0 +1,130 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAddUserToGroup,
+  useGroups,
+  useRemoveUserFromGroup,
+  useUserGroups,
+} from '../hooks/use-identity-groups.js';
+import { IdentityProvider } from '../providers/identity-provider.js';
+
+import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityGroup } from '@granit/identity';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const sampleGroup: IdentityGroup = {
+  id: 'group-1',
+  name: 'developers',
+  path: '/developers',
+  subGroups: [],
+};
+
+function createWrapper(client: AxiosInstance, providerBasePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: IdentityConfig = { client, providerBasePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <IdentityProvider config={config}>{children}</IdentityProvider>
+    );
+  };
+}
+
+describe('use-identity-groups', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useGroups', () => {
+    it('fetches all groups', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+
+      const { result } = renderHook(() => useGroups(), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/groups');
+      expect(result.current.data).toEqual([sampleGroup]);
+    });
+  });
+
+  describe('useUserGroups', () => {
+    it('fetches groups for a user', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+
+      const { result } = renderHook(() => useUserGroups('user-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/groups');
+    });
+
+    it('is disabled when userId is empty', async () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useUserGroups(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useAddUserToGroup', () => {
+    it('adds user to group via PUT', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useAddUserToGroup(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', groupId: 'group-1' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.put).toHaveBeenCalledWith('/identity/provider/users/user-1/groups/group-1');
+    });
+  });
+
+  describe('useRemoveUserFromGroup', () => {
+    it('removes user from group via DELETE', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useRemoveUserFromGroup(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', groupId: 'group-1' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith('/identity/provider/users/user-1/groups/group-1');
+    });
+
+    it('exposes error state on failure', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockRejectedValue(new Error('Not found'));
+
+      const { result } = renderHook(() => useRemoveUserFromGroup(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', groupId: 'group-1' });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe('Not found');
+    });
+  });
+});

--- a/packages/@granit/react-identity/src/__tests__/use-identity-passwords.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-passwords.test.tsx
@@ -1,0 +1,127 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  usePasswordChangedAt,
+  useSendPasswordResetEmail,
+  useSetTemporaryPassword,
+} from '../hooks/use-identity-passwords.js';
+import { IdentityProvider } from '../providers/identity-provider.js';
+
+import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: IdentityConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <IdentityProvider config={config}>{children}</IdentityProvider>
+    );
+  };
+}
+
+describe('use-identity-passwords', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('usePasswordChangedAt', () => {
+    it('fetches password changed-at timestamp', async () => {
+      const client = createMockClient();
+      const response = { changedAt: '2026-03-15T08:00:00Z' };
+      vi.mocked(client.get).mockResolvedValue({ data: response });
+
+      const { result } = renderHook(() => usePasswordChangedAt('user-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith(
+        '/identity/provider/users/user-1/password/changed-at'
+      );
+      expect(result.current.data).toEqual(response);
+    });
+
+    it('handles null changedAt', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: { changedAt: null } });
+
+      const { result } = renderHook(() => usePasswordChangedAt('user-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.changedAt).toBeNull();
+    });
+
+    it('is disabled when userId is empty', async () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => usePasswordChangedAt(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useSendPasswordResetEmail', () => {
+    it('sends reset email via POST', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useSendPasswordResetEmail(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('user-1');
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith(
+        '/identity/provider/users/user-1/password/reset-email'
+      );
+    });
+
+    it('exposes error state on 501', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockRejectedValue(new Error('Not Implemented'));
+
+      const { result } = renderHook(() => useSendPasswordResetEmail(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('user-1');
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe('Not Implemented');
+    });
+  });
+
+  describe('useSetTemporaryPassword', () => {
+    it('sets temporary password via POST', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useSetTemporaryPassword(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', password: 'temp123!' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith(
+        '/identity/provider/users/user-1/password/temporary',
+        { password: 'temp123!' }
+      );
+    });
+  });
+});

--- a/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
@@ -1,0 +1,188 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useCreateUser,
+  useProviderUser,
+  useProviderUsers,
+  useSetUserEnabled,
+  useUpdateUser,
+} from '../hooks/use-identity-provider-users.js';
+import { IdentityProvider } from '../providers/identity-provider.js';
+
+import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityUser } from '@granit/identity';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const sampleUser: IdentityUser = {
+  id: 'user-1',
+  username: 'jdoe',
+  email: 'jdoe@example.com',
+  firstName: 'John',
+  lastName: 'Doe',
+  enabled: true,
+  attributes: null,
+};
+
+function createWrapper(client: AxiosInstance, providerBasePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: IdentityConfig = { client, providerBasePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <IdentityProvider config={config}>{children}</IdentityProvider>
+    );
+  };
+}
+
+describe('use-identity-provider-users', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useProviderUsers', () => {
+    it('fetches users from provider', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleUser] });
+
+      const { result } = renderHook(() => useProviderUsers(), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/users', {
+        params: undefined,
+      });
+      expect(result.current.data).toEqual([sampleUser]);
+    });
+
+    it('passes search params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      const params = { search: 'john', max: 10 };
+      const { result } = renderHook(() => useProviderUsers(params), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/users', { params });
+    });
+
+    it('uses custom providerBasePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useProviderUsers(), {
+        wrapper: createWrapper(client, '/custom/provider'),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/custom/provider/users', {
+        params: undefined,
+      });
+    });
+  });
+
+  describe('useProviderUser', () => {
+    it('fetches a single user by ID', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleUser });
+
+      const { result } = renderHook(() => useProviderUser('user-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1');
+      expect(result.current.data).toEqual(sampleUser);
+    });
+
+    it('is disabled when userId is empty', async () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useProviderUser(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useCreateUser', () => {
+    it('creates a user via POST', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleUser });
+
+      const { result } = renderHook(() => useCreateUser(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ username: 'jdoe', email: 'jdoe@example.com', enabled: true });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith('/identity/provider/users', {
+        username: 'jdoe',
+        email: 'jdoe@example.com',
+        enabled: true,
+      });
+    });
+  });
+
+  describe('useUpdateUser', () => {
+    it('updates a user via PUT', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleUser });
+
+      const { result } = renderHook(() => useUpdateUser(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', request: { email: 'new@example.com' } });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.put).toHaveBeenCalledWith('/identity/provider/users/user-1', {
+        email: 'new@example.com',
+      });
+    });
+  });
+
+  describe('useSetUserEnabled', () => {
+    it('disables a user via PATCH', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useSetUserEnabled(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', enabled: false });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.patch).toHaveBeenCalledWith('/identity/provider/users/user-1/enabled', {
+        enabled: false,
+      });
+    });
+
+    it('exposes error state on failure', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockRejectedValue(new Error('Forbidden'));
+
+      const { result } = renderHook(() => useSetUserEnabled(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', enabled: false });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe('Forbidden');
+    });
+  });
+});

--- a/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
@@ -48,12 +48,12 @@ describe('useIdentityRgpd', () => {
     result.current.erase.mutate('user-1');
 
     await waitFor(() => expect(result.current.erase.isSuccess).toBe(true));
-    expect(client.delete).toHaveBeenCalledWith('/identity/users/user-1/erase');
+    expect(client.delete).toHaveBeenCalledWith('/identity/users/user-1');
   });
 
   it('pseudonymize mutation pseudonymizes user cache', async () => {
     const client = createMockClient();
-    vi.mocked(client.post).mockResolvedValue({ data: undefined });
+    vi.mocked(client.patch).mockResolvedValue({ data: undefined });
 
     const { result } = renderHook(() => useIdentityRgpd(), {
       wrapper: createWrapper(client),
@@ -62,7 +62,7 @@ describe('useIdentityRgpd', () => {
     result.current.pseudonymize.mutate('user-1');
 
     await waitFor(() => expect(result.current.pseudonymize.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/identity/users/user-1/pseudonymize');
+    expect(client.patch).toHaveBeenCalledWith('/identity/users/user-1/pseudonymize');
   });
 
   it('uses custom basePath', async () => {
@@ -76,7 +76,7 @@ describe('useIdentityRgpd', () => {
     result.current.erase.mutate('user-1');
 
     await waitFor(() => expect(result.current.erase.isSuccess).toBe(true));
-    expect(client.delete).toHaveBeenCalledWith('/custom/path/user-1/erase');
+    expect(client.delete).toHaveBeenCalledWith('/custom/path/user-1');
   });
 
   it('exposes error state on erase failure', async () => {
@@ -95,7 +95,7 @@ describe('useIdentityRgpd', () => {
 
   it('exposes error state on pseudonymize failure', async () => {
     const client = createMockClient();
-    vi.mocked(client.post).mockRejectedValue(new Error('Not found'));
+    vi.mocked(client.patch).mockRejectedValue(new Error('Not found'));
 
     const { result } = renderHook(() => useIdentityRgpd(), {
       wrapper: createWrapper(client),

--- a/packages/@granit/react-identity/src/__tests__/use-identity-roles.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-roles.test.tsx
@@ -1,0 +1,155 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAssignRole,
+  useRemoveRole,
+  useRoleMembers,
+  useRoles,
+  useUserRoles,
+} from '../hooks/use-identity-roles.js';
+import { IdentityProvider } from '../providers/identity-provider.js';
+
+import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityRole } from '@granit/identity';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const sampleRole: IdentityRole = {
+  id: 'role-1',
+  name: 'admin',
+  description: 'Administrator',
+};
+
+function createWrapper(client: AxiosInstance, providerBasePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: IdentityConfig = { client, providerBasePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <IdentityProvider config={config}>{children}</IdentityProvider>
+    );
+  };
+}
+
+describe('use-identity-roles', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useRoles', () => {
+    it('fetches all roles', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleRole] });
+
+      const { result } = renderHook(() => useRoles(), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/roles');
+      expect(result.current.data).toEqual([sampleRole]);
+    });
+  });
+
+  describe('useUserRoles', () => {
+    it('fetches roles for a user', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleRole] });
+
+      const { result } = renderHook(() => useUserRoles('user-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/roles');
+    });
+
+    it('is disabled when userId is empty', async () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useUserRoles(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useRoleMembers', () => {
+    it('fetches members of a role', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      const { result } = renderHook(() => useRoleMembers('admin'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/roles/admin/members');
+    });
+
+    it('is disabled when roleName is empty', async () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useRoleMembers(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useAssignRole', () => {
+    it('assigns a role via PUT', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useAssignRole(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', roleName: 'admin' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.put).toHaveBeenCalledWith('/identity/provider/users/user-1/roles/admin');
+    });
+  });
+
+  describe('useRemoveRole', () => {
+    it('removes a role via DELETE', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useRemoveRole(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', roleName: 'admin' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith('/identity/provider/users/user-1/roles/admin');
+    });
+
+    it('uses custom providerBasePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useRemoveRole(), {
+        wrapper: createWrapper(client, '/custom/provider'),
+      });
+
+      result.current.mutate({ userId: 'user-1', roleName: 'admin' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith('/custom/provider/users/user-1/roles/admin');
+    });
+  });
+});

--- a/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
@@ -1,0 +1,157 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useTerminateAllSessions,
+  useTerminateSession,
+  useUserDeviceActivity,
+  useUserSessions,
+} from '../hooks/use-identity-sessions.js';
+import { IdentityProvider } from '../providers/identity-provider.js';
+
+import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityDeviceActivity, IdentitySession } from '@granit/identity';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const sampleSession: IdentitySession = {
+  sessionId: 'session-1',
+  ipAddress: '192.168.1.1',
+  startedAt: '2026-03-20T10:00:00Z',
+  lastAccess: '2026-03-20T12:00:00Z',
+  rememberMe: false,
+  clients: ['web-app'],
+};
+
+const sampleDevice: IdentityDeviceActivity = {
+  ipAddress: '192.168.1.1',
+  lastAccess: '2026-03-20T12:00:00Z',
+  device: 'Desktop',
+  os: 'Windows',
+  osVersion: '11',
+  browser: 'Chrome',
+  mobile: false,
+  current: true,
+  sessions: [sampleSession],
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: IdentityConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <IdentityProvider config={config}>{children}</IdentityProvider>
+    );
+  };
+}
+
+describe('use-identity-sessions', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useUserSessions', () => {
+    it('fetches sessions for a user', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleSession] });
+
+      const { result } = renderHook(() => useUserSessions('user-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/sessions');
+      expect(result.current.data).toEqual([sampleSession]);
+    });
+
+    it('is disabled when userId is empty', async () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useUserSessions(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useUserDeviceActivity', () => {
+    it('fetches device activity for a user', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleDevice] });
+
+      const { result } = renderHook(() => useUserDeviceActivity('user-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/devices');
+      expect(result.current.data).toEqual([sampleDevice]);
+    });
+
+    it('is disabled when userId is empty', async () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useUserDeviceActivity(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+    });
+  });
+
+  describe('useTerminateSession', () => {
+    it('terminates a specific session via DELETE', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useTerminateSession(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ userId: 'user-1', sessionId: 'session-1' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith(
+        '/identity/provider/users/user-1/sessions/session-1'
+      );
+    });
+  });
+
+  describe('useTerminateAllSessions', () => {
+    it('terminates all sessions via DELETE', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useTerminateAllSessions(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('user-1');
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith('/identity/provider/users/user-1/sessions');
+    });
+
+    it('exposes error state on failure', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockRejectedValue(new Error('Not Implemented'));
+
+      const { result } = renderHook(() => useTerminateAllSessions(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('user-1');
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe('Not Implemented');
+    });
+  });
+});

--- a/packages/@granit/react-identity/src/hooks/use-identity-groups.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-groups.ts
@@ -1,0 +1,115 @@
+import {
+  addUserToGroup,
+  fetchGroups,
+  fetchUserGroups,
+  removeUserFromGroup,
+} from '@granit/identity';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider.js';
+
+import type { IdentityGroup } from '@granit/identity';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List all groups from the identity provider.
+ *
+ * @example
+ * ```tsx
+ * const { data: groups } = useGroups();
+ * ```
+ */
+export function useGroups(): UseQueryResult<readonly IdentityGroup[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'groups'),
+    queryFn: () => fetchGroups(config.client, basePath),
+  });
+}
+
+/**
+ * List groups a user belongs to.
+ *
+ * The query is automatically disabled when `userId` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: groups } = useUserGroups(selectedUserId);
+ * ```
+ */
+export function useUserGroups(userId: string): UseQueryResult<readonly IdentityGroup[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'groups'),
+    queryFn: () => fetchUserGroups(config.client, basePath, userId),
+    enabled: userId.length > 0,
+  });
+}
+
+/** Variables for `useAddUserToGroup` and `useRemoveUserFromGroup` mutations. */
+export type GroupMutationVariables = {
+  readonly userId: string;
+  readonly groupId: string;
+};
+
+/**
+ * Add a user to a group (idempotent).
+ * Invalidates group and user queries on success.
+ *
+ * @example
+ * ```tsx
+ * const addToGroup = useAddUserToGroup();
+ * await addToGroup.mutateAsync({ userId: 'user-1', groupId: 'group-1' });
+ * ```
+ */
+export function useAddUserToGroup(): UseMutationResult<void, Error, GroupMutationVariables> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, groupId }: GroupMutationVariables) =>
+      addUserToGroup(config.client, basePath, userId, groupId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'groups'),
+      });
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}
+
+/**
+ * Remove a user from a group (idempotent).
+ * Invalidates group and user queries on success.
+ *
+ * @example
+ * ```tsx
+ * const removeFromGroup = useRemoveUserFromGroup();
+ * await removeFromGroup.mutateAsync({ userId: 'user-1', groupId: 'group-1' });
+ * ```
+ */
+export function useRemoveUserFromGroup(): UseMutationResult<void, Error, GroupMutationVariables> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, groupId }: GroupMutationVariables) =>
+      removeUserFromGroup(config.client, basePath, userId, groupId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'groups'),
+      });
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
@@ -1,0 +1,83 @@
+import {
+  fetchPasswordChangedAt,
+  sendPasswordResetEmail,
+  setTemporaryPassword,
+} from '@granit/identity';
+import { useMutation, useQuery } from '@tanstack/react-query';
+
+import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider.js';
+
+import type { IdentityPasswordChangedAtResponse } from '@granit/identity';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Get the last password change timestamp for a user.
+ *
+ * The query is automatically disabled when `userId` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data } = usePasswordChangedAt(selectedUserId);
+ * console.log(data?.changedAt);
+ * ```
+ */
+export function usePasswordChangedAt(
+  userId: string
+): UseQueryResult<IdentityPasswordChangedAtResponse> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'password-changed-at'),
+    queryFn: () => fetchPasswordChangedAt(config.client, basePath, userId),
+    enabled: userId.length > 0,
+  });
+}
+
+/**
+ * Send a password reset email to a user.
+ * May fail with 501 if `supportsNativePasswordResetEmail` is false.
+ *
+ * @example
+ * ```tsx
+ * const sendReset = useSendPasswordResetEmail();
+ * await sendReset.mutateAsync('user-1');
+ * ```
+ */
+export function useSendPasswordResetEmail(): UseMutationResult<void, Error, string> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: (userId: string) => sendPasswordResetEmail(config.client, basePath, userId),
+  });
+}
+
+/** Variables for `useSetTemporaryPassword` mutation. */
+export type SetTemporaryPasswordVariables = {
+  readonly userId: string;
+  readonly password: string;
+};
+
+/**
+ * Set a temporary password for a user.
+ *
+ * @example
+ * ```tsx
+ * const setPassword = useSetTemporaryPassword();
+ * await setPassword.mutateAsync({ userId: 'user-1', password: 'temp123!' });
+ * ```
+ */
+export function useSetTemporaryPassword(): UseMutationResult<
+  void,
+  Error,
+  SetTemporaryPasswordVariables
+> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, password }: SetTemporaryPasswordVariables) =>
+      setTemporaryPassword(config.client, basePath, userId, password),
+  });
+}

--- a/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
@@ -1,0 +1,149 @@
+import {
+  createUser,
+  fetchProviderUser,
+  fetchProviderUsers,
+  setUserEnabled,
+  updateUser,
+} from '@granit/identity';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider.js';
+
+import type {
+  IdentityProviderUserListParams,
+  IdentityUser,
+  IdentityUserCreateRequest,
+  IdentityUserUpdateRequest,
+} from '@granit/identity';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List/search users from the identity provider.
+ *
+ * @example
+ * ```tsx
+ * const { data: users } = useProviderUsers({ search: 'john', max: 20 });
+ * ```
+ */
+export function useProviderUsers(
+  params?: IdentityProviderUserListParams
+): UseQueryResult<readonly IdentityUser[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: [...buildIdentityQueryKey(config, 'provider', 'users', 'list'), params],
+    queryFn: () => fetchProviderUsers(config.client, basePath, params),
+  });
+}
+
+/**
+ * Fetch a single user by ID from the identity provider.
+ *
+ * The query is automatically disabled when `userId` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: user } = useProviderUser(selectedUserId);
+ * ```
+ */
+export function useProviderUser(userId: string): UseQueryResult<IdentityUser> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId),
+    queryFn: () => fetchProviderUser(config.client, basePath, userId),
+    enabled: userId.length > 0,
+  });
+}
+
+/**
+ * Create a new user in the identity provider.
+ * Invalidates provider user queries on success.
+ *
+ * @example
+ * ```tsx
+ * const createUser = useCreateUser();
+ * await createUser.mutateAsync({ username: 'jdoe', email: 'jdoe@example.com', enabled: true });
+ * ```
+ */
+export function useCreateUser(): UseMutationResult<IdentityUser, Error, IdentityUserCreateRequest> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: (request: IdentityUserCreateRequest) =>
+      createUser(config.client, basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}
+
+/** Variables for `useUpdateUser` mutation. */
+export type UpdateUserVariables = {
+  readonly userId: string;
+  readonly request: IdentityUserUpdateRequest;
+};
+
+/**
+ * Update an existing user in the identity provider.
+ * Invalidates provider user queries on success.
+ *
+ * @example
+ * ```tsx
+ * const updateUser = useUpdateUser();
+ * await updateUser.mutateAsync({ userId: 'user-1', request: { email: 'new@example.com' } });
+ * ```
+ */
+export function useUpdateUser(): UseMutationResult<IdentityUser, Error, UpdateUserVariables> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, request }: UpdateUserVariables) =>
+      updateUser(config.client, basePath, userId, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}
+
+/** Variables for `useSetUserEnabled` mutation. */
+export type SetUserEnabledVariables = {
+  readonly userId: string;
+  readonly enabled: boolean;
+};
+
+/**
+ * Enable or disable a user in the identity provider.
+ * Invalidates provider user queries on success.
+ *
+ * @example
+ * ```tsx
+ * const setEnabled = useSetUserEnabled();
+ * await setEnabled.mutateAsync({ userId: 'user-1', enabled: false });
+ * ```
+ */
+export function useSetUserEnabled(): UseMutationResult<void, Error, SetUserEnabledVariables> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, enabled }: SetUserEnabledVariables) =>
+      setUserEnabled(config.client, basePath, userId, enabled),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-identity/src/hooks/use-identity-roles.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-roles.ts
@@ -1,0 +1,137 @@
+import {
+  assignRole,
+  fetchRoleMembers,
+  fetchRoles,
+  fetchUserRoles,
+  removeRole,
+} from '@granit/identity';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider.js';
+
+import type { IdentityRole, IdentityUser } from '@granit/identity';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List all roles from the identity provider.
+ *
+ * @example
+ * ```tsx
+ * const { data: roles } = useRoles();
+ * ```
+ */
+export function useRoles(): UseQueryResult<readonly IdentityRole[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'roles'),
+    queryFn: () => fetchRoles(config.client, basePath),
+  });
+}
+
+/**
+ * List roles assigned to a user.
+ *
+ * The query is automatically disabled when `userId` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: roles } = useUserRoles(selectedUserId);
+ * ```
+ */
+export function useUserRoles(userId: string): UseQueryResult<readonly IdentityRole[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'roles'),
+    queryFn: () => fetchUserRoles(config.client, basePath, userId),
+    enabled: userId.length > 0,
+  });
+}
+
+/**
+ * List members of a role.
+ *
+ * The query is automatically disabled when `roleName` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: members } = useRoleMembers('admin');
+ * ```
+ */
+export function useRoleMembers(roleName: string): UseQueryResult<readonly IdentityUser[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'roles', roleName, 'members'),
+    queryFn: () => fetchRoleMembers(config.client, basePath, roleName),
+    enabled: roleName.length > 0,
+  });
+}
+
+/** Variables for `useAssignRole` and `useRemoveRole` mutations. */
+export type RoleMutationVariables = {
+  readonly userId: string;
+  readonly roleName: string;
+};
+
+/**
+ * Assign a role to a user (idempotent).
+ * Invalidates role and user queries on success.
+ *
+ * @example
+ * ```tsx
+ * const assign = useAssignRole();
+ * await assign.mutateAsync({ userId: 'user-1', roleName: 'admin' });
+ * ```
+ */
+export function useAssignRole(): UseMutationResult<void, Error, RoleMutationVariables> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, roleName }: RoleMutationVariables) =>
+      assignRole(config.client, basePath, userId, roleName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'roles'),
+      });
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}
+
+/**
+ * Remove a role from a user (idempotent).
+ * Invalidates role and user queries on success.
+ *
+ * @example
+ * ```tsx
+ * const remove = useRemoveRole();
+ * await remove.mutateAsync({ userId: 'user-1', roleName: 'admin' });
+ * ```
+ */
+export function useRemoveRole(): UseMutationResult<void, Error, RoleMutationVariables> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, roleName }: RoleMutationVariables) =>
+      removeRole(config.client, basePath, userId, roleName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'roles'),
+      });
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-identity/src/hooks/use-identity-sessions.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-sessions.ts
@@ -1,0 +1,114 @@
+import {
+  fetchUserDeviceActivity,
+  fetchUserSessions,
+  terminateAllSessions,
+  terminateSession,
+} from '@granit/identity';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider.js';
+
+import type { IdentityDeviceActivity, IdentitySession } from '@granit/identity';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List active sessions for a user.
+ *
+ * The query is automatically disabled when `userId` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: sessions } = useUserSessions(selectedUserId);
+ * ```
+ */
+export function useUserSessions(userId: string): UseQueryResult<readonly IdentitySession[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'sessions'),
+    queryFn: () => fetchUserSessions(config.client, basePath, userId),
+    enabled: userId.length > 0,
+  });
+}
+
+/**
+ * List device activity for a user.
+ *
+ * The query is automatically disabled when `userId` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: devices } = useUserDeviceActivity(selectedUserId);
+ * ```
+ */
+export function useUserDeviceActivity(
+  userId: string
+): UseQueryResult<readonly IdentityDeviceActivity[]> {
+  const config = useIdentityConfig();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'devices'),
+    queryFn: () => fetchUserDeviceActivity(config.client, basePath, userId),
+    enabled: userId.length > 0,
+  });
+}
+
+/** Variables for `useTerminateSession` mutation. */
+export type TerminateSessionVariables = {
+  readonly userId: string;
+  readonly sessionId: string;
+};
+
+/**
+ * Terminate a specific user session.
+ * May fail with 501 if `supportsIndividualSessionTermination` is false.
+ * Invalidates session queries on success.
+ *
+ * @example
+ * ```tsx
+ * const terminate = useTerminateSession();
+ * await terminate.mutateAsync({ userId: 'user-1', sessionId: 'session-1' });
+ * ```
+ */
+export function useTerminateSession(): UseMutationResult<void, Error, TerminateSessionVariables> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: ({ userId, sessionId }: TerminateSessionVariables) =>
+      terminateSession(config.client, basePath, userId, sessionId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}
+
+/**
+ * Terminate all active sessions for a user.
+ * Invalidates session queries on success.
+ *
+ * @example
+ * ```tsx
+ * const terminateAll = useTerminateAllSessions();
+ * await terminateAll.mutateAsync('user-1');
+ * ```
+ */
+export function useTerminateAllSessions(): UseMutationResult<void, Error, string> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.providerBasePath ?? '/identity/provider';
+
+  return useMutation({
+    mutationFn: (userId: string) => terminateAllSessions(config.client, basePath, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildIdentityQueryKey(config, 'provider', 'users'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-identity/src/index.ts
+++ b/packages/@granit/react-identity/src/index.ts
@@ -6,9 +6,58 @@ export {
 } from './providers/identity-provider.js';
 export type { IdentityConfig, IdentityProviderProps } from './providers/identity-provider.js';
 
-// Hooks
+// Hooks — Cache
 export { useIdentityCacheStats, useBatchResolveUsers } from './hooks/use-identity-cache.js';
 export { useIdentityCapabilities } from './hooks/use-identity-capabilities.js';
 export { useIdentityRgpd } from './hooks/use-identity-rgpd.js';
 export { useIdentitySync } from './hooks/use-identity-sync.js';
 export { useIdentityUser, useIdentityUsers } from './hooks/use-identity-users.js';
+
+// Hooks — Provider users
+export {
+  useCreateUser,
+  useProviderUser,
+  useProviderUsers,
+  useSetUserEnabled,
+  useUpdateUser,
+} from './hooks/use-identity-provider-users.js';
+export type {
+  SetUserEnabledVariables,
+  UpdateUserVariables,
+} from './hooks/use-identity-provider-users.js';
+
+// Hooks — Roles
+export {
+  useAssignRole,
+  useRemoveRole,
+  useRoleMembers,
+  useRoles,
+  useUserRoles,
+} from './hooks/use-identity-roles.js';
+export type { RoleMutationVariables } from './hooks/use-identity-roles.js';
+
+// Hooks — Groups
+export {
+  useAddUserToGroup,
+  useGroups,
+  useRemoveUserFromGroup,
+  useUserGroups,
+} from './hooks/use-identity-groups.js';
+export type { GroupMutationVariables } from './hooks/use-identity-groups.js';
+
+// Hooks — Sessions
+export {
+  useTerminateAllSessions,
+  useTerminateSession,
+  useUserDeviceActivity,
+  useUserSessions,
+} from './hooks/use-identity-sessions.js';
+export type { TerminateSessionVariables } from './hooks/use-identity-sessions.js';
+
+// Hooks — Passwords
+export {
+  usePasswordChangedAt,
+  useSendPasswordResetEmail,
+  useSetTemporaryPassword,
+} from './hooks/use-identity-passwords.js';
+export type { SetTemporaryPasswordVariables } from './hooks/use-identity-passwords.js';

--- a/packages/@granit/react-identity/src/providers/identity-provider.tsx
+++ b/packages/@granit/react-identity/src/providers/identity-provider.tsx
@@ -6,8 +6,10 @@ import type { ReactNode } from 'react';
 /** Configuration for the identity provider. */
 export interface IdentityConfig {
   readonly client: AxiosInstance;
-  /** Base path prefix before `/capabilities` (default: `/identity/users`). */
+  /** Base path for user cache endpoints (default: `/identity/users`). */
   readonly basePath?: string;
+  /** Base path for identity provider endpoints (default: `/identity/provider`). */
+  readonly providerBasePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 


### PR DESCRIPTION
## Summary

- **Extend `@granit/identity`** with 21 new identity provider API functions (users CRUD, roles, groups, sessions, passwords) and their associated types
- **Extend `@granit/react-identity`** with 17 new React Query hooks and `providerBasePath` config option (default: `/identity/provider`)
- **BREAKING**: Fix 2 RGPD route changes — `eraseUserCache` now calls `DELETE {basePath}/{userId}` (was `…/erase`), `pseudonymizeUserCache` now uses `PATCH` (was `POST`)

### New endpoints covered

| Group | Hooks | API functions |
|-------|-------|---------------|
| Provider Users | `useProviderUsers`, `useProviderUser`, `useCreateUser`, `useUpdateUser`, `useSetUserEnabled` | 5 |
| Roles | `useRoles`, `useUserRoles`, `useRoleMembers`, `useAssignRole`, `useRemoveRole` | 5 |
| Groups | `useGroups`, `useUserGroups`, `useAddUserToGroup`, `useRemoveUserFromGroup` | 4 |
| Sessions | `useUserSessions`, `useUserDeviceActivity`, `useTerminateSession`, `useTerminateAllSessions` | 4 |
| Passwords | `usePasswordChangedAt`, `useSendPasswordResetEmail`, `useSetTemporaryPassword` | 3 |

## Test plan

- [x] All 1278 tests pass (154 test files)
- [x] ESLint clean (`--max-warnings 0`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Existing RGPD tests updated for breaking route changes
- [ ] Verify consumer apps (guava-front, guava-admin) update `eraseUserCache` / `pseudonymizeUserCache` calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)
