### PR TITLE
feat(bff): add BFF authentication packages and api-client BFF mode

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -84,6 +84,16 @@
       "description": "Axios factory with Bearer token interceptor and shared response types",
       "exports": [
         {
+          "name": "ApiClientMode",
+          "kind": "type",
+          "signature": "type ApiClientMode = 'bearer' | 'bff'"
+        },
+        {
+          "name": "CsrfTokenGetter",
+          "kind": "type",
+          "signature": "type CsrfTokenGetter = () => string | null"
+        },
+        {
           "name": "ApiClientConfig",
           "kind": "interface",
           "signature": "interface ApiClientConfig",
@@ -97,6 +107,16 @@
               "name": "timeout",
               "kind": "property",
               "signature": "timeout?: number"
+            },
+            {
+              "name": "mode",
+              "kind": "property",
+              "signature": "mode?: ApiClientMode"
+            },
+            {
+              "name": "csrfTokenGetter",
+              "kind": "property",
+              "signature": "csrfTokenGetter?: CsrfTokenGetter"
             }
           ]
         },
@@ -205,6 +225,35 @@
           "kind": "interface",
           "signature": "interface BackgroundJobStatus",
           "members": []
+        }
+      ]
+    },
+    {
+      "name": "@granit/bff",
+      "description": "BFF authentication types and CSRF manager — TypeScript mirror of Granit.Bff .NET",
+      "exports": [
+        {
+          "name": "BffConfig",
+          "kind": "interface",
+          "signature": "interface BffConfig",
+          "members": []
+        },
+        {
+          "name": "BffUnauthenticated",
+          "kind": "interface",
+          "signature": "interface BffUnauthenticated",
+          "members": []
+        },
+        {
+          "name": "BffUser",
+          "kind": "interface",
+          "signature": "interface BffUser",
+          "members": []
+        },
+        {
+          "name": "BffUserResponse",
+          "kind": "type",
+          "signature": "type BffUserResponse = BffUser | BffUnauthenticated"
         }
       ]
     },
@@ -1126,6 +1175,60 @@
           "name": "BackgroundJobsOptions",
           "kind": "interface",
           "signature": "interface BackgroundJobsOptions",
+          "members": []
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-bff",
+      "description": "React bindings for @granit/bff — BffProvider, useAuth, useCsrf, useBffFetch, BffGuard",
+      "exports": [
+        {
+          "name": "BffProvider",
+          "kind": "function",
+          "signature": "function BffProvider("
+        },
+        {
+          "name": "useBffContext",
+          "kind": "function",
+          "signature": "function useBffContext(): BffContextType"
+        },
+        {
+          "name": "BffContextType",
+          "kind": "interface",
+          "signature": "interface BffContextType",
+          "members": []
+        },
+        {
+          "name": "BffProviderProps",
+          "kind": "interface",
+          "signature": "interface BffProviderProps",
+          "members": []
+        },
+        {
+          "name": "useBffAuth",
+          "kind": "function",
+          "signature": "function useBffAuth()"
+        },
+        {
+          "name": "useBffCsrf",
+          "kind": "function",
+          "signature": "function useBffCsrf()"
+        },
+        {
+          "name": "useBffFetch",
+          "kind": "function",
+          "signature": "function useBffFetch()"
+        },
+        {
+          "name": "BffGuard",
+          "kind": "function",
+          "signature": "function BffGuard("
+        },
+        {
+          "name": "BffGuardProps",
+          "kind": "interface",
+          "signature": "interface BffGuardProps",
           "members": []
         }
       ]

