### PR TITLE
refactor(scheduling): replace enum with const object for ScheduledActionStatus

### DIFF
--- a/packages/@granit/scheduling/src/types/index.ts
+++ b/packages/@granit/scheduling/src/types/index.ts
@@ -1,11 +1,14 @@
 /** Status of a scheduled action. Mirrors Granit.Scheduling.ScheduledActionStatus .NET enum. */
-export enum ScheduledActionStatus {
-  Pending = 0,
-  Executed = 1,
-  Cancelled = 2,
-  Failed = 3,
-  Processing = 4,
-}
+export const ScheduledActionStatus = {
+  Pending: 0,
+  Executed: 1,
+  Cancelled: 2,
+  Failed: 3,
+  Processing: 4,
+} as const;
+
+export type ScheduledActionStatus =
+  (typeof ScheduledActionStatus)[keyof typeof ScheduledActionStatus];
 
 /** Response DTO for a scheduled action. Mirrors Granit.Scheduling.ScheduledActionResponse .NET. */
 export interface ScheduledActionResponse {


### PR DESCRIPTION
## Summary

- Replace TypeScript `enum` with `as const` object + type union pattern for `ScheduledActionStatus`
- Better tree-shaking and runtime compatibility (no IIFE emitted)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm tsc` passes