### PR TITLE
fix: restore react-i18next v16 store event binding for async translations

### DIFF
--- a/packages/@granit/localization/src/create-localization.ts
+++ b/packages/@granit/localization/src/create-localization.ts
@@ -40,6 +40,13 @@ export function createLocalization(config?: LocalizationConfig): i18n {
       interpolation: {
         escapeValue: false,
       },
+      // react-i18next v16 defaults bindI18nStore to '' — useTranslation hooks
+      // no longer re-render when addResourceBundle fires 'added' events.
+      // We load translations asynchronously via applyTranslations (addResourceBundle),
+      // so hooks must listen for store changes to pick up the new resources.
+      react: {
+        bindI18nStore: 'added removed',
+      },
       resources: {},
     })
     .catch(() => undefined);

--- a/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
+++ b/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
@@ -15,6 +15,12 @@ export interface CognitoCoreResult extends CognitoAuthContextType {
   logout: (options?: LogoutOptions) => void;
 }
 
+interface CognitoSessionLike {
+  isValid: () => boolean;
+  getIdToken: () => { getJwtToken: () => string };
+  getAccessToken: () => { getJwtToken: () => string };
+}
+
 /** Extract standard OIDC claims from Cognito user attributes. */
 function extractUser(attributes: Record<string, string>): OidcUserInfo {
   return {
@@ -26,6 +32,26 @@ function extractUser(attributes: Record<string, string>): OidcUserInfo {
     family_name: attributes.family_name,
     picture: attributes.picture,
   };
+}
+
+/** Create a token-refresh function that resolves the current access token. */
+function createTokenRefresher(
+  cognitoUser: {
+    getSession: (cb: (err: Error | null, session: CognitoSessionLike | null) => void) => void;
+  },
+  onTokenRefreshError?: () => void
+): () => Promise<string | undefined> {
+  return () =>
+    new Promise((resolve) => {
+      cognitoUser.getSession((err, session) => {
+        if (err || !session?.isValid()) {
+          onTokenRefreshError?.();
+          resolve(undefined);
+          return;
+        }
+        resolve(session.getAccessToken().getJwtToken());
+      });
+    });
 }
 
 /**
@@ -58,63 +84,36 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
       return;
     }
 
-    const refreshToken = (): Promise<string | undefined> =>
-      new Promise((resolve) => {
-        cognitoUser.getSession(
-          (
-            refreshErr: Error | null,
-            refreshSession: {
-              isValid: () => boolean;
-              getAccessToken: () => { getJwtToken: () => string };
-            } | null
-          ) => {
-            if (refreshErr || !refreshSession?.isValid()) {
-              config.onTokenRefreshError?.();
-              resolve(undefined);
-              return;
-            }
-            resolve(refreshSession.getAccessToken().getJwtToken());
+    const refreshToken = createTokenRefresher(cognitoUser, config.onTokenRefreshError);
+
+    cognitoUser.getSession((err: Error | null, session: CognitoSessionLike | null) => {
+      if (err || !session?.isValid()) {
+        setLoading(false);
+        config.onSessionExpired?.();
+        return;
+      }
+
+      setAuthenticated(true);
+
+      cognitoUser.getUserAttributes((attrErr, attributes) => {
+        if (!attrErr && attributes) {
+          const attrMap: Record<string, string> = {};
+          for (const attr of attributes) {
+            attrMap[attr.Name] = attr.Value;
           }
-        );
+          setUser(extractUser(attrMap));
+        }
+        setLoading(false);
       });
 
-    cognitoUser.getSession(
-      (
-        err: Error | null,
-        session: {
-          isValid: () => boolean;
-          getIdToken: () => { getJwtToken: () => string };
-          getAccessToken: () => { getJwtToken: () => string };
-        } | null
-      ) => {
-        if (err || !session?.isValid()) {
-          setLoading(false);
-          config.onSessionExpired?.();
-          return;
-        }
+      setTokenGetter(refreshToken);
 
-        setAuthenticated(true);
-
-        cognitoUser.getUserAttributes((attrErr, attributes) => {
-          if (!attrErr && attributes) {
-            const attrMap: Record<string, string> = {};
-            for (const attr of attributes) {
-              attrMap[attr.Name] = attr.Value;
-            }
-            setUser(extractUser(attrMap));
-          }
-          setLoading(false);
-        });
-
-        setTokenGetter(refreshToken);
-
-        setOnUnauthorized(() => {
-          cognitoUser.signOut();
-          setAuthenticated(false);
-          setUser(null);
-        });
-      }
-    );
+      setOnUnauthorized(() => {
+        cognitoUser.signOut();
+        setAuthenticated(false);
+        setUser(null);
+      });
+    });
   }, [config.userPoolId, config.clientId, config.onSessionExpired, config.onTokenRefreshError]);
 
   const login = React.useCallback(


### PR DESCRIPTION
## Summary

- **Fix login page showing raw translation keys** (e.g. `Auth.LoginPage.Subtitle`) instead of translated text. react-i18next v16 changed `bindI18nStore` default from `'added removed'` to `''`, so `useTranslation()` hooks no longer re-render when `addResourceBundle` fires `'added'` events. Since `@granit/localization` loads translations asynchronously via `applyTranslations`, hooks must listen for store changes. Added `react: { bindI18nStore: 'added removed' }` to the i18next init config.
- **Extract `CognitoSessionLike` interface and `createTokenRefresher` helper** in `use-cognito-init` to reduce cognitive complexity (SonarQube code smell).

## Root cause

1. `applyTranslations` calls `addResourceBundle` which fires an `'added'` event on `i18n.store`
2. When locale matches (common case: `'fr'` === `'fr'`), `changeLanguage` is skipped — no `'languageChanged'` event
3. `useTranslation()` only listens to `'languageChanged'` by default (react-i18next v16) — misses the `'added'` event
4. Components never re-render after translations load → raw keys shown permanently

## Test plan

- [ ] Start app in BFF mode (`VITE_AUTH_PATTERN=bff`), verify login page shows translated text
- [ ] Switch locale in language switcher, verify translations update immediately
- [ ] Verify no regression on authenticated pages (dashboard, settings)