--- a/packages/@granit/api-client/src/__tests__/api-client.test.ts
+++ b/packages/@granit/api-client/src/__tests__/api-client.test.ts
@@ -10,7 +10,12 @@ import type {
 
 // Dynamic import type to get fresh module state per test
 interface ApiClientModule {
-  createApiClient: (config: ApiClientConfig) => AxiosInstance;
+  createApiClient: (
+    config: ApiClientConfig & {
+      mode?: 'bearer' | 'bff';
+      csrfTokenGetter?: () => string | null;
+    }
+  ) => AxiosInstance;
   setTokenGetter: (getter: () => Promise<string | undefined>) => void;
   setTenantGetter: (getter: () => string | undefined) => void;
   setOnUnauthorized: (callback: () => void) => void;
@@ -353,5 +358,143 @@ describe('401 response interceptor', () => {
 
     const response = await client.get('/test');
     expect(response.status).toBe(200);
+  });
+});
+
+describe('BFF mode', () => {
+  let mod: ApiClientModule;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    mod = await import('../index.ts');
+  });
+
+  it('should set withCredentials to true in BFF mode', () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+    });
+    expect(client.defaults.withCredentials).toBe(true);
+  });
+
+  it('should not set withCredentials in bearer mode', () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bearer',
+    });
+    expect(client.defaults.withCredentials).toBe(false);
+  });
+
+  it('should not set withCredentials when mode is omitted (default bearer)', () => {
+    const client = mod.createApiClient({ baseURL: 'https://api.example.com' });
+    expect(client.defaults.withCredentials).toBe(false);
+  });
+
+  it('should inject X-CSRF-Token on POST requests in BFF mode', async () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => 'csrf-123',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.post('/test', {});
+    expect(response.config.headers['X-CSRF-Token']).toBe('csrf-123');
+  });
+
+  it('should inject X-CSRF-Token on PUT requests in BFF mode', async () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => 'csrf-put',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.put('/test', {});
+    expect(response.config.headers['X-CSRF-Token']).toBe('csrf-put');
+  });
+
+  it('should inject X-CSRF-Token on DELETE requests in BFF mode', async () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => 'csrf-del',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.delete('/test');
+    expect(response.config.headers['X-CSRF-Token']).toBe('csrf-del');
+  });
+
+  it('should inject X-CSRF-Token on PATCH requests in BFF mode', async () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => 'csrf-patch',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.patch('/test', {});
+    expect(response.config.headers['X-CSRF-Token']).toBe('csrf-patch');
+  });
+
+  it('should NOT inject X-CSRF-Token on GET requests in BFF mode', async () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => 'csrf-get',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.get('/test');
+    expect(response.config.headers['X-CSRF-Token']).toBeUndefined();
+  });
+
+  it('should NOT inject X-CSRF-Token when csrfTokenGetter returns null', async () => {
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => null,
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.post('/test', {});
+    expect(response.config.headers['X-CSRF-Token']).toBeUndefined();
+  });
+
+  it('should NOT inject Authorization header in BFF mode', async () => {
+    mod.setTokenGetter(() => Promise.resolve('should-not-appear'));
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.get('/test');
+    expect(response.config.headers.Authorization).toBeUndefined();
+  });
+
+  it('should still inject X-Tenant-Id in BFF mode', async () => {
+    mod.setTenantGetter(() => 'tenant-bff');
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.get('/test');
+    expect(response.config.headers['X-Tenant-Id']).toBe('tenant-bff');
+  });
+
+  it('should still inject Idempotency-Key in BFF mode', async () => {
+    mod.setIdempotencyKeyGenerator(() => 'idem-bff');
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.post('/test', {});
+    expect(response.config.headers['Idempotency-Key']).toBe('idem-bff');
   });
 });

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -5,10 +5,29 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from 'axios';
 
