### PR TITLE
fix(scheduling): add missing tsup.config.ts for react-scheduling

### DIFF
--- a/packages/@granit/react-scheduling/tsup.config.ts
+++ b/packages/@granit/react-scheduling/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();


### PR DESCRIPTION
## Summary

- Add missing `tsup.config.ts` to `@granit/react-scheduling` — c9c912d added it for `@granit/scheduling` but missed the React counterpart, causing CI build failure (`No input files`)

## Test plan

- [x] `pnpm --filter @granit/react-scheduling build` succeeds locally
- [ ] CI build passes