### PR TITLE
chore(deps): upgrade Vite 8 + feat(bff): session management API

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -231,31 +231,7 @@
     {
       "name": "@granit/bff",
       "description": "BFF authentication types and CSRF manager — TypeScript mirror of Granit.Bff .NET",
-      "exports": [
-        {
-          "name": "BffConfig",
-          "kind": "interface",
-          "signature": "interface BffConfig",
-          "members": []
-        },
-        {
-          "name": "BffUnauthenticated",
-          "kind": "interface",
-          "signature": "interface BffUnauthenticated",
-          "members": []
-        },
-        {
-          "name": "BffUser",
-          "kind": "interface",
-          "signature": "interface BffUser",
-          "members": []
-        },
-        {
-          "name": "BffUserResponse",
-          "kind": "type",
-          "signature": "type BffUserResponse = BffUser | BffUnauthenticated"
-        }
-      ]
+      "exports": []
     },
     {
       "name": "@granit/blob-storage",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.14",
-    "@vitejs/plugin-react": "^5.2.0",
+    "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.0",
     "axios": "^1.13.6",
     "clsx": "^2.1.1",

--- a/packages/@granit/bff/src/__tests__/bff-session-api.test.ts
+++ b/packages/@granit/bff/src/__tests__/bff-session-api.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  fetchBffSessions,
+  revokeAllOtherBffSessions,
+  revokeBffSession,
+} from '../api/bff-session-api.js';
+import { CsrfManager } from '../csrf/csrf-manager.js';
+
+describe('BFF session API', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  describe('fetchBffSessions', () => {
+    it('should GET /{prefix}/bff/sessions with credentials', async () => {
+      const sessions = [
+        {
+          sessionId: 'ab12...yz89',
+          isCurrent: true,
+          createdAt: '2026-03-23T10:00:00Z',
+          userAgent: 'Mozilla/5.0',
+        },
+        {
+          sessionId: 'cd34...wx67',
+          isCurrent: false,
+          createdAt: '2026-03-22T08:00:00Z',
+          userAgent: null,
+        },
+      ];
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ sessions }), { status: 200 })
+      );
+
+      const result = await fetchBffSessions('/admin');
+
+      expect(globalThis.fetch).toHaveBeenCalledWith('/admin/bff/sessions', {
+        credentials: 'include',
+      });
+      expect(result).toEqual(sessions);
+    });
+
+    it('should throw on non-ok response', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('Unauthorized', { status: 401 }));
+
+      await expect(fetchBffSessions('/app')).rejects.toThrow('Failed to fetch BFF sessions: 401');
+    });
+
+    it('should return an empty array when no sessions exist', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValue(
+        new Response(JSON.stringify({ sessions: [] }), { status: 200 })
+      );
+
+      const result = await fetchBffSessions('/app');
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('revokeBffSession', () => {
+    it('should DELETE /{prefix}/bff/sessions/{id} with CSRF token', async () => {
+      // Setup CsrfManager with a token
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'csrf-123' }), { status: 200 })
+      );
+      const csrfManager = new CsrfManager('/admin');
+      await csrfManager.fetchToken();
+
+      // Mock the revoke call
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await revokeBffSession('/admin', 'ab12...yz89', csrfManager);
+
+      const lastCall = vi.mocked(globalThis.fetch).mock.calls[1];
+      expect(lastCall[0]).toBe('/admin/bff/sessions/ab12...yz89');
+      expect(lastCall[1]?.method).toBe('DELETE');
+      const headers = new Headers(lastCall[1]?.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('csrf-123');
+    });
+
+    it('should URL-encode the session ID', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'csrf-enc' }), { status: 200 })
+      );
+      const csrfManager = new CsrfManager('/app');
+      await csrfManager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await revokeBffSession('/app', 'id/with special', csrfManager);
+
+      const lastCall = vi.mocked(globalThis.fetch).mock.calls[1];
+      expect(lastCall[0]).toBe('/app/bff/sessions/id%2Fwith%20special');
+    });
+
+    it('should throw on 404 response', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'csrf-404' }), { status: 200 })
+      );
+      const csrfManager = new CsrfManager('/admin');
+      await csrfManager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response('Not found', { status: 404 }));
+
+      await expect(revokeBffSession('/admin', 'unknown', csrfManager)).rejects.toThrow(
+        'Failed to revoke BFF session: 404'
+      );
+    });
+  });
+
+  describe('revokeAllOtherBffSessions', () => {
+    it('should DELETE /{prefix}/bff/sessions with CSRF token', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'csrf-all' }), { status: 200 })
+      );
+      const csrfManager = new CsrfManager('/admin');
+      await csrfManager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+      await revokeAllOtherBffSessions('/admin', csrfManager);
+
+      const lastCall = vi.mocked(globalThis.fetch).mock.calls[1];
+      expect(lastCall[0]).toBe('/admin/bff/sessions');
+      expect(lastCall[1]?.method).toBe('DELETE');
+      const headers = new Headers(lastCall[1]?.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('csrf-all');
+    });
+
+    it('should throw on 401 response', async () => {
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ token: 'csrf-401' }), { status: 200 })
+      );
+      const csrfManager = new CsrfManager('/app');
+      await csrfManager.fetchToken();
+
+      vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+        new Response('Unauthorized', { status: 401 })
+      );
+
+      await expect(revokeAllOtherBffSessions('/app', csrfManager)).rejects.toThrow(
+        'Failed to revoke all other BFF sessions: 401'
+      );
+    });
+  });
+});

