### PR TITLE
feat(scheduling): add @granit/scheduling and @granit/react-scheduling packages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2318,6 +2318,11 @@
       ]
     },
     {
+      "name": "@granit/react-scheduling",
+      "description": "React hooks for scheduled action management — useScheduledActions, useCancelScheduledAction, useRescheduleScheduledAction",
+      "exports": []
+    },
+    {
       "name": "@granit/react-settings",
       "description": "React bindings for @granit/settings — SettingsProvider, useSetting, useSettings, useUpdateSetting, useDeleteSetting",
       "exports": [
@@ -2864,6 +2869,11 @@
     {
       "name": "@granit/reference-data",
       "description": "Generic reference data types and API — mirrors Granit.ReferenceData .NET",
+      "exports": []
+    },
+    {
+      "name": "@granit/scheduling",
+      "description": "Scheduled action types and API — mirrors Granit.Scheduling .NET contract",
       "exports": []
     },
     {

--- a/packages/@granit/react-scheduling/package.json
+++ b/packages/@granit/react-scheduling/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@granit/react-scheduling",
+  "description": "React hooks for scheduled action management — useScheduledActions, useCancelScheduledAction, useRescheduleScheduledAction",
+  "version": "0.3.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/scheduling": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
+++ b/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
@@ -1,0 +1,145 @@
+import {
+  cancelScheduledAction,
+  fetchScheduledActionById,
+  fetchScheduledActions,
+  rescheduleScheduledAction,
+} from '@granit/scheduling';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
+import type { RescheduleActionRequest, ScheduledActionResponse } from '@granit/scheduling';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+
+const DEFAULT_BASE_PATH = '/api/granit/scheduling';
+
+/** Options accepted by all scheduling hooks. */
+export interface SchedulingOptions {
+  /** Axios instance used for all requests. */
+  readonly client: AxiosInstance;
+  /** Base URL for the scheduling API. Defaults to `/api/granit/scheduling`. */
+  readonly basePath?: string;
+}
+
+/** Options for the list hook, extending base options with QueryEngine params. */
+export interface SchedulingListOptions extends SchedulingOptions {
+  /** QueryEngine request parameters (pagination, filters, sort, etc.). */
+  readonly request?: QueryRequest;
+  /** Auto-refetch interval in milliseconds. Defaults to `15_000` (15 s). Set to `false` to disable. */
+  readonly refetchInterval?: number | false;
+}
+
+/** Mutation variables for rescheduling an action. */
+export interface RescheduleVariables {
+  readonly id: string;
+  readonly request: RescheduleActionRequest;
+}
+
+/** Query key factory for scheduling queries. */
+export const schedulingKeys = {
+  all: ['scheduling', 'actions'] as const,
+  list: (request?: QueryRequest) => [...schedulingKeys.all, 'list', request ?? {}] as const,
+  detail: (id: string) => [...schedulingKeys.all, 'detail', id] as const,
+};
+
+/**
+ * Query hook that fetches a paginated list of scheduled actions via QueryEngine.
+ *
+ * Polls every 15 seconds by default to reflect live scheduler state.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useScheduledActions({ client: api, request: { page: 1, pageSize: 20 } });
+ * // data.items, data.totalCount
+ * ```
+ */
+export function useScheduledActions(
+  options: SchedulingListOptions
+): UseQueryResult<PagedResult<ScheduledActionResponse>> {
+  const { client, basePath = DEFAULT_BASE_PATH, request, refetchInterval = 15_000 } = options;
+
+  return useQuery({
+    queryKey: schedulingKeys.list(request),
+    queryFn: () => fetchScheduledActions(client, basePath, request),
+    refetchInterval,
+  });
+}
+
+/**
+ * Query hook that fetches a single scheduled action by ID.
+ *
+ * Polls every 15 seconds by default. The query is disabled when the ID is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: action } = useScheduledAction('550e8400-...', { client: api });
+ * ```
+ */
+export function useScheduledAction(
+  id: string,
+  options: SchedulingOptions & { readonly refetchInterval?: number | false }
+): UseQueryResult<ScheduledActionResponse> {
+  const { client, basePath = DEFAULT_BASE_PATH, refetchInterval = 15_000 } = options;
+
+  return useQuery({
+    queryKey: schedulingKeys.detail(id),
+    queryFn: () => fetchScheduledActionById(client, basePath, id),
+    refetchInterval,
+    enabled: id.length > 0,
+  });
+}
+
+/**
+ * Mutation hook to cancel a pending scheduled action.
+ *
+ * Sends `DELETE {basePath}/{id}` and invalidates the actions list on success.
+ *
+ * @example
+ * ```tsx
+ * const { mutate: cancel } = useCancelScheduledAction({ client: api });
+ * cancel('550e8400-...');
+ * ```
+ */
+export function useCancelScheduledAction(
+  options: SchedulingOptions
+): UseMutationResult<void, Error, string> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: string) => {
+      await cancelScheduledAction(client, basePath, id);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: schedulingKeys.all });
+    },
+  });
+}
+
+/**
+ * Mutation hook to reschedule a pending action to a new execution time.
+ *
+ * Sends `PUT {basePath}/{id}/reschedule` and invalidates both the list and the
+ * specific action detail on success.
+ *
+ * @example
+ * ```tsx
+ * const { mutate: reschedule } = useRescheduleScheduledAction({ client: api });
+ * reschedule({ id: '550e8400-...', request: { newExecuteAt: '2026-04-10T09:00:00Z' } });
+ * ```
+ */
+export function useRescheduleScheduledAction(
+  options: SchedulingOptions
+): UseMutationResult<ScheduledActionResponse, Error, RescheduleVariables> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, request }: RescheduleVariables) =>
+      rescheduleScheduledAction(client, basePath, id, request),
+    onSuccess: async (_data, { id }) => {
+      await queryClient.invalidateQueries({ queryKey: schedulingKeys.all });
+      await queryClient.invalidateQueries({ queryKey: schedulingKeys.detail(id) });
+    },
+  });
+}

