### PR TITLE
feat(account): add email change API and React hooks

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -46,6 +46,16 @@
           "signature": "async function sessionHeartbeat( client: AxiosInstance, basePath: string ): Promise<void>"
         },
         {
+          "name": "changeEmail",
+          "kind": "function",
+          "signature": "async function changeEmail( client: AxiosInstance, basePath: string, request: AccountChangeEmailRequest ): Promise<void>"
+        },
+        {
+          "name": "confirmEmailChange",
+          "kind": "function",
+          "signature": "async function confirmEmailChange( client: AxiosInstance, basePath: string, request: AccountConfirmEmailChangeRequest ): Promise<void>"
+        },
+        {
           "name": "deleteAccount",
           "kind": "function",
           "signature": "async function deleteAccount( client: AxiosInstance, basePath: string, request: AccountDeleteRequest ): Promise<void>"
@@ -977,6 +987,21 @@
           "members": []
         },
         {
+          "name": "useChangePassword",
+          "kind": "function",
+          "signature": "function useChangePassword(): UseMutationResult< void, Error, AccountPasswordChangeRequest >"
+        },
+        {
+          "name": "useForgotPassword",
+          "kind": "function",
+          "signature": "function useForgotPassword(): UseMutationResult< void, Error, AccountForgotPasswordRequest >"
+        },
+        {
+          "name": "useResetPassword",
+          "kind": "function",
+          "signature": "function useResetPassword(): UseMutationResult< void, Error, AccountPasswordResetRequest >"
+        },
+        {
           "name": "RenamePasskeyVariables",
           "kind": "interface",
           "signature": "interface RenamePasskeyVariables",
@@ -991,6 +1016,16 @@
           "name": "useSessionHeartbeat",
           "kind": "function",
           "signature": "function useSessionHeartbeat(): UseMutationResult<void, Error, void>"
+        },
+        {
+          "name": "useChangeEmail",
+          "kind": "function",
+          "signature": "function useChangeEmail(): UseMutationResult<void, Error, AccountChangeEmailRequest>"
+        },
+        {
+          "name": "useConfirmEmailChange",
+          "kind": "function",
+          "signature": "function useConfirmEmailChange(): UseMutationResult< void, Error, AccountConfirmEmailChangeRequest >"
         },
         {
           "name": "useDeleteAccount",

--- a/packages/@granit/account/src/__tests__/account-email-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-email-api.test.ts
@@ -1,0 +1,40 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { changeEmail, confirmEmailChange } from '../api/account-email-api.js';
+
+const BASE = '/api/account';
+
+describe('account-email-api', () => {
+  describe('changeEmail', () => {
+    it('sends POST /change-email with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await changeEmail(client, BASE, { newEmail: 'new@example.com' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/change-email`, {
+        newEmail: 'new@example.com',
+      });
+    });
+  });
+
+  describe('confirmEmailChange', () => {
+    it('sends POST /confirm-email-change with token and new email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await confirmEmailChange(client, BASE, {
+        userId: 'user-123',
+        newEmail: 'new@example.com',
+        token: 'confirm-token',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/confirm-email-change`, {
+        userId: 'user-123',
+        newEmail: 'new@example.com',
+        token: 'confirm-token',
+      });
+    });
+  });
+});

--- a/packages/@granit/account/src/api/account-email-api.ts
+++ b/packages/@granit/account/src/api/account-email-api.ts
@@ -1,0 +1,32 @@
+import type {
+  AccountChangeEmailRequest,
+  AccountConfirmEmailChangeRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * Request an email change (authenticated).
+ * Always returns 202 regardless of whether the email exists (anti-enumeration).
+ *
+ * `POST {basePath}/change-email`
+ */
+export async function changeEmail(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountChangeEmailRequest
+): Promise<void> {
+  await client.post(`${basePath}/change-email`, request);
+}
+
+/**
+ * Confirm an email change using the token from the confirmation email (anonymous).
+ *
+ * `POST {basePath}/confirm-email-change`
+ */
+export async function confirmEmailChange(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountConfirmEmailChangeRequest
+): Promise<void> {
+  await client.post(`${basePath}/confirm-email-change`, request);
+}

--- a/packages/@granit/account/src/index.ts
+++ b/packages/@granit/account/src/index.ts
@@ -25,6 +25,7 @@ export type {
 } from './types/index.js';
 export type { AccountImpersonationResult } from './types/index.js';
 export type { AccountDeleteRequest } from './types/index.js';
+export type { AccountChangeEmailRequest, AccountConfirmEmailChangeRequest } from './types/index.js';
 
 // Query keys
 export { accountKeys } from './hooks/query-keys.js';
@@ -70,6 +71,9 @@ export {
 
 // API — Session
 export { backToImpersonator, sessionHeartbeat } from './api/account-session-api.js';
+
+// API — Email change
+export { changeEmail, confirmEmailChange } from './api/account-email-api.js';
 
 // API — Deletion
 export { deleteAccount } from './api/account-deletion-api.js';

--- a/packages/@granit/account/src/types/account-email.ts
+++ b/packages/@granit/account/src/types/account-email.ts
@@ -1,0 +1,15 @@
+// ---------------------------------------------------------------------------
+// Account email types — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST /change-email`. */
+export interface AccountChangeEmailRequest {
+  readonly newEmail: string;
+}
+
+/** Request body for `POST /confirm-email-change`. */
+export interface AccountConfirmEmailChangeRequest {
+  readonly userId: string;
+  readonly newEmail: string;
+  readonly token: string;
+}

--- a/packages/@granit/account/src/types/index.ts
+++ b/packages/@granit/account/src/types/index.ts
@@ -1,12 +1,6 @@
-export type {
-  AccountRegisterRequest,
-  AccountRegisterResponse,
-} from './account-registration.js';
+export type { AccountRegisterRequest, AccountRegisterResponse } from './account-registration.js';
 
-export type {
-  AccountProfileResponse,
-  AccountProfileUpdateRequest,
-} from './account-profile.js';
+export type { AccountProfileResponse, AccountProfileUpdateRequest } from './account-profile.js';
 
 export type {
   AccountForgotPasswordRequest,
@@ -37,3 +31,8 @@ export type {
 export type { AccountImpersonationResult } from './account-session.js';
 
 export type { AccountDeleteRequest } from './account-deletion.js';
+
+export type {
+  AccountChangeEmailRequest,
+  AccountConfirmEmailChangeRequest,
+} from './account-email.js';

--- a/packages/@granit/react-account/src/__tests__/use-email.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-email.test.tsx
@@ -1,0 +1,116 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useChangeEmail, useConfirmEmailChange } from '../hooks/use-email.js';
+import { AccountProvider } from '../providers/account-provider.js';
+
+import type { AccountConfig } from '../providers/account-provider.js';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/account', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    changeEmail: vi.fn(),
+    confirmEmailChange: vi.fn(),
+  };
+});
+
+const { changeEmail, confirmEmailChange } = await import('@granit/account');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AccountConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AccountProvider config={config}>{children}</AccountProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useChangeEmail', () => {
+  it('should call changeEmail with correct arguments', async () => {
+    const client = createMockClient();
+    vi.mocked(changeEmail).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useChangeEmail(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ newEmail: 'new@example.com' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(changeEmail).toHaveBeenCalledWith(client, '/api/account', {
+      newEmail: 'new@example.com',
+    });
+  });
+
+  it('should handle error gracefully', async () => {
+    const client = createMockClient();
+    vi.mocked(changeEmail).mockRejectedValue(new Error('Service Unavailable'));
+
+    const { result } = renderHook(() => useChangeEmail(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ newEmail: 'new@example.com' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Service Unavailable');
+  });
+});
+
+describe('useConfirmEmailChange', () => {
+  it('should call confirmEmailChange with correct arguments', async () => {
+    const client = createMockClient();
+    vi.mocked(confirmEmailChange).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useConfirmEmailChange(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      userId: 'user-1',
+      newEmail: 'new@example.com',
+      token: 'confirm-token-abc',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(confirmEmailChange).toHaveBeenCalledWith(client, '/api/account', {
+      userId: 'user-1',
+      newEmail: 'new@example.com',
+      token: 'confirm-token-abc',
+    });
+  });
+
+  it('should handle invalid token error', async () => {
+    const client = createMockClient();
+    vi.mocked(confirmEmailChange).mockRejectedValue(new Error('Bad Request'));
+
+    const { result } = renderHook(() => useConfirmEmailChange(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({
+      userId: 'user-1',
+      newEmail: 'new@example.com',
+      token: 'expired-token',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Bad Request');
+  });
+});

--- a/packages/@granit/react-account/src/hooks/use-email.ts
+++ b/packages/@granit/react-account/src/hooks/use-email.ts
@@ -1,0 +1,31 @@
+import { changeEmail, confirmEmailChange } from '@granit/account';
+import { useMutation } from '@tanstack/react-query';
+
+import { useAccountConfig } from '../providers/account-provider.js';
+
+import type { AccountChangeEmailRequest, AccountConfirmEmailChangeRequest } from '@granit/account';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Requests an email change for the current user. */
+export function useChangeEmail(): UseMutationResult<void, Error, AccountChangeEmailRequest> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountChangeEmailRequest) =>
+      changeEmail(config.client, config.basePath!, request),
+  });
+}
+
+/** Confirms an email change using the token from the confirmation email. */
+export function useConfirmEmailChange(): UseMutationResult<
+  void,
+  Error,
+  AccountConfirmEmailChangeRequest
+> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountConfirmEmailChangeRequest) =>
+      confirmEmailChange(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-account/src/index.ts
+++ b/packages/@granit/react-account/src/index.ts
@@ -14,11 +14,7 @@ export { useConfirmEmail, useRegister, useResendConfirmation } from './hooks/use
 export type { ConfirmEmailVariables } from './hooks/use-registration.js';
 
 // Hooks — Password
-export {
-  useChangePassword,
-  useForgotPassword,
-  useResetPassword,
-} from './hooks/use-password.js';
+export { useChangePassword, useForgotPassword, useResetPassword } from './hooks/use-password.js';
 
 // Hooks — Two-Factor
 export {
@@ -48,6 +44,9 @@ export type { RenamePasskeyVariables } from './hooks/use-passkeys.js';
 
 // Hooks — Session
 export { useBackToImpersonator, useSessionHeartbeat } from './hooks/use-session.js';
+
+// Hooks — Email change
+export { useChangeEmail, useConfirmEmailChange } from './hooks/use-email.js';
 
 // Hooks — Deletion
 export { useDeleteAccount } from './hooks/use-account-deletion.js';


### PR DESCRIPTION
## Summary

- Add `changeEmail()` and `confirmEmailChange()` API functions to `@granit/account` matching the deployed `Granit.Identity.Local.Endpoints` contract
- Add `useChangeEmail()` and `useConfirmEmailChange()` mutation hooks to `@granit/react-account`
- Add types: `AccountChangeEmailRequest`, `AccountConfirmEmailChangeRequest`
- Full test coverage for both packages (6 tests)

## Endpoints

| Method | Path | Auth | Response |
|--------|------|------|----------|
| POST | `/api/account/change-email` | Authenticated | 202 Accepted |
| POST | `/api/account/confirm-email-change` | Anonymous | 204 No Content |

## Test plan

- [x] TypeScript check passes (`pnpm tsc`)
- [x] ESLint passes (`pnpm lint`)
- [x] `account-email-api.test.ts` — 2 tests pass
- [x] `use-email.test.tsx` — 4 tests pass
- [ ] Integrate in showcase-admin-react (separate PR)