### PR TITLE
fix(react-validation): pass PropertyName to validation error messages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2662,17 +2662,7 @@
         {
           "name": "createConstraintsResolver",
           "kind": "function",
-          "signature": "function createConstraintsResolver( constraints: SchemaConstraints, t: TranslateFunction ): ConstraintsResolver"
-        },
-        {
-          "name": "ConstraintsResolver",
-          "kind": "type",
-          "signature": "type ConstraintsResolver = ( values: Record<string, unknown>, context: unknown, options: { fields: Record<string, { name: string }> } ) => Promise<{ values: Record<string, unknown>; errors: Record<string, { type: string; message: string }>; }>"
-        },
-        {
-          "name": "TranslateFunction",
-          "kind": "type",
-          "signature": "type TranslateFunction = (key: string, params?: Record<string, unknown>) => string"
+          "signature": "function createConstraintsResolver( constraints: SchemaConstraints, t: TranslateFunction, options?: ConstraintsResolverOptions ): ConstraintsResolver"
         },
         {
           "name": "useFieldProps",

--- a/packages/@granit/react-validation/src/__tests__/create-constraints-resolver.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/create-constraints-resolver.test.ts
@@ -46,7 +46,7 @@ describe('createConstraintsResolver', () => {
     });
     expect(result.errors['name']).toEqual({
       type: 'Granit:Validation:NotEmptyValidator',
-      message: 'Granit:Validation:NotEmptyValidator',
+      message: 'Granit:Validation:NotEmptyValidator (PropertyName=name)',
     });
   });
 
@@ -77,6 +77,7 @@ describe('createConstraintsResolver', () => {
     });
     expect(t).toHaveBeenCalledWith('Granit:Validation:MaximumLengthValidator', {
       maxLength: 100,
+      PropertyName: 'name',
       nsSeparator: false,
     });
   });
@@ -118,5 +119,37 @@ describe('createConstraintsResolver', () => {
       fields: createFields('name'),
     });
     expect(result).toBeInstanceOf(Promise);
+  });
+
+  it('passes PropertyName to t() for validation errors', async () => {
+    t.mockClear();
+    const resolver = createConstraintsResolver(constraints, t);
+    await resolver({ name: '' }, undefined, { fields: createFields('name') });
+    expect(t).toHaveBeenCalledWith('Granit:Validation:NotEmptyValidator', {
+      PropertyName: 'name',
+      nsSeparator: false,
+    });
+  });
+
+  it('uses labelResolver for PropertyName when provided', async () => {
+    t.mockClear();
+    const resolver = createConstraintsResolver(constraints, t, {
+      labelResolver: (f) => f.toUpperCase(),
+    });
+    await resolver({ name: '' }, undefined, { fields: createFields('name') });
+    expect(t).toHaveBeenCalledWith('Granit:Validation:NotEmptyValidator', {
+      PropertyName: 'NAME',
+      nsSeparator: false,
+    });
+  });
+
+  it('falls back to fieldName when labelResolver is not provided', async () => {
+    t.mockClear();
+    const resolver = createConstraintsResolver(constraints, t);
+    await resolver({ email: '' }, undefined, { fields: createFields('email') });
+    expect(t).toHaveBeenCalledWith('Granit:Validation:NotEmptyValidator', {
+      PropertyName: 'email',
+      nsSeparator: false,
+    });
   });
 });

--- a/packages/@granit/react-validation/src/create-constraints-resolver.ts
+++ b/packages/@granit/react-validation/src/create-constraints-resolver.ts
@@ -18,6 +18,15 @@ export type ConstraintsResolver = (
   errors: Record<string, { type: string; message: string }>;
 }>;
 
+export interface ConstraintsResolverOptions {
+  /**
+   * Resolves a human-readable label for a field name.
+   * Used as {PropertyName} in validation messages.
+   * Defaults to the field name as-is.
+   */
+  readonly labelResolver?: (fieldName: string) => string;
+}
+
 /**
  * Creates a react-hook-form compatible resolver from OpenAPI-extracted constraints.
  * For each constrained field, calls validateField() and maps error codes to
@@ -25,12 +34,13 @@ export type ConstraintsResolver = (
  */
 export function createConstraintsResolver(
   constraints: SchemaConstraints,
-  t: TranslateFunction
+  t: TranslateFunction,
+  options?: ConstraintsResolverOptions
 ): ConstraintsResolver {
-  return async (values, _context, options) => {
+  return async (values, _context, formOptions) => {
     const errors: Record<string, { type: string; message: string }> = {};
 
-    for (const fieldName of Object.keys(options.fields)) {
+    for (const fieldName of Object.keys(formOptions.fields)) {
       const constraint = constraints[fieldName];
       if (!constraint) continue;
 
@@ -41,8 +51,11 @@ export function createConstraintsResolver(
 
       if (fieldErrors.length > 0) {
         const first = fieldErrors[0]!;
+        const propertyName = options?.labelResolver?.(fieldName) ?? fieldName;
+
         let message = t(first.code, {
           ...first.params,
+          PropertyName: propertyName,
           nsSeparator: false,
         } as Record<string, unknown>);
 

--- a/packages/@granit/react-validation/src/index.ts
+++ b/packages/@granit/react-validation/src/index.ts
@@ -1,6 +1,10 @@
 // Resolver
 export { createConstraintsResolver } from './create-constraints-resolver.js';
-export type { ConstraintsResolver, TranslateFunction } from './create-constraints-resolver.js';
+export type {
+  ConstraintsResolver,
+  ConstraintsResolverOptions,
+  TranslateFunction,
+} from './create-constraints-resolver.js';
 
 // Hooks
 export { useFieldProps } from './use-field-props.js';


### PR DESCRIPTION
## Summary

- `createConstraintsResolver` now passes `PropertyName` to the `t()` translation function, so i18next can interpolate `{{PropertyName}}` in validation messages instead of showing the raw `{PropertyName}` placeholder.
- Adds an optional `ConstraintsResolverOptions.labelResolver` callback to resolve human-readable labels (e.g. `firstName` → `First Name`); defaults to the raw field name.
- Exports the new `ConstraintsResolverOptions` type from `@granit/react-validation`.

## Backward compatibility

Fully backward-compatible:
- `PropertyName` is an additional interpolation param — existing `t()` keys that don't reference it are unaffected.
- The third `options` parameter is optional — existing 2-arg callers continue to work.

## Test plan

- [x] Updated 2 existing test assertions to expect `PropertyName` in `t()` calls
- [x] Added 3 new tests: default PropertyName, labelResolver override, fallback without resolver
- [x] All 30 tests pass (`pnpm vitest run packages/@granit/react-validation`)
- [x] Lint clean, TypeScript clean