+/** Authentication mode for the API client. */
+export type ApiClientMode = 'bearer' | 'bff';
+
+/** Getter that returns the current CSRF token, or null if unavailable. */
+export type CsrfTokenGetter = () => string | null;
+
 export interface ApiClientConfig {
   baseURL: string;
   /** Request timeout in milliseconds. Default: 10_000 */
   timeout?: number;
+  /**
+   * Authentication mode. Default: `'bearer'`.
+   *
+   * - `'bearer'` — Injects `Authorization: Bearer <token>` via the global token getter.
+   * - `'bff'` — Uses `withCredentials` (cookies) and injects `X-CSRF-Token` on mutations.
+   *   No Authorization header is sent (the BFF YARP proxy adds it server-side).
+   */
+  mode?: ApiClientMode;
+  /**
+   * CSRF token getter for BFF mode. Required when `mode` is `'bff'`.
+   * Typically obtained from `CsrfManager.getToken` in `@granit/bff`.
+   */
+  csrfTokenGetter?: CsrfTokenGetter;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,15 +94,24 @@ export function setIdempotencyKeyGenerator(
   _idempotencyKeyGenerator = generator;
 }
 
+const MUTATION_METHODS = new Set(['post', 'put', 'delete', 'patch']);
+
 /**
- * Create a pre-configured Axios instance with Bearer token injection,
- * optional X-Tenant-Id header, and a 401 response interceptor that
- * triggers the `onUnauthorized` callback (if registered via {@link setOnUnauthorized}).
+ * Create a pre-configured Axios instance.
+ *
+ * - **Bearer mode** (default): injects `Authorization: Bearer <token>` via the global token getter.
+ * - **BFF mode**: uses `withCredentials` (cookies) and injects `X-CSRF-Token` on mutations.
+ *
+ * Both modes support optional `X-Tenant-Id`, idempotency keys, and a 401 response interceptor.
  */
 export function createApiClient(config: ApiClientConfig): AxiosInstance {
+  const mode = config.mode ?? 'bearer';
+  const isBff = mode === 'bff';
+
   const instance = axios.create({
     baseURL: config.baseURL,
     timeout: config.timeout ?? 10_000,
+    withCredentials: isBff,
     headers: {
       'Content-Type': 'application/json',
     },
@@ -91,10 +119,21 @@ export function createApiClient(config: ApiClientConfig): AxiosInstance {
 
   instance.interceptors.request.use(
     async (req: InternalAxiosRequestConfig) => {
-      if (_tokenGetter) {
-        const token = await _tokenGetter();
-        if (token) {
-          req.headers.Authorization = `Bearer ${token}`;
+      if (isBff) {
+        // BFF mode: inject CSRF token on mutation methods
+        if (config.csrfTokenGetter && MUTATION_METHODS.has(req.method ?? '')) {
+          const csrfToken = config.csrfTokenGetter();
+          if (csrfToken) {
+            req.headers['X-CSRF-Token'] = csrfToken;
+          }
+        }
+      } else {
+        // Bearer mode: inject Authorization header
+        if (_tokenGetter) {
+          const token = await _tokenGetter();
+          if (token) {
+            req.headers.Authorization = `Bearer ${token}`;
+          }
         }
       }
       if (_tenantGetter) {

--- a/packages/@granit/bff/package.json
+++ b/packages/@granit/bff/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/bff",
+  "description": "BFF authentication types and CSRF manager — TypeScript mirror of Granit.Bff .NET",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/bff/src/__tests__/csrf-manager.test.ts
+++ b/packages/@granit/bff/src/__tests__/csrf-manager.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CsrfManager } from '../csrf/csrf-manager.js';
+
+describe('CsrfManager', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('fetchToken', () => {
+    it('should POST to /{prefix}/bff/csrf-token with credentials', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-abc' }), { status: 200 })
+      );
+
+      const manager = new CsrfManager('/admin');
+      await manager.fetchToken();
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('/admin/bff/csrf-token', {
+        method: 'POST',
+        credentials: 'include',
+      });
+    });
+
+    it('should store and return the fetched token', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-xyz' }), { status: 200 })
+      );
+
+      const manager = new CsrfManager('/app');
+      const token = await manager.fetchToken();
+
+      expect(token).toBe('csrf-xyz');
+      expect(manager.getToken()).toBe('csrf-xyz');
+    });
+
+    it('should throw on non-ok response', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+      const manager = new CsrfManager('/app');
+      await expect(manager.fetchToken()).rejects.toThrow('CSRF token fetch failed: 401');
+    });
+  });
+
+  describe('getToken', () => {
+    it('should return null before any fetch', () => {
+      const manager = new CsrfManager('/app');
+      expect(manager.getToken()).toBeNull();
+    });
+  });
+
+  describe('createFetchWithCsrf', () => {
+    it('should inject X-CSRF-Token on POST requests', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-post' }), { status: 200 })
+      );
+
+      const manager = new CsrfManager('/app');
+      await manager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockClear();
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      await wrappedFetch('/api/data', { method: 'POST' });
+
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('csrf-post');
+      expect(init?.credentials).toBe('include');
+    });
+
+    it('should inject X-CSRF-Token on PUT requests', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-put' }), { status: 200 })
+      );
+
+      const manager = new CsrfManager('/app');
+      await manager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockClear();
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      await wrappedFetch('/api/data', { method: 'PUT' });
+
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('csrf-put');
+    });
+
+    it('should inject X-CSRF-Token on DELETE requests', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-del' }), { status: 200 })
+      );
+
+      const manager = new CsrfManager('/app');
+      await manager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockClear();
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      await wrappedFetch('/api/data', { method: 'DELETE' });
+
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('csrf-del');
+    });
+
+    it('should inject X-CSRF-Token on PATCH requests', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-patch' }), { status: 200 })
+      );
+
+      const manager = new CsrfManager('/app');
+      await manager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockClear();
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      await wrappedFetch('/api/data', { method: 'PATCH' });
+
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('csrf-patch');
+    });
+
+    it('should NOT inject X-CSRF-Token on GET requests', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ token: 'csrf-get' }), { status: 200 })
+      );
+
+      const manager = new CsrfManager('/app');
+      await manager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockClear();
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      await wrappedFetch('/api/data', { method: 'GET' });
+
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-CSRF-Token')).toBeNull();
+      expect(init?.credentials).toBe('include');
+    });
+
+    it('should NOT inject X-CSRF-Token when no token is available', async () => {
+      const manager = new CsrfManager('/app');
+
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      await wrappedFetch('/api/data', { method: 'POST' });
+
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      const headers = new Headers(init?.headers);
+      expect(headers.get('X-CSRF-Token')).toBeNull();
+      expect(init?.credentials).toBe('include');
+    });
+
+    it('should always set credentials to include', async () => {
+      const manager = new CsrfManager('/app');
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      await wrappedFetch('/api/data');
+
+      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
+      expect(init?.credentials).toBe('include');
+    });
+  });
+});

