### PR TITLE
fix(react-bff): omit returnUrl when on root path

### DIFF
--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -86,8 +86,10 @@ export function BffProvider({ config, children }: BffProviderProps) {
   }, [csrfManager]);
 
   const login = useCallback(() => {
-    const returnUrl = encodeURIComponent(globalThis.location.pathname + globalThis.location.search);
-    globalThis.location.href = `${configRef.current.pathPrefix}/bff/login?returnUrl=${returnUrl}`;
+    const path = globalThis.location.pathname + globalThis.location.search;
+    const base = `${configRef.current.pathPrefix}/bff/login`;
+    globalThis.location.href =
+      path === '/' ? base : `${base}?returnUrl=${encodeURIComponent(path)}`;
   }, []);
 
   const logout = useCallback(() => {


### PR DESCRIPTION
## Summary

- Follow-up to #170: skip the `returnUrl` query parameter when the user is already on `/`, since the BFF backend defaults to root. Only append `returnUrl` for deeper routes.

## Test plan

- [ ] Login from `/` → redirects to `/admin/bff/login` (no query param)
- [ ] Login from `/admin/invoices?page=2` → redirects to `/admin/bff/login?returnUrl=%2Fadmin%2Finvoices%3Fpage%3D2`
- [ ] `pnpm --filter @granit/react-bff test` passes