### PR TITLE
fix: resolve 15 SonarQube code smells across 9 packages

### DIFF
--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -127,27 +127,24 @@ export function createApiClient(config: ApiClientConfig): AxiosInstance {
             req.headers['X-CSRF-Token'] = csrfToken;
           }
         }
-      } else {
+      } else if (_tokenGetter) {
         // Bearer mode: inject Authorization header
-        if (_tokenGetter) {
-          const token = await _tokenGetter();
-          if (token) {
-            req.headers.Authorization = `Bearer ${token}`;
-          }
+        const token = await _tokenGetter();
+        if (token) {
+          req.headers.Authorization = `Bearer ${token}`;
         }
       }
-      if (_tenantGetter) {
-        const tenantId = _tenantGetter();
-        if (tenantId) {
-          req.headers['X-Tenant-Id'] = tenantId;
-        }
+
+      const tenantId = _tenantGetter?.();
+      if (tenantId) {
+        req.headers['X-Tenant-Id'] = tenantId;
       }
-      if (_idempotencyKeyGenerator) {
-        const key = _idempotencyKeyGenerator(req);
-        if (key) {
-          req.headers['Idempotency-Key'] = key;
-        }
+
+      const idempotencyKey = _idempotencyKeyGenerator?.(req);
+      if (idempotencyKey) {
+        req.headers['Idempotency-Key'] = idempotencyKey;
       }
+
       return req;
     },
     /* v8 ignore next 3 */

--- a/packages/@granit/react-account/src/providers/account-provider.tsx
+++ b/packages/@granit/react-account/src/providers/account-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -33,11 +33,14 @@ export function buildAccountQueryKey(
 }
 
 export function AccountProvider({ config, children }: AccountProviderProps) {
-  const value: AccountConfig = {
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-  };
+  const value = useMemo<AccountConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+    }),
+    [config]
+  );
 
   return <AccountContext value={value}>{children}</AccountContext>;
 }

--- a/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
+++ b/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
@@ -58,6 +58,26 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
       return;
     }
 
+    const refreshToken = (): Promise<string | undefined> =>
+      new Promise((resolve) => {
+        cognitoUser.getSession(
+          (
+            refreshErr: Error | null,
+            refreshSession: {
+              isValid: () => boolean;
+              getAccessToken: () => { getJwtToken: () => string };
+            } | null
+          ) => {
+            if (refreshErr || !refreshSession?.isValid()) {
+              config.onTokenRefreshError?.();
+              resolve(undefined);
+              return;
+            }
+            resolve(refreshSession.getAccessToken().getJwtToken());
+          }
+        );
+      });
+
     cognitoUser.getSession(
       (
         err: Error | null,
@@ -86,26 +106,7 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
           setLoading(false);
         });
 
-        setTokenGetter(async (): Promise<string | undefined> => {
-          return new Promise((resolve) => {
-            cognitoUser.getSession(
-              (
-                refreshErr: Error | null,
-                refreshSession: {
-                  isValid: () => boolean;
-                  getAccessToken: () => { getJwtToken: () => string };
-                } | null
-              ) => {
-                if (refreshErr || !refreshSession?.isValid()) {
-                  config.onTokenRefreshError?.();
-                  resolve(undefined);
-                  return;
-                }
-                resolve(refreshSession.getAccessToken().getJwtToken());
-              }
-            );
-          });
-        });
+        setTokenGetter(refreshToken);
 
         setOnUnauthorized(() => {
           cognitoUser.signOut();
@@ -120,8 +121,8 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
     (options?: LoginOptions) => {
       if (!config.domain) return;
       const scopes = config.scopes?.join('+') ?? 'openid+profile+email';
-      const redirectUri = options?.redirectUri ?? window.location.origin;
-      window.location.href = `https://${config.domain}/login?client_id=${config.clientId}&response_type=code&scope=${scopes}&redirect_uri=${encodeURIComponent(redirectUri)}`;
+      const redirectUri = options?.redirectUri ?? globalThis.location.origin;
+      globalThis.location.href = `https://${config.domain}/login?client_id=${config.clientId}&response_type=code&scope=${scopes}&redirect_uri=${encodeURIComponent(redirectUri)}`;
     },
     [config.domain, config.clientId, config.scopes]
   );
@@ -134,7 +135,7 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
     setAuthenticated(false);
     setUser(null);
     if (options?.redirectUri) {
-      window.location.href = options.redirectUri;
+      globalThis.location.href = options.redirectUri;
     }
   }, []);
 

--- a/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
+++ b/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
@@ -118,7 +118,7 @@ export function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCo
     setAuthenticated(false);
     setUser(null);
     if (options?.redirectUri) {
-      window.location.href = options.redirectUri;
+      globalThis.location.href = options.redirectUri;
     }
   }, []);
 

--- a/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
+++ b/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -38,11 +38,14 @@ export function buildLocalAuthQueryKey(
 }
 
 export function LocalAuthProvider({ config, children }: LocalAuthProviderProps) {
-  const value: LocalAuthConfig = {
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-  };
+  const value = useMemo<LocalAuthConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+    }),
+    [config]
+  );
 
   return <LocalAuthContext value={value}>{children}</LocalAuthContext>;
 }

