### PR TITLE
refactor: update API base paths to match normalized backend routes

### DIFF
--- a/packages/@granit/background-jobs/src/__tests__/background-jobs-api.test.ts
+++ b/packages/@granit/background-jobs/src/__tests__/background-jobs-api.test.ts
@@ -7,7 +7,7 @@ import { fetchBackgroundJob, fetchBackgroundJobs } from '../api/background-jobs-
 import type { BackgroundJobStatus } from '../types/index.js';
 import type { PagedResult } from '@granit/query-engine';
 
-const BASE = '/api/v1/background-jobs';
+const BASE = '/api/v1/background-jobs/jobs';
 
 const mockJob: BackgroundJobStatus = {
   jobName: 'SendEmails',

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-group-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-group-api.test.ts
@@ -11,7 +11,7 @@ import {
 
 import type { AdminGroup } from '../types/index.js';
 
-const BASE = '/api/admin';
+const BASE = '/admin';
 
 const mockGroup: AdminGroup = {
   id: 'grp-001',

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
@@ -10,7 +10,7 @@ import {
 
 import type { AdminOidcApplication, AdminOidcApplicationSecretResponse } from '../types/index.js';
 
-const BASE = '/api/admin';
+const BASE = '/admin';
 
 const mockApplication: AdminOidcApplication = {
   clientId: 'my-spa',

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
@@ -9,7 +9,7 @@ import {
 
 import type { AdminOidcAuthorization } from '../types/index.js';
 
-const BASE = '/api/admin';
+const BASE = '/admin';
 
 const mockAuthorization: AdminOidcAuthorization = {
   id: 'auth-001',

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
@@ -5,7 +5,7 @@ import { createScope, deleteScope, listScopes } from '../api/admin-oidc-scope-ap
 
 import type { AdminOidcScope } from '../types/index.js';
 
-const BASE = '/api/admin';
+const BASE = '/admin';
 
 const mockScope: AdminOidcScope = {
   name: 'api',

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-role-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-role-api.test.ts
@@ -5,7 +5,7 @@ import { createRole, deleteRole, getRoleMembers, listRoles } from '../api/admin-
 
 import type { AdminRole, AdminRoleMember } from '../types/index.js';
 
-const BASE = '/api/admin';
+const BASE = '/admin';
 
 const mockRole: AdminRole = {
   name: 'editor',

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-user-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-user-api.test.ts
@@ -11,7 +11,7 @@ import {
 
 import type { AdminImpersonationResult, AdminUser, AdminUserPage } from '../types/index.js';
 
-const BASE = '/api/admin';
+const BASE = '/admin';
 
 const mockUser: AdminUser = {
   userId: 'user-001',

--- a/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
@@ -38,7 +38,7 @@ describe('AccountProvider', () => {
       wrapper: createWrapper(config),
     });
 
-    expect(result.current.basePath).toBe('/api/account');
+    expect(result.current.basePath).toBe('/account');
   });
 
   it('should apply default queryKeyPrefix when not provided', () => {

--- a/packages/@granit/react-account/src/__tests__/use-account-deletion.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-account-deletion.test.tsx
@@ -51,7 +51,7 @@ describe('useDeleteAccount', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteAccount).toHaveBeenCalledWith(client, '/api/account', {
+    expect(deleteAccount).toHaveBeenCalledWith(client, '/account', {
       password: 'MyP@ssword1!',
     });
   });

--- a/packages/@granit/react-account/src/__tests__/use-account-settings.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-account-settings.test.tsx
@@ -51,7 +51,7 @@ describe('useAccountSettings', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getAccountSettings).toHaveBeenCalledWith(client, '/api/account');
+    expect(getAccountSettings).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual({ allowSelfRegistration: true });
   });
 

--- a/packages/@granit/react-account/src/__tests__/use-email.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-email.test.tsx
@@ -52,7 +52,7 @@ describe('useChangeEmail', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(changeEmail).toHaveBeenCalledWith(client, '/api/account', {
+    expect(changeEmail).toHaveBeenCalledWith(client, '/account', {
       newEmail: 'new@example.com',
     });
   });
@@ -89,7 +89,7 @@ describe('useConfirmEmailChange', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(confirmEmailChange).toHaveBeenCalledWith(client, '/api/account', {
+    expect(confirmEmailChange).toHaveBeenCalledWith(client, '/account', {
       userId: 'user-1',
       newEmail: 'new@example.com',
       token: 'confirm-token-abc',

--- a/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
@@ -84,7 +84,7 @@ describe('useExternalLogins', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getExternalLogins).toHaveBeenCalledWith(client, '/api/account');
+    expect(getExternalLogins).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual(mockLogins);
   });
 
@@ -114,7 +114,7 @@ describe('useChallengeExternalLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(challengeExternalLogin).toHaveBeenCalledWith(client, '/api/account', 'Google');
+    expect(challengeExternalLogin).toHaveBeenCalledWith(client, '/account', 'Google');
   });
 });
 
@@ -132,7 +132,7 @@ describe('useUnlinkExternalLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(unlinkExternalLogin).toHaveBeenCalledWith(client, '/api/account', 'Google');
+    expect(unlinkExternalLogin).toHaveBeenCalledWith(client, '/account', 'Google');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'external-logins'],
     });

--- a/packages/@granit/react-account/src/__tests__/use-passkeys.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-passkeys.test.tsx
@@ -96,7 +96,7 @@ describe('usePasskeys', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getPasskeys).toHaveBeenCalledWith(client, '/api/account');
+    expect(getPasskeys).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual(mockPasskeys);
   });
 
@@ -127,7 +127,7 @@ describe('useBeginPasskeyRegistration', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(beginPasskeyRegistration).toHaveBeenCalledWith(client, '/api/account');
+    expect(beginPasskeyRegistration).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toBe(optionsJson);
   });
 });
@@ -151,7 +151,7 @@ describe('useCompletePasskeyRegistration', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(completePasskeyRegistration).toHaveBeenCalledWith(client, '/api/account', {
+    expect(completePasskeyRegistration).toHaveBeenCalledWith(client, '/account', {
       credentialJson: '{"id":"cred"}',
       name: 'New Key',
     });
@@ -181,7 +181,7 @@ describe('useRenamePasskey', () => {
 
     expect(renamePasskey).toHaveBeenCalledWith(
       client,
-      '/api/account',
+      '/account',
       toEntityId<'Passkey'>('pk-001'),
       {
         name: 'Renamed Key',
@@ -207,11 +207,7 @@ describe('useDeletePasskey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deletePasskey).toHaveBeenCalledWith(
-      client,
-      '/api/account',
-      toEntityId<'Passkey'>('pk-001')
-    );
+    expect(deletePasskey).toHaveBeenCalledWith(client, '/account', toEntityId<'Passkey'>('pk-001'));
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'passkeys'],
     });

--- a/packages/@granit/react-account/src/__tests__/use-password.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-password.test.tsx
@@ -5,11 +5,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  useChangePassword,
-  useForgotPassword,
-  useResetPassword,
-} from '../hooks/use-password.js';
+import { useChangePassword, useForgotPassword, useResetPassword } from '../hooks/use-password.js';
 import { AccountProvider } from '../providers/account-provider.js';
 
 import type { AccountConfig } from '../providers/account-provider.js';
@@ -60,7 +56,7 @@ describe('useChangePassword', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(changePassword).toHaveBeenCalledWith(client, '/api/account', {
+    expect(changePassword).toHaveBeenCalledWith(client, '/account', {
       currentPassword: 'OldP@ss1!',
       newPassword: 'NewP@ss1!',
     });
@@ -97,7 +93,7 @@ describe('useForgotPassword', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(forgotPassword).toHaveBeenCalledWith(client, '/api/account', {
+    expect(forgotPassword).toHaveBeenCalledWith(client, '/account', {
       email: 'user@example.com',
     });
   });
@@ -134,7 +130,7 @@ describe('useResetPassword', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(resetPassword).toHaveBeenCalledWith(client, '/api/account', {
+    expect(resetPassword).toHaveBeenCalledWith(client, '/account', {
       userId: 'user-1',
       token: 'reset-token-abc',
       newPassword: 'NewP@ss1!',

--- a/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
@@ -77,7 +77,7 @@ describe('useProfile', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getProfile).toHaveBeenCalledWith(client, '/api/account');
+    expect(getProfile).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual(mockProfile);
   });
 
@@ -109,7 +109,7 @@ describe('useUpdateProfile', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(updateProfile).toHaveBeenCalledWith(client, '/api/account', { firstName: 'Jane' });
+    expect(updateProfile).toHaveBeenCalledWith(client, '/account', { firstName: 'Jane' });
     expect(result.current.data).toEqual(updatedProfile);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'profile'],

--- a/packages/@granit/react-account/src/__tests__/use-registration.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-registration.test.tsx
@@ -5,11 +5,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  useConfirmEmail,
-  useRegister,
-  useResendConfirmation,
-} from '../hooks/use-registration.js';
+import { useConfirmEmail, useRegister, useResendConfirmation } from '../hooks/use-registration.js';
 import { AccountProvider } from '../providers/account-provider.js';
 
 import type { AccountConfig } from '../providers/account-provider.js';
@@ -27,8 +23,7 @@ vi.mock('@granit/account', async (importOriginal) => {
   };
 });
 
-const { registerAccount, confirmEmail, resendConfirmationEmail } =
-  await import('@granit/account');
+const { registerAccount, confirmEmail, resendConfirmationEmail } = await import('@granit/account');
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -67,7 +62,7 @@ describe('useRegister', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(registerAccount).toHaveBeenCalledWith(client, '/api/account', {
+    expect(registerAccount).toHaveBeenCalledWith(client, '/account', {
       email: 'user@example.com',
       password: 'P@ssword1!',
       firstName: 'John',
@@ -103,7 +98,7 @@ describe('useConfirmEmail', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(confirmEmail).toHaveBeenCalledWith(client, '/api/account', 'user-1', 'abc123');
+    expect(confirmEmail).toHaveBeenCalledWith(client, '/account', 'user-1', 'abc123');
   });
 
   it('should handle invalid token error', async () => {
@@ -134,7 +129,7 @@ describe('useResendConfirmation', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(resendConfirmationEmail).toHaveBeenCalledWith(client, '/api/account');
+    expect(resendConfirmationEmail).toHaveBeenCalledWith(client, '/account');
   });
 
   it('should handle rate limit error', async () => {

--- a/packages/@granit/react-account/src/__tests__/use-session.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-session.test.tsx
@@ -53,7 +53,7 @@ describe('useSessionHeartbeat', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(sessionHeartbeat).toHaveBeenCalledWith(client, '/api/account');
+    expect(sessionHeartbeat).toHaveBeenCalledWith(client, '/account');
   });
 
   it('should handle heartbeat error', async () => {
@@ -89,7 +89,7 @@ describe('useBackToImpersonator', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(backToImpersonator).toHaveBeenCalledWith(client, '/api/account');
+    expect(backToImpersonator).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual(response);
   });
 

--- a/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
@@ -91,7 +91,7 @@ describe('useTwoFactorStatus', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getTwoFactorStatus).toHaveBeenCalledWith(client, '/api/account');
+    expect(getTwoFactorStatus).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual(mockStatus);
   });
 
@@ -123,7 +123,7 @@ describe('useAuthenticatorKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getAuthenticatorKey).toHaveBeenCalledWith(client, '/api/account');
+    expect(getAuthenticatorKey).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual(mockKey);
   });
 });
@@ -145,7 +145,7 @@ describe('useEnableTwoFactor', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(enableTwoFactor).toHaveBeenCalledWith(client, '/api/account', { code: '123456' });
+    expect(enableTwoFactor).toHaveBeenCalledWith(client, '/account', { code: '123456' });
     expect(result.current.data).toEqual(response);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'two-factor'],
@@ -181,7 +181,7 @@ describe('useDisableTwoFactor', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(disableTwoFactor).toHaveBeenCalledWith(client, '/api/account');
+    expect(disableTwoFactor).toHaveBeenCalledWith(client, '/account');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'two-factor'],
     });
@@ -205,7 +205,7 @@ describe('useGenerateRecoveryCodes', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(generateRecoveryCodes).toHaveBeenCalledWith(client, '/api/account');
+    expect(generateRecoveryCodes).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toEqual(response);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'two-factor'],

--- a/packages/@granit/react-account/src/hooks/use-account-settings.ts
+++ b/packages/@granit/react-account/src/hooks/use-account-settings.ts
@@ -7,7 +7,7 @@ import type { AccountSettingsResponse } from '@granit/account';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
- * Fetches the public account settings (`GET /api/account/config`).
+ * Fetches the public account settings (`GET /account/config`).
  *
  * - No authentication required (anonymous endpoint).
  * - Cached indefinitely (`staleTime: Infinity`) — the setting rarely changes.

--- a/packages/@granit/react-account/src/providers/account-provider.tsx
+++ b/packages/@granit/react-account/src/providers/account-provider.tsx
@@ -14,7 +14,7 @@ export interface AccountProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/api/account';
+const DEFAULT_BASE_PATH = '/account';
 const DEFAULT_KEY_PREFIX = ['account'] as const;
 
 const AccountContext = createContext<AccountConfig | null>(null);

--- a/packages/@granit/react-account/src/testing/handlers.ts
+++ b/packages/@granit/react-account/src/testing/handlers.ts
@@ -14,9 +14,9 @@ import {
  * Create stateful MSW handlers for account self-service endpoints.
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
  *
- * @param baseUrl - API base path (default: `/api/account`)
+ * @param baseUrl - API base path (default: `/account`)
  */
-export function createAccountHandlers(baseUrl = '/api/account') {
+export function createAccountHandlers(baseUrl = '/account') {
   return [
     // ── Settings (anonymous) ─────────────────────────────────────────────────
     http.get(`${baseUrl}/config`, () => HttpResponse.json(mockAccountSettings)),

--- a/packages/@granit/react-auditing/src/__tests__/provider.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/provider.test.tsx
@@ -9,7 +9,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: AuditLogConfig = {
   client: {} as AxiosInstance,
-  basePath: '/audit-log',
+  basePath: '/api/v1/auditing',
 };
 
 function createWrapper(config: AuditLogConfig) {
@@ -25,7 +25,7 @@ describe('AuditLogProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/audit-log');
+    expect(result.current.basePath).toBe('/api/v1/auditing');
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
@@ -18,7 +18,7 @@ import type { AuditEntryDetail, AuditPage } from '@granit/auditing';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
-function createWrapper(client: AxiosInstance, basePath = '/audit-log') {
+function createWrapper(client: AxiosInstance, basePath = '/api/v1/auditing') {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
     const config: AuditLogConfig = { client, basePath };
@@ -49,7 +49,7 @@ describe('useAuditLogEntries', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(emptyPage);
-    expect(client.get).toHaveBeenCalledWith('/audit-log', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing', {
       params: { category: AuditCategory.DataMutation },
     });
   });
@@ -100,7 +100,7 @@ describe('useEntityAuditTrail', () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/audit-log/entity/Patient/42', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/entity/Patient/42', {
       params: { page: 1, pageSize: 10 },
     });
   });

--- a/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
+++ b/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the audit log provider. */
 export interface AuditLogConfig {
   readonly client: AxiosInstance;
-  /** Base path prefix (default: `/audit-log`). */
+  /** Base path prefix (default: `/api/v1/auditing/audit-entries`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
@@ -18,7 +18,7 @@ export interface AuditLogProviderProps {
 
 const AuditLogConfigContext = createContext<AuditLogConfig | null>(null);
 
-const DEFAULT_BASE_PATH = '/audit-log';
+const DEFAULT_BASE_PATH = '/api/v1/auditing/audit-entries';
 const DEFAULT_QUERY_KEY_PREFIX = ['audit-log'] as const;
 
 /** Provides audit log configuration to child components and hooks. */

--- a/packages/@granit/react-auditing/src/testing/handlers.ts
+++ b/packages/@granit/react-auditing/src/testing/handlers.ts
@@ -8,9 +8,9 @@ import type { AuditEntry, AuditEntryDetail } from '@granit/auditing';
 /**
  * Create stateful MSW handlers for audit log endpoints.
  *
- * @param baseUrl - API base path (default: `/api/v1/audit-log`)
+ * @param baseUrl - API base path (default: `/api/v1/auditing/audit-entries`)
  */
-export function createAuditHandlers(baseUrl = '/api/v1/audit-log') {
+export function createAuditHandlers(baseUrl = '/api/v1/auditing/audit-entries') {
   return [
     // GET list — filtered, sorted newest-first, paginated
     http.get(baseUrl, ({ request }) => {

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-key-mutations.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-key-mutations.test.tsx
@@ -68,7 +68,7 @@ describe('useCreateApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/api-keys', request);
+    expect(client.post).toHaveBeenCalledWith('/api/v1/authentication/api-keys', request);
     expect(result.current.data?.id).toBe('key-new');
     expect(result.current.data?.rawSecret).toBe('test-raw-secret-value');
   });
@@ -173,7 +173,7 @@ describe('useCreateApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/api-keys', request);
+    expect(client.post).toHaveBeenCalledWith('/api/v1/authentication/api-keys', request);
   });
 });
 
@@ -197,7 +197,7 @@ describe('useRevokeApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/api-keys/key-1/revoke');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/authentication/api-keys/key-1/revoke');
   });
 
   it('should use custom basePath when provided', async () => {
@@ -275,7 +275,7 @@ describe('useRotateApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/api-keys/key-old/rotate');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/authentication/api-keys/key-old/rotate');
     expect(result.current.data?.newKeyId).toBe('key-new');
     expect(result.current.data?.rawSecret).toBe('test-new-secret-value');
     expect(result.current.data?.oldKeyId).toBe('key-old');
@@ -371,7 +371,7 @@ describe('useUpdateApiKeyScopes', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.put).toHaveBeenCalledWith('/api/v1/api-keys/key-1/scopes', {
+    expect(client.put).toHaveBeenCalledWith('/api/v1/authentication/api-keys/key-1/scopes', {
       permissions: ['Invoices.Read', 'Invoices.Create'],
       allowedCidrs: ['10.0.0.0/8'],
     });
@@ -448,7 +448,7 @@ describe('useUpdateApiKeyScopes', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.put).toHaveBeenCalledWith('/api/v1/api-keys/key-1/scopes', {
+    expect(client.put).toHaveBeenCalledWith('/api/v1/authentication/api-keys/key-1/scopes', {
       permissions: [],
       allowedCidrs: [],
     });

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
@@ -59,7 +59,10 @@ describe('useApiKeys', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/api-keys', expect.objectContaining({}));
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/authentication/api-keys',
+      expect.objectContaining({})
+    );
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data![0].id).toBe('key-1');
   });
@@ -74,7 +77,7 @@ describe('useApiKeys', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
     expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/api-keys',
+      '/api/v1/authentication/api-keys',
       expect.objectContaining({ params: expect.objectContaining({ search: 'prod' }) })
     );
   });
@@ -89,7 +92,7 @@ describe('useApiKeys', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
     expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/api-keys',
+      '/api/v1/authentication/api-keys',
       expect.objectContaining({
         params: expect.objectContaining({ type: 'Secret,Webhook' }),
       })
@@ -106,7 +109,7 @@ describe('useApiKeys', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
     expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/api-keys',
+      '/api/v1/authentication/api-keys',
       expect.objectContaining({
         params: expect.objectContaining({ environment: 'staging' }),
       })
@@ -123,7 +126,7 @@ describe('useApiKeys', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
     expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/api-keys',
+      '/api/v1/authentication/api-keys',
       expect.objectContaining({
         params: expect.objectContaining({ includeRevoked: true }),
       })
@@ -140,7 +143,7 @@ describe('useApiKeys', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
     expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/api-keys',
+      '/api/v1/authentication/api-keys',
       expect.objectContaining({
         params: expect.objectContaining({ page: 2, pageSize: 25 }),
       })
@@ -202,7 +205,7 @@ describe('useApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/api-keys/key-1');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authentication/api-keys/key-1');
     expect(result.current.data?.id).toBe('key-1');
     expect(result.current.data?.name).toBe('Test Key');
   });

--- a/packages/@granit/react-authentication-api-keys/src/constants.ts
+++ b/packages/@granit/react-authentication-api-keys/src/constants.ts
@@ -1,1 +1,1 @@
-export const DEFAULT_BASE_PATH = '/api/v1/api-keys';
+export const DEFAULT_BASE_PATH = '/api/v1/authentication/api-keys';

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
@@ -14,7 +14,7 @@ import type { AxiosInstance } from 'axios';
 export interface ApiKeyHookOptions {
   /** Axios instance to use for HTTP requests. */
   client: AxiosInstance;
-  /** API base path. Defaults to `/api/v1/api-keys`. */
+  /** API base path. Defaults to `/api/v1/authentication/api-keys`. */
   basePath?: string;
 }
 

--- a/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
@@ -30,9 +30,9 @@ function generateSecret(type: string, environment: string): string {
 /**
  * Create stateful MSW handlers for API key endpoints.
  *
- * @param baseUrl - API base path (default: `/api/v1/api-keys`)
+ * @param baseUrl - API base path (default: `/api/v1/authentication/api-keys`)
  */
-export function createApiKeyHandlers(baseUrl = '/api/v1/api-keys') {
+export function createApiKeyHandlers(baseUrl = '/api/v1/authentication/api-keys') {
   const apiKeys: MutableApiKey[] = mockApiKeys.map((k) => ({ ...k }));
 
   return [

--- a/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
@@ -19,7 +19,7 @@ describe('LocalAuthProvider', () => {
     const { result } = renderHook(() => useLocalAuthConfig(), { wrapper });
 
     expect(result.current.client).toBe(client);
-    expect(result.current.basePath).toBe('/api/account');
+    expect(result.current.basePath).toBe('/account');
     expect(result.current.queryKeyPrefix).toEqual(['authentication-local']);
   });
 

--- a/packages/@granit/react-authentication-local/src/__tests__/use-begin-passkey-assertion.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-begin-passkey-assertion.test.tsx
@@ -52,7 +52,7 @@ describe('useBeginPasskeyAssertion', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(beginPasskeyAssertion).toHaveBeenCalledWith(client, '/api/account');
+    expect(beginPasskeyAssertion).toHaveBeenCalledWith(client, '/account');
     expect(result.current.data).toBe(optionsJson);
   });
 

--- a/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
@@ -60,7 +60,7 @@ describe('useCompletePasskeyAssertion', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(completePasskeyAssertion).toHaveBeenCalledWith(client, '/api/account', {
+    expect(completePasskeyAssertion).toHaveBeenCalledWith(client, '/account', {
       credentialJson: '{"id":"cred-1","response":{"authenticatorData":"..."}}',
     });
     expect(result.current.data).toEqual(response);

--- a/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
@@ -61,7 +61,7 @@ describe('useLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(loginAccount).toHaveBeenCalledWith(client, '/api/account', {
+    expect(loginAccount).toHaveBeenCalledWith(client, '/account', {
       login: 'user@example.com',
       password: 'P@ssw0rd!',
     });

--- a/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
@@ -58,7 +58,7 @@ describe('useVerifyTwoFactorLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/account', {
+    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/account', {
       code: '123456',
     });
     expect(result.current.data).toEqual(response);
@@ -82,7 +82,7 @@ describe('useVerifyTwoFactorLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/account', {
+    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/account', {
       code: 'ABCD-1234-EFGH',
       useRecoveryCode: true,
     });

--- a/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
+++ b/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
@@ -19,7 +19,7 @@ export interface LocalAuthProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/api/account';
+const DEFAULT_BASE_PATH = '/account';
 const DEFAULT_KEY_PREFIX = ['authentication-local'] as const;
 
 const LocalAuthContext = createContext<LocalAuthConfig | null>(null);

--- a/packages/@granit/react-authentication-local/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-local/src/testing/handlers.ts
@@ -11,9 +11,9 @@ import {
  * Create MSW handlers for local authentication endpoints (login, 2FA,
  * passkeys, password reset, registration, email confirmation).
  *
- * @param baseUrl - API base path (default: `/api/account`)
+ * @param baseUrl - API base path (default: `/account`)
  */
-export function createLocalAuthHandlers(baseUrl = '/api/account') {
+export function createLocalAuthHandlers(baseUrl = '/account') {
   return [
     // POST /login
     http.post(`${baseUrl}/login`, async ({ request }) => {

--- a/packages/@granit/react-authorization/src/__tests__/use-permission-definitions.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-permission-definitions.test.tsx
@@ -35,7 +35,7 @@ describe('usePermissionDefinitions', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toEqual(MOCK_GROUPS);
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auth/definitions');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/permissions/definitions');
   });
 
   it('should use custom basePath', async () => {
@@ -43,13 +43,13 @@ describe('usePermissionDefinitions', () => {
     vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
 
     const { result } = renderHook(
-      () => usePermissionDefinitions({ client, basePath: '/api/v1/auth' }),
+      () => usePermissionDefinitions({ client, basePath: '/api/v1/authorization' }),
       { wrapper: createQueryWrapper() }
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auth/definitions');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/permissions/definitions');
   });
 
   it('should not fetch when disabled', () => {

--- a/packages/@granit/react-authorization/src/__tests__/use-permission-grant.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-permission-grant.test.tsx
@@ -32,7 +32,7 @@ describe('usePermissionGrant', () => {
 
     await waitFor(() => expect(result.current.grant.isSuccess).toBe(true));
 
-    expect(client.put).toHaveBeenCalledWith('/api/v1/auth/roles/editor/Invoices.Create');
+    expect(client.put).toHaveBeenCalledWith('/api/v1/authorization/roles/editor/Invoices.Create');
   });
 
   it('should revoke a permission via DELETE', async () => {
@@ -49,7 +49,9 @@ describe('usePermissionGrant', () => {
 
     await waitFor(() => expect(result.current.revoke.isSuccess).toBe(true));
 
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/auth/roles/editor/Invoices.Delete');
+    expect(client.delete).toHaveBeenCalledWith(
+      '/api/v1/authorization/roles/editor/Invoices.Delete'
+    );
   });
 
   it('should use custom basePath', async () => {
@@ -57,9 +59,12 @@ describe('usePermissionGrant', () => {
     vi.mocked(client.put).mockResolvedValueOnce({ data: undefined });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => usePermissionGrant({ client, basePath: '/api/v1/auth' }), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => usePermissionGrant({ client, basePath: '/api/v1/authorization' }),
+      {
+        wrapper,
+      }
+    );
 
     result.current.grant.mutate({
       roleName: 'admin',
@@ -68,7 +73,7 @@ describe('usePermissionGrant', () => {
 
     await waitFor(() => expect(result.current.grant.isSuccess).toBe(true));
 
-    expect(client.put).toHaveBeenCalledWith('/api/v1/auth/roles/admin/Users.View');
+    expect(client.put).toHaveBeenCalledWith('/api/v1/authorization/roles/admin/Users.View');
   });
 
   it('should invalidate role query on successful grant', async () => {
@@ -144,6 +149,8 @@ describe('usePermissionGrant', () => {
 
     await waitFor(() => expect(result.current.grant.isSuccess).toBe(true));
 
-    expect(client.put).toHaveBeenCalledWith('/api/v1/auth/roles/r%C3%B4le/Perm.Sp%C3%A9cial');
+    expect(client.put).toHaveBeenCalledWith(
+      '/api/v1/authorization/roles/r%C3%B4le/Perm.Sp%C3%A9cial'
+    );
   });
 });

--- a/packages/@granit/react-authorization/src/__tests__/use-permissions.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-permissions.test.tsx
@@ -72,7 +72,7 @@ describe('usePermissions', () => {
     expect(result.current.error).toBeNull();
   });
 
-  it('should call GET /api/v1/auth/me with default basePath', async () => {
+  it('should call GET /api/v1/authorization/permissions with default basePath', async () => {
     const client = createMockClient();
     const { Wrapper } = createWrapper();
 
@@ -80,7 +80,7 @@ describe('usePermissions', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auth/me');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/permissions');
   });
 
   it('should use custom basePath when provided', async () => {
@@ -93,7 +93,7 @@ describe('usePermissions', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/me');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/permissions');
   });
 
   it('hasPermission should return true for a granted permission', async () => {

--- a/packages/@granit/react-authorization/src/__tests__/use-role-permissions.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-role-permissions.test.tsx
@@ -24,7 +24,7 @@ describe('useRolePermissions', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(result.current.data).toEqual(MOCK_GRANT);
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auth/roles/admin');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/roles/admin');
   });
 
   it('should use custom basePath', async () => {
@@ -32,13 +32,13 @@ describe('useRolePermissions', () => {
     vi.mocked(client.get).mockResolvedValueOnce({ data: MOCK_GRANT });
 
     const { result } = renderHook(
-      () => useRolePermissions({ client, roleName: 'editor', basePath: '/api/v1/auth' }),
+      () => useRolePermissions({ client, roleName: 'editor', basePath: '/api/v1/authorization' }),
       { wrapper: createQueryWrapper() }
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auth/roles/editor');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/roles/editor');
   });
 
   it('should encode special characters in role name', async () => {
@@ -53,7 +53,7 @@ describe('useRolePermissions', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auth/roles/r%C3%B4le%20sp%C3%A9cial');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/authorization/roles/r%C3%B4le%20sp%C3%A9cial');
   });
 
   it('should not fetch when disabled', () => {

--- a/packages/@granit/react-authorization/src/hooks/use-permission-definitions.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permission-definitions.ts
@@ -5,12 +5,12 @@ import { permissionKeys } from './use-permissions.js';
 import type { PermissionGroupDto, UsePermissionDefinitionsOptions } from '@granit/authorization';
 import type { UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/auth';
+const DEFAULT_BASE_PATH = '/api/v1/authorization';
 
 /**
  * Fetches all permission definitions grouped by module.
  *
- * Calls `GET {basePath}/definitions` (default `/api/v1/auth/definitions`) and returns
+ * Calls `GET {basePath}/permissions/definitions` (default `/api/v1/authorization/permissions/definitions`) and returns
  * the full permission tree used for admin UIs (role-permission matrix).
  *
  * @param options - Axios client instance and optional configuration.
@@ -32,7 +32,9 @@ export function usePermissionDefinitions(
   return useQuery({
     queryKey: permissionKeys.definitions(),
     queryFn: async () => {
-      const response = await client.get<PermissionGroupDto[]>(`${basePath}/definitions`);
+      const response = await client.get<PermissionGroupDto[]>(
+        `${basePath}/permissions/definitions`
+      );
       return response.data;
     },
     enabled: enabled ?? true,

--- a/packages/@granit/react-authorization/src/hooks/use-permission-grant.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permission-grant.ts
@@ -5,7 +5,7 @@ import { permissionKeys } from './use-permissions.js';
 import type { PermissionGrantParams, UsePermissionGrantOptions } from '@granit/authorization';
 import type { UseMutationResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/auth';
+const DEFAULT_BASE_PATH = '/api/v1/authorization';
 
 /** Return type of the {@link usePermissionGrant} hook. */
 export type UsePermissionGrantReturn = {

--- a/packages/@granit/react-authorization/src/hooks/use-permissions.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permissions.ts
@@ -11,7 +11,7 @@ import type {
 // Constants
 // ---------------------------------------------------------------------------
 
-const DEFAULT_BASE_PATH = '/api/v1/auth';
+const DEFAULT_BASE_PATH = '/api/v1/authorization';
 const EMPTY_SET: ReadonlySet<string> = new Set<string>();
 
 /** Query key factory for permission queries. */
@@ -29,7 +29,7 @@ export const permissionKeys = {
 /**
  * Fetches and caches the current user's granted permissions from the backend.
  *
- * Calls `GET {basePath}/me` (default `/api/v1/auth/me`) and returns a `Set<string>`
+ * Calls `GET {basePath}/permissions` (default `/api/v1/authorization/permissions`) and returns a `Set<string>`
  * of granted permission names with O(1) lookup helpers.
  *
  * Permissions are cached for the lifetime of the Keycloak session
@@ -53,7 +53,7 @@ export function usePermissions(options: UsePermissionsOptions): UsePermissionsRe
   const query = useQuery<PermissionsResponse>({
     queryKey: permissionKeys.me(),
     queryFn: async () => {
-      const response = await client.get<PermissionsResponse>(`${basePath}/me`);
+      const response = await client.get<PermissionsResponse>(`${basePath}/permissions`);
       return response.data;
     },
     enabled: enabled ?? true,

--- a/packages/@granit/react-authorization/src/hooks/use-role-permissions.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-role-permissions.ts
@@ -5,12 +5,12 @@ import { permissionKeys } from './use-permissions.js';
 import type { PermissionGrantDto, UseRolePermissionsOptions } from '@granit/authorization';
 import type { UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/auth';
+const DEFAULT_BASE_PATH = '/api/v1/authorization';
 
 /**
  * Fetches the permissions granted to a specific role.
  *
- * Calls `GET {basePath}/roles/{roleName}` (default `/api/v1/auth/roles/{roleName}`)
+ * Calls `GET {basePath}/roles/{roleName}` (default `/api/v1/authorization/roles/{roleName}`)
  * and returns the list of granted permission names.
  *
  * @param options - Axios client, role name, and optional configuration.

--- a/packages/@granit/react-authorization/src/testing/handlers.ts
+++ b/packages/@granit/react-authorization/src/testing/handlers.ts
@@ -7,12 +7,12 @@ import { mockPermissionGroups, mockRoleGrants } from './data.js';
  * Create stateful MSW handlers for authorization endpoints (permission
  * definitions and role-based grants).
  *
- * @param baseUrl - API base path (default: `/api/v1/auth`)
+ * @param baseUrl - API base path (default: `/api/v1/authorization`)
  */
-export function createAuthorizationHandlers(baseUrl = '/api/v1/auth') {
+export function createAuthorizationHandlers(baseUrl = '/api/v1/authorization') {
   return [
-    // GET /definitions — list all permission groups
-    http.get(`${baseUrl}/definitions`, () => {
+    // GET /permissions/definitions — list all permission groups
+    http.get(`${baseUrl}/permissions/definitions`, () => {
       return HttpResponse.json(mockPermissionGroups);
     }),
 

--- a/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
@@ -72,7 +72,7 @@ describe('useBackgroundJobs', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs', { params: undefined });
+    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs/jobs', { params: undefined });
     expect(result.current.data).toEqual(mockPage);
   });
 
@@ -102,7 +102,7 @@ describe('useBackgroundJobs', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs/jobs', {
       params: { page: 2, pageSize: 10 },
     });
   });
@@ -134,7 +134,7 @@ describe('usePauseJob', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/InvoiceSync/pause');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/InvoiceSync/pause');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: backgroundJobKeys.all,
     });
@@ -185,7 +185,7 @@ describe('useResumeJob', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/InvoiceSync/resume');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/InvoiceSync/resume');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: backgroundJobKeys.all,
     });
@@ -236,7 +236,7 @@ describe('useTriggerJob', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/InvoiceSync/trigger');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/InvoiceSync/trigger');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: backgroundJobKeys.all,
     });

--- a/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
+++ b/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
@@ -12,13 +12,13 @@ import type { PagedResult } from '@granit/query-engine';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 import type { AxiosInstance } from 'axios';
 
-const DEFAULT_BASE_PATH = '/api/v1/background-jobs';
+const DEFAULT_BASE_PATH = '/api/v1/background-jobs/jobs';
 
 /** Options accepted by all background-jobs hooks. */
 export interface BackgroundJobsOptions {
   /** Axios instance used for all requests. */
   readonly client: AxiosInstance;
-  /** Base URL for the background-jobs API. Defaults to `/api/v1/background-jobs`. */
+  /** Base URL for the background-jobs API. Defaults to `/api/v1/background-jobs/jobs`. */
   readonly basePath?: string;
   /** Pagination parameters for the list endpoint. */
   readonly params?: BackgroundJobListParams;

--- a/packages/@granit/react-background-jobs/src/testing/handlers.ts
+++ b/packages/@granit/react-background-jobs/src/testing/handlers.ts
@@ -11,9 +11,9 @@ import type { BackgroundJobStatus } from '@granit/background-jobs';
  * Handlers mutate the in-memory `mockBackgroundJobs` array — pause/resume/trigger
  * calls update state that subsequent GET calls reflect.
  *
- * @param baseUrl - API base path (default: `/api/v1/background-jobs`)
+ * @param baseUrl - API base path (default: `/api/v1/background-jobs/jobs`)
  */
-export function createBackgroundJobHandlers(baseUrl = '/api/v1/background-jobs') {
+export function createBackgroundJobHandlers(baseUrl = '/api/v1/background-jobs/jobs') {
   return [
     // GET list — sorted, paginated
     http.get(baseUrl, ({ request }) => {

--- a/packages/@granit/react-customer-balance/src/__tests__/customer-balance-provider.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/customer-balance-provider.test.tsx
@@ -13,7 +13,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: CustomerBalanceConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/granit/customer-balance',
+  basePath: '/api/v1/customer-balance',
 };
 
 function createWrapper(config: CustomerBalanceConfig) {
@@ -29,7 +29,7 @@ describe('CustomerBalanceProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/granit/customer-balance');
+    expect(result.current.basePath).toBe('/api/v1/customer-balance');
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
@@ -67,7 +67,7 @@ describe('use-customer-balance', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/customer-balance/balance');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/customer-balance/balance');
       expect(result.current.data).toEqual(sampleBalance);
     });
 
@@ -94,7 +94,7 @@ describe('use-customer-balance', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/customer-balance/transactions');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/customer-balance/transactions');
       expect(result.current.data).toEqual([sampleTransaction]);
     });
 
@@ -131,7 +131,7 @@ describe('use-customer-balance', () => {
       result.current.mutate(request);
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/customer-balance/credit', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/customer-balance/credit', request);
     });
 
     it('uses custom basePath', async () => {

--- a/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
+++ b/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
@@ -17,7 +17,7 @@ import type {
 } from '@granit/customer-balance';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/granit/customer-balance';
+const DEFAULT_BASE_PATH = '/api/v1/customer-balance';
 
 /**
  * Fetch the current customer balance.

--- a/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
+++ b/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the customer-balance provider. */
 export interface CustomerBalanceConfig {
   readonly client: AxiosInstance;
-  /** Base path for customer-balance endpoints (default: `/api/granit/customer-balance`). */
+  /** Base path for customer-balance endpoints (default: `/api/v1/customer-balance`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-features/src/__tests__/features-provider.test.tsx
+++ b/packages/@granit/react-features/src/__tests__/features-provider.test.tsx
@@ -13,7 +13,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: FeaturesConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/granit/features',
+  basePath: '/api/v1/features',
 };
 
 function createWrapper(config: FeaturesConfig) {
@@ -29,7 +29,7 @@ describe('FeaturesProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/granit/features');
+    expect(result.current.basePath).toBe('/api/v1/features');
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-features/src/__tests__/use-features.test.tsx
+++ b/packages/@granit/react-features/src/__tests__/use-features.test.tsx
@@ -79,7 +79,7 @@ describe('use-features', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/features/definitions');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/features/definitions');
       expect(result.current.data).toEqual([sampleGroup]);
     });
 
@@ -106,7 +106,7 @@ describe('use-features', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/features/values');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/features/values');
       expect(result.current.data).toEqual([sampleValue]);
     });
   });
@@ -121,7 +121,7 @@ describe('use-features', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/features/values/ui.dark-mode');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/features/values/ui.dark-mode');
       expect(result.current.data).toEqual(sampleValue);
     });
 
@@ -149,7 +149,7 @@ describe('use-features', () => {
       result.current.mutate({ name: 'ui.dark-mode', request: { value: 'true' } });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.put).toHaveBeenCalledWith('/api/granit/features/overrides/ui.dark-mode', {
+      expect(client.put).toHaveBeenCalledWith('/api/v1/features/overrides/ui.dark-mode', {
         value: 'true',
       });
     });
@@ -181,7 +181,7 @@ describe('use-features', () => {
       result.current.mutate('ui.dark-mode');
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.delete).toHaveBeenCalledWith('/api/granit/features/overrides/ui.dark-mode');
+      expect(client.delete).toHaveBeenCalledWith('/api/v1/features/overrides/ui.dark-mode');
     });
 
     it('exposes error state on failure', async () => {

--- a/packages/@granit/react-features/src/hooks/use-features.ts
+++ b/packages/@granit/react-features/src/hooks/use-features.ts
@@ -16,7 +16,7 @@ import type {
 } from '@granit/features';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/granit/features';
+const DEFAULT_BASE_PATH = '/api/v1/features';
 
 /**
  * Fetch all feature definitions grouped by category.

--- a/packages/@granit/react-features/src/providers/features-provider.tsx
+++ b/packages/@granit/react-features/src/providers/features-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the features provider. */
 export interface FeaturesConfig {
   readonly client: AxiosInstance;
-  /** Base path for features endpoints (default: `/api/granit/features`). */
+  /** Base path for features endpoints (default: `/api/v1/features`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-identity/src/__tests__/identity-provider.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/identity-provider.test.tsx
@@ -13,7 +13,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: IdentityConfig = {
   client: {} as AxiosInstance,
-  basePath: '/identity/users',
+  basePath: '/api/v1/identity/users',
 };
 
 function createWrapper(config: IdentityConfig) {
@@ -29,7 +29,7 @@ describe('IdentityProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/identity/users');
+    expect(result.current.basePath).toBe('/api/v1/identity/users');
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
@@ -68,7 +68,7 @@ describe('useIdentityCacheStats', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockStats);
-    expect(client.get).toHaveBeenCalledWith('/identity/users/stats');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/identity/users/stats');
   });
 
   it('uses custom basePath', async () => {
@@ -117,7 +117,7 @@ describe('useBatchResolveUsers', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockUsers);
-    expect(client.post).toHaveBeenCalledWith('/identity/users/batch', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/identity/users/batch', {
       userIds: [toEntityId<'User'>('user-1')],
     });
   });

--- a/packages/@granit/react-identity/src/__tests__/use-identity-groups.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-groups.test.tsx
@@ -53,7 +53,7 @@ describe('use-identity-groups', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/groups');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/groups');
       expect(result.current.data).toEqual([sampleGroup]);
     });
   });
@@ -68,7 +68,7 @@ describe('use-identity-groups', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/groups');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1/groups');
     });
 
     it('is disabled when userId is empty', async () => {
@@ -95,7 +95,9 @@ describe('use-identity-groups', () => {
       result.current.mutate({ userId: toEntityId<'User'>('user-1'), groupId: 'group-1' });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.put).toHaveBeenCalledWith('/identity/provider/users/user-1/groups/group-1');
+      expect(client.put).toHaveBeenCalledWith(
+        '/api/v1/identity/provider/users/user-1/groups/group-1'
+      );
     });
   });
 
@@ -111,7 +113,9 @@ describe('use-identity-groups', () => {
       result.current.mutate({ userId: toEntityId<'User'>('user-1'), groupId: 'group-1' });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.delete).toHaveBeenCalledWith('/identity/provider/users/user-1/groups/group-1');
+      expect(client.delete).toHaveBeenCalledWith(
+        '/api/v1/identity/provider/users/user-1/groups/group-1'
+      );
     });
 
     it('exposes error state on failure', async () => {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-passwords.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-passwords.test.tsx
@@ -46,7 +46,7 @@ describe('use-identity-passwords', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.get).toHaveBeenCalledWith(
-        '/identity/provider/users/user-1/password/changed-at'
+        '/api/v1/identity/provider/users/user-1/password/changed-at'
       );
       expect(result.current.data).toEqual(response);
     });
@@ -88,7 +88,7 @@ describe('use-identity-passwords', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith(
-        '/identity/provider/users/user-1/password/reset-email'
+        '/api/v1/identity/provider/users/user-1/password/reset-email'
       );
     });
 
@@ -120,7 +120,7 @@ describe('use-identity-passwords', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith(
-        '/identity/provider/users/user-1/password/temporary',
+        '/api/v1/identity/provider/users/user-1/password/temporary',
         { password: 'temp123!' }
       );
     });

--- a/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
@@ -57,7 +57,7 @@ describe('use-identity-provider-users', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/users', {
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/users', {
         params: undefined,
       });
       expect(result.current.data).toEqual([sampleUser]);
@@ -73,7 +73,7 @@ describe('use-identity-provider-users', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/users', { params });
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/users', { params });
     });
 
     it('uses custom providerBasePath', async () => {
@@ -101,7 +101,7 @@ describe('use-identity-provider-users', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1');
       expect(result.current.data).toEqual(sampleUser);
     });
 
@@ -129,7 +129,7 @@ describe('use-identity-provider-users', () => {
       result.current.mutate({ username: 'jdoe', email: 'jdoe@example.com', enabled: true });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/identity/provider/users', {
+      expect(client.post).toHaveBeenCalledWith('/api/v1/identity/provider/users', {
         username: 'jdoe',
         email: 'jdoe@example.com',
         enabled: true,
@@ -152,7 +152,7 @@ describe('use-identity-provider-users', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.put).toHaveBeenCalledWith('/identity/provider/users/user-1', {
+      expect(client.put).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1', {
         email: 'new@example.com',
       });
     });
@@ -170,7 +170,7 @@ describe('use-identity-provider-users', () => {
       result.current.mutate({ userId: toEntityId<'User'>('user-1'), enabled: false });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.patch).toHaveBeenCalledWith('/identity/provider/users/user-1/enabled', {
+      expect(client.patch).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1/enabled', {
         enabled: false,
       });
     });

--- a/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
@@ -49,7 +49,7 @@ describe('useIdentityRgpd', () => {
     result.current.erase.mutate(toEntityId<'User'>('user-1'));
 
     await waitFor(() => expect(result.current.erase.isSuccess).toBe(true));
-    expect(client.delete).toHaveBeenCalledWith('/identity/users/user-1');
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/identity/users/user-1');
   });
 
   it('uses custom basePath', async () => {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-roles.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-roles.test.tsx
@@ -53,7 +53,7 @@ describe('use-identity-roles', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/roles');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/roles');
       expect(result.current.data).toEqual([sampleRole]);
     });
   });
@@ -68,7 +68,7 @@ describe('use-identity-roles', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/roles');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1/roles');
     });
 
     it('is disabled when userId is empty', async () => {
@@ -93,7 +93,7 @@ describe('use-identity-roles', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/roles/admin/members');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/roles/admin/members');
     });
 
     it('is disabled when roleName is empty', async () => {
@@ -120,7 +120,7 @@ describe('use-identity-roles', () => {
       result.current.mutate({ userId: toEntityId<'User'>('user-1'), roleName: 'admin' });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.put).toHaveBeenCalledWith('/identity/provider/users/user-1/roles/admin');
+      expect(client.put).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1/roles/admin');
     });
   });
 
@@ -136,7 +136,9 @@ describe('use-identity-roles', () => {
       result.current.mutate({ userId: toEntityId<'User'>('user-1'), roleName: 'admin' });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.delete).toHaveBeenCalledWith('/identity/provider/users/user-1/roles/admin');
+      expect(client.delete).toHaveBeenCalledWith(
+        '/api/v1/identity/provider/users/user-1/roles/admin'
+      );
     });
 
     it('uses custom providerBasePath', async () => {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
@@ -67,7 +67,7 @@ describe('use-identity-sessions', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/sessions');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1/sessions');
       expect(result.current.data).toEqual([sampleSession]);
     });
 
@@ -93,7 +93,7 @@ describe('use-identity-sessions', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/identity/provider/users/user-1/devices');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1/devices');
       expect(result.current.data).toEqual([sampleDevice]);
     });
 
@@ -124,7 +124,7 @@ describe('use-identity-sessions', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.delete).toHaveBeenCalledWith(
-        '/identity/provider/users/user-1/sessions/session-1'
+        '/api/v1/identity/provider/users/user-1/sessions/session-1'
       );
     });
   });
@@ -141,7 +141,7 @@ describe('use-identity-sessions', () => {
       result.current.mutate(toEntityId<'User'>('user-1'));
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.delete).toHaveBeenCalledWith('/identity/provider/users/user-1/sessions');
+      expect(client.delete).toHaveBeenCalledWith('/api/v1/identity/provider/users/user-1/sessions');
     });
 
     it('exposes error state on failure', async () => {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-sync.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-sync.test.tsx
@@ -56,7 +56,7 @@ describe('useIdentitySync', () => {
     result.current.sync.mutate([toEntityId<'User'>('user-1'), toEntityId<'User'>('user-2')]);
 
     await waitFor(() => expect(result.current.sync.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/identity/users/sync', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/identity/users/sync', {
       userIds: [toEntityId<'User'>('user-1'), toEntityId<'User'>('user-2')],
     });
   });
@@ -73,7 +73,7 @@ describe('useIdentitySync', () => {
 
     await waitFor(() => expect(result.current.syncAll.isSuccess).toBe(true));
     expect(result.current.syncAll.data).toEqual(mockSyncAllResult);
-    expect(client.post).toHaveBeenCalledWith('/identity/users/sync-all');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/identity/users/sync-all');
   });
 
   it('syncStale mutation triggers stale sync', async () => {
@@ -88,7 +88,7 @@ describe('useIdentitySync', () => {
 
     await waitFor(() => expect(result.current.syncStale.isSuccess).toBe(true));
     expect(result.current.syncStale.data).toEqual(mockSyncStaleResult);
-    expect(client.post).toHaveBeenCalledWith('/identity/users/sync-stale');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/identity/users/sync-stale');
   });
 
   it('uses custom basePath', async () => {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
@@ -66,7 +66,7 @@ describe('useIdentityUsers', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockPage);
-    expect(client.get).toHaveBeenCalledWith('/identity/users/', { params: undefined });
+    expect(client.get).toHaveBeenCalledWith('/api/v1/identity/users/', { params: undefined });
   });
 
   it('passes search params to the API', async () => {
@@ -79,7 +79,7 @@ describe('useIdentityUsers', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/identity/users/', { params });
+    expect(client.get).toHaveBeenCalledWith('/api/v1/identity/users/', { params });
   });
 
   it('uses custom basePath', async () => {

--- a/packages/@granit/react-identity/src/hooks/use-identity-cache.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-cache.ts
@@ -23,7 +23,7 @@ export function useIdentityCacheStats(): UseQueryResult<IdentityUserCacheStats> 
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'cache-stats'),
-    queryFn: () => getCacheStats(config.client, config.basePath ?? '/identity/users'),
+    queryFn: () => getCacheStats(config.client, config.basePath ?? '/api/v1/identity/users'),
   });
 }
 
@@ -45,6 +45,6 @@ export function useBatchResolveUsers(): UseMutationResult<
 
   return useMutation({
     mutationFn: (userIds: UserId[]) =>
-      batchResolveUsers(config.client, config.basePath ?? '/identity/users', userIds),
+      batchResolveUsers(config.client, config.basePath ?? '/api/v1/identity/users', userIds),
   });
 }

--- a/packages/@granit/react-identity/src/hooks/use-identity-capabilities.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-capabilities.ts
@@ -27,7 +27,8 @@ export function useIdentityCapabilities(options?: {
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'capabilities'),
-    queryFn: () => fetchIdentityCapabilities(config.client, config.basePath ?? '/identity/users'),
+    queryFn: () =>
+      fetchIdentityCapabilities(config.client, config.basePath ?? '/api/v1/identity/users'),
     staleTime: Infinity,
     enabled: options?.enabled ?? true,
   });

--- a/packages/@granit/react-identity/src/hooks/use-identity-groups.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-groups.ts
@@ -22,7 +22,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useGroups(): UseQueryResult<readonly IdentityGroup[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'groups'),
@@ -42,7 +42,7 @@ export function useGroups(): UseQueryResult<readonly IdentityGroup[]> {
  */
 export function useUserGroups(userId: UserId): UseQueryResult<readonly IdentityGroup[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'groups'),
@@ -70,7 +70,7 @@ export type GroupMutationVariables = {
 export function useAddUserToGroup(): UseMutationResult<void, Error, GroupMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, groupId }: GroupMutationVariables) =>
@@ -99,7 +99,7 @@ export function useAddUserToGroup(): UseMutationResult<void, Error, GroupMutatio
 export function useRemoveUserFromGroup(): UseMutationResult<void, Error, GroupMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, groupId }: GroupMutationVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
@@ -26,7 +26,7 @@ export function usePasswordChangedAt(
   userId: UserId
 ): UseQueryResult<IdentityPasswordChangedAtResponse> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'password-changed-at'),
@@ -47,7 +47,7 @@ export function usePasswordChangedAt(
  */
 export function useSendPasswordResetEmail(): UseMutationResult<void, Error, UserId> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: (userId: UserId) => sendPasswordResetEmail(config.client, basePath, userId),
@@ -75,7 +75,7 @@ export function useSetTemporaryPassword(): UseMutationResult<
   SetTemporaryPasswordVariables
 > {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, password }: SetTemporaryPasswordVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
@@ -30,7 +30,7 @@ export function useProviderUsers(
   params?: IdentityProviderUserListParams
 ): UseQueryResult<readonly IdentityUser[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: [...buildIdentityQueryKey(config, 'provider', 'users', 'list'), params],
@@ -50,7 +50,7 @@ export function useProviderUsers(
  */
 export function useProviderUser(userId: UserId): UseQueryResult<IdentityUser> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId),
@@ -72,7 +72,7 @@ export function useProviderUser(userId: UserId): UseQueryResult<IdentityUser> {
 export function useCreateUser(): UseMutationResult<IdentityUser, Error, IdentityUserCreateRequest> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: (request: IdentityUserCreateRequest) =>
@@ -104,7 +104,7 @@ export type UpdateUserVariables = {
 export function useUpdateUser(): UseMutationResult<IdentityUser, Error, UpdateUserVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, request }: UpdateUserVariables) =>
@@ -136,7 +136,7 @@ export type SetUserEnabledVariables = {
 export function useSetUserEnabled(): UseMutationResult<void, Error, SetUserEnabledVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, enabled }: SetUserEnabledVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-rgpd.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-rgpd.ts
@@ -24,7 +24,7 @@ export function useIdentityRgpd(): {
 } {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/identity/users';
+  const basePath = config.basePath ?? '/api/v1/identity/users';
 
   const erase = useMutation({
     mutationFn: (userId: UserId) => eraseUserCache(config.client, basePath, userId),

--- a/packages/@granit/react-identity/src/hooks/use-identity-roles.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-roles.ts
@@ -23,7 +23,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useRoles(): UseQueryResult<readonly IdentityRole[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'roles'),
@@ -43,7 +43,7 @@ export function useRoles(): UseQueryResult<readonly IdentityRole[]> {
  */
 export function useUserRoles(userId: UserId): UseQueryResult<readonly IdentityRole[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'roles'),
@@ -64,7 +64,7 @@ export function useUserRoles(userId: UserId): UseQueryResult<readonly IdentityRo
  */
 export function useRoleMembers(roleName: string): UseQueryResult<readonly IdentityUser[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'roles', roleName, 'members'),
@@ -92,7 +92,7 @@ export type RoleMutationVariables = {
 export function useAssignRole(): UseMutationResult<void, Error, RoleMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, roleName }: RoleMutationVariables) =>
@@ -121,7 +121,7 @@ export function useAssignRole(): UseMutationResult<void, Error, RoleMutationVari
 export function useRemoveRole(): UseMutationResult<void, Error, RoleMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, roleName }: RoleMutationVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-sessions.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-sessions.ts
@@ -24,7 +24,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useUserSessions(userId: UserId): UseQueryResult<readonly IdentitySession[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'sessions'),
@@ -47,7 +47,7 @@ export function useUserDeviceActivity(
   userId: UserId
 ): UseQueryResult<readonly IdentityDeviceActivity[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'devices'),
@@ -76,7 +76,7 @@ export type TerminateSessionVariables = {
 export function useTerminateSession(): UseMutationResult<void, Error, TerminateSessionVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: ({ userId, sessionId }: TerminateSessionVariables) =>
@@ -102,7 +102,7 @@ export function useTerminateSession(): UseMutationResult<void, Error, TerminateS
 export function useTerminateAllSessions(): UseMutationResult<void, Error, UserId> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/identity/provider';
+  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
 
   return useMutation({
     mutationFn: (userId: UserId) => terminateAllSessions(config.client, basePath, userId),

--- a/packages/@granit/react-identity/src/hooks/use-identity-sync.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-sync.ts
@@ -32,7 +32,7 @@ export function useIdentitySync(): {
 } {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/identity/users';
+  const basePath = config.basePath ?? '/api/v1/identity/users';
 
   const sync = useMutation({
     mutationFn: (userIds: UserId[]) => syncUsers(config.client, basePath, userIds),

--- a/packages/@granit/react-identity/src/hooks/use-identity-users.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-users.ts
@@ -23,7 +23,7 @@ export function useIdentityUsers(
 
   return useQuery({
     queryKey: [...buildIdentityQueryKey(config, 'users', 'list'), params],
-    queryFn: () => searchUsers(config.client, config.basePath ?? '/identity/users', params),
+    queryFn: () => searchUsers(config.client, config.basePath ?? '/api/v1/identity/users', params),
   });
 }
 
@@ -45,7 +45,7 @@ export function useIdentityUser(userId: UserId): UseQueryResult<IdentityUser> {
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'users', userId),
-    queryFn: () => getUserById(config.client, config.basePath ?? '/identity/users', userId),
+    queryFn: () => getUserById(config.client, config.basePath ?? '/api/v1/identity/users', userId),
     enabled: userId.length > 0,
   });
 }

--- a/packages/@granit/react-identity/src/providers/identity-provider.tsx
+++ b/packages/@granit/react-identity/src/providers/identity-provider.tsx
@@ -8,7 +8,7 @@ export interface IdentityConfig {
   readonly client: AxiosInstance;
   /** Base path for user cache endpoints (default: `/identity/users`). */
   readonly basePath?: string;
-  /** Base path for identity provider endpoints (default: `/identity/provider`). */
+  /** Base path for identity provider endpoints (default: `/api/v1/identity/provider`). */
   readonly providerBasePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-invoicing/src/__tests__/invoicing-provider.test.tsx
+++ b/packages/@granit/react-invoicing/src/__tests__/invoicing-provider.test.tsx
@@ -13,7 +13,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: InvoicingConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/granit/invoicing',
+  basePath: '/api/v1/invoicing',
 };
 
 function createWrapper(config: InvoicingConfig) {
@@ -29,7 +29,7 @@ describe('InvoicingProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/granit/invoicing');
+    expect(result.current.basePath).toBe('/api/v1/invoicing');
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
+++ b/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
@@ -76,7 +76,7 @@ describe('useInvoices', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/granit/invoicing/invoices');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/invoicing/invoices');
     expect(result.current.data).toEqual([sampleInvoice]);
   });
 
@@ -119,7 +119,7 @@ describe('useInvoice', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/granit/invoicing/invoices/inv-1');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/invoicing/invoices/inv-1');
     expect(result.current.data).toEqual(sampleInvoice);
   });
 
@@ -152,7 +152,7 @@ describe('useDownloadInvoicePdf', () => {
     result.current.mutate('inv-1');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/granit/invoicing/invoices/inv-1/pdf', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/invoicing/invoices/inv-1/pdf', {
       responseType: 'blob',
     });
     expect(result.current.data).toBe(pdfBlob);
@@ -200,7 +200,7 @@ describe('useCreateInvoice', () => {
     result.current.mutate(request);
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/api/granit/invoicing/invoices', request);
+    expect(client.post).toHaveBeenCalledWith('/api/v1/invoicing/invoices', request);
   });
 
   it('exposes error state on failure', async () => {

--- a/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
+++ b/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
@@ -6,7 +6,7 @@ import { buildInvoicingQueryKey, useInvoicingConfig } from '../providers/invoici
 import type { InvoiceCreateRequest, InvoiceResponse } from '@granit/invoicing';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/granit/invoicing';
+const DEFAULT_BASE_PATH = '/api/v1/invoicing';
 
 /**
  * Fetch all invoices.

--- a/packages/@granit/react-invoicing/src/providers/invoicing-provider.tsx
+++ b/packages/@granit/react-invoicing/src/providers/invoicing-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the invoicing provider. */
 export interface InvoicingConfig {
   readonly client: AxiosInstance;
-  /** Base path for invoicing endpoints (default: `/api/granit/invoicing`). */
+  /** Base path for invoicing endpoints (default: `/api/v1/invoicing`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
+++ b/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
@@ -88,7 +88,7 @@ describe('use-metering', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meters');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/metering/meters');
       expect(result.current.data).toEqual([sampleMeter]);
     });
 
@@ -115,7 +115,7 @@ describe('use-metering', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/metering/meters/meter-1');
     });
 
     it('is disabled when id is empty', () => {
@@ -140,7 +140,7 @@ describe('use-metering', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/usage');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/metering/usage');
       expect(result.current.data).toEqual([sampleUsage]);
     });
   });
@@ -155,7 +155,7 @@ describe('use-metering', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/quota/meter-1');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/metering/quota/meter-1');
       expect(result.current.data).toEqual(sampleQuota);
     });
 
@@ -188,7 +188,7 @@ describe('use-metering', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/meters', {
+      expect(client.post).toHaveBeenCalledWith('/api/v1/metering/meters', {
         name: 'API Calls',
         unit: 'calls',
         aggregationType: 'Sum',
@@ -212,7 +212,7 @@ describe('use-metering', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.put).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1', {
+      expect(client.put).toHaveBeenCalledWith('/api/v1/metering/meters/meter-1', {
         name: 'Updated',
         unit: 'calls',
         description: null,
@@ -232,7 +232,7 @@ describe('use-metering', () => {
       result.current.mutate('meter-1');
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1/deactivate');
+      expect(client.post).toHaveBeenCalledWith('/api/v1/metering/meters/meter-1/deactivate');
     });
   });
 
@@ -260,7 +260,7 @@ describe('use-metering', () => {
       result.current.mutate(request);
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/events', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/metering/events', request);
     });
   });
 

--- a/packages/@granit/react-metering/src/hooks/use-metering.ts
+++ b/packages/@granit/react-metering/src/hooks/use-metering.ts
@@ -22,7 +22,7 @@ import type {
 } from '@granit/metering';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/granit/metering';
+const DEFAULT_BASE_PATH = '/api/v1/metering';
 
 // ---------------------------------------------------------------------------
 // Queries

--- a/packages/@granit/react-metering/src/providers/metering-provider.tsx
+++ b/packages/@granit/react-metering/src/providers/metering-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the metering provider. */
 export interface MeteringConfig {
   readonly client: AxiosInstance;
-  /** Base path for metering endpoints (default: `/api/granit/metering`). */
+  /** Base path for metering endpoints (default: `/api/v1/metering`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
+++ b/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
@@ -14,7 +14,7 @@ export interface TenantAdminProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/api/granit/admin';
+const DEFAULT_BASE_PATH = '/api/v1/multi-tenancy';
 const DEFAULT_KEY_PREFIX = ['tenant-admin'] as const;
 
 const TenantAdminContext = createContext<TenantAdminConfig | null>(null);

--- a/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
@@ -10,9 +10,9 @@ import type { AdminTenant } from '@granit/multi-tenancy';
  * Handlers mutate the in-memory `mockTenants` array — create/update/activate/
  * deactivate calls update state that subsequent GET calls reflect.
  *
- * @param baseUrl - API base path (default: `/api/granit/admin`)
+ * @param baseUrl - API base path (default: `/api/v1/multi-tenancy`)
  */
-export function createTenantHandlers(baseUrl = '/api/granit/admin') {
+export function createTenantHandlers(baseUrl = '/api/v1/multi-tenancy') {
   return [
     // GET /tenants — list all
     http.get(`${baseUrl}/tenants`, () => HttpResponse.json(mockTenants)),

--- a/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
@@ -38,7 +38,7 @@ describe('OpenIddictAdminProvider', () => {
       wrapper: createWrapper(config),
     });
 
-    expect(result.current.basePath).toBe('/api/admin');
+    expect(result.current.basePath).toBe('/admin');
   });
 
   it('should apply default queryKeyPrefix when not specified', () => {

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-groups.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-groups.test.tsx
@@ -66,7 +66,7 @@ describe('useAdminGroups', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listGroups).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(listGroups).toHaveBeenCalledWith(expect.anything(), '/admin');
     expect(result.current.data).toEqual(mockGroups);
   });
 
@@ -95,7 +95,7 @@ describe('useCreateAdminGroup', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createGroup).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+    expect(createGroup).toHaveBeenCalledWith(expect.anything(), '/admin', {
       name: 'Engineering',
       description: 'Engineering team',
     });
@@ -132,7 +132,7 @@ describe('useDeleteAdminGroup', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteGroup).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'grp-001');
+    expect(deleteGroup).toHaveBeenCalledWith(expect.anything(), '/admin', 'grp-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'groups'],
     });
@@ -165,7 +165,7 @@ describe('useAddGroupMember', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(addGroupMember).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'grp-001', {
+    expect(addGroupMember).toHaveBeenCalledWith(expect.anything(), '/admin', 'grp-001', {
       userId: 'usr-001',
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
@@ -202,7 +202,7 @@ describe('useRemoveGroupMember', () => {
 
     expect(removeGroupMember).toHaveBeenCalledWith(
       expect.anything(),
-      '/api/admin',
+      '/admin',
       'grp-001',
       'usr-001'
     );

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
@@ -60,7 +60,7 @@ describe('useAdminRoles', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listRoles).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(listRoles).toHaveBeenCalledWith(expect.anything(), '/admin');
     expect(result.current.data).toEqual(mockRoles);
   });
 
@@ -89,7 +89,7 @@ describe('useCreateAdminRole', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createRole).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+    expect(createRole).toHaveBeenCalledWith(expect.anything(), '/admin', {
       name: 'admin',
       description: 'Administrator role',
     });
@@ -132,7 +132,7 @@ describe('useAdminRoleMembers', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getRoleMembers).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'admin');
+    expect(getRoleMembers).toHaveBeenCalledWith(expect.anything(), '/admin', 'admin');
     expect(result.current.data).toEqual(mockMembers);
   });
 
@@ -158,7 +158,7 @@ describe('useDeleteAdminRole', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteRole).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'admin');
+    expect(deleteRole).toHaveBeenCalledWith(expect.anything(), '/admin', 'admin');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'roles'],
     });

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
@@ -87,7 +87,7 @@ describe('useAdminUsers', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listUsers).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+    expect(listUsers).toHaveBeenCalledWith(expect.anything(), '/admin', {
       search: 'admin',
       page: 1,
       pageSize: 10,
@@ -115,7 +115,7 @@ describe('useAdminUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getUser).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'usr-001');
+    expect(getUser).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
     expect(result.current.data).toEqual(mockUser);
   });
 
@@ -141,7 +141,7 @@ describe('useCreateAdminUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createUser).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+    expect(createUser).toHaveBeenCalledWith(expect.anything(), '/admin', {
       email: 'admin@example.com',
       firstName: 'Admin',
     });
@@ -178,7 +178,7 @@ describe('useDeleteAdminUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteUser).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'usr-001');
+    expect(deleteUser).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'users'],
     });
@@ -215,7 +215,7 @@ describe('useImpersonateUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(impersonateUser).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'usr-001');
+    expect(impersonateUser).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
     expect(result.current.data).toEqual(mockImpersonation);
   });
 

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
@@ -63,7 +63,7 @@ describe('useOidcApplications', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listApplications).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(listApplications).toHaveBeenCalledWith(expect.anything(), '/admin');
     expect(result.current.data).toEqual(mockApps);
   });
 
@@ -95,7 +95,7 @@ describe('useCreateOidcApplication', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createApplication).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+    expect(createApplication).toHaveBeenCalledWith(expect.anything(), '/admin', {
       clientId: 'guava-front',
       displayName: 'Guava Frontend',
     });
@@ -132,7 +132,7 @@ describe('useDeleteOidcApplication', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteApplication).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'guava-front');
+    expect(deleteApplication).toHaveBeenCalledWith(expect.anything(), '/admin', 'guava-front');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'applications'],
     });
@@ -170,7 +170,7 @@ describe('useRotateApplicationSecret', () => {
 
     expect(rotateApplicationSecret).toHaveBeenCalledWith(
       expect.anything(),
-      '/api/admin',
+      '/admin',
       'guava-front'
     );
     expect(result.current.data).toEqual(mockSecretResponse);

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
@@ -58,7 +58,7 @@ describe('useOidcAuthorizations', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/api/admin', undefined);
+    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/admin', undefined);
     expect(result.current.data).toEqual(mockAuthorizations);
   });
 
@@ -70,7 +70,7 @@ describe('useOidcAuthorizations', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/admin', {
       userId: 'usr-001',
     });
   });
@@ -100,7 +100,7 @@ describe('useRevokeAuthorization', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(revokeAuthorization).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'auth-001');
+    expect(revokeAuthorization).toHaveBeenCalledWith(expect.anything(), '/admin', 'auth-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'authorizations'],
     });
@@ -133,11 +133,7 @@ describe('useRevokeUserAuthorizations', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(revokeUserAuthorizations).toHaveBeenCalledWith(
-      expect.anything(),
-      '/api/admin',
-      'usr-001'
-    );
+    expect(revokeUserAuthorizations).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'authorizations'],
     });

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
@@ -51,7 +51,7 @@ describe('useOidcScopes', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listScopes).toHaveBeenCalledWith(expect.anything(), '/api/admin');
+    expect(listScopes).toHaveBeenCalledWith(expect.anything(), '/admin');
     expect(result.current.data).toEqual(mockScopes);
   });
 
@@ -84,7 +84,7 @@ describe('useCreateOidcScope', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createScope).toHaveBeenCalledWith(expect.anything(), '/api/admin', {
+    expect(createScope).toHaveBeenCalledWith(expect.anything(), '/admin', {
       name: 'api',
       displayName: 'API access',
       description: 'Grants API access',
@@ -122,7 +122,7 @@ describe('useDeleteOidcScope', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteScope).toHaveBeenCalledWith(expect.anything(), '/api/admin', 'api');
+    expect(deleteScope).toHaveBeenCalledWith(expect.anything(), '/admin', 'api');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'scopes'],
     });

--- a/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
+++ b/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
@@ -14,7 +14,7 @@ export interface OpenIddictAdminProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/api/admin';
+const DEFAULT_BASE_PATH = '/admin';
 const DEFAULT_KEY_PREFIX = ['openiddict-admin'] as const;
 
 const AdminContext = createContext<OpenIddictAdminConfig | null>(null);

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -23,9 +23,9 @@ import type {
  * Create stateful MSW handlers for OpenIddict admin endpoints.
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
  *
- * @param baseUrl - API base path (default: `/api/admin`)
+ * @param baseUrl - API base path (default: `/admin`)
  */
-export function createOpenIddictAdminHandlers(baseUrl = '/api/admin') {
+export function createOpenIddictAdminHandlers(baseUrl = '/admin') {
   return [
     // ── Users ────────────────────────────────────────────────────────────────
 

--- a/packages/@granit/react-payments/src/__tests__/payments-provider.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/payments-provider.test.tsx
@@ -13,7 +13,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: PaymentsConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/granit/payments',
+  basePath: '/api/v1/payments',
 };
 
 function createWrapper(config: PaymentsConfig) {
@@ -29,7 +29,7 @@ describe('PaymentsProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/granit/payments');
+    expect(result.current.basePath).toBe('/api/v1/payments');
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
@@ -122,7 +122,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/payments/transactions');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/transactions');
       expect(result.current.data).toEqual([sampleTransaction]);
     });
 
@@ -149,7 +149,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/payments/transactions/txn-1');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/transactions/txn-1');
       expect(result.current.data).toEqual(sampleTransaction);
     });
 
@@ -184,7 +184,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/payments/charge', expect.any(Object));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/payments/charge', expect.any(Object));
     });
 
     it('exposes error state on failure', async () => {
@@ -226,7 +226,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/payments/refund', expect.any(Object));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/payments/refund', expect.any(Object));
     });
   });
 
@@ -251,7 +251,7 @@ describe('use-payments', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data?.url).toBe('https://checkout.stripe.com/session/abc123');
-      expect(client.post).toHaveBeenCalledWith('/api/granit/payments/checkout', expect.any(Object));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/payments/checkout', expect.any(Object));
     });
   });
 
@@ -265,7 +265,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/payments/methods');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/methods');
       expect(result.current.data).toEqual([sampleMethod]);
     });
   });
@@ -280,7 +280,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/payments/methods/available');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/methods/available');
       expect(result.current.data).toEqual([sampleAvailableMethod]);
     });
   });
@@ -301,7 +301,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/payments/methods', expect.any(Object));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/payments/methods', expect.any(Object));
     });
   });
 
@@ -317,7 +317,7 @@ describe('use-payments', () => {
       result.current.mutate('pm-1');
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.delete).toHaveBeenCalledWith('/api/granit/payments/methods/pm-1');
+      expect(client.delete).toHaveBeenCalledWith('/api/v1/payments/methods/pm-1');
     });
 
     it('exposes error state on failure', async () => {

--- a/packages/@granit/react-payments/src/hooks/use-payments.ts
+++ b/packages/@granit/react-payments/src/hooks/use-payments.ts
@@ -26,7 +26,7 @@ import type {
 } from '@granit/payments';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/granit/payments';
+const DEFAULT_BASE_PATH = '/api/v1/payments';
 
 /**
  * List all payment transactions.

--- a/packages/@granit/react-payments/src/providers/payments-provider.tsx
+++ b/packages/@granit/react-payments/src/providers/payments-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the payments provider. */
 export interface PaymentsConfig {
   readonly client: AxiosInstance;
-  /** Base path for payment endpoints (default: `/api/granit/payments`). */
+  /** Base path for payment endpoints (default: `/api/v1/payments`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
+++ b/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
@@ -11,13 +11,13 @@ import type { RescheduleActionRequest, ScheduledActionResponse } from '@granit/s
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 import type { AxiosInstance } from 'axios';
 
-const DEFAULT_BASE_PATH = '/api/granit/scheduling';
+const DEFAULT_BASE_PATH = '/api/v1/scheduling/scheduled-actions';
 
 /** Options accepted by all scheduling hooks. */
 export interface SchedulingOptions {
   /** Axios instance used for all requests. */
   readonly client: AxiosInstance;
-  /** Base URL for the scheduling API. Defaults to `/api/granit/scheduling`. */
+  /** Base URL for the scheduling API. Defaults to `/api/v1/scheduling/scheduled-actions`. */
   readonly basePath?: string;
 }
 

--- a/packages/@granit/react-scheduling/src/testing/handlers.ts
+++ b/packages/@granit/react-scheduling/src/testing/handlers.ts
@@ -28,12 +28,12 @@ const statusPresetMap: Record<string, ScheduledActionStatus> = {
  * Create stateful MSW handlers for scheduled action endpoints.
  * Cancel and reschedule calls mutate the in-memory `mockScheduledActions` array.
  *
- * @param baseUrl - API base path (default: `/api/granit/scheduling`)
+ * @param baseUrl - API base path (default: `/api/v1/scheduling/scheduled-actions`)
  */
-export function createSchedulingHandlers(baseUrl = '/api/granit/scheduling') {
+export function createSchedulingHandlers(baseUrl = '/api/v1/scheduling/scheduled-actions') {
   return [
     // GET list — supports @granit/query-engine serialized params
-    http.get(`${baseUrl}/query`, ({ request }) => {
+    http.get(baseUrl, ({ request }) => {
       const url = new URL(request.url);
       const search = url.searchParams.get('search') ?? '';
 

--- a/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
@@ -73,7 +73,7 @@ describe('use-plans', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/subscriptions/plans');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/plans');
       expect(result.current.data).toEqual([samplePlan]);
     });
   });
@@ -88,7 +88,7 @@ describe('use-plans', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/subscriptions/plans/plan-1');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/plans/plan-1');
       expect(result.current.data).toEqual(samplePlan);
     });
 
@@ -125,7 +125,7 @@ describe('use-plans', () => {
       result.current.mutate(request);
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/subscriptions/plans', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/subscriptions/plans', request);
     });
   });
 
@@ -142,7 +142,7 @@ describe('use-plans', () => {
       result.current.mutate({ id: 'plan-1', request });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.put).toHaveBeenCalledWith('/api/granit/subscriptions/plans/plan-1', request);
+      expect(client.put).toHaveBeenCalledWith('/api/v1/subscriptions/plans/plan-1', request);
     });
   });
 
@@ -158,7 +158,7 @@ describe('use-plans', () => {
       result.current.mutate({ id: 'plan-1' });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/subscriptions/plans/plan-1/publish');
+      expect(client.post).toHaveBeenCalledWith('/api/v1/subscriptions/plans/plan-1/publish');
     });
   });
 
@@ -174,7 +174,7 @@ describe('use-plans', () => {
       result.current.mutate({ id: 'plan-1' });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/subscriptions/plans/plan-1/archive');
+      expect(client.post).toHaveBeenCalledWith('/api/v1/subscriptions/plans/plan-1/archive');
     });
   });
 
@@ -192,7 +192,7 @@ describe('use-plans', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/plans/plan-1/prices',
+        '/api/v1/subscriptions/plans/plan-1/prices',
         request
       );
     });
