### PR TITLE
feat: add 2FA/passkey login + Entra ID, Cognito, Google Cloud auth packages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -246,6 +246,11 @@
           "signature": "async function loginAccount( client: AxiosInstance, basePath: string, request: AccountLoginRequest ): Promise<AccountLoginResponse>"
         },
         {
+          "name": "verifyTwoFactorLogin",
+          "kind": "function",
+          "signature": "async function verifyTwoFactorLogin( client: AxiosInstance, basePath: string, request: AccountTwoFactorLoginRequest ): Promise<AccountLoginResponse>"
+        },
+        {
           "name": "beginPasskeyAssertion",
           "kind": "function",
           "signature": "async function beginPasskeyAssertion( client: AxiosInstance, basePath: string ): Promise<string>"
@@ -1169,6 +1174,11 @@
           "name": "useLogin",
           "kind": "function",
           "signature": "function useLogin(): UseMutationResult<AccountLoginResponse, Error, AccountLoginRequest>"
+        },
+        {
+          "name": "useVerifyTwoFactorLogin",
+          "kind": "function",
+          "signature": "function useVerifyTwoFactorLogin(): UseMutationResult< AccountLoginResponse, Error, AccountTwoFactorLoginRequest >"
         },
         {
           "name": "useBeginPasskeyAssertion",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -249,11 +249,6 @@
           "name": "verifyTwoFactorLogin",
           "kind": "function",
           "signature": "async function verifyTwoFactorLogin( client: AxiosInstance, basePath: string, request: AccountTwoFactorLoginRequest ): Promise<AccountLoginResponse>"
-        },
-        {
-          "name": "beginPasskeyAssertion",
-          "kind": "function",
-          "signature": "async function beginPasskeyAssertion( client: AxiosInstance, basePath: string ): Promise<string>"
         }
       ]
     },
@@ -1184,6 +1179,11 @@
           "name": "useBeginPasskeyAssertion",
           "kind": "function",
           "signature": "function useBeginPasskeyAssertion(): UseMutationResult<string, Error, void>"