--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -1,0 +1,52 @@
+// ---------------------------------------------------------------------------
+// CSRF token manager for BFF authentication.
+//
+// The BFF server requires an X-CSRF-Token header on all mutation requests
+// (POST, PUT, DELETE, PATCH). This manager fetches the token from the
+// /{prefix}/bff/csrf-token endpoint and provides a fetch wrapper that
+// auto-injects it on mutation methods.
+// ---------------------------------------------------------------------------
+
+const MUTATION_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
+
+/** Manages CSRF token lifecycle for BFF-authenticated SPAs. */
+export class CsrfManager {
+  private token: string | null = null;
+  private readonly pathPrefix: string;
+
+  constructor(pathPrefix: string) {
+    this.pathPrefix = pathPrefix;
+  }
+
+  /** Fetch a fresh CSRF token from the BFF server. */
+  async fetchToken(): Promise<string> {
+    const response = await fetch(`${this.pathPrefix}/bff/csrf-token`, {
+      method: 'POST',
+      credentials: 'include',
+    });
+    if (!response.ok) {
+      throw new Error(`CSRF token fetch failed: ${response.status}`);
+    }
+    const data = (await response.json()) as { token: string };
+    this.token = data.token;
+    return this.token;
+  }
+
+  /** Return the current CSRF token, or null if not yet fetched. */
+  getToken(): string | null {
+    return this.token;
+  }
+
+  /** Create a fetch wrapper that auto-injects X-CSRF-Token on mutation requests. */
+  createFetchWithCsrf(): typeof fetch {
+    return (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const method = (init?.method ?? 'GET').toUpperCase();
+      if (MUTATION_METHODS.has(method) && this.token) {
+        const headers = new Headers(init?.headers);
+        headers.set('X-CSRF-Token', this.token);
+        return fetch(input, { ...init, headers, credentials: 'include' });
+      }
+      return fetch(input, { ...init, credentials: 'include' });
+    };
+  }
+}

--- a/packages/@granit/bff/src/csrf/index.ts
+++ b/packages/@granit/bff/src/csrf/index.ts
@@ -1,0 +1,1 @@
+export { CsrfManager } from './csrf-manager.js';

--- a/packages/@granit/bff/src/index.ts
+++ b/packages/@granit/bff/src/index.ts
@@ -1,0 +1,3 @@
+export type { BffConfig, BffUnauthenticated, BffUser, BffUserResponse } from './types/index.js';
+
+export { CsrfManager } from './csrf/index.js';