@@ -208,9 +208,7 @@ describe('use-plans', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/plans/plan-1/prices/history'
-      );
+      expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/plans/plan-1/prices/history');
       expect(result.current.data).toEqual([samplePrice]);
     });
 

--- a/packages/@granit/react-subscriptions/src/__tests__/use-seats.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-seats.test.tsx
@@ -46,9 +46,7 @@ describe('use-seats', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/subscriptions/sub-1/seats'
-      );
+      expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/subscriptions/sub-1/seats');
       expect(result.current.data).toEqual([sampleSeat]);
     });
 
@@ -76,10 +74,9 @@ describe('use-seats', () => {
       result.current.mutate({ userId: 'user-1' });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/subscriptions/sub-1/seats',
-        { userId: 'user-1' }
-      );
+      expect(client.post).toHaveBeenCalledWith('/api/v1/subscriptions/subscriptions/sub-1/seats', {
+        userId: 'user-1',
+      });
       expect(result.current.data).toEqual(sampleSeat);
     });
   });
@@ -97,7 +94,7 @@ describe('use-seats', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.delete).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/subscriptions/sub-1/seats/user-1'
+        '/api/v1/subscriptions/subscriptions/sub-1/seats/user-1'
       );
     });
 

--- a/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
@@ -65,7 +65,7 @@ describe('use-subscriptions', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/subscriptions/subscriptions');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/subscriptions');
       expect(result.current.data).toEqual([sampleSubscription]);
     });
   });
