### PR TITLE
feat: refactor authentication packages and add local auth support

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -21,6 +21,21 @@
           "signature": "async function updateProfile( client: AxiosInstance, basePath: string, request: AccountProfileUpdateRequest ): Promise<AccountProfileResponse>"
         },
         {
+          "name": "changePassword",
+          "kind": "function",
+          "signature": "async function changePassword( client: AxiosInstance, basePath: string, request: AccountPasswordChangeRequest ): Promise<void>"
+        },
+        {
+          "name": "forgotPassword",
+          "kind": "function",
+          "signature": "async function forgotPassword( client: AxiosInstance, basePath: string, request: AccountForgotPasswordRequest ): Promise<void>"
+        },
+        {
+          "name": "resetPassword",
+          "kind": "function",
+          "signature": "async function resetPassword( client: AxiosInstance, basePath: string, request: AccountPasswordResetRequest ): Promise<void>"
+        },
+        {
           "name": "backToImpersonator",
           "kind": "function",
           "signature": "async function backToImpersonator( client: AxiosInstance, basePath: string ): Promise<AccountImpersonationResult>"
@@ -203,13 +218,39 @@
     },
     {
       "name": "@granit/authentication",
-      "description": "Keycloak/OIDC authentication types — TypeScript mirror of Granit.Authentication .NET",
+      "description": "Provider-agnostic OIDC authentication types — base context, user info, login/logout options",
       "exports": []
     },
     {
       "name": "@granit/authentication-api-keys",
       "description": "API key types — TypeScript mirror of Granit.Authentication.ApiKeys .NET",
       "exports": []
+    },
+    {
+      "name": "@granit/authentication-keycloak",
+      "description": "Keycloak OIDC authentication types — KeycloakAuthContextType, config, events",
+      "exports": []
+    },
+    {
+      "name": "@granit/authentication-local",
+      "description": "Local credential authentication types and API — headless login, passkey assertion — mirrors Granit.Identity.Local.Endpoints .NET contract",
+      "exports": [
+        {
+          "name": "localAuthKeys",
+          "kind": "const",
+          "signature": "const localAuthKeys"
+        },
+        {
+          "name": "loginAccount",
+          "kind": "function",
+          "signature": "async function loginAccount( client: AxiosInstance, basePath: string, request: AccountLoginRequest ): Promise<AccountLoginResponse>"
+        },
+        {
+          "name": "beginPasskeyAssertion",
+          "kind": "function",
+          "signature": "async function beginPasskeyAssertion( client: AxiosInstance, basePath: string ): Promise<string>"
+        }
+      ]
     },
     {
       "name": "@granit/authorization",
@@ -944,60 +985,8 @@
     },
     {
       "name": "@granit/react-authentication",
-      "description": "React bindings for @granit/authentication — Keycloak init hook, auth context factory, mock provider",
+      "description": "React bindings for @granit/authentication — generic auth context factory, mock provider",
       "exports": [
-        {
-          "name": "useKeycloakInit",
-          "kind": "function",
-          "signature": "function useKeycloakInit(config: KeycloakCoreConfig): KeycloakCoreResult"
-        },
-        {
-          "name": "KeycloakCoreResult",
-          "kind": "interface",
-          "signature": "interface KeycloakCoreResult extends BaseAuthContextType",
-          "members": [
-            {
-              "name": "keycloakRef",
-              "kind": "property",
-              "signature": "keycloakRef: React.RefObject<Keycloak | null>"
-            },
-            {
-              "name": "login",
-              "kind": "method",
-              "signature": "login: (options?: LoginOptions) => void"
-            },
-            {
-              "name": "logout",
-              "kind": "method",
-              "signature": "logout: (options?: LogoutOptions) => void"
-            },
-            {
-              "name": "register",
-              "kind": "method",
-              "signature": "register: (options?: Omit<LoginOptions, 'action'>) => void"
-            },
-            {
-              "name": "hasRealmRole",
-              "kind": "method",
-              "signature": "hasRealmRole: (role: string) => boolean"
-            },
-            {
-              "name": "hasResourceRole",
-              "kind": "method",
-              "signature": "hasResourceRole: (role: string, resource?: string) => boolean"
-            },
-            {
-              "name": "isTokenExpired",
-              "kind": "method",
-              "signature": "isTokenExpired: (minValidity?: number) => boolean"
-            },
-            {
-              "name": "tokenParsed",
-              "kind": "property",
-              "signature": "tokenParsed: Record<string, unknown> | undefined"
-            }
-          ]
-        },
         {
           "name": "createAuthContext",
           "kind": "function",
@@ -1099,6 +1088,92 @@
               "signature": "request: ApiKeyUpdateScopesRequest"
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-authentication-keycloak",
+      "description": "React hooks for Keycloak OIDC authentication — useKeycloakInit",
+      "exports": [
+        {
+          "name": "useKeycloakInit",
+          "kind": "function",
+          "signature": "function useKeycloakInit(config: KeycloakCoreConfig): KeycloakCoreResult"
+        },
+        {
+          "name": "KeycloakCoreResult",
+          "kind": "interface",
+          "signature": "interface KeycloakCoreResult extends KeycloakAuthContextType",
+          "members": [
+            {
+              "name": "keycloakRef",
+              "kind": "property",
+              "signature": "keycloakRef: React.RefObject<Keycloak | null>"
+            },
+            {
+              "name": "login",
+              "kind": "method",
+              "signature": "login: (options?: LoginOptions) => void"
+            },
+            {
+              "name": "logout",
+              "kind": "method",
+              "signature": "logout: (options?: LogoutOptions) => void"
+            },
+            {
+              "name": "register",
+              "kind": "method",
+              "signature": "register: (options?: Omit<LoginOptions, 'action'>) => void"
+            },
+            {
+              "name": "hasRealmRole",
+              "kind": "method",
+              "signature": "hasRealmRole: (role: string) => boolean"
+            },
+            {
+              "name": "hasResourceRole",
+              "kind": "method",
+              "signature": "hasResourceRole: (role: string, resource?: string) => boolean"
+            },
+            {
+              "name": "isTokenExpired",
+              "kind": "method",
+              "signature": "isTokenExpired: (minValidity?: number) => boolean"
+            },
+            {
+              "name": "tokenParsed",
+              "kind": "property",
+              "signature": "tokenParsed: Record<string, unknown> | undefined"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-authentication-local",
+      "description": "React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion",
+      "exports": [
+        {
+          "name": "LocalAuthConfig",
+          "kind": "interface",
+          "signature": "interface LocalAuthConfig",
+          "members": []
+        },
+        {
+          "name": "LocalAuthProviderProps",
+          "kind": "interface",
+          "signature": "interface LocalAuthProviderProps",
+          "members": []
+        },
+        {
+          "name": "useLogin",
+          "kind": "function",
+          "signature": "function useLogin(): UseMutationResult<AccountLoginResponse, Error, AccountLoginRequest>"
+        },
+        {
+          "name": "useBeginPasskeyAssertion",
+          "kind": "function",
+          "signature": "function useBeginPasskeyAssertion(): UseMutationResult<string, Error, void>"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -63,7 +63,11 @@
     "overrides": {
       "immutable": ">=5.1.5",
       "flatted": ">=3.4.2",
-      "@tanstack/query-core": "^5.95.0"
+      "@tanstack/query-core": "^5.95.0",
+      "picomatch": ">=4.0.4",
+      "yaml": ">=2.8.3",
+      "smol-toml": ">=1.6.1",
+      "brace-expansion": ">=5.0.5"
     }
   },
   "lint-staged": {

--- a/packages/@granit/account/src/__tests__/account-passkey-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-passkey-api.test.ts
@@ -2,7 +2,6 @@ import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
-  beginPasskeyAssertion,
   beginPasskeyRegistration,
   completePasskeyRegistration,
   deletePasskey,
@@ -69,19 +68,6 @@ describe('account-passkey-api', () => {
         name: 'iPhone',
       });
       expect(result).toEqual(response);
-    });
-  });
-
-  describe('beginPasskeyAssertion', () => {
-    it('sends POST /passkeys/assertion/begin and returns raw JSON', async () => {
-      const client = createMockClient();
-      const optionsJson = '{"challenge":"def456"}';
-      vi.mocked(client.post).mockResolvedValueOnce({ data: optionsJson });
-
-      const result = await beginPasskeyAssertion(client, BASE);
-
-      expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/assertion/begin`);
-      expect(result).toBe(optionsJson);
     });
   });
 

--- a/packages/@granit/account/src/api/account-passkey-api.ts
+++ b/packages/@granit/account/src/api/account-passkey-api.ts
@@ -51,21 +51,6 @@ export async function completePasskeyRegistration(
 }
 
 /**
- * Begin a WebAuthn assertion ceremony for passkey login (anonymous).
- * Returns raw `PublicKeyCredentialRequestOptions` JSON string.
- * Assertion completion goes through `/connect/token` (OIDC layer).
- *
- * `POST {basePath}/passkeys/assertion/begin`
- */
-export async function beginPasskeyAssertion(
-  client: AxiosInstance,
-  basePath: string
-): Promise<string> {
-  const { data } = await client.post<string>(`${basePath}/passkeys/assertion/begin`);
-  return data;
-}
-
-/**
  * Rename a passkey.
  *
  * `PATCH {basePath}/passkeys/{id}`

--- a/packages/@granit/account/src/index.ts
+++ b/packages/@granit/account/src/index.ts
@@ -1,12 +1,6 @@
 // Types
-export type {
-  AccountRegisterRequest,
-  AccountRegisterResponse,
-} from './types/index.js';
-export type {
-  AccountProfileResponse,
-  AccountProfileUpdateRequest,
-} from './types/index.js';
+export type { AccountRegisterRequest, AccountRegisterResponse } from './types/index.js';
+export type { AccountProfileResponse, AccountProfileUpdateRequest } from './types/index.js';
 export type {
   AccountForgotPasswordRequest,
   AccountPasswordChangeRequest,
@@ -46,11 +40,7 @@ export {
 export { getProfile, updateProfile } from './api/account-profile-api.js';
 
 // API — Password
-export {
-  changePassword,
-  forgotPassword,
-  resetPassword,
-} from './api/account-password-api.js';
+export { changePassword, forgotPassword, resetPassword } from './api/account-password-api.js';
 
 // API — Two-Factor
 export {
@@ -69,9 +59,8 @@ export {
   unlinkExternalLogin,
 } from './api/account-external-login-api.js';
 
-// API — Passkeys
+// API — Passkeys (beginPasskeyAssertion moved to @granit/authentication-local)
 export {
-  beginPasskeyAssertion,
   beginPasskeyRegistration,
   completePasskeyRegistration,
   deletePasskey,

--- a/packages/@granit/authentication-keycloak/package.json
+++ b/packages/@granit/authentication-keycloak/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@granit/authentication",
-  "description": "Provider-agnostic OIDC authentication types — base context, user info, login/logout options",
-  "version": "0.3.0",
+  "name": "@granit/authentication-keycloak",
+  "description": "Keycloak OIDC authentication types — KeycloakAuthContextType, config, events",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -12,6 +12,10 @@
   ],
   "scripts": {
     "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/authentication": "workspace:*",
+    "keycloak-js": "*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/authentication-keycloak/src/__tests__/keycloak-types.test.ts
+++ b/packages/@granit/authentication-keycloak/src/__tests__/keycloak-types.test.ts
@@ -1,0 +1,63 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type {
+  KeycloakAuthContextType,
+  KeycloakCoreConfig,
+  KeycloakEvent,
+  KeycloakUserInfo,
+} from '../index.js';
+
+describe('@granit/authentication-keycloak types', () => {
+  describe('KeycloakUserInfo', () => {
+    it('should require sub field', () => {
+      expectTypeOf<KeycloakUserInfo>().toHaveProperty('sub');
+      expectTypeOf<KeycloakUserInfo['sub']>().toBeString();
+    });
+
+    it('should have optional profile fields', () => {
+      expectTypeOf<KeycloakUserInfo>().toHaveProperty('email');
+      expectTypeOf<KeycloakUserInfo>().toHaveProperty('name');
+      expectTypeOf<KeycloakUserInfo>().toHaveProperty('preferred_username');
+      expectTypeOf<KeycloakUserInfo>().toHaveProperty('given_name');
+      expectTypeOf<KeycloakUserInfo>().toHaveProperty('family_name');
+    });
+  });
+
+  describe('KeycloakEvent', () => {
+    it('should accept valid event names', () => {
+      expectTypeOf<'onReady'>().toMatchTypeOf<KeycloakEvent>();
+      expectTypeOf<'onAuthSuccess'>().toMatchTypeOf<KeycloakEvent>();
+      expectTypeOf<'onAuthError'>().toMatchTypeOf<KeycloakEvent>();
+      expectTypeOf<'onTokenExpired'>().toMatchTypeOf<KeycloakEvent>();
+    });
+  });
+
+  describe('KeycloakAuthContextType', () => {
+    it('should extend BaseAuthContextType with keycloak field', () => {
+      expectTypeOf<KeycloakAuthContextType>().toHaveProperty('keycloak');
+      expectTypeOf<KeycloakAuthContextType>().toHaveProperty('authenticated');
+      expectTypeOf<KeycloakAuthContextType>().toHaveProperty('loading');
+      expectTypeOf<KeycloakAuthContextType>().toHaveProperty('user');
+      expectTypeOf<KeycloakAuthContextType>().toHaveProperty('login');
+      expectTypeOf<KeycloakAuthContextType>().toHaveProperty('logout');
+    });
+  });
+
+  describe('KeycloakCoreConfig', () => {
+    it('should require url, realm, and clientId', () => {
+      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('url');
+      expectTypeOf<KeycloakCoreConfig['url']>().toBeString();
+      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('realm');
+      expectTypeOf<KeycloakCoreConfig['realm']>().toBeString();
+      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('clientId');
+      expectTypeOf<KeycloakCoreConfig['clientId']>().toBeString();
+    });
+
+    it('should have optional lifecycle callbacks', () => {
+      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onTokenExpired');
+      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onAuthRefreshError');
+      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onAuthLogout');
+      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onEvent');
+    });
+  });
+});

--- a/packages/@granit/authentication-keycloak/src/index.ts
+++ b/packages/@granit/authentication-keycloak/src/index.ts
@@ -1,0 +1,6 @@
+export type {
+  KeycloakAuthContextType,
+  KeycloakCoreConfig,
+  KeycloakEvent,
+  KeycloakUserInfo,
+} from './types/index.js';

--- a/packages/@granit/authentication-keycloak/src/types/index.ts
+++ b/packages/@granit/authentication-keycloak/src/types/index.ts
@@ -1,0 +1,69 @@
+import type { BaseAuthContextType, OidcUserInfo } from '@granit/authentication';
+import type Keycloak from 'keycloak-js';
+
+// ---------------------------------------------------------------------------
+// Keycloak-specific user info (re-export of standard OIDC claims)
+// ---------------------------------------------------------------------------
+
+/** Keycloak user info — identical to `OidcUserInfo` (OIDC standard claims). */
+export type KeycloakUserInfo = OidcUserInfo;
+
+// ---------------------------------------------------------------------------
+// Event types
+// ---------------------------------------------------------------------------
+
+/** Keycloak lifecycle event names forwarded by useKeycloakInit. */
+export type KeycloakEvent =
+  | 'onReady'
+  | 'onAuthSuccess'
+  | 'onAuthError'
+  | 'onAuthRefreshSuccess'
+  | 'onAuthRefreshError'
+  | 'onAuthLogout'
+  | 'onTokenExpired';
+
+// ---------------------------------------------------------------------------
+// Auth context (extends generic base with Keycloak instance)
+// ---------------------------------------------------------------------------
+
+/** Keycloak-specific auth context — extends the generic base with the Keycloak instance. */
+export interface KeycloakAuthContextType extends BaseAuthContextType {
+  /** Live Keycloak instance — null before init completes. */
+  keycloak: Keycloak | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook configuration
+// ---------------------------------------------------------------------------
+
+export interface KeycloakCoreConfig {
+  url: string;
+  realm: string;
+  clientId: string;
+
+  /** Whether the silent SSO check is enabled (web-only, skip on native). Default: true */
+  silentCheckSso?: boolean;
+
+  /**
+   * Fall back to a regular `check-sso` redirect when the silent iframe check
+   * fails (e.g. Safari with third-party cookie blocking). Default: true
+   */
+  silentCheckSsoFallback?: boolean;
+
+  /**
+   * When true, extract user info from the decoded JWT (`tokenParsed`) instead
+   * of calling the `/userinfo` endpoint. Avoids an extra HTTP round-trip but
+   * requires the Keycloak client mappers to include the needed claims in the
+   * access token. Default: false (calls `loadUserInfo()`).
+   */
+  useTokenClaims?: boolean;
+
+  /** Called when the access token expires. */
+  onTokenExpired?: () => void;
+  /** Called when a token refresh attempt fails. */
+  onAuthRefreshError?: () => void;
+  /** Called when the Keycloak session is terminated (admin logout, SSO logout). */
+  onAuthLogout?: () => void;
+  /** Generic handler called for every Keycloak lifecycle event. */
+  onEvent?: (event: KeycloakEvent, error?: unknown) => void;
+}

--- a/packages/@granit/authentication-keycloak/tsconfig.json
+++ b/packages/@granit/authentication-keycloak/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/authentication-local/package.json
+++ b/packages/@granit/authentication-local/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@granit/authentication",
-  "description": "Provider-agnostic OIDC authentication types — base context, user info, login/logout options",
-  "version": "0.3.0",
+  "name": "@granit/authentication-local",
+  "description": "Local credential authentication types and API — headless login, passkey assertion — mirrors Granit.Identity.Local.Endpoints .NET contract",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -12,6 +12,12 @@
   ],
   "scripts": {
     "build": "tsup"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/authentication-local/src/__tests__/account-login-api.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/account-login-api.test.ts
@@ -1,0 +1,53 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { loginAccount } from '../api/account-login-api.js';
+
+import type { AccountLoginResponse } from '../types/index.js';
+
+const BASE = '/api/account';
+
+describe('account-login-api', () => {
+  describe('loginAccount', () => {
+    it('sends POST /login with credentials', async () => {
+      const client = createMockClient();
+      const response: AccountLoginResponse = {
+        succeeded: true,
+        requiresTwoFactor: false,
+        isLockedOut: false,
+        isNotAllowed: false,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await loginAccount(client, BASE, {
+        login: 'user@example.com',
+        password: 'P@ssw0rd!',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/login`, {
+        login: 'user@example.com',
+        password: 'P@ssw0rd!',
+      });
+      expect(result).toEqual(response);
+    });
+
+    it('returns requiresTwoFactor when 2FA is enabled', async () => {
+      const client = createMockClient();
+      const response: AccountLoginResponse = {
+        succeeded: false,
+        requiresTwoFactor: true,
+        isLockedOut: false,
+        isNotAllowed: false,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await loginAccount(client, BASE, {
+        login: 'user@example.com',
+        password: 'P@ssw0rd!',
+      });
+
+      expect(result.succeeded).toBe(false);
+      expect(result.requiresTwoFactor).toBe(true);
+    });
+  });
+});

--- a/packages/@granit/authentication-local/src/__tests__/account-passkey-assertion-api.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/account-passkey-assertion-api.test.ts
@@ -1,0 +1,21 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { beginPasskeyAssertion } from '../api/account-passkey-assertion-api.js';
+
+const BASE = '/api/account';
+
+describe('account-passkey-assertion-api', () => {
+  describe('beginPasskeyAssertion', () => {
+    it('sends POST /passkeys/assertion/begin and returns JSON options', async () => {
+      const client = createMockClient();
+      const optionsJson = '{"challenge":"abc123","rpId":"example.com"}';
+      vi.mocked(client.post).mockResolvedValueOnce({ data: optionsJson });
+
+      const result = await beginPasskeyAssertion(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/assertion/begin`);
+      expect(result).toBe(optionsJson);
+    });
+  });
+});

--- a/packages/@granit/authentication-local/src/api/account-login-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-login-api.ts
@@ -1,0 +1,23 @@
+import type { AccountLoginRequest, AccountLoginResponse } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Authenticate a user via local credentials (email/username + password).
+ *
+ * On success, the server sets an ASP.NET Core Identity session cookie.
+ * The caller should then redirect to the OIDC authorization endpoint
+ * (`/connect/authorize`) to complete the token exchange.
+ *
+ * The Axios instance must have `withCredentials: true` for the browser
+ * to accept the `Set-Cookie` header from the server.
+ *
+ * `POST {basePath}/login`
+ */
+export async function loginAccount(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountLoginRequest
+): Promise<AccountLoginResponse> {
+  const { data } = await client.post<AccountLoginResponse>(`${basePath}/login`, request);
+  return data;
+}

--- a/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
@@ -1,0 +1,16 @@
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Begin a WebAuthn assertion ceremony for passkey login (anonymous).
+ * Returns raw `PublicKeyCredentialRequestOptions` JSON string.
+ * Assertion completion goes through `/connect/token` (OIDC layer).
+ *
+ * `POST {basePath}/passkeys/assertion/begin`
+ */
+export async function beginPasskeyAssertion(
+  client: AxiosInstance,
+  basePath: string
+): Promise<string> {
+  const { data } = await client.post<string>(`${basePath}/passkeys/assertion/begin`);
+  return data;
+}

--- a/packages/@granit/authentication-local/src/hooks/query-keys.ts
+++ b/packages/@granit/authentication-local/src/hooks/query-keys.ts
@@ -1,0 +1,4 @@
+/** Query key factory for local authentication queries. */
+export const localAuthKeys = {
+  all: ['authentication-local'] as const,
+};

--- a/packages/@granit/authentication-local/src/index.ts
+++ b/packages/@granit/authentication-local/src/index.ts
@@ -1,0 +1,11 @@
+// Types
+export type { AccountLoginRequest, AccountLoginResponse } from './types/index.js';
+
+// Query keys
+export { localAuthKeys } from './hooks/query-keys.js';
+
+// API — Login
+export { loginAccount } from './api/account-login-api.js';
+
+// API — Passkey assertion (for login)
+export { beginPasskeyAssertion } from './api/account-passkey-assertion-api.js';

--- a/packages/@granit/authentication-local/src/types/account-login.ts
+++ b/packages/@granit/authentication-local/src/types/account-login.ts
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------
+// Account login types — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST {basePath}/login`. */
+export interface AccountLoginRequest {
+  readonly login: string;
+  readonly password: string;
+}
+
+/**
+ * Response from `POST {basePath}/login`.
+ *
+ * On success the server sets an ASP.NET Core Identity session cookie.
+ * The caller should then redirect to the OIDC authorization endpoint
+ * (`/connect/authorize`) to complete the token exchange.
+ */
+export interface AccountLoginResponse {
+  readonly succeeded: boolean;
+  readonly requiresTwoFactor: boolean;
+  readonly isLockedOut: boolean;
+  readonly isNotAllowed: boolean;
+}

--- a/packages/@granit/authentication-local/src/types/index.ts
+++ b/packages/@granit/authentication-local/src/types/index.ts
@@ -1,0 +1,1 @@
+export type { AccountLoginRequest, AccountLoginResponse } from './account-login.js';

--- a/packages/@granit/authentication-local/tsconfig.json
+++ b/packages/@granit/authentication-local/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/authentication/src/__tests__/authentication-types.test.ts
+++ b/packages/@granit/authentication/src/__tests__/authentication-types.test.ts
@@ -1,36 +1,20 @@
 import { describe, expectTypeOf, it } from 'vitest';
 
-import type {
-  BaseAuthContextType,
-  KeycloakCoreConfig,
-  KeycloakEvent,
-  KeycloakUserInfo,
-  LoginOptions,
-  LogoutOptions,
-} from '../index.js';
+import type { BaseAuthContextType, LoginOptions, LogoutOptions, OidcUserInfo } from '../index.js';
 
 describe('@granit/authentication types', () => {
-  describe('KeycloakUserInfo', () => {
+  describe('OidcUserInfo', () => {
     it('should require sub field', () => {
-      expectTypeOf<KeycloakUserInfo>().toHaveProperty('sub');
-      expectTypeOf<KeycloakUserInfo['sub']>().toBeString();
+      expectTypeOf<OidcUserInfo>().toHaveProperty('sub');
+      expectTypeOf<OidcUserInfo['sub']>().toBeString();
     });
 
     it('should have optional profile fields', () => {
-      expectTypeOf<KeycloakUserInfo>().toHaveProperty('email');
-      expectTypeOf<KeycloakUserInfo>().toHaveProperty('name');
-      expectTypeOf<KeycloakUserInfo>().toHaveProperty('preferred_username');
-      expectTypeOf<KeycloakUserInfo>().toHaveProperty('given_name');
-      expectTypeOf<KeycloakUserInfo>().toHaveProperty('family_name');
-    });
-  });
-
-  describe('KeycloakEvent', () => {
-    it('should accept valid event names', () => {
-      expectTypeOf<'onReady'>().toMatchTypeOf<KeycloakEvent>();
-      expectTypeOf<'onAuthSuccess'>().toMatchTypeOf<KeycloakEvent>();
-      expectTypeOf<'onAuthError'>().toMatchTypeOf<KeycloakEvent>();
-      expectTypeOf<'onTokenExpired'>().toMatchTypeOf<KeycloakEvent>();
+      expectTypeOf<OidcUserInfo>().toHaveProperty('email');
+      expectTypeOf<OidcUserInfo>().toHaveProperty('name');
+      expectTypeOf<OidcUserInfo>().toHaveProperty('preferred_username');
+      expectTypeOf<OidcUserInfo>().toHaveProperty('given_name');
+      expectTypeOf<OidcUserInfo>().toHaveProperty('family_name');
     });
   });
 
@@ -56,8 +40,7 @@ describe('@granit/authentication types', () => {
       expectTypeOf<BaseAuthContextType['loading']>().toBeBoolean();
     });
 
-    it('should have user and keycloak fields', () => {
-      expectTypeOf<BaseAuthContextType>().toHaveProperty('keycloak');
+    it('should have user field', () => {
       expectTypeOf<BaseAuthContextType>().toHaveProperty('user');
     });
 
@@ -67,23 +50,9 @@ describe('@granit/authentication types', () => {
       expectTypeOf<BaseAuthContextType['login']>().toBeFunction();
       expectTypeOf<BaseAuthContextType['logout']>().toBeFunction();
     });
-  });
 
-  describe('KeycloakCoreConfig', () => {
-    it('should require url, realm, and clientId', () => {
-      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('url');
-      expectTypeOf<KeycloakCoreConfig['url']>().toBeString();
-      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('realm');
-      expectTypeOf<KeycloakCoreConfig['realm']>().toBeString();
-      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('clientId');
-      expectTypeOf<KeycloakCoreConfig['clientId']>().toBeString();
-    });
-
-    it('should have optional lifecycle callbacks', () => {
-      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onTokenExpired');
-      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onAuthRefreshError');
-      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onAuthLogout');
-      expectTypeOf<KeycloakCoreConfig>().toHaveProperty('onEvent');
+    it('should NOT have keycloak field (provider-agnostic)', () => {
+      expectTypeOf<BaseAuthContextType>().not.toHaveProperty('keycloak');
     });
   });
 });

--- a/packages/@granit/authentication/src/index.ts
+++ b/packages/@granit/authentication/src/index.ts
@@ -1,8 +1,6 @@
 export type {
   BaseAuthContextType,
-  KeycloakCoreConfig,
-  KeycloakEvent,
-  KeycloakUserInfo,
   LoginOptions,
   LogoutOptions,
+  OidcUserInfo,
 } from './types/index.js';

--- a/packages/@granit/authentication/src/types/index.ts
+++ b/packages/@granit/authentication/src/types/index.ts
@@ -1,10 +1,9 @@
-import type Keycloak from 'keycloak-js';
-
 // ---------------------------------------------------------------------------
-// Keycloak / OIDC standard user claims
+// Standard OIDC user claims (provider-agnostic)
 // ---------------------------------------------------------------------------
 
-export interface KeycloakUserInfo {
+/** Standard OIDC user info claims — compatible with any OIDC provider. */
+export interface OidcUserInfo {
   sub: string;
   email?: string;
   email_verified?: boolean;
@@ -16,31 +15,17 @@ export interface KeycloakUserInfo {
 }
 
 // ---------------------------------------------------------------------------
-// Event types
+// Login / Logout option types (OIDC standard)
 // ---------------------------------------------------------------------------
 
-/** Keycloak lifecycle event names forwarded by useKeycloakInit. */
-export type KeycloakEvent =
-  | 'onReady'
-  | 'onAuthSuccess'
-  | 'onAuthError'
-  | 'onAuthRefreshSuccess'
-  | 'onAuthRefreshError'
-  | 'onAuthLogout'
-  | 'onTokenExpired';
-
-// ---------------------------------------------------------------------------
-// Login / Logout option types (mirrors keycloak-js but decoupled)
-// ---------------------------------------------------------------------------
-
-/** Options forwarded to `keycloak.login()`. All fields are optional. */
+/** Generic login options forwarded to the identity provider. */
 export interface LoginOptions {
   redirectUri?: string;
-  /** Bypass the Keycloak login page and redirect to a specific identity provider. */
+  /** Bypass the login page and redirect to a specific identity provider. */
   idpHint?: string;
   /** Pre-fill the username/email field on the login page. */
   loginHint?: string;
-  /** Force the Keycloak UI locale (e.g. `"fr"`). */
+  /** Force the IdP UI locale (e.g. `"fr"`). */
   locale?: string;
   /** Trigger a specific action: `"register"` for signup, or a required action name. */
   action?: string;
@@ -51,67 +36,27 @@ export interface LoginOptions {
   maxAge?: number;
 }
 
-/** Options forwarded to `keycloak.logout()`. */
+/** Generic logout options forwarded to the identity provider. */
 export interface LogoutOptions {
   /** URL to redirect to after logout completes. */
   redirectUri?: string;
 }
 
 // ---------------------------------------------------------------------------
-// Base auth context (shared by all consuming apps — kept minimal)
+// Base auth context (provider-agnostic, extended by each provider package)
 // ---------------------------------------------------------------------------
 
 /**
  * Base auth context shared by all consuming applications.
  *
- * Apps extend this interface with their own fields:
- * - guava-front: adds `register: () => void`
- * - guava-admin: adds `hasAdminRole: boolean`
+ * Provider-specific packages extend this interface:
+ * - `@granit/authentication-keycloak` adds `keycloak: Keycloak | null`
+ * - Consuming apps extend further with app-specific fields
  */
 export interface BaseAuthContextType {
-  /** Live Keycloak instance — null before init completes */
-  keycloak: Keycloak | null;
   authenticated: boolean;
   loading: boolean;
-  user: KeycloakUserInfo | null;
-  login: () => void;
-  logout: () => void;
-}
-
-// ---------------------------------------------------------------------------
-// Hook configuration
-// ---------------------------------------------------------------------------
-
-export interface KeycloakCoreConfig {
-  url: string;
-  realm: string;
-  clientId: string;
-
-  /** Whether the silent SSO check is enabled (web-only, skip on native). Default: true */
-  silentCheckSso?: boolean;
-
-  /**
-   * Fall back to a regular `check-sso` redirect when the silent iframe check
-   * fails (e.g. Safari with third-party cookie blocking). Default: true
-   */
-  silentCheckSsoFallback?: boolean;
-
-  /**
-   * When true, extract user info from the decoded JWT (`tokenParsed`) instead
-   * of calling the `/userinfo` endpoint. Avoids an extra HTTP round-trip but
-   * requires the Keycloak client mappers to include the needed claims in the
-   * access token. Default: false (calls `loadUserInfo()`).
-   */
-  useTokenClaims?: boolean;
-
-  // -- Lifecycle callbacks (all optional) ----------------------------------
-
-  /** Called when the access token expires. */
-  onTokenExpired?: () => void;
-  /** Called when a token refresh attempt fails. */
-  onAuthRefreshError?: () => void;
-  /** Called when the Keycloak session is terminated (admin logout, SSO logout). */
-  onAuthLogout?: () => void;
-  /** Generic handler called for every Keycloak lifecycle event. */
-  onEvent?: (event: KeycloakEvent, error?: unknown) => void;
+  user: OidcUserInfo | null;
+  login: (options?: LoginOptions) => void;
+  logout: (options?: LogoutOptions) => void;
 }

--- a/packages/@granit/react-authentication-keycloak/package.json
+++ b/packages/@granit/react-authentication-keycloak/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@granit/react-authentication",
-  "description": "React bindings for @granit/authentication — generic auth context factory, mock provider",
-  "version": "0.3.0",
+  "name": "@granit/react-authentication-keycloak",
+  "description": "React hooks for Keycloak OIDC authentication — useKeycloakInit",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -14,7 +14,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/authentication": "workspace:*",
+    "@granit/authentication-keycloak": "workspace:*",
+    "@granit/react-authentication": "workspace:*",
+    "keycloak-js": "*",
     "react": "^19.0.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-authentication-keycloak/src/__tests__/keycloak-core.test.tsx
+++ b/packages/@granit/react-authentication-keycloak/src/__tests__/keycloak-core.test.tsx
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useKeycloakInit } from '../hooks/use-keycloak-core.js';
 
-import type { KeycloakCoreConfig } from '@granit/authentication';
+import type { KeycloakCoreConfig } from '@granit/authentication-keycloak';
 
 // ---------------------------------------------------------------------------
 // Hoisted mock references (declared before vi.mock hoisting)
@@ -195,7 +195,7 @@ describe('useKeycloakInit', () => {
 
     await waitFor(() => expect(mockSetTokenGetter).toHaveBeenCalledOnce());
 
-    const getter = mockSetTokenGetter.mock.calls[0][0] as () => Promise<string | undefined>;
+    const getter = mockSetTokenGetter.mock.calls[0]![0] as () => Promise<string | undefined>;
     const token = await getter();
     expect(token).toBe('mock-access-token');
   });
@@ -207,7 +207,7 @@ describe('useKeycloakInit', () => {
 
     await waitFor(() => expect(mockSetTokenGetter).toHaveBeenCalledOnce());
 
-    const getter = mockSetTokenGetter.mock.calls[0][0] as () => Promise<string | undefined>;
+    const getter = mockSetTokenGetter.mock.calls[0]![0] as () => Promise<string | undefined>;
     const token = await getter();
     expect(token).toBeUndefined();
   });
@@ -218,7 +218,7 @@ describe('useKeycloakInit', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    const initArg = mockInit.mock.calls[0][0] as Record<string, unknown>;
+    const initArg = mockInit.mock.calls[0]![0] as Record<string, unknown>;
     expect(initArg).not.toHaveProperty('silentCheckSsoRedirectUri');
   });
 
@@ -433,8 +433,8 @@ describe('useKeycloakInit', () => {
 
       await waitFor(() => expect(result.current.loading).toBe(false));
 
-      expect(result.current.hasResourceRole('editor', 'guava-admin')).toBe(true);
-      expect(mockHasResourceRole).toHaveBeenCalledWith('editor', 'guava-admin');
+      expect(result.current.hasResourceRole('editor', 'showcase-admin')).toBe(true);
+      expect(mockHasResourceRole).toHaveBeenCalledWith('editor', 'showcase-admin');
     });
 
     it('should return false from hasRealmRole when not authenticated', async () => {
@@ -488,7 +488,7 @@ describe('useKeycloakInit', () => {
 
       await waitFor(() => expect(result.current.loading).toBe(false));
 
-      const initArg = mockInit.mock.calls[0][0] as Record<string, unknown>;
+      const initArg = mockInit.mock.calls[0]![0] as Record<string, unknown>;
       expect(initArg.silentCheckSsoFallback).toBe(false);
     });
 
@@ -498,7 +498,7 @@ describe('useKeycloakInit', () => {
 
       await waitFor(() => expect(result.current.loading).toBe(false));
 
-      const initArg = mockInit.mock.calls[0][0] as Record<string, unknown>;
+      const initArg = mockInit.mock.calls[0]![0] as Record<string, unknown>;
       expect(initArg.silentCheckSsoFallback).toBe(true);
     });
 

--- a/packages/@granit/react-authentication-keycloak/src/hooks/use-keycloak-core.ts
+++ b/packages/@granit/react-authentication-keycloak/src/hooks/use-keycloak-core.ts
@@ -2,15 +2,14 @@ import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
 import Keycloak from 'keycloak-js';
 import * as React from 'react';
 
+import type { LoginOptions, LogoutOptions } from '@granit/authentication';
 import type {
-  BaseAuthContextType,
+  KeycloakAuthContextType,
   KeycloakCoreConfig,
   KeycloakUserInfo,
-  LoginOptions,
-  LogoutOptions,
-} from '@granit/authentication';
+} from '@granit/authentication-keycloak';
 
-export interface KeycloakCoreResult extends BaseAuthContextType {
+export interface KeycloakCoreResult extends KeycloakAuthContextType {
   /**
    * Direct ref to the Keycloak instance.
    * Expose to consuming apps that need to build custom login/logout URLs (e.g. Capacitor).

--- a/packages/@granit/react-authentication-keycloak/src/index.ts
+++ b/packages/@granit/react-authentication-keycloak/src/index.ts
@@ -1,0 +1,2 @@
+export { useKeycloakInit } from './hooks/use-keycloak-core.js';
+export type { KeycloakCoreResult } from './hooks/use-keycloak-core.js';

--- a/packages/@granit/react-authentication-keycloak/tsconfig.json
+++ b/packages/@granit/react-authentication-keycloak/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-authentication-local/package.json
+++ b/packages/@granit/react-authentication-local/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@granit/react-authentication",
-  "description": "React bindings for @granit/authentication — generic auth context factory, mock provider",
-  "version": "0.3.0",
+  "name": "@granit/react-authentication-local",
+  "description": "React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -14,8 +14,14 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/authentication": "workspace:*",
+    "@granit/authentication-local": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
     "react": "^19.0.0"
+  },
+  "devDependencies": {
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
@@ -1,0 +1,49 @@
+import { createMockClient } from '@granit/testing';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { LocalAuthProvider, useLocalAuthConfig } from '../providers/local-auth-provider.js';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider.js';
+import type { ReactNode } from 'react';
+
+describe('LocalAuthProvider', () => {
+  it('should provide config with defaults', () => {
+    const client = createMockClient();
+    const config: LocalAuthConfig = { client };
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+
+    const { result } = renderHook(() => useLocalAuthConfig(), { wrapper });
+
+    expect(result.current.client).toBe(client);
+    expect(result.current.basePath).toBe('/api/account');
+    expect(result.current.queryKeyPrefix).toEqual(['authentication-local']);
+  });
+
+  it('should allow custom basePath and queryKeyPrefix', () => {
+    const client = createMockClient();
+    const config: LocalAuthConfig = {
+      client,
+      basePath: '/custom/auth',
+      queryKeyPrefix: ['custom'],
+    };
+
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+
+    const { result } = renderHook(() => useLocalAuthConfig(), { wrapper });
+
+    expect(result.current.basePath).toBe('/custom/auth');
+    expect(result.current.queryKeyPrefix).toEqual(['custom']);
+  });
+
+  it('should throw when used outside provider', () => {
+    expect(() => renderHook(() => useLocalAuthConfig())).toThrowError(
+      'useLocalAuthConfig must be used within a LocalAuthProvider'
+    );
+  });
+});

--- a/packages/@granit/react-authentication-local/src/__tests__/use-begin-passkey-assertion.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-begin-passkey-assertion.test.tsx
@@ -1,0 +1,72 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useBeginPasskeyAssertion } from '../hooks/use-begin-passkey-assertion.js';
+import { LocalAuthProvider } from '../providers/local-auth-provider.js';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    beginPasskeyAssertion: vi.fn(),
+  };
+});
+
+const { beginPasskeyAssertion } = await import('@granit/authentication-local');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: LocalAuthConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBeginPasskeyAssertion', () => {
+  it('should call beginPasskeyAssertion and return options JSON', async () => {
+    const client = createMockClient();
+    const optionsJson = '{"challenge":"abc123","rpId":"example.com"}';
+    vi.mocked(beginPasskeyAssertion).mockResolvedValue(optionsJson);
+
+    const { result } = renderHook(() => useBeginPasskeyAssertion(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(beginPasskeyAssertion).toHaveBeenCalledWith(client, '/api/account');
+    expect(result.current.data).toBe(optionsJson);
+  });
+
+  it('should handle assertion error', async () => {
+    const client = createMockClient();
+    vi.mocked(beginPasskeyAssertion).mockRejectedValue(new Error('Not supported'));
+
+    const { result } = renderHook(() => useBeginPasskeyAssertion(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Not supported');
+  });
+});

--- a/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
@@ -1,0 +1,84 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useLogin } from '../hooks/use-login.js';
+import { LocalAuthProvider } from '../providers/local-auth-provider.js';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider.js';
+import type { AccountLoginResponse } from '@granit/authentication-local';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    loginAccount: vi.fn(),
+  };
+});
+
+const { loginAccount } = await import('@granit/authentication-local');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: LocalAuthConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useLogin', () => {
+  it('should call loginAccount with correct arguments', async () => {
+    const client = createMockClient();
+    const response: AccountLoginResponse = {
+      succeeded: true,
+      requiresTwoFactor: false,
+      isLockedOut: false,
+      isNotAllowed: false,
+    };
+    vi.mocked(loginAccount).mockResolvedValue(response);
+
+    const { result } = renderHook(() => useLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(loginAccount).toHaveBeenCalledWith(client, '/api/account', {
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should handle login error', async () => {
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockRejectedValue(new Error('Unauthorized'));
+
+    const { result } = renderHook(() => useLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ login: 'bad@example.com', password: 'wrong' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Unauthorized');
+  });
+});

--- a/packages/@granit/react-authentication-local/src/hooks/use-begin-passkey-assertion.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-begin-passkey-assertion.ts
@@ -1,0 +1,15 @@
+import { beginPasskeyAssertion } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider.js';
+
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Begins a WebAuthn passkey assertion ceremony for login. */
+export function useBeginPasskeyAssertion(): UseMutationResult<string, Error, void> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: () => beginPasskeyAssertion(config.client, config.basePath!),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-login.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-login.ts
@@ -1,0 +1,17 @@
+import { loginAccount } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider.js';
+
+import type { AccountLoginRequest, AccountLoginResponse } from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Authenticates a user via local credentials (email/username + password). */
+export function useLogin(): UseMutationResult<AccountLoginResponse, Error, AccountLoginRequest> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountLoginRequest) =>
+      loginAccount(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/index.ts
+++ b/packages/@granit/react-authentication-local/src/index.ts
@@ -1,0 +1,11 @@
+// Provider
+export {
+  LocalAuthProvider,
+  buildLocalAuthQueryKey,
+  useLocalAuthConfig,
+} from './providers/local-auth-provider.js';
+export type { LocalAuthConfig, LocalAuthProviderProps } from './providers/local-auth-provider.js';
+
+// Hooks
+export { useLogin } from './hooks/use-login.js';
+export { useBeginPasskeyAssertion } from './hooks/use-begin-passkey-assertion.js';

--- a/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
+++ b/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext } from 'react';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+export interface LocalAuthConfig {
+  /**
+   * Axios instance for API calls.
+   * Must have `withCredentials: true` — the login endpoint sets an
+   * ASP.NET Core Identity session cookie (not a token).
+   */
+  readonly client: AxiosInstance;
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface LocalAuthProviderProps {
+  readonly config: LocalAuthConfig;
+  readonly children: ReactNode;
+}
+
+const DEFAULT_BASE_PATH = '/api/account';
+const DEFAULT_KEY_PREFIX = ['authentication-local'] as const;
+
+const LocalAuthContext = createContext<LocalAuthConfig | null>(null);
+
+export function useLocalAuthConfig(): LocalAuthConfig {
+  const config = useContext(LocalAuthContext);
+  if (!config) throw new Error('useLocalAuthConfig must be used within a LocalAuthProvider');
+  return config;
+}
+
+export function buildLocalAuthQueryKey(
+  config: LocalAuthConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
+}
+
+export function LocalAuthProvider({ config, children }: LocalAuthProviderProps) {
+  const value: LocalAuthConfig = {
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+  };
+
+  return <LocalAuthContext value={value}>{children}</LocalAuthContext>;
+}

--- a/packages/@granit/react-authentication-local/tsconfig.json
+++ b/packages/@granit/react-authentication-local/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-authentication/src/__tests__/mock-provider.test.tsx
+++ b/packages/@granit/react-authentication/src/__tests__/mock-provider.test.tsx
@@ -8,7 +8,6 @@ import { createAuthContext } from '../providers/use-auth-context.js';
 import type { BaseAuthContextType } from '@granit/authentication';
 
 const mockValue: BaseAuthContextType = {
-  keycloak: null,
   authenticated: true,
   loading: false,
   user: null,

--- a/packages/@granit/react-authentication/src/__tests__/use-auth-context.test.tsx
+++ b/packages/@granit/react-authentication/src/__tests__/use-auth-context.test.tsx
@@ -11,7 +11,6 @@ interface TestAuthContextType extends BaseAuthContextType {
 }
 
 const mockValue: TestAuthContextType = {
-  keycloak: null,
   authenticated: true,
   loading: false,
   user: null,

--- a/packages/@granit/react-authentication/src/index.ts
+++ b/packages/@granit/react-authentication/src/index.ts
@@ -1,4 +1,2 @@
-export { useKeycloakInit } from './hooks/use-keycloak-core.js';
-export type { KeycloakCoreResult } from './hooks/use-keycloak-core.js';
 export { createAuthContext } from './providers/use-auth-context.js';
 export { createMockProvider } from './providers/mock-provider.js';

--- a/packages/@granit/react-authentication/src/providers/mock-provider.tsx
+++ b/packages/@granit/react-authentication/src/providers/mock-provider.tsx
@@ -7,9 +7,8 @@ import type { BaseAuthContextType } from '@granit/authentication';
  *
  * @example
  * const MockAuthProvider = createMockProvider(AuthContext, {
- *   keycloak: null, authenticated: true, loading: false,
+ *   authenticated: true, loading: false,
  *   user: MOCK_USER, login: () => {}, logout: () => {},
- *   register: () => {},  // guava-front specific
  * });
  */
 export function createMockProvider<T extends BaseAuthContextType>(

--- a/packages/@granit/react-authentication/src/providers/use-auth-context.ts
+++ b/packages/@granit/react-authentication/src/providers/use-auth-context.ts
@@ -9,14 +9,8 @@ import type { BaseAuthContextType } from '@granit/authentication';
  * (extending BaseAuthContextType with app-specific fields).
  *
  * @example
- * // guava-front
- * interface AuthContextType extends BaseAuthContextType { register: () => void }
- * export const { AuthContext, useAuth } = createAuthContext<AuthContextType>();
- *
- * @example
- * // guava-admin
- * interface AuthContextType extends BaseAuthContextType { hasAdminRole: boolean }
- * export const { AuthContext, useAuth } = createAuthContext<AuthContextType>();
+ * interface AppAuthContext extends BaseAuthContextType { hasAdminRole: boolean }
+ * export const { AuthContext, useAuth } = createAuthContext<AppAuthContext>();
  */
 export function createAuthContext<T extends BaseAuthContextType>() {
   const AuthContext = React.createContext<T | undefined>(undefined);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,13 +189,28 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
-  packages/@granit/authentication:
+  packages/@granit/authentication: {}
+
+  packages/@granit/authentication-api-keys: {}
+
+  packages/@granit/authentication-keycloak:
     dependencies:
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
       keycloak-js:
         specifier: '*'
         version: 26.2.3
 
-  packages/@granit/authentication-api-keys: {}
+  packages/@granit/authentication-local:
+    dependencies:
+      axios:
+        specifier: '*'
+        version: 1.14.0
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
 
   packages/@granit/authorization:
     dependencies:
@@ -481,15 +496,9 @@ importers:
 
   packages/@granit/react-authentication:
     dependencies:
-      '@granit/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@granit/authentication':
         specifier: workspace:*
         version: link:../authentication
-      keycloak-js:
-        specifier: '*'
-        version: 26.2.3
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -505,6 +514,49 @@ importers:
       axios:
         specifier: '*'
         version: 1.13.6
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-authentication-keycloak:
+    dependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      '@granit/authentication-keycloak':
+        specifier: workspace:*
+        version: link:../authentication-keycloak
+      '@granit/react-authentication':
+        specifier: workspace:*
+        version: link:../react-authentication
+      keycloak-js:
+        specifier: '*'
+        version: 26.2.3
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+
+  packages/@granit/react-authentication-local:
+    dependencies:
+      '@granit/authentication-local':
+        specifier: workspace:*
+        version: link:../authentication-local
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.95.2(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.14.0
       react:
         specifier: ^19.0.0
         version: 19.2.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,10 @@ overrides:
   immutable: '>=5.1.5'
   flatted: '>=3.4.2'
   '@tanstack/query-core': ^5.95.0
+  picomatch: '>=4.0.4'
+  yaml: '>=2.8.3'
+  smol-toml: '>=1.6.1'
+  brace-expansion: '>=5.0.5'
 
 importers:
 
@@ -72,10 +76,10 @@ importers:
         version: 19.2.14
       '@vitejs/plugin-react':
         specifier: ^6.0.1
-        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: ^4.1.2
-        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)))
+        version: 4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)))
       axios:
         specifier: ^1.14.0
         version: 1.14.0
@@ -132,7 +136,7 @@ importers:
         version: 3.5.0
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@6.0.2)(yaml@2.8.2)
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@6.0.2)(yaml@2.8.3)
       typescript:
         specifier: ~6.0.2
         version: 6.0.2
@@ -141,10 +145,10 @@ importers:
         version: 8.57.2(eslint@10.1.0(jiti@2.6.1))(typescript@6.0.2)
       vite:
         specifier: ^8.0.3
-        version: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)
+        version: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
       vitest:
         specifier: ^4.1.2
-        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
 
   packages/@granit/account:
     dependencies:
@@ -1032,7 +1036,7 @@ importers:
         version: 19.2.4
       vitest:
         specifier: ^4.0.0
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
     devDependencies:
       '@granit/testing':
         specifier: workspace:*
@@ -1219,7 +1223,7 @@ importers:
         version: 1.13.6
       vitest:
         specifier: ^4.0.0
-        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
 
   packages/@granit/timeline:
     dependencies:
@@ -2866,8 +2870,8 @@ packages:
   bidi-js@1.0.3:
     resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
-  brace-expansion@5.0.4:
-    resolution: {integrity: sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==}
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -3277,7 +3281,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -4038,14 +4042,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -4064,7 +4060,7 @@ packages:
       jiti: '>=1.21.0'
       postcss: '>=8.0.9'
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -4291,8 +4287,8 @@ packages:
     resolution: {integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==}
     engines: {node: '>=20'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   source-map-js@1.2.1:
@@ -4546,7 +4542,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -4728,8 +4724,8 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -6025,12 +6021,12 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)
+      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
 
-  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)))':
+  '@vitest/coverage-v8@4.1.2(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.1.2
@@ -6042,7 +6038,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+      vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
 
   '@vitest/expect@4.1.0':
     dependencies:
@@ -6062,23 +6058,23 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@25.5.0)(typescript@6.0.2)
-      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)
+      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
 
-  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitest/mocker@4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.12.14(@types/node@25.5.0)(typescript@6.0.2)
-      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)
+      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.1.0':
     dependencies:
@@ -6226,7 +6222,7 @@ snapshots:
     dependencies:
       require-from-string: 2.0.2
 
-  brace-expansion@5.0.4:
+  brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
 
@@ -7032,10 +7028,10 @@ snapshots:
     dependencies:
       commander: 14.0.3
       listr2: 9.0.5
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       string-argv: 0.3.2
       tinyexec: 1.0.4
-      yaml: 2.8.2
+      yaml: 2.8.3
 
   listr2@9.0.5:
     dependencies:
@@ -7119,7 +7115,7 @@ snapshots:
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.0)
       micromatch: 4.0.8
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7322,7 +7318,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   mime-db@1.52.0: {}
 
@@ -7336,7 +7332,7 @@ snapshots:
 
   minimatch@10.2.4:
     dependencies:
-      brace-expansion: 5.0.4
+      brace-expansion: 5.0.5
 
   minimist@1.2.8: {}
 
@@ -7464,10 +7460,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
-  picomatch@4.0.3: {}
-
   picomatch@4.0.4: {}
 
   pirates@4.0.7: {}
@@ -7478,13 +7470,13 @@ snapshots:
       mlly: 1.8.1
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.2):
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.6.1
       postcss: 8.5.8
-      yaml: 2.8.2
+      yaml: 2.8.3
 
   postcss@8.5.8:
     dependencies:
@@ -7717,7 +7709,7 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   source-map-js@1.2.1: {}
 
@@ -7850,7 +7842,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@6.0.2)(yaml@2.8.2):
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@6.0.2)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.4)
       cac: 6.7.14
@@ -7861,7 +7853,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.2)
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -7959,7 +7951,7 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2):
+  vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -7972,15 +7964,15 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       sass: 1.97.3
-      yaml: 2.8.2
+      yaml: 2.8.3
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)):
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.0(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -7991,13 +7983,13 @@ snapshots:
       magic-string: 0.30.21
       obug: 2.1.1
       pathe: 2.0.3
-      picomatch: 4.0.3
+      picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)
+      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -8006,10 +7998,10 @@ snapshots:
     transitivePeerDependencies:
       - msw
 