--- a/packages/@granit/bff/src/types/index.ts
+++ b/packages/@granit/bff/src/types/index.ts
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// BFF authentication types — mirrors Granit.Bff .NET contract
+// ---------------------------------------------------------------------------
+
+/** Authenticated user returned by GET /{prefix}/bff/user. */
+export interface BffUser {
+  readonly authenticated: true;
+  readonly sub: string;
+  readonly name: string;
+  readonly email: string;
+  readonly roles: readonly string[];
+  readonly tenantId?: string;
+  readonly sessionExpiresAt: string;
+}
+
+/** Unauthenticated response from GET /{prefix}/bff/user. */
+export interface BffUnauthenticated {
+  readonly authenticated: false;
+}
+
+/** Union type for the /bff/user endpoint response. */
+export type BffUserResponse = BffUser | BffUnauthenticated;
+
+/** Configuration for the BFF authentication provider. */
+export interface BffConfig {
+  /** Path prefix for this frontend (e.g., "/admin"). */
+  readonly pathPrefix: string;
+  /** Called when /bff/user returns authenticated: false. Default: redirect to login. */
+  readonly onUnauthenticated?: () => void;
+  /** Polling interval for session check in ms. Default: 60000 (1 minute). 0 = disabled. */
+  readonly sessionCheckInterval?: number;
+}

--- a/packages/@granit/bff/tsconfig.json
+++ b/packages/@granit/bff/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/bff/tsup.config.ts
+++ b/packages/@granit/bff/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//],
+});