@@ -80,7 +80,7 @@ describe('use-subscriptions', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/subscriptions/subscriptions/active');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/subscriptions/active');
       expect(result.current.data).toEqual(sampleSubscription);
     });
   });
@@ -95,7 +95,7 @@ describe('use-subscriptions', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/granit/subscriptions/subscriptions/sub-1');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/subscriptions/sub-1');
     });
 
     it('is disabled when id is empty', async () => {
@@ -123,7 +123,7 @@ describe('use-subscriptions', () => {
       result.current.mutate(request);
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/granit/subscriptions/subscriptions', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/subscriptions/subscriptions', request);
     });
   });
 
@@ -141,7 +141,7 @@ describe('use-subscriptions', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/subscriptions/sub-1/cancel',
+        '/api/v1/subscriptions/subscriptions/sub-1/cancel',
         request
       );
     });
@@ -161,7 +161,7 @@ describe('use-subscriptions', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/subscriptions/sub-1/change-plan',
+        '/api/v1/subscriptions/subscriptions/sub-1/change-plan',
         request
       );
     });
@@ -181,7 +181,7 @@ describe('use-subscriptions', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/subscriptions/sub-1/migrate-price',
+        '/api/v1/subscriptions/subscriptions/sub-1/migrate-price',
         request
       );
     });
