### PR TITLE
feat: align entity names and API surface with .NET backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,9 +173,9 @@ jobs:
 
       - name: Check for drift
         run: |
-          if ! git diff --quiet -I '"generatedAt"' .mcp-front-index.json; then
+          if ! git diff --quiet .mcp-front-index.json; then
             echo "::error::.mcp-front-index.json is out of date. Run 'python3 scripts/generate-front-index.py' and commit."
-            git diff -I '"generatedAt"' .mcp-front-index.json
+            git diff .mcp-front-index.json
             exit 1
           fi
 

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1,5 +1,4 @@
 {
-  "generatedAt": "2026-03-22T14:09:29.131110+00:00",
   "repo": "granit-front",
   "packages": [
     {

--- a/packages/@granit/privacy/tsup.config.ts
+++ b/packages/@granit/privacy/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/react-privacy/tsup.config.ts
+++ b/packages/@granit/react-privacy/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/react-reference-data/src/__tests__/create-reference-data-hooks.test.tsx
+++ b/packages/@granit/react-reference-data/src/__tests__/create-reference-data-hooks.test.tsx
@@ -32,6 +32,8 @@ const mockEntry: TestEntity = {
   sortOrder: 1,
   validFrom: null,
   validTo: null,
+  parentCode: null,
+  extraProperties: null,
   createdAt: '2024-01-01T00:00:00Z',
   createdBy: 'system',
   modifiedAt: null,
@@ -39,7 +41,7 @@ const mockEntry: TestEntity = {
   extra: 'test-value',
 };
 
-const { keys, useList, useEntry, useCreate, useUpdate, useDeactivate } =
+const { keys, useList, useEntry, useChildren, useCreate, useUpdate, useDeactivate } =
   createReferenceDataHooks<TestEntity>('test-entity');
 
 // ---------------------------------------------------------------------------
@@ -62,6 +64,15 @@ describe('keys', () => {
 
   it('builds detail keys with code', () => {
     expect(keys.detail('BE')).toEqual(['reference-data', 'test-entity', 'detail', 'BE']);
+  });
+
+  it('builds children keys with parent code', () => {
+    expect(keys.children('ELECTRONICS')).toEqual([
+      'reference-data',
+      'test-entity',
+      'children',
+      'ELECTRONICS',
+    ]);
   });
 
   it('isolates keys between entity types', () => {
@@ -217,6 +228,80 @@ describe('useEntry', () => {
     vi.mocked(client.get).mockRejectedValue(new Error('Not found'));
 
     const { result } = renderHook(() => useEntry('XX', { client }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not found');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useChildren
+// ---------------------------------------------------------------------------
+
+describe('useChildren', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches children of a parent code', async () => {
+    const client = createMockClient();
+    const children = [{ ...mockEntry, code: 'CHILD-1', parentCode: 'BE' }];
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(children));
+
+    const { result } = renderHook(() => useChildren('BE', { client }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/reference-data/test-entity/BE/children');
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].parentCode).toBe('BE');
+  });
+
+  it('uses custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    const { result } = renderHook(() => useChildren('BE', { client, basePath: '/custom' }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/custom/BE/children');
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(() => useChildren('BE', { client, enabled: false }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when parent code is empty', () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(() => useChildren('', { client }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('exposes error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Not found'));
+
+    const { result } = renderHook(() => useChildren('XX', { client }), {
       wrapper: createQueryWrapper(),
     });
 

--- a/packages/@granit/react-reference-data/src/hooks/create-reference-data-hooks.ts
+++ b/packages/@granit/react-reference-data/src/hooks/create-reference-data-hooks.ts
@@ -1,6 +1,7 @@
 import {
   createReferenceDataEntry,
   deactivateReferenceDataEntry,
+  fetchReferenceDataChildren,
   fetchReferenceDataEntry,
   fetchReferenceDataList,
   updateReferenceDataEntry,
@@ -49,6 +50,16 @@ export interface ReferenceDataEntryHookOptions {
   readonly enabled?: boolean;
 }
 
+/** Options for the children hook (hierarchical types). */
+export interface ReferenceDataChildrenHookOptions {
+  /** Axios instance used for HTTP requests. */
+  readonly client: AxiosInstance;
+  /** Override the base path for this hook call. */
+  readonly basePath?: string;
+  /** Whether the query is enabled. Default: true. */
+  readonly enabled?: boolean;
+}
+
 /** Options for mutation hooks. */
 export interface ReferenceDataMutationHookOptions {
   /** Axios instance used for HTTP requests. */
@@ -70,6 +81,7 @@ export interface ReferenceDataKeys {
   readonly list: (params?: ReferenceDataQuery) => readonly unknown[];
   readonly details: () => readonly unknown[];
   readonly detail: (code: string) => readonly unknown[];
+  readonly children: (parentCode: string) => readonly unknown[];
 }
 
 // ---------------------------------------------------------------------------
@@ -116,6 +128,7 @@ export function createReferenceDataHooks<T extends ReferenceDataEntry>(
     list: (params?: ReferenceDataQuery) => [...keys.lists(), params],
     details: () => [...keys.all, 'detail'],
     detail: (code: string) => [...keys.details(), code],
+    children: (parentCode: string) => [...keys.all, 'children', parentCode],
   };
 
   // -- Query hooks ----------------------------------------------------------
@@ -137,6 +150,19 @@ export function createReferenceDataHooks<T extends ReferenceDataEntry>(
       queryKey: keys.detail(code),
       queryFn: async () => fetchReferenceDataEntry<T>(client, basePath, code),
       enabled: enabled && code.length > 0,
+    });
+  }
+
+  function useChildren(
+    parentCode: string,
+    options: ReferenceDataChildrenHookOptions
+  ): UseQueryResult<T[]> {
+    const { client, basePath = defaultBasePath, enabled = true } = options;
+
+    return useQuery({
+      queryKey: keys.children(parentCode),
+      queryFn: async () => fetchReferenceDataChildren<T>(client, basePath, parentCode),
+      enabled: enabled && parentCode.length > 0,
     });
   }
 
@@ -188,5 +214,5 @@ export function createReferenceDataHooks<T extends ReferenceDataEntry>(
     });
   }
 
-  return { keys, useList, useEntry, useCreate, useUpdate, useDeactivate };
+  return { keys, useList, useEntry, useChildren, useCreate, useUpdate, useDeactivate };
 }

--- a/packages/@granit/react-reference-data/src/index.ts
+++ b/packages/@granit/react-reference-data/src/index.ts
@@ -4,6 +4,7 @@ export { createReferenceDataHooks } from './hooks/create-reference-data-hooks.js
 // Option types
 export type {
   CreateReferenceDataHooksOptions,
+  ReferenceDataChildrenHookOptions,
   ReferenceDataEntryHookOptions,
   ReferenceDataKeys,
   ReferenceDataListHookOptions,

--- a/packages/@granit/reference-data/src/__tests__/reference-data-api.test.ts
+++ b/packages/@granit/reference-data/src/__tests__/reference-data-api.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createReferenceDataEntry,
   deactivateReferenceDataEntry,
+  fetchReferenceDataChildren,
   fetchReferenceDataEntry,
   fetchReferenceDataList,
   updateReferenceDataEntry,
@@ -34,6 +35,8 @@ const mockEntry: ReferenceDataEntry = {
   sortOrder: 1,
   validFrom: null,
   validTo: null,
+  parentCode: null,
+  extraProperties: null,
   createdAt: '2024-01-01T00:00:00Z',
   createdBy: 'system',
   modifiedAt: null,
@@ -149,6 +152,42 @@ describe('updateReferenceDataEntry', () => {
     });
 
     expect(result).toBeUndefined();
+  });
+});
+
+describe('fetchReferenceDataChildren', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('sends GET to basePath/{code}/children', async () => {
+    const client = createMockClient();
+    const children = [{ ...mockEntry, code: 'CHILD-1', parentCode: 'BE' }];
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(children));
+
+    const result = await fetchReferenceDataChildren(client, BASE_PATH, 'BE');
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE_PATH}/BE/children`);
+    expect(result).toHaveLength(1);
+    expect(result[0].parentCode).toBe('BE');
+  });
+
+  it('encodes special characters in parent code', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    await fetchReferenceDataChildren(client, BASE_PATH, 'A/B');
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE_PATH}/A%2FB/children`);
+  });
+
+  it('returns an empty array when no children exist', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    const result = await fetchReferenceDataChildren(client, BASE_PATH, 'LEAF');
+
+    expect(result).toEqual([]);
   });
 });
 

--- a/packages/@granit/reference-data/src/__tests__/reference-data-types.test.ts
+++ b/packages/@granit/reference-data/src/__tests__/reference-data-types.test.ts
@@ -43,6 +43,17 @@ describe('@granit/reference-data types', () => {
       expectTypeOf<ReferenceDataEntry['validTo']>().toEqualTypeOf<string | null>();
     });
 
+    it('should have hierarchical parent code', () => {
+      expectTypeOf<ReferenceDataEntry['parentCode']>().toEqualTypeOf<string | null>();
+    });
+
+    it('should have extra properties bag', () => {
+      expectTypeOf<ReferenceDataEntry['extraProperties']>().toEqualTypeOf<Record<
+        string,
+        string
+      > | null>();
+    });
+
     it('should have audit trail fields', () => {
       expectTypeOf<ReferenceDataEntry['createdAt']>().toBeString();
       expectTypeOf<ReferenceDataEntry['createdBy']>().toBeString();
@@ -82,6 +93,15 @@ describe('@granit/reference-data types', () => {
       >();
     });
 
+    it('should have optional parentCode and extraProperties', () => {
+      expectTypeOf<ReferenceDataCreateRequest['parentCode']>().toEqualTypeOf<
+        string | null | undefined
+      >();
+      expectTypeOf<ReferenceDataCreateRequest['extraProperties']>().toEqualTypeOf<
+        Record<string, string> | null | undefined
+      >();
+    });
+
     it('should not have isActive (always true on creation)', () => {
       expectTypeOf<ReferenceDataCreateRequest>().not.toHaveProperty('isActive');
     });
@@ -98,6 +118,15 @@ describe('@granit/reference-data types', () => {
 
     it('should have optional isActive for reactivation', () => {
       expectTypeOf<ReferenceDataUpdateRequest['isActive']>().toEqualTypeOf<boolean | undefined>();
+    });
+
+    it('should have optional parentCode and extraProperties', () => {
+      expectTypeOf<ReferenceDataUpdateRequest['parentCode']>().toEqualTypeOf<
+        string | null | undefined
+      >();
+      expectTypeOf<ReferenceDataUpdateRequest['extraProperties']>().toEqualTypeOf<
+        Record<string, string> | null | undefined
+      >();
     });
   });
 

--- a/packages/@granit/reference-data/src/api/reference-data-api.ts
+++ b/packages/@granit/reference-data/src/api/reference-data-api.ts
@@ -63,6 +63,23 @@ export async function updateReferenceDataEntry(
 }
 
 /**
+ * Fetch the direct children of a hierarchical reference data entry.
+ *
+ * `GET {basePath}/{code}/children`
+ *
+ * Returns active children ordered by sortOrder, then code.
+ * Throws 404 if the parent code does not exist.
+ */
+export async function fetchReferenceDataChildren<T extends ReferenceDataEntry>(
+  client: AxiosInstance,
+  basePath: string,
+  code: string
+): Promise<T[]> {
+  const { data } = await client.get<T[]>(`${basePath}/${encodeURIComponent(code)}/children`);
+  return data;
+}
+
+/**
  * Deactivate a reference data entry (soft delete).
  *
  * `DELETE {basePath}/{code}`

--- a/packages/@granit/reference-data/src/index.ts
+++ b/packages/@granit/reference-data/src/index.ts
@@ -11,6 +11,7 @@ export type {
 export {
   createReferenceDataEntry,
   deactivateReferenceDataEntry,
+  fetchReferenceDataChildren,
   fetchReferenceDataEntry,
   fetchReferenceDataList,
   updateReferenceDataEntry,

--- a/packages/@granit/reference-data/src/types/index.ts
+++ b/packages/@granit/reference-data/src/types/index.ts
@@ -31,6 +31,10 @@ export interface ReferenceDataEntry extends ReferenceDataLabels {
   readonly sortOrder: number;
   readonly validFrom: string | null;
   readonly validTo: string | null;
+  /** Parent code for hierarchical types (null for root entries). */
+  readonly parentCode: string | null;
+  /** Custom properties bag (all values are strings). */
+  readonly extraProperties: Record<string, string> | null;
   readonly createdAt: string;
   readonly createdBy: string;
   readonly modifiedAt: string | null;
@@ -49,6 +53,8 @@ export interface ReferenceDataCreateRequest extends Partial<ReferenceDataLabels>
   readonly sortOrder?: number;
   readonly validFrom?: string | null;
   readonly validTo?: string | null;
+  readonly parentCode?: string | null;
+  readonly extraProperties?: Record<string, string> | null;
 }
 
 /**
@@ -63,6 +69,8 @@ export interface ReferenceDataUpdateRequest extends Partial<ReferenceDataLabels>
   readonly isActive?: boolean;
   readonly validFrom?: string | null;
   readonly validTo?: string | null;
+  readonly parentCode?: string | null;
+  readonly extraProperties?: Record<string, string> | null;
 }
 
 /**

--- a/scripts/generate-front-index.py
+++ b/scripts/generate-front-index.py
@@ -17,7 +17,7 @@ import json
 import os
 import re
 import sys
-from datetime import datetime, timezone
+
 from pathlib import Path
 
 
@@ -387,7 +387,6 @@ def main() -> None:
             print(f"  {pkg['name']}: {len(exports)} exports")
 
     index = {
-        "generatedAt": datetime.now(timezone.utc).isoformat(),
         "repo": "granit-front",
         "packages": result,
     }


### PR DESCRIPTION
## Summary

- **Entity name alignment**: rename types, API functions, and hooks across all packages to match Granit .NET backend contracts (timeline, workflow, notifications, webhooks, templating, querying, features, settings, identity, data-exchange)
- **New packages**: `@granit/account`, `@granit/react-account`, `@granit/openiddict-admin`, `@granit/react-openiddict-admin`, `@granit/privacy`, `@granit/react-privacy` — full CRUD types, API functions, and React Query hooks mirroring their .NET counterparts
- **Generic reference-data**: refactor `@granit/reference-data` and `@granit/react-reference-data` from Country-specific to generic `createReferenceDataHooks<T>(entityName)` factory pattern, add ReferenceData v2 support (`parentCode`, `extraProperties`, `fetchReferenceDataChildren`, `useChildren`)
- **Admin API hooks**: add admin-level hooks for features, settings, localization, and webhooks (event types, retry delivery, webhook config)
- **Test coverage**: comprehensive tests for all new and refactored packages (≥ 80%)
- **Build fix**: add missing `tsup.config.ts` for privacy packages
- **MCP index**: stabilize `.mcp-front-index.json` by removing `generatedAt` timestamp

## Test plan

- [x] `pnpm lint` — 0 warnings
- [x] `pnpm tsc` — no errors across all 72 packages
- [x] `pnpm test` — all tests pass
- [ ] Verify consumer apps (guava-front, guava-admin) still compile with updated imports
- [ ] Review new package APIs against .NET backend OpenAPI specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)