### PR TITLE
fix(scheduling): add missing tsup.config.ts for build

### DIFF
--- a/packages/@granit/scheduling/tsup.config.ts
+++ b/packages/@granit/scheduling/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();


### PR DESCRIPTION
## Summary

- Add missing `tsup.config.ts` to `@granit/scheduling` — CI build was failing with "No input files"

## Test plan

- [ ] `pnpm --filter @granit/scheduling build` succeeds
- [ ] CI build pipeline passes