+        },
+        {
+          "name": "useCompletePasskeyAssertion",
+          "kind": "function",
+          "signature": "function useCompletePasskeyAssertion(): UseMutationResult< AccountLoginResponse, Error, AccountPasskeyAssertionCompleteRequest >"
         }
       ]
     },

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -227,6 +227,176 @@
       "exports": []
     },
     {
+      "name": "@granit/authentication-cognito",
+      "description": "AWS Cognito User Pools OIDC authentication types — CognitoAuthContextType, config",
+      "exports": [
+        {
+          "name": "CognitoAuthContextType",
+          "kind": "interface",
+          "signature": "interface CognitoAuthContextType extends BaseAuthContextType",
+          "members": [
+            {
+              "name": "userPool",
+              "kind": "property",
+              "signature": "userPool: CognitoUserPool | null"
+            }
+          ]
+        },
+        {
+          "name": "CognitoCoreConfig",
+          "kind": "interface",
+          "signature": "interface CognitoCoreConfig",
+          "members": [
+            {
+              "name": "userPoolId",
+              "kind": "property",
+              "signature": "userPoolId: string"
+            },
+            {
+              "name": "clientId",
+              "kind": "property",
+              "signature": "clientId: string"
+            },
+            {
+              "name": "region",
+              "kind": "property",
+              "signature": "region: string"
+            },
+            {
+              "name": "domain",
+              "kind": "property",
+              "signature": "domain?: string"
+            },
+            {
+              "name": "scopes",
+              "kind": "property",
+              "signature": "scopes?: readonly string[]"
+            },
+            {
+              "name": "onTokenRefreshError",
+              "kind": "method",
+              "signature": "onTokenRefreshError?: () => void"
+            },
+            {
+              "name": "onSessionExpired",
+              "kind": "method",
+              "signature": "onSessionExpired?: () => void"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/authentication-entraid",
+      "description": "Microsoft Entra ID (Azure AD) OIDC authentication types — EntraIdAuthContextType, config",
+      "exports": [
+        {
+          "name": "EntraIdAuthContextType",
+          "kind": "interface",
+          "signature": "interface EntraIdAuthContextType extends BaseAuthContextType",
+          "members": [
+            {
+              "name": "msalInstance",
+              "kind": "property",
+              "signature": "msalInstance: IPublicClientApplication | null"
+            }
+          ]
+        },
+        {
+          "name": "EntraIdCoreConfig",
+          "kind": "interface",
+          "signature": "interface EntraIdCoreConfig",
+          "members": [
+            {
+              "name": "clientId",
+              "kind": "property",
+              "signature": "clientId: string"
+            },
+            {
+              "name": "authority",
+              "kind": "property",
+              "signature": "authority: string"
+            },
+            {
+              "name": "redirectUri",
+              "kind": "property",
+              "signature": "redirectUri: string"
+            },
+            {
+              "name": "scopes",
+              "kind": "property",
+              "signature": "scopes?: readonly string[]"
+            },
+            {
+              "name": "onAcquireTokenFailure",
+              "kind": "method",
+              "signature": "onAcquireTokenFailure?: () => void"
+            },
+            {
+              "name": "onSessionEnd",
+              "kind": "method",
+              "signature": "onSessionEnd?: () => void"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/authentication-google-cloud",
+      "description": "Google Cloud Identity Platform (Firebase Auth) authentication types — GoogleCloudAuthContextType, config",
+      "exports": [
+        {
+          "name": "GoogleCloudAuthContextType",
+          "kind": "interface",
+          "signature": "interface GoogleCloudAuthContextType extends BaseAuthContextType",
+          "members": [
+            {
+              "name": "firebaseAuth",
+              "kind": "property",
+              "signature": "firebaseAuth: Auth | null"
+            }
+          ]
+        },
+        {
+          "name": "GoogleCloudCoreConfig",
+          "kind": "interface",
+          "signature": "interface GoogleCloudCoreConfig",
+          "members": [
+            {
+              "name": "apiKey",
+              "kind": "property",
+              "signature": "apiKey: string"
+            },
+            {
+              "name": "authDomain",
+              "kind": "property",
+              "signature": "authDomain: string"
+            },
+            {
+              "name": "projectId",
+              "kind": "property",
+              "signature": "projectId: string"
+            },
+            {
+              "name": "scopes",
+              "kind": "property",
+              "signature": "scopes?: readonly string[]"
+            },
+            {
+              "name": "onTokenRefreshError",
+              "kind": "method",
+              "signature": "onTokenRefreshError?: () => void"
+            },
+            {
+              "name": "onSessionExpired",
+              "kind": "method",
+              "signature": "onSessionExpired?: () => void"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "@granit/authentication-keycloak",
       "description": "Keycloak OIDC authentication types — KeycloakAuthContextType, config, events",
       "exports": []
@@ -1086,6 +1256,105 @@
               "name": "request",
               "kind": "property",
               "signature": "request: ApiKeyUpdateScopesRequest"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-authentication-cognito",
+      "description": "React hooks for AWS Cognito OIDC authentication — useCognitoInit",
+      "exports": [
+        {
+          "name": "useCognitoInit",
+          "kind": "function",
+          "signature": "function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult"
+        },
+        {
+          "name": "CognitoCoreResult",
+          "kind": "interface",
+          "signature": "interface CognitoCoreResult extends CognitoAuthContextType",
+          "members": [
+            {
+              "name": "userPoolRef",
+              "kind": "property",
+              "signature": "userPoolRef: React.RefObject<CognitoUserPool | null>"
+            },
+            {
+              "name": "login",
+              "kind": "method",
+              "signature": "login: (options?: LoginOptions) => void"
+            },
+            {
+              "name": "logout",
+              "kind": "method",
+              "signature": "logout: (options?: LogoutOptions) => void"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-authentication-entraid",
+      "description": "React hooks for Microsoft Entra ID OIDC authentication — useEntraIdInit",
+      "exports": [
+        {
+          "name": "useEntraIdInit",
+          "kind": "function",
+          "signature": "function useEntraIdInit(config: EntraIdCoreConfig): EntraIdCoreResult"
+        },
+        {
+          "name": "EntraIdCoreResult",
+          "kind": "interface",
+          "signature": "interface EntraIdCoreResult extends EntraIdAuthContextType",
+          "members": [
+            {
+              "name": "msalRef",
+              "kind": "property",
+              "signature": "msalRef: React.RefObject<PublicClientApplication | null>"
+            },
+            {
+              "name": "login",
+              "kind": "method",
+              "signature": "login: (options?: LoginOptions) => void"
+            },
+            {
+              "name": "logout",
+              "kind": "method",
+              "signature": "logout: (options?: LogoutOptions) => void"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-authentication-google-cloud",
+      "description": "React hooks for Google Cloud Identity Platform (Firebase Auth) — useGoogleCloudInit",
+      "exports": [
+        {
+          "name": "useGoogleCloudInit",
+          "kind": "function",
+          "signature": "function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCoreResult"
+        },
+        {
+          "name": "GoogleCloudCoreResult",
+          "kind": "interface",
+          "signature": "interface GoogleCloudCoreResult extends GoogleCloudAuthContextType",
+          "members": [
+            {
+              "name": "authRef",
+              "kind": "property",
+              "signature": "authRef: React.RefObject<Auth | null>"
+            },
+            {
+              "name": "login",
+              "kind": "method",
+              "signature": "login: (options?: LoginOptions) => void"
+            },
+            {
+              "name": "logout",
+              "kind": "method",
+              "signature": "logout: (options?: LogoutOptions) => void"
             }
           ]
         }

--- a/packages/@granit/authentication-cognito/package.json
+++ b/packages/@granit/authentication-cognito/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@granit/authentication-cognito",
+  "description": "AWS Cognito User Pools OIDC authentication types — CognitoAuthContextType, config",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/authentication": "workspace:*",
+    "amazon-cognito-identity-js": ">=6.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/authentication-cognito/src/__tests__/cognito-types.test.ts
+++ b/packages/@granit/authentication-cognito/src/__tests__/cognito-types.test.ts
@@ -1,0 +1,34 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { CognitoAuthContextType, CognitoCoreConfig } from '../index.js';
+
+describe('@granit/authentication-cognito types', () => {
+  describe('CognitoAuthContextType', () => {
+    it('should extend BaseAuthContextType with userPool field', () => {
+      expectTypeOf<CognitoAuthContextType>().toHaveProperty('userPool');
+      expectTypeOf<CognitoAuthContextType>().toHaveProperty('authenticated');
+      expectTypeOf<CognitoAuthContextType>().toHaveProperty('loading');
+      expectTypeOf<CognitoAuthContextType>().toHaveProperty('user');
+      expectTypeOf<CognitoAuthContextType>().toHaveProperty('login');
+      expectTypeOf<CognitoAuthContextType>().toHaveProperty('logout');
+    });
+  });
+
+  describe('CognitoCoreConfig', () => {
+    it('should require userPoolId, clientId, and region', () => {
+      expectTypeOf<CognitoCoreConfig>().toHaveProperty('userPoolId');
+      expectTypeOf<CognitoCoreConfig['userPoolId']>().toBeString();
+      expectTypeOf<CognitoCoreConfig>().toHaveProperty('clientId');
+      expectTypeOf<CognitoCoreConfig['clientId']>().toBeString();
+      expectTypeOf<CognitoCoreConfig>().toHaveProperty('region');
+      expectTypeOf<CognitoCoreConfig['region']>().toBeString();
+    });
+
+    it('should have optional domain, scopes, and callbacks', () => {
+      expectTypeOf<CognitoCoreConfig>().toHaveProperty('domain');
+      expectTypeOf<CognitoCoreConfig>().toHaveProperty('scopes');
+      expectTypeOf<CognitoCoreConfig>().toHaveProperty('onTokenRefreshError');
+      expectTypeOf<CognitoCoreConfig>().toHaveProperty('onSessionExpired');
+    });
+  });
+});

--- a/packages/@granit/authentication-cognito/src/index.ts
+++ b/packages/@granit/authentication-cognito/src/index.ts
@@ -1,0 +1,1 @@
+export type { CognitoAuthContextType, CognitoCoreConfig } from './types/index.js';

--- a/packages/@granit/authentication-cognito/src/types/index.ts
+++ b/packages/@granit/authentication-cognito/src/types/index.ts
@@ -1,0 +1,34 @@
+import type { BaseAuthContextType } from '@granit/authentication';
+import type { CognitoUserPool } from 'amazon-cognito-identity-js';
+
+// ---------------------------------------------------------------------------
+// Cognito auth context (extends generic base with Cognito user pool)
+// ---------------------------------------------------------------------------
+
+/** Cognito-specific auth context — extends the generic base with the Cognito user pool. */
+export interface CognitoAuthContextType extends BaseAuthContextType {
+  /** Live Cognito UserPool instance — null before init completes. */
+  userPool: CognitoUserPool | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook configuration
+// ---------------------------------------------------------------------------
+
+export interface CognitoCoreConfig {
+  /** Cognito User Pool ID (e.g. `eu-west-1_XXXXXXXXX`). */
+  userPoolId: string;
+  /** Cognito App Client ID. */
+  clientId: string;
+  /** AWS region (e.g. `eu-west-1`). */
+  region: string;
+  /** OAuth domain for hosted UI (e.g. `myapp.auth.eu-west-1.amazoncognito.com`). */
+  domain?: string;
+  /** OAuth scopes to request. */
+  scopes?: readonly string[];
+
+  /** Called when a token refresh fails. */
+  onTokenRefreshError?: () => void;
+  /** Called when the session expires. */
+  onSessionExpired?: () => void;
+}

--- a/packages/@granit/authentication-cognito/tsconfig.json
+++ b/packages/@granit/authentication-cognito/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/authentication-cognito/tsup.config.ts
+++ b/packages/@granit/authentication-cognito/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/authentication-entraid/package.json
+++ b/packages/@granit/authentication-entraid/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@granit/authentication-entraid",
+  "description": "Microsoft Entra ID (Azure AD) OIDC authentication types — EntraIdAuthContextType, config",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@azure/msal-browser": ">=3.0.0",
+    "@granit/authentication": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/authentication-entraid/src/__tests__/entraid-types.test.ts
+++ b/packages/@granit/authentication-entraid/src/__tests__/entraid-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { EntraIdAuthContextType, EntraIdCoreConfig } from '../index.js';
+
+describe('@granit/authentication-entraid types', () => {
+  describe('EntraIdAuthContextType', () => {
+    it('should extend BaseAuthContextType with msalInstance field', () => {
+      expectTypeOf<EntraIdAuthContextType>().toHaveProperty('msalInstance');
+      expectTypeOf<EntraIdAuthContextType>().toHaveProperty('authenticated');
+      expectTypeOf<EntraIdAuthContextType>().toHaveProperty('loading');
+      expectTypeOf<EntraIdAuthContextType>().toHaveProperty('user');
+      expectTypeOf<EntraIdAuthContextType>().toHaveProperty('login');
+      expectTypeOf<EntraIdAuthContextType>().toHaveProperty('logout');
+    });
+  });
+
+  describe('EntraIdCoreConfig', () => {
+    it('should require clientId, authority, and redirectUri', () => {
+      expectTypeOf<EntraIdCoreConfig>().toHaveProperty('clientId');
+      expectTypeOf<EntraIdCoreConfig['clientId']>().toBeString();
+      expectTypeOf<EntraIdCoreConfig>().toHaveProperty('authority');
+      expectTypeOf<EntraIdCoreConfig['authority']>().toBeString();
+      expectTypeOf<EntraIdCoreConfig>().toHaveProperty('redirectUri');
+      expectTypeOf<EntraIdCoreConfig['redirectUri']>().toBeString();
+    });
+
+    it('should have optional scopes and callbacks', () => {
+      expectTypeOf<EntraIdCoreConfig>().toHaveProperty('scopes');
+      expectTypeOf<EntraIdCoreConfig>().toHaveProperty('onAcquireTokenFailure');
+      expectTypeOf<EntraIdCoreConfig>().toHaveProperty('onSessionEnd');
+    });
+  });
+});

--- a/packages/@granit/authentication-entraid/src/index.ts
+++ b/packages/@granit/authentication-entraid/src/index.ts
@@ -1,0 +1,1 @@
+export type { EntraIdAuthContextType, EntraIdCoreConfig } from './types/index.js';

--- a/packages/@granit/authentication-entraid/src/types/index.ts
+++ b/packages/@granit/authentication-entraid/src/types/index.ts
@@ -1,0 +1,32 @@
+import type { IPublicClientApplication } from '@azure/msal-browser';
+import type { BaseAuthContextType } from '@granit/authentication';
+
+// ---------------------------------------------------------------------------
+// Entra ID auth context (extends generic base with MSAL instance)
+// ---------------------------------------------------------------------------
+
+/** Entra ID-specific auth context — extends the generic base with the MSAL instance. */
+export interface EntraIdAuthContextType extends BaseAuthContextType {
+  /** Live MSAL PublicClientApplication instance — null before init completes. */
+  msalInstance: IPublicClientApplication | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook configuration
+// ---------------------------------------------------------------------------
+
+export interface EntraIdCoreConfig {
+  /** Application (client) ID from Azure AD app registration. */
+  clientId: string;
+  /** Authority URL (e.g. `https://login.microsoftonline.com/{tenantId}`). */
+  authority: string;
+  /** Redirect URI registered in the Azure portal. */
+  redirectUri: string;
+  /** OAuth scopes to request (e.g. `["openid", "profile", "email"]`). */
+  scopes?: readonly string[];
+
+  /** Called when a silent token acquisition fails. */
+  onAcquireTokenFailure?: () => void;
+  /** Called when the user's session is terminated. */
+  onSessionEnd?: () => void;
+}

--- a/packages/@granit/authentication-entraid/tsconfig.json
+++ b/packages/@granit/authentication-entraid/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/authentication-entraid/tsup.config.ts
+++ b/packages/@granit/authentication-entraid/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/authentication-google-cloud/package.json
+++ b/packages/@granit/authentication-google-cloud/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@granit/authentication-google-cloud",
+  "description": "Google Cloud Identity Platform (Firebase Auth) authentication types — GoogleCloudAuthContextType, config",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/authentication": "workspace:*",
+    "firebase": ">=10.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/authentication-google-cloud/src/__tests__/google-cloud-types.test.ts
+++ b/packages/@granit/authentication-google-cloud/src/__tests__/google-cloud-types.test.ts
@@ -1,0 +1,33 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type { GoogleCloudAuthContextType, GoogleCloudCoreConfig } from '../index.js';
+
+describe('@granit/authentication-google-cloud types', () => {
+  describe('GoogleCloudAuthContextType', () => {
+    it('should extend BaseAuthContextType with firebaseAuth field', () => {
+      expectTypeOf<GoogleCloudAuthContextType>().toHaveProperty('firebaseAuth');
+      expectTypeOf<GoogleCloudAuthContextType>().toHaveProperty('authenticated');
+      expectTypeOf<GoogleCloudAuthContextType>().toHaveProperty('loading');
+      expectTypeOf<GoogleCloudAuthContextType>().toHaveProperty('user');
+      expectTypeOf<GoogleCloudAuthContextType>().toHaveProperty('login');
+      expectTypeOf<GoogleCloudAuthContextType>().toHaveProperty('logout');
+    });
+  });
+
+  describe('GoogleCloudCoreConfig', () => {
+    it('should require apiKey, authDomain, and projectId', () => {
+      expectTypeOf<GoogleCloudCoreConfig>().toHaveProperty('apiKey');
+      expectTypeOf<GoogleCloudCoreConfig['apiKey']>().toBeString();
+      expectTypeOf<GoogleCloudCoreConfig>().toHaveProperty('authDomain');
+      expectTypeOf<GoogleCloudCoreConfig['authDomain']>().toBeString();
+      expectTypeOf<GoogleCloudCoreConfig>().toHaveProperty('projectId');
+      expectTypeOf<GoogleCloudCoreConfig['projectId']>().toBeString();
+    });
+
+    it('should have optional scopes and callbacks', () => {
+      expectTypeOf<GoogleCloudCoreConfig>().toHaveProperty('scopes');
+      expectTypeOf<GoogleCloudCoreConfig>().toHaveProperty('onTokenRefreshError');
+      expectTypeOf<GoogleCloudCoreConfig>().toHaveProperty('onSessionExpired');
+    });
+  });
+});

--- a/packages/@granit/authentication-google-cloud/src/index.ts
+++ b/packages/@granit/authentication-google-cloud/src/index.ts
@@ -1,0 +1,1 @@
+export type { GoogleCloudAuthContextType, GoogleCloudCoreConfig } from './types/index.js';

--- a/packages/@granit/authentication-google-cloud/src/types/index.ts
+++ b/packages/@granit/authentication-google-cloud/src/types/index.ts
@@ -1,0 +1,32 @@
+import type { BaseAuthContextType } from '@granit/authentication';
+import type { Auth } from 'firebase/auth';
+
+// ---------------------------------------------------------------------------
+// Google Cloud auth context (extends generic base with Firebase Auth instance)
+// ---------------------------------------------------------------------------
+
+/** Google Cloud-specific auth context — extends the generic base with the Firebase Auth instance. */
+export interface GoogleCloudAuthContextType extends BaseAuthContextType {
+  /** Live Firebase Auth instance — null before init completes. */
+  firebaseAuth: Auth | null;
+}
+
+// ---------------------------------------------------------------------------
+// Hook configuration
+// ---------------------------------------------------------------------------
+
+export interface GoogleCloudCoreConfig {
+  /** Firebase API key. */
+  apiKey: string;
+  /** Firebase auth domain (e.g. `myproject.firebaseapp.com`). */
+  authDomain: string;
+  /** Firebase project ID. */
+  projectId: string;
+
+  /** OAuth scopes to request on sign-in. */
+  scopes?: readonly string[];
+  /** Called when a token refresh fails. */
+  onTokenRefreshError?: () => void;
+  /** Called when the session expires. */
+  onSessionExpired?: () => void;
+}

--- a/packages/@granit/authentication-google-cloud/tsconfig.json
+++ b/packages/@granit/authentication-google-cloud/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/authentication-google-cloud/tsup.config.ts
+++ b/packages/@granit/authentication-google-cloud/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/authentication-keycloak/tsup.config.ts
+++ b/packages/@granit/authentication-keycloak/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/authentication-local/src/__tests__/account-passkey-assertion-api.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/account-passkey-assertion-api.test.ts
@@ -1,7 +1,12 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { beginPasskeyAssertion } from '../api/account-passkey-assertion-api.js';
+import {
+  beginPasskeyAssertion,
+  completePasskeyAssertion,
+} from '../api/account-passkey-assertion-api.js';
+
+import type { AccountLoginResponse } from '../types/index.js';
 
 const BASE = '/api/account';
 
@@ -16,6 +21,28 @@ describe('account-passkey-assertion-api', () => {
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/assertion/begin`);
       expect(result).toBe(optionsJson);
+    });
+  });
+
+  describe('completePasskeyAssertion', () => {
+    it('sends POST /passkeys/assertion/complete with credential JSON', async () => {
+      const client = createMockClient();
+      const response: AccountLoginResponse = {
+        succeeded: true,
+        requiresTwoFactor: false,
+        isLockedOut: false,
+        isNotAllowed: false,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await completePasskeyAssertion(client, BASE, {
+        credentialJson: '{"id":"cred-1","response":{"authenticatorData":"..."}}',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/assertion/complete`, {
+        credentialJson: '{"id":"cred-1","response":{"authenticatorData":"..."}}',
+      });
+      expect(result).toEqual(response);
     });
   });
 });

--- a/packages/@granit/authentication-local/src/__tests__/account-two-factor-login-api.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/account-two-factor-login-api.test.ts
@@ -1,0 +1,54 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { verifyTwoFactorLogin } from '../api/account-two-factor-login-api.js';
+
+import type { AccountLoginResponse } from '../types/index.js';
+
+const BASE = '/api/account';
+
+describe('account-two-factor-login-api', () => {
+  describe('verifyTwoFactorLogin', () => {
+    it('sends POST /login/two-factor with TOTP code', async () => {
+      const client = createMockClient();
+      const response: AccountLoginResponse = {
+        succeeded: true,
+        requiresTwoFactor: false,
+        isLockedOut: false,
+        isNotAllowed: false,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await verifyTwoFactorLogin(client, BASE, {
+        code: '123456',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/login/two-factor`, {
+        code: '123456',
+      });
+      expect(result).toEqual(response);
+    });
+
+    it('sends POST /login/two-factor with recovery code', async () => {
+      const client = createMockClient();
+      const response: AccountLoginResponse = {
+        succeeded: true,
+        requiresTwoFactor: false,
+        isLockedOut: false,
+        isNotAllowed: false,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      const result = await verifyTwoFactorLogin(client, BASE, {
+        code: 'ABCD-1234-EFGH',
+        useRecoveryCode: true,
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/login/two-factor`, {
+        code: 'ABCD-1234-EFGH',
+        useRecoveryCode: true,
+      });
+      expect(result.succeeded).toBe(true);
+    });
+  });
+});

--- a/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
@@ -1,9 +1,15 @@
+import type {
+  AccountLoginResponse,
+  AccountPasskeyAssertionCompleteRequest,
+} from '../types/index.js';
 import type { AxiosInstance } from 'axios';
 
 /**
  * Begin a WebAuthn assertion ceremony for passkey login (anonymous).
  * Returns raw `PublicKeyCredentialRequestOptions` JSON string.
- * Assertion completion goes through `/connect/token` (OIDC layer).
+ *
+ * The caller should pass these options to `navigator.credentials.get()`,
+ * then submit the resulting credential via `completePasskeyAssertion()`.
  *
  * `POST {basePath}/passkeys/assertion/begin`
  */
@@ -12,5 +18,26 @@ export async function beginPasskeyAssertion(
   basePath: string
 ): Promise<string> {
   const { data } = await client.post<string>(`${basePath}/passkeys/assertion/begin`);
+  return data;
+}
+
+/**
+ * Complete a WebAuthn assertion ceremony for passkey login (anonymous).
+ *
+ * Submits the credential JSON obtained from `navigator.credentials.get()`
+ * after `beginPasskeyAssertion()`. On success the server sets an ASP.NET
+ * Core Identity session cookie.
+ *
+ * `POST {basePath}/passkeys/assertion/complete`
+ */
+export async function completePasskeyAssertion(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountPasskeyAssertionCompleteRequest
+): Promise<AccountLoginResponse> {
+  const { data } = await client.post<AccountLoginResponse>(
+    `${basePath}/passkeys/assertion/complete`,
+    request
+  );
   return data;
 }

--- a/packages/@granit/authentication-local/src/api/account-two-factor-login-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-two-factor-login-api.ts
@@ -1,0 +1,24 @@
+import type { AccountLoginResponse, AccountTwoFactorLoginRequest } from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Complete a two-factor login after the initial login returned
+ * `requiresTwoFactor: true`.
+ *
+ * The server identifies the user via the `Identity.TwoFactorUserId` cookie
+ * set during `POST {basePath}/login`. Spaces and dashes are stripped from
+ * the code server-side (authenticator app formatting).
+ *
+ * Set `useRecoveryCode: true` to use a single-use recovery code instead
+ * of a TOTP code.
+ *
+ * `POST {basePath}/login/two-factor`
+ */
+export async function verifyTwoFactorLogin(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountTwoFactorLoginRequest
+): Promise<AccountLoginResponse> {
+  const { data } = await client.post<AccountLoginResponse>(`${basePath}/login/two-factor`, request);
+  return data;
+}

--- a/packages/@granit/authentication-local/src/index.ts
+++ b/packages/@granit/authentication-local/src/index.ts
@@ -2,6 +2,7 @@
 export type {
   AccountLoginRequest,
   AccountLoginResponse,
+  AccountPasskeyAssertionCompleteRequest,
   AccountTwoFactorLoginRequest,
 } from './types/index.js';
 
@@ -15,4 +16,7 @@ export { loginAccount } from './api/account-login-api.js';
 export { verifyTwoFactorLogin } from './api/account-two-factor-login-api.js';
 
 // API — Passkey assertion (for login)
-export { beginPasskeyAssertion } from './api/account-passkey-assertion-api.js';
+export {
+  beginPasskeyAssertion,
+  completePasskeyAssertion,
+} from './api/account-passkey-assertion-api.js';

--- a/packages/@granit/authentication-local/src/index.ts
+++ b/packages/@granit/authentication-local/src/index.ts
@@ -1,11 +1,18 @@
 // Types
-export type { AccountLoginRequest, AccountLoginResponse } from './types/index.js';
+export type {
+  AccountLoginRequest,
+  AccountLoginResponse,
+  AccountTwoFactorLoginRequest,
+} from './types/index.js';
 
 // Query keys
 export { localAuthKeys } from './hooks/query-keys.js';
 
 // API — Login
 export { loginAccount } from './api/account-login-api.js';
+
+// API — Two-factor login verification
+export { verifyTwoFactorLogin } from './api/account-two-factor-login-api.js';
 
 // API — Passkey assertion (for login)
 export { beginPasskeyAssertion } from './api/account-passkey-assertion-api.js';

--- a/packages/@granit/authentication-local/src/types/account-login.ts
+++ b/packages/@granit/authentication-local/src/types/account-login.ts
@@ -21,3 +21,19 @@ export interface AccountLoginResponse {
   readonly isLockedOut: boolean;
   readonly isNotAllowed: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Two-factor login verification
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for `POST {basePath}/login/two-factor`.
+ *
+ * Submitted after a login attempt returns `requiresTwoFactor: true`.
+ * The server identifies the user via the `Identity.TwoFactorUserId` cookie
+ * set during the initial login.
+ */
+export interface AccountTwoFactorLoginRequest {
+  readonly code: string;
+  readonly useRecoveryCode?: boolean;
+}

--- a/packages/@granit/authentication-local/src/types/account-login.ts
+++ b/packages/@granit/authentication-local/src/types/account-login.ts
@@ -37,3 +37,17 @@ export interface AccountTwoFactorLoginRequest {
   readonly code: string;
   readonly useRecoveryCode?: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Passkey assertion completion
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for `POST {basePath}/passkeys/assertion/complete`.
+ *
+ * Submitted after `navigator.credentials.get()` completes the WebAuthn
+ * assertion ceremony initiated by `POST {basePath}/passkeys/assertion/begin`.
+ */
+export interface AccountPasskeyAssertionCompleteRequest {
+  readonly credentialJson: string;
+}

--- a/packages/@granit/authentication-local/src/types/index.ts
+++ b/packages/@granit/authentication-local/src/types/index.ts
@@ -1,5 +1,6 @@
 export type {
   AccountLoginRequest,
   AccountLoginResponse,
+  AccountPasskeyAssertionCompleteRequest,
   AccountTwoFactorLoginRequest,
 } from './account-login.js';

--- a/packages/@granit/authentication-local/src/types/index.ts
+++ b/packages/@granit/authentication-local/src/types/index.ts
@@ -1,1 +1,5 @@
-export type { AccountLoginRequest, AccountLoginResponse } from './account-login.js';
+export type {
+  AccountLoginRequest,
+  AccountLoginResponse,
+  AccountTwoFactorLoginRequest,
+} from './account-login.js';

--- a/packages/@granit/authentication-local/tsup.config.ts
+++ b/packages/@granit/authentication-local/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-authentication-cognito/package.json
+++ b/packages/@granit/react-authentication-cognito/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/react-authentication-cognito",
+  "description": "React hooks for AWS Cognito OIDC authentication — useCognitoInit",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-cognito": "workspace:*",
+    "@granit/react-authentication": "workspace:*",
+    "amazon-cognito-identity-js": ">=6.0.0",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
+++ b/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
@@ -1,0 +1,150 @@
+import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
+import { CognitoUserPool } from 'amazon-cognito-identity-js';
+import * as React from 'react';
+
+import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
+import type { CognitoAuthContextType, CognitoCoreConfig } from '@granit/authentication-cognito';
+
+export interface CognitoCoreResult extends CognitoAuthContextType {
+  /** Direct ref to the Cognito UserPool instance. */
+  userPoolRef: React.RefObject<CognitoUserPool | null>;
+
+  /** Redirect to the Cognito Hosted UI for login. */
+  login: (options?: LoginOptions) => void;
+  /** Sign out from Cognito (local + optionally global). */
+  logout: (options?: LogoutOptions) => void;
+}
+
+/** Extract standard OIDC claims from Cognito user attributes. */
+function extractUser(attributes: Record<string, string>): OidcUserInfo {
+  return {
+    sub: attributes.sub ?? '',
+    email: attributes.email,
+    name: attributes.name,
+    preferred_username: attributes.preferred_username,
+    given_name: attributes.given_name,
+    family_name: attributes.family_name,
+    picture: attributes.picture,
+  };
+}
+
+/**
+ * AWS Cognito initialization hook.
+ *
+ * Handles: UserPool instantiation, current session check, token refresh,
+ * user attribute extraction, and wiring the Bearer token to `@granit/api-client`.
+ */
+export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
+  const [authenticated, setAuthenticated] = React.useState(false);
+  const [loading, setLoading] = React.useState(true);
+  const [user, setUser] = React.useState<OidcUserInfo | null>(null);
+
+  const userPoolRef = React.useRef<CognitoUserPool | null>(null);
+  const initStartedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (initStartedRef.current) return;
+    initStartedRef.current = true;
+
+    const pool = new CognitoUserPool({
+      UserPoolId: config.userPoolId,
+      ClientId: config.clientId,
+    });
+    userPoolRef.current = pool;
+
+    const cognitoUser = pool.getCurrentUser();
+    if (!cognitoUser) {
+      setLoading(false);
+      return;
+    }
+
+    cognitoUser.getSession(
+      (
+        err: Error | null,
+        session: {
+          isValid: () => boolean;
+          getIdToken: () => { getJwtToken: () => string };
+          getAccessToken: () => { getJwtToken: () => string };
+        } | null
+      ) => {
+        if (err || !session?.isValid()) {
+          setLoading(false);
+          config.onSessionExpired?.();
+          return;
+        }
+
+        setAuthenticated(true);
+
+        cognitoUser.getUserAttributes((attrErr, attributes) => {
+          if (!attrErr && attributes) {
+            const attrMap: Record<string, string> = {};
+            for (const attr of attributes) {
+              attrMap[attr.Name] = attr.Value;
+            }
+            setUser(extractUser(attrMap));
+          }
+          setLoading(false);
+        });
+
+        setTokenGetter(async (): Promise<string | undefined> => {
+          return new Promise((resolve) => {
+            cognitoUser.getSession(
+              (
+                refreshErr: Error | null,
+                refreshSession: {
+                  isValid: () => boolean;
+                  getAccessToken: () => { getJwtToken: () => string };
+                } | null
+              ) => {
+                if (refreshErr || !refreshSession?.isValid()) {
+                  config.onTokenRefreshError?.();
+                  resolve(undefined);
+                  return;
+                }
+                resolve(refreshSession.getAccessToken().getJwtToken());
+              }
+            );
+          });
+        });
+
+        setOnUnauthorized(() => {
+          cognitoUser.signOut();
+          setAuthenticated(false);
+          setUser(null);
+        });
+      }
+    );
+  }, [config.userPoolId, config.clientId, config.onSessionExpired, config.onTokenRefreshError]);
+
+  const login = React.useCallback(
+    (options?: LoginOptions) => {
+      if (!config.domain) return;
+      const scopes = config.scopes?.join('+') ?? 'openid+profile+email';
+      const redirectUri = options?.redirectUri ?? window.location.origin;
+      window.location.href = `https://${config.domain}/login?client_id=${config.clientId}&response_type=code&scope=${scopes}&redirect_uri=${encodeURIComponent(redirectUri)}`;
+    },
+    [config.domain, config.clientId, config.scopes]
+  );
+
+  const logout = React.useCallback((options?: LogoutOptions) => {
+    const cognitoUser = userPoolRef.current?.getCurrentUser();
+    if (cognitoUser) {
+      cognitoUser.signOut();
+    }
+    setAuthenticated(false);
+    setUser(null);
+    if (options?.redirectUri) {
+      window.location.href = options.redirectUri;
+    }
+  }, []);
+
+  return {
+    userPoolRef,
+    userPool: userPoolRef.current,
+    authenticated,
+    loading,
+    user,
+    login,
+    logout,
+  };
+}

--- a/packages/@granit/react-authentication-cognito/src/index.ts
+++ b/packages/@granit/react-authentication-cognito/src/index.ts
@@ -1,0 +1,2 @@
+export { useCognitoInit } from './hooks/use-cognito-init.js';
+export type { CognitoCoreResult } from './hooks/use-cognito-init.js';

--- a/packages/@granit/react-authentication-cognito/tsconfig.json
+++ b/packages/@granit/react-authentication-cognito/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-authentication-cognito/tsup.config.ts
+++ b/packages/@granit/react-authentication-cognito/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-authentication-entraid/package.json
+++ b/packages/@granit/react-authentication-entraid/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/react-authentication-entraid",
+  "description": "React hooks for Microsoft Entra ID OIDC authentication — useEntraIdInit",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@azure/msal-browser": ">=3.0.0",
+    "@granit/api-client": "workspace:*",
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-entraid": "workspace:*",
+    "@granit/react-authentication": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
+++ b/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
@@ -1,0 +1,138 @@
+import { PublicClientApplication, InteractionRequiredAuthError } from '@azure/msal-browser';
+import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
+import * as React from 'react';
+
+import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
+import type { EntraIdAuthContextType, EntraIdCoreConfig } from '@granit/authentication-entraid';
+
+export interface EntraIdCoreResult extends EntraIdAuthContextType {
+  /** Direct ref to the MSAL PublicClientApplication instance. */
+  msalRef: React.RefObject<PublicClientApplication | null>;
+
+  /** Redirect to the Entra ID login page with optional overrides. */
+  login: (options?: LoginOptions) => void;
+  /** Redirect to the Entra ID logout page with optional overrides. */
+  logout: (options?: LogoutOptions) => void;
+}
+
+const DEFAULT_SCOPES = ['openid', 'profile', 'email'] as const;
+
+/** Extract standard OIDC claims from MSAL account info. */
+function extractUser(account: {
+  username?: string;
+  name?: string;
+  idTokenClaims?: Record<string, unknown>;
+}): OidcUserInfo {
+  const claims = account.idTokenClaims ?? {};
+  return {
+    sub: (claims.sub ?? claims.oid ?? '') as string,
+    email: (claims.email ?? account.username) as string | undefined,
+    name: (claims.name ?? account.name) as string | undefined,
+    preferred_username: account.username,
+    given_name: claims.given_name as string | undefined,
+    family_name: claims.family_name as string | undefined,
+  };
+}
+
+/**
+ * Microsoft Entra ID initialization hook.
+ *
+ * Handles: MSAL instantiation, silent SSO check, token acquisition,
+ * user info extraction from ID token claims, and wiring the Bearer
+ * token to `@granit/api-client`.
+ */
+export function useEntraIdInit(config: EntraIdCoreConfig): EntraIdCoreResult {
+  const [authenticated, setAuthenticated] = React.useState(false);
+  const [loading, setLoading] = React.useState(true);
+  const [user, setUser] = React.useState<OidcUserInfo | null>(null);
+
+  const msalRef = React.useRef<PublicClientApplication | null>(null);
+  const initStartedRef = React.useRef(false);
+
+  const scopes = React.useMemo(() => [...(config.scopes ?? DEFAULT_SCOPES)], [config.scopes]);
+
+  React.useEffect(() => {
+    if (initStartedRef.current) return;
+    initStartedRef.current = true;
+
+    const initMsal = async () => {
+      try {
+        const msalInstance = new PublicClientApplication({
+          auth: {
+            clientId: config.clientId,
+            authority: config.authority,
+            redirectUri: config.redirectUri,
+          },
+          cache: { cacheLocation: 'sessionStorage' },
+        });
+
+        await msalInstance.initialize();
+        msalRef.current = msalInstance;
+
+        // Handle redirect response (after login redirect)
+        const response = await msalInstance.handleRedirectPromise();
+        if (response?.account) {
+          msalInstance.setActiveAccount(response.account);
+        }
+
+        const activeAccount = msalInstance.getActiveAccount() ?? msalInstance.getAllAccounts()[0];
+
+        if (activeAccount) {
+          msalInstance.setActiveAccount(activeAccount);
+          setUser(extractUser(activeAccount));
+          setAuthenticated(true);
+
+          setTokenGetter(async (): Promise<string | undefined> => {
+            try {
+              const result = await msalInstance.acquireTokenSilent({ scopes });
+              return result.accessToken;
+            } catch (err) {
+              if (err instanceof InteractionRequiredAuthError) {
+                config.onAcquireTokenFailure?.();
+              }
+              return undefined;
+            }
+          });
+
+          setOnUnauthorized(() => {
+            msalInstance.logoutRedirect();
+          });
+        }
+      } catch {
+        // MSAL init failed — stay unauthenticated
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void initMsal();
+  }, [config.clientId, config.authority, config.redirectUri, scopes, config.onAcquireTokenFailure]);
+
+  const login = React.useCallback(
+    async (options?: LoginOptions) => {
+      await msalRef.current?.loginRedirect({
+        scopes,
+        redirectUri: options?.redirectUri,
+        loginHint: options?.loginHint,
+        prompt: options?.prompt,
+      });
+    },
+    [scopes]
+  );
+
+  const logout = React.useCallback(async (options?: LogoutOptions) => {
+    await msalRef.current?.logoutRedirect({
+      postLogoutRedirectUri: options?.redirectUri,
+    });
+  }, []);
+
+  return {
+    msalRef,
+    msalInstance: msalRef.current,
+    authenticated,
+    loading,
+    user,
+    login,
+    logout,
+  };
+}

--- a/packages/@granit/react-authentication-entraid/src/index.ts
+++ b/packages/@granit/react-authentication-entraid/src/index.ts
@@ -1,0 +1,2 @@
+export { useEntraIdInit } from './hooks/use-entraid-init.js';
+export type { EntraIdCoreResult } from './hooks/use-entraid-init.js';

--- a/packages/@granit/react-authentication-entraid/tsconfig.json
+++ b/packages/@granit/react-authentication-entraid/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-authentication-entraid/tsup.config.ts
+++ b/packages/@granit/react-authentication-entraid/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-authentication-google-cloud/package.json
+++ b/packages/@granit/react-authentication-google-cloud/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/react-authentication-google-cloud",
+  "description": "React hooks for Google Cloud Identity Platform (Firebase Auth) — useGoogleCloudInit",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/authentication": "workspace:*",
+    "@granit/authentication-google-cloud": "workspace:*",
+    "@granit/react-authentication": "workspace:*",
+    "firebase": ">=10.0.0",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
+++ b/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
@@ -1,0 +1,134 @@
+import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
+import { initializeApp } from 'firebase/app';
+import {
+  getAuth,
+  onAuthStateChanged,
+  signInWithRedirect,
+  signOut,
+  GoogleAuthProvider,
+} from 'firebase/auth';
+import * as React from 'react';
+
+import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
+import type {
+  GoogleCloudAuthContextType,
+  GoogleCloudCoreConfig,
+} from '@granit/authentication-google-cloud';
+import type { Auth, User } from 'firebase/auth';
+
+export interface GoogleCloudCoreResult extends GoogleCloudAuthContextType {
+  /** Direct ref to the Firebase Auth instance. */
+  authRef: React.RefObject<Auth | null>;
+
+  /** Sign in via Google redirect. */
+  login: (options?: LoginOptions) => void;
+  /** Sign out from Firebase Auth. */
+  logout: (options?: LogoutOptions) => void;
+}
+
+/** Extract standard OIDC claims from Firebase User. */
+function extractUser(firebaseUser: User): OidcUserInfo {
+  return {
+    sub: firebaseUser.uid,
+    email: firebaseUser.email ?? undefined,
+    name: firebaseUser.displayName ?? undefined,
+    picture: firebaseUser.photoURL ?? undefined,
+  };
+}
+
+/**
+ * Google Cloud Identity Platform (Firebase Auth) initialization hook.
+ *
+ * Handles: Firebase app init, auth state listener, token acquisition,
+ * user info extraction, and wiring the Bearer token to `@granit/api-client`.
+ */
+export function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCoreResult {
+  const [authenticated, setAuthenticated] = React.useState(false);
+  const [loading, setLoading] = React.useState(true);
+  const [user, setUser] = React.useState<OidcUserInfo | null>(null);
+
+  const authRef = React.useRef<Auth | null>(null);
+  const initStartedRef = React.useRef(false);
+
+  React.useEffect(() => {
+    if (initStartedRef.current) return;
+    initStartedRef.current = true;
+
+    const app = initializeApp({
+      apiKey: config.apiKey,
+      authDomain: config.authDomain,
+      projectId: config.projectId,
+    });
+
+    const auth = getAuth(app);
+    authRef.current = auth;
+
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
+      if (firebaseUser) {
+        setAuthenticated(true);
+        setUser(extractUser(firebaseUser));
+
+        setTokenGetter(async (): Promise<string | undefined> => {
+          try {
+            return await firebaseUser.getIdToken();
+          } catch {
+            config.onTokenRefreshError?.();
+            return undefined;
+          }
+        });
+
+        setOnUnauthorized(() => {
+          signOut(auth);
+        });
+      } else {
+        setAuthenticated(false);
+        setUser(null);
+        config.onSessionExpired?.();
+      }
+      setLoading(false);
+    });
+
+    return () => unsubscribe();
+  }, [
+    config.apiKey,
+    config.authDomain,
+    config.projectId,
+    config.onTokenRefreshError,
+    config.onSessionExpired,
+  ]);
+
+  const login = React.useCallback(
+    async (_options?: LoginOptions) => {
+      if (!authRef.current) return;
+      const provider = new GoogleAuthProvider();
+      if (config.scopes) {
+        for (const scope of config.scopes) {
+          provider.addScope(scope);
+        }
+      }
+      await signInWithRedirect(authRef.current, provider);
+    },
+    [config.scopes]
+  );
+
+  const logout = React.useCallback(async (options?: LogoutOptions) => {
+    if (authRef.current) {
+      await signOut(authRef.current);
+    }
+    setAuthenticated(false);
+    setUser(null);
+    if (options?.redirectUri) {
+      window.location.href = options.redirectUri;
+    }
+  }, []);
+
+  return {
+    authRef,
+    firebaseAuth: authRef.current,
+    authenticated,
+    loading,
+    user,
+    login,
+    logout,
+  };
+}

--- a/packages/@granit/react-authentication-google-cloud/src/index.ts
+++ b/packages/@granit/react-authentication-google-cloud/src/index.ts
@@ -1,0 +1,2 @@
+export { useGoogleCloudInit } from './hooks/use-google-cloud-init.js';
+export type { GoogleCloudCoreResult } from './hooks/use-google-cloud-init.js';

--- a/packages/@granit/react-authentication-google-cloud/tsconfig.json
+++ b/packages/@granit/react-authentication-google-cloud/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-authentication-google-cloud/tsup.config.ts
+++ b/packages/@granit/react-authentication-google-cloud/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-authentication-keycloak/tsup.config.ts
+++ b/packages/@granit/react-authentication-keycloak/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
@@ -1,0 +1,82 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useCompletePasskeyAssertion } from '../hooks/use-complete-passkey-assertion.js';
+import { LocalAuthProvider } from '../providers/local-auth-provider.js';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider.js';
+import type { AccountLoginResponse } from '@granit/authentication-local';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    completePasskeyAssertion: vi.fn(),
+  };
+});
+
+const { completePasskeyAssertion } = await import('@granit/authentication-local');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: LocalAuthConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useCompletePasskeyAssertion', () => {
+  it('should call completePasskeyAssertion with credential JSON', async () => {
+    const client = createMockClient();
+    const response: AccountLoginResponse = {
+      succeeded: true,
+      requiresTwoFactor: false,
+      isLockedOut: false,
+      isNotAllowed: false,
+    };
+    vi.mocked(completePasskeyAssertion).mockResolvedValue(response);
+
+    const { result } = renderHook(() => useCompletePasskeyAssertion(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      credentialJson: '{"id":"cred-1","response":{"authenticatorData":"..."}}',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(completePasskeyAssertion).toHaveBeenCalledWith(client, '/api/account', {
+      credentialJson: '{"id":"cred-1","response":{"authenticatorData":"..."}}',
+    });
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should handle assertion failure', async () => {
+    const client = createMockClient();
+    vi.mocked(completePasskeyAssertion).mockRejectedValue(new Error('Invalid credential'));
+
+    const { result } = renderHook(() => useCompletePasskeyAssertion(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ credentialJson: '{"invalid":"data"}' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Invalid credential');
+  });
+});

--- a/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
@@ -1,0 +1,104 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useVerifyTwoFactorLogin } from '../hooks/use-verify-two-factor-login.js';
+import { LocalAuthProvider } from '../providers/local-auth-provider.js';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider.js';
+import type { AccountLoginResponse } from '@granit/authentication-local';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    verifyTwoFactorLogin: vi.fn(),
+  };
+});
+
+const { verifyTwoFactorLogin } = await import('@granit/authentication-local');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: LocalAuthConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useVerifyTwoFactorLogin', () => {
+  it('should call verifyTwoFactorLogin with TOTP code', async () => {
+    const client = createMockClient();
+    const response: AccountLoginResponse = {
+      succeeded: true,
+      requiresTwoFactor: false,
+      isLockedOut: false,
+      isNotAllowed: false,
+    };
+    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(response);
+
+    const { result } = renderHook(() => useVerifyTwoFactorLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ code: '123456' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/account', {
+      code: '123456',
+    });
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('should call verifyTwoFactorLogin with recovery code', async () => {
+    const client = createMockClient();
+    const response: AccountLoginResponse = {
+      succeeded: true,
+      requiresTwoFactor: false,
+      isLockedOut: false,
+      isNotAllowed: false,
+    };
+    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(response);
+
+    const { result } = renderHook(() => useVerifyTwoFactorLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ code: 'ABCD-1234-EFGH', useRecoveryCode: true });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/account', {
+      code: 'ABCD-1234-EFGH',
+      useRecoveryCode: true,
+    });
+  });
+
+  it('should handle invalid code error', async () => {
+    const client = createMockClient();
+    vi.mocked(verifyTwoFactorLogin).mockRejectedValue(new Error('Invalid code'));
+
+    const { result } = renderHook(() => useVerifyTwoFactorLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ code: '000000' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Invalid code');
+  });
+});

--- a/packages/@granit/react-authentication-local/src/hooks/use-complete-passkey-assertion.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-complete-passkey-assertion.ts
@@ -1,0 +1,29 @@
+import { completePasskeyAssertion } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider.js';
+
+import type {
+  AccountLoginResponse,
+  AccountPasskeyAssertionCompleteRequest,
+} from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Completes a WebAuthn passkey assertion ceremony for login.
+ *
+ * Call after `navigator.credentials.get()` succeeds with the options
+ * from `useBeginPasskeyAssertion()`.
+ */
+export function useCompletePasskeyAssertion(): UseMutationResult<
+  AccountLoginResponse,
+  Error,
+  AccountPasskeyAssertionCompleteRequest
+> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountPasskeyAssertionCompleteRequest) =>
+      completePasskeyAssertion(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-verify-two-factor-login.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-verify-two-factor-login.ts
@@ -1,0 +1,27 @@
+import { verifyTwoFactorLogin } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider.js';
+
+import type {
+  AccountLoginResponse,
+  AccountTwoFactorLoginRequest,
+} from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Completes a two-factor login after the initial login returned
+ * `requiresTwoFactor: true`. Submits a TOTP code or recovery code.
+ */
+export function useVerifyTwoFactorLogin(): UseMutationResult<
+  AccountLoginResponse,
+  Error,
+  AccountTwoFactorLoginRequest
+> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountTwoFactorLoginRequest) =>
+      verifyTwoFactorLogin(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/index.ts
+++ b/packages/@granit/react-authentication-local/src/index.ts
@@ -8,4 +8,5 @@ export type { LocalAuthConfig, LocalAuthProviderProps } from './providers/local-
 
 // Hooks
 export { useLogin } from './hooks/use-login.js';
+export { useVerifyTwoFactorLogin } from './hooks/use-verify-two-factor-login.js';
 export { useBeginPasskeyAssertion } from './hooks/use-begin-passkey-assertion.js';

--- a/packages/@granit/react-authentication-local/src/index.ts
+++ b/packages/@granit/react-authentication-local/src/index.ts
@@ -10,3 +10,4 @@ export type { LocalAuthConfig, LocalAuthProviderProps } from './providers/local-
 export { useLogin } from './hooks/use-login.js';
 export { useVerifyTwoFactorLogin } from './hooks/use-verify-two-factor-login.js';
 export { useBeginPasskeyAssertion } from './hooks/use-begin-passkey-assertion.js';
+export { useCompletePasskeyAssertion } from './hooks/use-complete-passkey-assertion.js';

--- a/packages/@granit/react-authentication-local/tsup.config.ts
+++ b/packages/@granit/react-authentication-local/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,33 @@ importers:
 
   packages/@granit/authentication-api-keys: {}
 
+  packages/@granit/authentication-cognito:
+    dependencies:
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      amazon-cognito-identity-js:
+        specifier: '>=6.0.0'
+        version: 6.3.16
+
+  packages/@granit/authentication-entraid:
+    dependencies:
+      '@azure/msal-browser':
+        specifier: '>=3.0.0'
+        version: 5.6.2
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+
+  packages/@granit/authentication-google-cloud:
+    dependencies:
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      firebase:
+        specifier: '>=10.0.0'
+        version: 12.11.0
+
   packages/@granit/authentication-keycloak:
     dependencies:
       '@granit/authentication':
@@ -528,6 +555,69 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+
+  packages/@granit/react-authentication-cognito:
+    dependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      '@granit/authentication-cognito':
+        specifier: workspace:*
+        version: link:../authentication-cognito
+      '@granit/react-authentication':
+        specifier: workspace:*
+        version: link:../react-authentication
+      amazon-cognito-identity-js:
+        specifier: '>=6.0.0'
+        version: 6.3.16
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+
+  packages/@granit/react-authentication-entraid:
+    dependencies:
+      '@azure/msal-browser':
+        specifier: '>=3.0.0'
+        version: 5.6.2
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      '@granit/authentication-entraid':
+        specifier: workspace:*
+        version: link:../authentication-entraid
+      '@granit/react-authentication':
+        specifier: workspace:*
+        version: link:../react-authentication
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+
+  packages/@granit/react-authentication-google-cloud:
+    dependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/authentication':
+        specifier: workspace:*
+        version: link:../authentication
+      '@granit/authentication-google-cloud':
+        specifier: workspace:*
+        version: link:../authentication-google-cloud
+      '@granit/react-authentication':
+        specifier: workspace:*
+        version: link:../react-authentication
+      firebase:
+        specifier: '>=10.0.0'
+        version: 12.11.0
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
 
   packages/@granit/react-authentication-keycloak:
     dependencies:
@@ -1311,6 +1401,27 @@ packages:
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
 
+  '@aws-crypto/sha256-js@1.2.2':
+    resolution: {integrity: sha512-Nr1QJIbW/afYYGzYvrF70LtaHrIRtd4TNAglX8BvlfxJLZ45SAmueIKYl5tWoNBPzp65ymXGFK0Bb1vZUpuc9g==}
+
+  '@aws-crypto/util@1.2.2':
+    resolution: {integrity: sha512-H8PjG5WJ4wz0UXAFXeJjWCW1vkvIJ3qUUD+rGRwJ2/hj+xT58Qle2MTql/2MGzkU+1JLAFuR6aJpLAjHwhmwwg==}
+
+  '@aws-sdk/types@3.973.6':
+    resolution: {integrity: sha512-Atfcy4E++beKtwJHiDln2Nby8W/mam64opFPTiHEqgsthqeydFS1pY+OUlN1ouNOmf8ArPU/6cDS65anOP3KQw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    resolution: {integrity: sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==}
+
+  '@azure/msal-browser@5.6.2':
+    resolution: {integrity: sha512-ZgcN9ToRJ80f+wNPBBKYJ+DG0jlW7ktEjYtSNkNsTrlHVMhKB8tKMdI1yIG1I9BJtykkXtqnuOjlJaEMC7J6aw==}
+    engines: {node: '>=0.8.0'}
+
+  '@azure/msal-common@16.4.0':
+    resolution: {integrity: sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==}
+    engines: {node: '>=0.8.0'}
+
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
     engines: {node: '>=6.9.0'}
@@ -1738,6 +1849,225 @@ packages:
     peerDependenciesMeta:
       '@noble/hashes':
         optional: true
+
+  '@firebase/ai@2.10.0':
+    resolution: {integrity: sha512-1lI6HomyoO/8RSJb6ItyHLpHnB2z27m5F4aX/Vpi1nhwWoxdNjkq+6UQOykHyCE0KairojOE5qQ20i1tnF0nNA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@firebase/app-types': 0.x
+
+  '@firebase/analytics-compat@0.2.27':
+    resolution: {integrity: sha512-ZObpYpAxL6JfgH7GnvlDD0sbzGZ0o4nijV8skatV9ZX49hJtCYbFqaEcPYptT94rgX1KUoKEderC7/fa7hybtw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/analytics-types@0.8.3':
+    resolution: {integrity: sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==}
+
+  '@firebase/analytics@0.10.21':
+    resolution: {integrity: sha512-j2y2q65BlgLGB5Pwjhv/Jopw2X/TBTzvAtI5z/DSp56U4wBj7LfhBfzbdCtFPges+Wz0g55GdoawXibOH5jGng==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-check-compat@0.4.2':
+    resolution: {integrity: sha512-M91NhxqbSkI0ChkJWy69blC+rPr6HEgaeRllddSaU1pQ/7IiegeCQM9pPDIgvWnwnBSzKhUHpe6ro/jhJ+cvzw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/app-check-interop-types@0.3.3':
+    resolution: {integrity: sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==}
+
+  '@firebase/app-check-types@0.5.3':
+    resolution: {integrity: sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==}
+
+  '@firebase/app-check@0.11.2':
+    resolution: {integrity: sha512-jcXQVMHAQ5AEKzVD5C7s5fmAYeFOuN6lAJeNTgZK2B9aLnofWaJt8u1A8Idm8gpsBBYSaY3cVyeH5SWMOVPBLQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/app-compat@0.5.10':
+    resolution: {integrity: sha512-tFmBuZL0/v1h6eyKRgWI58ucft6dEJmAi9nhPUXoAW4ZbPSTlnsh31AuEwUoRTz+wwRk9gmgss9GZV05ZM9Kug==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/app-types@0.9.3':
+    resolution: {integrity: sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==}
+
+  '@firebase/app@0.14.10':
+    resolution: {integrity: sha512-PlPhdtjgWUra+LImQTnXOUqUa/jcufZhizdR93ZjlQSS3ahCtDTG6pJw7j0OwFal18DQjICXfeVNsUUrcNisfA==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/auth-compat@0.6.4':
+    resolution: {integrity: sha512-2pj8m/hnqXvMLfC0Mk+fORVTM5DQPkS6l8JpMgtoAWGVgCmYnoWdFMaNWtKbmCxBEyvMA3FlnCJyzrUSMWTfuA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/auth-interop-types@0.2.4':
+    resolution: {integrity: sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==}
+
+  '@firebase/auth-types@0.13.0':
+    resolution: {integrity: sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/auth@1.12.2':
+    resolution: {integrity: sha512-CZJL8V10Vzibs+pDTXdQF+hot1IigIoqF4a4lA/qr5Deo1srcefiyIfgg28B67Lk7IxZhwfJMuI+1bu2xBmV0A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+      '@react-native-async-storage/async-storage': ^2.2.0
+    peerDependenciesMeta:
+      '@react-native-async-storage/async-storage':
+        optional: true
+
+  '@firebase/component@0.7.2':
+    resolution: {integrity: sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/data-connect@0.5.0':
+    resolution: {integrity: sha512-G3GYHpWNJJ95502RQLApzw0jaG3pScHl+J/2MdxIuB51xtHnkRL6KvIAP3fFF1drUewWJHOnDA1U+q4Evf3KSw==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/database-compat@2.1.2':
+    resolution: {integrity: sha512-j4A6IhVZbgxAzT6gJJC2PfOxYCK9SrDrUO7nTM4EscTYtKkAkzsbKoCnDdjFapQfnsncvPWjqVTr/0PffUwg3g==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/database-types@1.0.18':
+    resolution: {integrity: sha512-yOY8IC2go9lfbVDMiy2ATun4EB2AFwocPaQADwMN/RHRUAZSM4rlAV7PGbWPSG/YhkJ2A9xQAiAENgSua9G5Fg==}
+
+  '@firebase/database@1.1.2':
+    resolution: {integrity: sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/firestore-compat@0.4.7':
+    resolution: {integrity: sha512-Et4XxtGnjp0Q9tmaEMETnY5GHJ8gQ9+RN6sSTT4ETWKmym2d6gIjarw0rCQcx+7BrWVYLEIOAXSXysl0b3xnUA==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/firestore-types@3.0.3':
+    resolution: {integrity: sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/firestore@4.13.0':
+    resolution: {integrity: sha512-7i4cVNJXTMim7/P7UsNim0DwyLPk4QQ3y1oSNzv4l0ykJOKYCiFMOuEeUxUYvrReXDJxWHrT/4XMeVQm+13rRw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/functions-compat@0.4.3':
+    resolution: {integrity: sha512-BxkEwWgx1of0tKaao/r2VR6WBLk/RAiyztatiONPrPE8gkitFkOnOCxf8i9cUyA5hX5RGt5H30uNn25Q6QNEmQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/functions-types@0.6.3':
+    resolution: {integrity: sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==}
+
+  '@firebase/functions@0.13.3':
+    resolution: {integrity: sha512-csO7ckK3SSs+NUZW1nms9EK7ckHe/1QOjiP8uAkCYa7ND18s44vjE9g3KxEeIUpyEPqZaX1EhJuFyZjHigAcYw==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/installations-compat@0.2.21':
+    resolution: {integrity: sha512-zahIUkaVKbR8zmTeBHkdfaVl6JGWlhVoSjF7CVH33nFqD3SlPEpEEegn2GNT5iAfsVdtlCyJJ9GW4YKjq+RJKQ==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/installations-types@0.5.3':
+    resolution: {integrity: sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+
+  '@firebase/installations@0.6.21':
+    resolution: {integrity: sha512-xGFGTeICJZ5vhrmmDukeczIcFULFXybojML2+QSDFoKj5A7zbGN7KzFGSKNhDkIxpjzsYG9IleJyUebuAcmqWA==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/logger@0.5.0':
+    resolution: {integrity: sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/messaging-compat@0.2.25':
+    resolution: {integrity: sha512-eoOQqGLtRlseTdiemTN44LlHZpltK5gnhq8XVUuLgtIOG+odtDzrz2UoTpcJWSzaJQVxNLb/x9f39tHdDM4N4w==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/messaging-interop-types@0.2.3':
+    resolution: {integrity: sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==}
+
+  '@firebase/messaging@0.12.25':
+    resolution: {integrity: sha512-7RhDwoDHlOK1/ou0/LeubxmjcngsTjDdrY/ssg2vwAVpUuVAhQzQvuCAOYxcX5wNC1zCgQ54AP1vdngBwbCmOQ==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/performance-compat@0.2.24':
+    resolution: {integrity: sha512-YRlejH8wLt7ThWao+HXoKUHUrZKGYq+otxkPS+8nuE5PeN1cBXX7NAJl9ueuUkBwMIrnKdnDqL/voHXxDAAt3g==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/performance-types@0.2.3':
+    resolution: {integrity: sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==}
+
+  '@firebase/performance@0.7.11':
+    resolution: {integrity: sha512-V3uAhrz7IYJuji+OgT3qYTGKxpek/TViXti9OSsUJ4AexZ3jQjYH5Yrn7JvBxk8MGiSLsC872hh+BxQiPZsm7g==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/remote-config-compat@0.2.23':
+    resolution: {integrity: sha512-4+KqRRHEUUmKT6tFmnpWATOsaFfmSuBs1jXH8JzVtMLEYqq/WS9IDM92OdefFDSrAA2xGd0WN004z8mKeIIscw==}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/remote-config-types@0.5.0':
+    resolution: {integrity: sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==}
+
+  '@firebase/remote-config@0.8.2':
+    resolution: {integrity: sha512-5EXqOThV4upjK9D38d/qOSVwOqRhemlaOFk9vCkMNNALeIlwr+4pLjtLNo4qoY8etQmU/1q4aIATE9N8PFqg0g==}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/storage-compat@0.4.2':
+    resolution: {integrity: sha512-R+aB38wxCH5zjIO/xu9KznI7fgiPuZAG98uVm1NcidHyyupGgIDLKigGmRGBZMnxibe/m2oxNKoZpfEbUX2aQQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app-compat': 0.x
+
+  '@firebase/storage-types@0.8.3':
+    resolution: {integrity: sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==}
+    peerDependencies:
+      '@firebase/app-types': 0.x
+      '@firebase/util': 1.x
+
+  '@firebase/storage@0.14.2':
+    resolution: {integrity: sha512-o/culaTeJ8GRpKXRJov21rux/n9dRaSOWLebyatFP2sqEdCxQPjVA1H9Z2fzYwQxMIU0JVmC7SPPmU11v7L6vQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      '@firebase/app': 0.x
+
+  '@firebase/util@1.15.0':
+    resolution: {integrity: sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==}
+    engines: {node: '>=20.0.0'}
+
+  '@firebase/webchannel-wrapper@1.0.5':
+    resolution: {integrity: sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==}
+
+  '@grpc/grpc-js@1.9.15':
+    resolution: {integrity: sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==}
+    engines: {node: ^8.13.0 || >=10.10.0}
+
+  '@grpc/proto-loader@0.7.15':
+    resolution: {integrity: sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==}
+    engines: {node: '>=6'}
+    hasBin: true
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -2432,6 +2762,10 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@smithy/types@4.13.1':
+    resolution: {integrity: sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==}
+    engines: {node: '>=18.0.0'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -2799,6 +3133,9 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  amazon-cognito-identity-js@6.3.16:
+    resolution: {integrity: sha512-HPGSBGD6Q36t99puWh0LnptxO/4icnk2kqIQ9cTJ2tFQo5NMUnWQIgtrTAk8nm+caqUbjDzXzG56GBjI2tS6jQ==}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -2862,6 +3199,9 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
   baseline-browser-mapping@2.10.12:
     resolution: {integrity: sha512-qyq26DxfY4awP2gIRXhhLWfwzwI+N5Nxk6iQi8EFizIaWIjqicQTE4sLnZZVdeKPRcVNoJOkkpfzoIYuvCKaIQ==}
     engines: {node: '>=6.0.0'}
@@ -2882,6 +3222,9 @@ packages:
     resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
+
+  buffer@4.9.2:
+    resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -3258,6 +3601,9 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-base64-decode@1.0.0:
+    resolution: {integrity: sha512-qwaScUgUGBYeDNRnbc/KyllVU88Jk1pRHPStuF/lO7B0/RTRLj7U0lkdTAutlBblY08rwZDff6tNU9cjv6j//Q==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -3276,6 +3622,10 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  faye-websocket@0.11.4:
+    resolution: {integrity: sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==}
+    engines: {node: '>=0.8.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3300,6 +3650,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  firebase@12.11.0:
+    resolution: {integrity: sha512-W9f3Y+cgQYgF9gvCGxt0upec8zwAtiQVcHuU8MfzUIgVU/9fRQWtu48Geiv1lsigtBz9QHML++Km9xAKO5GB5Q==}
 
   fix-dts-default-cjs-exports@1.0.1:
     resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
@@ -3417,6 +3770,9 @@ packages:
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
 
+  http-parser-js@0.5.10:
+    resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -3445,6 +3801,12 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  idb@7.1.1:
+    resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
+
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -3544,12 +3906,18 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+
+  isomorphic-unfetch@3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3570,6 +3938,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-cookie@2.2.1:
+    resolution: {integrity: sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -4232,6 +4603,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   sass@1.97.3:
     resolution: {integrity: sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==}
     engines: {node: '>=14.0.0'}
@@ -4435,6 +4809,9 @@ packages:
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
 
+  tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4494,6 +4871,9 @@ packages:
   undici@7.24.5:
     resolution: {integrity: sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==}
     engines: {node: '>=20.18.1'}
+
+  unfetch@4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
 
   unicorn-magic@0.4.0:
     resolution: {integrity: sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==}
@@ -4647,6 +5027,9 @@ packages:
     resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
     engines: {node: '>=18'}
 
+  web-vitals@4.2.4:
+    resolution: {integrity: sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==}
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -4657,6 +5040,14 @@ packages:
   webpack-merge@5.10.0:
     resolution: {integrity: sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==}
     engines: {node: '>=10.0.0'}
+
+  websocket-driver@0.7.4:
+    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+    engines: {node: '>=0.8.0'}
+
+  websocket-extensions@0.1.4:
+    resolution: {integrity: sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==}
+    engines: {node: '>=0.8.0'}
 
   whatwg-mimetype@5.0.0:
     resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
@@ -4769,6 +5160,33 @@ snapshots:
       lru-cache: 11.2.7
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@aws-crypto/sha256-js@1.2.2':
+    dependencies:
+      '@aws-crypto/util': 1.2.2
+      '@aws-sdk/types': 3.973.6
+      tslib: 1.14.1
+
+  '@aws-crypto/util@1.2.2':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-utf8-browser': 3.259.0
+      tslib: 1.14.1
+
+  '@aws-sdk/types@3.973.6':
+    dependencies:
+      '@smithy/types': 4.13.1
+      tslib: 2.8.1
+
+  '@aws-sdk/util-utf8-browser@3.259.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@azure/msal-browser@5.6.2':
+    dependencies:
+      '@azure/msal-common': 16.4.0
+
+  '@azure/msal-common@16.4.0': {}
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -5171,6 +5589,336 @@ snapshots:
       levn: 0.4.1
 
   '@exodus/bytes@1.15.0': {}
+
+  '@firebase/ai@2.10.0(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/app-types': 0.9.3
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/analytics-compat@0.2.27(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/analytics': 0.10.21(@firebase/app@0.14.10)
+      '@firebase/analytics-types': 0.8.3
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/analytics-types@0.8.3': {}
+
+  '@firebase/analytics@0.10.21(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/installations': 0.6.21(@firebase/app@0.14.10)
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/app-check-compat@0.4.2(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-check': 0.11.2(@firebase/app@0.14.10)
+      '@firebase/app-check-types': 0.5.3
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/app-check-interop-types@0.3.3': {}
+
+  '@firebase/app-check-types@0.5.3': {}
+
+  '@firebase/app-check@0.11.2(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/app-compat@0.5.10':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/app-types@0.9.3': {}
+
+  '@firebase/app@0.14.10':
+    dependencies:
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/auth-compat@0.6.4(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/auth': 1.12.2(@firebase/app@0.14.10)
+      '@firebase/auth-types': 0.13.0(@firebase/app-types@0.9.3)(@firebase/util@1.15.0)
+      '@firebase/component': 0.7.2
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+      - '@react-native-async-storage/async-storage'
+
+  '@firebase/auth-interop-types@0.2.4': {}
+
+  '@firebase/auth-types@0.13.0(@firebase/app-types@0.9.3)(@firebase/util@1.15.0)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.15.0
+
+  '@firebase/auth@1.12.2(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/component@0.7.2':
+    dependencies:
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/data-connect@0.5.0(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/database-compat@2.1.2':
+    dependencies:
+      '@firebase/component': 0.7.2
+      '@firebase/database': 1.1.2
+      '@firebase/database-types': 1.0.18
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/database-types@1.0.18':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.15.0
+
+  '@firebase/database@1.1.2':
+    dependencies:
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      faye-websocket: 0.11.4
+      tslib: 2.8.1
+
+  '@firebase/firestore-compat@0.4.7(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/firestore': 4.13.0(@firebase/app@0.14.10)
+      '@firebase/firestore-types': 3.0.3(@firebase/app-types@0.9.3)(@firebase/util@1.15.0)
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/firestore-types@3.0.3(@firebase/app-types@0.9.3)(@firebase/util@1.15.0)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.15.0
+
+  '@firebase/firestore@4.13.0(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      '@firebase/webchannel-wrapper': 1.0.5
+      '@grpc/grpc-js': 1.9.15
+      '@grpc/proto-loader': 0.7.15
+      tslib: 2.8.1
+
+  '@firebase/functions-compat@0.4.3(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/functions': 0.13.3(@firebase/app@0.14.10)
+      '@firebase/functions-types': 0.6.3
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/functions-types@0.6.3': {}
+
+  '@firebase/functions@0.13.3(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/app-check-interop-types': 0.3.3
+      '@firebase/auth-interop-types': 0.2.4
+      '@firebase/component': 0.7.2
+      '@firebase/messaging-interop-types': 0.2.3
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/installations-compat@0.2.21(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/installations': 0.6.21(@firebase/app@0.14.10)
+      '@firebase/installations-types': 0.5.3(@firebase/app-types@0.9.3)
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/installations-types@0.5.3(@firebase/app-types@0.9.3)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+
+  '@firebase/installations@0.6.21(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/util': 1.15.0
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/logger@0.5.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/messaging-compat@0.2.25(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/messaging': 0.12.25(@firebase/app@0.14.10)
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/messaging-interop-types@0.2.3': {}
+
+  '@firebase/messaging@0.12.25(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/installations': 0.6.21(@firebase/app@0.14.10)
+      '@firebase/messaging-interop-types': 0.2.3
+      '@firebase/util': 1.15.0
+      idb: 7.1.1
+      tslib: 2.8.1
+
+  '@firebase/performance-compat@0.2.24(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/performance': 0.7.11(@firebase/app@0.14.10)
+      '@firebase/performance-types': 0.2.3
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/performance-types@0.2.3': {}
+
+  '@firebase/performance@0.7.11(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/installations': 0.6.21(@firebase/app@0.14.10)
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+      web-vitals: 4.2.4
+
+  '@firebase/remote-config-compat@0.2.23(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/logger': 0.5.0
+      '@firebase/remote-config': 0.8.2(@firebase/app@0.14.10)
+      '@firebase/remote-config-types': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+
+  '@firebase/remote-config-types@0.5.0': {}
+
+  '@firebase/remote-config@0.8.2(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/installations': 0.6.21(@firebase/app@0.14.10)
+      '@firebase/logger': 0.5.0
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/storage-compat@0.4.2(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app-compat': 0.5.10
+      '@firebase/component': 0.7.2
+      '@firebase/storage': 0.14.2(@firebase/app@0.14.10)
+      '@firebase/storage-types': 0.8.3(@firebase/app-types@0.9.3)(@firebase/util@1.15.0)
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@firebase/app'
+      - '@firebase/app-types'
+
+  '@firebase/storage-types@0.8.3(@firebase/app-types@0.9.3)(@firebase/util@1.15.0)':
+    dependencies:
+      '@firebase/app-types': 0.9.3
+      '@firebase/util': 1.15.0
+
+  '@firebase/storage@0.14.2(@firebase/app@0.14.10)':
+    dependencies:
+      '@firebase/app': 0.14.10
+      '@firebase/component': 0.7.2
+      '@firebase/util': 1.15.0
+      tslib: 2.8.1
+
+  '@firebase/util@1.15.0':
+    dependencies:
+      tslib: 2.8.1
+
+  '@firebase/webchannel-wrapper@1.0.5': {}
+
+  '@grpc/grpc-js@1.9.15':
+    dependencies:
+      '@grpc/proto-loader': 0.7.15
+      '@types/node': 25.5.0
+
+  '@grpc/proto-loader@0.7.15':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.4
+      yargs: 17.7.2
 
   '@humanfs/core@0.19.1': {}
 
@@ -5774,6 +6522,10 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@smithy/types@4.13.1':
+    dependencies:
+      tslib: 2.8.1
+
   '@standard-schema/spec@1.1.0': {}
 
   '@tanstack/query-core@5.95.0': {}
@@ -6152,6 +6904,16 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  amazon-cognito-identity-js@6.3.16:
+    dependencies:
+      '@aws-crypto/sha256-js': 1.2.2
+      buffer: 4.9.2
+      fast-base64-decode: 1.0.0
+      isomorphic-unfetch: 3.1.0
+      js-cookie: 2.2.1
+    transitivePeerDependencies:
+      - encoding
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -6216,6 +6978,8 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
+  base64-js@1.5.1: {}
+
   baseline-browser-mapping@2.10.12: {}
 
   bidi-js@1.0.3:
@@ -6237,6 +7001,12 @@ snapshots:
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  buffer@4.9.2:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+      isarray: 1.0.0
 
   bundle-require@5.1.0(esbuild@0.27.4):
     dependencies:
@@ -6610,6 +7380,8 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-base64-decode@1.0.0: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -6629,6 +7401,10 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
+
+  faye-websocket@0.11.4:
+    dependencies:
+      websocket-driver: 0.7.4
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -6651,6 +7427,39 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  firebase@12.11.0:
+    dependencies:
+      '@firebase/ai': 2.10.0(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)
+      '@firebase/analytics': 0.10.21(@firebase/app@0.14.10)
+      '@firebase/analytics-compat': 0.2.27(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)
+      '@firebase/app': 0.14.10
+      '@firebase/app-check': 0.11.2(@firebase/app@0.14.10)
+      '@firebase/app-check-compat': 0.4.2(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)
+      '@firebase/app-compat': 0.5.10
+      '@firebase/app-types': 0.9.3
+      '@firebase/auth': 1.12.2(@firebase/app@0.14.10)
+      '@firebase/auth-compat': 0.6.4(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)
+      '@firebase/data-connect': 0.5.0(@firebase/app@0.14.10)
+      '@firebase/database': 1.1.2
+      '@firebase/database-compat': 2.1.2
+      '@firebase/firestore': 4.13.0(@firebase/app@0.14.10)
+      '@firebase/firestore-compat': 0.4.7(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)
+      '@firebase/functions': 0.13.3(@firebase/app@0.14.10)
+      '@firebase/functions-compat': 0.4.3(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)
+      '@firebase/installations': 0.6.21(@firebase/app@0.14.10)
+      '@firebase/installations-compat': 0.2.21(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)
+      '@firebase/messaging': 0.12.25(@firebase/app@0.14.10)
+      '@firebase/messaging-compat': 0.2.25(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)
+      '@firebase/performance': 0.7.11(@firebase/app@0.14.10)
+      '@firebase/performance-compat': 0.2.24(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)
+      '@firebase/remote-config': 0.8.2(@firebase/app@0.14.10)
+      '@firebase/remote-config-compat': 0.2.23(@firebase/app-compat@0.5.10)(@firebase/app@0.14.10)
+      '@firebase/storage': 0.14.2(@firebase/app@0.14.10)
+      '@firebase/storage-compat': 0.4.2(@firebase/app-compat@0.5.10)(@firebase/app-types@0.9.3)(@firebase/app@0.14.10)
+      '@firebase/util': 1.15.0
+    transitivePeerDependencies:
+      - '@react-native-async-storage/async-storage'
 
   fix-dts-default-cjs-exports@1.0.1:
     dependencies:
@@ -6769,6 +7578,8 @@ snapshots:
     dependencies:
       void-elements: 3.1.0
 
+  http-parser-js@0.5.10: {}
+
   husky@9.1.7: {}
 
   i18next@25.8.13(typescript@5.9.3):
@@ -6788,6 +7599,10 @@ snapshots:
       '@babel/runtime': 7.29.2
     optionalDependencies:
       typescript: 6.0.2
+
+  idb@7.1.1: {}
+
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -6868,9 +7683,18 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  isarray@1.0.0: {}
+
   isexe@2.0.0: {}
 
   isobject@3.0.1: {}
+
+  isomorphic-unfetch@3.1.0:
+    dependencies:
+      node-fetch: 2.7.0
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -6888,6 +7712,8 @@ snapshots:
   jiti@2.6.1: {}
 
   joycon@3.1.1: {}
+
+  js-cookie@2.2.1: {}
 
   js-tokens@10.0.0: {}
 
@@ -7663,6 +8489,8 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.2.1: {}
+
   sass@1.97.3:
     dependencies:
       chokidar: 4.0.3
@@ -7840,6 +8668,8 @@ snapshots:
 
   ts-interface-checker@0.1.13: {}
 
+  tslib@1.14.1: {}
+
   tslib@2.8.1: {}
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@6.0.2)(yaml@2.8.3):
@@ -7901,6 +8731,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.24.5: {}
+
+  unfetch@4.2.0: {}
 
   unicorn-magic@0.4.0: {}
 
@@ -8033,6 +8865,8 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
+  web-vitals@4.2.4: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@8.0.1: {}
@@ -8042,6 +8876,14 @@ snapshots:
       clone-deep: 4.0.1
       flat: 5.0.2
       wildcard: 2.0.1
+
+  websocket-driver@0.7.4:
+    dependencies:
+      http-parser-js: 0.5.10
+      safe-buffer: 5.2.1
+      websocket-extensions: 0.1.4
+
+  websocket-extensions@0.1.4: {}
 
   whatwg-mimetype@5.0.0: {}
 


### PR DESCRIPTION
## Summary

Completes the authentication packages refactoring started in #144:

- Add **2FA login verification** to `@granit/authentication-local`: `AccountTwoFactorLoginRequest` type, `verifyTwoFactorLogin()` API, `useVerifyTwoFactorLogin()` hook — mirrors `POST /api/account/login/two-factor`
- Add **passkey assertion completion** to `@granit/authentication-local`: `AccountPasskeyAssertionCompleteRequest` type, `completePasskeyAssertion()` API, `useCompletePasskeyAssertion()` hook — mirrors `POST /api/account/passkeys/assertion/complete`
- Add **3 federated provider packages** for backend parity:
  - `@granit/authentication-entraid` + `@granit/react-authentication-entraid` (MSAL.js)
  - `@granit/authentication-cognito` + `@granit/react-authentication-cognito` (amazon-cognito-identity-js)
  - `@granit/authentication-google-cloud` + `@granit/react-authentication-google-cloud` (Firebase Auth)
- Add missing `tsup.config.ts` for all new packages (CI build fix)

### Complete login flows now covered

| Flow | Steps |
|---|---|
| Password | `useLogin()` → redirect `/connect/authorize` |
| Password + 2FA | `useLogin()` → `useVerifyTwoFactorLogin()` → redirect |
| Passkey | `useBeginPasskeyAssertion()` → `navigator.credentials.get()` → `useCompletePasskeyAssertion()` → redirect |

### Backend ↔ frontend parity

| Backend .NET | Frontend types | Frontend React |
|---|---|---|
| `Authentication.JwtBearer.Keycloak` | `authentication-keycloak` (PR #144) | `react-authentication-keycloak` (PR #144) |
| `Authentication.JwtBearer.EntraId` | `authentication-entraid` | `react-authentication-entraid` |
| `Authentication.JwtBearer.Cognito` | `authentication-cognito` | `react-authentication-cognito` |
| `Authentication.JwtBearer.GoogleCloud` | `authentication-google-cloud` | `react-authentication-google-cloud` |
| `Identity.Local.Endpoints` (login) | `authentication-local` | `react-authentication-local` |

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest run` — 221 files, 1750 tests passed
- [x] `pnpm build` — all 84 packages build successfully
