### PR TITLE
feat(authentication-local): add extractReturnUrl and useLoginWithRedirect for BFF headless login

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -419,6 +419,11 @@
           "name": "verifyTwoFactorLogin",
           "kind": "function",
           "signature": "async function verifyTwoFactorLogin( client: AxiosInstance, basePath: string, request: AccountTwoFactorLoginRequest ): Promise<AccountLoginResponse>"
+        },
+        {
+          "name": "extractReturnUrl",
+          "kind": "function",
+          "signature": "function extractReturnUrl(search?: string): string | null"
         }
       ]
     },
@@ -1438,6 +1443,11 @@
           "name": "useLogin",
           "kind": "function",
           "signature": "function useLogin(): UseMutationResult<AccountLoginResponse, Error, AccountLoginRequest>"
+        },
+        {
+          "name": "useLoginWithRedirect",
+          "kind": "function",
+          "signature": "function useLoginWithRedirect( options?: UseLoginWithRedirectOptions ): UseLoginWithRedirectResult"
         },
         {
           "name": "useVerifyTwoFactorLogin",

--- a/packages/@granit/authentication-local/src/__tests__/extract-return-url.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/extract-return-url.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { extractReturnUrl } from '../utils/extract-return-url.js';
+
+describe('extractReturnUrl', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('extracts a simple relative returnUrl', () => {
+    expect(extractReturnUrl('?returnUrl=%2Fdashboard')).toBe('/dashboard');
+  });
+
+  it('extracts a returnUrl with nested query parameters', () => {
+    const search =
+      '?returnUrl=%2Fconnect%2Fauthorize%3Fclient_id%3Dadmin%26redirect_uri%3Dhttps%253A%252F%252Fapp.local%252Fcallback';
+    const result = extractReturnUrl(search);
+    expect(result).toMatch(/^\/connect\/authorize\?client_id=admin/);
+  });
+
+  it('returns null when returnUrl is absent', () => {
+    expect(extractReturnUrl('?foo=bar')).toBeNull();
+  });
+
+  it('returns null for an empty search string', () => {
+    expect(extractReturnUrl('')).toBeNull();
+  });
+
+  it('returns null for an empty returnUrl value', () => {
+    expect(extractReturnUrl('?returnUrl=')).toBeNull();
+  });
+
+  it('rejects absolute URLs (open redirect)', () => {
+    expect(extractReturnUrl('?returnUrl=https%3A%2F%2Fevil.com')).toBeNull();
+  });
+
+  it('rejects protocol-relative URLs (open redirect)', () => {
+    expect(extractReturnUrl('?returnUrl=%2F%2Fevil.com')).toBeNull();
+  });
+
+  it('falls back to globalThis.location.search when no argument', () => {
+    vi.stubGlobal('location', { search: '?returnUrl=%2Fhome' });
+    expect(extractReturnUrl()).toBe('/home');
+  });
+
+  it('returns null when globalThis.location is undefined', () => {
+    vi.stubGlobal('location', undefined);
+    expect(extractReturnUrl()).toBeNull();
+  });
+});

--- a/packages/@granit/authentication-local/src/index.ts
+++ b/packages/@granit/authentication-local/src/index.ts
@@ -20,3 +20,6 @@ export {
   beginPasskeyAssertion,
   completePasskeyAssertion,
 } from './api/account-passkey-assertion-api.js';
+
+// Utilities
+export { extractReturnUrl } from './utils/extract-return-url.js';

--- a/packages/@granit/authentication-local/src/utils/extract-return-url.ts
+++ b/packages/@granit/authentication-local/src/utils/extract-return-url.ts
@@ -1,0 +1,24 @@
+/**
+ * Extract the `returnUrl` query parameter from a URL search string.
+ *
+ * Used after headless login to redirect the browser to the OIDC authorization
+ * endpoint (`/connect/authorize`) that the Identity Server originally intended.
+ *
+ * Only relative URLs (starting with `/`) are accepted — absolute URLs and
+ * protocol-relative URLs (`//evil.com`) are rejected to prevent open-redirect
+ * attacks.
+ *
+ * @param search - URL search string (e.g. `?returnUrl=%2Fconnect%2Fauthorize`).
+ *                 Defaults to `globalThis.location.search`.
+ * @returns The decoded return URL, or `null` if absent or unsafe.
+ */
+export function extractReturnUrl(search?: string): string | null {
+  const params = new URLSearchParams(search ?? globalThis.location?.search ?? '');
+  const returnUrl = params.get('returnUrl');
+  if (!returnUrl) return null;
+
+  // Only allow relative paths — reject absolute and protocol-relative URLs
+  if (returnUrl.startsWith('/') && !returnUrl.startsWith('//')) return returnUrl;
+
+  return null;
+}