@@ -206,7 +206,7 @@ describe('use-subscriptions', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/subscriptions/subscriptions/bulk-migrate-price',
+        '/api/v1/subscriptions/subscriptions/bulk-migrate-price',
         request
       );
       expect(result.current.data).toEqual(bulkResponse);

--- a/packages/@granit/react-subscriptions/src/hooks/use-plans.ts
+++ b/packages/@granit/react-subscriptions/src/hooks/use-plans.ts
@@ -34,7 +34,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function usePlans(): UseQueryResult<readonly PlanResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'plans'),
@@ -54,7 +54,7 @@ export function usePlans(): UseQueryResult<readonly PlanResponse[]> {
  */
 export function usePlan(id: string): UseQueryResult<PlanResponse> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'plans', id),
@@ -79,7 +79,7 @@ export type CreatePlanVariables = PlanCreateRequest;
 export function useCreatePlan(): UseMutationResult<PlanResponse, Error, CreatePlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: (request: CreatePlanVariables) => createPlan(config.client, basePath, request),
@@ -110,7 +110,7 @@ export type UpdatePlanVariables = {
 export function useUpdatePlan(): UseMutationResult<PlanResponse, Error, UpdatePlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ id, request }: UpdatePlanVariables) =>
@@ -141,7 +141,7 @@ export type PublishPlanVariables = {
 export function usePublishPlan(): UseMutationResult<void, Error, PublishPlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ id }: PublishPlanVariables) => publishPlan(config.client, basePath, id),