-  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)):
+  vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.0)(jsdom@29.0.1)(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.2
-      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2))
+      '@vitest/mocker': 4.1.2(msw@2.12.14(@types/node@25.5.0)(typescript@6.0.2))(vite@8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
       '@vitest/pretty-format': 4.1.2
       '@vitest/runner': 4.1.2
       '@vitest/snapshot': 4.1.2
@@ -8026,7 +8018,7 @@ snapshots:
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.2)
+      vite: 8.0.3(@emnapi/core@1.9.0)(@emnapi/runtime@1.9.0)(@types/node@25.5.0)(esbuild@0.27.4)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -8107,7 +8099,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yaml@2.8.2: {}
+  yaml@2.8.3: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
## Summary

- Refactor `@granit/authentication` into a **provider-agnostic base** package — removes `keycloak-js` peer dependency, renames `KeycloakUserInfo` to `OidcUserInfo`, removes `keycloak` field from `BaseAuthContextType`
- Extract **`@granit/authentication-keycloak`** and **`@granit/react-authentication-keycloak`** — all Keycloak-specific types (`KeycloakCoreConfig`, `KeycloakEvent`, `KeycloakAuthContextType`) and `useKeycloakInit` hook moved here
- Create **`@granit/authentication-local`** and **`@granit/react-authentication-local`** — headless credential login (`loginAccount`, `beginPasskeyAssertion`), `LocalAuthProvider`, `useLogin()`, `useBeginPasskeyAssertion()` hooks
- Move `beginPasskeyAssertion` from `@granit/account` to `@granit/authentication-local` (anonymous login endpoint, not account self-service)

### Architecture

```
@granit/authentication              → generic base (OidcUserInfo, BaseAuthContextType)
@granit/react-authentication        → generic factories (createAuthContext, createMockProvider)
@granit/authentication-keycloak     → Keycloak types (NEW)
@granit/react-authentication-keycloak → useKeycloakInit (MOVED)
@granit/authentication-local        → local login types + API (NEW)
@granit/react-authentication-local  → local login hooks + provider (NEW)
```

This enables future `authentication-entraid`, `authentication-cognito`, `authentication-google-cloud` packages using the same pattern.

### Breaking changes

- `KeycloakCoreConfig`, `KeycloakEvent`, `KeycloakUserInfo` → import from `@granit/authentication-keycloak`
- `useKeycloakInit`, `KeycloakCoreResult` → import from `@granit/react-authentication-keycloak`
- `BaseAuthContextType` no longer has `keycloak` field — use `KeycloakAuthContextType` from `authentication-keycloak`
- `beginPasskeyAssertion` → import from `@granit/authentication-local` instead of `@granit/account`

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run` — 215 files, 1733 tests passed
- [ ] Update showcase-admin-react imports (separate PR/prompt)