--- a/packages/@granit/react-bff/src/hooks/use-bff-sessions.ts
+++ b/packages/@granit/react-bff/src/hooks/use-bff-sessions.ts
@@ -51,7 +51,7 @@ export function useBffSessions(): UseBffSessionsResult {
   useEffect(() => {
     mountedRef.current = true;
     if (isAuthenticated) {
-      void refetch();
+      refetch().catch(() => undefined);
     } else if (!authLoading) {
       setSessions([]);
     }

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -1,5 +1,13 @@
 import { CsrfManager } from '@granit/bff';
-import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 
 import type { BffConfig, BffUser } from '@granit/bff';
 import type { ReactNode } from 'react';
@@ -77,29 +85,28 @@ export function BffProvider({ config, children }: BffProviderProps) {
     };
   }, [csrfManager]);
 
-  const login = () => {
-    window.location.href = `${configRef.current.pathPrefix}/bff/login`;
-  };
+  const login = useCallback(() => {
+    globalThis.location.href = `${configRef.current.pathPrefix}/bff/login`;
+  }, []);
 
-  const logout = () => {
-    window.location.href = `${configRef.current.pathPrefix}/bff/logout`;
-  };
+  const logout = useCallback(() => {
+    globalThis.location.href = `${configRef.current.pathPrefix}/bff/logout`;
+  }, []);
 
-  return (
-    <BffContext.Provider
-      value={{
-        user,
-        isAuthenticated: user !== null,
-        isLoading,
-        login,
-        logout,
-        csrfManager,
-        pathPrefix: config.pathPrefix,
-      }}
-    >
-      {children}
-    </BffContext.Provider>
+  const value = useMemo<BffContextType>(
+    () => ({
+      user,
+      isAuthenticated: user !== null,
+      isLoading,
+      login,
+      logout,
+      csrfManager,
+      pathPrefix: config.pathPrefix,
+    }),
+    [user, isLoading, login, logout, csrfManager, config.pathPrefix]
   );
+
+  return <BffContext.Provider value={value}>{children}</BffContext.Provider>;
 }
 
 /**

--- a/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
+++ b/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo } from 'react';
 
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -33,11 +33,14 @@ export function buildAdminQueryKey(
 }
 
 export function OpenIddictAdminProvider({ config, children }: OpenIddictAdminProviderProps) {
-  const value: OpenIddictAdminConfig = {
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-  };
+  const value = useMemo<OpenIddictAdminConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+    }),
+    [config]
+  );
 
   return <AdminContext value={value}>{children}</AdminContext>;
 }

--- a/packages/@granit/react-privacy/src/hooks/use-privacy-deletion.ts
+++ b/packages/@granit/react-privacy/src/hooks/use-privacy-deletion.ts
@@ -1,9 +1,4 @@
-import {
-  cancelDeletion,
-  getDeletionStatus,
-  listDeletions,
-  requestDeletion,
-} from '@granit/privacy';
+import { cancelDeletion, getDeletionStatus, listDeletions, requestDeletion } from '@granit/privacy';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { buildPrivacyQueryKey, usePrivacyConfig } from '../providers/privacy-provider.js';
@@ -23,8 +18,8 @@ export function useRequestDeletion(): UseMutationResult<
   return useMutation({
     mutationFn: (request: PrivacyDeletionRequest) =>
       requestDeletion(config.client, config.basePath!, request),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: buildPrivacyQueryKey(config, 'deletion'),
       });
     },
@@ -42,9 +37,7 @@ export function useDeletionRequests(): UseQueryResult<PrivacyDeletionResponse[]>
 }
 
 /** Get the status of a specific deletion request. */
-export function useDeletionStatus(
-  requestId: string
-): UseQueryResult<PrivacyDeletionResponse> {
+export function useDeletionStatus(requestId: string): UseQueryResult<PrivacyDeletionResponse> {
   const config = usePrivacyConfig();
 
   return useQuery({
@@ -60,10 +53,9 @@ export function useCancelDeletion(): UseMutationResult<void, Error, string> {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (requestId: string) =>
-      cancelDeletion(config.client, config.basePath!, requestId),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({
+    mutationFn: (requestId: string) => cancelDeletion(config.client, config.basePath!, requestId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: buildPrivacyQueryKey(config, 'deletion'),
       });
     },


### PR DESCRIPTION
## Summary

- **api-client**: reduce cognitive complexity from 19 to 12 by merging `else { if }` into `else if` and flattening tenant/idempotency header injection with optional chaining
- **react-account, react-authentication-local, react-openiddict-admin**: wrap context provider values in `useMemo` to prevent unnecessary re-renders
- **react-bff**: `useMemo` + `useCallback` for provider value stability, `globalThis` over `window`, replace `void` operator with `.catch()`
- **react-authentication-cognito**: extract `refreshToken` helper to reduce function nesting depth (was >4 levels), `globalThis` over `window`
- **react-authentication-google-cloud**: `globalThis` over `window`
- **react-privacy**: `async`/`await` in `onSuccess` callbacks instead of `void` operator

## SonarQube issues resolved (15)

| Severity | Rule | File(s) | Count |
|----------|------|---------|-------|
| Critical | Cognitive complexity > 15 | `api-client/index.ts` | 1 |
| Critical | Function nesting > 4 levels | `use-cognito-init.ts` | 1 |
| Critical | `void` operator | `use-bff-sessions.ts`, `use-privacy-deletion.ts` | 3 |
| Major | Context value not memoized | 4 providers | 4 |
| Major | `if` only statement in `else` | `api-client/index.ts` | 1 |
| Minor | `window` → `globalThis` | `use-cognito-init.ts`, `use-google-cloud-init.ts`, `bff-provider.tsx` | 5 |

## Test plan

- [x] `pnpm lint` — zero warnings
- [x] `pnpm tsc` — no type errors
- [ ] SonarQube re-scan confirms all 15 issues resolved