--- a/packages/@granit/react-bff/package.json
+++ b/packages/@granit/react-bff/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@granit/react-bff",
+  "description": "React bindings for @granit/bff — BffProvider, useAuth, useCsrf, useBffFetch, BffGuard",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/bff": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-bff/src/__tests__/bff-provider.test.tsx
+++ b/packages/@granit/react-bff/src/__tests__/bff-provider.test.tsx
@@ -1,0 +1,244 @@
+import { render, renderHook, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BffGuard } from '../components/bff-guard.js';
+import { useBffAuth } from '../hooks/use-bff-auth.js';
+import { useBffCsrf } from '../hooks/use-bff-csrf.js';
+import { useBffFetch } from '../hooks/use-bff-fetch.js';
+import { BffProvider, useBffContext } from '../providers/bff-provider.js';
+
+import type { BffConfig } from '@granit/bff';
+
+const authenticatedResponse = {
+  authenticated: true,
+  sub: 'user-123',
+  name: 'Alice',
+  email: 'alice@test.com',
+  roles: ['admin'],
+  tenantId: 'tenant-1',
+  sessionExpiresAt: '2026-03-22T20:00:00Z',
+};
+
+const unauthenticatedResponse = { authenticated: false };
+
+const csrfResponse = { token: 'csrf-test-token' };
+
+function mockFetchSequence(...responses: object[]) {
+  const fn = vi.fn();
+  for (const resp of responses) {
+    fn.mockResolvedValueOnce(new Response(JSON.stringify(resp), { status: 200 }));
+  }
+  return fn;
+}
+
+function createWrapper(config: BffConfig) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <BffProvider config={config}>{children}</BffProvider>
+  );
+}
+
+describe('BffProvider', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch /bff/user on mount', async () => {
+    globalThis.fetch = mockFetchSequence(authenticatedResponse, csrfResponse);
+
+    const config: BffConfig = { pathPrefix: '/admin', sessionCheckInterval: 0 };
+    const { result } = renderHook(() => useBffAuth(), {
+      wrapper: createWrapper(config),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(true);
+    expect(result.current.user?.name).toBe('Alice');
+    expect(result.current.user?.sub).toBe('user-123');
+  });
+
+  it('should set user to null when not authenticated', async () => {
+    globalThis.fetch = mockFetchSequence(unauthenticatedResponse);
+
+    const config: BffConfig = { pathPrefix: '/app', sessionCheckInterval: 0 };
+    const { result } = renderHook(() => useBffAuth(), {
+      wrapper: createWrapper(config),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('should call onUnauthenticated when user is not authenticated', async () => {
+    const onUnauthenticated = vi.fn();
+    globalThis.fetch = mockFetchSequence(unauthenticatedResponse);
+
+    const config: BffConfig = {
+      pathPrefix: '/app',
+      sessionCheckInterval: 0,
+      onUnauthenticated,
+    };
+    renderHook(() => useBffAuth(), { wrapper: createWrapper(config) });
+
+    await waitFor(() => {
+      expect(onUnauthenticated).toHaveBeenCalledOnce();
+    });
+  });
+
+  it('should handle fetch errors gracefully', async () => {
+    vi.mocked(globalThis.fetch).mockRejectedValue(new Error('Network error'));
+
+    const config: BffConfig = { pathPrefix: '/app', sessionCheckInterval: 0 };
+    const { result } = renderHook(() => useBffAuth(), {
+      wrapper: createWrapper(config),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isAuthenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('should fetch CSRF token after successful auth check', async () => {
+    globalThis.fetch = mockFetchSequence(authenticatedResponse, csrfResponse);
+
+    const config: BffConfig = { pathPrefix: '/admin', sessionCheckInterval: 0 };
+    const { result } = renderHook(() => useBffCsrf(), {
+      wrapper: createWrapper(config),
+    });
+
+    await waitFor(() => {
+      expect(result.current.csrfToken).toBe('csrf-test-token');
+    });
+  });
+});
+
+describe('useBffContext', () => {
+  it('should throw when used outside BffProvider', () => {
+    expect(() => {
+      renderHook(() => useBffContext());
+    }).toThrow('useBffContext must be used within a <BffProvider>');
+  });
+});
+
+describe('useBffFetch', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should return a fetch function', async () => {
+    globalThis.fetch = mockFetchSequence(authenticatedResponse, csrfResponse);
+
+    const config: BffConfig = { pathPrefix: '/app', sessionCheckInterval: 0 };
+    const { result } = renderHook(() => useBffFetch(), {
+      wrapper: createWrapper(config),
+    });
+
+    await waitFor(() => {
+      expect(typeof result.current).toBe('function');
+    });
+  });
+});
+
+describe('BffGuard', () => {
+  const originalFetch = globalThis.fetch;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, href: '' },
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: originalLocation,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it('should show fallback while loading', () => {
+    // fetch never resolves — stays in loading state
+    vi.mocked(globalThis.fetch).mockReturnValue(new Promise(() => {}));
+
+    const config: BffConfig = { pathPrefix: '/app', sessionCheckInterval: 0 };
+
+    render(
+      <BffProvider config={config}>
+        <BffGuard fallback={<span data-testid="loading">Loading...</span>}>
+          <span data-testid="content">Protected</span>
+        </BffGuard>
+      </BffProvider>
+    );
+
+    expect(screen.getByTestId('loading')).toBeTruthy();
+    expect(screen.queryByTestId('content')).toBeNull();
+  });
+
+  it('should render children when authenticated', async () => {
+    globalThis.fetch = mockFetchSequence(authenticatedResponse, csrfResponse);
+
+    const config: BffConfig = { pathPrefix: '/app', sessionCheckInterval: 0 };
+
+    render(
+      <BffProvider config={config}>
+        <BffGuard>
+          <span data-testid="content">Protected</span>
+        </BffGuard>
+      </BffProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('content')).toBeTruthy();
+    });
+  });
+
+  it('should redirect to login when not authenticated', async () => {
+    globalThis.fetch = mockFetchSequence(unauthenticatedResponse);
+
+    const config: BffConfig = { pathPrefix: '/admin', sessionCheckInterval: 0 };
+
+    render(
+      <BffProvider config={config}>
+        <BffGuard>
+          <span data-testid="content">Protected</span>
+        </BffGuard>
+      </BffProvider>
+    );
+
+    await waitFor(() => {
+      expect(window.location.href).toBe('/admin/bff/login');
+    });
+
+    expect(screen.queryByTestId('content')).toBeNull();
+  });
+});

--- a/packages/@granit/react-bff/src/components/bff-guard.tsx
+++ b/packages/@granit/react-bff/src/components/bff-guard.tsx
@@ -1,0 +1,26 @@
+import { useBffAuth } from '../hooks/use-bff-auth.js';
+
+import type { ReactNode } from 'react';
+
+export interface BffGuardProps {
+  readonly children: ReactNode;
+  /** Shown while the session check is loading. Defaults to null. */
+  readonly fallback?: ReactNode;
+}
+
+/**
+ * Renders children only if the user is authenticated.
+ * Redirects to the BFF login endpoint otherwise.
+ */
+export function BffGuard({ children, fallback }: BffGuardProps) {
+  const { isAuthenticated, isLoading, login } = useBffAuth();
+
+  if (isLoading) return <>{fallback ?? null}</>;
+
+  if (!isAuthenticated) {
+    login();
+    return null;
+  }
+
+  return <>{children}</>;
+}

--- a/packages/@granit/react-bff/src/hooks/use-bff-auth.ts
+++ b/packages/@granit/react-bff/src/hooks/use-bff-auth.ts
@@ -1,0 +1,13 @@
+import { useBffContext } from '../providers/bff-provider.js';
+
+/**
+ * Hook to access BFF authentication state and actions.
+ *
+ * Returns user, isAuthenticated, isLoading, login(), and logout().
+ *
+ * @throws Error if used outside of a `<BffProvider>`.
+ */
+export function useBffAuth() {
+  const { user, isAuthenticated, isLoading, login, logout } = useBffContext();
+  return { user, isAuthenticated, isLoading, login, logout } as const;
+}

--- a/packages/@granit/react-bff/src/hooks/use-bff-csrf.ts
+++ b/packages/@granit/react-bff/src/hooks/use-bff-csrf.ts
@@ -1,0 +1,18 @@
+import { useCallback } from 'react';
+
+import { useBffContext } from '../providers/bff-provider.js';
+
+/**
+ * Hook to access the current CSRF token and refresh it.
+ *
+ * @throws Error if used outside of a `<BffProvider>`.
+ */
+export function useBffCsrf() {
+  const { csrfManager } = useBffContext();
+
+  const csrfToken = csrfManager.getToken();
+
+  const refreshCsrf = useCallback(() => csrfManager.fetchToken(), [csrfManager]);
+
+  return { csrfToken, refreshCsrf } as const;
+}

--- a/packages/@granit/react-bff/src/hooks/use-bff-fetch.ts
+++ b/packages/@granit/react-bff/src/hooks/use-bff-fetch.ts
@@ -1,0 +1,14 @@
+import { useMemo } from 'react';
+
+import { useBffContext } from '../providers/bff-provider.js';
+
+/**
+ * Hook that returns a `fetch` wrapper with automatic CSRF token injection
+ * on mutation requests (POST, PUT, DELETE, PATCH) and `credentials: 'include'`.
+ *
+ * @throws Error if used outside of a `<BffProvider>`.
+ */
+export function useBffFetch() {
+  const { csrfManager } = useBffContext();
+  return useMemo(() => csrfManager.createFetchWithCsrf(), [csrfManager]);
+}

--- a/packages/@granit/react-bff/src/index.ts
+++ b/packages/@granit/react-bff/src/index.ts
@@ -1,0 +1,9 @@
+export { BffProvider, useBffContext } from './providers/bff-provider.js';
+export type { BffContextType, BffProviderProps } from './providers/bff-provider.js';
+
+export { useBffAuth } from './hooks/use-bff-auth.js';
+export { useBffCsrf } from './hooks/use-bff-csrf.js';
+export { useBffFetch } from './hooks/use-bff-fetch.js';
+
+export { BffGuard } from './components/bff-guard.js';
+export type { BffGuardProps } from './components/bff-guard.js';

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -1,0 +1,113 @@
+import { CsrfManager } from '@granit/bff';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+
+import type { BffConfig, BffUser } from '@granit/bff';
+import type { ReactNode } from 'react';
+
+/** Shape of the BFF authentication context. */
+export interface BffContextType {
+  /** The authenticated user, or null if not authenticated. */
+  readonly user: BffUser | null;
+  /** Whether the user is authenticated. */
+  readonly isAuthenticated: boolean;
+  /** Whether the initial session check is in progress. */
+  readonly isLoading: boolean;
+  /** Redirect to the BFF login endpoint. */
+  readonly login: () => void;
+  /** Redirect to the BFF logout endpoint. */
+  readonly logout: () => void;
+  /** CSRF manager instance for advanced use cases. */
+  readonly csrfManager: CsrfManager;
+}
+
+const BffContext = createContext<BffContextType | null>(null);
+
+export interface BffProviderProps {
+  readonly config: BffConfig;
+  readonly children: ReactNode;
+}
+
+/** Provides BFF authentication context to the React tree. */
+export function BffProvider({ config, children }: BffProviderProps) {
+  const [user, setUser] = useState<BffUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [csrfManager] = useState(() => new CsrfManager(config.pathPrefix));
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const checkSession = async () => {
+      try {
+        const response = await fetch(`${configRef.current.pathPrefix}/bff/user`, {
+          credentials: 'include',
+        });
+        const data = await response.json();
+        if (cancelled) return;
+        if (data.authenticated) {
+          setUser(data as BffUser);
+          await csrfManager.fetchToken();
+        } else {
+          setUser(null);
+          configRef.current.onUnauthenticated?.();
+        }
+      } catch {
+        if (!cancelled) setUser(null);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
+
+    void checkSession();
+
+    const interval = configRef.current.sessionCheckInterval ?? 60_000;
+    if (interval > 0) {
+      const timer = setInterval(() => void checkSession(), interval);
+      return () => {
+        cancelled = true;
+        clearInterval(timer);
+      };
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [csrfManager]);
+
+  const login = () => {
+    window.location.href = `${configRef.current.pathPrefix}/bff/login`;
+  };
+
+  const logout = () => {
+    window.location.href = `${configRef.current.pathPrefix}/bff/logout`;
+  };
+
+  return (
+    <BffContext.Provider
+      value={{
+        user,
+        isAuthenticated: user !== null,
+        isLoading,
+        login,
+        logout,
+        csrfManager,
+      }}
+    >
+      {children}
+    </BffContext.Provider>
+  );
+}
+
+/**
+ * Access the BFF authentication context.
+ *
+ * @throws Error if used outside of a `<BffProvider>`.
+ */
+export function useBffContext(): BffContextType {
+  const context = useContext(BffContext);
+  if (!context) {
+    throw new Error('useBffContext must be used within a <BffProvider>');
+  }
+  return context;
+}

--- a/packages/@granit/react-bff/tsconfig.json
+++ b/packages/@granit/react-bff/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/bff": ["../bff/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-bff/tsup.config.ts
+++ b/packages/@granit/react-bff/tsup.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: { tsconfig: '../../../tsconfig.build.json' },
+  clean: true,
+  external: [/^@granit\//, 'react'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,6 +230,8 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/bff: {}
+
   packages/@granit/blob-storage:
     dependencies:
       axios:
@@ -568,6 +570,15 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+
+  packages/@granit/react-bff:
+    dependencies:
+      '@granit/bff':
+        specifier: workspace:*
+        version: link:../bff
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
 
   packages/@granit/react-blob-storage:
     dependencies:


### PR DESCRIPTION
## Summary

- Add `@granit/bff` package: `BffUser`, `BffConfig` types and `CsrfManager` (CSRF token fetch + `fetch` wrapper with auto-injection)
- Add `@granit/react-bff` package: `BffProvider`, `useBffAuth`, `useBffCsrf`, `useBffFetch`, `BffGuard`
- Extend `@granit/api-client` with `mode: 'bearer' | 'bff'` option — BFF mode sets `withCredentials`, injects `X-CSRF-Token` on mutations, and skips the `Authorization` header

## Context

The Granit.Bff .NET module provides a Backend For Frontend security proxy where OIDC tokens never leave the server — the SPA only sees an HTTP-only session cookie. These packages integrate the BFF flow as an **alternative** to the existing Keycloak direct auth (`@granit/react-authentication`). Apps choose their mode: `'keycloak' | 'bff' | 'mock'`.

## Test plan

- [x] `CsrfManager`: token fetch, storage, header injection on POST/PUT/DELETE/PATCH, no injection on GET (11 tests)
- [x] `BffProvider`: session check, authenticated/unauthenticated flows, CSRF auto-fetch, error handling (10 tests)
- [x] `BffGuard`: loading fallback, redirect to login, render children when authenticated
- [x] `api-client` BFF mode: `withCredentials`, CSRF injection, no `Authorization` header, tenant/idempotency still work (11 tests)
- [x] Full workspace: 1704 tests passing, lint clean, tsc clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)