### PR TITLE
fix: align entity names and add account/openiddict-admin packages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T22:49:38.710788+00:00",
+  "generatedAt": "2026-03-21T22:57:29.878558+00:00",
   "repo": "granit-front",
   "packages": [
     {

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-03-21T22:47:46.250794+00:00",
+  "generatedAt": "2026-03-21T22:49:38.710788+00:00",
   "repo": "granit-front",
   "packages": [
     {

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1,7 +1,43 @@
 {
-  "generatedAt": "2026-03-21T15:53:25.873425+00:00",
+  "generatedAt": "2026-03-21T22:47:46.250794+00:00",
   "repo": "granit-front",
   "packages": [
+    {
+      "name": "@granit/account",
+      "description": "Account self-service types and API functions — mirrors Granit.OpenIddict.Endpoints .NET contract",
+      "exports": [
+        {
+          "name": "accountKeys",
+          "kind": "const",
+          "signature": "const accountKeys"
+        },
+        {
+          "name": "getProfile",
+          "kind": "function",
+          "signature": "async function getProfile( client: AxiosInstance, basePath: string ): Promise<AccountProfileResponse>"
+        },
+        {
+          "name": "updateProfile",
+          "kind": "function",
+          "signature": "async function updateProfile( client: AxiosInstance, basePath: string, request: AccountProfileUpdateRequest ): Promise<AccountProfileResponse>"
+        },
+        {
+          "name": "backToImpersonator",
+          "kind": "function",
+          "signature": "async function backToImpersonator( client: AxiosInstance, basePath: string ): Promise<AccountImpersonationResult>"
+        },
+        {
+          "name": "sessionHeartbeat",
+          "kind": "function",
+          "signature": "async function sessionHeartbeat( client: AxiosInstance, basePath: string ): Promise<void>"
+        },
+        {
+          "name": "deleteAccount",
+          "kind": "function",
+          "signature": "async function deleteAccount( client: AxiosInstance, basePath: string, request: AccountDeleteRequest ): Promise<void>"
+        }
+      ]
+    },
     {
       "name": "@granit/ai",
       "description": "AI workspace management, chat completion, embedding generation, and usage tracking types and API functions — mirrors Granit.AI.Endpoints .NET",
@@ -591,6 +627,17 @@
       ]
     },
     {
+      "name": "@granit/openiddict-admin",
+      "description": "OpenIddict admin management types and API functions — mirrors Granit.OpenIddict.Endpoints .NET contract",
+      "exports": [
+        {
+          "name": "openIddictAdminKeys",
+          "kind": "const",
+          "signature": "const openIddictAdminKeys"
+        }
+      ]
+    },
+    {
       "name": "@granit/privacy",
       "description": "GDPR privacy types and API — data export, deletion, legal agreements — mirrors Granit.Privacy .NET contract",
       "exports": []
@@ -644,6 +691,76 @@
           "name": "serializeQueryRequest",
           "kind": "function",
           "signature": "function serializeQueryRequest(params: QueryRequest): string"
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-account",
+      "description": "React hooks for account self-service — useProfile, useRegister, useChangePassword, useTwoFactorStatus, usePasskeys",
+      "exports": [
+        {
+          "name": "AccountConfig",
+          "kind": "interface",
+          "signature": "interface AccountConfig",
+          "members": []
+        },
+        {
+          "name": "AccountProviderProps",
+          "kind": "interface",
+          "signature": "interface AccountProviderProps",
+          "members": []
+        },
+        {
+          "name": "useProfile",
+          "kind": "function",
+          "signature": "function useProfile(): UseQueryResult<AccountProfileResponse>"
+        },
+        {
+          "name": "useUpdateProfile",
+          "kind": "function",
+          "signature": "function useUpdateProfile(): UseMutationResult< AccountProfileResponse, Error, AccountProfileUpdateRequest >"
+        },
+        {
+          "name": "useConfirmEmail",
+          "kind": "function",
+          "signature": "function useConfirmEmail(): UseMutationResult<void, Error, ConfirmEmailVariables>"
+        },
+        {
+          "name": "useRegister",
+          "kind": "function",
+          "signature": "function useRegister(): UseMutationResult< AccountRegisterResponse, Error, AccountRegisterRequest >"
+        },
+        {
+          "name": "useResendConfirmation",
+          "kind": "function",
+          "signature": "function useResendConfirmation(): UseMutationResult<void, Error, void>"
+        },
+        {
+          "name": "ConfirmEmailVariables",
+          "kind": "interface",
+          "signature": "interface ConfirmEmailVariables",
+          "members": []
+        },
+        {
+          "name": "RenamePasskeyVariables",
+          "kind": "interface",
+          "signature": "interface RenamePasskeyVariables",
+          "members": []
+        },
+        {
+          "name": "useBackToImpersonator",
+          "kind": "function",
+          "signature": "function useBackToImpersonator(): UseMutationResult< AccountImpersonationResult, Error, void >"
+        },
+        {
+          "name": "useSessionHeartbeat",
+          "kind": "function",
+          "signature": "function useSessionHeartbeat(): UseMutationResult<void, Error, void>"
+        },
+        {
+          "name": "useDeleteAccount",
+          "kind": "function",
+          "signature": "function useDeleteAccount(): UseMutationResult<void, Error, AccountDeleteRequest>"
         }
       ]
     },
@@ -1642,6 +1759,11 @@
           "members": []
         }
       ]
+    },
+    {
+      "name": "@granit/react-openiddict-admin",
+      "description": "React hooks for OpenIddict admin management — useAdminUsers, useAdminRoles, useOidcApplications, useOidcScopes",
+      "exports": []
     },
     {
       "name": "@granit/react-privacy",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,8 @@
 
 | Package                                   | Purpose                                                                                                                                                                                                                                       |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@granit/account`                         | Account self-service types and API: registration, profile, password, 2FA/TOTP, external logins, passkeys/WebAuthn, session, deletion — mirrors `Granit.OpenIddict.Endpoints` .NET contract                                                    |
+| `@granit/react-account`                   | React hooks for `@granit/account`: `AccountProvider`, `useProfile`, `useRegister`, `useChangePassword`, `useTwoFactorStatus`, `usePasskeys`, `useExternalLogins`, `useSessionHeartbeat`, `useDeleteAccount`                                   |
 | `@granit/logger`                          | Configurable logger factory (`createLogger(prefix)`)                                                                                                                                                                                          |
 | `@granit/utils`                           | Shared utilities (`cn`, `formatDate`, `formatNumber`, …)                                                                                                                                                                                      |
 | `@granit/api-client`                      | Axios factory (`createApiClient`, `setTokenGetter`), shared response types (`ProblemDetails`), error classes (`HttpError`, `ValidationError`, `TimeoutError`)                                                                                 |
@@ -36,6 +38,8 @@
 | `@granit/react-notifications-web-push`    | React hooks for `@granit/notifications-web-push`: `useWebPush` (permission, subscribe, unsubscribe)                                                                                                                                           |
 | `@granit/notifications-mobile-push`       | Mobile Push (FCM/APNs) device token registration: `registerDeviceToken`, `unregisterDeviceToken`, `fetchDeviceTokens`                                                                                                                         |
 | `@granit/react-notifications-mobile-push` | React hooks for `@granit/notifications-mobile-push`: `useMobilePush`, `useDeviceTokens`                                                                                                                                                       |
+| `@granit/openiddict-admin`                | OpenIddict admin management types and API: user/role/group CRUD, OIDC application/scope/authorization management — mirrors `Granit.OpenIddict.Endpoints` .NET                                                                                 |
+| `@granit/react-openiddict-admin`          | React hooks for `@granit/openiddict-admin`: `OpenIddictAdminProvider`, `useAdminUsers`, `useAdminRoles`, `useAdminGroups`, `useOidcApplications`, `useOidcScopes`, `useOidcAuthorizations`                                                    |
 | `@granit/querying`                        | Data grid types and utilities: `QueryParams`, `FilterEntry`, `QueryMetadata`, `SavedView` — types mirroring `Granit.Querying` .NET contract                                                                                                   |
 | `@granit/react-querying`                  | React bindings for `@granit/querying`: `QueryProvider`, `useQueryEndpoint`, `useQueryMeta`, `useSavedViews`, `useSmartFilter`, `usePagination`, `useInfiniteScroll`                                                                           |
 | `@granit/data-exchange`                   | Tabular data exchange types and API: export/import types mirroring `Granit.DataExchange` .NET contract                                                                                                                                        |
@@ -133,6 +137,8 @@ Full frontend conventions: `../granit-dotnet/docs/guide/conventions/frontend/`
 - **`@granit/authentication` base interface**: `BaseAuthContextType` is the shared base
   — apps extend it with their own fields (`register` in front, `hasAdminRole` in admin)
 - **Peer dep matrix** (actual `peerDependencies` from each `package.json`):
+  - `@granit/account` → `axios`
+  - `@granit/react-account` → `react`, `@tanstack/react-query`, `axios`, `@granit/account`
   - `@granit/utils` → `clsx`, `tailwind-merge`, `date-fns`
   - `@granit/api-client` → `axios`
   - `@granit/blob-storage` → `axios`
@@ -156,6 +162,8 @@ Full frontend conventions: `../granit-dotnet/docs/guide/conventions/frontend/`
   - `@granit/react-notifications-web-push` → `react`, `axios`, `@granit/notifications-web-push`
   - `@granit/notifications-mobile-push` → `axios`
   - `@granit/react-notifications-mobile-push` → `react`, `axios`, `@capacitor/push-notifications`, `@granit/notifications-mobile-push`, `@tanstack/react-query`
+  - `@granit/openiddict-admin` → `@granit/querying`, `axios`
+  - `@granit/react-openiddict-admin` → `react`, `@tanstack/react-query`, `axios`, `@granit/openiddict-admin`
   - `@granit/querying` → `@granit/utils`, `axios`
   - `@granit/react-querying` → `react`, `react-dom`, `axios`, `@tanstack/react-query`, `@granit/querying`, `@granit/utils`
   - `@granit/data-exchange` → `@granit/querying`, `@granit/utils`, `axios`

--- a/packages/@granit/account/package.json
+++ b/packages/@granit/account/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@granit/account",
+  "description": "Account self-service types and API functions — mirrors Granit.OpenIddict.Endpoints .NET contract",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/account/src/__tests__/account-deletion-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-deletion-api.test.ts
@@ -1,0 +1,19 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { deleteAccount } from '../api/account-deletion-api.js';
+
+const BASE = '/api/account';
+
+describe('account-deletion-api', () => {
+  describe('deleteAccount', () => {
+    it('sends POST /delete with password confirmation', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await deleteAccount(client, BASE, { password: 'MyP@ssw0rd!' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/delete`, { password: 'MyP@ssw0rd!' });
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
@@ -1,0 +1,86 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  challengeExternalLogin,
+  externalLoginCallback,
+  getExternalLogins,
+  unlinkExternalLogin,
+} from '../api/account-external-login-api.js';
+
+import type {
+  AccountExternalLoginCallbackResponse,
+  AccountExternalLoginInfo,
+} from '../types/index.js';
+
+const BASE = '/api/account';
+
+const mockLogins: readonly AccountExternalLoginInfo[] = [
+  { loginProvider: 'Google', providerKey: 'google-123', providerDisplayName: 'Google' },
+  { loginProvider: 'Microsoft', providerKey: 'ms-456', providerDisplayName: 'Microsoft' },
+];
+
+describe('account-external-login-api', () => {
+  describe('getExternalLogins', () => {
+    it('sends GET /external-logins', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockLogins });
+
+      const result = await getExternalLogins(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/external-logins`);
+      expect(result).toEqual(mockLogins);
+    });
+  });
+
+  describe('challengeExternalLogin', () => {
+    it('sends POST /external-logins/challenge/{provider}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await challengeExternalLogin(client, BASE, 'Google');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/external-logins/challenge/Google`);
+    });
+
+    it('encodes provider name with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await challengeExternalLogin(client, BASE, 'provider/name');
+
+      expect(client.post).toHaveBeenCalledWith(
+        `${BASE}/external-logins/challenge/provider%2Fname`
+      );
+    });
+  });
+
+  describe('externalLoginCallback', () => {
+    it('sends GET /external-logins/callback with provider query param', async () => {
+      const client = createMockClient();
+      const response: AccountExternalLoginCallbackResponse = {
+        userId: 'user-123',
+        isNewUser: false,
+      };
+      vi.mocked(client.get).mockResolvedValueOnce({ data: response });
+
+      const result = await externalLoginCallback(client, BASE, 'Google');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/external-logins/callback`, {
+        params: { provider: 'Google' },
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('unlinkExternalLogin', () => {
+    it('sends DELETE /external-logins/{provider}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await unlinkExternalLogin(client, BASE, 'Google');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/external-logins/Google`);
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/account-passkey-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-passkey-api.test.ts
@@ -1,0 +1,120 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  beginPasskeyAssertion,
+  beginPasskeyRegistration,
+  completePasskeyRegistration,
+  deletePasskey,
+  getPasskeys,
+  renamePasskey,
+} from '../api/account-passkey-api.js';
+
+import type { AccountPasskeyCreatedResponse, AccountPasskeyInfo } from '../types/index.js';
+
+const BASE = '/api/account';
+
+const mockPasskeys: readonly AccountPasskeyInfo[] = [
+  {
+    id: 'pk-001',
+    name: 'MacBook Pro',
+    createdAt: '2026-03-01T08:00:00Z',
+    lastUsedAt: '2026-03-20T10:00:00Z',
+  },
+];
+
+describe('account-passkey-api', () => {
+  describe('getPasskeys', () => {
+    it('sends GET /passkeys', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockPasskeys });
+
+      const result = await getPasskeys(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/passkeys`);
+      expect(result).toEqual(mockPasskeys);
+    });
+  });
+
+  describe('beginPasskeyRegistration', () => {
+    it('sends POST /passkeys/register/begin and returns raw JSON', async () => {
+      const client = createMockClient();
+      const optionsJson = '{"challenge":"abc123"}';
+      vi.mocked(client.post).mockResolvedValueOnce({ data: optionsJson });
+
+      const result = await beginPasskeyRegistration(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/register/begin`);
+      expect(result).toBe(optionsJson);
+    });
+  });
+
+  describe('completePasskeyRegistration', () => {
+    it('sends POST /passkeys/register/complete with credential', async () => {
+      const client = createMockClient();
+      const response: AccountPasskeyCreatedResponse = {
+        id: 'pk-002',
+        name: 'iPhone',
+        createdAt: '2026-03-21T12:00:00Z',
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await completePasskeyRegistration(client, BASE, {
+        credentialJson: '{"attestation":"..."}',
+        name: 'iPhone',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/register/complete`, {
+        credentialJson: '{"attestation":"..."}',
+        name: 'iPhone',
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('beginPasskeyAssertion', () => {
+    it('sends POST /passkeys/assertion/begin and returns raw JSON', async () => {
+      const client = createMockClient();
+      const optionsJson = '{"challenge":"def456"}';
+      vi.mocked(client.post).mockResolvedValueOnce({ data: optionsJson });
+
+      const result = await beginPasskeyAssertion(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/assertion/begin`);
+      expect(result).toBe(optionsJson);
+    });
+  });
+
+  describe('renamePasskey', () => {
+    it('sends PATCH /passkeys/{id} with new name', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValueOnce({ data: undefined });
+
+      await renamePasskey(client, BASE, 'pk-001', { name: 'Work Laptop' });
+
+      expect(client.patch).toHaveBeenCalledWith(`${BASE}/passkeys/pk-001`, {
+        name: 'Work Laptop',
+      });
+    });
+
+    it('encodes passkey ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValueOnce({ data: undefined });
+
+      await renamePasskey(client, BASE, 'id/slash', { name: 'Test' });
+
+      expect(client.patch).toHaveBeenCalledWith(`${BASE}/passkeys/id%2Fslash`, { name: 'Test' });
+    });
+  });
+
+  describe('deletePasskey', () => {
+    it('sends DELETE /passkeys/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deletePasskey(client, BASE, 'pk-001');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/passkeys/pk-001`);
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/account-password-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-password-api.test.ts
@@ -1,0 +1,57 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { changePassword, forgotPassword, resetPassword } from '../api/account-password-api.js';
+
+const BASE = '/api/account';
+
+describe('account-password-api', () => {
+  describe('changePassword', () => {
+    it('sends POST /change-password with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await changePassword(client, BASE, {
+        currentPassword: 'OldPass1!',
+        newPassword: 'NewPass2!',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/change-password`, {
+        currentPassword: 'OldPass1!',
+        newPassword: 'NewPass2!',
+      });
+    });
+  });
+
+  describe('forgotPassword', () => {
+    it('sends POST /forgot-password with email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await forgotPassword(client, BASE, { email: 'user@example.com' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/forgot-password`, {
+        email: 'user@example.com',
+      });
+    });
+  });
+
+  describe('resetPassword', () => {
+    it('sends POST /reset-password with token and new password', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await resetPassword(client, BASE, {
+        userId: 'user-123',
+        token: 'reset-token',
+        newPassword: 'NewPass3!',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/reset-password`, {
+        userId: 'user-123',
+        token: 'reset-token',
+        newPassword: 'NewPass3!',
+      });
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/account-profile-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-profile-api.test.ts
@@ -1,0 +1,46 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getProfile, updateProfile } from '../api/account-profile-api.js';
+
+import type { AccountProfileResponse } from '../types/index.js';
+
+const BASE = '/api/account';
+
+const mockProfile: AccountProfileResponse = {
+  userId: '550e8400-e29b-41d4-a716-446655440000',
+  email: 'user@example.com',
+  emailConfirmed: true,
+  firstName: 'John',
+  lastName: 'Doe',
+  twoFactorEnabled: false,
+  hasPassword: true,
+  externalLogins: [],
+};
+
+describe('account-profile-api', () => {
+  describe('getProfile', () => {
+    it('sends GET /profile', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockProfile });
+
+      const result = await getProfile(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/profile`);
+      expect(result).toEqual(mockProfile);
+    });
+  });
+
+  describe('updateProfile', () => {
+    it('sends PUT /profile with request body', async () => {
+      const client = createMockClient();
+      const updated = { ...mockProfile, firstName: 'Jane' };
+      vi.mocked(client.put).mockResolvedValueOnce({ data: updated });
+
+      const result = await updateProfile(client, BASE, { firstName: 'Jane' });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/profile`, { firstName: 'Jane' });
+      expect(result.firstName).toBe('Jane');
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/account-registration-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-registration-api.test.ts
@@ -1,0 +1,61 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { confirmEmail, registerAccount, resendConfirmationEmail } from '../api/account-registration-api.js';
+
+import type { AccountRegisterResponse } from '../types/index.js';
+
+const BASE = '/api/account';
+
+const mockRegisterResponse: AccountRegisterResponse = {
+  userId: '550e8400-e29b-41d4-a716-446655440000',
+  requiresEmailConfirmation: true,
+};
+
+describe('account-registration-api', () => {
+  describe('registerAccount', () => {
+    it('sends POST /register with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockRegisterResponse });
+
+      const result = await registerAccount(client, BASE, {
+        email: 'user@example.com',
+        password: 'P@ssw0rd!',
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/register`, {
+        email: 'user@example.com',
+        password: 'P@ssw0rd!',
+        firstName: 'John',
+        lastName: 'Doe',
+      });
+      expect(result).toEqual(mockRegisterResponse);
+    });
+  });
+
+  describe('confirmEmail', () => {
+    it('sends GET /confirm-email with query params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: undefined });
+
+      await confirmEmail(client, BASE, 'user-id-123', 'token-abc');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/confirm-email`, {
+        params: { userId: 'user-id-123', token: 'token-abc' },
+      });
+    });
+  });
+
+  describe('resendConfirmationEmail', () => {
+    it('sends POST /resend-confirmation-email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await resendConfirmationEmail(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/resend-confirmation-email`);
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/account-session-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-session-api.test.ts
@@ -1,0 +1,38 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { backToImpersonator, sessionHeartbeat } from '../api/account-session-api.js';
+
+import type { AccountImpersonationResult } from '../types/index.js';
+
+const BASE = '/api/account';
+
+describe('account-session-api', () => {
+  describe('sessionHeartbeat', () => {
+    it('sends POST /session/heartbeat', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await sessionHeartbeat(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/session/heartbeat`);
+    });
+  });
+
+  describe('backToImpersonator', () => {
+    it('sends POST /session/back-to-impersonator and returns tokens', async () => {
+      const client = createMockClient();
+      const response: AccountImpersonationResult = {
+        accessToken: 'new-access-token',
+        refreshToken: 'new-refresh-token',
+        expiresIn: 3600,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await backToImpersonator(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/session/back-to-impersonator`);
+      expect(result).toEqual(response);
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/account-two-factor-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-two-factor-api.test.ts
@@ -1,0 +1,95 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  disableTwoFactor,
+  enableTwoFactor,
+  generateRecoveryCodes,
+  getAuthenticatorKey,
+  getTwoFactorStatus,
+} from '../api/account-two-factor-api.js';
+
+import type {
+  AccountAuthenticatorKeyResponse,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from '../types/index.js';
+
+const BASE = '/api/account';
+
+const mockStatus: AccountTwoFactorStatusResponse = {
+  isEnabled: false,
+  hasAuthenticatorApp: false,
+  recoveryCodesLeft: 0,
+};
+
+const mockAuthKey: AccountAuthenticatorKeyResponse = {
+  sharedKey: 'JBSWY3DPEHPK3PXP',
+  qrCodeUri: 'otpauth://totp/Granit:user@example.com?secret=JBSWY3DPEHPK3PXP&issuer=Granit',
+};
+
+const mockRecoveryCodes: readonly string[] = ['AAAA-BBBB', 'CCCC-DDDD', 'EEEE-FFFF'];
+
+describe('account-two-factor-api', () => {
+  describe('getTwoFactorStatus', () => {
+    it('sends GET /two-factor', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockStatus });
+
+      const result = await getTwoFactorStatus(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/two-factor`);
+      expect(result).toEqual(mockStatus);
+    });
+  });
+
+  describe('getAuthenticatorKey', () => {
+    it('sends GET /two-factor/authenticator-key', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockAuthKey });
+
+      const result = await getAuthenticatorKey(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/two-factor/authenticator-key`);
+      expect(result).toEqual(mockAuthKey);
+    });
+  });
+
+  describe('enableTwoFactor', () => {
+    it('sends POST /two-factor/enable with TOTP code', async () => {
+      const client = createMockClient();
+      const response: AccountTwoFactorEnableResponse = { recoveryCodes: mockRecoveryCodes };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await enableTwoFactor(client, BASE, { code: '123456' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/enable`, { code: '123456' });
+      expect(result.recoveryCodes).toEqual(mockRecoveryCodes);
+    });
+  });
+
+  describe('disableTwoFactor', () => {
+    it('sends POST /two-factor/disable', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await disableTwoFactor(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/disable`);
+    });
+  });
+
+  describe('generateRecoveryCodes', () => {
+    it('sends POST /two-factor/recovery-codes', async () => {
+      const client = createMockClient();
+      const response: AccountRecoveryCodesResponse = { recoveryCodes: mockRecoveryCodes };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await generateRecoveryCodes(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/recovery-codes`);
+      expect(result.recoveryCodes).toEqual(mockRecoveryCodes);
+    });
+  });
+});

--- a/packages/@granit/account/src/__tests__/query-keys.test.ts
+++ b/packages/@granit/account/src/__tests__/query-keys.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { accountKeys } from '../hooks/query-keys.js';
+
+describe('accountKeys', () => {
+  it('should return base key for all', () => {
+    expect(accountKeys.all).toEqual(['account']);
+  });
+
+  it('should return profile key', () => {
+    expect(accountKeys.profile()).toEqual(['account', 'profile']);
+  });
+
+  it('should return two-factor key', () => {
+    expect(accountKeys.twoFactor()).toEqual(['account', 'two-factor']);
+  });
+
+  it('should return authenticator-key nested under two-factor', () => {
+    expect(accountKeys.authenticatorKey()).toEqual([
+      'account',
+      'two-factor',
+      'authenticator-key',
+    ]);
+  });
+
+  it('should return external-logins key', () => {
+    expect(accountKeys.externalLogins()).toEqual(['account', 'external-logins']);
+  });
+
+  it('should return passkeys key', () => {
+    expect(accountKeys.passkeys()).toEqual(['account', 'passkeys']);
+  });
+});

--- a/packages/@granit/account/src/api/account-deletion-api.ts
+++ b/packages/@granit/account/src/api/account-deletion-api.ts
@@ -1,0 +1,15 @@
+import type { AccountDeleteRequest } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Request account deletion (GDPR Art. 17). Deletion is asynchronous.
+ *
+ * `POST {basePath}/delete`
+ */
+export async function deleteAccount(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountDeleteRequest
+): Promise<void> {
+  await client.post(`${basePath}/delete`, request);
+}

--- a/packages/@granit/account/src/api/account-external-login-api.ts
+++ b/packages/@granit/account/src/api/account-external-login-api.ts
@@ -1,0 +1,63 @@
+import type {
+  AccountExternalLoginCallbackResponse,
+  AccountExternalLoginInfo,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * List linked external login providers for the current user.
+ *
+ * `GET {basePath}/external-logins`
+ */
+export async function getExternalLogins(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly AccountExternalLoginInfo[]> {
+  const { data } = await client.get<readonly AccountExternalLoginInfo[]>(
+    `${basePath}/external-logins`
+  );
+  return data;
+}
+
+/**
+ * Initiate an OAuth challenge with an external provider.
+ *
+ * `POST {basePath}/external-logins/challenge/{provider}`
+ */
+export async function challengeExternalLogin(
+  client: AxiosInstance,
+  basePath: string,
+  provider: string
+): Promise<void> {
+  await client.post(`${basePath}/external-logins/challenge/${encodeURIComponent(provider)}`);
+}
+
+/**
+ * Process the external login callback after OAuth redirect.
+ *
+ * `GET {basePath}/external-logins/callback?provider=...`
+ */
+export async function externalLoginCallback(
+  client: AxiosInstance,
+  basePath: string,
+  provider: string
+): Promise<AccountExternalLoginCallbackResponse> {
+  const { data } = await client.get<AccountExternalLoginCallbackResponse>(
+    `${basePath}/external-logins/callback`,
+    { params: { provider } }
+  );
+  return data;
+}
+
+/**
+ * Unlink an external login provider from the current user.
+ *
+ * `DELETE {basePath}/external-logins/{provider}`
+ */
+export async function unlinkExternalLogin(
+  client: AxiosInstance,
+  basePath: string,
+  provider: string
+): Promise<void> {
+  await client.delete(`${basePath}/external-logins/${encodeURIComponent(provider)}`);
+}

--- a/packages/@granit/account/src/api/account-passkey-api.ts
+++ b/packages/@granit/account/src/api/account-passkey-api.ts
@@ -1,0 +1,93 @@
+import type {
+  AccountPasskeyCreatedResponse,
+  AccountPasskeyInfo,
+  AccountPasskeyRegistrationRequest,
+  AccountPasskeyRenameRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * List all registered passkeys for the current user.
+ *
+ * `GET {basePath}/passkeys`
+ */
+export async function getPasskeys(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly AccountPasskeyInfo[]> {
+  const { data } = await client.get<readonly AccountPasskeyInfo[]>(`${basePath}/passkeys`);
+  return data;
+}
+
+/**
+ * Begin a WebAuthn passkey registration ceremony.
+ * Returns raw `PublicKeyCredentialCreationOptions` JSON string.
+ *
+ * `POST {basePath}/passkeys/register/begin`
+ */
+export async function beginPasskeyRegistration(
+  client: AxiosInstance,
+  basePath: string
+): Promise<string> {
+  const { data } = await client.post<string>(`${basePath}/passkeys/register/begin`);
+  return data;
+}
+
+/**
+ * Complete a WebAuthn passkey registration ceremony.
+ *
+ * `POST {basePath}/passkeys/register/complete`
+ */
+export async function completePasskeyRegistration(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountPasskeyRegistrationRequest
+): Promise<AccountPasskeyCreatedResponse> {
+  const { data } = await client.post<AccountPasskeyCreatedResponse>(
+    `${basePath}/passkeys/register/complete`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Begin a WebAuthn assertion ceremony for passkey login (anonymous).
+ * Returns raw `PublicKeyCredentialRequestOptions` JSON string.
+ * Assertion completion goes through `/connect/token` (OIDC layer).
+ *
+ * `POST {basePath}/passkeys/assertion/begin`
+ */
+export async function beginPasskeyAssertion(
+  client: AxiosInstance,
+  basePath: string
+): Promise<string> {
+  const { data } = await client.post<string>(`${basePath}/passkeys/assertion/begin`);
+  return data;
+}
+
+/**
+ * Rename a passkey.
+ *
+ * `PATCH {basePath}/passkeys/{id}`
+ */
+export async function renamePasskey(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: AccountPasskeyRenameRequest
+): Promise<void> {
+  await client.patch(`${basePath}/passkeys/${encodeURIComponent(id)}`, request);
+}
+
+/**
+ * Delete a passkey.
+ *
+ * `DELETE {basePath}/passkeys/{id}`
+ */
+export async function deletePasskey(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(`${basePath}/passkeys/${encodeURIComponent(id)}`);
+}

--- a/packages/@granit/account/src/api/account-password-api.ts
+++ b/packages/@granit/account/src/api/account-password-api.ts
@@ -1,0 +1,46 @@
+import type {
+  AccountForgotPasswordRequest,
+  AccountPasswordChangeRequest,
+  AccountPasswordResetRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Change the current user's password (authenticated).
+ *
+ * `POST {basePath}/change-password`
+ */
+export async function changePassword(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountPasswordChangeRequest
+): Promise<void> {
+  await client.post(`${basePath}/change-password`, request);
+}
+
+/**
+ * Request a password reset email (anonymous).
+ * Always returns 202 regardless of whether the email exists (anti-enumeration).
+ *
+ * `POST {basePath}/forgot-password`
+ */
+export async function forgotPassword(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountForgotPasswordRequest
+): Promise<void> {
+  await client.post(`${basePath}/forgot-password`, request);
+}
+
+/**
+ * Reset a password using the token from the reset email (anonymous).
+ *
+ * `POST {basePath}/reset-password`
+ */
+export async function resetPassword(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountPasswordResetRequest
+): Promise<void> {
+  await client.post(`${basePath}/reset-password`, request);
+}

--- a/packages/@granit/account/src/api/account-profile-api.ts
+++ b/packages/@granit/account/src/api/account-profile-api.ts
@@ -1,0 +1,32 @@
+import type {
+  AccountProfileResponse,
+  AccountProfileUpdateRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Get the current user's profile.
+ *
+ * `GET {basePath}/profile`
+ */
+export async function getProfile(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountProfileResponse> {
+  const { data } = await client.get<AccountProfileResponse>(`${basePath}/profile`);
+  return data;
+}
+
+/**
+ * Update the current user's profile (name fields only).
+ *
+ * `PUT {basePath}/profile`
+ */
+export async function updateProfile(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountProfileUpdateRequest
+): Promise<AccountProfileResponse> {
+  const { data } = await client.put<AccountProfileResponse>(`${basePath}/profile`, request);
+  return data;
+}

--- a/packages/@granit/account/src/api/account-registration-api.ts
+++ b/packages/@granit/account/src/api/account-registration-api.ts
@@ -1,0 +1,42 @@
+import type { AccountRegisterRequest, AccountRegisterResponse } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Register a new user account.
+ *
+ * `POST {basePath}/register`
+ */
+export async function registerAccount(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountRegisterRequest
+): Promise<AccountRegisterResponse> {
+  const { data } = await client.post<AccountRegisterResponse>(`${basePath}/register`, request);
+  return data;
+}
+
+/**
+ * Confirm an email address using the token from the confirmation email.
+ *
+ * `GET {basePath}/confirm-email?userId=...&token=...`
+ */
+export async function confirmEmail(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  token: string
+): Promise<void> {
+  await client.get(`${basePath}/confirm-email`, { params: { userId, token } });
+}
+
+/**
+ * Resend the email confirmation link (authenticated).
+ *
+ * `POST {basePath}/resend-confirmation-email`
+ */
+export async function resendConfirmationEmail(
+  client: AxiosInstance,
+  basePath: string
+): Promise<void> {
+  await client.post(`${basePath}/resend-confirmation-email`);
+}

--- a/packages/@granit/account/src/api/account-session-api.ts
+++ b/packages/@granit/account/src/api/account-session-api.ts
@@ -1,0 +1,31 @@
+import type { AccountImpersonationResult } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Send a session heartbeat to prevent idle timeout.
+ * Should be called every 5 minutes when the user is active.
+ *
+ * `POST {basePath}/session/heartbeat`
+ */
+export async function sessionHeartbeat(
+  client: AxiosInstance,
+  basePath: string
+): Promise<void> {
+  await client.post(`${basePath}/session/heartbeat`);
+}
+
+/**
+ * End an impersonation session and return to the original admin account.
+ * Only valid when the current token contains an `impersonator_id` claim.
+ *
+ * `POST {basePath}/session/back-to-impersonator`
+ */
+export async function backToImpersonator(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountImpersonationResult> {
+  const { data } = await client.post<AccountImpersonationResult>(
+    `${basePath}/session/back-to-impersonator`
+  );
+  return data;
+}

--- a/packages/@granit/account/src/api/account-two-factor-api.ts
+++ b/packages/@granit/account/src/api/account-two-factor-api.ts
@@ -1,0 +1,80 @@
+import type {
+  AccountAuthenticatorKeyResponse,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorEnableRequest,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Get the current user's 2FA status.
+ *
+ * `GET {basePath}/two-factor`
+ */
+export async function getTwoFactorStatus(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountTwoFactorStatusResponse> {
+  const { data } = await client.get<AccountTwoFactorStatusResponse>(`${basePath}/two-factor`);
+  return data;
+}
+
+/**
+ * Get the TOTP authenticator key and QR code URI for 2FA setup.
+ *
+ * `GET {basePath}/two-factor/authenticator-key`
+ */
+export async function getAuthenticatorKey(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountAuthenticatorKeyResponse> {
+  const { data } = await client.get<AccountAuthenticatorKeyResponse>(
+    `${basePath}/two-factor/authenticator-key`
+  );
+  return data;
+}
+
+/**
+ * Enable 2FA by verifying a TOTP code. Returns recovery codes.
+ *
+ * `POST {basePath}/two-factor/enable`
+ */
+export async function enableTwoFactor(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountTwoFactorEnableRequest
+): Promise<AccountTwoFactorEnableResponse> {
+  const { data } = await client.post<AccountTwoFactorEnableResponse>(
+    `${basePath}/two-factor/enable`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Disable 2FA for the current user.
+ *
+ * `POST {basePath}/two-factor/disable`
+ */
+export async function disableTwoFactor(
+  client: AxiosInstance,
+  basePath: string
+): Promise<void> {
+  await client.post(`${basePath}/two-factor/disable`);
+}
+
+/**
+ * Generate new recovery codes (invalidates previous ones).
+ *
+ * `POST {basePath}/two-factor/recovery-codes`
+ */
+export async function generateRecoveryCodes(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountRecoveryCodesResponse> {
+  const { data } = await client.post<AccountRecoveryCodesResponse>(
+    `${basePath}/two-factor/recovery-codes`
+  );
+  return data;
+}

--- a/packages/@granit/account/src/hooks/query-keys.ts
+++ b/packages/@granit/account/src/hooks/query-keys.ts
@@ -1,0 +1,9 @@
+/** Query key factory for account queries. */
+export const accountKeys = {
+  all: ['account'] as const,
+  profile: () => [...accountKeys.all, 'profile'] as const,
+  twoFactor: () => [...accountKeys.all, 'two-factor'] as const,
+  authenticatorKey: () => [...accountKeys.twoFactor(), 'authenticator-key'] as const,
+  externalLogins: () => [...accountKeys.all, 'external-logins'] as const,
+  passkeys: () => [...accountKeys.all, 'passkeys'] as const,
+};

--- a/packages/@granit/account/src/index.ts
+++ b/packages/@granit/account/src/index.ts
@@ -1,0 +1,86 @@
+// Types
+export type {
+  AccountRegisterRequest,
+  AccountRegisterResponse,
+} from './types/index.js';
+export type {
+  AccountProfileResponse,
+  AccountProfileUpdateRequest,
+} from './types/index.js';
+export type {
+  AccountForgotPasswordRequest,
+  AccountPasswordChangeRequest,
+  AccountPasswordResetRequest,
+} from './types/index.js';
+export type {
+  AccountAuthenticatorKeyResponse,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorEnableRequest,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from './types/index.js';
+export type {
+  AccountExternalLoginCallbackResponse,
+  AccountExternalLoginInfo,
+} from './types/index.js';
+export type {
+  AccountPasskeyCreatedResponse,
+  AccountPasskeyInfo,
+  AccountPasskeyRegistrationRequest,
+  AccountPasskeyRenameRequest,
+} from './types/index.js';
+export type { AccountImpersonationResult } from './types/index.js';
+export type { AccountDeleteRequest } from './types/index.js';
+
+// Query keys
+export { accountKeys } from './hooks/query-keys.js';
+
+// API — Registration
+export {
+  confirmEmail,
+  registerAccount,
+  resendConfirmationEmail,
+} from './api/account-registration-api.js';
+
+// API — Profile
+export { getProfile, updateProfile } from './api/account-profile-api.js';
+
+// API — Password
+export {
+  changePassword,
+  forgotPassword,
+  resetPassword,
+} from './api/account-password-api.js';
+
+// API — Two-Factor
+export {
+  disableTwoFactor,
+  enableTwoFactor,
+  generateRecoveryCodes,
+  getAuthenticatorKey,
+  getTwoFactorStatus,
+} from './api/account-two-factor-api.js';
+
+// API — External Logins
+export {
+  challengeExternalLogin,
+  externalLoginCallback,
+  getExternalLogins,
+  unlinkExternalLogin,
+} from './api/account-external-login-api.js';
+
+// API — Passkeys
+export {
+  beginPasskeyAssertion,
+  beginPasskeyRegistration,
+  completePasskeyRegistration,
+  deletePasskey,
+  getPasskeys,
+  renamePasskey,
+} from './api/account-passkey-api.js';
+
+// API — Session
+export { backToImpersonator, sessionHeartbeat } from './api/account-session-api.js';
+
+// API — Deletion
+export { deleteAccount } from './api/account-deletion-api.js';

--- a/packages/@granit/account/src/types/account-deletion.ts
+++ b/packages/@granit/account/src/types/account-deletion.ts
@@ -1,0 +1,8 @@
+// ---------------------------------------------------------------------------
+// Account deletion types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST /delete`. */
+export interface AccountDeleteRequest {
+  readonly password: string;
+}

--- a/packages/@granit/account/src/types/account-external-login.ts
+++ b/packages/@granit/account/src/types/account-external-login.ts
@@ -1,0 +1,16 @@
+// ---------------------------------------------------------------------------
+// Account external login types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** External login info returned by `GET /external-logins`. */
+export interface AccountExternalLoginInfo {
+  readonly loginProvider: string;
+  readonly providerKey: string;
+  readonly providerDisplayName: string | null;
+}
+
+/** Response from `GET /external-logins/callback`. */
+export interface AccountExternalLoginCallbackResponse {
+  readonly userId: string;
+  readonly isNewUser: boolean;
+}

--- a/packages/@granit/account/src/types/account-passkey.ts
+++ b/packages/@granit/account/src/types/account-passkey.ts
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------
+// Account passkey (WebAuthn) types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Passkey descriptor returned by `GET /passkeys`. */
+export interface AccountPasskeyInfo {
+  readonly id: string;
+  readonly name: string | null;
+  readonly createdAt: string;
+  readonly lastUsedAt: string | null;
+}
+
+/** Request body for `POST /passkeys/register/complete`. */
+export interface AccountPasskeyRegistrationRequest {
+  readonly credentialJson: string;
+  readonly name?: string;
+}
+
+/** Response from `POST /passkeys/register/complete`. */
+export interface AccountPasskeyCreatedResponse {
+  readonly id: string;
+  readonly name: string | null;
+  readonly createdAt: string;
+}
+
+/** Request body for `PATCH /passkeys/{id}`. */
+export interface AccountPasskeyRenameRequest {
+  readonly name: string;
+}

--- a/packages/@granit/account/src/types/account-password.ts
+++ b/packages/@granit/account/src/types/account-password.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// Account password types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST /change-password`. */
+export interface AccountPasswordChangeRequest {
+  readonly currentPassword: string;
+  readonly newPassword: string;
+}
+
+/** Request body for `POST /forgot-password`. */
+export interface AccountForgotPasswordRequest {
+  readonly email: string;
+}
+
+/** Request body for `POST /reset-password`. */
+export interface AccountPasswordResetRequest {
+  readonly userId: string;
+  readonly token: string;
+  readonly newPassword: string;
+}

--- a/packages/@granit/account/src/types/account-profile.ts
+++ b/packages/@granit/account/src/types/account-profile.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// Account profile types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Response from `GET /profile`. */
+export interface AccountProfileResponse {
+  readonly userId: string;
+  readonly email: string;
+  readonly emailConfirmed: boolean;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+  readonly twoFactorEnabled: boolean;
+  readonly hasPassword: boolean;
+  readonly externalLogins: readonly string[];
+}
+
+/** Request body for `PUT /profile`. */
+export interface AccountProfileUpdateRequest {
+  readonly firstName?: string;
+  readonly lastName?: string;
+}

--- a/packages/@granit/account/src/types/account-registration.ts
+++ b/packages/@granit/account/src/types/account-registration.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// Account registration types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST /register`. */
+export interface AccountRegisterRequest {
+  readonly email: string;
+  readonly password: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+}
+
+/** Response from `POST /register`. */
+export interface AccountRegisterResponse {
+  readonly userId: string;
+  readonly requiresEmailConfirmation: boolean;
+}

--- a/packages/@granit/account/src/types/account-session.ts
+++ b/packages/@granit/account/src/types/account-session.ts
@@ -1,0 +1,10 @@
+// ---------------------------------------------------------------------------
+// Account session types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Response from `POST /session/back-to-impersonator`. */
+export interface AccountImpersonationResult {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresIn: number;
+}

--- a/packages/@granit/account/src/types/account-two-factor.ts
+++ b/packages/@granit/account/src/types/account-two-factor.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// Account two-factor types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Response from `GET /two-factor`. */
+export interface AccountTwoFactorStatusResponse {
+  readonly isEnabled: boolean;
+  readonly hasAuthenticatorApp: boolean;
+  readonly recoveryCodesLeft: number;
+}
+
+/** Response from `GET /two-factor/authenticator-key`. */
+export interface AccountAuthenticatorKeyResponse {
+  readonly sharedKey: string;
+  readonly qrCodeUri: string;
+}
+
+/** Request body for `POST /two-factor/enable`. */
+export interface AccountTwoFactorEnableRequest {
+  readonly code: string;
+}
+
+/** Response from `POST /two-factor/enable`. */
+export interface AccountTwoFactorEnableResponse {
+  readonly recoveryCodes: readonly string[];
+}
+
+/** Response from `POST /two-factor/recovery-codes`. */
+export interface AccountRecoveryCodesResponse {
+  readonly recoveryCodes: readonly string[];
+}

--- a/packages/@granit/account/src/types/index.ts
+++ b/packages/@granit/account/src/types/index.ts
@@ -1,0 +1,39 @@
+export type {
+  AccountRegisterRequest,
+  AccountRegisterResponse,
+} from './account-registration.js';
+
+export type {
+  AccountProfileResponse,
+  AccountProfileUpdateRequest,
+} from './account-profile.js';
+
+export type {
+  AccountForgotPasswordRequest,
+  AccountPasswordChangeRequest,
+  AccountPasswordResetRequest,
+} from './account-password.js';
+
+export type {
+  AccountAuthenticatorKeyResponse,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorEnableRequest,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from './account-two-factor.js';
+
+export type {
+  AccountExternalLoginCallbackResponse,
+  AccountExternalLoginInfo,
+} from './account-external-login.js';
+
+export type {
+  AccountPasskeyCreatedResponse,
+  AccountPasskeyInfo,
+  AccountPasskeyRegistrationRequest,
+  AccountPasskeyRenameRequest,
+} from './account-passkey.js';
+
+export type { AccountImpersonationResult } from './account-session.js';
+
+export type { AccountDeleteRequest } from './account-deletion.js';

--- a/packages/@granit/account/tsconfig.json
+++ b/packages/@granit/account/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/account/tsup.config.ts
+++ b/packages/@granit/account/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/openiddict-admin/package.json
+++ b/packages/@granit/openiddict-admin/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/openiddict-admin",
+  "description": "OpenIddict admin management types and API functions — mirrors Granit.OpenIddict.Endpoints .NET contract",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/querying": "workspace:*",
+    "axios": "*"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-group-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-group-api.test.ts
@@ -1,0 +1,127 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  addGroupMember,
+  createGroup,
+  deleteGroup,
+  listGroups,
+  removeGroupMember,
+} from '../api/admin-group-api.js';
+
+import type { AdminGroup } from '../types/index.js';
+
+const BASE = '/api/admin';
+
+const mockGroup: AdminGroup = {
+  id: 'grp-001',
+  name: 'Developers',
+  path: null,
+  subGroups: [],
+};
+
+describe('admin-group-api', () => {
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  describe('listGroups', () => {
+    it('sends GET to /groups', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [mockGroup] });
+
+      const result = await listGroups(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/groups`);
+      expect(result).toEqual([mockGroup]);
+    });
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  describe('createGroup', () => {
+    it('sends POST with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockGroup });
+
+      const result = await createGroup(client, BASE, {
+        name: 'editors',
+        description: 'Content editors group',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/groups`, {
+        name: 'editors',
+        description: 'Content editors group',
+      });
+      expect(result).toEqual(mockGroup);
+    });
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  describe('deleteGroup', () => {
+    it('sends DELETE to /groups/{groupId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteGroup(client, BASE, 'grp-001');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/groups/grp-001`);
+    });
+
+    it('encodes group ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteGroup(client, BASE, 'id/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/groups/id%2Fslash`);
+    });
+  });
+
+  // ── Members ───────────────────────────────────────────────────────────────
+
+  describe('addGroupMember', () => {
+    it('sends POST to /groups/{groupId}/members with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await addGroupMember(client, BASE, 'grp-001', { userId: 'user-001' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/groups/grp-001/members`, {
+        userId: 'user-001',
+      });
+    });
+
+    it('encodes group ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await addGroupMember(client, BASE, 'id/slash', { userId: 'user-001' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/groups/id%2Fslash/members`, {
+        userId: 'user-001',
+      });
+    });
+  });
+
+  describe('removeGroupMember', () => {
+    it('sends DELETE to /groups/{groupId}/members/{userId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await removeGroupMember(client, BASE, 'grp-001', 'user-001');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/groups/grp-001/members/user-001`);
+    });
+
+    it('encodes both IDs with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await removeGroupMember(client, BASE, 'id/slash', 'user/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `${BASE}/groups/id%2Fslash/members/user%2Fslash`
+      );
+    });
+  });
+});

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
@@ -1,0 +1,119 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createApplication,
+  deleteApplication,
+  listApplications,
+  rotateApplicationSecret,
+} from '../api/admin-oidc-application-api.js';
+
+import type {
+  AdminOidcApplication,
+  AdminOidcApplicationSecretResponse,
+} from '../types/index.js';
+
+const BASE = '/api/admin';
+
+const mockApplication: AdminOidcApplication = {
+  id: 'app-001',
+  clientId: 'my-spa',
+  displayName: 'My SPA',
+  type: 'public',
+  permissions: ['openid', 'profile'],
+  redirectUris: ['https://app.example.com/callback'],
+  postLogoutRedirectUris: ['https://app.example.com/logout'],
+};
+
+describe('admin-oidc-application-api', () => {
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  describe('listApplications', () => {
+    it('sends GET to /oidc/applications', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [mockApplication] });
+
+      const result = await listApplications(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/oidc/applications`);
+      expect(result).toEqual([mockApplication]);
+    });
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  describe('createApplication', () => {
+    it('sends POST with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockApplication });
+
+      const result = await createApplication(client, BASE, {
+        clientId: 'my-spa',
+        displayName: 'My SPA',
+        permissions: ['openid', 'profile'],
+        redirectUris: ['https://app.example.com/callback'],
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/oidc/applications`, {
+        clientId: 'my-spa',
+        displayName: 'My SPA',
+        permissions: ['openid', 'profile'],
+        redirectUris: ['https://app.example.com/callback'],
+      });
+      expect(result).toEqual(mockApplication);
+    });
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  describe('deleteApplication', () => {
+    it('sends DELETE to /oidc/applications/{clientId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteApplication(client, BASE, 'my-spa');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/applications/my-spa`);
+    });
+
+    it('encodes client ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteApplication(client, BASE, 'id/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/applications/id%2Fslash`);
+    });
+  });
+
+  // ── Rotate secret ─────────────────────────────────────────────────────────
+
+  describe('rotateApplicationSecret', () => {
+    it('sends POST to /oidc/applications/{clientId}/rotate-secret', async () => {
+      const client = createMockClient();
+      const response: AdminOidcApplicationSecretResponse = {
+        clientId: 'my-spa',
+        newSecret: 'new-secret-value',
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await rotateApplicationSecret(client, BASE, 'my-spa');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/oidc/applications/my-spa/rotate-secret`);
+      expect(result).toEqual(response);
+    });
+
+    it('encodes client ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({
+        data: { newSecret: 'secret' },
+      });
+
+      await rotateApplicationSecret(client, BASE, 'id/slash');
+
+      expect(client.post).toHaveBeenCalledWith(
+        `${BASE}/oidc/applications/id%2Fslash/rotate-secret`
+      );
+    });
+  });
+});

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
@@ -1,0 +1,99 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  listAuthorizations,
+  revokeAuthorization,
+  revokeUserAuthorizations,
+} from '../api/admin-oidc-authorization-api.js';
+
+import type { AdminOidcAuthorization } from '../types/index.js';
+
+const BASE = '/api/admin';
+
+const mockAuthorization: AdminOidcAuthorization = {
+  id: 'auth-001',
+  subject: 'user-001',
+  type: 'permanent',
+  status: 'valid',
+};
+
+const mockAuthorizations: readonly AdminOidcAuthorization[] = [mockAuthorization];
+
+describe('admin-oidc-authorization-api', () => {
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  describe('listAuthorizations', () => {
+    it('sends GET to /oidc/authorizations with params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockAuthorizations });
+
+      const result = await listAuthorizations(client, BASE, {
+        userId: 'user-001',
+      });
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/oidc/authorizations`, {
+        params: { userId: 'user-001' },
+      });
+      expect(result).toEqual(mockAuthorizations);
+    });
+
+    it('sends GET to /oidc/authorizations without params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockAuthorizations });
+
+      const result = await listAuthorizations(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/oidc/authorizations`, {
+        params: undefined,
+      });
+      expect(result).toEqual(mockAuthorizations);
+    });
+  });
+
+  // ── Revoke ────────────────────────────────────────────────────────────────
+
+  describe('revokeAuthorization', () => {
+    it('sends DELETE to /oidc/authorizations/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await revokeAuthorization(client, BASE, 'auth-001');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/authorizations/auth-001`);
+    });
+
+    it('encodes authorization ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await revokeAuthorization(client, BASE, 'id/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/authorizations/id%2Fslash`);
+    });
+  });
+
+  // ── Revoke user authorizations ──────────────────────────────────────────
+
+  describe('revokeUserAuthorizations', () => {
+    it('sends DELETE to /oidc/authorizations/user/{userId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await revokeUserAuthorizations(client, BASE, 'user-001');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/authorizations/user/user-001`);
+    });
+
+    it('encodes user ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await revokeUserAuthorizations(client, BASE, 'id/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(
+        `${BASE}/oidc/authorizations/user/id%2Fslash`
+      );
+    });
+  });
+});

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
@@ -1,0 +1,79 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createScope,
+  deleteScope,
+  listScopes,
+} from '../api/admin-oidc-scope-api.js';
+
+import type { AdminOidcScope } from '../types/index.js';
+
+const BASE = '/api/admin';
+
+const mockScope: AdminOidcScope = {
+  id: 'scope-001',
+  name: 'api',
+  displayName: 'API Access',
+  resources: ['resource-server-1'],
+};
+
+describe('admin-oidc-scope-api', () => {
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  describe('listScopes', () => {
+    it('sends GET to /oidc/scopes', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [mockScope] });
+
+      const result = await listScopes(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/oidc/scopes`);
+      expect(result).toEqual([mockScope]);
+    });
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  describe('createScope', () => {
+    it('sends POST with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockScope });
+
+      const result = await createScope(client, BASE, {
+        name: 'api',
+        displayName: 'API Access',
+        resources: ['resource-server-1'],
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/oidc/scopes`, {
+        name: 'api',
+        displayName: 'API Access',
+        resources: ['resource-server-1'],
+      });
+      expect(result).toEqual(mockScope);
+    });
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  describe('deleteScope', () => {
+    it('sends DELETE to /oidc/scopes/{scopeName}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteScope(client, BASE, 'api');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/scopes/api`);
+    });
+
+    it('encodes scope name with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteScope(client, BASE, 'scope/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/scopes/scope%2Fslash`);
+    });
+  });
+});

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-role-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-role-api.test.ts
@@ -1,0 +1,107 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createRole,
+  deleteRole,
+  getRoleMembers,
+  listRoles,
+} from '../api/admin-role-api.js';
+
+import type { AdminRole, AdminRoleMember } from '../types/index.js';
+
+const BASE = '/api/admin';
+
+const mockRole: AdminRole = {
+  id: 'role-001',
+  name: 'editor',
+  description: 'Content editor role',
+};
+
+const mockMember: AdminRoleMember = {
+  id: 'user-001',
+  email: 'alice@example.com',
+  firstName: 'Alice',
+  lastName: 'Doe',
+};
+
+describe('admin-role-api', () => {
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  describe('listRoles', () => {
+    it('sends GET to /roles', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [mockRole] });
+
+      const result = await listRoles(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/roles`);
+      expect(result).toEqual([mockRole]);
+    });
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  describe('createRole', () => {
+    it('sends POST with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockRole });
+
+      const result = await createRole(client, BASE, {
+        name: 'editor',
+        description: 'Content editor role',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/roles`, {
+        name: 'editor',
+        description: 'Content editor role',
+      });
+      expect(result).toEqual(mockRole);
+    });
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  describe('deleteRole', () => {
+    it('sends DELETE to /roles/{roleName}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteRole(client, BASE, 'editor');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/roles/editor`);
+    });
+
+    it('encodes role name with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteRole(client, BASE, 'role/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/roles/role%2Fslash`);
+    });
+  });
+
+  // ── Members ───────────────────────────────────────────────────────────────
+
+  describe('getRoleMembers', () => {
+    it('sends GET to /roles/{roleName}/members', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [mockMember] });
+
+      const result = await getRoleMembers(client, BASE, 'editor');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/roles/editor/members`);
+      expect(result).toEqual([mockMember]);
+    });
+
+    it('encodes role name with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+
+      await getRoleMembers(client, BASE, 'role/slash');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/roles/role%2Fslash/members`);
+    });
+  });
+});

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-user-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-user-api.test.ts
@@ -1,0 +1,159 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createUser,
+  deleteUser,
+  getUser,
+  impersonateUser,
+  listUsers,
+} from '../api/admin-user-api.js';
+
+import type {
+  AdminImpersonationResult,
+  AdminUser,
+  AdminUserPage,
+} from '../types/index.js';
+
+const BASE = '/api/admin';
+
+const mockUser: AdminUser = {
+  id: 'user-001',
+  email: 'alice@example.com',
+  firstName: 'Alice',
+  lastName: 'Doe',
+  emailConfirmed: true,
+  isDeleted: false,
+  roles: ['admin'],
+  groups: ['editors'],
+};
+
+const mockUserPage: AdminUserPage = {
+  items: [mockUser],
+  totalCount: 1,
+};
+
+describe('admin-user-api', () => {
+  // ── List ──────────────────────────────────────────────────────────────────
+
+  describe('listUsers', () => {
+    it('sends GET to /users with params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockUserPage });
+
+      const result = await listUsers(client, BASE, { search: 'alice', page: 1, pageSize: 10 });
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/users`, {
+        params: { search: 'alice', page: 1, pageSize: 10 },
+      });
+      expect(result).toEqual(mockUserPage);
+    });
+
+    it('sends GET to /users without params', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockUserPage });
+
+      const result = await listUsers(client, BASE);
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/users`, { params: undefined });
+      expect(result).toEqual(mockUserPage);
+    });
+  });
+
+  // ── Get ───────────────────────────────────────────────────────────────────
+
+  describe('getUser', () => {
+    it('sends GET to /users/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockUser });
+
+      const result = await getUser(client, BASE, 'user-001');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/users/user-001`);
+      expect(result).toEqual(mockUser);
+    });
+
+    it('encodes user ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: mockUser });
+
+      await getUser(client, BASE, 'id/slash');
+
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/users/id%2Fslash`);
+    });
+  });
+
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  describe('createUser', () => {
+    it('sends POST with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockUser });
+
+      const result = await createUser(client, BASE, {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Doe',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/users`, {
+        email: 'alice@example.com',
+        firstName: 'Alice',
+        lastName: 'Doe',
+      });
+      expect(result).toEqual(mockUser);
+    });
+  });
+
+  // ── Delete ────────────────────────────────────────────────────────────────
+
+  describe('deleteUser', () => {
+    it('sends DELETE to /users/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteUser(client, BASE, 'user-001');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/users/user-001`);
+    });
+
+    it('encodes user ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await deleteUser(client, BASE, 'id/slash');
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/users/id%2Fslash`);
+    });
+  });
+
+  // ── Impersonate ───────────────────────────────────────────────────────────
+
+  describe('impersonateUser', () => {
+    it('sends POST to /users/{id}/impersonate', async () => {
+      const client = createMockClient();
+      const response: AdminImpersonationResult = {
+        accessToken: 'eyJ...',
+        refreshToken: 'ref...',
+        expiresIn: 3600,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await impersonateUser(client, BASE, 'user-001');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/users/user-001/impersonate`);
+      expect(result).toEqual(response);
+    });
+
+    it('encodes user ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({
+        data: { accessToken: 'x', refreshToken: 'y', expiresIn: 60 },
+      });
+
+      await impersonateUser(client, BASE, 'id/slash');
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/users/id%2Fslash/impersonate`);
+    });
+  });
+});

--- a/packages/@granit/openiddict-admin/src/__tests__/query-keys.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/query-keys.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { openIddictAdminKeys } from '../hooks/query-keys.js';
+
+describe('openIddictAdminKeys', () => {
+  it('should return base key for all', () => {
+    expect(openIddictAdminKeys.all).toEqual(['openiddict-admin']);
+  });
+
+  it('should return users key', () => {
+    expect(openIddictAdminKeys.users()).toEqual(['openiddict-admin', 'users']);
+  });
+
+  it('should return user key with id', () => {
+    expect(openIddictAdminKeys.user('usr-001')).toEqual([
+      'openiddict-admin',
+      'users',
+      'usr-001',
+    ]);
+  });
+
+  it('should return roles key', () => {
+    expect(openIddictAdminKeys.roles()).toEqual(['openiddict-admin', 'roles']);
+  });
+
+  it('should return roleMembers key with name', () => {
+    expect(openIddictAdminKeys.roleMembers('admin')).toEqual([
+      'openiddict-admin',
+      'roles',
+      'admin',
+      'members',
+    ]);
+  });
+
+  it('should return groups key', () => {
+    expect(openIddictAdminKeys.groups()).toEqual(['openiddict-admin', 'groups']);
+  });
+
+  it('should return applications key', () => {
+    expect(openIddictAdminKeys.applications()).toEqual([
+      'openiddict-admin',
+      'oidc',
+      'applications',
+    ]);
+  });
+
+  it('should return scopes key', () => {
+    expect(openIddictAdminKeys.scopes()).toEqual([
+      'openiddict-admin',
+      'oidc',
+      'scopes',
+    ]);
+  });
+
+  it('should return authorizations key', () => {
+    expect(openIddictAdminKeys.authorizations()).toEqual([
+      'openiddict-admin',
+      'oidc',
+      'authorizations',
+    ]);
+  });
+});

--- a/packages/@granit/openiddict-admin/src/api/admin-group-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-group-api.ts
@@ -1,0 +1,81 @@
+import type {
+  AdminGroup,
+  AdminGroupCreateRequest,
+  AdminGroupMemberRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+// ── Group CRUD ───────────────────────────────────────────────────────────────
+
+/**
+ * List all groups.
+ *
+ * `GET {basePath}/groups`
+ */
+export async function listGroups(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly AdminGroup[]> {
+  const { data } = await client.get<readonly AdminGroup[]>(`${basePath}/groups`);
+  return data;
+}
+
+/**
+ * Create a new group.
+ *
+ * `POST {basePath}/groups`
+ */
+export async function createGroup(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminGroupCreateRequest
+): Promise<AdminGroup> {
+  const { data } = await client.post<AdminGroup>(`${basePath}/groups`, request);
+  return data;
+}
+
+/**
+ * Delete a group by ID.
+ *
+ * `DELETE {basePath}/groups/{groupId}`
+ */
+export async function deleteGroup(
+  client: AxiosInstance,
+  basePath: string,
+  groupId: string
+): Promise<void> {
+  await client.delete(`${basePath}/groups/${encodeURIComponent(groupId)}`);
+}
+
+/**
+ * Add a member to a group.
+ *
+ * `POST {basePath}/groups/{groupId}/members`
+ */
+export async function addGroupMember(
+  client: AxiosInstance,
+  basePath: string,
+  groupId: string,
+  request: AdminGroupMemberRequest
+): Promise<void> {
+  await client.post(
+    `${basePath}/groups/${encodeURIComponent(groupId)}/members`,
+    request
+  );
+}
+
+/**
+ * Remove a member from a group.
+ *
+ * `DELETE {basePath}/groups/{groupId}/members/{userId}`
+ */
+export async function removeGroupMember(
+  client: AxiosInstance,
+  basePath: string,
+  groupId: string,
+  userId: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}`
+  );
+}

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
@@ -1,0 +1,71 @@
+import type {
+  AdminOidcApplication,
+  AdminOidcApplicationCreateRequest,
+  AdminOidcApplicationSecretResponse,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+// ── OIDC Application CRUD ────────────────────────────────────────────────────
+
+/**
+ * List all OIDC applications.
+ *
+ * `GET {basePath}/oidc/applications`
+ */
+export async function listApplications(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly AdminOidcApplication[]> {
+  const { data } = await client.get<readonly AdminOidcApplication[]>(
+    `${basePath}/oidc/applications`
+  );
+  return data;
+}
+
+/**
+ * Create a new OIDC application.
+ *
+ * `POST {basePath}/oidc/applications`
+ */
+export async function createApplication(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminOidcApplicationCreateRequest
+): Promise<AdminOidcApplication> {
+  const { data } = await client.post<AdminOidcApplication>(
+    `${basePath}/oidc/applications`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Delete an OIDC application by client ID.
+ *
+ * `DELETE {basePath}/oidc/applications/{clientId}`
+ */
+export async function deleteApplication(
+  client: AxiosInstance,
+  basePath: string,
+  clientId: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/oidc/applications/${encodeURIComponent(clientId)}`
+  );
+}
+
+/**
+ * Rotate the client secret for an OIDC application.
+ *
+ * `POST {basePath}/oidc/applications/{clientId}/rotate-secret`
+ */
+export async function rotateApplicationSecret(
+  client: AxiosInstance,
+  basePath: string,
+  clientId: string
+): Promise<AdminOidcApplicationSecretResponse> {
+  const { data } = await client.post<AdminOidcApplicationSecretResponse>(
+    `${basePath}/oidc/applications/${encodeURIComponent(clientId)}/rotate-secret`
+  );
+  return data;
+}

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-authorization-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-authorization-api.ts
@@ -1,0 +1,54 @@
+import type {
+  AdminOidcAuthorization,
+  AdminOidcAuthorizationListParams,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+// ── OIDC Authorization management ────────────────────────────────────────────
+
+/**
+ * List OIDC authorizations with optional filtering.
+ *
+ * `GET {basePath}/oidc/authorizations`
+ */
+export async function listAuthorizations(
+  client: AxiosInstance,
+  basePath: string,
+  params?: AdminOidcAuthorizationListParams
+): Promise<readonly AdminOidcAuthorization[]> {
+  const { data } = await client.get<readonly AdminOidcAuthorization[]>(
+    `${basePath}/oidc/authorizations`,
+    { params }
+  );
+  return data;
+}
+
+/**
+ * Revoke a single OIDC authorization by ID.
+ *
+ * `DELETE {basePath}/oidc/authorizations/{id}`
+ */
+export async function revokeAuthorization(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/oidc/authorizations/${encodeURIComponent(id)}`
+  );
+}
+
+/**
+ * Revoke all OIDC authorizations for a given user.
+ *
+ * `DELETE {basePath}/oidc/authorizations/user/{userId}`
+ */
+export async function revokeUserAuthorizations(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/oidc/authorizations/user/${encodeURIComponent(userId)}`
+  );
+}

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
@@ -1,0 +1,54 @@
+import type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+// ── OIDC Scope CRUD ──────────────────────────────────────────────────────────
+
+/**
+ * List all OIDC scopes.
+ *
+ * `GET {basePath}/oidc/scopes`
+ */
+export async function listScopes(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly AdminOidcScope[]> {
+  const { data } = await client.get<readonly AdminOidcScope[]>(
+    `${basePath}/oidc/scopes`
+  );
+  return data;
+}
+
+/**
+ * Create a new OIDC scope.
+ *
+ * `POST {basePath}/oidc/scopes`
+ */
+export async function createScope(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminOidcScopeCreateRequest
+): Promise<AdminOidcScope> {
+  const { data } = await client.post<AdminOidcScope>(
+    `${basePath}/oidc/scopes`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Delete an OIDC scope by name.
+ *
+ * `DELETE {basePath}/oidc/scopes/{scopeName}`
+ */
+export async function deleteScope(
+  client: AxiosInstance,
+  basePath: string,
+  scopeName: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/oidc/scopes/${encodeURIComponent(scopeName)}`
+  );
+}

--- a/packages/@granit/openiddict-admin/src/api/admin-role-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-role-api.ts
@@ -1,0 +1,64 @@
+import type {
+  AdminRole,
+  AdminRoleCreateRequest,
+  AdminRoleMember,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+// ── Role CRUD ────────────────────────────────────────────────────────────────
+
+/**
+ * List all roles.
+ *
+ * `GET {basePath}/roles`
+ */
+export async function listRoles(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly AdminRole[]> {
+  const { data } = await client.get<readonly AdminRole[]>(`${basePath}/roles`);
+  return data;
+}
+
+/**
+ * Create a new role.
+ *
+ * `POST {basePath}/roles`
+ */
+export async function createRole(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminRoleCreateRequest
+): Promise<AdminRole> {
+  const { data } = await client.post<AdminRole>(`${basePath}/roles`, request);
+  return data;
+}
+
+/**
+ * Delete a role by name.
+ *
+ * `DELETE {basePath}/roles/{roleName}`
+ */
+export async function deleteRole(
+  client: AxiosInstance,
+  basePath: string,
+  roleName: string
+): Promise<void> {
+  await client.delete(`${basePath}/roles/${encodeURIComponent(roleName)}`);
+}
+
+/**
+ * Get members of a role.
+ *
+ * `GET {basePath}/roles/{roleName}/members`
+ */
+export async function getRoleMembers(
+  client: AxiosInstance,
+  basePath: string,
+  roleName: string
+): Promise<readonly AdminRoleMember[]> {
+  const { data } = await client.get<readonly AdminRoleMember[]>(
+    `${basePath}/roles/${encodeURIComponent(roleName)}/members`
+  );
+  return data;
+}

--- a/packages/@granit/openiddict-admin/src/api/admin-user-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-user-api.ts
@@ -1,0 +1,83 @@
+import type {
+  AdminImpersonationResult,
+  AdminUser,
+  AdminUserCreateRequest,
+  AdminUserListParams,
+  AdminUserPage,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+// ── User CRUD ────────────────────────────────────────────────────────────────
+
+/**
+ * List admin users with optional search and pagination.
+ *
+ * `GET {basePath}/users`
+ */
+export async function listUsers(
+  client: AxiosInstance,
+  basePath: string,
+  params?: AdminUserListParams
+): Promise<AdminUserPage> {
+  const { data } = await client.get<AdminUserPage>(`${basePath}/users`, { params });
+  return data;
+}
+
+/**
+ * Get a single admin user by ID.
+ *
+ * `GET {basePath}/users/{id}`
+ */
+export async function getUser(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<AdminUser> {
+  const { data } = await client.get<AdminUser>(
+    `${basePath}/users/${encodeURIComponent(id)}`
+  );
+  return data;
+}
+
+/**
+ * Create a new admin user.
+ *
+ * `POST {basePath}/users`
+ */
+export async function createUser(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminUserCreateRequest
+): Promise<AdminUser> {
+  const { data } = await client.post<AdminUser>(`${basePath}/users`, request);
+  return data;
+}
+
+/**
+ * Delete an admin user.
+ *
+ * `DELETE {basePath}/users/{id}`
+ */
+export async function deleteUser(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(`${basePath}/users/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Impersonate a user. Returns short-lived tokens.
+ *
+ * `POST {basePath}/users/{id}/impersonate`
+ */
+export async function impersonateUser(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<AdminImpersonationResult> {
+  const { data } = await client.post<AdminImpersonationResult>(
+    `${basePath}/users/${encodeURIComponent(id)}/impersonate`
+  );
+  return data;
+}

--- a/packages/@granit/openiddict-admin/src/hooks/query-keys.ts
+++ b/packages/@granit/openiddict-admin/src/hooks/query-keys.ts
@@ -1,0 +1,12 @@
+/** Query key factory for OpenIddict admin queries. */
+export const openIddictAdminKeys = {
+  all: ['openiddict-admin'] as const,
+  users: () => [...openIddictAdminKeys.all, 'users'] as const,
+  user: (id: string) => [...openIddictAdminKeys.users(), id] as const,
+  roles: () => [...openIddictAdminKeys.all, 'roles'] as const,
+  roleMembers: (name: string) => [...openIddictAdminKeys.roles(), name, 'members'] as const,
+  groups: () => [...openIddictAdminKeys.all, 'groups'] as const,
+  applications: () => [...openIddictAdminKeys.all, 'oidc', 'applications'] as const,
+  scopes: () => [...openIddictAdminKeys.all, 'oidc', 'scopes'] as const,
+  authorizations: () => [...openIddictAdminKeys.all, 'oidc', 'authorizations'] as const,
+};

--- a/packages/@granit/openiddict-admin/src/index.ts
+++ b/packages/@granit/openiddict-admin/src/index.ts
@@ -1,0 +1,72 @@
+// Types
+export type {
+  AdminGroup,
+  AdminGroupCreateRequest,
+  AdminGroupMemberRequest,
+  AdminImpersonationResult,
+  AdminOidcApplication,
+  AdminOidcApplicationCreateRequest,
+  AdminOidcApplicationSecretResponse,
+  AdminOidcAuthorization,
+  AdminOidcAuthorizationListParams,
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+  AdminRole,
+  AdminRoleCreateRequest,
+  AdminRoleMember,
+  AdminUser,
+  AdminUserCreateRequest,
+  AdminUserListParams,
+  AdminUserPage,
+} from './types/index.js';
+
+// Query keys
+export { openIddictAdminKeys } from './hooks/query-keys.js';
+
+// API — Users
+export {
+  createUser,
+  deleteUser,
+  getUser,
+  impersonateUser,
+  listUsers,
+} from './api/admin-user-api.js';
+
+// API — Roles
+export {
+  createRole,
+  deleteRole,
+  getRoleMembers,
+  listRoles,
+} from './api/admin-role-api.js';
+
+// API — Groups
+export {
+  addGroupMember,
+  createGroup,
+  deleteGroup,
+  listGroups,
+  removeGroupMember,
+} from './api/admin-group-api.js';
+
+// API — OIDC Applications
+export {
+  createApplication,
+  deleteApplication,
+  listApplications,
+  rotateApplicationSecret,
+} from './api/admin-oidc-application-api.js';
+
+// API — OIDC Scopes
+export {
+  createScope,
+  deleteScope,
+  listScopes,
+} from './api/admin-oidc-scope-api.js';
+
+// API — OIDC Authorizations
+export {
+  listAuthorizations,
+  revokeAuthorization,
+  revokeUserAuthorizations,
+} from './api/admin-oidc-authorization-api.js';

--- a/packages/@granit/openiddict-admin/src/types/admin-group.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-group.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------
+// Admin group types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Group descriptor. */
+export interface AdminGroup {
+  readonly id: string;
+  readonly name: string;
+  readonly path: string | null;
+  readonly subGroups: readonly AdminGroup[];
+}
+
+/** Request body for `POST /groups`. */
+export interface AdminGroupCreateRequest {
+  readonly name: string;
+  readonly description?: string;
+}
+
+/** Request body for `POST /groups/{groupId}/members`. */
+export interface AdminGroupMemberRequest {
+  readonly userId: string;
+}

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
@@ -1,0 +1,30 @@
+// ---------------------------------------------------------------------------
+// Admin OIDC application types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** OIDC application descriptor. */
+export interface AdminOidcApplication {
+  readonly id: string;
+  readonly clientId: string;
+  readonly displayName: string | null;
+  readonly type: string;
+  readonly permissions: readonly string[];
+  readonly redirectUris: readonly string[];
+  readonly postLogoutRedirectUris: readonly string[];
+}
+
+/** Request body for `POST /oidc/applications`. */
+export interface AdminOidcApplicationCreateRequest {
+  readonly clientId: string;
+  readonly clientSecret?: string;
+  readonly displayName?: string;
+  readonly permissions?: readonly string[];
+  readonly redirectUris?: readonly string[];
+  readonly postLogoutRedirectUris?: readonly string[];
+}
+
+/** Response from `POST /oidc/applications/{clientId}/rotate-secret`. */
+export interface AdminOidcApplicationSecretResponse {
+  readonly clientId: string;
+  readonly newSecret: string;
+}

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// Admin OIDC authorization types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Query parameters for `GET /oidc/authorizations`. */
+export interface AdminOidcAuthorizationListParams {
+  readonly userId?: string;
+  readonly clientId?: string;
+}
+
+/** OIDC authorization descriptor. */
+export interface AdminOidcAuthorization {
+  readonly id: string;
+  readonly subject: string;
+  readonly status: string;
+  readonly type: string;
+}

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-scope.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-scope.ts
@@ -1,0 +1,18 @@
+// ---------------------------------------------------------------------------
+// Admin OIDC scope types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** OIDC scope descriptor. */
+export interface AdminOidcScope {
+  readonly id: string;
+  readonly name: string;
+  readonly displayName: string | null;
+  readonly resources: readonly string[];
+}
+
+/** Request body for `POST /oidc/scopes`. */
+export interface AdminOidcScopeCreateRequest {
+  readonly name: string;
+  readonly displayName?: string;
+  readonly resources?: readonly string[];
+}

--- a/packages/@granit/openiddict-admin/src/types/admin-role.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-role.ts
@@ -1,0 +1,24 @@
+// ---------------------------------------------------------------------------
+// Admin role types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Role descriptor. */
+export interface AdminRole {
+  readonly id: string;
+  readonly name: string;
+  readonly description: string | null;
+}
+
+/** Request body for `POST /roles`. */
+export interface AdminRoleCreateRequest {
+  readonly name: string;
+  readonly description?: string;
+}
+
+/** Role member (simplified user). */
+export interface AdminRoleMember {
+  readonly id: string;
+  readonly email: string;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+}

--- a/packages/@granit/openiddict-admin/src/types/admin-user.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-user.ts
@@ -1,0 +1,42 @@
+// ---------------------------------------------------------------------------
+// Admin user types — mirrors Granit.OpenIddict.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+import type { PagedResult } from '@granit/querying';
+
+/** Query parameters for `GET /users`. */
+export interface AdminUserListParams {
+  readonly search?: string;
+  readonly page?: number;
+  readonly pageSize?: number;
+}
+
+/** User descriptor returned by admin endpoints. */
+export interface AdminUser {
+  readonly id: string;
+  readonly email: string;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+  readonly emailConfirmed: boolean;
+  readonly isDeleted: boolean;
+  readonly roles: readonly string[];
+  readonly groups: readonly string[];
+}
+
+/** Paginated list of admin users. */
+export type AdminUserPage = PagedResult<AdminUser>;
+
+/** Request body for `POST /users`. */
+export interface AdminUserCreateRequest {
+  readonly email: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
+  readonly temporaryPassword?: string;
+}
+
+/** Response from impersonation endpoints. */
+export interface AdminImpersonationResult {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresIn: number;
+}

--- a/packages/@granit/openiddict-admin/src/types/index.ts
+++ b/packages/@granit/openiddict-admin/src/types/index.ts
@@ -1,0 +1,35 @@
+export type {
+  AdminGroup,
+  AdminGroupCreateRequest,
+  AdminGroupMemberRequest,
+} from './admin-group.js';
+
+export type {
+  AdminOidcApplication,
+  AdminOidcApplicationCreateRequest,
+  AdminOidcApplicationSecretResponse,
+} from './admin-oidc-application.js';
+
+export type {
+  AdminOidcAuthorization,
+  AdminOidcAuthorizationListParams,
+} from './admin-oidc-authorization.js';
+
+export type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+} from './admin-oidc-scope.js';
+
+export type {
+  AdminRole,
+  AdminRoleCreateRequest,
+  AdminRoleMember,
+} from './admin-role.js';
+
+export type {
+  AdminImpersonationResult,
+  AdminUser,
+  AdminUserCreateRequest,
+  AdminUserListParams,
+  AdminUserPage,
+} from './admin-user.js';

--- a/packages/@granit/openiddict-admin/tsconfig.json
+++ b/packages/@granit/openiddict-admin/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/openiddict-admin/tsup.config.ts
+++ b/packages/@granit/openiddict-admin/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/querying/src/validation/validate-query-request.ts
+++ b/packages/@granit/querying/src/validation/validate-query-request.ts
@@ -14,6 +14,33 @@ function serializeSortString(sort: readonly SortEntry[]): string {
   return sort.map((s) => (s.direction === 'desc' ? `-${s.field}` : s.field)).join(',');
 }
 
+function truncateString(value: string | undefined, maxLength: number): string | undefined {
+  return value ? value.slice(0, maxLength) : value;
+}
+
+function clampPagination(result: Record<string, unknown>, params: QueryRequest): void {
+  if (params.cursor && params.page != null) {
+    delete result.page;
+  }
+  if (result.page != null) {
+    result.page = Math.max(QUERY_LIMITS.PAGE_MIN, result.page as number);
+  }
+  if (params.pageSize != null) {
+    result.pageSize = Math.min(
+      QUERY_LIMITS.PAGE_SIZE_MAX,
+      Math.max(QUERY_LIMITS.PAGE_SIZE_MIN, params.pageSize)
+    );
+  }
+}
+
+function clampSort(sort: readonly SortEntry[]): readonly SortEntry[] {
+  let clamped = [...sort];
+  while (clamped.length > 0 && serializeSortString(clamped).length > QUERY_LIMITS.SORT_MAX_LENGTH) {
+    clamped = clamped.slice(0, -1);
+  }
+  return clamped;
+}
+
 /**
  * Validate and clamp a QueryRequest to server-enforced limits.
  *
@@ -27,36 +54,12 @@ function serializeSortString(sort: readonly SortEntry[]): string {
 export function validateQueryRequest(params: QueryRequest): QueryRequest {
   const result: Record<string, unknown> = { ...params };
 
-  // Page / cursor mutual exclusion — cursor wins
-  if (params.cursor && params.page != null) {
-    delete result.page;
-  }
+  clampPagination(result, params);
 
-  // Page clamping
-  if (result.page != null) {
-    result.page = Math.max(QUERY_LIMITS.PAGE_MIN, result.page as number);
-  }
+  result.search = truncateString(params.search, QUERY_LIMITS.SEARCH_MAX_LENGTH);
+  result.cursor = truncateString(params.cursor, QUERY_LIMITS.CURSOR_MAX_LENGTH);
+  result.groupBy = truncateString(params.groupBy, QUERY_LIMITS.GROUP_BY_MAX_LENGTH);
 
-  // PageSize clamping
-  if (params.pageSize != null) {
-    result.pageSize = Math.min(
-      QUERY_LIMITS.PAGE_SIZE_MAX,
-      Math.max(QUERY_LIMITS.PAGE_SIZE_MIN, params.pageSize)
-    );
-  }
-
-  // String truncation
-  if (params.search) {
-    result.search = params.search.slice(0, QUERY_LIMITS.SEARCH_MAX_LENGTH);
-  }
-  if (params.cursor) {
-    result.cursor = params.cursor.slice(0, QUERY_LIMITS.CURSOR_MAX_LENGTH);
-  }
-  if (params.groupBy) {
-    result.groupBy = params.groupBy.slice(0, QUERY_LIMITS.GROUP_BY_MAX_LENGTH);
-  }
-
-  // Array slicing
   if (params.filters && params.filters.length > QUERY_LIMITS.FILTERS_MAX_COUNT) {
     result.filters = params.filters.slice(0, QUERY_LIMITS.FILTERS_MAX_COUNT);
   }
@@ -64,7 +67,6 @@ export function validateQueryRequest(params: QueryRequest): QueryRequest {
     result.quickFilters = params.quickFilters.slice(0, QUERY_LIMITS.QUICK_FILTERS_MAX_COUNT);
   }
 
-  // Presets: keep first N entries
   if (params.presets) {
     const entries = Object.entries(params.presets);
     if (entries.length > QUERY_LIMITS.PRESETS_MAX_ENTRIES) {
@@ -72,13 +74,8 @@ export function validateQueryRequest(params: QueryRequest): QueryRequest {
     }
   }
 
-  // Sort: drop trailing entries until serialized length fits
   if (params.sort && params.sort.length > 0) {
-    let sort = [...params.sort];
-    while (sort.length > 0 && serializeSortString(sort).length > QUERY_LIMITS.SORT_MAX_LENGTH) {
-      sort = sort.slice(0, -1);
-    }
-    result.sort = sort;
+    result.sort = clampSort(params.sort);
   }
 
   return result as QueryRequest;

--- a/packages/@granit/react-account/package.json
+++ b/packages/@granit/react-account/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/react-account",
+  "description": "React hooks for account self-service — useProfile, useRegister, useChangePassword, useTwoFactorStatus, usePasskeys",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/account": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
@@ -1,0 +1,78 @@
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AccountProvider,
+  buildAccountQueryKey,
+  useAccountConfig,
+} from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AxiosInstance } from 'axios';
+
+const mockConfig: AccountConfig = {
+  client: {} as AxiosInstance,
+  basePath: '/custom/account',
+};
+
+function createWrapper(config: AccountConfig) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <AccountProvider config={config}>{children}</AccountProvider>;
+  };
+}
+
+describe('AccountProvider', () => {
+  it('should provide config via useAccountConfig', () => {
+    const { result } = renderHook(() => useAccountConfig(), {
+      wrapper: createWrapper(mockConfig),
+    });
+
+    expect(result.current.client).toBe(mockConfig.client);
+    expect(result.current.basePath).toBe('/custom/account');
+  });
+
+  it('should apply default basePath when not provided', () => {
+    const config: AccountConfig = { client: {} as AxiosInstance };
+    const { result } = renderHook(() => useAccountConfig(), {
+      wrapper: createWrapper(config),
+    });
+
+    expect(result.current.basePath).toBe('/api/account');
+  });
+
+  it('should apply default queryKeyPrefix when not provided', () => {
+    const config: AccountConfig = { client: {} as AxiosInstance };
+    const { result } = renderHook(() => useAccountConfig(), {
+      wrapper: createWrapper(config),
+    });
+
+    expect(result.current.queryKeyPrefix).toEqual(['account']);
+  });
+
+  it('should throw when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useAccountConfig());
+    }).toThrow('useAccountConfig must be used within an AccountProvider');
+  });
+});
+
+describe('buildAccountQueryKey', () => {
+  it('should build key with default prefix', () => {
+    const config: AccountConfig = { client: {} as AxiosInstance };
+    const key = buildAccountQueryKey(config, 'profile');
+    expect(key).toEqual(['account', 'profile']);
+  });
+
+  it('should build key with custom prefix', () => {
+    const config: AccountConfig = { client: {} as AxiosInstance, queryKeyPrefix: ['custom'] };
+    const key = buildAccountQueryKey(config, 'profile');
+    expect(key).toEqual(['custom', 'profile']);
+  });
+
+  it('should support multiple segments', () => {
+    const config: AccountConfig = { client: {} as AxiosInstance };
+    const key = buildAccountQueryKey(config, 'two-factor', 'authenticator-key');
+    expect(key).toEqual(['account', 'two-factor', 'authenticator-key']);
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-account-deletion.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-account-deletion.test.tsx
@@ -1,0 +1,86 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDeleteAccount } from '../hooks/use-account-deletion.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    deleteAccount: vi.fn(),
+  };
+});
+
+const { deleteAccount } = await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useDeleteAccount', () => {
+  it('should call deleteAccount with password confirmation', async () => {
+    const client = createMockClient();
+    vi.mocked(deleteAccount).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteAccount(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ password: 'MyP@ssword1!' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteAccount).toHaveBeenCalledWith(client, '/api/account', {
+      password: 'MyP@ssword1!',
+    });
+  });
+
+  it('should handle wrong password error', async () => {
+    const client = createMockClient();
+    vi.mocked(deleteAccount).mockRejectedValue(new Error('Bad Request'));
+
+    const { result } = renderHook(() => useDeleteAccount(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ password: 'wrong' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+
+  it('should handle unauthorized error', async () => {
+    const client = createMockClient();
+    vi.mocked(deleteAccount).mockRejectedValue(new Error('Unauthorized'));
+
+    const { result } = renderHook(() => useDeleteAccount(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ password: 'MyP@ssword1!' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Unauthorized');
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
@@ -1,0 +1,154 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useChallengeExternalLogin,
+  useExternalLogins,
+  useUnlinkExternalLogin,
+} from '../hooks/use-external-logins.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AccountExternalLoginInfo } from '@granit/account';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getExternalLogins: vi.fn(),
+    challengeExternalLogin: vi.fn(),
+    unlinkExternalLogin: vi.fn(),
+  };
+});
+
+const { getExternalLogins, challengeExternalLogin, unlinkExternalLogin } =
+  await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+function createWrapperWithQueryClient(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  const config: AccountConfig = { client };
+  return {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        <AccountProvider config={config}>{children}</AccountProvider>
+      ),
+    queryClient,
+  };
+}
+
+const mockLogins: readonly AccountExternalLoginInfo[] = [
+  {
+    loginProvider: 'Google',
+    providerKey: 'goog-123',
+    providerDisplayName: 'Google',
+  },
+  {
+    loginProvider: 'Microsoft',
+    providerKey: 'ms-456',
+    providerDisplayName: 'Microsoft',
+  },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useExternalLogins', () => {
+  it('should fetch external logins', async () => {
+    const client = createMockClient();
+    vi.mocked(getExternalLogins).mockResolvedValue(mockLogins);
+
+    const { result } = renderHook(() => useExternalLogins(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getExternalLogins).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toEqual(mockLogins);
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(getExternalLogins).mockRejectedValue(new Error('Unauthorized'));
+
+    const { result } = renderHook(() => useExternalLogins(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Unauthorized');
+  });
+});
+
+describe('useChallengeExternalLogin', () => {
+  it('should call challengeExternalLogin with provider', async () => {
+    const client = createMockClient();
+    vi.mocked(challengeExternalLogin).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useChallengeExternalLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate('Google');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(challengeExternalLogin).toHaveBeenCalledWith(client, '/api/account', 'Google');
+  });
+});
+
+describe('useUnlinkExternalLogin', () => {
+  it('should call unlinkExternalLogin and invalidate on success', async () => {
+    const client = createMockClient();
+    vi.mocked(unlinkExternalLogin).mockResolvedValue(undefined);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUnlinkExternalLogin(), { wrapper });
+
+    result.current.mutate('Google');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(unlinkExternalLogin).toHaveBeenCalledWith(client, '/api/account', 'Google');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'external-logins'],
+    });
+  });
+
+  it('should handle unlink error', async () => {
+    const client = createMockClient();
+    vi.mocked(unlinkExternalLogin).mockRejectedValue(new Error('Forbidden'));
+
+    const { result } = renderHook(() => useUnlinkExternalLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate('Google');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-passkeys.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-passkeys.test.tsx
@@ -1,0 +1,220 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useBeginPasskeyRegistration,
+  useCompletePasskeyRegistration,
+  useDeletePasskey,
+  usePasskeys,
+  useRenamePasskey,
+} from '../hooks/use-passkeys.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AccountPasskeyCreatedResponse, AccountPasskeyInfo } from '@granit/account';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getPasskeys: vi.fn(),
+    beginPasskeyRegistration: vi.fn(),
+    completePasskeyRegistration: vi.fn(),
+    renamePasskey: vi.fn(),
+    deletePasskey: vi.fn(),
+  };
+});
+
+const {
+  getPasskeys,
+  beginPasskeyRegistration,
+  completePasskeyRegistration,
+  renamePasskey,
+  deletePasskey,
+} = await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+function createWrapperWithQueryClient(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  const config: AccountConfig = { client };
+  return {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        <AccountProvider config={config}>{children}</AccountProvider>
+      ),
+    queryClient,
+  };
+}
+
+const mockPasskeys: readonly AccountPasskeyInfo[] = [
+  {
+    id: 'pk-001',
+    name: 'YubiKey 5',
+    createdAt: '2026-03-01T08:00:00Z',
+    lastUsedAt: '2026-03-20T10:00:00Z',
+  },
+  {
+    id: 'pk-002',
+    name: null,
+    createdAt: '2026-03-10T12:00:00Z',
+    lastUsedAt: null,
+  },
+];
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('usePasskeys', () => {
+  it('should fetch passkeys', async () => {
+    const client = createMockClient();
+    vi.mocked(getPasskeys).mockResolvedValue(mockPasskeys);
+
+    const { result } = renderHook(() => usePasskeys(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getPasskeys).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toEqual(mockPasskeys);
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(getPasskeys).mockRejectedValue(new Error('Unauthorized'));
+
+    const { result } = renderHook(() => usePasskeys(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Unauthorized');
+  });
+});
+
+describe('useBeginPasskeyRegistration', () => {
+  it('should call beginPasskeyRegistration', async () => {
+    const client = createMockClient();
+    const optionsJson = '{"challenge":"abc"}';
+    vi.mocked(beginPasskeyRegistration).mockResolvedValue(optionsJson);
+
+    const { result } = renderHook(() => useBeginPasskeyRegistration(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(beginPasskeyRegistration).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toBe(optionsJson);
+  });
+});
+
+describe('useCompletePasskeyRegistration', () => {
+  it('should call completePasskeyRegistration and invalidate passkeys on success', async () => {
+    const client = createMockClient();
+    const response: AccountPasskeyCreatedResponse = {
+      id: 'pk-003',
+      name: 'New Key',
+      createdAt: '2026-03-21T09:00:00Z',
+    };
+    vi.mocked(completePasskeyRegistration).mockResolvedValue(response);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCompletePasskeyRegistration(), { wrapper });
+
+    result.current.mutate({ credentialJson: '{"id":"cred"}', name: 'New Key' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(completePasskeyRegistration).toHaveBeenCalledWith(client, '/api/account', {
+      credentialJson: '{"id":"cred"}',
+      name: 'New Key',
+    });
+    expect(result.current.data).toEqual(response);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'passkeys'],
+    });
+  });
+});
+
+describe('useRenamePasskey', () => {
+  it('should call renamePasskey and invalidate passkeys on success', async () => {
+    const client = createMockClient();
+    vi.mocked(renamePasskey).mockResolvedValue(undefined);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRenamePasskey(), { wrapper });
+
+    result.current.mutate({ id: 'pk-001', request: { name: 'Renamed Key' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(renamePasskey).toHaveBeenCalledWith(client, '/api/account', 'pk-001', {
+      name: 'Renamed Key',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'passkeys'],
+    });
+  });
+});
+
+describe('useDeletePasskey', () => {
+  it('should call deletePasskey and invalidate passkeys on success', async () => {
+    const client = createMockClient();
+    vi.mocked(deletePasskey).mockResolvedValue(undefined);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeletePasskey(), { wrapper });
+
+    result.current.mutate('pk-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deletePasskey).toHaveBeenCalledWith(client, '/api/account', 'pk-001');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'passkeys'],
+    });
+  });
+
+  it('should handle delete error', async () => {
+    const client = createMockClient();
+    vi.mocked(deletePasskey).mockRejectedValue(new Error('Not Found'));
+
+    const { result } = renderHook(() => useDeletePasskey(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate('pk-999');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-password.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-password.test.tsx
@@ -1,0 +1,161 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useChangePassword,
+  useForgotPassword,
+  useResetPassword,
+} from '../hooks/use-password.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    changePassword: vi.fn(),
+    forgotPassword: vi.fn(),
+    resetPassword: vi.fn(),
+  };
+});
+
+const { changePassword, forgotPassword, resetPassword } = await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useChangePassword', () => {
+  it('should call changePassword with correct arguments', async () => {
+    const client = createMockClient();
+    vi.mocked(changePassword).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useChangePassword(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      currentPassword: 'OldP@ss1!',
+      newPassword: 'NewP@ss1!',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(changePassword).toHaveBeenCalledWith(client, '/api/account', {
+      currentPassword: 'OldP@ss1!',
+      newPassword: 'NewP@ss1!',
+    });
+  });
+
+  it('should handle wrong current password error', async () => {
+    const client = createMockClient();
+    vi.mocked(changePassword).mockRejectedValue(new Error('Bad Request'));
+
+    const { result } = renderHook(() => useChangePassword(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      currentPassword: 'wrong',
+      newPassword: 'NewP@ss1!',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});
+
+describe('useForgotPassword', () => {
+  it('should call forgotPassword with correct arguments', async () => {
+    const client = createMockClient();
+    vi.mocked(forgotPassword).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useForgotPassword(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ email: 'user@example.com' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(forgotPassword).toHaveBeenCalledWith(client, '/api/account', {
+      email: 'user@example.com',
+    });
+  });
+
+  it('should handle error gracefully', async () => {
+    const client = createMockClient();
+    vi.mocked(forgotPassword).mockRejectedValue(new Error('Service Unavailable'));
+
+    const { result } = renderHook(() => useForgotPassword(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ email: 'user@example.com' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Service Unavailable');
+  });
+});
+
+describe('useResetPassword', () => {
+  it('should call resetPassword with correct arguments', async () => {
+    const client = createMockClient();
+    vi.mocked(resetPassword).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useResetPassword(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      userId: 'user-1',
+      token: 'reset-token-abc',
+      newPassword: 'NewP@ss1!',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(resetPassword).toHaveBeenCalledWith(client, '/api/account', {
+      userId: 'user-1',
+      token: 'reset-token-abc',
+      newPassword: 'NewP@ss1!',
+    });
+  });
+
+  it('should handle invalid reset token error', async () => {
+    const client = createMockClient();
+    vi.mocked(resetPassword).mockRejectedValue(new Error('Bad Request'));
+
+    const { result } = renderHook(() => useResetPassword(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      userId: 'user-1',
+      token: 'expired-token',
+      newPassword: 'NewP@ss1!',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
@@ -1,0 +1,131 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useProfile, useUpdateProfile } from '../hooks/use-profile.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AccountProfileResponse } from '@granit/account';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getProfile: vi.fn(),
+    updateProfile: vi.fn(),
+  };
+});
+
+const { getProfile, updateProfile } = await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+function createWrapperWithQueryClient(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  const config: AccountConfig = { client };
+  return {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        <AccountProvider config={config}>{children}</AccountProvider>
+      ),
+    queryClient,
+  };
+}
+
+const mockProfile: AccountProfileResponse = {
+  userId: 'user-1',
+  email: 'user@example.com',
+  emailConfirmed: true,
+  firstName: 'John',
+  lastName: 'Doe',
+  twoFactorEnabled: false,
+  hasPassword: true,
+  externalLogins: [],
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useProfile', () => {
+  it('should fetch profile with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(getProfile).mockResolvedValue(mockProfile);
+
+    const { result } = renderHook(() => useProfile(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getProfile).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toEqual(mockProfile);
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(getProfile).mockRejectedValue(new Error('Unauthorized'));
+
+    const { result } = renderHook(() => useProfile(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Unauthorized');
+  });
+});
+
+describe('useUpdateProfile', () => {
+  it('should call updateProfile and invalidate profile query on success', async () => {
+    const client = createMockClient();
+    const updatedProfile: AccountProfileResponse = { ...mockProfile, firstName: 'Jane' };
+    vi.mocked(updateProfile).mockResolvedValue(updatedProfile);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateProfile(), { wrapper });
+
+    result.current.mutate({ firstName: 'Jane' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(updateProfile).toHaveBeenCalledWith(client, '/api/account', { firstName: 'Jane' });
+    expect(result.current.data).toEqual(updatedProfile);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'profile'],
+    });
+  });
+
+  it('should handle update error', async () => {
+    const client = createMockClient();
+    vi.mocked(updateProfile).mockRejectedValue(new Error('Bad Request'));
+
+    const { result } = renderHook(() => useUpdateProfile(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ firstName: '' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-registration.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-registration.test.tsx
@@ -1,0 +1,153 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useConfirmEmail,
+  useRegister,
+  useResendConfirmation,
+} from '../hooks/use-registration.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AccountRegisterResponse } from '@granit/account';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    registerAccount: vi.fn(),
+    confirmEmail: vi.fn(),
+    resendConfirmationEmail: vi.fn(),
+  };
+});
+
+const { registerAccount, confirmEmail, resendConfirmationEmail } =
+  await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useRegister', () => {
+  it('should call registerAccount with correct arguments', async () => {
+    const client = createMockClient();
+    const response: AccountRegisterResponse = {
+      userId: 'user-1',
+      requiresEmailConfirmation: true,
+    };
+    vi.mocked(registerAccount).mockResolvedValue(response);
+
+    const { result } = renderHook(() => useRegister(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      email: 'user@example.com',
+      password: 'P@ssword1!',
+      firstName: 'John',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(registerAccount).toHaveBeenCalledWith(client, '/api/account', {
+      email: 'user@example.com',
+      password: 'P@ssword1!',
+      firstName: 'John',
+    });
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should handle registration error', async () => {
+    const client = createMockClient();
+    vi.mocked(registerAccount).mockRejectedValue(new Error('Conflict'));
+
+    const { result } = renderHook(() => useRegister(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ email: 'dup@example.com', password: 'P@ssword1!' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useConfirmEmail', () => {
+  it('should call confirmEmail with userId and token', async () => {
+    const client = createMockClient();
+    vi.mocked(confirmEmail).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useConfirmEmail(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ userId: 'user-1', token: 'abc123' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(confirmEmail).toHaveBeenCalledWith(client, '/api/account', 'user-1', 'abc123');
+  });
+
+  it('should handle invalid token error', async () => {
+    const client = createMockClient();
+    vi.mocked(confirmEmail).mockRejectedValue(new Error('Invalid token'));
+
+    const { result } = renderHook(() => useConfirmEmail(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ userId: 'user-1', token: 'invalid' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Invalid token');
+  });
+});
+
+describe('useResendConfirmation', () => {
+  it('should call resendConfirmationEmail', async () => {
+    const client = createMockClient();
+    vi.mocked(resendConfirmationEmail).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useResendConfirmation(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(resendConfirmationEmail).toHaveBeenCalledWith(client, '/api/account');
+  });
+
+  it('should handle rate limit error', async () => {
+    const client = createMockClient();
+    vi.mocked(resendConfirmationEmail).mockRejectedValue(new Error('Too Many Requests'));
+
+    const { result } = renderHook(() => useResendConfirmation(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Too Many Requests');
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-session.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-session.test.tsx
@@ -1,0 +1,109 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useBackToImpersonator, useSessionHeartbeat } from '../hooks/use-session.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AccountImpersonationResult } from '@granit/account';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    sessionHeartbeat: vi.fn(),
+    backToImpersonator: vi.fn(),
+  };
+});
+
+const { sessionHeartbeat, backToImpersonator } = await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useSessionHeartbeat', () => {
+  it('should call sessionHeartbeat', async () => {
+    const client = createMockClient();
+    vi.mocked(sessionHeartbeat).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useSessionHeartbeat(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(sessionHeartbeat).toHaveBeenCalledWith(client, '/api/account');
+  });
+
+  it('should handle heartbeat error', async () => {
+    const client = createMockClient();
+    vi.mocked(sessionHeartbeat).mockRejectedValue(new Error('Unauthorized'));
+
+    const { result } = renderHook(() => useSessionHeartbeat(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Unauthorized');
+  });
+});
+
+describe('useBackToImpersonator', () => {
+  it('should call backToImpersonator', async () => {
+    const client = createMockClient();
+    const response: AccountImpersonationResult = {
+      accessToken: 'new-access-token',
+      refreshToken: 'new-refresh-token',
+      expiresIn: 3600,
+    };
+    vi.mocked(backToImpersonator).mockResolvedValue(response);
+
+    const { result } = renderHook(() => useBackToImpersonator(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(backToImpersonator).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should handle error when not impersonating', async () => {
+    const client = createMockClient();
+    vi.mocked(backToImpersonator).mockRejectedValue(new Error('Forbidden'));
+
+    const { result } = renderHook(() => useBackToImpersonator(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
@@ -1,0 +1,214 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAuthenticatorKey,
+  useDisableTwoFactor,
+  useEnableTwoFactor,
+  useGenerateRecoveryCodes,
+  useTwoFactorStatus,
+} from '../hooks/use-two-factor.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type {
+  AccountAuthenticatorKeyResponse,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from '@granit/account';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getTwoFactorStatus: vi.fn(),
+    getAuthenticatorKey: vi.fn(),
+    enableTwoFactor: vi.fn(),
+    disableTwoFactor: vi.fn(),
+    generateRecoveryCodes: vi.fn(),
+  };
+});
+
+const {
+  getTwoFactorStatus,
+  getAuthenticatorKey,
+  enableTwoFactor,
+  disableTwoFactor,
+  generateRecoveryCodes,
+} = await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+function createWrapperWithQueryClient(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  const config: AccountConfig = { client };
+  return {
+    wrapper: ({ children }: { children: ReactNode }) =>
+      React.createElement(
+        QueryClientProvider,
+        { client: queryClient },
+        <AccountProvider config={config}>{children}</AccountProvider>
+      ),
+    queryClient,
+  };
+}
+
+const mockStatus: AccountTwoFactorStatusResponse = {
+  isEnabled: false,
+  hasAuthenticatorApp: false,
+  recoveryCodesLeft: 0,
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useTwoFactorStatus', () => {
+  it('should fetch two-factor status', async () => {
+    const client = createMockClient();
+    vi.mocked(getTwoFactorStatus).mockResolvedValue(mockStatus);
+
+    const { result } = renderHook(() => useTwoFactorStatus(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getTwoFactorStatus).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toEqual(mockStatus);
+  });
+
+  it('should handle fetch error', async () => {
+    const client = createMockClient();
+    vi.mocked(getTwoFactorStatus).mockRejectedValue(new Error('Unauthorized'));
+
+    const { result } = renderHook(() => useTwoFactorStatus(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Unauthorized');
+  });
+});
+
+describe('useAuthenticatorKey', () => {
+  it('should fetch authenticator key', async () => {
+    const client = createMockClient();
+    const mockKey: AccountAuthenticatorKeyResponse = {
+      sharedKey: 'ABCD1234',
+      qrCodeUri: 'otpauth://totp/app:user@example.com?secret=ABCD1234',
+    };
+    vi.mocked(getAuthenticatorKey).mockResolvedValue(mockKey);
+
+    const { result } = renderHook(() => useAuthenticatorKey(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getAuthenticatorKey).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toEqual(mockKey);
+  });
+});
+
+describe('useEnableTwoFactor', () => {
+  it('should call enableTwoFactor and invalidate two-factor query on success', async () => {
+    const client = createMockClient();
+    const response: AccountTwoFactorEnableResponse = {
+      recoveryCodes: ['CODE1', 'CODE2', 'CODE3'],
+    };
+    vi.mocked(enableTwoFactor).mockResolvedValue(response);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useEnableTwoFactor(), { wrapper });
+
+    result.current.mutate({ code: '123456' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(enableTwoFactor).toHaveBeenCalledWith(client, '/api/account', { code: '123456' });
+    expect(result.current.data).toEqual(response);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'two-factor'],
+    });
+  });
+
+  it('should handle invalid code error', async () => {
+    const client = createMockClient();
+    vi.mocked(enableTwoFactor).mockRejectedValue(new Error('Bad Request'));
+
+    const { result } = renderHook(() => useEnableTwoFactor(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ code: '000000' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});
+
+describe('useDisableTwoFactor', () => {
+  it('should call disableTwoFactor and invalidate two-factor query on success', async () => {
+    const client = createMockClient();
+    vi.mocked(disableTwoFactor).mockResolvedValue(undefined);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDisableTwoFactor(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(disableTwoFactor).toHaveBeenCalledWith(client, '/api/account');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'two-factor'],
+    });
+  });
+});
+
+describe('useGenerateRecoveryCodes', () => {
+  it('should call generateRecoveryCodes and invalidate two-factor query on success', async () => {
+    const client = createMockClient();
+    const response: AccountRecoveryCodesResponse = {
+      recoveryCodes: ['NEW1', 'NEW2', 'NEW3'],
+    };
+    vi.mocked(generateRecoveryCodes).mockResolvedValue(response);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useGenerateRecoveryCodes(), { wrapper });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(generateRecoveryCodes).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toEqual(response);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'two-factor'],
+    });
+  });
+});

--- a/packages/@granit/react-account/src/hooks/use-account-deletion.ts
+++ b/packages/@granit/react-account/src/hooks/use-account-deletion.ts
@@ -1,0 +1,17 @@
+import { deleteAccount } from '@granit/account';
+import { useMutation } from '@tanstack/react-query';
+
+import { useAccountConfig } from '../providers/account-provider.js';
+
+import type { AccountDeleteRequest } from '@granit/account';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Requests account deletion (GDPR Art. 17). */
+export function useDeleteAccount(): UseMutationResult<void, Error, AccountDeleteRequest> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountDeleteRequest) =>
+      deleteAccount(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-account/src/hooks/use-external-logins.ts
+++ b/packages/@granit/react-account/src/hooks/use-external-logins.ts
@@ -1,0 +1,47 @@
+import {
+  challengeExternalLogin,
+  getExternalLogins,
+  unlinkExternalLogin,
+} from '@granit/account';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAccountQueryKey, useAccountConfig } from '../providers/account-provider.js';
+
+import type { AccountExternalLoginInfo } from '@granit/account';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches the list of linked external login providers. */
+export function useExternalLogins(): UseQueryResult<readonly AccountExternalLoginInfo[]> {
+  const config = useAccountConfig();
+
+  return useQuery({
+    queryKey: buildAccountQueryKey(config, 'external-logins'),
+    queryFn: () => getExternalLogins(config.client, config.basePath!),
+  });
+}
+
+/** Initiates an OAuth challenge with an external provider. */
+export function useChallengeExternalLogin(): UseMutationResult<void, Error, string> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (provider: string) =>
+      challengeExternalLogin(config.client, config.basePath!, provider),
+  });
+}
+
+/** Unlinks an external login provider. Invalidates external logins query on success. */
+export function useUnlinkExternalLogin(): UseMutationResult<void, Error, string> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (provider: string) =>
+      unlinkExternalLogin(config.client, config.basePath!, provider),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'external-logins'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-account/src/hooks/use-passkeys.ts
+++ b/packages/@granit/react-account/src/hooks/use-passkeys.ts
@@ -1,0 +1,94 @@
+import {
+  beginPasskeyRegistration,
+  completePasskeyRegistration,
+  deletePasskey,
+  getPasskeys,
+  renamePasskey,
+} from '@granit/account';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAccountQueryKey, useAccountConfig } from '../providers/account-provider.js';
+
+import type {
+  AccountPasskeyCreatedResponse,
+  AccountPasskeyInfo,
+  AccountPasskeyRegistrationRequest,
+  AccountPasskeyRenameRequest,
+} from '@granit/account';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches all registered passkeys. */
+export function usePasskeys(): UseQueryResult<readonly AccountPasskeyInfo[]> {
+  const config = useAccountConfig();
+
+  return useQuery({
+    queryKey: buildAccountQueryKey(config, 'passkeys'),
+    queryFn: () => getPasskeys(config.client, config.basePath!),
+  });
+}
+
+/** Begins a WebAuthn passkey registration ceremony. Returns raw JSON options. */
+export function useBeginPasskeyRegistration(): UseMutationResult<string, Error, void> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: () => beginPasskeyRegistration(config.client, config.basePath!),
+  });
+}
+
+/** Completes a WebAuthn passkey registration. Invalidates passkeys on success. */
+export function useCompletePasskeyRegistration(): UseMutationResult<
+  AccountPasskeyCreatedResponse,
+  Error,
+  AccountPasskeyRegistrationRequest
+> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountPasskeyRegistrationRequest) =>
+      completePasskeyRegistration(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'passkeys'),
+      });
+    },
+  });
+}
+
+/** Rename passkey variables. */
+export interface RenamePasskeyVariables {
+  readonly id: string;
+  readonly request: AccountPasskeyRenameRequest;
+}
+
+/** Renames a passkey. Invalidates passkeys on success. */
+export function useRenamePasskey(): UseMutationResult<void, Error, RenamePasskeyVariables> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: RenamePasskeyVariables) =>
+      renamePasskey(config.client, config.basePath!, id, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'passkeys'),
+      });
+    },
+  });
+}
+
+/** Deletes a passkey. Invalidates passkeys on success. */
+export function useDeletePasskey(): UseMutationResult<void, Error, string> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deletePasskey(config.client, config.basePath!, id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'passkeys'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-account/src/hooks/use-password.ts
+++ b/packages/@granit/react-account/src/hooks/use-password.ts
@@ -1,0 +1,53 @@
+import { changePassword, forgotPassword, resetPassword } from '@granit/account';
+import { useMutation } from '@tanstack/react-query';
+
+import { useAccountConfig } from '../providers/account-provider.js';
+
+import type {
+  AccountForgotPasswordRequest,
+  AccountPasswordChangeRequest,
+  AccountPasswordResetRequest,
+} from '@granit/account';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Changes the current user's password. */
+export function useChangePassword(): UseMutationResult<
+  void,
+  Error,
+  AccountPasswordChangeRequest
+> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountPasswordChangeRequest) =>
+      changePassword(config.client, config.basePath!, request),
+  });
+}
+
+/** Requests a password reset email. */
+export function useForgotPassword(): UseMutationResult<
+  void,
+  Error,
+  AccountForgotPasswordRequest
+> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountForgotPasswordRequest) =>
+      forgotPassword(config.client, config.basePath!, request),
+  });
+}
+
+/** Resets a password using the token from the reset email. */
+export function useResetPassword(): UseMutationResult<
+  void,
+  Error,
+  AccountPasswordResetRequest
+> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountPasswordResetRequest) =>
+      resetPassword(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-account/src/hooks/use-profile.ts
+++ b/packages/@granit/react-account/src/hooks/use-profile.ts
@@ -1,0 +1,37 @@
+import { getProfile, updateProfile } from '@granit/account';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAccountQueryKey, useAccountConfig } from '../providers/account-provider.js';
+
+import type { AccountProfileResponse, AccountProfileUpdateRequest } from '@granit/account';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches the current user's profile. */
+export function useProfile(): UseQueryResult<AccountProfileResponse> {
+  const config = useAccountConfig();
+
+  return useQuery({
+    queryKey: buildAccountQueryKey(config, 'profile'),
+    queryFn: () => getProfile(config.client, config.basePath!),
+  });
+}
+
+/** Updates the current user's profile. Invalidates the profile query on success. */
+export function useUpdateProfile(): UseMutationResult<
+  AccountProfileResponse,
+  Error,
+  AccountProfileUpdateRequest
+> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountProfileUpdateRequest) =>
+      updateProfile(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'profile'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-account/src/hooks/use-registration.ts
+++ b/packages/@granit/react-account/src/hooks/use-registration.ts
@@ -1,0 +1,46 @@
+import { confirmEmail, registerAccount, resendConfirmationEmail } from '@granit/account';
+import { useMutation } from '@tanstack/react-query';
+
+import { useAccountConfig } from '../providers/account-provider.js';
+
+import type { AccountRegisterRequest, AccountRegisterResponse } from '@granit/account';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Registers a new user account. */
+export function useRegister(): UseMutationResult<
+  AccountRegisterResponse,
+  Error,
+  AccountRegisterRequest
+> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountRegisterRequest) =>
+      registerAccount(config.client, config.basePath!, request),
+  });
+}
+
+/** Confirm email variables. */
+export interface ConfirmEmailVariables {
+  readonly userId: string;
+  readonly token: string;
+}
+
+/** Confirms a user's email address using the token from the confirmation email. */
+export function useConfirmEmail(): UseMutationResult<void, Error, ConfirmEmailVariables> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: ({ userId, token }: ConfirmEmailVariables) =>
+      confirmEmail(config.client, config.basePath!, userId, token),
+  });
+}
+
+/** Resends the email confirmation link. */
+export function useResendConfirmation(): UseMutationResult<void, Error, void> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: () => resendConfirmationEmail(config.client, config.basePath!),
+  });
+}

--- a/packages/@granit/react-account/src/hooks/use-session.ts
+++ b/packages/@granit/react-account/src/hooks/use-session.ts
@@ -1,0 +1,29 @@
+import { backToImpersonator, sessionHeartbeat } from '@granit/account';
+import { useMutation } from '@tanstack/react-query';
+
+import { useAccountConfig } from '../providers/account-provider.js';
+
+import type { AccountImpersonationResult } from '@granit/account';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Sends a session heartbeat to prevent idle timeout. */
+export function useSessionHeartbeat(): UseMutationResult<void, Error, void> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: () => sessionHeartbeat(config.client, config.basePath!),
+  });
+}
+
+/** Ends an impersonation session and returns to the original admin account. */
+export function useBackToImpersonator(): UseMutationResult<
+  AccountImpersonationResult,
+  Error,
+  void
+> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: () => backToImpersonator(config.client, config.basePath!),
+  });
+}

--- a/packages/@granit/react-account/src/hooks/use-two-factor.ts
+++ b/packages/@granit/react-account/src/hooks/use-two-factor.ts
@@ -1,0 +1,93 @@
+import {
+  disableTwoFactor,
+  enableTwoFactor,
+  generateRecoveryCodes,
+  getAuthenticatorKey,
+  getTwoFactorStatus,
+} from '@granit/account';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAccountQueryKey, useAccountConfig } from '../providers/account-provider.js';
+
+import type {
+  AccountAuthenticatorKeyResponse,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorEnableRequest,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from '@granit/account';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches the current user's 2FA status. */
+export function useTwoFactorStatus(): UseQueryResult<AccountTwoFactorStatusResponse> {
+  const config = useAccountConfig();
+
+  return useQuery({
+    queryKey: buildAccountQueryKey(config, 'two-factor'),
+    queryFn: () => getTwoFactorStatus(config.client, config.basePath!),
+  });
+}
+
+/** Fetches the TOTP authenticator key and QR code URI. */
+export function useAuthenticatorKey(): UseQueryResult<AccountAuthenticatorKeyResponse> {
+  const config = useAccountConfig();
+
+  return useQuery({
+    queryKey: buildAccountQueryKey(config, 'two-factor', 'authenticator-key'),
+    queryFn: () => getAuthenticatorKey(config.client, config.basePath!),
+  });
+}
+
+/** Enables 2FA with a TOTP verification code. Invalidates 2FA status on success. */
+export function useEnableTwoFactor(): UseMutationResult<
+  AccountTwoFactorEnableResponse,
+  Error,
+  AccountTwoFactorEnableRequest
+> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountTwoFactorEnableRequest) =>
+      enableTwoFactor(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'two-factor'),
+      });
+    },
+  });
+}
+
+/** Disables 2FA. Invalidates 2FA status on success. */
+export function useDisableTwoFactor(): UseMutationResult<void, Error, void> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => disableTwoFactor(config.client, config.basePath!),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'two-factor'),
+      });
+    },
+  });
+}
+
+/** Generates new recovery codes. Invalidates 2FA status on success. */
+export function useGenerateRecoveryCodes(): UseMutationResult<
+  AccountRecoveryCodesResponse,
+  Error,
+  void
+> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => generateRecoveryCodes(config.client, config.basePath!),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'two-factor'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-account/src/index.ts
+++ b/packages/@granit/react-account/src/index.ts
@@ -1,0 +1,53 @@
+// Provider
+export {
+  AccountProvider,
+  buildAccountQueryKey,
+  useAccountConfig,
+} from './providers/account-provider.js';
+export type { AccountConfig, AccountProviderProps } from './providers/account-provider.js';
+
+// Hooks — Profile
+export { useProfile, useUpdateProfile } from './hooks/use-profile.js';
+
+// Hooks — Registration
+export { useConfirmEmail, useRegister, useResendConfirmation } from './hooks/use-registration.js';
+export type { ConfirmEmailVariables } from './hooks/use-registration.js';
+
+// Hooks — Password
+export {
+  useChangePassword,
+  useForgotPassword,
+  useResetPassword,
+} from './hooks/use-password.js';
+
+// Hooks — Two-Factor
+export {
+  useAuthenticatorKey,
+  useDisableTwoFactor,
+  useEnableTwoFactor,
+  useGenerateRecoveryCodes,
+  useTwoFactorStatus,
+} from './hooks/use-two-factor.js';
+
+// Hooks — External Logins
+export {
+  useChallengeExternalLogin,
+  useExternalLogins,
+  useUnlinkExternalLogin,
+} from './hooks/use-external-logins.js';
+
+// Hooks — Passkeys
+export {
+  useBeginPasskeyRegistration,
+  useCompletePasskeyRegistration,
+  useDeletePasskey,
+  usePasskeys,
+  useRenamePasskey,
+} from './hooks/use-passkeys.js';
+export type { RenamePasskeyVariables } from './hooks/use-passkeys.js';
+
+// Hooks — Session
+export { useBackToImpersonator, useSessionHeartbeat } from './hooks/use-session.js';
+
+// Hooks — Deletion
+export { useDeleteAccount } from './hooks/use-account-deletion.js';

--- a/packages/@granit/react-account/src/providers/account-provider.tsx
+++ b/packages/@granit/react-account/src/providers/account-provider.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext } from 'react';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+export interface AccountConfig {
+  readonly client: AxiosInstance;
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface AccountProviderProps {
+  readonly config: AccountConfig;
+  readonly children: ReactNode;
+}
+
+const DEFAULT_BASE_PATH = '/api/account';
+const DEFAULT_KEY_PREFIX = ['account'] as const;
+
+const AccountContext = createContext<AccountConfig | null>(null);
+
+export function useAccountConfig(): AccountConfig {
+  const config = useContext(AccountContext);
+  if (!config) throw new Error('useAccountConfig must be used within an AccountProvider');
+  return config;
+}
+
+export function buildAccountQueryKey(
+  config: AccountConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
+}
+
+export function AccountProvider({ config, children }: AccountProviderProps) {
+  const value: AccountConfig = {
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+  };
+
+  return <AccountContext value={value}>{children}</AccountContext>;
+}

--- a/packages/@granit/react-account/tsconfig.json
+++ b/packages/@granit/react-account/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-account/tsup.config.ts
+++ b/packages/@granit/react-account/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//, /^react/, /^@tanstack\//],
+});

--- a/packages/@granit/react-openiddict-admin/package.json
+++ b/packages/@granit/react-openiddict-admin/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@granit/react-openiddict-admin",
+  "description": "React hooks for OpenIddict admin management — useAdminUsers, useAdminRoles, useOidcApplications, useOidcScopes",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/openiddict-admin": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
@@ -1,0 +1,81 @@
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  OpenIddictAdminProvider,
+  buildAdminQueryKey,
+  useAdminConfig,
+} from '../providers/openiddict-admin-provider.js';
+
+import type { OpenIddictAdminConfig } from '../providers/openiddict-admin-provider.js';
+import type { AxiosInstance } from 'axios';
+
+const mockConfig: OpenIddictAdminConfig = {
+  client: {} as AxiosInstance,
+  basePath: '/api/custom',
+};
+
+function createWrapper(config: OpenIddictAdminConfig) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <OpenIddictAdminProvider config={config}>{children}</OpenIddictAdminProvider>;
+  };
+}
+
+describe('OpenIddictAdminProvider', () => {
+  it('should provide config via useAdminConfig', () => {
+    const { result } = renderHook(() => useAdminConfig(), {
+      wrapper: createWrapper(mockConfig),
+    });
+
+    expect(result.current.client).toBe(mockConfig.client);
+    expect(result.current.basePath).toBe('/api/custom');
+  });
+
+  it('should apply default basePath when not specified', () => {
+    const config: OpenIddictAdminConfig = { client: {} as AxiosInstance };
+    const { result } = renderHook(() => useAdminConfig(), {
+      wrapper: createWrapper(config),
+    });
+
+    expect(result.current.basePath).toBe('/api/admin');
+  });
+
+  it('should apply default queryKeyPrefix when not specified', () => {
+    const config: OpenIddictAdminConfig = { client: {} as AxiosInstance };
+    const { result } = renderHook(() => useAdminConfig(), {
+      wrapper: createWrapper(config),
+    });
+
+    expect(result.current.queryKeyPrefix).toEqual(['openiddict-admin']);
+  });
+
+  it('should throw when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useAdminConfig());
+    }).toThrow('useAdminConfig must be used within an OpenIddictAdminProvider');
+  });
+});
+
+describe('buildAdminQueryKey', () => {
+  it('should build key with default prefix', () => {
+    const config: OpenIddictAdminConfig = { client: {} as AxiosInstance };
+    const key = buildAdminQueryKey(config, 'users');
+    expect(key).toEqual(['openiddict-admin', 'users']);
+  });
+
+  it('should build key with custom prefix', () => {
+    const config: OpenIddictAdminConfig = {
+      client: {} as AxiosInstance,
+      queryKeyPrefix: ['custom'],
+    };
+    const key = buildAdminQueryKey(config, 'users', 'detail');
+    expect(key).toEqual(['custom', 'users', 'detail']);
+  });
+
+  it('should build key with multiple segments', () => {
+    const config: OpenIddictAdminConfig = { client: {} as AxiosInstance };
+    const key = buildAdminQueryKey(config, 'oidc', 'applications');
+    expect(key).toEqual(['openiddict-admin', 'oidc', 'applications']);
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-groups.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-groups.test.tsx
@@ -1,0 +1,232 @@
+import {
+  addGroupMember,
+  createGroup,
+  deleteGroup,
+  listGroups,
+  removeGroupMember,
+} from '@granit/openiddict-admin';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useAddGroupMember,
+  useAdminGroups,
+  useCreateAdminGroup,
+  useDeleteAdminGroup,
+  useRemoveGroupMember,
+} from '../hooks/use-admin-groups.js';
+import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider.js';
+
+import type { AdminGroup } from '@granit/openiddict-admin';
+
+vi.mock('@granit/openiddict-admin', () => ({
+  listGroups: vi.fn(),
+  createGroup: vi.fn(),
+  deleteGroup: vi.fn(),
+  addGroupMember: vi.fn(),
+  removeGroupMember: vi.fn(),
+}));
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const client = createMockClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OpenIddictAdminProvider config={{ client }}>
+          {children}
+        </OpenIddictAdminProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+    client,
+  };
+}
+
+const mockGroup: AdminGroup = {
+  id: 'grp-001',
+  name: 'Engineering',
+  path: '/engineering',
+  subGroups: [],
+};
+
+const mockGroups: readonly AdminGroup[] = [
+  mockGroup,
+  { id: 'grp-002', name: 'Marketing', path: null, subGroups: [] },
+];
+
+describe('useAdminGroups', () => {
+  it('should fetch all groups', async () => {
+    vi.mocked(listGroups).mockResolvedValueOnce(mockGroups);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminGroups(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listGroups).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(result.current.data).toEqual(mockGroups);
+  });
+
+  it('should handle fetch error', async () => {
+    vi.mocked(listGroups).mockRejectedValueOnce(new Error('Server Error'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminGroups(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Server Error');
+  });
+});
+
+describe('useCreateAdminGroup', () => {
+  it('should create a group and invalidate groups query', async () => {
+    vi.mocked(createGroup).mockResolvedValueOnce(mockGroup);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateAdminGroup(), { wrapper });
+
+    result.current.mutate({ name: 'Engineering', description: 'Engineering team' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(createGroup).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      { name: 'Engineering', description: 'Engineering team' }
+    );
+    expect(result.current.data).toEqual(mockGroup);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'groups'],
+    });
+  });
+
+  it('should handle creation error', async () => {
+    vi.mocked(createGroup).mockRejectedValueOnce(new Error('Bad Request'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateAdminGroup(), { wrapper });
+
+    result.current.mutate({ name: '' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});
+
+describe('useDeleteAdminGroup', () => {
+  it('should delete a group and invalidate groups query', async () => {
+    vi.mocked(deleteGroup).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteAdminGroup(), { wrapper });
+
+    result.current.mutate('grp-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteGroup).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'grp-001');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'groups'],
+    });
+  });
+
+  it('should handle delete error', async () => {
+    vi.mocked(deleteGroup).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteAdminGroup(), { wrapper });
+
+    result.current.mutate('invalid-id');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});
+
+describe('useAddGroupMember', () => {
+  it('should add a member and invalidate groups query', async () => {
+    vi.mocked(addGroupMember).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAddGroupMember(), { wrapper });
+
+    result.current.mutate({ groupId: 'grp-001', request: { userId: 'usr-001' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(addGroupMember).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      'grp-001',
+      { userId: 'usr-001' }
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'groups'],
+    });
+  });
+
+  it('should handle add member error', async () => {
+    vi.mocked(addGroupMember).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAddGroupMember(), { wrapper });
+
+    result.current.mutate({ groupId: 'grp-001', request: { userId: 'usr-001' } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useRemoveGroupMember', () => {
+  it('should remove a member and invalidate groups query', async () => {
+    vi.mocked(removeGroupMember).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRemoveGroupMember(), { wrapper });
+
+    result.current.mutate({ groupId: 'grp-001', userId: 'usr-001' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(removeGroupMember).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      'grp-001',
+      'usr-001'
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'groups'],
+    });
+  });
+
+  it('should handle remove member error', async () => {
+    vi.mocked(removeGroupMember).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRemoveGroupMember(), { wrapper });
+
+    result.current.mutate({ groupId: 'grp-001', userId: 'invalid' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
@@ -14,9 +14,7 @@ import {
 } from '../hooks/use-admin-roles.js';
 import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider.js';
 
-import type { AdminRoleMember } from '@granit/openiddict-admin';
-
-import type { AdminRole } from '@granit/openiddict-admin';
+import type { AdminRole, AdminRoleMember } from '@granit/openiddict-admin';
 
 vi.mock('@granit/openiddict-admin', () => ({
   listRoles: vi.fn(),
@@ -35,9 +33,7 @@ function createWrapper() {
   return {
     wrapper: ({ children }: { children: React.ReactNode }) => (
       <QueryClientProvider client={queryClient}>
-        <OpenIddictAdminProvider config={{ client }}>
-          {children}
-        </OpenIddictAdminProvider>
+        <OpenIddictAdminProvider config={{ client }}>{children}</OpenIddictAdminProvider>
       </QueryClientProvider>
     ),
     queryClient,
@@ -94,11 +90,10 @@ describe('useCreateAdminRole', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createRole).toHaveBeenCalledWith(
-      expect.anything(),
-      '/api/admin',
-      { name: 'admin', description: 'Administrator role' }
-    );
+    expect(createRole).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+      name: 'admin',
+      description: 'Administrator role',
+    });
     expect(result.current.data).toEqual(mockRole);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'roles'],

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
@@ -1,0 +1,179 @@
+import { createRole, deleteRole, getRoleMembers, listRoles } from '@granit/openiddict-admin';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAdminRoleMembers,
+  useAdminRoles,
+  useCreateAdminRole,
+  useDeleteAdminRole,
+} from '../hooks/use-admin-roles.js';
+import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider.js';
+
+import type { AdminRoleMember } from '@granit/openiddict-admin';
+
+import type { AdminRole } from '@granit/openiddict-admin';
+
+vi.mock('@granit/openiddict-admin', () => ({
+  listRoles: vi.fn(),
+  createRole: vi.fn(),
+  deleteRole: vi.fn(),
+  getRoleMembers: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const client = createMockClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OpenIddictAdminProvider config={{ client }}>
+          {children}
+        </OpenIddictAdminProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+    client,
+  };
+}
+
+const mockRole: AdminRole = {
+  id: 'role-001',
+  name: 'admin',
+  description: 'Administrator role',
+};
+
+const mockRoles: readonly AdminRole[] = [
+  mockRole,
+  { id: 'role-002', name: 'user', description: 'Standard user role' },
+];
+
+describe('useAdminRoles', () => {
+  it('should fetch all roles', async () => {
+    vi.mocked(listRoles).mockResolvedValueOnce(mockRoles);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminRoles(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listRoles).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(result.current.data).toEqual(mockRoles);
+  });
+
+  it('should handle fetch error', async () => {
+    vi.mocked(listRoles).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminRoles(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});
+
+describe('useCreateAdminRole', () => {
+  it('should create a role and invalidate roles query', async () => {
+    vi.mocked(createRole).mockResolvedValueOnce(mockRole);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateAdminRole(), { wrapper });
+
+    result.current.mutate({ name: 'admin', description: 'Administrator role' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(createRole).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      { name: 'admin', description: 'Administrator role' }
+    );
+    expect(result.current.data).toEqual(mockRole);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'roles'],
+    });
+  });
+
+  it('should handle creation error', async () => {
+    vi.mocked(createRole).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateAdminRole(), { wrapper });
+
+    result.current.mutate({ name: 'admin' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useAdminRoleMembers', () => {
+  const mockMembers: readonly AdminRoleMember[] = [
+    { id: 'usr-001', email: 'admin@example.com', firstName: 'Admin', lastName: 'User' },
+  ];
+
+  it('should fetch role members', async () => {
+    vi.mocked(getRoleMembers).mockResolvedValueOnce(mockMembers);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminRoleMembers('admin'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getRoleMembers).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'admin');
+    expect(result.current.data).toEqual(mockMembers);
+  });
+
+  it('should be disabled when roleName is empty', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminRoleMembers(''), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getRoleMembers).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteAdminRole', () => {
+  it('should delete a role and invalidate roles query', async () => {
+    vi.mocked(deleteRole).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteAdminRole(), { wrapper });
+
+    result.current.mutate('admin');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteRole).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'admin');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'roles'],
+    });
+  });
+
+  it('should handle delete error when role has members', async () => {
+    vi.mocked(deleteRole).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteAdminRole(), { wrapper });
+
+    result.current.mutate('admin');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
@@ -1,0 +1,233 @@
+import { createUser, deleteUser, getUser, impersonateUser, listUsers } from '@granit/openiddict-admin';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAdminUser,
+  useAdminUsers,
+  useCreateAdminUser,
+  useDeleteAdminUser,
+  useImpersonateUser,
+} from '../hooks/use-admin-users.js';
+import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider.js';
+
+import type { AdminImpersonationResult, AdminUser, AdminUserPage } from '@granit/openiddict-admin';
+
+vi.mock('@granit/openiddict-admin', () => ({
+  listUsers: vi.fn(),
+  getUser: vi.fn(),
+  createUser: vi.fn(),
+  deleteUser: vi.fn(),
+  impersonateUser: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const client = createMockClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OpenIddictAdminProvider config={{ client }}>
+          {children}
+        </OpenIddictAdminProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+    client,
+  };
+}
+
+const mockUser: AdminUser = {
+  id: 'usr-001',
+  email: 'admin@example.com',
+  firstName: 'Admin',
+  lastName: 'User',
+  emailConfirmed: true,
+  isDeleted: false,
+  roles: ['admin'],
+  groups: ['staff'],
+};
+
+const mockPage: AdminUserPage = {
+  items: [mockUser],
+  totalCount: 1,
+};
+
+describe('useAdminUsers', () => {
+  it('should fetch users list', async () => {
+    vi.mocked(listUsers).mockResolvedValueOnce(mockPage);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminUsers(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listUsers).toHaveBeenCalled();
+    expect(result.current.data).toEqual(mockPage);
+  });
+
+  it('should pass params to listUsers', async () => {
+    vi.mocked(listUsers).mockResolvedValueOnce(mockPage);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useAdminUsers({ search: 'admin', page: 1, pageSize: 10 }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listUsers).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      { search: 'admin', page: 1, pageSize: 10 }
+    );
+  });
+
+  it('should handle fetch error', async () => {
+    vi.mocked(listUsers).mockRejectedValueOnce(new Error('Server Error'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminUsers(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Server Error');
+  });
+});
+
+describe('useAdminUser', () => {
+  it('should fetch a single user by ID', async () => {
+    vi.mocked(getUser).mockResolvedValueOnce(mockUser);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminUser('usr-001'), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getUser).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'usr-001');
+    expect(result.current.data).toEqual(mockUser);
+  });
+
+  it('should be disabled when id is empty', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useAdminUser(''), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getUser).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCreateAdminUser', () => {
+  it('should create a user and invalidate users query', async () => {
+    vi.mocked(createUser).mockResolvedValueOnce(mockUser);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateAdminUser(), { wrapper });
+
+    result.current.mutate({ email: 'admin@example.com', firstName: 'Admin' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(createUser).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      { email: 'admin@example.com', firstName: 'Admin' }
+    );
+    expect(result.current.data).toEqual(mockUser);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'users'],
+    });
+  });
+
+  it('should handle creation error', async () => {
+    vi.mocked(createUser).mockRejectedValueOnce(new Error('Bad Request'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateAdminUser(), { wrapper });
+
+    result.current.mutate({ email: 'invalid' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});
+
+describe('useDeleteAdminUser', () => {
+  it('should delete a user and invalidate users query', async () => {
+    vi.mocked(deleteUser).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteAdminUser(), { wrapper });
+
+    result.current.mutate('usr-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteUser).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'usr-001');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'users'],
+    });
+  });
+
+  it('should handle delete error', async () => {
+    vi.mocked(deleteUser).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteAdminUser(), { wrapper });
+
+    result.current.mutate('invalid-id');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});
+
+describe('useImpersonateUser', () => {
+  const mockImpersonation: AdminImpersonationResult = {
+    accessToken: 'impersonated-access-token',
+    refreshToken: 'impersonated-refresh-token',
+    expiresIn: 3600,
+  };
+
+  it('should impersonate a user and return tokens', async () => {
+    vi.mocked(impersonateUser).mockResolvedValueOnce(mockImpersonation);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useImpersonateUser(), { wrapper });
+
+    result.current.mutate('usr-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(impersonateUser).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'usr-001');
+    expect(result.current.data).toEqual(mockImpersonation);
+  });
+
+  it('should handle impersonation error', async () => {
+    vi.mocked(impersonateUser).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useImpersonateUser(), { wrapper });
+
+    result.current.mutate('usr-001');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
@@ -1,0 +1,206 @@
+import {
+  createApplication,
+  deleteApplication,
+  listApplications,
+  rotateApplicationSecret,
+} from '@granit/openiddict-admin';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useCreateOidcApplication,
+  useDeleteOidcApplication,
+  useOidcApplications,
+  useRotateApplicationSecret,
+} from '../hooks/use-oidc-applications.js';
+import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider.js';
+
+import type {
+  AdminOidcApplication,
+  AdminOidcApplicationSecretResponse,
+} from '@granit/openiddict-admin';
+
+vi.mock('@granit/openiddict-admin', () => ({
+  listApplications: vi.fn(),
+  createApplication: vi.fn(),
+  deleteApplication: vi.fn(),
+  rotateApplicationSecret: vi.fn(),
+}));
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const client = createMockClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OpenIddictAdminProvider config={{ client }}>
+          {children}
+        </OpenIddictAdminProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+    client,
+  };
+}
+
+const mockApp: AdminOidcApplication = {
+  id: 'app-001',
+  clientId: 'guava-front',
+  displayName: 'Guava Frontend',
+  type: 'confidential',
+  permissions: ['openid', 'profile'],
+  redirectUris: ['https://app.example.com/callback'],
+  postLogoutRedirectUris: ['https://app.example.com'],
+};
+
+const mockApps: readonly AdminOidcApplication[] = [mockApp];
+
+describe('useOidcApplications', () => {
+  it('should fetch all OIDC applications', async () => {
+    vi.mocked(listApplications).mockResolvedValueOnce(mockApps);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOidcApplications(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listApplications).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(result.current.data).toEqual(mockApps);
+  });
+
+  it('should handle fetch error', async () => {
+    vi.mocked(listApplications).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOidcApplications(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});
+
+describe('useCreateOidcApplication', () => {
+  it('should create an application and invalidate applications query', async () => {
+    vi.mocked(createApplication).mockResolvedValueOnce(mockApp);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateOidcApplication(), { wrapper });
+
+    result.current.mutate({
+      clientId: 'guava-front',
+      displayName: 'Guava Frontend',
+      permissions: ['openid', 'profile'],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(createApplication).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      {
+        clientId: 'guava-front',
+        displayName: 'Guava Frontend',
+        permissions: ['openid', 'profile'],
+      }
+    );
+    expect(result.current.data).toEqual(mockApp);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'applications'],
+    });
+  });
+
+  it('should handle creation error', async () => {
+    vi.mocked(createApplication).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateOidcApplication(), { wrapper });
+
+    result.current.mutate({ clientId: 'duplicate' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useDeleteOidcApplication', () => {
+  it('should delete an application and invalidate applications query', async () => {
+    vi.mocked(deleteApplication).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteOidcApplication(), { wrapper });
+
+    result.current.mutate('guava-front');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteApplication).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      'guava-front'
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'applications'],
+    });
+  });
+
+  it('should handle delete error', async () => {
+    vi.mocked(deleteApplication).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteOidcApplication(), { wrapper });
+
+    result.current.mutate('invalid');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});
+
+describe('useRotateApplicationSecret', () => {
+  const mockSecretResponse: AdminOidcApplicationSecretResponse = {
+    clientId: 'guava-front',
+    newSecret: 'generated-secret-value',
+  };
+
+  it('should rotate application secret', async () => {
+    vi.mocked(rotateApplicationSecret).mockResolvedValueOnce(mockSecretResponse);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRotateApplicationSecret(), { wrapper });
+
+    result.current.mutate('guava-front');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(rotateApplicationSecret).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      'guava-front'
+    );
+    expect(result.current.data).toEqual(mockSecretResponse);
+  });
+
+  it('should handle rotate error', async () => {
+    vi.mocked(rotateApplicationSecret).mockRejectedValueOnce(new Error('Forbidden'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRotateApplicationSecret(), { wrapper });
+
+    result.current.mutate('guava-front');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Forbidden');
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
@@ -1,0 +1,172 @@
+import {
+  listAuthorizations,
+  revokeAuthorization,
+  revokeUserAuthorizations,
+} from '@granit/openiddict-admin';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useOidcAuthorizations,
+  useRevokeAuthorization,
+  useRevokeUserAuthorizations,
+} from '../hooks/use-oidc-authorizations.js';
+import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider.js';
+
+import type { AdminOidcAuthorization } from '@granit/openiddict-admin';
+
+vi.mock('@granit/openiddict-admin', () => ({
+  listAuthorizations: vi.fn(),
+  revokeAuthorization: vi.fn(),
+  revokeUserAuthorizations: vi.fn(),
+}));
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const client = createMockClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OpenIddictAdminProvider config={{ client }}>
+          {children}
+        </OpenIddictAdminProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+    client,
+  };
+}
+
+const mockAuthorizations: readonly AdminOidcAuthorization[] = [
+  {
+    id: 'auth-001',
+    subject: 'usr-001',
+    type: 'permanent',
+    status: 'valid',
+  },
+];
+
+describe('useOidcAuthorizations', () => {
+  it('should fetch authorizations', async () => {
+    vi.mocked(listAuthorizations).mockResolvedValueOnce(mockAuthorizations);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOidcAuthorizations(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listAuthorizations).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      undefined
+    );
+    expect(result.current.data).toEqual(mockAuthorizations);
+  });
+
+  it('should pass params to listAuthorizations', async () => {
+    vi.mocked(listAuthorizations).mockResolvedValueOnce(mockAuthorizations);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useOidcAuthorizations({ userId: 'usr-001' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listAuthorizations).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      { userId: 'usr-001' }
+    );
+  });
+
+  it('should handle fetch error', async () => {
+    vi.mocked(listAuthorizations).mockRejectedValueOnce(new Error('Server Error'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOidcAuthorizations(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Server Error');
+  });
+});
+
+describe('useRevokeAuthorization', () => {
+  it('should revoke an authorization and invalidate authorizations query', async () => {
+    vi.mocked(revokeAuthorization).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRevokeAuthorization(), { wrapper });
+
+    result.current.mutate('auth-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(revokeAuthorization).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      'auth-001'
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'authorizations'],
+    });
+  });
+
+  it('should handle revoke error', async () => {
+    vi.mocked(revokeAuthorization).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRevokeAuthorization(), { wrapper });
+
+    result.current.mutate('invalid-id');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});
+
+describe('useRevokeUserAuthorizations', () => {
+  it('should revoke all user authorizations and invalidate query', async () => {
+    vi.mocked(revokeUserAuthorizations).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRevokeUserAuthorizations(), { wrapper });
+
+    result.current.mutate('usr-001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(revokeUserAuthorizations).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      'usr-001'
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'authorizations'],
+    });
+  });
+
+  it('should handle revoke all error', async () => {
+    vi.mocked(revokeUserAuthorizations).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRevokeUserAuthorizations(), { wrapper });
+
+    result.current.mutate('invalid-user');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
@@ -1,0 +1,150 @@
+import { createScope, deleteScope, listScopes } from '@granit/openiddict-admin';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useCreateOidcScope,
+  useDeleteOidcScope,
+  useOidcScopes,
+} from '../hooks/use-oidc-scopes.js';
+import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider.js';
+
+import type { AdminOidcScope } from '@granit/openiddict-admin';
+
+vi.mock('@granit/openiddict-admin', () => ({
+  listScopes: vi.fn(),
+  createScope: vi.fn(),
+  deleteScope: vi.fn(),
+}));
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  const client = createMockClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <OpenIddictAdminProvider config={{ client }}>
+          {children}
+        </OpenIddictAdminProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+    client,
+  };
+}
+
+const mockScope: AdminOidcScope = {
+  id: 'scope-001',
+  name: 'api',
+  displayName: 'API access',
+  resources: ['guava-backend'],
+};
+
+const mockScopes: readonly AdminOidcScope[] = [
+  mockScope,
+  { id: 'scope-002', name: 'openid', displayName: 'OpenID', resources: [] },
+];
+
+describe('useOidcScopes', () => {
+  it('should fetch all OIDC scopes', async () => {
+    vi.mocked(listScopes).mockResolvedValueOnce(mockScopes);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOidcScopes(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listScopes).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(result.current.data).toEqual(mockScopes);
+  });
+
+  it('should handle fetch error', async () => {
+    vi.mocked(listScopes).mockRejectedValueOnce(new Error('Server Error'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useOidcScopes(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Server Error');
+  });
+});
+
+describe('useCreateOidcScope', () => {
+  it('should create a scope and invalidate scopes query', async () => {
+    vi.mocked(createScope).mockResolvedValueOnce(mockScope);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateOidcScope(), { wrapper });
+
+    result.current.mutate({
+      name: 'api',
+      displayName: 'API access',
+      resources: ['guava-backend'],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(createScope).toHaveBeenCalledWith(
+      expect.anything(),
+      '/api/admin',
+      { name: 'api', displayName: 'API access', resources: ['guava-backend'] }
+    );
+    expect(result.current.data).toEqual(mockScope);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'scopes'],
+    });
+  });
+
+  it('should handle creation error', async () => {
+    vi.mocked(createScope).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateOidcScope(), { wrapper });
+
+    result.current.mutate({ name: 'duplicate' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useDeleteOidcScope', () => {
+  it('should delete a scope and invalidate scopes query', async () => {
+    vi.mocked(deleteScope).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteOidcScope(), { wrapper });
+
+    result.current.mutate('api');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(deleteScope).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'api');
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'scopes'],
+    });
+  });
+
+  it('should handle delete error', async () => {
+    vi.mocked(deleteScope).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useDeleteOidcScope(), { wrapper });
+
+    result.current.mutate('invalid');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-admin-groups.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-admin-groups.ts
@@ -1,0 +1,110 @@
+import {
+  addGroupMember,
+  createGroup,
+  deleteGroup,
+  listGroups,
+  removeGroupMember,
+} from '@granit/openiddict-admin';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider.js';
+
+import type {
+  AdminGroup,
+  AdminGroupCreateRequest,
+  AdminGroupMemberRequest,
+} from '@granit/openiddict-admin';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches all groups. */
+export function useAdminGroups(): UseQueryResult<readonly AdminGroup[]> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: buildAdminQueryKey(config, 'groups'),
+    queryFn: () => listGroups(config.client, config.basePath!),
+  });
+}
+
+/** Creates a new group. Invalidates groups on success. */
+export function useCreateAdminGroup(): UseMutationResult<
+  AdminGroup,
+  Error,
+  AdminGroupCreateRequest
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AdminGroupCreateRequest) =>
+      createGroup(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'groups'),
+      });
+    },
+  });
+}
+
+/** Deletes a group. Invalidates groups on success. */
+export function useDeleteAdminGroup(): UseMutationResult<void, Error, string> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (groupId: string) => deleteGroup(config.client, config.basePath!, groupId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'groups'),
+      });
+    },
+  });
+}
+
+/** Add group member variables. */
+export interface AddGroupMemberVariables {
+  readonly groupId: string;
+  readonly request: AdminGroupMemberRequest;
+}
+
+/** Adds a user to a group. Invalidates groups on success. */
+export function useAddGroupMember(): UseMutationResult<void, Error, AddGroupMemberVariables> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ groupId, request }: AddGroupMemberVariables) =>
+      addGroupMember(config.client, config.basePath!, groupId, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'groups'),
+      });
+    },
+  });
+}
+
+/** Remove group member variables. */
+export interface RemoveGroupMemberVariables {
+  readonly groupId: string;
+  readonly userId: string;
+}
+
+/** Removes a user from a group. Invalidates groups on success. */
+export function useRemoveGroupMember(): UseMutationResult<
+  void,
+  Error,
+  RemoveGroupMemberVariables
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ groupId, userId }: RemoveGroupMemberVariables) =>
+      removeGroupMember(config.client, config.basePath!, groupId, userId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'groups'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-admin-roles.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-admin-roles.ts
@@ -1,0 +1,74 @@
+import {
+  createRole,
+  deleteRole,
+  getRoleMembers,
+  listRoles,
+} from '@granit/openiddict-admin';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider.js';
+
+import type {
+  AdminRole,
+  AdminRoleCreateRequest,
+  AdminRoleMember,
+} from '@granit/openiddict-admin';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches all roles. */
+export function useAdminRoles(): UseQueryResult<readonly AdminRole[]> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: buildAdminQueryKey(config, 'roles'),
+    queryFn: () => listRoles(config.client, config.basePath!),
+  });
+}
+
+/** Fetches members of a role. Disabled when roleName is empty. */
+export function useAdminRoleMembers(
+  roleName: string
+): UseQueryResult<readonly AdminRoleMember[]> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: [...buildAdminQueryKey(config, 'roles'), roleName, 'members'],
+    queryFn: () => getRoleMembers(config.client, config.basePath!, roleName),
+    enabled: roleName.length > 0,
+  });
+}
+
+/** Creates a new role. Invalidates roles on success. */
+export function useCreateAdminRole(): UseMutationResult<
+  AdminRole,
+  Error,
+  AdminRoleCreateRequest
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AdminRoleCreateRequest) =>
+      createRole(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'roles'),
+      });
+    },
+  });
+}
+
+/** Deletes a role. Invalidates roles on success. */
+export function useDeleteAdminRole(): UseMutationResult<void, Error, string> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (roleName: string) => deleteRole(config.client, config.basePath!, roleName),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'roles'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-admin-users.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-admin-users.ts
@@ -1,0 +1,90 @@
+import {
+  createUser,
+  deleteUser,
+  getUser,
+  impersonateUser,
+  listUsers,
+} from '@granit/openiddict-admin';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider.js';
+
+import type {
+  AdminImpersonationResult,
+  AdminUser,
+  AdminUserCreateRequest,
+  AdminUserListParams,
+  AdminUserPage,
+} from '@granit/openiddict-admin';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches paginated admin users. */
+export function useAdminUsers(
+  params?: AdminUserListParams
+): UseQueryResult<AdminUserPage> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: [...buildAdminQueryKey(config, 'users'), params],
+    queryFn: () => listUsers(config.client, config.basePath!, params),
+  });
+}
+
+/** Fetches a single user by ID. Disabled when id is empty. */
+export function useAdminUser(id: string): UseQueryResult<AdminUser> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: [...buildAdminQueryKey(config, 'users'), id],
+    queryFn: () => getUser(config.client, config.basePath!, id),
+    enabled: id.length > 0,
+  });
+}
+
+/** Creates a new admin user. Invalidates users on success. */
+export function useCreateAdminUser(): UseMutationResult<
+  AdminUser,
+  Error,
+  AdminUserCreateRequest
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AdminUserCreateRequest) =>
+      createUser(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'users'),
+      });
+    },
+  });
+}
+
+/** Deletes a user (soft-delete). Invalidates users on success. */
+export function useDeleteAdminUser(): UseMutationResult<void, Error, string> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: string) => deleteUser(config.client, config.basePath!, userId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'users'),
+      });
+    },
+  });
+}
+
+/** Impersonates a user. Returns new tokens. */
+export function useImpersonateUser(): UseMutationResult<
+  AdminImpersonationResult,
+  Error,
+  string
+> {
+  const config = useAdminConfig();
+
+  return useMutation({
+    mutationFn: (userId: string) => impersonateUser(config.client, config.basePath!, userId),
+  });
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-applications.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-applications.ts
@@ -1,0 +1,76 @@
+import {
+  createApplication,
+  deleteApplication,
+  listApplications,
+  rotateApplicationSecret,
+} from '@granit/openiddict-admin';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider.js';
+
+import type {
+  AdminOidcApplication,
+  AdminOidcApplicationCreateRequest,
+  AdminOidcApplicationSecretResponse,
+} from '@granit/openiddict-admin';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches all OIDC applications. */
+export function useOidcApplications(): UseQueryResult<readonly AdminOidcApplication[]> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: buildAdminQueryKey(config, 'oidc', 'applications'),
+    queryFn: () => listApplications(config.client, config.basePath!),
+  });
+}
+
+/** Creates an OIDC application. Invalidates applications on success. */
+export function useCreateOidcApplication(): UseMutationResult<
+  AdminOidcApplication,
+  Error,
+  AdminOidcApplicationCreateRequest
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AdminOidcApplicationCreateRequest) =>
+      createApplication(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'applications'),
+      });
+    },
+  });
+}
+
+/** Deletes an OIDC application. Invalidates applications on success. */
+export function useDeleteOidcApplication(): UseMutationResult<void, Error, string> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (clientId: string) =>
+      deleteApplication(config.client, config.basePath!, clientId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'applications'),
+      });
+    },
+  });
+}
+
+/** Rotates an OIDC application's client secret. */
+export function useRotateApplicationSecret(): UseMutationResult<
+  AdminOidcApplicationSecretResponse,
+  Error,
+  string
+> {
+  const config = useAdminConfig();
+
+  return useMutation({
+    mutationFn: (clientId: string) =>
+      rotateApplicationSecret(config.client, config.basePath!, clientId),
+  });
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-authorizations.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-authorizations.ts
@@ -1,0 +1,57 @@
+import {
+  listAuthorizations,
+  revokeAuthorization,
+  revokeUserAuthorizations,
+} from '@granit/openiddict-admin';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider.js';
+
+import type {
+  AdminOidcAuthorization,
+  AdminOidcAuthorizationListParams,
+} from '@granit/openiddict-admin';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches OIDC authorizations with optional filtering. */
+export function useOidcAuthorizations(
+  params?: AdminOidcAuthorizationListParams
+): UseQueryResult<readonly AdminOidcAuthorization[]> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: [...buildAdminQueryKey(config, 'oidc', 'authorizations'), params],
+    queryFn: () => listAuthorizations(config.client, config.basePath!, params),
+  });
+}
+
+/** Revokes a single authorization. Invalidates authorizations on success. */
+export function useRevokeAuthorization(): UseMutationResult<void, Error, string> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => revokeAuthorization(config.client, config.basePath!, id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'authorizations'),
+      });
+    },
+  });
+}
+
+/** Revokes all authorizations for a user. Invalidates authorizations on success. */
+export function useRevokeUserAuthorizations(): UseMutationResult<void, Error, string> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: string) =>
+      revokeUserAuthorizations(config.client, config.basePath!, userId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'authorizations'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-scopes.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-scopes.ts
@@ -1,0 +1,53 @@
+import { createScope, deleteScope, listScopes } from '@granit/openiddict-admin';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider.js';
+
+import type { AdminOidcScope, AdminOidcScopeCreateRequest } from '@granit/openiddict-admin';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches all OIDC scopes. */
+export function useOidcScopes(): UseQueryResult<readonly AdminOidcScope[]> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: buildAdminQueryKey(config, 'oidc', 'scopes'),
+    queryFn: () => listScopes(config.client, config.basePath!),
+  });
+}
+
+/** Creates an OIDC scope. Invalidates scopes on success. */
+export function useCreateOidcScope(): UseMutationResult<
+  AdminOidcScope,
+  Error,
+  AdminOidcScopeCreateRequest
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AdminOidcScopeCreateRequest) =>
+      createScope(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'scopes'),
+      });
+    },
+  });
+}
+
+/** Deletes an OIDC scope. Invalidates scopes on success. */
+export function useDeleteOidcScope(): UseMutationResult<void, Error, string> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (scopeName: string) =>
+      deleteScope(config.client, config.basePath!, scopeName),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'scopes'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-openiddict-admin/src/index.ts
+++ b/packages/@granit/react-openiddict-admin/src/index.ts
@@ -1,0 +1,62 @@
+// Provider
+export {
+  OpenIddictAdminProvider,
+  buildAdminQueryKey,
+  useAdminConfig,
+} from './providers/openiddict-admin-provider.js';
+export type {
+  OpenIddictAdminConfig,
+  OpenIddictAdminProviderProps,
+} from './providers/openiddict-admin-provider.js';
+
+// Hooks — Users
+export {
+  useAdminUser,
+  useAdminUsers,
+  useCreateAdminUser,
+  useDeleteAdminUser,
+  useImpersonateUser,
+} from './hooks/use-admin-users.js';
+
+// Hooks — Roles
+export {
+  useAdminRoleMembers,
+  useAdminRoles,
+  useCreateAdminRole,
+  useDeleteAdminRole,
+} from './hooks/use-admin-roles.js';
+
+// Hooks — Groups
+export {
+  useAddGroupMember,
+  useAdminGroups,
+  useCreateAdminGroup,
+  useDeleteAdminGroup,
+  useRemoveGroupMember,
+} from './hooks/use-admin-groups.js';
+export type {
+  AddGroupMemberVariables,
+  RemoveGroupMemberVariables,
+} from './hooks/use-admin-groups.js';
+
+// Hooks — OIDC Applications
+export {
+  useCreateOidcApplication,
+  useDeleteOidcApplication,
+  useOidcApplications,
+  useRotateApplicationSecret,
+} from './hooks/use-oidc-applications.js';
+
+// Hooks — OIDC Scopes
+export {
+  useCreateOidcScope,
+  useDeleteOidcScope,
+  useOidcScopes,
+} from './hooks/use-oidc-scopes.js';
+
+// Hooks — OIDC Authorizations
+export {
+  useOidcAuthorizations,
+  useRevokeAuthorization,
+  useRevokeUserAuthorizations,
+} from './hooks/use-oidc-authorizations.js';

--- a/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
+++ b/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
@@ -1,0 +1,43 @@
+import { createContext, useContext } from 'react';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+export interface OpenIddictAdminConfig {
+  readonly client: AxiosInstance;
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface OpenIddictAdminProviderProps {
+  readonly config: OpenIddictAdminConfig;
+  readonly children: ReactNode;
+}
+
+const DEFAULT_BASE_PATH = '/api/admin';
+const DEFAULT_KEY_PREFIX = ['openiddict-admin'] as const;
+
+const AdminContext = createContext<OpenIddictAdminConfig | null>(null);
+
+export function useAdminConfig(): OpenIddictAdminConfig {
+  const config = useContext(AdminContext);
+  if (!config) throw new Error('useAdminConfig must be used within an OpenIddictAdminProvider');
+  return config;
+}
+
+export function buildAdminQueryKey(
+  config: OpenIddictAdminConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
+}
+
+export function OpenIddictAdminProvider({ config, children }: OpenIddictAdminProviderProps) {
+  const value: OpenIddictAdminConfig = {
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+  };
+
+  return <AdminContext value={value}>{children}</AdminContext>;
+}

--- a/packages/@granit/react-openiddict-admin/tsconfig.json
+++ b/packages/@granit/react-openiddict-admin/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-openiddict-admin/tsup.config.ts
+++ b/packages/@granit/react-openiddict-admin/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//, /^react/, /^@tanstack\//],
+});

--- a/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
+++ b/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -33,11 +33,14 @@ export function buildPrivacyQueryKey(
 }
 
 export function PrivacyProvider({ config, children }: PrivacyProviderProps) {
-  const value: PrivacyConfig = {
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-  };
+  const value = useMemo<PrivacyConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+    }),
+    [config]
+  );
 
   return <PrivacyContext value={value}>{children}</PrivacyContext>;
 }

--- a/packages/@granit/react-validation/src/use-server-validation.ts
+++ b/packages/@granit/react-validation/src/use-server-validation.ts
@@ -61,14 +61,10 @@ export function useServerValidation(options: UseServerValidationOptions): Server
       return;
     }
 
-    // Empty value on non-required field — skip
-    if (isEmpty(value) && !constraint.required) {
-      setState(IDLE);
-      return;
-    }
+    const validatorKey = constraint.granitValidator;
 
-    // Empty value on required field — let client resolver handle it
-    if (isEmpty(value) && constraint.required) {
+    // Empty value — skip (required or not, let client resolver handle it)
+    if (isEmpty(value)) {
       setState(IDLE);
       return;
     }
@@ -87,7 +83,7 @@ export function useServerValidation(options: UseServerValidationOptions): Server
 
       setState(VALIDATING);
 
-      validateFieldServer(client, constraint.granitValidator!, value, basePath, controller.signal)
+      validateFieldServer(client, validatorKey, value, basePath, controller.signal)
         .then((status) => {
           if (controller.signal.aborted) return;
 
@@ -96,7 +92,7 @@ export function useServerValidation(options: UseServerValidationOptions): Server
           } else if (status === 'Invalid') {
             setState({
               status: 'invalid',
-              message: t(constraint.granitValidator!, { nsSeparator: false }),
+              message: t(validatorKey, { nsSeparator: false }),
             });
           } else {
             // ValidatorNotFound — no server validator available

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -160,6 +160,16 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jsdom@29.0.0)(msw@2.12.12(@types/node@25.3.3)(typescript@5.9.3))(vite@7.3.1(@types/node@25.3.3)(jiti@2.6.1)(lightningcss@1.31.1)(sass@1.97.3)(yaml@2.8.2))
 
+  packages/@granit/account:
+    dependencies:
+      axios:
+        specifier: '*'
+        version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/ai:
     dependencies:
       axios:
@@ -369,6 +379,19 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/openiddict-admin:
+    dependencies:
+      '@granit/querying':
+        specifier: workspace:*
+        version: link:../querying
+      axios:
+        specifier: '*'
+        version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/privacy:
     dependencies:
       axios:
@@ -388,6 +411,28 @@ importers:
         specifier: '*'
         version: 1.13.6
     devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-account:
+    dependencies:
+      '@granit/account':
+        specifier: workspace:*
+        version: link:../account
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -755,6 +800,28 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.4
+
+  packages/@granit/react-openiddict-admin:
+    dependencies:
+      '@granit/openiddict-admin':
+        specifier: workspace:*
+        version: link:../openiddict-admin
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.90.21(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
 
   packages/@granit/react-privacy:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
       ),
       '@granit/api-client': path.resolve(__dirname, 'packages/@granit/api-client/src/index.ts'),
       '@granit/audit-log': path.resolve(__dirname, 'packages/@granit/audit-log/src/index.ts'),
+      '@granit/account': path.resolve(__dirname, 'packages/@granit/account/src/index.ts'),
       '@granit/ai': path.resolve(__dirname, 'packages/@granit/ai/src/index.ts'),
       '@granit/background-jobs': path.resolve(
         __dirname,
@@ -52,6 +53,10 @@ export default defineConfig({
         'packages/@granit/multi-tenancy/src/index.ts'
       ),
       '@granit/logger-otlp': path.resolve(__dirname, 'packages/@granit/logger-otlp/src/index.ts'),
+      '@granit/openiddict-admin': path.resolve(
+        __dirname,
+        'packages/@granit/openiddict-admin/src/index.ts'
+      ),
       '@granit/notifications-mobile-push': path.resolve(
         __dirname,
         'packages/@granit/notifications-mobile-push/src/index.ts'
@@ -72,6 +77,7 @@ export default defineConfig({
         __dirname,
         'packages/@granit/notifications/src/index.ts'
       ),
+      '@granit/privacy': path.resolve(__dirname, 'packages/@granit/privacy/src/index.ts'),
       '@granit/querying': path.resolve(__dirname, 'packages/@granit/querying/src/index.ts'),
       '@granit/validation': path.resolve(__dirname, 'packages/@granit/validation/src/index.ts'),
       '@granit/react-reference-data': path.resolve(
@@ -86,6 +92,10 @@ export default defineConfig({
       '@granit/react-audit-log': path.resolve(
         __dirname,
         'packages/@granit/react-audit-log/src/index.ts'
+      ),
+      '@granit/react-account': path.resolve(
+        __dirname,
+        'packages/@granit/react-account/src/index.ts'
       ),
       '@granit/react-authentication-api-keys': path.resolve(
         __dirname,
@@ -135,6 +145,10 @@ export default defineConfig({
         __dirname,
         'packages/@granit/react-localization/src/index.ts'
       ),
+      '@granit/react-openiddict-admin': path.resolve(
+        __dirname,
+        'packages/@granit/react-openiddict-admin/src/index.ts'
+      ),
       '@granit/react-notifications': path.resolve(
         __dirname,
         'packages/@granit/react-notifications/src/index.ts'
@@ -146,6 +160,10 @@ export default defineConfig({
       '@granit/react-notifications-web-push': path.resolve(
         __dirname,
         'packages/@granit/react-notifications-web-push/src/index.ts'
+      ),
+      '@granit/react-privacy': path.resolve(
+        __dirname,
+        'packages/@granit/react-privacy/src/index.ts'
       ),
       '@granit/react-querying': path.resolve(
         __dirname,


### PR DESCRIPTION
## Summary

- Align entity type names and API routes with .NET backend contracts across all `@granit/*` packages
- Add `@granit/account` and `@granit/react-account` — account self-service (registration, profile, password, 2FA/TOTP, passkeys, external logins, session, deletion)
- Add `@granit/openiddict-admin` and `@granit/react-openiddict-admin` — admin management (users, roles, groups, OIDC applications, scopes, authorizations)
- Add admin API endpoints and hooks for features, settings, localization, webhooks, identity
- Ensure all packages meet 80% coverage threshold (all new packages at 100% on hooks/API)

## Test plan

- [x] All 1587 tests pass across 200 test files
- [x] All new packages at 100% coverage on API and hooks layers
- [x] Coverage thresholds (80% statements/branches/functions/lines) met globally
- [x] ESLint clean (`--max-warnings 0`)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] Pre-commit hooks pass (lint, tsc, commitlint, front-index generation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)