@@ -171,7 +171,7 @@ export type ArchivePlanVariables = {
 export function useArchivePlan(): UseMutationResult<void, Error, ArchivePlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ id }: ArchivePlanVariables) => archivePlan(config.client, basePath, id),
@@ -206,7 +206,7 @@ export function useCreatePriceVersion(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ planId, request }: CreatePriceVersionVariables) =>
@@ -231,7 +231,7 @@ export function useCreatePriceVersion(): UseMutationResult<
  */
 export function usePlanPriceHistory(planId: string): UseQueryResult<readonly PlanPriceResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'plans', planId, 'prices', 'history'),

--- a/packages/@granit/react-subscriptions/src/hooks/use-seats.ts
+++ b/packages/@granit/react-subscriptions/src/hooks/use-seats.ts
@@ -21,7 +21,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useSeats(subscriptionId: string): UseQueryResult<readonly SeatResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions', subscriptionId, 'seats'),
@@ -48,7 +48,7 @@ export function useAssignSeat(
 ): UseMutationResult<SeatResponse, Error, AssignSeatVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: (request: AssignSeatVariables) =>
@@ -81,7 +81,7 @@ export function useRevokeSeat(
 ): UseMutationResult<void, Error, RevokeSeatVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ userId }: RevokeSeatVariables) =>