--- a/packages/@granit/bff/src/api/bff-session-api.ts
+++ b/packages/@granit/bff/src/api/bff-session-api.ts
@@ -1,0 +1,71 @@
+// ---------------------------------------------------------------------------
+// BFF session management API — mirrors Granit.Bff.Endpoints.BffSessionEndpoints
+//
+// Uses native fetch with credentials: 'include' (cookie-based BFF auth).
+// Mutation endpoints (DELETE) require a CSRF token via CsrfManager.
+// ---------------------------------------------------------------------------
+
+import type { CsrfManager } from '../csrf/index.js';
+import type { BffSessionInfo, BffSessionListResponse } from '../types/index.js';
+
+/**
+ * Lists the current user's active BFF sessions.
+ *
+ * Session IDs are masked server-side for security.
+ *
+ * @returns Array of active sessions with metadata.
+ * @throws Error on non-OK response (401 if not authenticated).
+ */
+export async function fetchBffSessions(pathPrefix: string): Promise<readonly BffSessionInfo[]> {
+  const response = await fetch(`${pathPrefix}/bff/sessions`, {
+    credentials: 'include',
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to fetch BFF sessions: ${response.status}`);
+  }
+  const data = (await response.json()) as BffSessionListResponse;
+  return data.sessions;
+}
+
+/**
+ * Revokes a specific BFF session by its (masked) ID.
+ *
+ * Cannot revoke the current session — use logout instead.
+ *
+ * @param sessionId - The masked session ID to revoke.
+ * @throws Error on non-OK response (404 if not found, 401 if not authenticated).
+ */
+export async function revokeBffSession(
+  pathPrefix: string,
+  sessionId: string,
+  csrfManager: CsrfManager
+): Promise<void> {
+  const fetchWithCsrf = csrfManager.createFetchWithCsrf();
+  const response = await fetchWithCsrf(
+    `${pathPrefix}/bff/sessions/${encodeURIComponent(sessionId)}`,
+    { method: 'DELETE' }
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to revoke BFF session: ${response.status}`);
+  }
+}
+
+/**
+ * Revokes all other BFF sessions except the current one.
+ *
+ * Use case: "Log out everywhere else".
+ *
+ * @throws Error on non-OK response (401 if not authenticated).
+ */
+export async function revokeAllOtherBffSessions(
+  pathPrefix: string,
+  csrfManager: CsrfManager
+): Promise<void> {
+  const fetchWithCsrf = csrfManager.createFetchWithCsrf();
+  const response = await fetchWithCsrf(`${pathPrefix}/bff/sessions`, {
+    method: 'DELETE',
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to revoke all other BFF sessions: ${response.status}`);
+  }
+}

--- a/packages/@granit/bff/src/index.ts
+++ b/packages/@granit/bff/src/index.ts
@@ -1,3 +1,16 @@
-export type { BffConfig, BffUnauthenticated, BffUser, BffUserResponse } from './types/index.js';
+export type {
+  BffConfig,
+  BffSessionInfo,
+  BffSessionListResponse,
+  BffUnauthenticated,
+  BffUser,
+  BffUserResponse,
+} from './types/index.js';
 
 export { CsrfManager } from './csrf/index.js';
+
+export {
+  fetchBffSessions,
+  revokeAllOtherBffSessions,
+  revokeBffSession,
+} from './api/bff-session-api.js';

--- a/packages/@granit/bff/src/types/index.ts
+++ b/packages/@granit/bff/src/types/index.ts
@@ -21,6 +21,23 @@ export interface BffUnauthenticated {
 /** Union type for the /bff/user endpoint response. */
 export type BffUserResponse = BffUser | BffUnauthenticated;
 
+/** A single BFF session entry. Session IDs are masked server-side for security. */
+export interface BffSessionInfo {
+  /** Masked session identifier (e.g. "ab12...yz89"). */
+  readonly sessionId: string;
+  /** Whether this is the calling session. */
+  readonly isCurrent: boolean;
+  /** When the session was created. ISO 8601 string. */
+  readonly createdAt: string;
+  /** User-Agent string captured at session creation, if available. */
+  readonly userAgent: string | null;
+}
+
+/** Response from GET /{prefix}/bff/sessions. */
+export interface BffSessionListResponse {
+  readonly sessions: readonly BffSessionInfo[];
+}
+
 /** Configuration for the BFF authentication provider. */
 export interface BffConfig {
   /** Path prefix for this frontend (e.g., "/admin"). */

--- a/packages/@granit/react-bff/src/__tests__/bff-sessions.test.tsx
+++ b/packages/@granit/react-bff/src/__tests__/bff-sessions.test.tsx
@@ -1,0 +1,269 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useBffSessions,
+  useRevokeBffSession,
+  useRevokeAllOtherBffSessions,
+} from '../hooks/use-bff-sessions.js';
+import { BffProvider } from '../providers/bff-provider.js';
+
+import type { BffConfig } from '@granit/bff';
+
+const authenticatedResponse = {
+  authenticated: true,
+  sub: 'user-123',
+  name: 'Alice',
+  email: 'alice@test.com',
+  roles: ['admin'],
+  tenantId: 'tenant-1',
+  sessionExpiresAt: '2026-03-23T20:00:00Z',
+};
+
+const csrfResponse = { token: 'csrf-test-token' };
+
+const sessionsResponse = {
+  sessions: [
+    {
+      sessionId: 'ab12...yz89',
+      isCurrent: true,
+      createdAt: '2026-03-23T10:00:00Z',
+      userAgent: 'Mozilla/5.0',
+    },
+    {
+      sessionId: 'cd34...wx67',
+      isCurrent: false,
+      createdAt: '2026-03-22T08:00:00Z',
+      userAgent: null,
+    },
+  ],
+};
+
+function mockFetchResponses(...responses: Array<{ body: object; status?: number }>) {
+  const fn = vi.fn();
+  for (const resp of responses) {
+    fn.mockResolvedValueOnce(
+      new Response(JSON.stringify(resp.body), { status: resp.status ?? 200 })
+    );
+  }
+  return fn;
+}
+
+function createWrapper(config: BffConfig) {
+  return ({ children }: { children: React.ReactNode }) => (
+    <BffProvider config={config}>{children}</BffProvider>
+  );
+}
+
+const defaultConfig: BffConfig = { pathPrefix: '/admin', sessionCheckInterval: 0 };
+
+describe('useBffSessions', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should fetch sessions when authenticated', async () => {
+    globalThis.fetch = mockFetchResponses(
+      { body: authenticatedResponse },
+      { body: csrfResponse },
+      { body: sessionsResponse }
+    );
+
+    const { result } = renderHook(() => useBffSessions(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessions).toHaveLength(2);
+    });
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.sessions[0].sessionId).toBe('ab12...yz89');
+    expect(result.current.sessions[0].isCurrent).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('should return empty sessions when not authenticated', async () => {
+    globalThis.fetch = mockFetchResponses({ body: { authenticated: false } });
+
+    const { result } = renderHook(() => useBffSessions(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it('should set error on fetch failure', async () => {
+    globalThis.fetch = mockFetchResponses({ body: authenticatedResponse }, { body: csrfResponse });
+    // The sessions fetch fails
+    vi.mocked(globalThis.fetch).mockRejectedValueOnce(new Error('Network error'));
+
+    const { result } = renderHook(() => useBffSessions(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).not.toBeNull();
+    });
+
+    expect(result.current.error?.message).toBe('Network error');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.sessions).toEqual([]);
+  });
+
+  it('should support refetch', async () => {
+    globalThis.fetch = mockFetchResponses(
+      { body: authenticatedResponse },
+      { body: csrfResponse },
+      { body: { sessions: [sessionsResponse.sessions[0]] } },
+      { body: sessionsResponse }
+    );
+
+    const { result } = renderHook(() => useBffSessions(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    await waitFor(() => {
+      expect(result.current.sessions).toHaveLength(1);
+    });
+
+    await act(async () => {
+      await result.current.refetch();
+    });
+
+    expect(result.current.sessions).toHaveLength(2);
+  });
+});
+
+describe('useRevokeBffSession', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should revoke a session and toggle isRevoking', async () => {
+    globalThis.fetch = mockFetchResponses({ body: authenticatedResponse }, { body: csrfResponse });
+    // Revoke response
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const { result } = renderHook(() => useRevokeBffSession(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    // Wait for auth init
+    await waitFor(() => {
+      expect(result.current.isRevoking).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.revoke('cd34...wx67');
+    });
+
+    expect(result.current.isRevoking).toBe(false);
+
+    // Verify the DELETE call was made
+    const calls = vi.mocked(globalThis.fetch).mock.calls;
+    const deleteCall = calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('/bff/sessions/cd34...wx67')
+    );
+    expect(deleteCall).toBeDefined();
+    expect(deleteCall?.[1]?.method).toBe('DELETE');
+  });
+
+  it('should propagate errors from revoke', async () => {
+    globalThis.fetch = mockFetchResponses({ body: authenticatedResponse }, { body: csrfResponse });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response('Not found', { status: 404 }));
+
+    const { result } = renderHook(() => useRevokeBffSession(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRevoking).toBe(false);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.revoke('unknown-id');
+      })
+    ).rejects.toThrow('Failed to revoke BFF session: 404');
+  });
+});
+
+describe('useRevokeAllOtherBffSessions', () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('should revoke all other sessions', async () => {
+    globalThis.fetch = mockFetchResponses({ body: authenticatedResponse }, { body: csrfResponse });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(new Response(null, { status: 204 }));
+
+    const { result } = renderHook(() => useRevokeAllOtherBffSessions(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRevoking).toBe(false);
+    });
+
+    await act(async () => {
+      await result.current.revokeAll();
+    });
+
+    expect(result.current.isRevoking).toBe(false);
+
+    // Verify the DELETE call was made to /bff/sessions (no ID suffix)
+    const calls = vi.mocked(globalThis.fetch).mock.calls;
+    const deleteCall = calls.find(
+      (c) => typeof c[0] === 'string' && c[0] === '/admin/bff/sessions' && c[1]?.method === 'DELETE'
+    );
+    expect(deleteCall).toBeDefined();
+  });
+
+  it('should propagate errors from revokeAll', async () => {
+    globalThis.fetch = mockFetchResponses({ body: authenticatedResponse }, { body: csrfResponse });
+    vi.mocked(globalThis.fetch).mockResolvedValueOnce(
+      new Response('Unauthorized', { status: 401 })
+    );
+
+    const { result } = renderHook(() => useRevokeAllOtherBffSessions(), {
+      wrapper: createWrapper(defaultConfig),
+    });
+
+    await waitFor(() => {
+      expect(result.current.isRevoking).toBe(false);
+    });
+
+    await expect(
+      act(async () => {
+        await result.current.revokeAll();
+      })
+    ).rejects.toThrow('Failed to revoke all other BFF sessions: 401');
+  });
+});

--- a/packages/@granit/react-bff/src/hooks/use-bff-sessions.ts
+++ b/packages/@granit/react-bff/src/hooks/use-bff-sessions.ts
@@ -1,0 +1,125 @@
+import { fetchBffSessions, revokeAllOtherBffSessions, revokeBffSession } from '@granit/bff';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useBffContext } from '../providers/bff-provider.js';
+
+import type { BffSessionInfo } from '@granit/bff';
+
+interface UseBffSessionsResult {
+  /** Active sessions for the current user. Empty array while loading. */
+  readonly sessions: readonly BffSessionInfo[];
+  /** Whether the initial fetch is in progress. */
+  readonly isLoading: boolean;
+  /** Error from the last fetch attempt, or null. */
+  readonly error: Error | null;
+  /** Re-fetch the session list. */
+  readonly refetch: () => Promise<void>;
+}
+
+/**
+ * Hook to list the current user's active BFF sessions.
+ *
+ * Only fetches when the user is authenticated.
+ */
+export function useBffSessions(): UseBffSessionsResult {
+  const { isAuthenticated, isLoading: authLoading, pathPrefix } = useBffContext();
+
+  const [sessions, setSessions] = useState<readonly BffSessionInfo[]>([]);
+  const [fetchLoading, setFetchLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const mountedRef = useRef(true);
+
+  const refetch = useCallback(async () => {
+    try {
+      setFetchLoading(true);
+      setError(null);
+      const result = await fetchBffSessions(pathPrefix);
+      if (mountedRef.current) {
+        setSessions(result);
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(err instanceof Error ? err : new Error(String(err)));
+      }
+    } finally {
+      if (mountedRef.current) {
+        setFetchLoading(false);
+      }
+    }
+  }, [pathPrefix]);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    if (isAuthenticated) {
+      void refetch();
+    } else if (!authLoading) {
+      setSessions([]);
+    }
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [isAuthenticated, authLoading, refetch]);
+
+  const isLoading = authLoading || fetchLoading;
+
+  return { sessions, isLoading, error, refetch } as const;
+}
+
+interface UseRevokeBffSessionResult {
+  /** Revoke a specific session by its masked ID. Returns a promise that resolves on success. */
+  readonly revoke: (sessionId: string) => Promise<void>;
+  /** Whether a revocation is in progress. */
+  readonly isRevoking: boolean;
+}
+
+/**
+ * Hook to revoke a specific BFF session.
+ *
+ * Cannot revoke the current session — use logout instead.
+ */
+export function useRevokeBffSession(): UseRevokeBffSessionResult {
+  const { pathPrefix, csrfManager } = useBffContext();
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const revoke = useCallback(
+    async (sessionId: string) => {
+      setIsRevoking(true);
+      try {
+        await revokeBffSession(pathPrefix, sessionId, csrfManager);
+      } finally {
+        setIsRevoking(false);
+      }
+    },
+    [pathPrefix, csrfManager]
+  );
+
+  return { revoke, isRevoking } as const;
+}
+
+interface UseRevokeAllOtherBffSessionsResult {
+  /** Revoke all sessions except the current one ("log out everywhere else"). */
+  readonly revokeAll: () => Promise<void>;
+  /** Whether a revocation is in progress. */
+  readonly isRevoking: boolean;
+}
+
+/**
+ * Hook to revoke all other BFF sessions except the current one.
+ *
+ * Use case: "Log out everywhere else".
+ */
+export function useRevokeAllOtherBffSessions(): UseRevokeAllOtherBffSessionsResult {
+  const { pathPrefix, csrfManager } = useBffContext();
+  const [isRevoking, setIsRevoking] = useState(false);
+
+  const revokeAll = useCallback(async () => {
+    setIsRevoking(true);
+    try {
+      await revokeAllOtherBffSessions(pathPrefix, csrfManager);
+    } finally {
+      setIsRevoking(false);
+    }
+  }, [pathPrefix, csrfManager]);
+
+  return { revokeAll, isRevoking } as const;
+}

--- a/packages/@granit/react-bff/src/index.ts
+++ b/packages/@granit/react-bff/src/index.ts
@@ -5,5 +5,11 @@ export { useBffAuth } from './hooks/use-bff-auth.js';
 export { useBffCsrf } from './hooks/use-bff-csrf.js';
 export { useBffFetch } from './hooks/use-bff-fetch.js';
 
+export {
+  useBffSessions,
+  useRevokeBffSession,
+  useRevokeAllOtherBffSessions,
+} from './hooks/use-bff-sessions.js';
+
 export { BffGuard } from './components/bff-guard.js';
 export type { BffGuardProps } from './components/bff-guard.js';

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -18,6 +18,8 @@ export interface BffContextType {
   readonly logout: () => void;
   /** CSRF manager instance for advanced use cases. */
   readonly csrfManager: CsrfManager;
+  /** Path prefix for this frontend (e.g., "/admin"). */
+  readonly pathPrefix: string;
 }
 
 const BffContext = createContext<BffContextType | null>(null);
@@ -92,6 +94,7 @@ export function BffProvider({ config, children }: BffProviderProps) {
         login,
         logout,
         csrfManager,
+        pathPrefix: config.pathPrefix,
       }}
     >
       {children}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,8 +77,8 @@ importers:
         specifier: ^19.2.14
         version: 19.2.14
       '@vitejs/plugin-react':
-        specifier: ^5.2.0
-        version: 5.2.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+        specifier: ^6.0.1
+        version: 6.0.1(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
       '@vitest/coverage-v8':
         specifier: ^4.1.0
         version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)))
@@ -1299,10 +1299,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
 
-  '@babel/helper-plugin-utils@7.28.6':
-    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -1323,18 +1319,6 @@ packages:
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1':
-    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1':
-    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
 
   '@babel/runtime@7.28.6':
     resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
@@ -1492,14 +1476,8 @@ packages:
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
-
   '@emnapi/runtime@1.9.0':
     resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
-
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
 
   '@emnapi/wasi-threads@1.2.0':
     resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
@@ -1967,36 +1945,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -2278,36 +2262,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.10':
     resolution: {integrity: sha512-vELN+HNb2IzuzSBUOD4NHmP9yrGwl1DVM29wlQvx1OLSclL0NgVWnVDKl/8tEks79EFek/kebQKnNJkIAA4W2g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-ZqrufYTgzxbHwpqOjzSsb0UV/aV2TFIY5rP8HdsiPTv/CuAgCRjM6s9cYFwQ4CNH+hf9Y4erHW1GjZuZ7WoI7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-gSlmVS1FZJSRicA6IyjoRoKAFK7IIHBs7xJuHRSmjImqk3mPPWbR7RhbnfH2G6bcmMEllCt2vQ/7u9e6bBnByg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.10':
     resolution: {integrity: sha512-eOCKUpluKgfObT2pHjztnaWEIbUabWzk3qPZ5PuacuPmr4+JtQG4k2vGTY0H15edaTnicgU428XW/IH6AimcQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.10':
     resolution: {integrity: sha512-Xdf2jQbfQowJnLcgYfD/m0Uu0Qj5OdxKallD78/IPPfzaiaI4KRAwZzHcKQ4ig1gtg1SuzC7jovNiM2TzQsBXA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.10':
     resolution: {integrity: sha512-o1hYe8hLi1EY6jgPFyxQgQ1wcycX+qz8eEbVmot2hFkgUzPxy9+kF0u0NIQBeDq+Mko47AkaFFaChcvZa9UX9Q==}
@@ -2335,8 +2325,8 @@ packages:
   '@rolldown/pluginutils@1.0.0-rc.10':
     resolution: {integrity: sha512-UkVDEFk1w3mveXeKgaTuYfKWtPbvgck1dT8TUG3bnccrH0XtLTuAyfCoks4Q/M5ZGToSVJTIQYCzy2g/atAOeg==}
 
-  '@rolldown/pluginutils@1.0.0-rc.3':
-    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     resolution: {integrity: sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==}
@@ -2372,66 +2362,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2516,24 +2519,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -2635,18 +2642,6 @@ packages:
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
-
-  '@types/babel__core@7.20.5':
-    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
-
-  '@types/babel__generator@7.27.0':
-    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
-
-  '@types/babel__template@7.4.4':
-    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
-
-  '@types/babel__traverse@7.28.0':
-    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -2782,41 +2777,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2838,11 +2841,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitejs/plugin-react@5.2.0':
-    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+  '@vitejs/plugin-react@6.0.1':
+    resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^8.0.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/coverage-v8@4.1.0':
     resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
@@ -3807,24 +3817,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4291,10 +4305,6 @@ packages:
 
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
-
-  react-refresh@0.18.0:
-    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
-    engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
@@ -4991,8 +5001,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-plugin-utils@7.28.6': {}
-
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -5007,16 +5015,6 @@ snapshots:
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
-
-  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
-
-  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/helper-plugin-utils': 7.28.6
 
   '@babel/runtime@7.28.6': {}
 
@@ -5211,18 +5209,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/core@1.9.1':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.0
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.9.0':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -5436,8 +5423,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -5901,7 +5888,7 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.0-rc.10': {}
 
-  '@rolldown/pluginutils@1.0.0-rc.3': {}
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
 
   '@rollup/rollup-android-arm-eabi@4.59.0':
     optional: true
@@ -6124,27 +6111,6 @@ snapshots:
 
   '@types/aria-query@5.0.4': {}
 
-  '@types/babel__core@7.20.5':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-      '@types/babel__generator': 7.27.0
-      '@types/babel__template': 7.4.4
-      '@types/babel__traverse': 7.28.0
-
-  '@types/babel__generator@7.27.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
-  '@types/babel__template@7.4.4':
-    dependencies:
-      '@babel/parser': 7.29.2
-      '@babel/types': 7.29.0
-
-  '@types/babel__traverse@7.28.0':
-    dependencies:
-      '@babel/types': 7.29.0
-
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -6328,17 +6294,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@5.2.0(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))':
     dependencies:
-      '@babel/core': 7.29.0
-      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
-      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rolldown/pluginutils': 1.0.0-rc.3
-      '@types/babel__core': 7.20.5
-      react-refresh: 0.18.0
+      '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)
-    transitivePeerDependencies:
-      - supports-color
 
   '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@25.3.3)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.3.3)(typescript@5.9.3))(vite@8.0.1(@types/node@25.3.3)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)))':
     dependencies:
@@ -7852,8 +7811,6 @@ snapshots:
       typescript: 5.9.3
 
   react-is@17.0.2: {}
-
-  react-refresh@0.18.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
     dependencies:


### PR DESCRIPTION
## Summary

- **Vite 7 → 8** and `@vitejs/plugin-react` 5 → 6 (dependabot bump + manual lockfile alignment)
- **BFF session management SDK** — expose the 3 `BffSessionEndpoints` from the .NET backend:
  - `@granit/bff`: `BffSessionInfo` / `BffSessionListResponse` types, `fetchBffSessions`, `revokeBffSession`, `revokeAllOtherBffSessions` API functions
  - `@granit/react-bff`: `useBffSessions`, `useRevokeBffSession`, `useRevokeAllOtherBffSessions` hooks, `pathPrefix` exposed from `BffProvider`
  - Full test coverage for both packages (8 API tests + 7 hook tests)

## Test plan

- [x] `pnpm lint` — clean (0 warnings)
- [x] `pnpm tsc` — clean
- [x] `pnpm vitest run` — 37 tests passing (BFF packages)
- [ ] Verify showcase-admin-react works with the new hooks (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)