--- a/packages/@granit/react-authentication-local/src/__tests__/use-login-with-redirect.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-login-with-redirect.test.tsx
@@ -1,0 +1,215 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useLoginWithRedirect } from '../hooks/use-login-with-redirect.js';
+import { LocalAuthProvider } from '../providers/local-auth-provider.js';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider.js';
+import type { AccountLoginResponse } from '@granit/authentication-local';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    loginAccount: vi.fn(),
+  };
+});
+
+const { loginAccount } = await import('@granit/authentication-local');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: LocalAuthConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+  };
+}
+
+const succeededResponse: AccountLoginResponse = {
+  succeeded: true,
+  requiresTwoFactor: false,
+  isLockedOut: false,
+  isNotAllowed: false,
+};
+
+const twoFactorResponse: AccountLoginResponse = {
+  succeeded: false,
+  requiresTwoFactor: true,
+  isLockedOut: false,
+  isNotAllowed: false,
+};
+
+const lockedOutResponse: AccountLoginResponse = {
+  succeeded: false,
+  requiresTwoFactor: false,
+  isLockedOut: true,
+  isNotAllowed: false,
+};
+
+const notAllowedResponse: AccountLoginResponse = {
+  succeeded: false,
+  requiresTwoFactor: false,
+  isLockedOut: false,
+  isNotAllowed: true,
+};
+
+let locationMock: { href: string; search: string };
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+});
+
+function stubLocation(search = '') {
+  locationMock = { href: '', search };
+  vi.stubGlobal('location', locationMock);
+}
+
+describe('useLoginWithRedirect', () => {
+  it('redirects to returnUrl on success', async () => {
+    stubLocation();
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockResolvedValue(succeededResponse);
+
+    const { result } = renderHook(
+      () =>
+        useLoginWithRedirect({
+          search: '?returnUrl=%2Fconnect%2Fauthorize%3Fclient_id%3Dadmin',
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    result.current.loginAndRedirect({
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+
+    expect(locationMock.href).toBe('/connect/authorize?client_id=admin');
+  });
+
+  it('redirects to fallbackUrl when returnUrl is absent', async () => {
+    stubLocation();
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockResolvedValue(succeededResponse);
+
+    const { result } = renderHook(
+      () => useLoginWithRedirect({ search: '', fallbackUrl: '/dashboard' }),
+      { wrapper: createWrapper(client) }
+    );
+
+    result.current.loginAndRedirect({
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+
+    expect(locationMock.href).toBe('/dashboard');
+  });
+
+  it('redirects to "/" when no returnUrl and no fallbackUrl', async () => {
+    stubLocation();
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockResolvedValue(succeededResponse);
+
+    const { result } = renderHook(() => useLoginWithRedirect({ search: '' }), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.loginAndRedirect({
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+
+    expect(locationMock.href).toBe('/');
+  });
+
+  it('calls onTwoFactorRequired when 2FA is needed', async () => {
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockResolvedValue(twoFactorResponse);
+    const onTwoFactorRequired = vi.fn();
+
+    const { result } = renderHook(() => useLoginWithRedirect({ search: '', onTwoFactorRequired }), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.loginAndRedirect({
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+
+    expect(onTwoFactorRequired).toHaveBeenCalledOnce();
+  });
+
+  it('calls onLockedOut when account is locked', async () => {
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockResolvedValue(lockedOutResponse);
+    const onLockedOut = vi.fn();
+
+    const { result } = renderHook(() => useLoginWithRedirect({ search: '', onLockedOut }), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.loginAndRedirect({
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+
+    expect(onLockedOut).toHaveBeenCalledOnce();
+  });
+
+  it('calls onNotAllowed when login is not allowed', async () => {
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockResolvedValue(notAllowedResponse);
+    const onNotAllowed = vi.fn();
+
+    const { result } = renderHook(() => useLoginWithRedirect({ search: '', onNotAllowed }), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.loginAndRedirect({
+      login: 'user@example.com',
+      password: 'P@ssw0rd!',
+    });
+
+    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
+
+    expect(onNotAllowed).toHaveBeenCalledOnce();
+  });
+
+  it('exposes the underlying mutation for UI state', async () => {
+    const client = createMockClient();
+    vi.mocked(loginAccount).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useLoginWithRedirect({ search: '' }), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.loginAndRedirect({
+      login: 'user@example.com',
+      password: 'wrong',
+    });
+
+    await waitFor(() => expect(result.current.mutation.isError).toBe(true));
+
+    expect(result.current.mutation.error?.message).toBe('Network error');
+  });
+});

--- a/packages/@granit/react-authentication-local/src/hooks/use-login-with-redirect.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-login-with-redirect.ts
@@ -1,0 +1,88 @@
+import { extractReturnUrl, loginAccount } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+import { useCallback, useRef } from 'react';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider.js';
+
+import type { AccountLoginRequest, AccountLoginResponse } from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+export interface UseLoginWithRedirectOptions {
+  /**
+   * URL search string to extract `returnUrl` from.
+   * Defaults to `globalThis.location.search`.
+   */
+  readonly search?: string;
+  /** Fallback URL when no `returnUrl` is found. Defaults to `"/"`. */
+  readonly fallbackUrl?: string;
+  /** Called when the server requires two-factor authentication. */
+  readonly onTwoFactorRequired?: () => void;
+  /** Called when the account is locked out. */
+  readonly onLockedOut?: () => void;
+  /** Called when login is not allowed (e.g. unconfirmed email). */
+  readonly onNotAllowed?: () => void;
+}
+
+export interface UseLoginWithRedirectResult {
+  /**
+   * Submit credentials and auto-redirect to `returnUrl` on success.
+   *
+   * On non-success responses (`requiresTwoFactor`, `isLockedOut`, `isNotAllowed`),
+   * the corresponding callback from {@link UseLoginWithRedirectOptions} is invoked.
+   */
+  readonly loginAndRedirect: (request: AccountLoginRequest) => void;
+  /** The underlying React Query mutation for UI state (`isPending`, `error`, etc.). */
+  readonly mutation: UseMutationResult<AccountLoginResponse, Error, AccountLoginRequest>;
+}
+
+/**
+ * Wraps {@link useLogin} with automatic redirect to the `returnUrl` query
+ * parameter on successful login.
+ *
+ * Designed for the BFF headless-login flow:
+ * 1. BFF redirects unauthenticated users to `/login?returnUrl=/connect/authorize?…`
+ * 2. The login page calls `loginAndRedirect({ login, password })`
+ * 3. On `succeeded: true`, the browser navigates to `returnUrl`
+ *    (which hits `/connect/authorize` with the Identity cookie now set)
+ * 4. OpenIddict issues the authorization code and redirects back to the BFF callback
+ */
+export function useLoginWithRedirect(
+  options?: UseLoginWithRedirectOptions
+): UseLoginWithRedirectResult {
+  const config = useLocalAuthConfig();
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  const mutation = useMutation({
+    mutationFn: (request: AccountLoginRequest) =>
+      loginAccount(config.client, config.basePath!, request),
+  });
+
+  const loginAndRedirect = useCallback(
+    (request: AccountLoginRequest) => {
+      mutation.mutate(request, {
+        onSuccess: (data) => {
+          if (data.succeeded) {
+            const returnUrl = extractReturnUrl(optionsRef.current?.search);
+            globalThis.location.href = returnUrl ?? optionsRef.current?.fallbackUrl ?? '/';
+            return;
+          }
+          if (data.requiresTwoFactor) {
+            optionsRef.current?.onTwoFactorRequired?.();
+            return;
+          }
+          if (data.isLockedOut) {
+            optionsRef.current?.onLockedOut?.();
+            return;
+          }
+          if (data.isNotAllowed) {
+            optionsRef.current?.onNotAllowed?.();
+          }
+        },
+      });
+    },
+    [mutation]
+  );
+
+  return { loginAndRedirect, mutation };
+}

--- a/packages/@granit/react-authentication-local/src/index.ts
+++ b/packages/@granit/react-authentication-local/src/index.ts
@@ -8,6 +8,11 @@ export type { LocalAuthConfig, LocalAuthProviderProps } from './providers/local-
 
 // Hooks
 export { useLogin } from './hooks/use-login.js';
+export { useLoginWithRedirect } from './hooks/use-login-with-redirect.js';
+export type {
+  UseLoginWithRedirectOptions,
+  UseLoginWithRedirectResult,
+} from './hooks/use-login-with-redirect.js';
 export { useVerifyTwoFactorLogin } from './hooks/use-verify-two-factor-login.js';
 export { useBeginPasskeyAssertion } from './hooks/use-begin-passkey-assertion.js';
 export { useCompletePasskeyAssertion } from './hooks/use-complete-passkey-assertion.js';


### PR DESCRIPTION
## Summary

- Add `extractReturnUrl(search?)` utility to `@granit/authentication-local` — extracts the `returnUrl` query parameter with open-redirect protection (rejects absolute/protocol-relative URLs)
- Add `useLoginWithRedirect(options?)` hook to `@granit/react-authentication-local` — wraps `useLogin` with automatic redirect to `returnUrl` on success, plus callbacks for `requiresTwoFactor`, `isLockedOut`, `isNotAllowed`
- 16 new tests (9 for `extractReturnUrl`, 7 for `useLoginWithRedirect`)

### Context

In the BFF headless-login flow, the Identity Server redirects unauthenticated users to `/login?returnUrl=/connect/authorize?…`. After a successful credential login, the app must navigate to that `returnUrl` so OpenIddict can issue the authorization code. Without framework support, consumers hardcode redirects (e.g., to `/login`) and the OIDC flow breaks.

### Consumer usage

```tsx
// Before (bug: hardcoded redirect)
const login = useLogin();
login.mutate(credentials, { onSuccess: () => navigate('/login') });

// After (auto-redirects to returnUrl)
const { loginAndRedirect, mutation } = useLoginWithRedirect({
  onTwoFactorRequired: () => setShowTwoFactor(true),
});
loginAndRedirect(credentials);
```

`extractReturnUrl` is also exported standalone for 2FA/passkey `onSuccess` handlers.

## Test plan

- [x] `extractReturnUrl` — relative URL extraction, nested query params, empty/missing, open-redirect rejection, globalThis fallback
- [x] `useLoginWithRedirect` — redirect on success, fallbackUrl, default `/`, 2FA/locked/notAllowed callbacks, error propagation
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] All 1766 tests pass