--- a/packages/@granit/react-scheduling/src/index.ts
+++ b/packages/@granit/react-scheduling/src/index.ts
@@ -1,0 +1,15 @@
+// Hooks
+export {
+  schedulingKeys,
+  useCancelScheduledAction,
+  useRescheduleScheduledAction,
+  useScheduledAction,
+  useScheduledActions,
+} from './hooks/use-scheduling.js';
+
+// Types
+export type {
+  RescheduleVariables,
+  SchedulingListOptions,
+  SchedulingOptions,
+} from './hooks/use-scheduling.js';

--- a/packages/@granit/react-scheduling/tsconfig.json
+++ b/packages/@granit/react-scheduling/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/scheduling": ["../scheduling/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/scheduling/package.json
+++ b/packages/@granit/scheduling/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/scheduling",
+  "description": "Scheduled action types and API — mirrors Granit.Scheduling .NET contract",
+  "version": "0.3.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/query-engine": "workspace:*",
+    "axios": "*"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/scheduling/src/api/scheduling-api.ts
+++ b/packages/@granit/scheduling/src/api/scheduling-api.ts
@@ -1,0 +1,64 @@
+import { fetchPage } from '@granit/query-engine';
+
+import type { RescheduleActionRequest, ScheduledActionResponse } from '../types/index.js';
+import type { QueryRequest } from '@granit/query-engine';
+import type { PagedResult } from '@granit/query-engine';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Fetch a scheduled action by ID.
+ *
+ * `GET {basePath}/{id}`
+ */
+export async function fetchScheduledActionById(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<ScheduledActionResponse> {
+  const { data } = await client.get<ScheduledActionResponse>(`${basePath}/${id}`);
+  return data;
+}
+
+/**
+ * Fetch a paginated, filterable, sortable list of scheduled actions via QueryEngine.
+ *
+ * `GET {basePath}/query?page=&pageSize=&...`
+ */
+export async function fetchScheduledActions(
+  client: AxiosInstance,
+  basePath: string,
+  request: QueryRequest = {}
+): Promise<PagedResult<ScheduledActionResponse>> {
+  return fetchPage<ScheduledActionResponse>(client, `${basePath}/query`, request);
+}
+
+/**
+ * Cancel a pending scheduled action.
+ *
+ * `DELETE {basePath}/{id}` — returns 204 on success, 404/409 on error.
+ */
+export async function cancelScheduledAction(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(`${basePath}/${id}`);
+}
+
+/**
+ * Reschedule a pending action to a new execution time.
+ *
+ * `PUT {basePath}/{id}/reschedule` — returns 200 on success, 404/409 on error.
+ */
+export async function rescheduleScheduledAction(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: RescheduleActionRequest
+): Promise<ScheduledActionResponse> {
+  const { data } = await client.put<ScheduledActionResponse>(
+    `${basePath}/${id}/reschedule`,
+    request
+  );
+  return data;
+}

--- a/packages/@granit/scheduling/src/constants.ts
+++ b/packages/@granit/scheduling/src/constants.ts
@@ -1,0 +1,23 @@
+/** Permission strings for the Scheduling module. */
+export const SCHEDULING_PERMISSIONS = {
+  ACTIONS_READ: 'Scheduling.Actions.Read',
+  ACTIONS_MANAGE: 'Scheduling.Actions.Manage',
+} as const;
+
+/** Status → badge color mapping for UI rendering. */
+export const SCHEDULING_STATUS_COLORS = {
+  0: 'blue',
+  1: 'green',
+  2: 'gray',
+  3: 'red',
+  4: 'amber',
+} as const;
+
+/** Status → human-readable label mapping. */
+export const SCHEDULING_STATUS_LABELS = {
+  0: 'Pending',
+  1: 'Executed',
+  2: 'Cancelled',
+  3: 'Failed',
+  4: 'Processing',
+} as const;

--- a/packages/@granit/scheduling/src/index.ts
+++ b/packages/@granit/scheduling/src/index.ts
@@ -1,0 +1,21 @@
+// Types
+export {
+  ScheduledActionStatus,
+  type RescheduleActionRequest,
+  type ScheduledActionResponse,
+} from './types/index.js';
+
+// Constants
+export {
+  SCHEDULING_PERMISSIONS,
+  SCHEDULING_STATUS_COLORS,
+  SCHEDULING_STATUS_LABELS,
+} from './constants.js';
+
+// API
+export {
+  cancelScheduledAction,
+  fetchScheduledActionById,
+  fetchScheduledActions,
+  rescheduleScheduledAction,
+} from './api/scheduling-api.js';

--- a/packages/@granit/scheduling/src/types/index.ts
+++ b/packages/@granit/scheduling/src/types/index.ts
@@ -1,0 +1,26 @@
+/** Status of a scheduled action. Mirrors Granit.Scheduling.ScheduledActionStatus .NET enum. */
+export enum ScheduledActionStatus {
+  Pending = 0,
+  Executed = 1,
+  Cancelled = 2,
+  Failed = 3,
+  Processing = 4,
+}
+
+/** Response DTO for a scheduled action. Mirrors Granit.Scheduling.ScheduledActionResponse .NET. */
+export interface ScheduledActionResponse {
+  readonly id: string;
+  readonly payloadType: string;
+  readonly executeAt: string;
+  readonly correlationId: string | null;
+  readonly status: ScheduledActionStatus;
+  readonly executedAt: string | null;
+  readonly cancelledBy: string | null;
+  readonly failureReason: string | null;
+  readonly createdAt: string;
+}
+
+/** Request body for rescheduling a pending action. */
+export interface RescheduleActionRequest {
+  readonly newExecuteAt: string;
+}

--- a/packages/@granit/scheduling/tsconfig.json
+++ b/packages/@granit/scheduling/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1057,6 +1057,31 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/react-scheduling:
+    dependencies:
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/scheduling':
+        specifier: workspace:*
+        version: link:../scheduling
+      '@tanstack/react-query':
+        specifier: ^5.0.0
+        version: 5.95.2(react@19.2.4)
+      axios:
+        specifier: '*'
+        version: 1.14.0
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-settings:
     dependencies:
       '@granit/settings':
@@ -1276,6 +1301,19 @@ importers:
       axios:
         specifier: '*'
         version: 1.13.6
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/scheduling:
+    dependencies:
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      axios:
+        specifier: '*'
+        version: 1.14.0
     devDependencies:
       '@granit/testing':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

- Add `@granit/scheduling` package: types (`ScheduledActionResponse`, `ScheduledActionStatus`, `RescheduleActionRequest`), API functions (`fetchScheduledActionById`, `fetchScheduledActions` via QueryEngine, `cancelScheduledAction`, `rescheduleScheduledAction`), permission constants, and status badge color/label mappings
- Add `@granit/react-scheduling` package: TanStack Query hooks (`useScheduledActions`, `useScheduledAction`, `useCancelScheduledAction`, `useRescheduleScheduledAction`) with 15s polling and automatic cache invalidation
- Mirrors the `@granit/background-jobs` / `@granit/react-background-jobs` package pattern

## API Surface

| Hook | Type | Description |
|------|------|-------------|
| `useScheduledActions` | Query | Paginated list via QueryEngine with polling |
| `useScheduledAction` | Query | Single action by ID with polling |
| `useCancelScheduledAction` | Mutation | `DELETE /{id}`, invalidates list |
| `useRescheduleScheduledAction` | Mutation | `PUT /{id}/reschedule`, invalidates list + detail |

## Test plan

- [ ] `pnpm lint` passes
- [ ] `pnpm tsc` passes
- [ ] Verify exports via `import { ... } from '@granit/scheduling'` in consumer app
- [ ] Verify hooks work with `QueryProvider` in showcase-admin-react
