### PR TITLE
fix(react-bff): pass returnUrl on BFF login redirect

### DIFF
--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -86,7 +86,8 @@ export function BffProvider({ config, children }: BffProviderProps) {
   }, [csrfManager]);
 
   const login = useCallback(() => {
-    globalThis.location.href = `${configRef.current.pathPrefix}/bff/login`;
+    const returnUrl = encodeURIComponent(globalThis.location.pathname + globalThis.location.search);
+    globalThis.location.href = `${configRef.current.pathPrefix}/bff/login?returnUrl=${returnUrl}`;
   }, []);
 
   const logout = useCallback(() => {


### PR DESCRIPTION
## Summary

- After BFF login, redirect the user back to the page they were on (`pathname + search`) instead of the root route.

## Test plan

- [ ] Login from a nested route (e.g. `/admin/invoices?page=2`) → after authentication, user lands back on `/admin/invoices?page=2`
- [ ] Login from root `/` → still works as before