### PR TITLE
fix: align entity type names with .NET backend contracts

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T00:14:50.862451+00:00",
+  "generatedAt": "2026-03-21T09:48:03.438367+00:00",
   "repo": "granit-front",
   "packages": [
     {
@@ -592,7 +592,7 @@
         {
           "name": "getAvailableChannels",
           "kind": "function",
-          "signature": "function getAvailableChannels(preferences: readonly NotificationPreferenceDto[]): string[]"
+          "signature": "function getAvailableChannels(preferences: readonly NotificationPreference[]): string[]"
         },
         {
           "name": "NotificationChannels",
@@ -1449,7 +1449,7 @@
             {
               "name": "lastNotification",
               "kind": "property",
-              "signature": "lastNotification: NotificationDto | null"
+              "signature": "lastNotification: UserNotification | null"
             },
             {
               "name": "connectionState",
@@ -1517,7 +1517,7 @@
             {
               "name": "notifications",
               "kind": "property",
-              "signature": "notifications: readonly NotificationDto[]"
+              "signature": "notifications: readonly UserNotification[]"
             },
             {
               "name": "totalCount",
@@ -1584,7 +1584,7 @@
             {
               "name": "preferences",
               "kind": "property",
-              "signature": "preferences: NotificationPreferenceDto[]"
+              "signature": "preferences: NotificationPreference[]"
             },
             {
               "name": "loading",
@@ -2059,7 +2059,7 @@
             {
               "name": "entries",
               "kind": "property",
-              "signature": "entries: readonly TimelineStreamEntry[]"
+              "signature": "entries: readonly TimelineEntry[]"
             },
             {
               "name": "totalCount",
@@ -2099,7 +2099,7 @@
             {
               "name": "addOptimisticEntry",
               "kind": "method",
-              "signature": "addOptimisticEntry: (entry: TimelineStreamEntry) => void"
+              "signature": "addOptimisticEntry: (entry: TimelineEntry) => void"
             },
             {
               "name": "removeOptimisticEntry",
@@ -2225,6 +2225,11 @@
           "signature": "function useDeliveries( subscriptionId: string, options: WebhooksOptions ): UseQueryResult<WebhookDeliveryAttemptResponse[]>"
         },
         {
+          "name": "useRetryDelivery",
+          "kind": "function",
+          "signature": "function useRetryDelivery( options: RetryDeliveryOptions ): UseMutationResult<void, Error,"
+        },
+        {
           "name": "useWebhookStats",
           "kind": "function",
           "signature": "function useWebhookStats( options: WebhooksOptions ): UseQueryResult<WebhookSubscriptionStatsResponse>"
@@ -2233,6 +2238,12 @@
           "name": "WebhooksOptions",
           "kind": "interface",
           "signature": "interface WebhooksOptions",
+          "members": []
+        },
+        {
+          "name": "RetryDeliveryOptions",
+          "kind": "interface",
+          "signature": "interface RetryDeliveryOptions",
           "members": []
         }
       ]
@@ -2303,7 +2314,7 @@
             {
               "name": "transitions",
               "kind": "property",
-              "signature": "transitions: readonly TransitionDto[]"
+              "signature": "transitions: readonly WorkflowTransition[]"
             },
             {
               "name": "loading",
@@ -2596,7 +2607,7 @@
         {
           "name": "WorkflowHistoryPage",
           "kind": "type",
-          "signature": "type WorkflowHistoryPage = PagedResult<TransitionHistoryDto>"
+          "signature": "type WorkflowHistoryPage = PagedResult<TransitionHistory>"
         }
       ]
     }

--- a/packages/@granit/data-exchange/src/export/api/export-api.ts
+++ b/packages/@granit/data-exchange/src/export/api/export-api.ts
@@ -1,7 +1,4 @@
-import type {
-  ExportDefinitionResponse,
-  ExportFieldDescriptor,
-} from '../types/export-definition.js';
+import type { ExportDefinitionResponse, ExportField } from '../types/export-definition.js';
 import type { CreateExportJobRequest, ExportJobResponse } from '../types/export-job.js';
 import type { PagedResult, PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
@@ -33,8 +30,8 @@ export async function fetchExportFields(
   client: AxiosInstance,
   basePath: string,
   definitionName: string
-): Promise<readonly ExportFieldDescriptor[]> {
-  const response = await client.get<ExportFieldDescriptor[]>(
+): Promise<readonly ExportField[]> {
+  const response = await client.get<ExportField[]>(
     `${basePath}/definitions/${encodeURIComponent(definitionName)}/fields`
   );
   return response.data;

--- a/packages/@granit/data-exchange/src/export/index.ts
+++ b/packages/@granit/data-exchange/src/export/index.ts
@@ -1,5 +1,5 @@
 // Types
-export type { ExportDefinitionResponse, ExportFieldDescriptor } from './types/export-definition.js';
+export type { ExportDefinitionResponse, ExportField } from './types/export-definition.js';
 
 export type {
   CreateExportJobRequest,

--- a/packages/@granit/data-exchange/src/export/types/export-definition.ts
+++ b/packages/@granit/data-exchange/src/export/types/export-definition.ts
@@ -2,7 +2,7 @@
  * Metadata about a single exportable field.
  * Mirrors `Granit.DataExchange.Endpoints.Dtos.Export.ExportFieldResponse`.
  */
-export interface ExportFieldDescriptor {
+export interface ExportField {
   readonly propertyPath: string;
   readonly clrTypeName: string;
   readonly header: string | null;

--- a/packages/@granit/data-exchange/src/export/types/index.ts
+++ b/packages/@granit/data-exchange/src/export/types/index.ts
@@ -1,4 +1,4 @@
-export type { ExportDefinitionResponse, ExportFieldDescriptor } from './export-definition.js';
+export type { ExportDefinitionResponse, ExportField } from './export-definition.js';
 
 export type { CreateExportJobRequest, ExportJobResponse, ExportJobStatus } from './export-job.js';
 

--- a/packages/@granit/data-exchange/src/index.ts
+++ b/packages/@granit/data-exchange/src/index.ts
@@ -6,7 +6,7 @@
 export type {
   CreateExportJobRequest,
   ExportDefinitionResponse,
-  ExportFieldDescriptor,
+  ExportField,
   ExportJobListParams,
   ExportJobResponse,
   ExportJobStatus,

--- a/packages/@granit/features/src/api/features-api.ts
+++ b/packages/@granit/features/src/api/features-api.ts
@@ -1,5 +1,5 @@
 import type {
-  FeatureGroupDefinition,
+  FeatureGroup,
   FeatureValueResponse,
   FeatureValuesMap,
   SetFeatureOverrideRequest,
@@ -14,8 +14,8 @@ import type { AxiosInstance } from 'axios';
 export async function fetchFeatureDefinitions(
   client: AxiosInstance,
   basePath: string
-): Promise<FeatureGroupDefinition[]> {
-  const response = await client.get<FeatureGroupDefinition[]>(`${basePath}/features/definitions`);
+): Promise<FeatureGroup[]> {
+  const response = await client.get<FeatureGroup[]>(`${basePath}/features/definitions`);
   return response.data;
 }
 

--- a/packages/@granit/features/src/index.ts
+++ b/packages/@granit/features/src/index.ts
@@ -1,11 +1,11 @@
 // Types
 export type {
   FeatureDefinition,
-  FeatureGroupDefinition,
+  FeatureGroup,
   FeatureValueResponse,
   FeatureValueType,
   FeatureValuesMap,
-  NumericConstraint,
+  FeatureNumericConstraint,
   SelectionValues,
   SetFeatureOverrideRequest,
 } from './types/index.js';

--- a/packages/@granit/features/src/types/index.ts
+++ b/packages/@granit/features/src/types/index.ts
@@ -1,8 +1,8 @@
 /** Storage and validation type of a feature value. Mirrors `Granit.Features.ValueTypes.FeatureValueType`. */
 export type FeatureValueType = 'Toggle' | 'Numeric' | 'Selection';
 
-/** Min/max bounds for Numeric features. Mirrors `Granit.Features.ValueTypes.NumericConstraint`. */
-export interface NumericConstraint {
+/** Min/max bounds for Numeric features. Mirrors `Granit.Features.ValueTypes.FeatureNumericConstraint`. */
+export interface FeatureNumericConstraint {
   readonly min: number;
   readonly max: number;
 }
@@ -17,14 +17,14 @@ export interface FeatureDefinition {
   readonly name: string;
   readonly defaultValue: string;
   readonly valueType: FeatureValueType;
-  readonly numericConstraint: NumericConstraint | null;
+  readonly numericConstraint: FeatureNumericConstraint | null;
   readonly selectionValues: SelectionValues | null;
   readonly displayName: string | null;
   readonly description: string | null;
 }
 
-/** Grouped feature definitions. Mirrors `Granit.Features.Definitions.FeatureGroupDefinition`. */
-export interface FeatureGroupDefinition {
+/** Grouped feature definitions. Mirrors `Granit.Features.Definitions.FeatureGroup`. */
+export interface FeatureGroup {
   readonly name: string;
   readonly displayName: string | null;
   readonly features: readonly FeatureDefinition[];

--- a/packages/@granit/notifications-signalr/src/__tests__/create-signalr-transport.test.ts
+++ b/packages/@granit/notifications-signalr/src/__tests__/create-signalr-transport.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { createSignalRTransport } from '../transports/create-signalr-transport.js';
 
-import type { NotificationDto } from '@granit/notifications';
+import type { UserNotification } from '@granit/notifications';
 
 let lastConnection: {
   start: ReturnType<typeof vi.fn>;
@@ -119,9 +119,9 @@ describe('createSignalRTransport', () => {
     const receiveCall = lastConnection.on.mock.calls.find(
       (call: unknown[]) => call[0] === 'ReceiveNotification'
     );
-    const handler = receiveCall![1] as (n: NotificationDto) => void;
+    const handler = receiveCall![1] as (n: UserNotification) => void;
 
-    const mockNotif: NotificationDto = {
+    const mockNotif: UserNotification = {
       id: 'n-1',
       title: 'Test',
       body: null,
@@ -183,7 +183,7 @@ describe('createSignalRTransport', () => {
     const receiveCall = lastConnection.on.mock.calls.find(
       (call: unknown[]) => call[0] === 'ReceiveNotification'
     );
-    const handler = receiveCall![1] as (n: NotificationDto) => void;
+    const handler = receiveCall![1] as (n: UserNotification) => void;
 
     handler({
       id: 'n-1',

--- a/packages/@granit/notifications-signalr/src/transports/create-signalr-transport.ts
+++ b/packages/@granit/notifications-signalr/src/transports/create-signalr-transport.ts
@@ -2,7 +2,7 @@ import { HttpTransportType, HubConnectionBuilder, LogLevel } from '@microsoft/si
 
 import type {
   ConnectionState,
-  NotificationDto,
+  UserNotification,
   NotificationTransport,
 } from '@granit/notifications';
 import type { HubConnection } from '@microsoft/signalr';
@@ -30,7 +30,7 @@ export interface SignalRTransportConfig {
 export function createSignalRTransport(config: SignalRTransportConfig): NotificationTransport {
   let connection: HubConnection | null = null;
   let currentState: ConnectionState = 'disconnected';
-  const notificationListeners = new Set<(notification: NotificationDto) => void>();
+  const notificationListeners = new Set<(notification: UserNotification) => void>();
   const stateListeners = new Set<(state: ConnectionState) => void>();
 
   function setState(state: ConnectionState) {
@@ -57,7 +57,7 @@ export function createSignalRTransport(config: SignalRTransportConfig): Notifica
         .configureLogging(LogLevel.Warning)
         .build();
 
-      connection.on('ReceiveNotification', (notification: NotificationDto) => {
+      connection.on('ReceiveNotification', (notification: UserNotification) => {
         for (const listener of notificationListeners) {
           listener(notification);
         }

--- a/packages/@granit/notifications-sse/src/__tests__/create-sse-transport.test.ts
+++ b/packages/@granit/notifications-sse/src/__tests__/create-sse-transport.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { NotificationDto } from '@granit/notifications';
+import type { UserNotification } from '@granit/notifications';
 
 let capturedUrl: string | null = null;
 let capturedOptions: Record<string, unknown> | null = null;
@@ -60,7 +60,7 @@ describe('createSseTransport', () => {
       event: string;
       data: string;
     }) => void;
-    const mockNotif: NotificationDto = {
+    const mockNotif: UserNotification = {
       id: 'n-1',
       title: 'SSE Notification',
       body: null,

--- a/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
+++ b/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
@@ -2,7 +2,7 @@ import { EventStreamContentType, fetchEventSource } from '@microsoft/fetch-event
 
 import type {
   ConnectionState,
-  NotificationDto,
+  UserNotification,
   NotificationTransport,
 } from '@granit/notifications';
 
@@ -38,7 +38,7 @@ export function createSseTransport(config: SseTransportConfig): NotificationTran
   const heartbeatType = config.heartbeatTypeName ?? '__heartbeat__';
   let abortController: AbortController | null = null;
   let currentState: ConnectionState = 'disconnected';
-  const notificationListeners = new Set<(notification: NotificationDto) => void>();
+  const notificationListeners = new Set<(notification: UserNotification) => void>();
   const stateListeners = new Set<(state: ConnectionState) => void>();
 
   function setState(state: ConnectionState) {
@@ -75,7 +75,7 @@ export function createSseTransport(config: SseTransportConfig): NotificationTran
           if (event.event === heartbeatType || !event.data) return;
 
           try {
-            const notification = JSON.parse(event.data) as NotificationDto;
+            const notification = JSON.parse(event.data) as UserNotification;
             for (const listener of notificationListeners) {
               listener(notification);
             }

--- a/packages/@granit/notifications/src/__tests__/get-available-channels.test.ts
+++ b/packages/@granit/notifications/src/__tests__/get-available-channels.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { getAvailableChannels } from '../types/index.js';
 
-import type { NotificationPreferenceDto } from '../types/index.js';
+import type { NotificationPreference } from '../types/index.js';
 
 describe('getAvailableChannels', () => {
   it('should return empty array for empty preferences', () => {
@@ -10,7 +10,7 @@ describe('getAvailableChannels', () => {
   });
 
   it('should extract channel keys from the first preference', () => {
-    const preferences: NotificationPreferenceDto[] = [
+    const preferences: NotificationPreference[] = [
       {
         notificationType: 'document_update',
         label: 'Document updates',
@@ -27,7 +27,7 @@ describe('getAvailableChannels', () => {
   });
 
   it('should handle preferences with a single channel', () => {
-    const preferences: NotificationPreferenceDto[] = [
+    const preferences: NotificationPreference[] = [
       {
         notificationType: 'alert',
         label: 'Alert',

--- a/packages/@granit/notifications/src/__tests__/notification-api.test.ts
+++ b/packages/@granit/notifications/src/__tests__/notification-api.test.ts
@@ -12,10 +12,10 @@ import {
 } from '../api/notification-api.js';
 
 import type {
-  ActivityFeedPageDto,
-  NotificationDto,
-  NotificationPageDto,
-  NotificationPreferenceDto,
+  ActivityFeedPage,
+  UserNotification,
+  UserNotificationPage,
+  NotificationPreference,
 } from '../types/index.js';
 
 describe('notification-api', () => {
@@ -23,7 +23,7 @@ describe('notification-api', () => {
   // fetchNotifications
   // -----------------------------------------------------------------------
   it('should send GET with pagination params (fetchNotifications)', async () => {
-    const page: NotificationPageDto = {
+    const page: UserNotificationPage = {
       items: [],
       totalCount: 0,
       nextCursor: null,
@@ -44,7 +44,7 @@ describe('notification-api', () => {
   // markAsRead
   // -----------------------------------------------------------------------
   it('should send PATCH to the correct URL (markAsRead)', async () => {
-    const notification: NotificationDto = {
+    const notification: UserNotification = {
       id: 'n-1',
       title: 'Test',
       body: null,
@@ -93,7 +93,7 @@ describe('notification-api', () => {
   // fetchEntityActivityFeed
   // -----------------------------------------------------------------------
   it('should send GET with entity path (fetchEntityActivityFeed)', async () => {
-    const page: ActivityFeedPageDto = { items: [], totalCount: 0, nextCursor: null };
+    const page: ActivityFeedPage = { items: [], totalCount: 0, nextCursor: null };
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(page));
 
@@ -112,7 +112,7 @@ describe('notification-api', () => {
   // fetchPreferences
   // -----------------------------------------------------------------------
   it('should send GET for preferences (fetchPreferences)', async () => {
-    const prefs: NotificationPreferenceDto[] = [];
+    const prefs: NotificationPreference[] = [];
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(prefs));
 
@@ -126,7 +126,7 @@ describe('notification-api', () => {
   // updatePreference
   // -----------------------------------------------------------------------
   it('should send PUT with preference data (updatePreference)', async () => {
-    const pref: NotificationPreferenceDto = {
+    const pref: NotificationPreference = {
       notificationType: 'AppointmentReminder',
       label: 'Rappel de rendez-vous',
       channels: { inApp: true, email: false, push: true },

--- a/packages/@granit/notifications/src/api/notification-api.ts
+++ b/packages/@granit/notifications/src/api/notification-api.ts
@@ -1,8 +1,8 @@
 import type {
-  ActivityFeedPageDto,
-  NotificationDto,
-  NotificationPageDto,
-  NotificationPreferenceDto,
+  ActivityFeedPage,
+  UserNotification,
+  UserNotificationPage,
+  NotificationPreference,
 } from '../types/index.js';
 import type { PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
@@ -19,8 +19,8 @@ export async function fetchNotifications(
   client: AxiosInstance,
   basePath: string,
   params: PaginationParams = {}
-): Promise<NotificationPageDto> {
-  const { data } = await client.get<NotificationPageDto>(buildUrl(basePath, 'notifications'), {
+): Promise<UserNotificationPage> {
+  const { data } = await client.get<UserNotificationPage>(buildUrl(basePath, 'notifications'), {
     params,
   });
   return data;
@@ -30,8 +30,8 @@ export async function markAsRead(
   client: AxiosInstance,
   basePath: string,
   notificationId: string
-): Promise<NotificationDto> {
-  const { data } = await client.patch<NotificationDto>(
+): Promise<UserNotification> {
+  const { data } = await client.patch<UserNotification>(
     buildUrl(basePath, 'notifications', notificationId, 'read')
   );
   return data;
@@ -62,8 +62,8 @@ export async function fetchEntityActivityFeed(
   entityType: string,
   entityId: string,
   params: PaginationParams = {}
-): Promise<ActivityFeedPageDto> {
-  const { data } = await client.get<ActivityFeedPageDto>(
+): Promise<ActivityFeedPage> {
+  const { data } = await client.get<ActivityFeedPage>(
     buildUrl(basePath, 'activity-feed', entityType, entityId),
     { params }
   );
@@ -77,8 +77,8 @@ export async function fetchEntityActivityFeed(
 export async function fetchPreferences(
   client: AxiosInstance,
   basePath: string
-): Promise<NotificationPreferenceDto[]> {
-  const { data } = await client.get<NotificationPreferenceDto[]>(
+): Promise<NotificationPreference[]> {
+  const { data } = await client.get<NotificationPreference[]>(
     buildUrl(basePath, 'notification-preferences')
   );
   return data;
@@ -87,9 +87,9 @@ export async function fetchPreferences(
 export async function updatePreference(
   client: AxiosInstance,
   basePath: string,
-  preference: NotificationPreferenceDto
-): Promise<NotificationPreferenceDto> {
-  const { data } = await client.put<NotificationPreferenceDto>(
+  preference: NotificationPreference
+): Promise<NotificationPreference> {
+  const { data } = await client.put<NotificationPreference>(
     buildUrl(basePath, 'notification-preferences', preference.notificationType),
     preference
   );

--- a/packages/@granit/notifications/src/index.ts
+++ b/packages/@granit/notifications/src/index.ts
@@ -1,15 +1,15 @@
 // Types
 export type {
-  ActivityFeedEntryDto,
-  ActivityFeedPageDto,
+  ActivityFeedEntry,
+  ActivityFeedPage,
   ConnectionState,
   NotificationChannel,
   NotificationConfig,
-  NotificationDto,
-  NotificationPageDto,
-  NotificationPreferenceDto,
+  NotificationPreference,
   NotificationSeverity,
   NotificationTransport,
+  UserNotification,
+  UserNotificationPage,
 } from './types/index.js';
 
 export { getAvailableChannels, NotificationChannels } from './types/index.js';

--- a/packages/@granit/notifications/src/types/index.ts
+++ b/packages/@granit/notifications/src/types/index.ts
@@ -2,12 +2,12 @@ import type { PagedResult } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
-// Notification DTOs — aligned with Granit .NET backend contracts
+// Notification types — aligned with Granit.Notifications .NET backend
 // ---------------------------------------------------------------------------
 
 export type NotificationSeverity = 'info' | 'success' | 'warning' | 'error';
 
-export interface NotificationDto {
+export interface UserNotification {
   id: string;
   title: string;
   body: string | null;
@@ -19,7 +19,7 @@ export interface NotificationDto {
   readAt: string | null;
 }
 
-export type NotificationPageDto = PagedResult<NotificationDto> & {
+export type UserNotificationPage = PagedResult<UserNotification> & {
   readonly unreadCount: number;
 };
 
@@ -27,7 +27,7 @@ export type NotificationPageDto = PagedResult<NotificationDto> & {
 // Activity feed
 // ---------------------------------------------------------------------------
 
-export interface ActivityFeedEntryDto {
+export interface ActivityFeedEntry {
   id: string;
   title: string;
   body: string | null;
@@ -37,7 +37,7 @@ export interface ActivityFeedEntryDto {
   userDisplayName: string | null;
 }
 
-export type ActivityFeedPageDto = PagedResult<ActivityFeedEntryDto>;
+export type ActivityFeedPage = PagedResult<ActivityFeedEntry>;
 
 // ---------------------------------------------------------------------------
 // Channels — extensible string type with well-known constants
@@ -75,7 +75,7 @@ export const NotificationChannels = {
 // Preferences
 // ---------------------------------------------------------------------------
 
-export interface NotificationPreferenceDto {
+export interface NotificationPreference {
   notificationType: string;
   label: string;
   channels: Record<string, boolean>;
@@ -108,7 +108,7 @@ export interface NotificationTransport {
    * Subscribes to incoming notifications.
    * Returns an unsubscribe function.
    */
-  onNotification(callback: (notification: NotificationDto) => void): () => void;
+  onNotification(callback: (notification: UserNotification) => void): () => void;
 
   /**
    * Subscribes to connection state changes.
@@ -134,7 +134,7 @@ export interface NotificationConfig {
  * Extracts the list of available channels from a preferences response.
  * Useful for dynamically rendering a preferences matrix without hardcoding channels.
  */
-export function getAvailableChannels(preferences: readonly NotificationPreferenceDto[]): string[] {
+export function getAvailableChannels(preferences: readonly NotificationPreference[]): string[] {
   if (preferences.length === 0) return [];
   return Object.keys(preferences[0].channels);
 }

--- a/packages/@granit/react-data-exchange/src/export/hooks/use-export-definition.ts
+++ b/packages/@granit/react-data-exchange/src/export/hooks/use-export-definition.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildExportQueryKey, useExportConfig } from '../providers/export-provider.js';
 
-import type { ExportDefinitionResponse, ExportFieldDescriptor } from '@granit/data-exchange';
+import type { ExportDefinitionResponse, ExportField } from '@granit/data-exchange';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -24,7 +24,7 @@ export function useExportDefinitions(): UseQueryResult<readonly ExportDefinition
  */
 export function useExportFields(
   definitionName: string | undefined
-): UseQueryResult<readonly ExportFieldDescriptor[]> {
+): UseQueryResult<readonly ExportField[]> {
   const config = useExportConfig();
 
   return useQuery({

--- a/packages/@granit/react-features/src/hooks/use-feature-definitions.ts
+++ b/packages/@granit/react-features/src/hooks/use-feature-definitions.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildFeaturesQueryKey, useFeaturesConfig } from '../providers/features-provider.js';
 
-import type { FeatureGroupDefinition } from '@granit/features';
+import type { FeatureGroup } from '@granit/features';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -17,7 +17,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
  */
 export function useFeatureDefinitions(options?: {
   enabled?: boolean;
-}): UseQueryResult<FeatureGroupDefinition[]> {
+}): UseQueryResult<FeatureGroup[]> {
   const config = useFeaturesConfig();
 
   return useQuery({

--- a/packages/@granit/react-notifications/src/__tests__/notification-provider.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/notification-provider.test.tsx
@@ -10,7 +10,7 @@ import { createMockClient } from './test-utils.js';
 
 import type {
   NotificationConfig,
-  NotificationDto,
+  UserNotification,
   NotificationTransport,
 } from '@granit/notifications';
 import type { AxiosInstance } from 'axios';
@@ -106,7 +106,7 @@ describe('NotificationProvider', () => {
   });
 
   it('should handle incoming notifications from transport', async () => {
-    let notificationCallback: ((n: NotificationDto) => void) | null = null;
+    let notificationCallback: ((n: UserNotification) => void) | null = null;
 
     const transport = createMockTransport({
       onNotification: vi.fn((cb) => {
@@ -121,7 +121,7 @@ describe('NotificationProvider', () => {
 
     await waitFor(() => expect(result.current.connectionState).toBe('connected'));
 
-    const mockNotif: NotificationDto = {
+    const mockNotif: UserNotification = {
       id: 'n-99',
       title: 'Real-time notification',
       body: null,

--- a/packages/@granit/react-notifications/src/__tests__/use-entity-activity-feed.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/use-entity-activity-feed.test.ts
@@ -10,9 +10,9 @@ import {
   createWrapperWithoutBasePath,
 } from './test-utils.js';
 
-import type { ActivityFeedPageDto } from '@granit/notifications';
+import type { ActivityFeedPage } from '@granit/notifications';
 
-const MOCK_FEED: ActivityFeedPageDto = {
+const MOCK_FEED: ActivityFeedPage = {
   items: [
     {
       id: 'a-1',
@@ -68,7 +68,7 @@ describe('useEntityActivityFeed', () => {
   });
 
   it('should report hasMore correctly', async () => {
-    const page: ActivityFeedPageDto = {
+    const page: ActivityFeedPage = {
       items: [MOCK_FEED.items[0]],
       totalCount: 25,
       nextCursor: null,
@@ -92,13 +92,13 @@ describe('useEntityActivityFeed', () => {
   });
 
   it('should load more entries when loadMore is called', async () => {
-    const page1: ActivityFeedPageDto = {
+    const page1: ActivityFeedPage = {
       items: [MOCK_FEED.items[0]],
       totalCount: 2,
       nextCursor: null,
     };
     const entry2 = { ...MOCK_FEED.items[0], id: 'a-2', title: 'Deuxième entrée' };
-    const page2: ActivityFeedPageDto = {
+    const page2: ActivityFeedPage = {
       items: [entry2],
       totalCount: 2,
       nextCursor: null,
@@ -168,7 +168,7 @@ describe('useEntityActivityFeed', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    const updatedFeed: ActivityFeedPageDto = {
+    const updatedFeed: ActivityFeedPage = {
       items: [{ ...MOCK_FEED.items[0], title: 'Mis à jour' }],
       totalCount: 1,
       nextCursor: null,
@@ -202,7 +202,7 @@ describe('useEntityActivityFeed', () => {
   });
 
   it('should report hasMore as false when all entries are loaded', async () => {
-    const page: ActivityFeedPageDto = {
+    const page: ActivityFeedPage = {
       items: [MOCK_FEED.items[0]],
       totalCount: 1,
       nextCursor: null,

--- a/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/use-notification-preferences.test.ts
@@ -10,9 +10,9 @@ import {
   createWrapperWithoutBasePath,
 } from './test-utils.js';
 
-import type { NotificationPreferenceDto } from '@granit/notifications';
+import type { NotificationPreference } from '@granit/notifications';
 
-const MOCK_PREFS: NotificationPreferenceDto[] = [
+const MOCK_PREFS: NotificationPreference[] = [
   {
     notificationType: 'AppointmentReminder',
     label: 'Rappel de rendez-vous',
@@ -44,7 +44,7 @@ describe('useNotificationPreferences', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(MOCK_PREFS));
 
-    const updatedPref: NotificationPreferenceDto = {
+    const updatedPref: NotificationPreference = {
       ...MOCK_PREFS[0],
       channels: { inApp: true, email: false, push: false },
     };
@@ -163,7 +163,7 @@ describe('useNotificationPreferences', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    const updatedPrefs: NotificationPreferenceDto[] = [
+    const updatedPrefs: NotificationPreference[] = [
       { ...MOCK_PREFS[0], channels: { inApp: false, email: true, push: true } },
     ];
     vi.mocked(client.get).mockResolvedValue(axiosResponse(updatedPrefs));

--- a/packages/@granit/react-notifications/src/__tests__/use-notifications.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/use-notifications.test.ts
@@ -10,9 +10,9 @@ import {
   createWrapperWithoutBasePath,
 } from './test-utils.js';
 
-import type { NotificationDto, NotificationPageDto } from '@granit/notifications';
+import type { UserNotification, UserNotificationPage } from '@granit/notifications';
 
-const MOCK_NOTIFICATION: NotificationDto = {
+const MOCK_NOTIFICATION: UserNotification = {
   id: 'n-1',
   title: 'Nouveau message',
   body: 'Contenu du message',
@@ -24,7 +24,7 @@ const MOCK_NOTIFICATION: NotificationDto = {
   readAt: null,
 };
 
-const MOCK_PAGE: NotificationPageDto = {
+const MOCK_PAGE: UserNotificationPage = {
   items: [MOCK_NOTIFICATION],
   totalCount: 1,
   nextCursor: null,
@@ -86,7 +86,7 @@ describe('useNotifications', () => {
   });
 
   it('should report hasMore when totalCount > loaded items', async () => {
-    const page: NotificationPageDto = {
+    const page: UserNotificationPage = {
       items: [MOCK_NOTIFICATION],
       totalCount: 50,
       nextCursor: null,
@@ -119,18 +119,18 @@ describe('useNotifications', () => {
   });
 
   it('should load more notifications when loadMore is called', async () => {
-    const page1: NotificationPageDto = {
+    const page1: UserNotificationPage = {
       items: [MOCK_NOTIFICATION],
       totalCount: 2,
       nextCursor: null,
       unreadCount: 2,
     };
-    const n2: NotificationDto = {
+    const n2: UserNotification = {
       ...MOCK_NOTIFICATION,
       id: 'n-2',
       title: 'Deuxième notification',
     };
-    const page2: NotificationPageDto = {
+    const page2: UserNotificationPage = {
       items: [n2],
       totalCount: 2,
       nextCursor: null,
@@ -186,7 +186,7 @@ describe('useNotifications', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    const updatedPage: NotificationPageDto = {
+    const updatedPage: UserNotificationPage = {
       items: [{ ...MOCK_NOTIFICATION, title: 'Mis à jour' }],
       totalCount: 1,
       nextCursor: null,
@@ -216,12 +216,12 @@ describe('useNotifications', () => {
   });
 
   it('should not modify other notifications when marking one as read', async () => {
-    const n2: NotificationDto = {
+    const n2: UserNotification = {
       ...MOCK_NOTIFICATION,
       id: 'n-2',
       title: 'Autre notification',
     };
-    const page: NotificationPageDto = {
+    const page: UserNotificationPage = {
       items: [MOCK_NOTIFICATION, n2],
       totalCount: 2,
       nextCursor: null,

--- a/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
@@ -5,7 +5,7 @@ import { useNotificationContext } from '../providers/notification-provider.js';
 
 import { usePaginatedFetch } from './use-paginated-fetch.js';
 
-import type { ActivityFeedEntryDto, ActivityFeedPageDto } from '@granit/notifications';
+import type { ActivityFeedEntry, ActivityFeedPage } from '@granit/notifications';
 
 export interface UseEntityActivityFeedOptions {
   entityType: string;
@@ -14,7 +14,7 @@ export interface UseEntityActivityFeedOptions {
 }
 
 export interface UseEntityActivityFeedReturn {
-  entries: readonly ActivityFeedEntryDto[];
+  entries: readonly ActivityFeedEntry[];
   totalCount: number | null;
   loading: boolean;
   loadingMore: boolean;
@@ -54,7 +54,7 @@ export function useEntityActivityFeed(
     hasMore,
     loadMore,
     refresh,
-  } = usePaginatedFetch<ActivityFeedEntryDto, ActivityFeedPageDto>({
+  } = usePaginatedFetch<ActivityFeedEntry, ActivityFeedPage>({
     fetcher,
     pageSize,
   });

--- a/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
@@ -3,11 +3,11 @@ import { useCallback, useEffect, useOptimistic, useRef, useState, useTransition 
 
 import { useNotificationContext } from '../providers/notification-provider.js';
 
-import type { NotificationChannel, NotificationPreferenceDto } from '@granit/notifications';
+import type { NotificationChannel, NotificationPreference } from '@granit/notifications';
 import type { AxiosInstance } from 'axios';
 
 export interface UseNotificationPreferencesReturn {
-  preferences: NotificationPreferenceDto[];
+  preferences: NotificationPreference[];
   loading: boolean;
   error: Error | null;
   saving: boolean;
@@ -17,16 +17,16 @@ export interface UseNotificationPreferencesReturn {
 
 type OptimisticAction = {
   notificationType: string;
-  updated: NotificationPreferenceDto;
+  updated: NotificationPreference;
 };
 
 async function savePreference(
   apiClient: AxiosInstance,
   basePath: string,
   notificationType: string,
-  updated: NotificationPreferenceDto,
+  updated: NotificationPreference,
   mountedRef: React.RefObject<boolean>,
-  setPreferences: React.Dispatch<React.SetStateAction<NotificationPreferenceDto[]>>,
+  setPreferences: React.Dispatch<React.SetStateAction<NotificationPreference[]>>,
   setError: React.Dispatch<React.SetStateAction<Error | null>>
 ): Promise<void> {
   try {
@@ -55,14 +55,14 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
   const { config } = useNotificationContext();
   const basePath = config.basePath ?? '/api';
 
-  const [preferences, setPreferences] = useState<NotificationPreferenceDto[]>([]);
+  const [preferences, setPreferences] = useState<NotificationPreference[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
   const mountedRef = useRef(true);
 
   const [optimisticPreferences, applyOptimistic] = useOptimistic(
     preferences,
-    (state: NotificationPreferenceDto[], action: OptimisticAction) =>
+    (state: NotificationPreference[], action: OptimisticAction) =>
       state.map((p) => (p.notificationType === action.notificationType ? action.updated : p))
   );
 
@@ -97,7 +97,7 @@ export function useNotificationPreferences(): UseNotificationPreferencesReturn {
       const pref = preferences.find((p) => p.notificationType === notificationType);
       if (!pref) return;
 
-      const updated: NotificationPreferenceDto = {
+      const updated: NotificationPreference = {
         ...pref,
         channels: { ...pref.channels, [channel]: enabled },
       };

--- a/packages/@granit/react-notifications/src/hooks/use-notifications.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notifications.ts
@@ -5,14 +5,14 @@ import { useNotificationContext } from '../providers/notification-provider.js';
 
 import { usePaginatedFetch } from './use-paginated-fetch.js';
 
-import type { NotificationDto, NotificationPageDto } from '@granit/notifications';
+import type { UserNotification, UserNotificationPage } from '@granit/notifications';
 
 export interface UseNotificationsOptions {
   pageSize?: number;
 }
 
 export interface UseNotificationsReturn {
-  notifications: readonly NotificationDto[];
+  notifications: readonly UserNotification[];
   totalCount: number | null;
   loading: boolean;
   loadingMore: boolean;
@@ -41,7 +41,7 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
   );
 
   const onSuccess = useCallback(
-    (page: NotificationPageDto) => setUnreadCount(page.unreadCount),
+    (page: UserNotificationPage) => setUnreadCount(page.unreadCount),
     [setUnreadCount]
   );
 
@@ -55,7 +55,7 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
     hasMore,
     loadMore,
     refresh,
-  } = usePaginatedFetch<NotificationDto, NotificationPageDto>({
+  } = usePaginatedFetch<UserNotification, UserNotificationPage>({
     fetcher,
     pageSize,
     onSuccess,
@@ -64,8 +64,8 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
   const markRead = useCallback(
     async (id: string) => {
       const updated = await markAsRead(config.apiClient, basePath, id);
-      setNotifications((prev: readonly NotificationDto[]) =>
-        prev.map((n: NotificationDto) => (n.id === id ? updated : n))
+      setNotifications((prev: readonly UserNotification[]) =>
+        prev.map((n: UserNotification) => (n.id === id ? updated : n))
       );
       setUnreadCount((prev: number) => Math.max(0, prev - 1));
     },
@@ -74,8 +74,8 @@ export function useNotifications(options: UseNotificationsOptions = {}): UseNoti
 
   const markAllRead = useCallback(async () => {
     await markAllAsRead(config.apiClient, basePath);
-    setNotifications((prev: readonly NotificationDto[]) =>
-      prev.map((n: NotificationDto) => ({ ...n, isRead: true, readAt: new Date().toISOString() }))
+    setNotifications((prev: readonly UserNotification[]) =>
+      prev.map((n: UserNotification) => ({ ...n, isRead: true, readAt: new Date().toISOString() }))
     );
     setUnreadCount(0);
   }, [config.apiClient, basePath, setUnreadCount, setNotifications]);

--- a/packages/@granit/react-notifications/src/hooks/use-real-time-notifications.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-real-time-notifications.ts
@@ -1,9 +1,9 @@
 import { useNotificationContext } from '../providers/notification-provider.js';
 
-import type { ConnectionState, NotificationDto } from '@granit/notifications';
+import type { ConnectionState, UserNotification } from '@granit/notifications';
 
 export interface UseRealTimeNotificationsReturn {
-  lastNotification: NotificationDto | null;
+  lastNotification: UserNotification | null;
   connectionState: ConnectionState;
 }
 

--- a/packages/@granit/react-notifications/src/providers/notification-provider.tsx
+++ b/packages/@granit/react-notifications/src/providers/notification-provider.tsx
@@ -3,7 +3,7 @@ import { createContext, useCallback, useContext, useEffect, useMemo, useState } 
 import type {
   ConnectionState,
   NotificationConfig,
-  NotificationDto,
+  UserNotification,
   NotificationTransport,
 } from '@granit/notifications';
 
@@ -14,7 +14,7 @@ import type {
 interface NotificationContextValue {
   config: NotificationConfig;
   connectionState: ConnectionState;
-  lastNotification: NotificationDto | null;
+  lastNotification: UserNotification | null;
   unreadCount: number;
   setUnreadCount: (count: number | ((prev: number) => number)) => void;
 }
@@ -50,7 +50,7 @@ export function NotificationProvider({
   transport,
 }: Readonly<NotificationProviderProps>) {
   const [connectionState, setConnectionState] = useState<ConnectionState>('disconnected');
-  const [lastNotification, setLastNotification] = useState<NotificationDto | null>(null);
+  const [lastNotification, setLastNotification] = useState<UserNotification | null>(null);
   const [unreadCount, setUnreadCount] = useState(0);
 
   useEffect(() => {

--- a/packages/@granit/react-templating/src/hooks/use-template-categories.ts
+++ b/packages/@granit/react-templating/src/hooks/use-template-categories.ts
@@ -9,10 +9,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useTemplatingConfig } from '../providers/templating-provider.js';
 
-import type {
-  CreateTemplateCategoryRequest,
-  UpdateTemplateCategoryRequest,
-} from '@granit/templating';
+import type { SaveTemplateCategoryRequest } from '@granit/templating';
 
 export function useTemplateCategories() {
   const { client, basePath, queryKeyPrefix } = useTemplatingConfig();
@@ -31,13 +28,12 @@ export function useTemplateCategoryMutations() {
     queryClient.invalidateQueries({ queryKey: templateKeys.categories(queryKeyPrefix) });
 
   const createMutation = useMutation({
-    mutationFn: (request: CreateTemplateCategoryRequest) =>
-      createCategory(client, basePath, request),
+    mutationFn: (request: SaveTemplateCategoryRequest) => createCategory(client, basePath, request),
     onSuccess: () => invalidateCategories(),
   });
 
   const updateMutation = useMutation({
-    mutationFn: ({ id, request }: { id: string; request: UpdateTemplateCategoryRequest }) =>
+    mutationFn: ({ id, request }: { id: string; request: SaveTemplateCategoryRequest }) =>
       updateCategory(client, basePath, id, request),
     onSuccess: () => invalidateCategories(),
   });

--- a/packages/@granit/react-timeline/src/__tests__/use-timeline.test.ts
+++ b/packages/@granit/react-timeline/src/__tests__/use-timeline.test.ts
@@ -5,9 +5,9 @@ import { useTimeline } from '../hooks/use-timeline.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
-import type { TimelineStreamEntry, TimelineStreamPage } from '@granit/timeline';
+import type { TimelineEntry, TimelineEntryPage } from '@granit/timeline';
 
-function makeEntry(overrides: Partial<TimelineStreamEntry> = {}): TimelineStreamEntry {
+function makeEntry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
   return {
     id: 'e-1',
     entityType: 'Patient',
@@ -26,7 +26,7 @@ function makeEntry(overrides: Partial<TimelineStreamEntry> = {}): TimelineStream
 describe('useTimeline', () => {
   it('should load entries on mount', async () => {
     const client = createMockClient();
-    const page: TimelineStreamPage = {
+    const page: TimelineEntryPage = {
       items: [makeEntry()],
       totalCount: 1,
       nextCursor: null,
@@ -64,7 +64,7 @@ describe('useTimeline', () => {
   it('should detect hasMore when totalCount > loaded entries', async () => {
     const client = createMockClient();
     const items = Array.from({ length: 20 }, (_, i) => makeEntry({ id: `e-${i}` }));
-    const page: TimelineStreamPage = { items, totalCount: 50, nextCursor: null };
+    const page: TimelineEntryPage = { items, totalCount: 50, nextCursor: null };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(page));
 
     const { result } = renderHook(
@@ -81,12 +81,12 @@ describe('useTimeline', () => {
 
   it('should load more entries via loadMore', async () => {
     const client = createMockClient();
-    const firstPage: TimelineStreamPage = {
+    const firstPage: TimelineEntryPage = {
       items: [makeEntry({ id: 'e-1' })],
       totalCount: 2,
       nextCursor: null,
     };
-    const secondPage: TimelineStreamPage = {
+    const secondPage: TimelineEntryPage = {
       items: [makeEntry({ id: 'e-2', body: 'Second' })],
       totalCount: 2,
       nextCursor: null,
@@ -113,7 +113,7 @@ describe('useTimeline', () => {
 
   it('should add an optimistic entry at the top', async () => {
     const client = createMockClient();
-    const page: TimelineStreamPage = {
+    const page: TimelineEntryPage = {
       items: [makeEntry({ id: 'e-1' })],
       totalCount: 1,
       nextCursor: null,
@@ -137,7 +137,7 @@ describe('useTimeline', () => {
 
   it('should remove an optimistic entry by id', async () => {
     const client = createMockClient();
-    const page: TimelineStreamPage = {
+    const page: TimelineEntryPage = {
       items: [makeEntry({ id: 'e-1' }), makeEntry({ id: 'e-2' })],
       totalCount: 2,
       nextCursor: null,

--- a/packages/@granit/react-timeline/src/hooks/use-timeline-actions.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-timeline-actions.ts
@@ -4,19 +4,19 @@ import { useCallback, useState } from 'react';
 
 import { useTimelineConfig } from '../providers/timeline-provider.js';
 
-import type { CreateTimelineEntryRequest, TimelineStreamEntry } from '@granit/timeline';
+import type { CreateTimelineEntryRequest, TimelineEntry } from '@granit/timeline';
 
 const logger = createLogger('timeline:actions');
 
 export interface UseTimelineActionsOptions {
   entityType: string;
   entityId: string;
-  onEntryCreated?: (entry: TimelineStreamEntry) => void;
+  onEntryCreated?: (entry: TimelineEntry) => void;
   onEntryDeleted?: (entryId: string) => void;
 }
 
 export interface UseTimelineActionsReturn {
-  postEntry: (request: CreateTimelineEntryRequest) => Promise<TimelineStreamEntry>;
+  postEntry: (request: CreateTimelineEntryRequest) => Promise<TimelineEntry>;
   removeEntry: (entryId: string) => Promise<void>;
   posting: boolean;
   deleting: boolean;
@@ -36,7 +36,7 @@ export function useTimelineActions({
   const [error, setError] = useState<Error | null>(null);
 
   const postEntry = useCallback(
-    async (request: CreateTimelineEntryRequest): Promise<TimelineStreamEntry> => {
+    async (request: CreateTimelineEntryRequest): Promise<TimelineEntry> => {
       setPosting(true);
       setError(null);
 

--- a/packages/@granit/react-timeline/src/hooks/use-timeline.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-timeline.ts
@@ -4,7 +4,7 @@ import { useCallback } from 'react';
 
 import { useTimelineConfig } from '../providers/timeline-provider.js';
 
-import type { TimelineStreamEntry } from '@granit/timeline';
+import type { TimelineEntry } from '@granit/timeline';
 
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -15,7 +15,7 @@ export interface UseTimelineOptions {
 }
 
 export interface UseTimelineReturn {
-  entries: readonly TimelineStreamEntry[];
+  entries: readonly TimelineEntry[];
   totalCount: number | null;
   loading: boolean;
   loadingMore: boolean;
@@ -23,7 +23,7 @@ export interface UseTimelineReturn {
   hasMore: boolean;
   loadMore: () => void;
   refresh: () => void;
-  addOptimisticEntry: (entry: TimelineStreamEntry) => void;
+  addOptimisticEntry: (entry: TimelineEntry) => void;
   removeOptimisticEntry: (entryId: string) => void;
 }
 
@@ -56,10 +56,10 @@ export function useTimeline({
     hasMore,
     loadMore,
     refresh,
-  } = useInfiniteScroll<TimelineStreamEntry>({ fetcher, pageSize });
+  } = useInfiniteScroll<TimelineEntry>({ fetcher, pageSize });
 
   const addOptimisticEntry = useCallback(
-    (entry: TimelineStreamEntry) => {
+    (entry: TimelineEntry) => {
       setEntries((prev) => [entry, ...prev]);
     },
     [setEntries]

--- a/packages/@granit/react-webhooks/src/__tests__/use-deliveries.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-deliveries.test.tsx
@@ -32,6 +32,7 @@ const mockDeliveries: WebhookDeliveryAttemptResponse[] = [
     durationMs: 142,
     errorMessage: null,
     isSuccess: true,
+    payload: null,
   },
   {
     deliveryId: 'del-002',
@@ -45,6 +46,7 @@ const mockDeliveries: WebhookDeliveryAttemptResponse[] = [
     durationMs: 3021,
     errorMessage: 'Internal Server Error',
     isSuccess: false,
+    payload: null,
   },
 ];
 

--- a/packages/@granit/react-webhooks/src/__tests__/use-retry-delivery.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-retry-delivery.test.tsx
@@ -1,0 +1,84 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { webhooksKeys } from '@granit/webhooks';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useRetryDelivery } from '../hooks/use-retry-delivery.js';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
+
+describe('useRetryDelivery', () => {
+  it('should send POST to /deliveries/{deliveryId}/retry and invalidate deliveries', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRetryDelivery({ client }), {
+      wrapper,
+    });
+
+    result.current.mutate({
+      deliveryId: 'del-001',
+      subscriptionId: 'sub-001',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/deliveries/del-001/retry');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: webhooksKeys.deliveries('sub-001'),
+    });
+  });
+
+  it('should use custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useRetryDelivery({ client, basePath: '/custom/webhooks' }),
+      { wrapper }
+    );
+
+    result.current.mutate({
+      deliveryId: 'del-002',
+      subscriptionId: 'sub-001',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith('/custom/webhooks/deliveries/del-002/retry');
+  });
+
+  it('should handle retry error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRetryDelivery({ client }), {
+      wrapper,
+    });
+
+    result.current.mutate({
+      deliveryId: 'del-999',
+      subscriptionId: 'sub-001',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-webhooks/src/constants.ts
+++ b/packages/@granit/react-webhooks/src/constants.ts
@@ -1,1 +1,3 @@
 export const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
+
+export const DEFAULT_WEBHOOKS_BASE_PATH = '/api/v1/webhooks';

--- a/packages/@granit/react-webhooks/src/hooks/use-retry-delivery.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-retry-delivery.ts
@@ -1,0 +1,34 @@
+import { retryDelivery, webhooksKeys } from '@granit/webhooks';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { DEFAULT_WEBHOOKS_BASE_PATH } from '../constants.js';
+
+import type { UseMutationResult } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+
+export interface RetryDeliveryOptions {
+  readonly client: AxiosInstance;
+  /** Webhooks root path (e.g. `/api/v1/webhooks`). Defaults to `/api/v1/webhooks`. */
+  readonly basePath?: string;
+}
+
+/**
+ * Mutation hook to retry a previously failed webhook delivery attempt.
+ *
+ * Invalidates the deliveries query for the related subscription on success.
+ */
+export function useRetryDelivery(
+  options: RetryDeliveryOptions
+): UseMutationResult<void, Error, { deliveryId: string; subscriptionId: string }> {
+  const { client, basePath = DEFAULT_WEBHOOKS_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ deliveryId }) => retryDelivery(client, basePath, deliveryId),
+    onSuccess: async (_data, { subscriptionId }) => {
+      await queryClient.invalidateQueries({
+        queryKey: webhooksKeys.deliveries(subscriptionId),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-webhooks/src/index.ts
+++ b/packages/@granit/react-webhooks/src/index.ts
@@ -12,7 +12,9 @@ export {
 } from './hooks/use-subscription-lifecycle.js';
 export { useRotateSecret, useTestPing } from './hooks/use-subscription-operations.js';
 export { useDeliveries } from './hooks/use-deliveries.js';
+export { useRetryDelivery } from './hooks/use-retry-delivery.js';
 export { useWebhookStats } from './hooks/use-webhook-stats.js';
 
 // Types
 export type { WebhooksOptions } from './hooks/use-subscription.js';
+export type { RetryDeliveryOptions } from './hooks/use-retry-delivery.js';

--- a/packages/@granit/react-workflow/src/__tests__/use-execute-transition.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-execute-transition.test.ts
@@ -5,12 +5,12 @@ import { useExecuteTransition } from '../hooks/use-execute-transition.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
-import type { TransitionResultDto } from '@granit/workflow';
+import type { WorkflowTransitionResult } from '@granit/workflow';
 
 describe('useExecuteTransition', () => {
   it('should execute a transition successfully', async () => {
     const client = createMockClient();
-    const transitionResult: TransitionResultDto = {
+    const transitionResult: WorkflowTransitionResult = {
       succeeded: true,
       resultingState: 'Published',
       outcome: 'Completed',
@@ -22,7 +22,7 @@ describe('useExecuteTransition', () => {
       wrapper: createWrapper(client),
     });
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Draft', 'Published', 'Approved');
     });
@@ -47,7 +47,7 @@ describe('useExecuteTransition', () => {
       wrapper: createWrapper(client),
     });
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Draft', 'Published');
     });
@@ -103,7 +103,7 @@ describe('useExecuteTransition', () => {
       wrapper: createWrapper(client),
     });
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Draft', 'Published');
     });
@@ -117,7 +117,7 @@ describe('useExecuteTransition', () => {
 
   it('should handle approval-requested outcome', async () => {
     const client = createMockClient();
-    const transitionResult: TransitionResultDto = {
+    const transitionResult: WorkflowTransitionResult = {
       succeeded: true,
       resultingState: 'PendingReview',
       outcome: 'ApprovalRequested',
@@ -128,7 +128,7 @@ describe('useExecuteTransition', () => {
       wrapper: createWrapper(client),
     });
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Draft', 'Published');
     });

--- a/packages/@granit/react-workflow/src/__tests__/use-transitions.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-transitions.test.ts
@@ -5,12 +5,12 @@ import { useTransitions } from '../hooks/use-transitions.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
-import type { WorkflowStatusDto } from '@granit/workflow';
+import type { WorkflowStatus } from '@granit/workflow';
 
 describe('useTransitions', () => {
   it('should load transitions on mount', async () => {
     const client = createMockClient();
-    const status: WorkflowStatusDto = {
+    const status: WorkflowStatus = {
       currentState: 'Draft',
       availableTransitions: [
         { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
@@ -113,13 +113,13 @@ describe('useTransitions', () => {
 
   it('should refetch when refetch is called', async () => {
     const client = createMockClient();
-    const status1: WorkflowStatusDto = {
+    const status1: WorkflowStatus = {
       currentState: 'Draft',
       availableTransitions: [
         { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
       ],
     };
-    const status2: WorkflowStatusDto = {
+    const status2: WorkflowStatus = {
       currentState: 'Draft',
       availableTransitions: [
         { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },

--- a/packages/@granit/react-workflow/src/__tests__/use-workflow-history.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-workflow-history.test.ts
@@ -5,9 +5,9 @@ import { useWorkflowHistory } from '../hooks/use-workflow-history.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
-import type { TransitionHistoryDto } from '@granit/workflow';
+import type { TransitionHistory } from '@granit/workflow';
 
-const sampleHistory: TransitionHistoryDto[] = [
+const sampleHistory: TransitionHistory[] = [
   {
     previousState: 'Draft',
     newState: 'PendingReview',

--- a/packages/@granit/react-workflow/src/__tests__/use-workflow-status.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-workflow-status.test.ts
@@ -5,12 +5,12 @@ import { useWorkflowStatus } from '../hooks/use-workflow-status.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
-import type { WorkflowStatusDto } from '@granit/workflow';
+import type { WorkflowStatus } from '@granit/workflow';
 
 describe('useWorkflowStatus', () => {
   it('should load status on mount', async () => {
     const client = createMockClient();
-    const status: WorkflowStatusDto = {
+    const status: WorkflowStatus = {
       currentState: 'Draft',
       availableTransitions: [
         { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
@@ -119,11 +119,11 @@ describe('useWorkflowStatus', () => {
 
   it('should refetch when refetch is called', async () => {
     const client = createMockClient();
-    const status1: WorkflowStatusDto = {
+    const status1: WorkflowStatus = {
       currentState: 'Draft',
       availableTransitions: [],
     };
-    const status2: WorkflowStatusDto = {
+    const status2: WorkflowStatus = {
       currentState: 'Published',
       availableTransitions: [],
     };

--- a/packages/@granit/react-workflow/src/__tests__/use-workflow-transition.test.ts
+++ b/packages/@granit/react-workflow/src/__tests__/use-workflow-transition.test.ts
@@ -5,12 +5,12 @@ import { useWorkflowTransition } from '../hooks/use-workflow-transition.js';
 
 import { axiosResponse, createMockClient, createWrapper } from './test-utils.tsx';
 
-import type { TransitionResultDto } from '@granit/workflow';
+import type { WorkflowTransitionResult } from '@granit/workflow';
 
 describe('useWorkflowTransition', () => {
   it('should execute a transition successfully', async () => {
     const client = createMockClient();
-    const transitionResult: TransitionResultDto = {
+    const transitionResult: WorkflowTransitionResult = {
       succeeded: true,
       resultingState: 'Published',
       outcome: 'Completed',
@@ -28,7 +28,7 @@ describe('useWorkflowTransition', () => {
       { wrapper: createWrapper(client) }
     );
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Published', 'Validated');
     });
@@ -58,7 +58,7 @@ describe('useWorkflowTransition', () => {
       { wrapper: createWrapper(client) }
     );
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Published');
     });
@@ -125,7 +125,7 @@ describe('useWorkflowTransition', () => {
       { wrapper: createWrapper(client) }
     );
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Published');
     });
@@ -139,7 +139,7 @@ describe('useWorkflowTransition', () => {
 
   it('should handle approval-requested outcome', async () => {
     const client = createMockClient();
-    const transitionResult: TransitionResultDto = {
+    const transitionResult: WorkflowTransitionResult = {
       succeeded: true,
       resultingState: 'PendingReview',
       outcome: 'ApprovalRequested',
@@ -155,7 +155,7 @@ describe('useWorkflowTransition', () => {
       { wrapper: createWrapper(client) }
     );
 
-    let returned: TransitionResultDto | null = null;
+    let returned: WorkflowTransitionResult | null = null;
     await act(async () => {
       returned = await result.current.transition('Published');
     });

--- a/packages/@granit/react-workflow/src/hooks/use-execute-transition.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-execute-transition.ts
@@ -4,12 +4,12 @@ import { useCallback, useState } from 'react';
 
 import { useWorkflowConfig } from '../providers/workflow-provider.js';
 
-import type { TransitionResultDto } from '@granit/workflow';
+import type { WorkflowTransitionResult } from '@granit/workflow';
 
 const logger = createLogger('workflow:execute-transition');
 
 export interface UseExecuteTransitionOptions {
-  onSuccess?: (result: TransitionResultDto) => void;
+  onSuccess?: (result: WorkflowTransitionResult) => void;
   onError?: (error: Error) => void;
 }
 
@@ -18,9 +18,9 @@ export interface UseExecuteTransitionReturn {
     currentState: string,
     targetState: string,
     comment?: string
-  ) => Promise<TransitionResultDto | null>;
+  ) => Promise<WorkflowTransitionResult | null>;
   loading: boolean;
-  result: TransitionResultDto | null;
+  result: WorkflowTransitionResult | null;
   error: Error | null;
 }
 
@@ -30,7 +30,7 @@ export function useExecuteTransition(
   const { apiClient, basePath } = useWorkflowConfig();
 
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<TransitionResultDto | null>(null);
+  const [result, setResult] = useState<WorkflowTransitionResult | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   const transition = useCallback(
@@ -38,7 +38,7 @@ export function useExecuteTransition(
       currentState: string,
       targetState: string,
       comment?: string
-    ): Promise<TransitionResultDto | null> => {
+    ): Promise<WorkflowTransitionResult | null> => {
       setLoading(true);
       setError(null);
 

--- a/packages/@granit/react-workflow/src/hooks/use-transitions.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-transitions.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useWorkflowConfig } from '../providers/workflow-provider.js';
 
-import type { TransitionDto } from '@granit/workflow';
+import type { WorkflowTransition } from '@granit/workflow';
 
 const logger = createLogger('workflow:transitions');
 
@@ -13,7 +13,7 @@ export interface UseTransitionsOptions {
 }
 
 export interface UseTransitionsReturn {
-  transitions: readonly TransitionDto[];
+  transitions: readonly WorkflowTransition[];
   loading: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
@@ -22,7 +22,7 @@ export interface UseTransitionsReturn {
 export function useTransitions({ currentState }: UseTransitionsOptions): UseTransitionsReturn {
   const { apiClient, basePath } = useWorkflowConfig();
 
-  const [transitions, setTransitions] = useState<readonly TransitionDto[]>([]);
+  const [transitions, setTransitions] = useState<readonly WorkflowTransition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 

--- a/packages/@granit/react-workflow/src/hooks/use-workflow-history.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-workflow-history.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useWorkflowConfig } from '../providers/workflow-provider.js';
 
-import type { TransitionHistoryDto } from '@granit/workflow';
+import type { TransitionHistory } from '@granit/workflow';
 
 const logger = createLogger('workflow:history');
 
@@ -15,7 +15,7 @@ export interface UseWorkflowHistoryOptions {
 }
 
 export interface UseWorkflowHistoryReturn {
-  history: readonly TransitionHistoryDto[];
+  history: readonly TransitionHistory[];
   loading: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
@@ -28,7 +28,7 @@ export function useWorkflowHistory({
 }: UseWorkflowHistoryOptions): UseWorkflowHistoryReturn {
   const { apiClient, basePath } = useWorkflowConfig();
 
-  const [history, setHistory] = useState<readonly TransitionHistoryDto[]>([]);
+  const [history, setHistory] = useState<readonly TransitionHistory[]>([]);
   const [loading, setLoading] = useState(enabled);
   const [error, setError] = useState<Error | null>(null);
 

--- a/packages/@granit/react-workflow/src/hooks/use-workflow-status.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-workflow-status.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useWorkflowConfig } from '../providers/workflow-provider.js';
 
-import type { TransitionDto } from '@granit/workflow';
+import type { WorkflowTransition } from '@granit/workflow';
 
 const logger = createLogger('workflow:status');
 
@@ -15,7 +15,7 @@ export interface UseWorkflowStatusOptions {
 
 export interface UseWorkflowStatusReturn {
   currentState: string | null;
-  transitions: readonly TransitionDto[];
+  transitions: readonly WorkflowTransition[];
   loading: boolean;
   error: Error | null;
   refetch: () => Promise<void>;
@@ -28,7 +28,7 @@ export function useWorkflowStatus({
   const { apiClient, basePath } = useWorkflowConfig();
 
   const [currentState, setCurrentState] = useState<string | null>(null);
-  const [transitions, setTransitions] = useState<readonly TransitionDto[]>([]);
+  const [transitions, setTransitions] = useState<readonly WorkflowTransition[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<Error | null>(null);
 

--- a/packages/@granit/react-workflow/src/hooks/use-workflow-transition.ts
+++ b/packages/@granit/react-workflow/src/hooks/use-workflow-transition.ts
@@ -4,21 +4,21 @@ import { useCallback, useState } from 'react';
 
 import { useWorkflowConfig } from '../providers/workflow-provider.js';
 
-import type { TransitionResultDto } from '@granit/workflow';
+import type { WorkflowTransitionResult } from '@granit/workflow';
 
 const logger = createLogger('workflow:transition');
 
 export interface UseWorkflowTransitionOptions {
   entityType: string;
   entityId: string;
-  onSuccess?: (result: TransitionResultDto) => void;
+  onSuccess?: (result: WorkflowTransitionResult) => void;
   onError?: (error: Error) => void;
 }
 
 export interface UseWorkflowTransitionReturn {
-  transition: (targetState: string, comment?: string) => Promise<TransitionResultDto | null>;
+  transition: (targetState: string, comment?: string) => Promise<WorkflowTransitionResult | null>;
   loading: boolean;
-  result: TransitionResultDto | null;
+  result: WorkflowTransitionResult | null;
   error: Error | null;
 }
 
@@ -31,11 +31,11 @@ export function useWorkflowTransition({
   const { apiClient, basePath } = useWorkflowConfig();
 
   const [loading, setLoading] = useState(false);
-  const [result, setResult] = useState<TransitionResultDto | null>(null);
+  const [result, setResult] = useState<WorkflowTransitionResult | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   const transition = useCallback(
-    async (targetState: string, comment?: string): Promise<TransitionResultDto | null> => {
+    async (targetState: string, comment?: string): Promise<WorkflowTransitionResult | null> => {
       setLoading(true);
       setError(null);
 

--- a/packages/@granit/templating/src/__tests__/api.test.ts
+++ b/packages/@granit/templating/src/__tests__/api.test.ts
@@ -25,7 +25,7 @@ import type {
   TemplateCategory,
   TemplateDetail,
   TemplateHistory,
-  TemplateLifecycleInfo,
+  TemplateLifecycle,
   TemplateListItem,
   TemplatePreviewResponse,
   TemplateRevision,
@@ -172,7 +172,7 @@ describe('templates-api', () => {
   describe('getLifecycleInfo', () => {
     it('should call GET /templates/{name}/lifecycle', async () => {
       const client = createMockClient();
-      const info: TemplateLifecycleInfo = {
+      const info: TemplateLifecycle = {
         name: 'Billing.Invoice',
         currentStatus: TemplateLifecycleStatus.Draft,
         workflowEnabled: true,

--- a/packages/@granit/templating/src/api/templates-api.ts
+++ b/packages/@granit/templating/src/api/templates-api.ts
@@ -1,17 +1,16 @@
 import type {
-  CreateTemplateCategoryRequest,
+  SaveTemplateCategoryRequest,
   SaveTemplateRequest,
   TemplateCategory,
   TemplateDetail,
   TemplateHistory,
-  TemplateLifecycleInfo,
+  TemplateLifecycle,
   TemplateListItem,
   TemplateListParams,
   TemplatePreviewRequest,
   TemplatePreviewResponse,
   TemplateRevision,
   TemplateVariables,
-  UpdateTemplateCategoryRequest,
 } from '../types/index.js';
 import type { PagedResult, PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
@@ -103,11 +102,10 @@ export async function getLifecycleInfo(
   basePath: string,
   name: string,
   culture?: string
-): Promise<TemplateLifecycleInfo> {
-  const { data } = await client.get<TemplateLifecycleInfo>(
-    templateUrl(basePath, name, 'lifecycle'),
-    { params: { culture } }
-  );
+): Promise<TemplateLifecycle> {
+  const { data } = await client.get<TemplateLifecycle>(templateUrl(basePath, name, 'lifecycle'), {
+    params: { culture },
+  });
   return data;
 }
 
@@ -196,7 +194,7 @@ export async function getCategories(
 export async function createCategory(
   client: AxiosInstance,
   basePath: string,
-  request: CreateTemplateCategoryRequest
+  request: SaveTemplateCategoryRequest
 ): Promise<TemplateCategory> {
   const { data } = await client.post<TemplateCategory>(`${basePath}/templates/categories`, request);
   return data;
@@ -206,7 +204,7 @@ export async function updateCategory(
   client: AxiosInstance,
   basePath: string,
   id: string,
-  request: UpdateTemplateCategoryRequest
+  request: SaveTemplateCategoryRequest
 ): Promise<TemplateCategory> {
   const { data } = await client.put<TemplateCategory>(
     `${basePath}/templates/categories/${encodeURIComponent(id)}`,

--- a/packages/@granit/templating/src/index.ts
+++ b/packages/@granit/templating/src/index.ts
@@ -6,14 +6,14 @@
 export { DocumentFormat, TemplateLifecycleStatus } from './types/index.js';
 
 export type {
-  CreateTemplateCategoryRequest,
   DocumentFormatValue,
+  SaveTemplateCategoryRequest,
   SaveTemplateRequest,
   TemplateCategory,
   TemplateDetail,
   TemplateHistory,
   TemplateKey,
-  TemplateLifecycleInfo,
+  TemplateLifecycle,
   TemplateLifecycleStatusValue,
   TemplateListItem,
   TemplateListParams,
@@ -25,7 +25,6 @@ export type {
   TemplateVariable,
   TemplateVariables,
   TemplatingConfig,
-  UpdateTemplateCategoryRequest,
 } from './types/index.js';
 
 // Query keys (for advanced usage / custom queries)

--- a/packages/@granit/templating/src/types/index.ts
+++ b/packages/@granit/templating/src/types/index.ts
@@ -1,14 +1,14 @@
 export { DocumentFormat, TemplateLifecycleStatus } from './template-types.js';
 
 export type {
-  CreateTemplateCategoryRequest,
   DocumentFormatValue,
+  SaveTemplateCategoryRequest,
   SaveTemplateRequest,
   TemplateCategory,
   TemplateDetail,
   TemplateHistory,
   TemplateKey,
-  TemplateLifecycleInfo,
+  TemplateLifecycle,
   TemplateLifecycleStatusValue,
   TemplateListItem,
   TemplateListParams,
@@ -20,5 +20,4 @@ export type {
   TemplateVariable,
   TemplateVariables,
   TemplatingConfig,
-  UpdateTemplateCategoryRequest,
 } from './template-types.js';

--- a/packages/@granit/templating/src/types/template-types.ts
+++ b/packages/@granit/templating/src/types/template-types.ts
@@ -89,7 +89,7 @@ export type SaveTemplateRequest = {
 
 // ── Lifecycle ──
 
-export type TemplateLifecycleInfo = {
+export type TemplateLifecycle = {
   readonly name: string;
   readonly culture?: string;
   readonly currentStatus: TemplateLifecycleStatusValue;
@@ -146,18 +146,11 @@ export type TemplateCategory = {
   readonly templateCount: number;
 };
 
-export type CreateTemplateCategoryRequest = {
+export type SaveTemplateCategoryRequest = {
   readonly name: string;
   readonly description?: string;
   readonly icon?: string;
   readonly sortOrder?: number;
-};
-
-export type UpdateTemplateCategoryRequest = {
-  readonly name: string;
-  readonly description?: string;
-  readonly icon?: string;
-  readonly sortOrder: number;
 };
 
 // ── History (paginated) ──

--- a/packages/@granit/timeline/src/__tests__/api.test.ts
+++ b/packages/@granit/timeline/src/__tests__/api.test.ts
@@ -10,7 +10,7 @@ import {
   unfollowEntity,
 } from '../api/timeline-api.js';
 
-import type { CreateTimelineEntryRequest, TimelineStreamPage } from '../types/index.js';
+import type { CreateTimelineEntryRequest, TimelineEntryPage } from '../types/index.js';
 import type { AxiosInstance } from 'axios';
 
 const BASE_PATH = '/api/v1/timeline';
@@ -24,7 +24,7 @@ describe('timeline API', () => {
 
   describe('fetchStream', () => {
     it('should call GET /{entityType}/{entityId} with query params', async () => {
-      const page: TimelineStreamPage = { items: [], totalCount: 0, nextCursor: null };
+      const page: TimelineEntryPage = { items: [], totalCount: 0, nextCursor: null };
       vi.mocked(client.get).mockResolvedValue(axiosResponse(page));
 
       const result = await fetchStream(client, BASE_PATH, 'Patient', 'p-1', {

--- a/packages/@granit/timeline/src/api/timeline-api.ts
+++ b/packages/@granit/timeline/src/api/timeline-api.ts
@@ -1,8 +1,8 @@
 import type {
   CreateTimelineEntryRequest,
   TimelineQueryParams,
-  TimelineStreamEntry,
-  TimelineStreamPage,
+  TimelineEntry,
+  TimelineEntryPage,
 } from '../types/index.js';
 import type { AxiosInstance } from 'axios';
 
@@ -22,8 +22,8 @@ export async function fetchStream(
   entityType: string,
   entityId: string,
   params?: TimelineQueryParams
-): Promise<TimelineStreamPage> {
-  const { data } = await client.get<TimelineStreamPage>(buildUrl(basePath, entityType, entityId), {
+): Promise<TimelineEntryPage> {
+  const { data } = await client.get<TimelineEntryPage>(buildUrl(basePath, entityType, entityId), {
     params,
   });
   return data;
@@ -35,8 +35,8 @@ export async function createEntry(
   entityType: string,
   entityId: string,
   request: CreateTimelineEntryRequest
-): Promise<TimelineStreamEntry> {
-  const { data } = await client.post<TimelineStreamEntry>(
+): Promise<TimelineEntry> {
+  const { data } = await client.post<TimelineEntry>(
     buildUrl(basePath, entityType, entityId, 'entries'),
     request
   );

--- a/packages/@granit/timeline/src/index.ts
+++ b/packages/@granit/timeline/src/index.ts
@@ -2,8 +2,8 @@
 export {
   TimelineEntryType,
   type TimelineEntryTypeValue,
-  type TimelineStreamEntry,
-  type TimelineStreamPage,
+  type TimelineEntry,
+  type TimelineEntryPage,
   type CreateTimelineEntryRequest,
   type TimelineQueryParams,
   type TimelineConfig,

--- a/packages/@granit/timeline/src/types/index.ts
+++ b/packages/@granit/timeline/src/types/index.ts
@@ -1,5 +1,5 @@
 export { TimelineEntryType, type TimelineEntryTypeValue } from './entry-type.js';
-export type { TimelineStreamEntry, TimelineStreamPage } from './stream.js';
+export type { TimelineEntry, TimelineEntryPage } from './stream.js';
 export type { CreateTimelineEntryRequest, TimelineQueryParams } from './request.js';
 export type { TimelineConfig } from './config.js';
 export type { MentionSuggestion } from './mention.js';

--- a/packages/@granit/timeline/src/types/stream.ts
+++ b/packages/@granit/timeline/src/types/stream.ts
@@ -3,7 +3,7 @@ import type { PagedResult } from '@granit/querying';
 
 // --- API response types ---
 
-export interface TimelineStreamEntry {
+export interface TimelineEntry {
   readonly id: string;
   readonly entityType: string;
   readonly entityId: string;
@@ -16,4 +16,4 @@ export interface TimelineStreamEntry {
   readonly attachmentBlobIds: readonly string[];
 }
 
-export type TimelineStreamPage = PagedResult<TimelineStreamEntry>;
+export type TimelineEntryPage = PagedResult<TimelineEntry>;

--- a/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
+++ b/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
@@ -9,6 +9,7 @@ import {
   getDeliveries,
   getStats,
   getSubscription,
+  retryDelivery,
   rotateSecret,
   suspendSubscription,
   testPing,
@@ -229,6 +230,7 @@ describe('webhooks-api', () => {
           durationMs: 142,
           errorMessage: null,
           isSuccess: true,
+          payload: null,
         },
       ];
       vi.mocked(client.get).mockResolvedValueOnce({ data: response });
@@ -237,6 +239,26 @@ describe('webhooks-api', () => {
 
       expect(client.get).toHaveBeenCalledWith(`${BASE}/sub-001/deliveries`);
       expect(result).toEqual(response);
+    });
+  });
+
+  describe('retryDelivery', () => {
+    it('sends POST to /deliveries/{deliveryId}/retry', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await retryDelivery(client, '/api/v1/webhooks', 'del-001');
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/deliveries/del-001/retry');
+    });
+
+    it('encodes delivery ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await retryDelivery(client, '/api/v1/webhooks', 'id/slash');
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/webhooks/deliveries/id%2Fslash/retry');
     });
   });
 });

--- a/packages/@granit/webhooks/src/api/webhooks-api.ts
+++ b/packages/@granit/webhooks/src/api/webhooks-api.ts
@@ -190,3 +190,18 @@ export async function getDeliveries(
   );
   return data;
 }
+
+/**
+ * Retry a previously failed webhook delivery attempt.
+ *
+ * `POST {basePath}/deliveries/{deliveryId}/retry`
+ *
+ * @param basePath - The webhooks root path (e.g. `/api/v1/webhooks`), **not** the subscriptions path.
+ */
+export async function retryDelivery(
+  client: AxiosInstance,
+  basePath: string,
+  deliveryId: string
+): Promise<void> {
+  await client.post(`${basePath}/deliveries/${encodeURIComponent(deliveryId)}/retry`);
+}

--- a/packages/@granit/webhooks/src/index.ts
+++ b/packages/@granit/webhooks/src/index.ts
@@ -26,6 +26,7 @@ export {
   getDeliveries,
   getStats,
   getSubscription,
+  retryDelivery,
   rotateSecret,
   suspendSubscription,
   testPing,

--- a/packages/@granit/webhooks/src/types/index.ts
+++ b/packages/@granit/webhooks/src/types/index.ts
@@ -95,4 +95,6 @@ export interface WebhookDeliveryAttemptResponse {
   readonly durationMs: number;
   readonly errorMessage: string | null;
   readonly isSuccess: boolean;
+  /** Serialized JSON body. `null` when `WebhooksOptions.StorePayload` is `false` (default). */
+  readonly payload: string | null;
 }

--- a/packages/@granit/workflow/src/__tests__/api.test.ts
+++ b/packages/@granit/workflow/src/__tests__/api.test.ts
@@ -10,9 +10,9 @@ import {
 } from '../api/workflow-api.js';
 
 import type {
-  TransitionHistoryDto,
-  TransitionResultDto,
-  WorkflowStatusDto,
+  TransitionHistory,
+  WorkflowTransitionResult,
+  WorkflowStatus,
 } from '../types/index.js';
 
 describe('workflow api', () => {
@@ -22,7 +22,7 @@ describe('workflow api', () => {
 
   it('should call GET with correct URL for fetchStatus', async () => {
     const client = createMockClient();
-    const status: WorkflowStatusDto = {
+    const status: WorkflowStatus = {
       currentState: 'Draft',
       availableTransitions: [
         { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
@@ -38,7 +38,7 @@ describe('workflow api', () => {
 
   it('should call POST with correct URL and body for executeTransition', async () => {
     const client = createMockClient();
-    const transitionResult: TransitionResultDto = {
+    const transitionResult: WorkflowTransitionResult = {
       succeeded: true,
       resultingState: 'Published',
       outcome: 'Completed',
@@ -59,7 +59,7 @@ describe('workflow api', () => {
 
   it('should call GET with correct URL for fetchHistory', async () => {
     const client = createMockClient();
-    const historyItems: TransitionHistoryDto[] = [
+    const historyItems: TransitionHistory[] = [
       {
         previousState: 'Draft',
         newState: 'Published',
@@ -82,7 +82,7 @@ describe('workflow api', () => {
 
   it('should call GET with query param for fetchTransitions', async () => {
     const client = createMockClient();
-    const status: WorkflowStatusDto = {
+    const status: WorkflowStatus = {
       currentState: 'Draft',
       availableTransitions: [
         { targetState: 'Published', name: 'Publier', allowed: true, requiresApproval: false },
@@ -101,7 +101,7 @@ describe('workflow api', () => {
 
   it('should call POST with query param and body for executeStateMachineTransition', async () => {
     const client = createMockClient();
-    const transitionResult: TransitionResultDto = {
+    const transitionResult: WorkflowTransitionResult = {
       succeeded: true,
       resultingState: 'Published',
       outcome: 'Completed',
@@ -123,7 +123,7 @@ describe('workflow api', () => {
 
   it('should pass pagination params to fetchHistory when provided', async () => {
     const client = createMockClient();
-    const historyItems: TransitionHistoryDto[] = [
+    const historyItems: TransitionHistory[] = [
       {
         previousState: 'Draft',
         newState: 'Published',

--- a/packages/@granit/workflow/src/api/workflow-api.ts
+++ b/packages/@granit/workflow/src/api/workflow-api.ts
@@ -1,8 +1,8 @@
 import type {
-  TransitionHistoryDto,
-  TransitionRequestDto,
-  TransitionResultDto,
-  WorkflowStatusDto,
+  TransitionHistory,
+  WorkflowTransitionRequest,
+  WorkflowTransitionResult,
+  WorkflowStatus,
 } from '../types/index.js';
 import type { PagedResult, PaginationParams } from '@granit/querying';
 import type { AxiosInstance } from 'axios';
@@ -23,8 +23,8 @@ export async function fetchStatus(
   basePath: string,
   entityType: string,
   entityId: string
-): Promise<WorkflowStatusDto> {
-  const { data } = await client.get<WorkflowStatusDto>(
+): Promise<WorkflowStatus> {
+  const { data } = await client.get<WorkflowStatus>(
     buildUrl(basePath, entityType, entityId, 'transitions')
   );
   return data;
@@ -36,9 +36,9 @@ export async function executeTransition(
   basePath: string,
   entityType: string,
   entityId: string,
-  request: TransitionRequestDto
-): Promise<TransitionResultDto> {
-  const { data } = await client.post<TransitionResultDto>(
+  request: WorkflowTransitionRequest
+): Promise<WorkflowTransitionResult> {
+  const { data } = await client.post<WorkflowTransitionResult>(
     buildUrl(basePath, entityType, entityId, 'transition'),
     request
   );
@@ -50,8 +50,8 @@ export async function fetchTransitions(
   client: AxiosInstance,
   basePath: string,
   currentState: string
-): Promise<WorkflowStatusDto> {
-  const { data } = await client.get<WorkflowStatusDto>(`${basePath}/transitions`, {
+): Promise<WorkflowStatus> {
+  const { data } = await client.get<WorkflowStatus>(`${basePath}/transitions`, {
     params: { currentState },
   });
   return data;
@@ -62,16 +62,16 @@ export async function executeStateMachineTransition(
   client: AxiosInstance,
   basePath: string,
   currentState: string,
-  request: TransitionRequestDto
-): Promise<TransitionResultDto> {
-  const { data } = await client.post<TransitionResultDto>(`${basePath}/transitions`, request, {
+  request: WorkflowTransitionRequest
+): Promise<WorkflowTransitionResult> {
+  const { data } = await client.post<WorkflowTransitionResult>(`${basePath}/transitions`, request, {
     params: { currentState },
   });
   return data;
 }
 
 /** Response shape for the paginated workflow history endpoint. */
-export type WorkflowHistoryPage = PagedResult<TransitionHistoryDto>;
+export type WorkflowHistoryPage = PagedResult<TransitionHistory>;
 
 /** Fetch the transition history (HDS audit trail) for an entity. */
 export async function fetchHistory(

--- a/packages/@granit/workflow/src/index.ts
+++ b/packages/@granit/workflow/src/index.ts
@@ -7,14 +7,14 @@ export { TransitionOutcome } from './types/index.js';
 export { WorkflowLifecycleStatus } from './types/index.js';
 
 export type {
-  TransitionDto,
-  TransitionHistoryDto,
+  WorkflowTransition,
+  TransitionHistory,
   TransitionOutcomeValue,
-  TransitionRequestDto,
-  TransitionResultDto,
+  WorkflowTransitionRequest,
+  WorkflowTransitionResult,
   WorkflowConfig,
   WorkflowLifecycleStatusValue,
-  WorkflowStatusDto,
+  WorkflowStatus,
 } from './types/index.js';
 
 // API

--- a/packages/@granit/workflow/src/types/index.ts
+++ b/packages/@granit/workflow/src/types/index.ts
@@ -5,12 +5,12 @@ export { WorkflowLifecycleStatus } from './lifecycle-status.js';
 export type { WorkflowLifecycleStatusValue } from './lifecycle-status.js';
 
 export type {
-  TransitionDto,
-  TransitionHistoryDto,
-  TransitionRequestDto,
-  TransitionResultDto,
+  WorkflowTransition,
+  TransitionHistory,
+  WorkflowTransitionRequest,
+  WorkflowTransitionResult,
 } from './transition.js';
 
-export type { WorkflowStatusDto } from './workflow-status.js';
+export type { WorkflowStatus } from './workflow-status.js';
 
 export type { WorkflowConfig } from './config.js';

--- a/packages/@granit/workflow/src/types/transition.ts
+++ b/packages/@granit/workflow/src/types/transition.ts
@@ -1,7 +1,7 @@
 import type { TransitionOutcomeValue } from './transition-outcome.js';
 
 /** Single available workflow transition. */
-export interface TransitionDto {
+export interface WorkflowTransition {
   readonly targetState: string;
   readonly name: string;
   readonly allowed: boolean;
@@ -9,20 +9,20 @@ export interface TransitionDto {
 }
 
 /** Result of a transition attempt. */
-export interface TransitionResultDto {
+export interface WorkflowTransitionResult {
   readonly succeeded: boolean;
   readonly resultingState: string;
   readonly outcome: TransitionOutcomeValue;
 }
 
 /** Request body to trigger a transition. */
-export interface TransitionRequestDto {
+export interface WorkflowTransitionRequest {
   readonly targetState: string;
   readonly comment?: string;
 }
 
 /** Single entry in the workflow transition history (HDS audit trail). */
-export interface TransitionHistoryDto {
+export interface TransitionHistory {
   readonly previousState: string;
   readonly newState: string;
   readonly transitionedAt: string;

--- a/packages/@granit/workflow/src/types/workflow-status.ts
+++ b/packages/@granit/workflow/src/types/workflow-status.ts
@@ -1,7 +1,7 @@
-import type { TransitionDto } from './transition.js';
+import type { WorkflowTransition } from './transition.js';
 
 /** Current workflow status of an entity. */
-export interface WorkflowStatusDto {
+export interface WorkflowStatus {
   readonly currentState: string;
-  readonly availableTransitions: readonly TransitionDto[];
+  readonly availableTransitions: readonly WorkflowTransition[];
 }


### PR DESCRIPTION
## Summary

- Rename frontend types to match their .NET counterparts exactly across 6 packages
- Remove `Dto` suffix from notifications and workflow types
- Add `Workflow` prefix to transition types for consistency
- Merge `Create/UpdateTemplateCategoryRequest` into single `SaveTemplateCategoryRequest`
- Fix pre-existing webhooks test (missing `payload` field) and lint error

### Renamed types

| Package | Before | After |
|---|---|---|
| notifications | `NotificationDto` | `UserNotification` |
| notifications | `NotificationPageDto` | `UserNotificationPage` |
| notifications | `ActivityFeedEntryDto` | `ActivityFeedEntry` |
| notifications | `ActivityFeedPageDto` | `ActivityFeedPage` |
| notifications | `NotificationPreferenceDto` | `NotificationPreference` |
| workflow | `WorkflowStatusDto` | `WorkflowStatus` |
| workflow | `TransitionDto` | `WorkflowTransition` |
| workflow | `TransitionResultDto` | `WorkflowTransitionResult` |
| workflow | `TransitionRequestDto` | `WorkflowTransitionRequest` |
| workflow | `TransitionHistoryDto` | `TransitionHistory` |
| timeline | `TimelineStreamEntry` | `TimelineEntry` |
| timeline | `TimelineStreamPage` | `TimelineEntryPage` |
| data-exchange | `ExportFieldDescriptor` | `ExportField` |
| features | `FeatureGroupDefinition` | `FeatureGroup` |
| features | `NumericConstraint` | `FeatureNumericConstraint` |
| templating | `TemplateLifecycleInfo` | `TemplateLifecycle` |
| templating | `Create/UpdateTemplateCategoryRequest` | `SaveTemplateCategoryRequest` |

### Consumer impact

- **guava-admin**: 16 files updated (notifications, workflow, timeline, data-exchange)
- **guava-front**: no references to renamed types

## Test plan

- [x] `pnpm tsc` — 0 errors
- [x] `pnpm lint` — 0 errors, 0 warnings
- [x] `npx vitest run` — 162 files, 1368 tests passed
- [ ] Verify guava-admin builds with updated types


🤖 Generated with [Claude Code](https://claude.com/claude-code)