--- a/packages/@granit/react-subscriptions/src/hooks/use-subscriptions.ts
+++ b/packages/@granit/react-subscriptions/src/hooks/use-subscriptions.ts
@@ -36,7 +36,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useSubscriptions(): UseQueryResult<readonly SubscriptionResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions'),
@@ -54,7 +54,7 @@ export function useSubscriptions(): UseQueryResult<readonly SubscriptionResponse
  */
 export function useActiveSubscription(): UseQueryResult<SubscriptionResponse> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions', 'active'),
@@ -74,7 +74,7 @@ export function useActiveSubscription(): UseQueryResult<SubscriptionResponse> {
  */
 export function useSubscription(id: string): UseQueryResult<SubscriptionResponse> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions', id),
@@ -103,7 +103,7 @@ export function useCreateSubscription(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: (request: CreateSubscriptionVariables) =>
@@ -139,7 +139,7 @@ export function useCancelSubscription(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ id, request }: CancelSubscriptionVariables) =>
@@ -175,7 +175,7 @@ export function useChangeSubscriptionPlan(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ id, request }: ChangeSubscriptionPlanVariables) =>
@@ -211,7 +211,7 @@ export function useMigrateSubscriptionPrice(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: ({ id, request }: MigrateSubscriptionPriceVariables) =>
@@ -244,7 +244,7 @@ export function useBulkMigrateSubscriptionPrice(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/granit/subscriptions';
+  const basePath = config.basePath ?? '/api/v1/subscriptions';
 
   return useMutation({
     mutationFn: (request: BulkMigrateSubscriptionPriceVariables) =>

--- a/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
+++ b/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the subscriptions provider. */
 export interface SubscriptionsConfig {
   readonly client: AxiosInstance;
-  /** Base path for subscriptions endpoints (default: `/api/granit/subscriptions`). */
+  /** Base path for subscriptions endpoints (default: `/api/v1/subscriptions`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-tax/src/__tests__/tax-provider.test.tsx
+++ b/packages/@granit/react-tax/src/__tests__/tax-provider.test.tsx
@@ -9,7 +9,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: TaxConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/granit/tax',
+  basePath: '/api/v1/tax',
 };
 
 function createWrapper(config: TaxConfig) {
@@ -25,7 +25,7 @@ describe('TaxProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/granit/tax');
+    expect(result.current.basePath).toBe('/api/v1/tax');
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
+++ b/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
@@ -78,7 +78,7 @@ describe('useValidateTaxId', () => {
     result.current.mutate({ taxId: 'BE0123456789', countryCode: 'BE' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/api/granit/tax/validate', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/tax/validate', {
       taxId: 'BE0123456789',
       countryCode: 'BE',
     });
@@ -136,7 +136,7 @@ describe('useTaxRates', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/granit/tax/rates');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/tax/rates');
     expect(result.current.data).toEqual(rates);
   });
 
@@ -183,7 +183,7 @@ describe('useTaxRateByCountry', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/granit/tax/rates/BE');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/tax/rates/BE');
     expect(result.current.data).toEqual(mockBelgiumRate);
   });
 

--- a/packages/@granit/react-tax/src/hooks/use-tax.ts
+++ b/packages/@granit/react-tax/src/hooks/use-tax.ts
@@ -23,7 +23,7 @@ export function useValidateTaxId(): UseMutationResult<
   TaxValidateRequest
 > {
   const config = useTaxConfig();
-  const basePath = config.basePath ?? '/api/granit/tax';
+  const basePath = config.basePath ?? '/api/v1/tax';
 
   return useMutation({
     mutationFn: (request: TaxValidateRequest) => validateTaxId(config.client, basePath, request),
@@ -40,7 +40,7 @@ export function useValidateTaxId(): UseMutationResult<
  */
 export function useTaxRates(): UseQueryResult<readonly TaxRateResponse[]> {
   const config = useTaxConfig();
-  const basePath = config.basePath ?? '/api/granit/tax';
+  const basePath = config.basePath ?? '/api/v1/tax';
 
   return useQuery({
     queryKey: buildTaxQueryKey(config, 'rates'),
@@ -60,7 +60,7 @@ export function useTaxRates(): UseQueryResult<readonly TaxRateResponse[]> {
  */
 export function useTaxRateByCountry(countryCode: string): UseQueryResult<TaxRateResponse> {
   const config = useTaxConfig();
-  const basePath = config.basePath ?? '/api/granit/tax';
+  const basePath = config.basePath ?? '/api/v1/tax';
 
   return useQuery({
     queryKey: buildTaxQueryKey(config, 'rates', countryCode),

--- a/packages/@granit/react-tax/src/providers/tax-provider.tsx
+++ b/packages/@granit/react-tax/src/providers/tax-provider.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react';
 /** Configuration for the tax provider. */
 export interface TaxConfig {
   readonly client: AxiosInstance;
-  /** Base path for tax endpoints (default: `/api/granit/tax`). */
+  /** Base path for tax endpoints (default: `/api/v1/tax`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }

--- a/packages/@granit/react-templating/src/testing/handlers.ts
+++ b/packages/@granit/react-templating/src/testing/handlers.ts
@@ -16,9 +16,9 @@ import type { SaveTemplateCategoryRequest, TemplateCategory } from '@granit/temp
  * Create stateful MSW handlers for templating endpoints.
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
  *
- * @param baseUrl - API base path (default: `/api/v1`)
+ * @param baseUrl - API base path (default: `/api/v1/templating`)
  */
-export function createTemplatesHandlers(baseUrl = '/api/v1') {
+export function createTemplatesHandlers(baseUrl = '/api/v1/templating') {
   const BASE = `${baseUrl}/templates`;
 
   let templates = [...mockTemplatesData];

--- a/packages/@granit/react-webhooks/src/__tests__/use-deliveries.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-deliveries.test.tsx
@@ -61,7 +61,7 @@ describe('useDeliveries', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/deliveries/query', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/deliveries', {
       params: { subscriptionId: 'sub-001' },
     });
     expect(result.current.data).toEqual(mockDeliveries);
@@ -89,7 +89,7 @@ describe('useDeliveries', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/webhooks/deliveries/query', {
+    expect(client.get).toHaveBeenCalledWith('/api/v2/webhooks/deliveries', {
       params: { subscriptionId: 'sub-001' },
     });
   });

--- a/packages/@granit/scheduling/src/api/scheduling-api.ts
+++ b/packages/@granit/scheduling/src/api/scheduling-api.ts
@@ -21,14 +21,14 @@ export async function fetchScheduledActionById(
 /**
  * Fetch a paginated, filterable, sortable list of scheduled actions via QueryEngine.
  *
- * `GET {basePath}/query?page=&pageSize=&...`
+ * `GET {basePath}?page=&pageSize=&...`
  */
 export async function fetchScheduledActions(
   client: AxiosInstance,
   basePath: string,
   request: QueryRequest = {}
 ): Promise<PagedResult<ScheduledActionResponse>> {
-  return fetchPage<ScheduledActionResponse>(client, `${basePath}/query`, request);
+  return fetchPage<ScheduledActionResponse>(client, basePath, request);
 }
 
 /**

--- a/packages/@granit/templating/src/__tests__/api.test.ts
+++ b/packages/@granit/templating/src/__tests__/api.test.ts
@@ -35,7 +35,7 @@ import type {
 } from '../types/index.js';
 import type { PagedResult } from '@granit/query-engine';
 
-const basePath = '/api/v1';
+const basePath = '/api/v1/templating';
 
 describe('templates-api', () => {
   describe('getTemplates', () => {
@@ -61,7 +61,7 @@ describe('templates-api', () => {
         status: TemplateLifecycleStatus.Draft,
       });
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates', {
+      expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates', {
         params: { status: TemplateLifecycleStatus.Draft },
       });
       expect(result).toEqual(response);
@@ -73,7 +73,9 @@ describe('templates-api', () => {
 
       await getTemplates(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates', { params: undefined });
+      expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates', {
+        params: undefined,
+      });
     });
   });
 
@@ -98,7 +100,7 @@ describe('templates-api', () => {
 
       const result = await getTemplate(client, basePath, 'Billing.Invoice', 'fr-BE');
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice', {
+      expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates/Billing.Invoice', {
         params: { culture: 'fr-BE' },
       });
       expect(result).toEqual(detail);
@@ -114,7 +116,7 @@ describe('templates-api', () => {
 
       const result = await saveDraft(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith('/api/v1/templates', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/templating/templates', request);
       expect(result).toEqual(detail);
     });
   });
@@ -128,7 +130,10 @@ describe('templates-api', () => {
 
       const result = await updateDraft(client, basePath, 'Billing.Invoice', request);
 
-      expect(client.put).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice', request);
+      expect(client.put).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice',
+        request
+      );
       expect(result).toEqual(detail);
     });
   });
@@ -140,9 +145,12 @@ describe('templates-api', () => {
 
       await deleteDraft(client, basePath, 'Billing.Invoice', 'fr-BE');
 
-      expect(client.delete).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/draft', {
-        params: { culture: 'fr-BE' },
-      });
+      expect(client.delete).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice/draft',
+        {
+          params: { culture: 'fr-BE' },
+        }
+      );
     });
   });
 
@@ -153,9 +161,13 @@ describe('templates-api', () => {
 
       await publishTemplate(client, basePath, 'Billing.Invoice');
 
-      expect(client.post).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/publish', null, {
-        params: { culture: undefined },
-      });
+      expect(client.post).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice/publish',
+        null,
+        {
+          params: { culture: undefined },
+        }
+      );
     });
   });
 
@@ -167,7 +179,7 @@ describe('templates-api', () => {
       await unpublishTemplate(client, basePath, 'Billing.Invoice', 'fr-BE');
 
       expect(client.post).toHaveBeenCalledWith(
-        '/api/v1/templates/Billing.Invoice/unpublish',
+        '/api/v1/templating/templates/Billing.Invoice/unpublish',
         null,
         { params: { culture: 'fr-BE' } }
       );
@@ -187,9 +199,12 @@ describe('templates-api', () => {
 
       const result = await getLifecycleInfo(client, basePath, 'Billing.Invoice');
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/lifecycle', {
-        params: { culture: undefined },
-      });
+      expect(client.get).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice/lifecycle',
+        {
+          params: { culture: undefined },
+        }
+      );
       expect(result).toEqual(info);
     });
   });
@@ -210,9 +225,12 @@ describe('templates-api', () => {
         pageSize: 20,
       });
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/history', {
-        params: { page: 1, pageSize: 20 },
-      });
+      expect(client.get).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice/history',
+        {
+          params: { page: 1, pageSize: 20 },
+        }
+      );
       expect(result).toEqual(history);
     });
   });
@@ -235,7 +253,9 @@ describe('templates-api', () => {
 
       const result = await getRevision(client, basePath, 'Billing.Invoice', 'rev-1');
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/history/rev-1');
+      expect(client.get).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice/history/rev-1'
+      );
       expect(result).toEqual(revision);
     });
   });
@@ -254,9 +274,12 @@ describe('templates-api', () => {
         data: { title: 'Test' },
       });
 
-      expect(client.post).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/preview', {
-        data: { title: 'Test' },
-      });
+      expect(client.post).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice/preview',
+        {
+          data: { title: 'Test' },
+        }
+      );
       expect(result).toEqual(response);
     });
   });
@@ -273,7 +296,9 @@ describe('templates-api', () => {
 
       const result = await getVariables(client, basePath, 'Billing.Invoice');
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/variables');
+      expect(client.get).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/Billing.Invoice/variables'
+      );
       expect(result).toEqual(variables);
     });
   });
@@ -286,7 +311,7 @@ describe('templates-api', () => {
 
       const result = await getLayouts(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates/layouts');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates/layouts');
       expect(result).toEqual(layouts);
     });
 
@@ -315,7 +340,7 @@ describe('templates-api', () => {
 
       const result = await getCategories(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/templates/categories');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates/categories');
       expect(result).toEqual(categories);
     });
 
@@ -332,7 +357,7 @@ describe('templates-api', () => {
 
       const result = await createCategory(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith('/api/v1/templates/categories', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/templating/templates/categories', request);
       expect(result).toEqual(category);
     });
 
@@ -349,7 +374,10 @@ describe('templates-api', () => {
 
       const result = await updateCategory(client, basePath, 'cat-1', request);
 
-      expect(client.put).toHaveBeenCalledWith('/api/v1/templates/categories/cat-1', request);
+      expect(client.put).toHaveBeenCalledWith(
+        '/api/v1/templating/templates/categories/cat-1',
+        request
+      );
       expect(result).toEqual(category);
     });
 
@@ -359,7 +387,7 @@ describe('templates-api', () => {
 
       await deleteCategory(client, basePath, 'cat-1');
 
-      expect(client.delete).toHaveBeenCalledWith('/api/v1/templates/categories/cat-1');
+      expect(client.delete).toHaveBeenCalledWith('/api/v1/templating/templates/categories/cat-1');
     });
   });
 });

--- a/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
+++ b/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
@@ -216,7 +216,7 @@ describe('webhooks-api', () => {
   // ── Deliveries ────────────────────────────────────────────────────────────
 
   describe('getDeliveries', () => {
-    it('sends GET to /deliveries/query with subscriptionId param', async () => {
+    it('sends GET to /deliveries with subscriptionId param', async () => {
       const client = createMockClient();
       const response: WebhookDeliveryAttemptResponse[] = [
         {
@@ -238,7 +238,7 @@ describe('webhooks-api', () => {
 
       const result = await getDeliveries(client, '/api/v1/webhooks', { subscriptionId: 'sub-001' });
 
-      expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/deliveries/query', {
+      expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/deliveries', {
         params: { subscriptionId: 'sub-001' },
       });
       expect(result).toEqual(response);

--- a/packages/@granit/webhooks/src/api/webhooks-api.ts
+++ b/packages/@granit/webhooks/src/api/webhooks-api.ts
@@ -210,7 +210,7 @@ export async function getStats(
 /**
  * Query webhook delivery attempts.
  *
- * `GET {basePath}/deliveries/query`
+ * `GET {basePath}/deliveries`
  *
  * @param basePath - The webhooks root path (e.g. `/api/v1/webhooks`), **not** the subscriptions path.
  */
@@ -219,10 +219,9 @@ export async function getDeliveries(
   basePath: string,
   params?: { subscriptionId?: string }
 ): Promise<WebhookDeliveryAttemptResponse[]> {
-  const { data } = await client.get<WebhookDeliveryAttemptResponse[]>(
-    `${basePath}/deliveries/query`,
-    { params }
-  );
+  const { data } = await client.get<WebhookDeliveryAttemptResponse[]>(`${basePath}/deliveries`, {
+    params,
+  });
   return data;
 }
 


### PR DESCRIPTION
## Summary

- Update all API base paths across 119 files to match the normalized backend route convention `/{module-kebab}/{entity-kebab}/...`
- Covers: constants, provider defaults, hooks, MSW test handlers, and test assertions
- All lint and prettier checks pass

Companion PR: granit-fx/granit-dotnet#964

## Test plan

- [ ] `pnpm test` passes across all affected packages
- [ ] Smoke test showcase admin app with updated backend
