### PR TITLE
refactor: uniformize DEFAULT_BASE_PATH via constants.ts

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1635,14 +1635,7 @@
     {
       "name": "@granit/react-background-jobs",
       "description": "React hooks for background job monitoring — useBackgroundJobs, usePauseJob, useResumeJob, useTriggerJob",
-      "exports": [
-        {
-          "name": "BackgroundJobsOptions",
-          "kind": "interface",
-          "signature": "interface BackgroundJobsOptions",
-          "members": []
-        }
-      ]
+      "exports": []
     },
     {
       "name": "@granit/react-bff",
@@ -2237,7 +2230,7 @@
         {
           "name": "useDeviceTokens",
           "kind": "function",
-          "signature": "function useDeviceTokens( options: DeviceTokensOptions ): UseQueryResult<readonly MobilePushTokenResponse[]>"
+          "signature": "function useDeviceTokens(): UseQueryResult<readonly MobilePushTokenResponse[]>"
         },
         {
           "name": "deviceTokenKeys",
@@ -2245,20 +2238,14 @@
           "signature": "const deviceTokenKeys"
         },
         {
-          "name": "DeviceTokensOptions",
-          "kind": "interface",
-          "signature": "interface DeviceTokensOptions",
-          "members": []
-        },
-        {
           "name": "useMobilePush",
           "kind": "function",
-          "signature": "function useMobilePush(config: MobilePushConfig): UseMobilePushReturn"
+          "signature": "function useMobilePush(options: MobilePushHookOptions): UseMobilePushReturn"
         },
         {
-          "name": "MobilePushConfig",
+          "name": "MobilePushHookOptions",
           "kind": "interface",
-          "signature": "interface MobilePushConfig",
+          "signature": "interface MobilePushHookOptions",
           "members": []
         },
         {
@@ -2277,6 +2264,16 @@
               "signature": "unregister: () => Promise<void>"
             }
           ]
+        },
+        {
+          "name": "MobilePushProvider",
+          "kind": "function",
+          "signature": "function MobilePushProvider("
+        },
+        {
+          "name": "useMobilePushConfig",
+          "kind": "function",
+          "signature": "function useMobilePushConfig(): MobilePushProviderConfig"
         }
       ]
     },
@@ -2287,7 +2284,7 @@
         {
           "name": "useWebPush",
           "kind": "function",
-          "signature": "function useWebPush(config: WebPushConfig): UseWebPushReturn"
+          "signature": "function useWebPush(): UseWebPushReturn"
         },
         {
           "name": "UseWebPushReturn",
@@ -2307,10 +2304,14 @@
           ]
         },
         {
-          "name": "WebPushConfig",
-          "kind": "interface",
-          "signature": "interface WebPushConfig",
-          "members": []
+          "name": "WebPushProvider",
+          "kind": "function",
+          "signature": "function WebPushProvider("
+        },
+        {
+          "name": "useWebPushConfig",
+          "kind": "function",
+          "signature": "function useWebPushConfig(): WebPushProviderConfig"
         }
       ]
     },
@@ -2466,7 +2467,20 @@
     {
       "name": "@granit/react-scheduling",
       "description": "React hooks for scheduled action management — useScheduledActions, useCancelScheduledAction, useRescheduleScheduledAction",
-      "exports": []
+      "exports": [
+        {
+          "name": "SchedulingConfig",
+          "kind": "interface",
+          "signature": "interface SchedulingConfig",
+          "members": []
+        },
+        {
+          "name": "SchedulingProviderProps",
+          "kind": "interface",
+          "signature": "interface SchedulingProviderProps",
+          "members": []
+        }
+      ]
     },
     {
       "name": "@granit/react-settings",

--- a/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/account-provider.test.tsx
@@ -38,7 +38,7 @@ describe('AccountProvider', () => {
       wrapper: createWrapper(config),
     });
 
-    expect(result.current.basePath).toBe('/account');
+    expect(result.current.basePath).toBe('/api/v1/account');
   });
 
   it('should apply default queryKeyPrefix when not provided', () => {

--- a/packages/@granit/react-account/src/__tests__/use-account-deletion.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-account-deletion.test.tsx
@@ -51,7 +51,7 @@ describe('useDeleteAccount', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteAccount).toHaveBeenCalledWith(client, '/account', {
+    expect(deleteAccount).toHaveBeenCalledWith(client, '/api/v1/account', {
       password: 'MyP@ssword1!',
     });
   });

--- a/packages/@granit/react-account/src/__tests__/use-account-settings.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-account-settings.test.tsx
@@ -51,7 +51,7 @@ describe('useAccountSettings', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getAccountSettings).toHaveBeenCalledWith(client, '/account');
+    expect(getAccountSettings).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual({ allowSelfRegistration: true });
   });
 

--- a/packages/@granit/react-account/src/__tests__/use-email.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-email.test.tsx
@@ -52,7 +52,7 @@ describe('useChangeEmail', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(changeEmail).toHaveBeenCalledWith(client, '/account', {
+    expect(changeEmail).toHaveBeenCalledWith(client, '/api/v1/account', {
       newEmail: 'new@example.com',
     });
   });
@@ -89,7 +89,7 @@ describe('useConfirmEmailChange', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(confirmEmailChange).toHaveBeenCalledWith(client, '/account', {
+    expect(confirmEmailChange).toHaveBeenCalledWith(client, '/api/v1/account', {
       userId: 'user-1',
       newEmail: 'new@example.com',
       token: 'confirm-token-abc',

--- a/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
@@ -84,7 +84,7 @@ describe('useExternalLogins', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getExternalLogins).toHaveBeenCalledWith(client, '/account');
+    expect(getExternalLogins).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual(mockLogins);
   });
 
@@ -114,7 +114,7 @@ describe('useChallengeExternalLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(challengeExternalLogin).toHaveBeenCalledWith(client, '/account', 'Google');
+    expect(challengeExternalLogin).toHaveBeenCalledWith(client, '/api/v1/account', 'Google');
   });
 });
 
@@ -132,7 +132,7 @@ describe('useUnlinkExternalLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(unlinkExternalLogin).toHaveBeenCalledWith(client, '/account', 'Google');
+    expect(unlinkExternalLogin).toHaveBeenCalledWith(client, '/api/v1/account', 'Google');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'external-logins'],
     });

--- a/packages/@granit/react-account/src/__tests__/use-passkeys.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-passkeys.test.tsx
@@ -96,7 +96,7 @@ describe('usePasskeys', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getPasskeys).toHaveBeenCalledWith(client, '/account');
+    expect(getPasskeys).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual(mockPasskeys);
   });
 
@@ -127,7 +127,7 @@ describe('useBeginPasskeyRegistration', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(beginPasskeyRegistration).toHaveBeenCalledWith(client, '/account');
+    expect(beginPasskeyRegistration).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toBe(optionsJson);
   });
 });
@@ -151,7 +151,7 @@ describe('useCompletePasskeyRegistration', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(completePasskeyRegistration).toHaveBeenCalledWith(client, '/account', {
+    expect(completePasskeyRegistration).toHaveBeenCalledWith(client, '/api/v1/account', {
       credentialJson: '{"id":"cred"}',
       name: 'New Key',
     });
@@ -181,7 +181,7 @@ describe('useRenamePasskey', () => {
 
     expect(renamePasskey).toHaveBeenCalledWith(
       client,
-      '/account',
+      '/api/v1/account',
       toEntityId<'Passkey'>('pk-001'),
       {
         name: 'Renamed Key',
@@ -207,7 +207,7 @@ describe('useDeletePasskey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deletePasskey).toHaveBeenCalledWith(client, '/account', toEntityId<'Passkey'>('pk-001'));
+    expect(deletePasskey).toHaveBeenCalledWith(client, '/api/v1/account', toEntityId<'Passkey'>('pk-001'));
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'passkeys'],
     });

--- a/packages/@granit/react-account/src/__tests__/use-password.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-password.test.tsx
@@ -56,7 +56,7 @@ describe('useChangePassword', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(changePassword).toHaveBeenCalledWith(client, '/account', {
+    expect(changePassword).toHaveBeenCalledWith(client, '/api/v1/account', {
       currentPassword: 'OldP@ss1!',
       newPassword: 'NewP@ss1!',
     });
@@ -93,7 +93,7 @@ describe('useForgotPassword', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(forgotPassword).toHaveBeenCalledWith(client, '/account', {
+    expect(forgotPassword).toHaveBeenCalledWith(client, '/api/v1/account', {
       email: 'user@example.com',
     });
   });
@@ -130,7 +130,7 @@ describe('useResetPassword', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(resetPassword).toHaveBeenCalledWith(client, '/account', {
+    expect(resetPassword).toHaveBeenCalledWith(client, '/api/v1/account', {
       userId: 'user-1',
       token: 'reset-token-abc',
       newPassword: 'NewP@ss1!',

--- a/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-profile.test.tsx
@@ -77,7 +77,7 @@ describe('useProfile', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getProfile).toHaveBeenCalledWith(client, '/account');
+    expect(getProfile).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual(mockProfile);
   });
 
@@ -109,7 +109,7 @@ describe('useUpdateProfile', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(updateProfile).toHaveBeenCalledWith(client, '/account', { firstName: 'Jane' });
+    expect(updateProfile).toHaveBeenCalledWith(client, '/api/v1/account', { firstName: 'Jane' });
     expect(result.current.data).toEqual(updatedProfile);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'profile'],

--- a/packages/@granit/react-account/src/__tests__/use-registration.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-registration.test.tsx
@@ -62,7 +62,7 @@ describe('useRegister', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(registerAccount).toHaveBeenCalledWith(client, '/account', {
+    expect(registerAccount).toHaveBeenCalledWith(client, '/api/v1/account', {
       email: 'user@example.com',
       password: 'P@ssword1!',
       firstName: 'John',
@@ -98,7 +98,7 @@ describe('useConfirmEmail', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(confirmEmail).toHaveBeenCalledWith(client, '/account', 'user-1', 'abc123');
+    expect(confirmEmail).toHaveBeenCalledWith(client, '/api/v1/account', 'user-1', 'abc123');
   });
 
   it('should handle invalid token error', async () => {
@@ -129,7 +129,7 @@ describe('useResendConfirmation', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(resendConfirmationEmail).toHaveBeenCalledWith(client, '/account');
+    expect(resendConfirmationEmail).toHaveBeenCalledWith(client, '/api/v1/account');
   });
 
   it('should handle rate limit error', async () => {

--- a/packages/@granit/react-account/src/__tests__/use-session.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-session.test.tsx
@@ -53,7 +53,7 @@ describe('useSessionHeartbeat', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(sessionHeartbeat).toHaveBeenCalledWith(client, '/account');
+    expect(sessionHeartbeat).toHaveBeenCalledWith(client, '/api/v1/account');
   });
 
   it('should handle heartbeat error', async () => {
@@ -89,7 +89,7 @@ describe('useBackToImpersonator', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(backToImpersonator).toHaveBeenCalledWith(client, '/account');
+    expect(backToImpersonator).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual(response);
   });
 

--- a/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
@@ -91,7 +91,7 @@ describe('useTwoFactorStatus', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getTwoFactorStatus).toHaveBeenCalledWith(client, '/account');
+    expect(getTwoFactorStatus).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual(mockStatus);
   });
 
@@ -123,7 +123,7 @@ describe('useAuthenticatorKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getAuthenticatorKey).toHaveBeenCalledWith(client, '/account');
+    expect(getAuthenticatorKey).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual(mockKey);
   });
 });
@@ -145,7 +145,7 @@ describe('useEnableTwoFactor', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(enableTwoFactor).toHaveBeenCalledWith(client, '/account', { code: '123456' });
+    expect(enableTwoFactor).toHaveBeenCalledWith(client, '/api/v1/account', { code: '123456' });
     expect(result.current.data).toEqual(response);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'two-factor'],
@@ -181,7 +181,7 @@ describe('useDisableTwoFactor', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(disableTwoFactor).toHaveBeenCalledWith(client, '/account');
+    expect(disableTwoFactor).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'two-factor'],
     });
@@ -205,7 +205,7 @@ describe('useGenerateRecoveryCodes', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(generateRecoveryCodes).toHaveBeenCalledWith(client, '/account');
+    expect(generateRecoveryCodes).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toEqual(response);
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'two-factor'],

--- a/packages/@granit/react-account/src/constants.ts
+++ b/packages/@granit/react-account/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'account';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-account/src/hooks/use-account-settings.ts
+++ b/packages/@granit/react-account/src/hooks/use-account-settings.ts
@@ -7,7 +7,7 @@ import type { AccountSettingsResponse } from '@granit/account';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
- * Fetches the public account settings (`GET /account/config`).
+ * Fetches the public account settings (`GET {basePath}/config`).
  *
  * - No authentication required (anonymous endpoint).
  * - Cached indefinitely (`staleTime: Infinity`) — the setting rarely changes.

--- a/packages/@granit/react-account/src/providers/account-provider.tsx
+++ b/packages/@granit/react-account/src/providers/account-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -14,7 +16,6 @@ export interface AccountProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/account';
 const DEFAULT_KEY_PREFIX = ['account'] as const;
 
 const AccountContext = createContext<AccountConfig | null>(null);

--- a/packages/@granit/react-account/src/testing/handlers.ts
+++ b/packages/@granit/react-account/src/testing/handlers.ts
@@ -2,6 +2,8 @@ import { noContent, notFound } from '@granit/testing/msw';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import {
   mockAccountSettings,
   mockExternalLogins,
@@ -14,9 +16,9 @@ import {
  * Create stateful MSW handlers for account self-service endpoints.
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
  *
- * @param baseUrl - API base path (default: `/account`)
+ * @param baseUrl - API base path (default: `/api/v1/account`)
  */
-export function createAccountHandlers(baseUrl = '/account') {
+export function createAccountHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // ── Settings (anonymous) ─────────────────────────────────────────────────
     http.get(`${baseUrl}/config`, () => HttpResponse.json(mockAccountSettings)),

--- a/packages/@granit/react-auditing/src/__tests__/provider.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/provider.test.tsx
@@ -4,15 +4,15 @@ import { describe, expect, it } from 'vitest';
 import { useAuditLogConfig } from '../providers/audit-log-provider.js';
 import { AuditLogProvider } from '../providers/audit-log-provider.js';
 
-import type { AuditLogConfig } from '../providers/audit-log-provider.js';
+import type { AuditLogProviderProps } from '../providers/audit-log-provider.js';
 import type { AxiosInstance } from 'axios';
 
-const mockConfig: AuditLogConfig = {
+const mockConfig: AuditLogProviderProps['config'] = {
   client: {} as AxiosInstance,
   basePath: '/api/v1/auditing',
 };
 
-function createWrapper(config: AuditLogConfig) {
+function createWrapper(config: AuditLogProviderProps['config']) {
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return <AuditLogProvider config={config}>{children}</AuditLogProvider>;
   };

--- a/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
@@ -13,7 +13,7 @@ import {
 } from '../hooks/use-audit-log.js';
 import { AuditLogProvider } from '../providers/audit-log-provider.js';
 
-import type { AuditLogConfig } from '../providers/audit-log-provider.js';
+import type { AuditLogProviderProps } from '../providers/audit-log-provider.js';
 import type { AuditEntryDetail, AuditPage } from '@granit/auditing';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -21,7 +21,7 @@ import type { ReactNode } from 'react';
 function createWrapper(client: AxiosInstance, basePath = '/api/v1/auditing') {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: AuditLogConfig = { client, basePath };
+    const config: AuditLogProviderProps['config'] = { client, basePath };
     return (
       <QueryClientProvider client={queryClient}>
         <AuditLogProvider config={config}>{children}</AuditLogProvider>
@@ -49,7 +49,7 @@ describe('useAuditLogEntries', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(emptyPage);
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/audit-entries', {
       params: { category: AuditCategory.DataMutation },
     });
   });
@@ -100,7 +100,7 @@ describe('useEntityAuditTrail', () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/entity/Patient/42', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/audit-entries/entity/Patient/42', {
       params: { page: 1, pageSize: 10 },
     });
   });

--- a/packages/@granit/react-auditing/src/constants.ts
+++ b/packages/@granit/react-auditing/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'auditing';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
+++ b/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
@@ -1,11 +1,7 @@
 import { fetchAuditLogEntries, fetchAuditLogEntry, fetchEntityAuditTrail } from '@granit/auditing';
 import { useQuery } from '@tanstack/react-query';
 
-import {
-  buildAuditLogQueryKey,
-  DEFAULT_BASE_PATH,
-  useAuditLogConfig,
-} from '../providers/audit-log-provider.js';
+import { buildAuditLogQueryKey, useAuditLogConfig } from '../providers/audit-log-provider.js';
 
 import type { AuditEntryDetail, AuditListParams, AuditPage } from '@granit/auditing';
 import type { PaginationParams } from '@granit/query-engine';
@@ -21,11 +17,12 @@ import type { UseQueryResult } from '@tanstack/react-query';
  */
 export function useAuditLogEntries(params?: AuditListParams): UseQueryResult<AuditPage> {
   const config = useAuditLogConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath;
+  const auditEntriesPath = `${basePath}/audit-entries`;
 
   return useQuery({
     queryKey: buildAuditLogQueryKey(config, 'list', params),
-    queryFn: () => fetchAuditLogEntries(config.client, basePath, params),
+    queryFn: () => fetchAuditLogEntries(config.client, auditEntriesPath, params),
   });
 }
 
@@ -39,11 +36,12 @@ export function useAuditLogEntries(params?: AuditListParams): UseQueryResult<Aud
  */
 export function useAuditLogEntry(id: string): UseQueryResult<AuditEntryDetail> {
   const config = useAuditLogConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath;
+  const auditEntriesPath = `${basePath}/audit-entries`;
 
   return useQuery({
     queryKey: buildAuditLogQueryKey(config, 'detail', id),
-    queryFn: () => fetchAuditLogEntry(config.client, basePath, id),
+    queryFn: () => fetchAuditLogEntry(config.client, auditEntriesPath, id),
     enabled: id.length > 0,
   });
 }
@@ -62,11 +60,12 @@ export function useEntityAuditTrail(
   params?: PaginationParams
 ): UseQueryResult<AuditPage> {
   const config = useAuditLogConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath;
+  const auditEntriesPath = `${basePath}/audit-entries`;
 
   return useQuery({
     queryKey: buildAuditLogQueryKey(config, 'entity', entityType, entityId, params),
-    queryFn: () => fetchEntityAuditTrail(config.client, basePath, entityType, entityId, params),
+    queryFn: () => fetchEntityAuditTrail(config.client, auditEntriesPath, entityType, entityId, params),
     enabled: entityType.length > 0 && entityId.length > 0,
   });
 }

--- a/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
+++ b/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
@@ -1,29 +1,37 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
 /** Configuration for the audit log provider. */
 export interface AuditLogConfig {
   readonly client: AxiosInstance;
-  /** Base path prefix (default: `/api/v1/auditing/audit-entries`). */
-  readonly basePath?: string;
+  /** Base path prefix (default: `/api/v1/auditing`). */
+  readonly basePath: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 
+/** Props accepted by {@link AuditLogProvider}. `basePath` is optional — the default is applied by the provider. */
 export interface AuditLogProviderProps {
-  readonly config: AuditLogConfig;
+  readonly config: Omit<AuditLogConfig, 'basePath'> & Partial<Pick<AuditLogConfig, 'basePath'>>;
   readonly children: ReactNode;
 }
 
 const AuditLogConfigContext = createContext<AuditLogConfig | null>(null);
 
-const DEFAULT_BASE_PATH = '/api/v1/auditing/audit-entries';
 const DEFAULT_QUERY_KEY_PREFIX = ['audit-log'] as const;
 
 /** Provides audit log configuration to child components and hooks. */
 export function AuditLogProvider({ config, children }: Readonly<AuditLogProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo<AuditLogConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    }),
+    [config]
+  );
   return <AuditLogConfigContext value={value}>{children}</AuditLogConfigContext>;
 }
 
@@ -45,4 +53,4 @@ export function buildAuditLogQueryKey(
   return [...prefix, ...segments];
 }
 
-export { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX };
+export { DEFAULT_QUERY_KEY_PREFIX };

--- a/packages/@granit/react-auditing/src/testing/handlers.ts
+++ b/packages/@granit/react-auditing/src/testing/handlers.ts
@@ -1,6 +1,8 @@
 import { notFound, pagedResponse } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import { mockAuditEntries } from './data.js';
 
 import type { AuditEntry, AuditEntryDetail } from '@granit/auditing';
@@ -8,12 +10,13 @@ import type { AuditEntry, AuditEntryDetail } from '@granit/auditing';
 /**
  * Create stateful MSW handlers for audit log endpoints.
  *
- * @param baseUrl - API base path (default: `/api/v1/auditing/audit-entries`)
+ * @param baseUrl - API base path (default: `/api/v1/auditing`)
  */
-export function createAuditHandlers(baseUrl = '/api/v1/auditing/audit-entries') {
+export function createAuditHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  const auditEntriesUrl = `${baseUrl}/audit-entries`;
   return [
     // GET list — filtered, sorted newest-first, paginated
-    http.get(baseUrl, ({ request }) => {
+    http.get(auditEntriesUrl, ({ request }) => {
       const url = new URL(request.url);
       const page = Number(url.searchParams.get('page') ?? 1);
       const pageSize = Number(url.searchParams.get('pageSize') ?? 20);
@@ -33,7 +36,7 @@ export function createAuditHandlers(baseUrl = '/api/v1/auditing/audit-entries') 
     }),
 
     // GET single entry detail
-    http.get(`${baseUrl}/:id`, ({ params }) => {
+    http.get(`${auditEntriesUrl}/:id`, ({ params }) => {
       const entry = mockAuditEntries.find((e) => e.id === params.id);
       if (!entry) return notFound();
 

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-key-mutations.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-key-mutations.test.tsx
@@ -88,7 +88,7 @@ describe('useCreateApiKey', () => {
     vi.mocked(client.post).mockResolvedValueOnce({ data: createResponse });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useCreateApiKey({ client, basePath: '/api/v2/api-keys' }), {
+    const { result } = renderHook(() => useCreateApiKey({ client, basePath: '/api/v2/authentication' }), {
       wrapper,
     });
 
@@ -96,7 +96,7 @@ describe('useCreateApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/api-keys', expect.any(Object));
+    expect(client.post).toHaveBeenCalledWith('/api/v2/authentication/api-keys', expect.any(Object));
   });
 
   it('should invalidate the list cache on success', async () => {
@@ -205,7 +205,7 @@ describe('useRevokeApiKey', () => {
     vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useRevokeApiKey({ client, basePath: '/api/v2/api-keys' }), {
+    const { result } = renderHook(() => useRevokeApiKey({ client, basePath: '/api/v2/authentication' }), {
       wrapper,
     });
 
@@ -213,7 +213,7 @@ describe('useRevokeApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/api-keys/key-1/revoke');
+    expect(client.post).toHaveBeenCalledWith('/api/v2/authentication/api-keys/key-1/revoke');
   });
 
   it('should invalidate both list and detail caches on success', async () => {
@@ -294,7 +294,7 @@ describe('useRotateApiKey', () => {
     });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useRotateApiKey({ client, basePath: '/api/v2/api-keys' }), {
+    const { result } = renderHook(() => useRotateApiKey({ client, basePath: '/api/v2/authentication' }), {
       wrapper,
     });
 
@@ -302,7 +302,7 @@ describe('useRotateApiKey', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/api-keys/k1/rotate');
+    expect(client.post).toHaveBeenCalledWith('/api/v2/authentication/api-keys/k1/rotate');
   });
 
   it('should invalidate both list and detail caches on success', async () => {
@@ -383,7 +383,7 @@ describe('useUpdateApiKeyScopes', () => {
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(
-      () => useUpdateApiKeyScopes({ client, basePath: '/api/v2/api-keys' }),
+      () => useUpdateApiKeyScopes({ client, basePath: '/api/v2/authentication' }),
       { wrapper }
     );
 
@@ -394,7 +394,7 @@ describe('useUpdateApiKeyScopes', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.put).toHaveBeenCalledWith('/api/v2/api-keys/key-1/scopes', expect.any(Object));
+    expect(client.put).toHaveBeenCalledWith('/api/v2/authentication/api-keys/key-1/scopes', expect.any(Object));
   });
 
   it('should invalidate both list and detail caches on success', async () => {

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
@@ -155,11 +155,11 @@ describe('useApiKeys', () => {
     vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
 
     const { wrapper } = createWrapper();
-    renderHook(() => useApiKeys({ client, basePath: '/api/v2/api-keys' }), { wrapper });
+    renderHook(() => useApiKeys({ client, basePath: '/api/v2/authentication' }), { wrapper });
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/api-keys', expect.any(Object));
+    expect(client.get).toHaveBeenCalledWith('/api/v2/authentication/api-keys', expect.any(Object));
   });
 
   it('should surface errors from the API', async () => {
@@ -215,11 +215,11 @@ describe('useApiKey', () => {
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockApiKey });
 
     const { wrapper } = createWrapper();
-    renderHook(() => useApiKey('key-1', { client, basePath: '/api/v2/api-keys' }), { wrapper });
+    renderHook(() => useApiKey('key-1', { client, basePath: '/api/v2/authentication' }), { wrapper });
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/api-keys/key-1');
+    expect(client.get).toHaveBeenCalledWith('/api/v2/authentication/api-keys/key-1');
   });
 
   it('should not fetch when id is empty', async () => {

--- a/packages/@granit/react-authentication-api-keys/src/constants.ts
+++ b/packages/@granit/react-authentication-api-keys/src/constants.ts
@@ -1,1 +1,3 @@
-export const DEFAULT_BASE_PATH = '/api/v1/authentication/api-keys';
+export const API_VERSION = 'v1';
+export const MODULE = 'authentication';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-key-mutations.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-key-mutations.ts
@@ -38,7 +38,7 @@ export function useCreateApiKey(
 
   return useMutation({
     mutationFn: async (request: ApiKeyCreateRequest) => {
-      const response = await client.post<ApiKeyCreateResponse>(basePath, request);
+      const response = await client.post<ApiKeyCreateResponse>(`${basePath}/api-keys`, request);
       return response.data;
     },
     onSuccess: () => {
@@ -73,7 +73,7 @@ export function useRevokeApiKey(
 
   return useMutation({
     mutationFn: async (id: string) => {
-      await client.post(`${basePath}/${id}/revoke`);
+      await client.post(`${basePath}/api-keys/${id}/revoke`);
     },
     onSuccess: (_data, id) => {
       queryClient.invalidateQueries({ queryKey: apiKeyKeys.lists() });
@@ -109,7 +109,7 @@ export function useRotateApiKey(
 
   return useMutation({
     mutationFn: async (id: string) => {
-      const response = await client.post<ApiKeyRotateResponse>(`${basePath}/${id}/rotate`);
+      const response = await client.post<ApiKeyRotateResponse>(`${basePath}/api-keys/${id}/rotate`);
       return response.data;
     },
     onSuccess: (_data, id) => {
@@ -154,7 +154,7 @@ export function useUpdateApiKeyScopes(
 
   return useMutation({
     mutationFn: async ({ id, request }: UpdateApiKeyScopesVariables) => {
-      await client.put(`${basePath}/${id}/scopes`, request);
+      await client.put(`${basePath}/api-keys/${id}/scopes`, request);
     },
     onSuccess: (_data, { id }) => {
       queryClient.invalidateQueries({ queryKey: apiKeyKeys.lists() });

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-key.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-key.ts
@@ -27,7 +27,7 @@ export function useApiKey(id: string, options: ApiKeyHookOptions): UseQueryResul
   return useQuery({
     queryKey: apiKeyKeys.detail(id),
     queryFn: async () => {
-      const response = await client.get<ApiKeyResponse>(`${basePath}/${id}`);
+      const response = await client.get<ApiKeyResponse>(`${basePath}/api-keys/${id}`);
       return response.data;
     },
     enabled: Boolean(id),

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
@@ -14,7 +14,7 @@ import type { AxiosInstance } from 'axios';
 export interface ApiKeyHookOptions {
   /** Axios instance to use for HTTP requests. */
   client: AxiosInstance;
-  /** API base path. Defaults to `/api/v1/authentication/api-keys`. */
+  /** API base path. Defaults to `/api/v1/authentication`. */
   basePath?: string;
 }
 
@@ -70,7 +70,7 @@ export function useApiKeys(
   return useQuery({
     queryKey: apiKeyKeys.list(params),
     queryFn: async () => {
-      const response = await client.get<ApiKeyResponse[]>(basePath, {
+      const response = await client.get<ApiKeyResponse[]>(`${basePath}/api-keys`, {
         params: {
           search: params.search,
           type: params.type?.join(','),

--- a/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { notFound, pagedResponse } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -32,7 +33,7 @@ function generateSecret(type: string, environment: string): string {
  *
  * @param baseUrl - API base path (default: `/api/v1/authentication/api-keys`)
  */
-export function createApiKeyHandlers(baseUrl = '/api/v1/authentication/api-keys') {
+export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) {
   const apiKeys: MutableApiKey[] = mockApiKeys.map((k) => ({ ...k }));
 
   return [

--- a/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
@@ -19,7 +19,7 @@ describe('LocalAuthProvider', () => {
     const { result } = renderHook(() => useLocalAuthConfig(), { wrapper });
 
     expect(result.current.client).toBe(client);
-    expect(result.current.basePath).toBe('/account');
+    expect(result.current.basePath).toBe('/api/v1/account');
     expect(result.current.queryKeyPrefix).toEqual(['authentication-local']);
   });
 

--- a/packages/@granit/react-authentication-local/src/__tests__/use-begin-passkey-assertion.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-begin-passkey-assertion.test.tsx
@@ -52,7 +52,7 @@ describe('useBeginPasskeyAssertion', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(beginPasskeyAssertion).toHaveBeenCalledWith(client, '/account');
+    expect(beginPasskeyAssertion).toHaveBeenCalledWith(client, '/api/v1/account');
     expect(result.current.data).toBe(optionsJson);
   });
 

--- a/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-complete-passkey-assertion.test.tsx
@@ -60,7 +60,7 @@ describe('useCompletePasskeyAssertion', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(completePasskeyAssertion).toHaveBeenCalledWith(client, '/account', {
+    expect(completePasskeyAssertion).toHaveBeenCalledWith(client, '/api/v1/account', {
       credentialJson: '{"id":"cred-1","response":{"authenticatorData":"..."}}',
     });
     expect(result.current.data).toEqual(response);

--- a/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-login.test.tsx
@@ -61,7 +61,7 @@ describe('useLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(loginAccount).toHaveBeenCalledWith(client, '/account', {
+    expect(loginAccount).toHaveBeenCalledWith(client, '/api/v1/account', {
       login: 'user@example.com',
       password: 'P@ssw0rd!',
     });

--- a/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
@@ -58,7 +58,7 @@ describe('useVerifyTwoFactorLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/account', {
+    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/v1/account', {
       code: '123456',
     });
     expect(result.current.data).toEqual(response);
@@ -82,7 +82,7 @@ describe('useVerifyTwoFactorLogin', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/account', {
+    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/v1/account', {
       code: 'ABCD-1234-EFGH',
       useRecoveryCode: true,
     });

--- a/packages/@granit/react-authentication-local/src/constants.ts
+++ b/packages/@granit/react-authentication-local/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'account';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
+++ b/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -19,7 +21,6 @@ export interface LocalAuthProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/account';
 const DEFAULT_KEY_PREFIX = ['authentication-local'] as const;
 
 const LocalAuthContext = createContext<LocalAuthConfig | null>(null);

--- a/packages/@granit/react-authentication-local/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-local/src/testing/handlers.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import {
   MOCK_CREDENTIALS,
   MOCK_TOTP_CODE,
@@ -11,9 +13,9 @@ import {
  * Create MSW handlers for local authentication endpoints (login, 2FA,
  * passkeys, password reset, registration, email confirmation).
  *
- * @param baseUrl - API base path (default: `/account`)
+ * @param baseUrl - API base path (default: `/api/v1/account`)
  */
-export function createLocalAuthHandlers(baseUrl = '/account') {
+export function createLocalAuthHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // POST /login
     http.post(`${baseUrl}/login`, async ({ request }) => {

--- a/packages/@granit/react-authorization/src/constants.ts
+++ b/packages/@granit/react-authorization/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'authorization';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-authorization/src/hooks/use-permission-definitions.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permission-definitions.ts
@@ -1,11 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { permissionKeys } from './use-permissions.js';
 
 import type { PermissionGroupDto, UsePermissionDefinitionsOptions } from '@granit/authorization';
 import type { UseQueryResult } from '@tanstack/react-query';
-
-const DEFAULT_BASE_PATH = '/api/v1/authorization';
 
 /**
  * Fetches all permission definitions grouped by module.

--- a/packages/@granit/react-authorization/src/hooks/use-permission-grant.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permission-grant.ts
@@ -1,11 +1,10 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { permissionKeys } from './use-permissions.js';
 
 import type { PermissionGrantParams, UsePermissionGrantOptions } from '@granit/authorization';
 import type { UseMutationResult } from '@tanstack/react-query';
-
-const DEFAULT_BASE_PATH = '/api/v1/authorization';
 
 /** Return type of the {@link usePermissionGrant} hook. */
 export type UsePermissionGrantReturn = {

--- a/packages/@granit/react-authorization/src/hooks/use-permissions.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permissions.ts
@@ -1,17 +1,13 @@
 import { useQuery } from '@tanstack/react-query';
 import * as React from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type {
   PermissionsResponse,
   UsePermissionsOptions,
   UsePermissionsReturn,
 } from '@granit/authorization';
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const DEFAULT_BASE_PATH = '/api/v1/authorization';
 const EMPTY_SET: ReadonlySet<string> = new Set<string>();
 
 /** Query key factory for permission queries. */

--- a/packages/@granit/react-authorization/src/hooks/use-role-permissions.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-role-permissions.ts
@@ -1,11 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { permissionKeys } from './use-permissions.js';
 
 import type { PermissionGrantDto, UseRolePermissionsOptions } from '@granit/authorization';
 import type { UseQueryResult } from '@tanstack/react-query';
-
-const DEFAULT_BASE_PATH = '/api/v1/authorization';
 
 /**
  * Fetches the permissions granted to a specific role.

--- a/packages/@granit/react-authorization/src/testing/handlers.ts
+++ b/packages/@granit/react-authorization/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { noContent, notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockPermissionGroups, mockRoleGrants } from './data.js';
 
 /**
@@ -9,7 +10,7 @@ import { mockPermissionGroups, mockRoleGrants } from './data.js';
  *
  * @param baseUrl - API base path (default: `/api/v1/authorization`)
  */
-export function createAuthorizationHandlers(baseUrl = '/api/v1/authorization') {
+export function createAuthorizationHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET /permissions/definitions — list all permission groups
     http.get(`${baseUrl}/permissions/definitions`, () => {

--- a/packages/@granit/react-background-jobs/src/__tests__/use-background-job.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/use-background-job.test.tsx
@@ -1,12 +1,30 @@
-import { createQueryWrapper } from '@granit/react-testing';
+import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
 import { toISODateString } from '@granit/types';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { useBackgroundJob } from '../hooks/use-background-jobs.js';
+import { BackgroundJobsProvider } from '../providers/background-jobs-provider.js';
 
+import type { BackgroundJobsConfig } from '../providers/background-jobs-provider.js';
 import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { AxiosInstance } from 'axios';
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  const queryClient = createTestQueryClient();
+  const config: BackgroundJobsConfig = { client, basePath };
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <BackgroundJobsProvider config={config}>{children}</BackgroundJobsProvider>
+      </QueryClientProvider>
+    ),
+    queryClient,
+  };
+}
 
 const mockJob: BackgroundJobStatus = {
   jobName: 'InvoiceSync',
@@ -24,12 +42,12 @@ describe('useBackgroundJob', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockJob });
 
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useBackgroundJob('InvoiceSync', { client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBackgroundJob('InvoiceSync'), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs/InvoiceSync');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/InvoiceSync');
     expect(result.current.data).toEqual(mockJob);
   });
 
@@ -37,22 +55,22 @@ describe('useBackgroundJob', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockJob });
 
-    const wrapper = createQueryWrapper();
+    const { wrapper } = createWrapper(client, '/api/v2/bg');
     const { result } = renderHook(
-      () => useBackgroundJob('InvoiceSync', { client, basePath: '/api/v2/jobs' }),
+      () => useBackgroundJob('InvoiceSync'),
       { wrapper }
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/jobs/InvoiceSync');
+    expect(client.get).toHaveBeenCalledWith('/api/v2/bg/jobs/InvoiceSync');
   });
 
   it('should not fetch when name is empty', () => {
     const client = createMockClient();
 
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useBackgroundJob('', { client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBackgroundJob(''), { wrapper });
 
     expect(result.current.fetchStatus).toBe('idle');
     expect(client.get).not.toHaveBeenCalled();
@@ -62,8 +80,8 @@ describe('useBackgroundJob', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockRejectedValueOnce(new Error('Not Found'));
 
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useBackgroundJob('MissingJob', { client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBackgroundJob('MissingJob'), { wrapper });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
@@ -74,13 +92,13 @@ describe('useBackgroundJob', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockJob });
 
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useBackgroundJob('job/with spaces', { client }), {
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBackgroundJob('job/with spaces'), {
       wrapper,
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs/job%2Fwith%20spaces');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/background-jobs/jobs/job%2Fwith%20spaces');
   });
 });

--- a/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/use-background-jobs.test.tsx
@@ -13,15 +13,21 @@ import {
   useResumeJob,
   useTriggerJob,
 } from '../hooks/use-background-jobs.js';
+import { BackgroundJobsProvider } from '../providers/background-jobs-provider.js';
 
+import type { BackgroundJobsConfig } from '../providers/background-jobs-provider.js';
 import type { BackgroundJobStatus } from '@granit/background-jobs';
 import type { PagedResult } from '@granit/query-engine';
+import type { AxiosInstance } from 'axios';
 
-function createWrapper() {
+function createWrapper(client: AxiosInstance, basePath?: string) {
   const queryClient = createTestQueryClient();
+  const config: BackgroundJobsConfig = { client, basePath };
   return {
     wrapper: ({ children }: { children: React.ReactNode }) => (
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <BackgroundJobsProvider config={config}>{children}</BackgroundJobsProvider>
+      </QueryClientProvider>
     ),
     queryClient,
   };
@@ -67,8 +73,8 @@ describe('useBackgroundJobs', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockPage });
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useBackgroundJobs({ client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBackgroundJobs(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -80,23 +86,21 @@ describe('useBackgroundJobs', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockPage });
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useBackgroundJobs({ client, basePath: '/api/v2/jobs' }), {
-      wrapper,
-    });
+    const { wrapper } = createWrapper(client, '/api/v2/bg');
+    const { result } = renderHook(() => useBackgroundJobs(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/jobs', { params: undefined });
+    expect(client.get).toHaveBeenCalledWith('/api/v2/bg/jobs', { params: undefined });
   });
 
   it('should pass pagination params to the request', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: mockPage });
 
-    const { wrapper } = createWrapper();
+    const { wrapper } = createWrapper(client);
     const { result } = renderHook(
-      () => useBackgroundJobs({ client, params: { page: 2, pageSize: 10 } }),
+      () => useBackgroundJobs({ page: 2, pageSize: 10 }),
       { wrapper }
     );
 
@@ -111,8 +115,8 @@ describe('useBackgroundJobs', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockRejectedValueOnce(new Error('Unauthorized'));
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useBackgroundJobs({ client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBackgroundJobs(), { wrapper });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
@@ -125,10 +129,10 @@ describe('usePauseJob', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
-    const { wrapper, queryClient } = createWrapper();
+    const { wrapper, queryClient } = createWrapper(client);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const { result } = renderHook(() => usePauseJob({ client }), { wrapper });
+    const { result } = renderHook(() => usePauseJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
@@ -144,24 +148,22 @@ describe('usePauseJob', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => usePauseJob({ client, basePath: '/api/v2/jobs' }), {
-      wrapper,
-    });
+    const { wrapper } = createWrapper(client, '/api/v2/bg');
+    const { result } = renderHook(() => usePauseJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/jobs/InvoiceSync/pause');
+    expect(client.post).toHaveBeenCalledWith('/api/v2/bg/jobs/InvoiceSync/pause');
   });
 
   it('should handle pause error', async () => {
     const client = createMockClient();
     vi.mocked(client.post).mockRejectedValueOnce(new Error('Forbidden'));
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => usePauseJob({ client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => usePauseJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
@@ -176,10 +178,10 @@ describe('useResumeJob', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
-    const { wrapper, queryClient } = createWrapper();
+    const { wrapper, queryClient } = createWrapper(client);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const { result } = renderHook(() => useResumeJob({ client }), { wrapper });
+    const { result } = renderHook(() => useResumeJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
@@ -195,24 +197,22 @@ describe('useResumeJob', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useResumeJob({ client, basePath: '/api/v2/jobs' }), {
-      wrapper,
-    });
+    const { wrapper } = createWrapper(client, '/api/v2/bg');
+    const { result } = renderHook(() => useResumeJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/jobs/InvoiceSync/resume');
+    expect(client.post).toHaveBeenCalledWith('/api/v2/bg/jobs/InvoiceSync/resume');
   });
 
   it('should handle resume error', async () => {
     const client = createMockClient();
     vi.mocked(client.post).mockRejectedValueOnce(new Error('Service Unavailable'));
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useResumeJob({ client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useResumeJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
@@ -227,10 +227,10 @@ describe('useTriggerJob', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
-    const { wrapper, queryClient } = createWrapper();
+    const { wrapper, queryClient } = createWrapper(client);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const { result } = renderHook(() => useTriggerJob({ client }), { wrapper });
+    const { result } = renderHook(() => useTriggerJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
@@ -246,24 +246,22 @@ describe('useTriggerJob', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useTriggerJob({ client, basePath: '/api/v2/jobs' }), {
-      wrapper,
-    });
+    const { wrapper } = createWrapper(client, '/api/v2/bg');
+    const { result } = renderHook(() => useTriggerJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/jobs/InvoiceSync/trigger');
+    expect(client.post).toHaveBeenCalledWith('/api/v2/bg/jobs/InvoiceSync/trigger');
   });
 
   it('should handle trigger error', async () => {
     const client = createMockClient();
     vi.mocked(client.post).mockRejectedValueOnce(new Error('Conflict'));
 
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useTriggerJob({ client }), { wrapper });
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useTriggerJob(), { wrapper });
 
     result.current.mutate('InvoiceSync');
 

--- a/packages/@granit/react-background-jobs/src/constants.ts
+++ b/packages/@granit/react-background-jobs/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'background-jobs';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
+++ b/packages/@granit/react-background-jobs/src/hooks/use-background-jobs.ts
@@ -7,22 +7,11 @@ import {
 } from '@granit/background-jobs';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { useBackgroundJobsConfig } from '../providers/background-jobs-provider.js';
+
 import type { BackgroundJobListParams, BackgroundJobStatus } from '@granit/background-jobs';
 import type { PagedResult } from '@granit/query-engine';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
-
-const DEFAULT_BASE_PATH = '/api/v1/background-jobs/jobs';
-
-/** Options accepted by all background-jobs hooks. */
-export interface BackgroundJobsOptions {
-  /** Axios instance used for all requests. */
-  readonly client: AxiosInstance;
-  /** Base URL for the background-jobs API. Defaults to `/api/v1/background-jobs/jobs`. */
-  readonly basePath?: string;
-  /** Pagination parameters for the list endpoint. */
-  readonly params?: BackgroundJobListParams;
-}
 
 /** Query key factory for background jobs queries. */
 export const backgroundJobKeys = {
@@ -39,18 +28,19 @@ export const backgroundJobKeys = {
  *
  * @example
  * ```tsx
- * const { data } = useBackgroundJobs({ client: api });
+ * const { data } = useBackgroundJobs();
  * // data.items, data.totalCount, data.hasMore
  * ```
  */
 export function useBackgroundJobs(
-  options: BackgroundJobsOptions
+  params?: BackgroundJobListParams
 ): UseQueryResult<PagedResult<BackgroundJobStatus>> {
-  const { client, basePath = DEFAULT_BASE_PATH, params } = options;
+  const { client, basePath } = useBackgroundJobsConfig();
+  const jobsPath = `${basePath}/jobs`;
 
   return useQuery({
     queryKey: backgroundJobKeys.list(params),
-    queryFn: () => fetchBackgroundJobs(client, basePath, params),
+    queryFn: () => fetchBackgroundJobs(client, jobsPath, params),
     refetchInterval: 15_000,
   });
 }
@@ -63,18 +53,18 @@ export function useBackgroundJobs(
  *
  * @example
  * ```tsx
- * const { data: job } = useBackgroundJob('InvoiceSync', { client: api });
+ * const { data: job } = useBackgroundJob('InvoiceSync');
  * ```
  */
 export function useBackgroundJob(
-  name: string,
-  options: BackgroundJobsOptions
+  name: string
 ): UseQueryResult<BackgroundJobStatus> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+  const { client, basePath } = useBackgroundJobsConfig();
+  const jobsPath = `${basePath}/jobs`;
 
   return useQuery({
     queryKey: backgroundJobKeys.job(name),
-    queryFn: () => fetchBackgroundJob(client, basePath, name),
+    queryFn: () => fetchBackgroundJob(client, jobsPath, name),
     refetchInterval: 15_000,
     enabled: name.length > 0,
   });
@@ -83,23 +73,22 @@ export function useBackgroundJob(
 /**
  * Mutation hook to pause a background job by name.
  *
- * Sends `POST {basePath}/{name}/pause` and invalidates the jobs list on success.
+ * Sends `POST {basePath}/jobs/{name}/pause` and invalidates the jobs list on success.
  *
  * @example
  * ```tsx
- * const { mutate: pause } = usePauseJob({ client: api });
+ * const { mutate: pause } = usePauseJob();
  * pause('InvoiceSync');
  * ```
  */
-export function usePauseJob(
-  options: BackgroundJobsOptions
-): UseMutationResult<void, Error, string> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+export function usePauseJob(): UseMutationResult<void, Error, string> {
+  const { client, basePath } = useBackgroundJobsConfig();
+  const jobsPath = `${basePath}/jobs`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (jobName: string) => {
-      await pauseJob(client, basePath, jobName);
+      await pauseJob(client, jobsPath, jobName);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
@@ -110,23 +99,22 @@ export function usePauseJob(
 /**
  * Mutation hook to resume a paused background job by name.
  *
- * Sends `POST {basePath}/{name}/resume` and invalidates the jobs list on success.
+ * Sends `POST {basePath}/jobs/{name}/resume` and invalidates the jobs list on success.
  *
  * @example
  * ```tsx
- * const { mutate: resume } = useResumeJob({ client: api });
+ * const { mutate: resume } = useResumeJob();
  * resume('InvoiceSync');
  * ```
  */
-export function useResumeJob(
-  options: BackgroundJobsOptions
-): UseMutationResult<void, Error, string> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+export function useResumeJob(): UseMutationResult<void, Error, string> {
+  const { client, basePath } = useBackgroundJobsConfig();
+  const jobsPath = `${basePath}/jobs`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (jobName: string) => {
-      await resumeJob(client, basePath, jobName);
+      await resumeJob(client, jobsPath, jobName);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });
@@ -137,23 +125,22 @@ export function useResumeJob(
 /**
  * Mutation hook to manually trigger a background job by name.
  *
- * Sends `POST {basePath}/{name}/trigger` and invalidates the jobs list on success.
+ * Sends `POST {basePath}/jobs/{name}/trigger` and invalidates the jobs list on success.
  *
  * @example
  * ```tsx
- * const { mutate: trigger } = useTriggerJob({ client: api });
+ * const { mutate: trigger } = useTriggerJob();
  * trigger('InvoiceSync');
  * ```
  */
-export function useTriggerJob(
-  options: BackgroundJobsOptions
-): UseMutationResult<void, Error, string> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+export function useTriggerJob(): UseMutationResult<void, Error, string> {
+  const { client, basePath } = useBackgroundJobsConfig();
+  const jobsPath = `${basePath}/jobs`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (jobName: string) => {
-      await triggerJob(client, basePath, jobName);
+      await triggerJob(client, jobsPath, jobName);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: backgroundJobKeys.all });

--- a/packages/@granit/react-background-jobs/src/index.ts
+++ b/packages/@granit/react-background-jobs/src/index.ts
@@ -1,3 +1,10 @@
+// Provider
+export {
+  BackgroundJobsProvider,
+  buildBackgroundJobsQueryKey,
+  useBackgroundJobsConfig,
+} from './providers/background-jobs-provider.js';
+
 // Hooks
 export {
   backgroundJobKeys,
@@ -9,4 +16,7 @@ export {
 } from './hooks/use-background-jobs.js';
 
 // Types
-export type { BackgroundJobsOptions } from './hooks/use-background-jobs.js';
+export type {
+  BackgroundJobsConfig,
+  BackgroundJobsProviderProps,
+} from './providers/background-jobs-provider.js';

--- a/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
+++ b/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+/** Configuration for the background jobs provider. */
+export interface BackgroundJobsConfig {
+  readonly client: AxiosInstance;
+  /** Base path for background-jobs endpoints (default: `/api/v1/background-jobs`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface BackgroundJobsProviderProps {
+  readonly config: BackgroundJobsConfig;
+  readonly children: ReactNode;
+}
+
+const BackgroundJobsConfigContext = createContext<BackgroundJobsConfig | null>(null);
+
+/** Provides background jobs configuration to child components and hooks. */
+export function BackgroundJobsProvider({ config, children }: Readonly<BackgroundJobsProviderProps>) {
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
+  return <BackgroundJobsConfigContext value={value}>{children}</BackgroundJobsConfigContext>;
+}
+
+/** Returns the background jobs configuration from the nearest `BackgroundJobsProvider`. */
+export function useBackgroundJobsConfig(): BackgroundJobsConfig {
+  const ctx = useContext(BackgroundJobsConfigContext);
+  if (!ctx) {
+    throw new Error('useBackgroundJobsConfig must be used within a BackgroundJobsProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for background jobs operations. */
+export function buildBackgroundJobsQueryKey(
+  config: BackgroundJobsConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? ['background-jobs'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-background-jobs/src/testing/handlers.ts
+++ b/packages/@granit/react-background-jobs/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { accepted, noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -11,12 +12,14 @@ import type { BackgroundJobStatus } from '@granit/background-jobs';
  * Handlers mutate the in-memory `mockBackgroundJobs` array — pause/resume/trigger
  * calls update state that subsequent GET calls reflect.
  *
- * @param baseUrl - API base path (default: `/api/v1/background-jobs/jobs`)
+ * @param baseUrl - Module base path (default: `/api/v1/background-jobs`)
  */
-export function createBackgroundJobHandlers(baseUrl = '/api/v1/background-jobs/jobs') {
+export function createBackgroundJobHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  const jobsUrl = `${baseUrl}/jobs`;
+
   return [
     // GET list — sorted, paginated
-    http.get(baseUrl, ({ request }) => {
+    http.get(jobsUrl, ({ request }) => {
       const url = new URL(request.url);
       const page = Number(url.searchParams.get('page') ?? 1);
       const pageSize = Number(url.searchParams.get('pageSize') ?? 20);
@@ -31,14 +34,14 @@ export function createBackgroundJobHandlers(baseUrl = '/api/v1/background-jobs/j
     }),
 
     // GET single job
-    http.get(`${baseUrl}/:name`, ({ params }) => {
+    http.get(`${jobsUrl}/:name`, ({ params }) => {
       const job = mockBackgroundJobs.find((j) => j.jobName === params.name);
       if (!job) return notFound();
       return HttpResponse.json(job);
     }),
 
     // POST pause
-    http.post(`${baseUrl}/:name/pause`, ({ params }) => {
+    http.post(`${jobsUrl}/:name/pause`, ({ params }) => {
       const job = mockBackgroundJobs.find((j) => j.jobName === params.name);
       if (!job) return notFound();
       job.isEnabled = false;
@@ -47,7 +50,7 @@ export function createBackgroundJobHandlers(baseUrl = '/api/v1/background-jobs/j
     }),
 
     // POST resume
-    http.post(`${baseUrl}/:name/resume`, ({ params }) => {
+    http.post(`${jobsUrl}/:name/resume`, ({ params }) => {
       const job = mockBackgroundJobs.find((j) => j.jobName === params.name);
       if (!job) return notFound();
       job.isEnabled = true;
@@ -56,7 +59,7 @@ export function createBackgroundJobHandlers(baseUrl = '/api/v1/background-jobs/j
     }),
 
     // POST trigger
-    http.post(`${baseUrl}/:name/trigger`, ({ params }) => {
+    http.post(`${jobsUrl}/:name/trigger`, ({ params }) => {
       const job = mockBackgroundJobs.find((j) => j.jobName === params.name);
       if (!job) return notFound();
       job.lastExecutedAt = toISODateString(new Date().toISOString());

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-cleanup.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-cleanup.test.tsx
@@ -32,7 +32,7 @@ describe('useCleanupOrphans', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/cleanup-orphans');
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/cleanup-orphans');
     expect(result.current.data).toEqual(response);
   });
 
@@ -41,7 +41,7 @@ describe('useCleanupOrphans', () => {
     vi.mocked(client.post).mockResolvedValueOnce({ data: { cleanedCount: 0 } });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useCleanupOrphans({ client, basePath: '/api/v2/blobs' }), {
+    const { result } = renderHook(() => useCleanupOrphans({ client, basePath: '/api/v2/blob-storage' }), {
       wrapper,
     });
 
@@ -49,7 +49,7 @@ describe('useCleanupOrphans', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/blobs/cleanup-orphans');
+    expect(client.post).toHaveBeenCalledWith('/api/v2/blob-storage/blobs/cleanup-orphans');
   });
 
   it('should handle error', async () => {

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-download.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-download.test.tsx
@@ -38,7 +38,7 @@ describe('useDownloadUrl', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/abc-123/download-url', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/abc-123/download-url', {
       containerName: 'docs',
       fileName: 'report.pdf',
     });
@@ -50,9 +50,10 @@ describe('useDownloadUrl', () => {
     vi.mocked(client.post).mockResolvedValueOnce({ data: {} });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useDownloadUrl({ client, basePath: '/api/v2/blobs' }), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => useDownloadUrl({ client, basePath: '/api/v2/blob-storage' }),
+      { wrapper }
+    );
 
     result.current.mutate({
       id: 'abc-123',
@@ -62,7 +63,7 @@ describe('useDownloadUrl', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(client.post).toHaveBeenCalledWith(
-      '/api/v2/blobs/abc-123/download-url',
+      '/api/v2/blob-storage/blobs/abc-123/download-url',
       expect.any(Object)
     );
   });

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
@@ -44,7 +44,7 @@ describe('useInitiateUpload', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/upload', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/upload', {
       containerName: 'docs',
       fileName: 'report.pdf',
       contentType: 'application/pdf',
@@ -58,7 +58,7 @@ describe('useInitiateUpload', () => {
     vi.mocked(client.post).mockResolvedValueOnce({ data: {} });
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useInitiateUpload({ client, basePath: '/api/v2/blobs' }), {
+    const { result } = renderHook(() => useInitiateUpload({ client, basePath: '/api/v2/blob-storage' }), {
       wrapper,
     });
 
@@ -71,7 +71,7 @@ describe('useInitiateUpload', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v2/blobs/upload', expect.any(Object));
+    expect(client.post).toHaveBeenCalledWith('/api/v2/blob-storage/blobs/upload', expect.any(Object));
   });
 
   it('should handle error', async () => {
@@ -116,7 +116,7 @@ describe('useConfirmUpload', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/abc-123/confirm', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/abc-123/confirm', {
       containerName: 'docs',
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
@@ -156,7 +156,7 @@ describe('useDeleteBlob', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/blobs/abc-123', {
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/abc-123', {
       data: { containerName: 'docs', deletionReason: 'RGPD Art. 17' },
     });
     expect(invalidateSpy).toHaveBeenCalledWith({

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
@@ -125,7 +125,7 @@ describe('useBlobUpload', () => {
     expect(result.current.state.blobId).toBe('blob-456');
     expect(result.current.state.result).toEqual(mockConfirmation);
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/upload', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/upload', {
       containerName: 'docs',
       fileName: 'test.png',
       contentType: 'image/png',
@@ -214,7 +214,7 @@ describe('useBlobUpload', () => {
       await waitFor(() => expect(xhrInstances).toHaveLength(1));
     });
 
-    expect(client.post).toHaveBeenCalledWith('/api/v1/blobs/upload', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/upload', {
       containerName: 'docs',
       fileName: 'unknown',
       contentType: 'application/octet-stream',

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob.test.tsx
@@ -48,7 +48,7 @@ describe('useBlob', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/blobs/abc-123', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/abc-123', {
       params: { containerName: 'medical-images' },
     });
     expect(result.current.data).toEqual(mockDescriptor);
@@ -60,13 +60,13 @@ describe('useBlob', () => {
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(
-      () => useBlob('abc-123', 'docs', { client, basePath: '/api/v2/blobs' }),
+      () => useBlob('abc-123', 'docs', { client, basePath: '/api/v2/blob-storage' }),
       { wrapper }
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/blobs/abc-123', {
+    expect(client.get).toHaveBeenCalledWith('/api/v2/blob-storage/blobs/abc-123', {
       params: { containerName: 'docs' },
     });
   });

--- a/packages/@granit/react-blob-storage/src/constants.ts
+++ b/packages/@granit/react-blob-storage/src/constants.ts
@@ -1,1 +1,3 @@
-export const DEFAULT_BASE_PATH = '/api/v1/blobs';
+export const API_VERSION = 'v1';
+export const MODULE = 'blob-storage';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
@@ -24,6 +24,6 @@ export function useCleanupOrphans(
   const { client, basePath = DEFAULT_BASE_PATH } = options;
 
   return useMutation({
-    mutationFn: () => cleanupOrphans(client, basePath),
+    mutationFn: () => cleanupOrphans(client, `${basePath}/blobs`),
   });
 }

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-download.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-download.ts
@@ -30,6 +30,6 @@ export function useDownloadUrl(
   const { client, basePath = DEFAULT_BASE_PATH } = options;
 
   return useMutation({
-    mutationFn: ({ id, request }) => getDownloadUrl(client, basePath, id, request),
+    mutationFn: ({ id, request }) => getDownloadUrl(client, `${basePath}/blobs`, id, request),
   });
 }

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
@@ -30,7 +30,8 @@ export function useInitiateUpload(
   const { client, basePath = DEFAULT_BASE_PATH } = options;
 
   return useMutation({
-    mutationFn: (request: BlobUploadInitiateRequest) => initiateUpload(client, basePath, request),
+    mutationFn: (request: BlobUploadInitiateRequest) =>
+      initiateUpload(client, `${basePath}/blobs`, request),
   });
 }
 
@@ -57,7 +58,7 @@ export function useConfirmUpload(
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, request }) => confirmUpload(client, basePath, id, request),
+    mutationFn: ({ id, request }) => confirmUpload(client, `${basePath}/blobs`, id, request),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
     },
@@ -83,7 +84,7 @@ export function useDeleteBlob(
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, request }) => deleteBlob(client, basePath, id, request),
+    mutationFn: ({ id, request }) => deleteBlob(client, `${basePath}/blobs`, id, request),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
     },

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
@@ -153,7 +153,7 @@ export function useBlobUpload(options: BlobStorageOptions): UseBlobUploadReturn 
           error: null,
         });
 
-        const ticket = await initiateUpload(client, basePath, {
+        const ticket = await initiateUpload(client, `${basePath}/blobs`, {
           containerName,
           fileName: file.name,
           contentType: file.type || 'application/octet-stream',
@@ -180,7 +180,7 @@ export function useBlobUpload(options: BlobStorageOptions): UseBlobUploadReturn 
         // Step 3: Confirm upload
         setState((prev) => ({ ...prev, phase: 'confirming', progress: 100 }));
 
-        const confirmation = await confirmUpload(client, basePath, ticket.blobId, {
+        const confirmation = await confirmUpload(client, `${basePath}/blobs`, ticket.blobId, {
           containerName,
         });
 

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
@@ -11,7 +11,7 @@ import type { AxiosInstance } from 'axios';
 export interface BlobStorageOptions {
   /** Axios instance used for all requests. */
   readonly client: AxiosInstance;
-  /** Base URL for the blob-storage API. Defaults to `/api/v1/blobs`. */
+  /** Base URL for the blob-storage API. Defaults to `/api/v1/blob-storage`. */
   readonly basePath?: string;
 }
 
@@ -34,7 +34,7 @@ export function useBlob(
 
   return useQuery({
     queryKey: blobStorageKeys.blob(id, containerName),
-    queryFn: () => getBlob(client, basePath, id, containerName),
+    queryFn: () => getBlob(client, `${basePath}/blobs`, id, containerName),
     enabled: id.length > 0 && containerName.length > 0,
   });
 }

--- a/packages/@granit/react-blob-storage/src/testing/handlers.ts
+++ b/packages/@granit/react-blob-storage/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import {
   applyStringFilter,
   groupBy as groupByField,
@@ -26,9 +27,9 @@ const STATUS_LABELS: Record<BlobStatusValue, string> = {
  *
  * @param baseUrl - API base path (default: `/api/v1/blob-storage`)
  */
-export function createBlobStorageHandlers(baseUrl = '/api/v1/blob-storage') {
+export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
-    http.get(`${baseUrl}/meta`, () => {
+    http.get(`${baseUrl}/blobs/meta`, () => {
       return HttpResponse.json({
         columns: [
           {
@@ -125,7 +126,7 @@ export function createBlobStorageHandlers(baseUrl = '/api/v1/blob-storage') {
       });
     }),
 
-    http.get(baseUrl, ({ request }) => {
+    http.get(`${baseUrl}/blobs`, ({ request }) => {
       const url = new URL(request.url);
       const search = url.searchParams.get('search') ?? '';
       const filters = parseFilters(url);
@@ -185,7 +186,7 @@ export function createBlobStorageHandlers(baseUrl = '/api/v1/blob-storage') {
       return HttpResponse.json(paginate(filtered, url));
     }),
 
-    http.get(`${baseUrl}/:id`, ({ params }) => {
+    http.get(`${baseUrl}/blobs/:id`, ({ params }) => {
       const blob = mockBlobs.find((b) => b.id === params.id);
       if (!blob) return new HttpResponse(null, { status: 404 });
       return HttpResponse.json(blob);

--- a/packages/@granit/react-customer-balance/src/__tests__/customer-balance-provider.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/customer-balance-provider.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import {
   CustomerBalanceProvider,
   buildCustomerBalanceQueryKey,
@@ -13,7 +14,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: CustomerBalanceConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/v1/customer-balance',
+  basePath: DEFAULT_BASE_PATH,
 };
 
 function createWrapper(config: CustomerBalanceConfig) {
@@ -29,7 +30,7 @@ describe('CustomerBalanceProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/v1/customer-balance');
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-customer-balance/src/constants.ts
+++ b/packages/@granit/react-customer-balance/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'customer-balance';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
+++ b/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
@@ -17,8 +17,6 @@ import type {
 } from '@granit/customer-balance';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/customer-balance';
-
 /**
  * Fetch the current customer balance.
  *
@@ -29,7 +27,7 @@ const DEFAULT_BASE_PATH = '/api/v1/customer-balance';
  */
 export function useCustomerBalance(): UseQueryResult<CustomerBalanceResponse> {
   const config = useCustomerBalanceConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildCustomerBalanceQueryKey(config, 'balance'),
@@ -47,7 +45,7 @@ export function useCustomerBalance(): UseQueryResult<CustomerBalanceResponse> {
  */
 export function useBalanceTransactions(): UseQueryResult<readonly BalanceTransactionResponse[]> {
   const config = useCustomerBalanceConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildCustomerBalanceQueryKey(config, 'transactions'),
@@ -68,7 +66,7 @@ export function useBalanceTransactions(): UseQueryResult<readonly BalanceTransac
 export function useAddAdminCredit(): UseMutationResult<void, Error, AdminCreditRequest> {
   const config = useCustomerBalanceConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: AdminCreditRequest) => addAdminCredit(config.client, basePath, request),

--- a/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
+++ b/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -23,7 +25,10 @@ export function CustomerBalanceProvider({
   config,
   children,
 }: Readonly<CustomerBalanceProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
   return <CustomerBalanceConfigContext value={value}>{children}</CustomerBalanceConfigContext>;
 }
 

--- a/packages/@granit/react-customer-balance/src/testing/handlers.ts
+++ b/packages/@granit/react-customer-balance/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { sampleBalance, sampleTransactions } from './data.js';
 
 import type { AdminCreditRequest } from '@granit/customer-balance';
@@ -9,9 +10,9 @@ import type { AdminCreditRequest } from '@granit/customer-balance';
  * Create stateful MSW handlers for customer balance endpoints.
  * Credit mutations update the in-memory balance amount.
  *
- * @param baseUrl - API base path (default: `/api/v1/granit/customer-balance`)
+ * @param baseUrl - API base path (default: `/api/v1/customer-balance`)
  */
-export function createCustomerBalanceHandlers(baseUrl = '/api/v1/granit/customer-balance') {
+export function createCustomerBalanceHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET current balance
     http.get(baseUrl, () => {

--- a/packages/@granit/react-data-exchange/src/constants.ts
+++ b/packages/@granit/react-data-exchange/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'data-exchange';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-data-exchange/src/export/providers/export-provider.tsx
+++ b/packages/@granit/react-data-exchange/src/export/providers/export-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -9,8 +11,8 @@ import type { ReactNode } from 'react';
 export interface ExportConfig {
   /** Axios instance used for API calls. */
   readonly client: AxiosInstance;
-  /** Base path for export metadata endpoints (e.g. `/api/v1/data-exchange/metadata`). */
-  readonly basePath: string;
+  /** Base path for export metadata endpoints (default: `/api/v1/data-exchange`). */
+  readonly basePath?: string;
   /** Optional prefix for React Query keys. */
   readonly queryKeyPrefix?: readonly string[];
 }
@@ -26,20 +28,29 @@ const ExportConfigContext = createContext<ExportConfig | null>(null);
  * Provides export configuration to child components and hooks.
  */
 export function ExportProvider({ config, children }: Readonly<ExportProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo<ExportConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    }),
+    [config]
+  );
   return <ExportConfigContext value={value}>{children}</ExportConfigContext>;
 }
+
+/** Resolved config where basePath is always set. */
+export type ResolvedExportConfig = ExportConfig & { readonly basePath: string };
 
 /**
  * Returns the export configuration from the nearest `ExportProvider`.
  * Throws if used outside a provider.
  */
-export function useExportConfig(): ExportConfig {
+export function useExportConfig(): ResolvedExportConfig {
   const ctx = useContext(ExportConfigContext);
   if (!ctx) {
     throw new Error('useExportConfig must be used within an ExportProvider');
   }
-  return ctx;
+  return ctx as ResolvedExportConfig;
 }
 
 /**

--- a/packages/@granit/react-data-exchange/src/import/providers/import-provider.tsx
+++ b/packages/@granit/react-data-exchange/src/import/providers/import-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -9,8 +11,8 @@ import type { ReactNode } from 'react';
 export interface ImportConfig {
   /** Axios instance used for API calls. */
   readonly client: AxiosInstance;
-  /** Base path for import endpoints (e.g. `/api/v1/data-exchange`). */
-  readonly basePath: string;
+  /** Base path for import endpoints (default: `/api/v1/data-exchange`). */
+  readonly basePath?: string;
   /** Optional prefix for React Query keys. */
   readonly queryKeyPrefix?: readonly string[];
 }
@@ -26,20 +28,29 @@ const ImportConfigContext = createContext<ImportConfig | null>(null);
  * Provides import configuration to child components and hooks.
  */
 export function ImportProvider({ config, children }: Readonly<ImportProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo<ImportConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    }),
+    [config]
+  );
   return <ImportConfigContext value={value}>{children}</ImportConfigContext>;
 }
+
+/** Resolved config where basePath is always set. */
+export type ResolvedImportConfig = ImportConfig & { readonly basePath: string };
 
 /**
  * Returns the import configuration from the nearest `ImportProvider`.
  * Throws if used outside a provider.
  */
-export function useImportConfig(): ImportConfig {
+export function useImportConfig(): ResolvedImportConfig {
   const ctx = useContext(ImportConfigContext);
   if (!ctx) {
     throw new Error('useImportConfig must be used within an ImportProvider');
   }
-  return ctx;
+  return ctx as ResolvedImportConfig;
 }
 
 /**

--- a/packages/@granit/react-data-exchange/src/testing/handlers.ts
+++ b/packages/@granit/react-data-exchange/src/testing/handlers.ts
@@ -1,6 +1,8 @@
 import { paginate } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import { mockExportHistory, mockImportHistory } from './data.js';
 
 import type { ExportJobResponse, ImportJobResponse } from '@granit/data-exchange';
@@ -311,9 +313,9 @@ let importJobCounter = 0;
  * @param exportJobsBase - Export jobs base path (default: `/api/v1/data-exchange/metadata/jobs`)
  */
 export function createDataExchangeHandlers(
-  metadataBase = '/api/v1/data-exchange/metadata',
-  importBase = '/api/v1/data-exchange',
-  exportJobsBase = '/api/v1/data-exchange/metadata/jobs'
+  metadataBase = `${DEFAULT_BASE_PATH}/metadata`,
+  importBase = DEFAULT_BASE_PATH,
+  exportJobsBase = `${DEFAULT_BASE_PATH}/metadata/jobs`
 ) {
   return [
     // Export: definitions

--- a/packages/@granit/react-diagnostics/src/constants.ts
+++ b/packages/@granit/react-diagnostics/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'diagnostics';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-diagnostics/src/testing/handlers.ts
+++ b/packages/@granit/react-diagnostics/src/testing/handlers.ts
@@ -1,5 +1,6 @@
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockDiagnosticsHealth } from './data.js';
 
 /**
@@ -9,7 +10,7 @@ import { mockDiagnosticsHealth } from './data.js';
  *
  * @param baseUrl - API base path (default: `/api/v1/diagnostics`)
  */
-export function createDiagnosticsHandlers(baseUrl = '/api/v1/diagnostics') {
+export function createDiagnosticsHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     http.get(`${baseUrl}/health`, () => {
       return HttpResponse.json({

--- a/packages/@granit/react-features/src/__tests__/features-provider.test.tsx
+++ b/packages/@granit/react-features/src/__tests__/features-provider.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import {
   FeaturesProvider,
   buildFeaturesQueryKey,
@@ -13,7 +14,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: FeaturesConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/v1/features',
+  basePath: DEFAULT_BASE_PATH,
 };
 
 function createWrapper(config: FeaturesConfig) {
@@ -29,7 +30,7 @@ describe('FeaturesProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/v1/features');
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-features/src/constants.ts
+++ b/packages/@granit/react-features/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'features';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-features/src/hooks/use-features.ts
+++ b/packages/@granit/react-features/src/hooks/use-features.ts
@@ -16,8 +16,6 @@ import type {
 } from '@granit/features';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/features';
-
 /**
  * Fetch all feature definitions grouped by category.
  *
@@ -28,7 +26,7 @@ const DEFAULT_BASE_PATH = '/api/v1/features';
  */
 export function useFeatureDefinitions(): UseQueryResult<readonly FeatureGroupResponse[]> {
   const config = useFeaturesConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildFeaturesQueryKey(config, 'definitions'),
@@ -46,7 +44,7 @@ export function useFeatureDefinitions(): UseQueryResult<readonly FeatureGroupRes
  */
 export function useFeatureValues(): UseQueryResult<readonly FeatureValueResponse[]> {
   const config = useFeaturesConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildFeaturesQueryKey(config, 'values'),
@@ -66,7 +64,7 @@ export function useFeatureValues(): UseQueryResult<readonly FeatureValueResponse
  */
 export function useFeatureValue(name: string): UseQueryResult<FeatureValueResponse> {
   const config = useFeaturesConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildFeaturesQueryKey(config, 'values', name),
@@ -98,7 +96,7 @@ export function useSetFeatureOverride(): UseMutationResult<
 > {
   const config = useFeaturesConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: ({ name, request }: SetFeatureOverrideVariables) =>
@@ -127,7 +125,7 @@ export function useSetFeatureOverride(): UseMutationResult<
 export function useDeleteFeatureOverride(): UseMutationResult<void, Error, string> {
   const config = useFeaturesConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (name: string) => deleteFeatureOverride(config.client, basePath, name),

--- a/packages/@granit/react-features/src/providers/features-provider.tsx
+++ b/packages/@granit/react-features/src/providers/features-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,7 +22,10 @@ const FeaturesConfigContext = createContext<FeaturesConfig | null>(null);
 
 /** Provides features configuration to child components and hooks. */
 export function FeaturesProvider({ config, children }: Readonly<FeaturesProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
   return <FeaturesConfigContext value={value}>{children}</FeaturesConfigContext>;
 }
 

--- a/packages/@granit/react-features/src/testing/handlers.ts
+++ b/packages/@granit/react-features/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { noContent, notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockFeatureGroups, mockFeatureValues } from './data.js';
 
 import type { FeatureValueResponse } from '@granit/features';
@@ -12,9 +13,9 @@ type Mutable<T> = { -readonly [K in keyof T]: T[K] };
  * The `featureValues` array is a mutable copy — override/delete calls
  * update state that subsequent GET calls reflect.
  *
- * @param baseUrl - API base path (default: `/api/v1/granit/features`)
+ * @param baseUrl - API base path (default: `/api/v1/features`)
  */
-export function createFeaturesHandlers(baseUrl = '/api/v1/granit/features') {
+export function createFeaturesHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const featureValues: Mutable<FeatureValueResponse>[] = structuredClone(
     mockFeatureValues
   ) as Mutable<FeatureValueResponse>[];

--- a/packages/@granit/react-identity/src/__tests__/identity-provider.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/identity-provider.test.tsx
@@ -14,6 +14,7 @@ import type { AxiosInstance } from 'axios';
 const mockConfig: IdentityConfig = {
   client: {} as AxiosInstance,
   basePath: '/api/v1/identity/users',
+  providerBasePath: '/api/v1/identity/provider',
 };
 
 function createWrapper(config: IdentityConfig) {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useBatchResolveUsers, useIdentityCacheStats } from '../hooks/use-identity-cache.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { IdentityUser, IdentityUserCacheStats } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -21,7 +21,7 @@ import type { ReactNode } from 'react';
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, basePath };
+    const config: IdentityProviderProps['config'] = { client, basePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-capabilities.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-capabilities.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useIdentityCapabilities } from '../hooks/use-identity-capabilities.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { IdentityProviderCapabilities } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -20,7 +20,7 @@ import type { ReactNode } from 'react';
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, basePath };
+    const config: IdentityProviderProps['config'] = { client, basePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-groups.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-groups.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '../hooks/use-identity-groups.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { IdentityGroup } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -29,7 +29,7 @@ const sampleGroup: IdentityGroup = {
 function createWrapper(client: AxiosInstance, providerBasePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, providerBasePath };
+    const config: IdentityProviderProps['config'] = { client, providerBasePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-passwords.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-passwords.test.tsx
@@ -13,14 +13,14 @@ import {
 } from '../hooks/use-identity-passwords.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client };
+    const config: IdentityProviderProps['config'] = { client };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '../hooks/use-identity-provider-users.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { IdentityUser } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -33,7 +33,7 @@ const sampleUser: IdentityUser = {
 function createWrapper(client: AxiosInstance, providerBasePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, providerBasePath };
+    const config: IdentityProviderProps['config'] = { client, providerBasePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useIdentityRgpd } from '../hooks/use-identity-rgpd.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,7 +20,7 @@ import type { ReactNode } from 'react';
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, basePath };
+    const config: IdentityProviderProps['config'] = { client, basePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-roles.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-roles.test.tsx
@@ -15,7 +15,7 @@ import {
 } from '../hooks/use-identity-roles.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { IdentityRole } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -29,7 +29,7 @@ const sampleRole: IdentityRole = {
 function createWrapper(client: AxiosInstance, providerBasePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, providerBasePath };
+    const config: IdentityProviderProps['config'] = { client, providerBasePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
@@ -14,7 +14,7 @@ import {
 } from '../hooks/use-identity-sessions.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { IdentityDeviceActivity, IdentitySession } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -43,7 +43,7 @@ const sampleDevice: IdentityDeviceActivity = {
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client };
+    const config: IdentityProviderProps['config'] = { client };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-sync.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-sync.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useIdentitySync } from '../hooks/use-identity-sync.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type {
   IdentityUserCacheSyncAllResult,
   IdentityUserCacheSyncStaleResult,
@@ -24,7 +24,7 @@ import type { ReactNode } from 'react';
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, basePath };
+    const config: IdentityProviderProps['config'] = { client, basePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
@@ -9,7 +9,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useIdentityUser, useIdentityUsers } from '../hooks/use-identity-users.js';
 import { IdentityProvider } from '../providers/identity-provider.js';
 
-import type { IdentityConfig } from '../providers/identity-provider.js';
+import type { IdentityProviderProps } from '../providers/identity-provider.js';
 import type { IdentityUser, IdentityUserPage } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -21,7 +21,7 @@ import type { ReactNode } from 'react';
 function createWrapper(client: AxiosInstance, basePath?: string) {
   return function Wrapper({ children }: { children: ReactNode }) {
     const queryClient = createTestQueryClient();
-    const config: IdentityConfig = { client, basePath };
+    const config: IdentityProviderProps['config'] = { client, basePath };
     return React.createElement(
       QueryClientProvider,
       { client: queryClient },

--- a/packages/@granit/react-identity/src/constants.ts
+++ b/packages/@granit/react-identity/src/constants.ts
@@ -1,0 +1,4 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'identity';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}/users`;
+export const DEFAULT_PROVIDER_BASE_PATH = `/api/${API_VERSION}/${MODULE}/provider`;

--- a/packages/@granit/react-identity/src/hooks/use-identity-cache.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-cache.ts
@@ -23,7 +23,7 @@ export function useIdentityCacheStats(): UseQueryResult<IdentityUserCacheStats> 
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'cache-stats'),
-    queryFn: () => getCacheStats(config.client, config.basePath ?? '/api/v1/identity/users'),
+    queryFn: () => getCacheStats(config.client, config.basePath),
   });
 }
 
@@ -45,6 +45,6 @@ export function useBatchResolveUsers(): UseMutationResult<
 
   return useMutation({
     mutationFn: (userIds: UserId[]) =>
-      batchResolveUsers(config.client, config.basePath ?? '/api/v1/identity/users', userIds),
+      batchResolveUsers(config.client, config.basePath, userIds),
   });
 }

--- a/packages/@granit/react-identity/src/hooks/use-identity-capabilities.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-capabilities.ts
@@ -28,7 +28,7 @@ export function useIdentityCapabilities(options?: {
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'capabilities'),
     queryFn: () =>
-      fetchIdentityCapabilities(config.client, config.basePath ?? '/api/v1/identity/users'),
+      fetchIdentityCapabilities(config.client, config.basePath),
     staleTime: Infinity,
     enabled: options?.enabled ?? true,
   });

--- a/packages/@granit/react-identity/src/hooks/use-identity-groups.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-groups.ts
@@ -22,7 +22,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useGroups(): UseQueryResult<readonly IdentityGroup[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'groups'),
@@ -42,7 +42,7 @@ export function useGroups(): UseQueryResult<readonly IdentityGroup[]> {
  */
 export function useUserGroups(userId: UserId): UseQueryResult<readonly IdentityGroup[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'groups'),
@@ -70,7 +70,7 @@ export type GroupMutationVariables = {
 export function useAddUserToGroup(): UseMutationResult<void, Error, GroupMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, groupId }: GroupMutationVariables) =>
@@ -99,7 +99,7 @@ export function useAddUserToGroup(): UseMutationResult<void, Error, GroupMutatio
 export function useRemoveUserFromGroup(): UseMutationResult<void, Error, GroupMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, groupId }: GroupMutationVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
@@ -26,7 +26,7 @@ export function usePasswordChangedAt(
   userId: UserId
 ): UseQueryResult<IdentityPasswordChangedAtResponse> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'password-changed-at'),
@@ -47,7 +47,7 @@ export function usePasswordChangedAt(
  */
 export function useSendPasswordResetEmail(): UseMutationResult<void, Error, UserId> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: (userId: UserId) => sendPasswordResetEmail(config.client, basePath, userId),
@@ -75,7 +75,7 @@ export function useSetTemporaryPassword(): UseMutationResult<
   SetTemporaryPasswordVariables
 > {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, password }: SetTemporaryPasswordVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
@@ -30,7 +30,7 @@ export function useProviderUsers(
   params?: IdentityProviderUserListParams
 ): UseQueryResult<readonly IdentityUser[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: [...buildIdentityQueryKey(config, 'provider', 'users', 'list'), params],
@@ -50,7 +50,7 @@ export function useProviderUsers(
  */
 export function useProviderUser(userId: UserId): UseQueryResult<IdentityUser> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId),
@@ -72,7 +72,7 @@ export function useProviderUser(userId: UserId): UseQueryResult<IdentityUser> {
 export function useCreateUser(): UseMutationResult<IdentityUser, Error, IdentityUserCreateRequest> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: (request: IdentityUserCreateRequest) =>
@@ -104,7 +104,7 @@ export type UpdateUserVariables = {
 export function useUpdateUser(): UseMutationResult<IdentityUser, Error, UpdateUserVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, request }: UpdateUserVariables) =>
@@ -136,7 +136,7 @@ export type SetUserEnabledVariables = {
 export function useSetUserEnabled(): UseMutationResult<void, Error, SetUserEnabledVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, enabled }: SetUserEnabledVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-rgpd.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-rgpd.ts
@@ -24,7 +24,7 @@ export function useIdentityRgpd(): {
 } {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/identity/users';
+  const basePath = config.basePath;
 
   const erase = useMutation({
     mutationFn: (userId: UserId) => eraseUserCache(config.client, basePath, userId),

--- a/packages/@granit/react-identity/src/hooks/use-identity-roles.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-roles.ts
@@ -23,7 +23,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useRoles(): UseQueryResult<readonly IdentityRole[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'roles'),
@@ -43,7 +43,7 @@ export function useRoles(): UseQueryResult<readonly IdentityRole[]> {
  */
 export function useUserRoles(userId: UserId): UseQueryResult<readonly IdentityRole[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'roles'),
@@ -64,7 +64,7 @@ export function useUserRoles(userId: UserId): UseQueryResult<readonly IdentityRo
  */
 export function useRoleMembers(roleName: string): UseQueryResult<readonly IdentityUser[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'roles', roleName, 'members'),
@@ -92,7 +92,7 @@ export type RoleMutationVariables = {
 export function useAssignRole(): UseMutationResult<void, Error, RoleMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, roleName }: RoleMutationVariables) =>
@@ -121,7 +121,7 @@ export function useAssignRole(): UseMutationResult<void, Error, RoleMutationVari
 export function useRemoveRole(): UseMutationResult<void, Error, RoleMutationVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, roleName }: RoleMutationVariables) =>

--- a/packages/@granit/react-identity/src/hooks/use-identity-sessions.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-sessions.ts
@@ -24,7 +24,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useUserSessions(userId: UserId): UseQueryResult<readonly IdentitySession[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'sessions'),
@@ -47,7 +47,7 @@ export function useUserDeviceActivity(
   userId: UserId
 ): UseQueryResult<readonly IdentityDeviceActivity[]> {
   const config = useIdentityConfig();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'provider', 'users', userId, 'devices'),
@@ -76,7 +76,7 @@ export type TerminateSessionVariables = {
 export function useTerminateSession(): UseMutationResult<void, Error, TerminateSessionVariables> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: ({ userId, sessionId }: TerminateSessionVariables) =>
@@ -102,7 +102,7 @@ export function useTerminateSession(): UseMutationResult<void, Error, TerminateS
 export function useTerminateAllSessions(): UseMutationResult<void, Error, UserId> {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.providerBasePath ?? '/api/v1/identity/provider';
+  const basePath = config.providerBasePath;
 
   return useMutation({
     mutationFn: (userId: UserId) => terminateAllSessions(config.client, basePath, userId),

--- a/packages/@granit/react-identity/src/hooks/use-identity-sync.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-sync.ts
@@ -32,7 +32,7 @@ export function useIdentitySync(): {
 } {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/identity/users';
+  const basePath = config.basePath;
 
   const sync = useMutation({
     mutationFn: (userIds: UserId[]) => syncUsers(config.client, basePath, userIds),

--- a/packages/@granit/react-identity/src/hooks/use-identity-users.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-users.ts
@@ -23,7 +23,7 @@ export function useIdentityUsers(
 
   return useQuery({
     queryKey: [...buildIdentityQueryKey(config, 'users', 'list'), params],
-    queryFn: () => searchUsers(config.client, config.basePath ?? '/api/v1/identity/users', params),
+    queryFn: () => searchUsers(config.client, config.basePath, params),
   });
 }
 
@@ -45,7 +45,7 @@ export function useIdentityUser(userId: UserId): UseQueryResult<IdentityUser> {
 
   return useQuery({
     queryKey: buildIdentityQueryKey(config, 'users', userId),
-    queryFn: () => getUserById(config.client, config.basePath ?? '/api/v1/identity/users', userId),
+    queryFn: () => getUserById(config.client, config.basePath, userId),
     enabled: userId.length > 0,
   });
 }

--- a/packages/@granit/react-identity/src/providers/identity-provider.tsx
+++ b/packages/@granit/react-identity/src/providers/identity-provider.tsx
@@ -1,20 +1,24 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH, DEFAULT_PROVIDER_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
 /** Configuration for the identity provider. */
 export interface IdentityConfig {
   readonly client: AxiosInstance;
-  /** Base path for user cache endpoints (default: `/identity/users`). */
-  readonly basePath?: string;
+  /** Base path for user cache endpoints (default: `/api/v1/identity/users`). */
+  readonly basePath: string;
   /** Base path for identity provider endpoints (default: `/api/v1/identity/provider`). */
-  readonly providerBasePath?: string;
+  readonly providerBasePath: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 
+/** Props accepted by {@link IdentityProvider}. Paths are optional — defaults are applied by the provider. */
 export interface IdentityProviderProps {
-  readonly config: IdentityConfig;
+  readonly config: Omit<IdentityConfig, 'basePath' | 'providerBasePath'> &
+    Partial<Pick<IdentityConfig, 'basePath' | 'providerBasePath'>>;
   readonly children: ReactNode;
 }
 
@@ -22,7 +26,14 @@ const IdentityConfigContext = createContext<IdentityConfig | null>(null);
 
 /** Provides identity configuration to child components and hooks. */
 export function IdentityProvider({ config, children }: Readonly<IdentityProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo<IdentityConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      providerBasePath: config.providerBasePath ?? DEFAULT_PROVIDER_BASE_PATH,
+    }),
+    [config]
+  );
   return <IdentityConfigContext value={value}>{children}</IdentityConfigContext>;
 }
 

--- a/packages/@granit/react-identity/src/testing/handlers.ts
+++ b/packages/@granit/react-identity/src/testing/handlers.ts
@@ -1,5 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH, DEFAULT_PROVIDER_BASE_PATH } from '../constants.js';
+
 import { mockDevices, mockPasswordChangedAt, mockSessions, mockUsers } from './data.js';
 
 import type { IdentityProviderCapabilities, IdentityUser } from '@granit/identity';
@@ -128,8 +130,8 @@ function toIdentityUser(u: IdentityUser) {
  * @param cacheBase    - Cache API base path (default: `/api/v1/identity/users`)
  */
 export function createIdentityHandlers(
-  providerBase = '/api/v1/identity/provider',
-  cacheBase = '/api/v1/identity/users'
+  providerBase = DEFAULT_PROVIDER_BASE_PATH,
+  cacheBase = DEFAULT_BASE_PATH
 ) {
   return [
     // ── Cache endpoints (/identity/users) ───────────────────────────────────

--- a/packages/@granit/react-invoicing/src/__tests__/invoicing-provider.test.tsx
+++ b/packages/@granit/react-invoicing/src/__tests__/invoicing-provider.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import {
   InvoicingProvider,
   buildInvoicingQueryKey,
@@ -13,7 +14,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: InvoicingConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/v1/invoicing',
+  basePath: DEFAULT_BASE_PATH,
 };
 
 function createWrapper(config: InvoicingConfig) {
@@ -29,7 +30,7 @@ describe('InvoicingProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/v1/invoicing');
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-invoicing/src/constants.ts
+++ b/packages/@granit/react-invoicing/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'invoicing';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
+++ b/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
@@ -6,8 +6,6 @@ import { buildInvoicingQueryKey, useInvoicingConfig } from '../providers/invoici
 import type { InvoiceCreateRequest, InvoiceResponse } from '@granit/invoicing';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/invoicing';
-
 /**
  * Fetch all invoices.
  *
@@ -18,7 +16,7 @@ const DEFAULT_BASE_PATH = '/api/v1/invoicing';
  */
 export function useInvoices(): UseQueryResult<readonly InvoiceResponse[]> {
   const config = useInvoicingConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildInvoicingQueryKey(config, 'invoices', 'list'),
@@ -38,7 +36,7 @@ export function useInvoices(): UseQueryResult<readonly InvoiceResponse[]> {
  */
 export function useInvoice(id: string): UseQueryResult<InvoiceResponse> {
   const config = useInvoicingConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildInvoicingQueryKey(config, 'invoices', id),
@@ -60,7 +58,7 @@ export function useInvoice(id: string): UseQueryResult<InvoiceResponse> {
  */
 export function useDownloadInvoicePdf(): UseMutationResult<Blob, Error, string> {
   const config = useInvoicingConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (id: string) => downloadInvoicePdf(config.client, basePath, id),
@@ -84,7 +82,7 @@ export function useCreateInvoice(): UseMutationResult<
 > {
   const config = useInvoicingConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: InvoiceCreateRequest) => createInvoice(config.client, basePath, request),

--- a/packages/@granit/react-invoicing/src/providers/invoicing-provider.tsx
+++ b/packages/@granit/react-invoicing/src/providers/invoicing-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,7 +22,10 @@ const InvoicingConfigContext = createContext<InvoicingConfig | null>(null);
 
 /** Provides invoicing configuration to child components and hooks. */
 export function InvoicingProvider({ config, children }: Readonly<InvoicingProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
   return <InvoicingConfigContext value={value}>{children}</InvoicingConfigContext>;
 }
 

--- a/packages/@granit/react-invoicing/src/testing/handlers.ts
+++ b/packages/@granit/react-invoicing/src/testing/handlers.ts
@@ -2,6 +2,7 @@ import { notFound } from '@granit/testing/msw';
 import { toEntityId } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { sampleInvoices } from './data.js';
 
 import type { InvoiceCreateRequest } from '@granit/invoicing';
@@ -10,9 +11,9 @@ import type { InvoiceCreateRequest } from '@granit/invoicing';
  * Create stateful MSW handlers for invoicing endpoints.
  * New invoices created via POST are appended to the in-memory list.
  *
- * @param baseUrl - API base path (default: `/api/v1/granit/invoicing`)
+ * @param baseUrl - API base path (default: `/api/v1/invoicing`)
  */
-export function createInvoicingHandlers(baseUrl = '/api/v1/granit/invoicing') {
+export function createInvoicingHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET list all invoices
     http.get(`${baseUrl}/invoices`, () => {

--- a/packages/@granit/react-localization/src/constants.ts
+++ b/packages/@granit/react-localization/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'localization';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-localization/src/testing/handlers.ts
+++ b/packages/@granit/react-localization/src/testing/handlers.ts
@@ -2,6 +2,7 @@ import { noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { buildMockLocalization, mockLanguages, mockLocalizationOverrides } from './data.js';
 
 import type { LocalizationOverride } from '@granit/localization';
@@ -12,7 +13,7 @@ import type { LocalizationOverride } from '@granit/localization';
  *
  * @param baseUrl - API base path (default: `/api/v1/localization`)
  */
-export function createLocalizationHandlers(baseUrl = '/api/v1/localization') {
+export function createLocalizationHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const languages = [...mockLanguages];
   let overrides: LocalizationOverride[] = [...mockLocalizationOverrides];
   const overridesBase = `${baseUrl}/overrides`;

--- a/packages/@granit/react-metering/src/constants.ts
+++ b/packages/@granit/react-metering/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'metering';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-metering/src/hooks/use-metering.ts
+++ b/packages/@granit/react-metering/src/hooks/use-metering.ts
@@ -22,8 +22,6 @@ import type {
 } from '@granit/metering';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/metering';
-
 // ---------------------------------------------------------------------------
 // Queries
 // ---------------------------------------------------------------------------
@@ -38,7 +36,7 @@ const DEFAULT_BASE_PATH = '/api/v1/metering';
  */
 export function useActiveMeters(): UseQueryResult<readonly MeterDefinitionResponse[]> {
   const config = useMeteringConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildMeteringQueryKey(config, 'meters'),
@@ -58,7 +56,7 @@ export function useActiveMeters(): UseQueryResult<readonly MeterDefinitionRespon
  */
 export function useMeterDefinition(id: string): UseQueryResult<MeterDefinitionResponse> {
   const config = useMeteringConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildMeteringQueryKey(config, 'meters', id),
@@ -77,7 +75,7 @@ export function useMeterDefinition(id: string): UseQueryResult<MeterDefinitionRe
  */
 export function useUsageForPeriod(): UseQueryResult<readonly UsageAggregateResponse[]> {
   const config = useMeteringConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildMeteringQueryKey(config, 'usage'),
@@ -97,7 +95,7 @@ export function useUsageForPeriod(): UseQueryResult<readonly UsageAggregateRespo
  */
 export function useMeteringQuota(meterId: string): UseQueryResult<MeteringQuotaStatusResponse> {
   const config = useMeteringConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildMeteringQueryKey(config, 'quota', meterId),
@@ -127,7 +125,7 @@ export function useCreateMeterDefinition(): UseMutationResult<
 > {
   const config = useMeteringConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: MeterDefinitionCreateRequest) =>
@@ -163,7 +161,7 @@ export function useUpdateMeterDefinition(): UseMutationResult<
 > {
   const config = useMeteringConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: ({ id, request }: UpdateMeterDefinitionVariables) =>
@@ -189,7 +187,7 @@ export function useUpdateMeterDefinition(): UseMutationResult<
 export function useDeactivateMeterDefinition(): UseMutationResult<void, Error, string> {
   const config = useMeteringConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (id: string) => deactivateMeterDefinition(config.client, basePath, id),
@@ -214,7 +212,7 @@ export function useDeactivateMeterDefinition(): UseMutationResult<void, Error, s
 export function useRecordUsageEvents(): UseMutationResult<void, Error, RecordUsageRequest> {
   const config = useMeteringConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: RecordUsageRequest) =>

--- a/packages/@granit/react-metering/src/providers/metering-provider.tsx
+++ b/packages/@granit/react-metering/src/providers/metering-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,7 +22,10 @@ const MeteringConfigContext = createContext<MeteringConfig | null>(null);
 
 /** Provides metering configuration to child components and hooks. */
 export function MeteringProvider({ config, children }: Readonly<MeteringProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
   return <MeteringConfigContext value={value}>{children}</MeteringConfigContext>;
 }
 

--- a/packages/@granit/react-metering/src/testing/handlers.ts
+++ b/packages/@granit/react-metering/src/testing/handlers.ts
@@ -2,6 +2,7 @@ import { noContent, notFound } from '@granit/testing/msw';
 import { toEntityId } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { sampleMeters, sampleQuota, sampleUsage } from './data.js';
 
 import type { MeterDefinitionResponse } from '@granit/metering';
@@ -10,9 +11,9 @@ import type { MeterDefinitionResponse } from '@granit/metering';
  * Create stateful MSW handlers for metering endpoints.
  * Meter mutations (create/update/deactivate) persist in the in-memory list.
  *
- * @param baseUrl - API base path (default: `/api/v1/granit/metering`)
+ * @param baseUrl - API base path (default: `/api/v1/metering`)
  */
-export function createMeteringHandlers(baseUrl = '/api/v1/granit/metering') {
+export function createMeteringHandlers(baseUrl = DEFAULT_BASE_PATH) {
   let meters = [...sampleMeters];
 
   return [

--- a/packages/@granit/react-multi-tenancy/src/constants.ts
+++ b/packages/@granit/react-multi-tenancy/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'multi-tenancy';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
+++ b/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -14,7 +16,6 @@ export interface TenantAdminProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/api/v1/multi-tenancy';
 const DEFAULT_KEY_PREFIX = ['tenant-admin'] as const;
 
 const TenantAdminContext = createContext<TenantAdminConfig | null>(null);

--- a/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { noContent, notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockTenants } from './data.js';
 
 import type { AdminTenant } from '@granit/multi-tenancy';
@@ -12,7 +13,7 @@ import type { AdminTenant } from '@granit/multi-tenancy';
  *
  * @param baseUrl - API base path (default: `/api/v1/multi-tenancy`)
  */
-export function createTenantHandlers(baseUrl = '/api/v1/multi-tenancy') {
+export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET /tenants — list all
     http.get(`${baseUrl}/tenants`, () => HttpResponse.json(mockTenants)),

--- a/packages/@granit/react-notifications-mobile-push/src/__tests__/use-device-tokens.test.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/__tests__/use-device-tokens.test.tsx
@@ -1,12 +1,16 @@
 import { fetchDeviceTokens } from '@granit/notifications-mobile-push';
-import { createQueryWrapper } from '@granit/react-testing';
+import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { deviceTokenKeys, useDeviceTokens } from '../hooks/use-device-tokens.js';
+import { MobilePushProvider } from '../providers/mobile-push-provider.js';
 
 import type { MobilePushTokenResponse } from '@granit/notifications-mobile-push';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
 
 vi.mock('@granit/notifications-mobile-push', () => ({
   fetchDeviceTokens: vi.fn(),
@@ -25,6 +29,17 @@ const mockTokens: readonly MobilePushTokenResponse[] = [
   },
 ];
 
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MobilePushProvider config={{ client, basePath }}>{children}</MobilePushProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
 describe('deviceTokenKeys', () => {
   it('should produce stable list key', () => {
     expect(deviceTokenKeys.list()).toEqual(['device-tokens', 'list']);
@@ -36,12 +51,12 @@ describe('useDeviceTokens', () => {
     vi.mocked(fetchDeviceTokens).mockResolvedValueOnce(mockTokens);
 
     const client = createMockClient();
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useDeviceTokens({ client }), { wrapper });
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(() => useDeviceTokens(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(fetchDeviceTokens).toHaveBeenCalledWith(client, '/api/v1');
+    expect(fetchDeviceTokens).toHaveBeenCalledWith(client, '/api/v1/notifications');
     expect(result.current.data).toEqual(mockTokens);
   });
 
@@ -49,10 +64,8 @@ describe('useDeviceTokens', () => {
     vi.mocked(fetchDeviceTokens).mockResolvedValueOnce(mockTokens);
 
     const client = createMockClient();
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useDeviceTokens({ client, basePath: '/custom/api' }), {
-      wrapper,
-    });
+    const wrapper = createWrapper(client, '/custom/api');
+    const { result } = renderHook(() => useDeviceTokens(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
@@ -63,8 +76,8 @@ describe('useDeviceTokens', () => {
     vi.mocked(fetchDeviceTokens).mockRejectedValueOnce(new Error('Unauthorized'));
 
     const client = createMockClient();
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useDeviceTokens({ client }), { wrapper });
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(() => useDeviceTokens(), { wrapper });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
@@ -75,8 +88,8 @@ describe('useDeviceTokens', () => {
     vi.mocked(fetchDeviceTokens).mockResolvedValueOnce([]);
 
     const client = createMockClient();
-    const wrapper = createQueryWrapper();
-    const { result } = renderHook(() => useDeviceTokens({ client }), { wrapper });
+    const wrapper = createWrapper(client);
+    const { result } = renderHook(() => useDeviceTokens(), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 

--- a/packages/@granit/react-notifications-mobile-push/src/__tests__/use-mobile-push.test.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/__tests__/use-mobile-push.test.tsx
@@ -2,9 +2,11 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useMobilePush } from '../hooks/use-mobile-push.js';
+import { MobilePushProvider } from '../providers/mobile-push-provider.js';
 
-import type { MobilePushConfig } from '../hooks/use-mobile-push.js';
+import type { MobilePushProviderProps } from '../providers/mobile-push-provider.js';
 import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
 
 const mockCheckPermissions = vi.fn();
 const mockRequestPermissions = vi.fn();
@@ -37,11 +39,14 @@ function createMockAxios(): AxiosInstance {
   } as unknown as AxiosInstance;
 }
 
-function createConfig(overrides?: Partial<MobilePushConfig>): MobilePushConfig {
+function createWrapper(overrides?: Partial<MobilePushProviderProps['config']>) {
+  const client = overrides?.client ?? createMockAxios();
+  const config: MobilePushProviderProps['config'] = { client, ...overrides };
   return {
-    apiClient: createMockAxios(),
-    platform: 'android',
-    ...overrides,
+    client,
+    wrapper({ children }: { children: ReactNode }) {
+      return <MobilePushProvider config={config}>{children}</MobilePushProvider>;
+    },
   };
 }
 
@@ -56,7 +61,8 @@ describe('useMobilePush', () => {
   });
 
   it('should initialize with default state', () => {
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     expect(result.current.isRegistered).toBe(false);
     expect(result.current.loading).toBe(false);
@@ -64,7 +70,8 @@ describe('useMobilePush', () => {
   });
 
   it('should expose register and unregister functions', () => {
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     expect(typeof result.current.register).toBe('function');
     expect(typeof result.current.unregister).toBe('function');
@@ -74,7 +81,8 @@ describe('useMobilePush', () => {
     mockCheckPermissions.mockResolvedValue({ receive: 'prompt' });
     mockRequestPermissions.mockResolvedValue({ receive: 'denied' });
 
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -99,8 +107,8 @@ describe('useMobilePush', () => {
       return Promise.resolve({ remove: vi.fn() });
     });
 
-    const config = createConfig();
-    const { result } = renderHook(() => useMobilePush(config));
+    const { wrapper, client } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -109,7 +117,7 @@ describe('useMobilePush', () => {
     expect(result.current.isRegistered).toBe(true);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(mockRegisterDeviceToken).toHaveBeenCalledWith(config.apiClient, '/api/v1', {
+    expect(mockRegisterDeviceToken).toHaveBeenCalledWith(client, '/api/v1/notifications', {
       token: 'device-token-123',
       platform: 'android',
     });
@@ -126,7 +134,8 @@ describe('useMobilePush', () => {
       return Promise.resolve({ remove: vi.fn() });
     });
 
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -147,7 +156,8 @@ describe('useMobilePush', () => {
       return Promise.resolve({ remove: vi.fn() });
     });
 
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -169,8 +179,8 @@ describe('useMobilePush', () => {
       return Promise.resolve({ remove: vi.fn() });
     });
 
-    const config = createConfig({ basePath: '/custom' });
-    const { result } = renderHook(() => useMobilePush(config));
+    const { wrapper, client } = createWrapper({ basePath: '/custom' });
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -185,15 +195,12 @@ describe('useMobilePush', () => {
     expect(result.current.isRegistered).toBe(false);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
-    expect(mockUnregisterDeviceToken).toHaveBeenCalledWith(
-      config.apiClient,
-      '/custom',
-      'token-789'
-    );
+    expect(mockUnregisterDeviceToken).toHaveBeenCalledWith(client, '/custom', 'token-789');
   });
 
   it('should handle unregister when no token exists', async () => {
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.unregister();
@@ -215,7 +222,8 @@ describe('useMobilePush', () => {
       return Promise.resolve({ remove: vi.fn() });
     });
 
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();
@@ -233,14 +241,16 @@ describe('useMobilePush', () => {
     expect(result.current.loading).toBe(false);
   });
 
-  it('should use default basePath', () => {
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+  it('should use default basePath from provider', () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     expect(result.current.error).toBeNull();
   });
 
-  it('should accept custom basePath', () => {
-    const { result } = renderHook(() => useMobilePush(createConfig({ basePath: '/custom/api' })));
+  it('should accept custom basePath via provider', () => {
+    const { wrapper } = createWrapper({ basePath: '/custom/api' });
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     expect(result.current.error).toBeNull();
   });
@@ -248,7 +258,8 @@ describe('useMobilePush', () => {
   it('should wrap non-Error thrown values', async () => {
     mockCheckPermissions.mockRejectedValueOnce('string error');
 
-    const { result } = renderHook(() => useMobilePush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useMobilePush({ platform: 'android' }), { wrapper });
 
     await act(async () => {
       await result.current.register();

--- a/packages/@granit/react-notifications-mobile-push/src/constants.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'notifications';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-notifications-mobile-push/src/hooks/use-device-tokens.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/hooks/use-device-tokens.ts
@@ -1,19 +1,10 @@
 import { fetchDeviceTokens } from '@granit/notifications-mobile-push';
 import { useQuery } from '@tanstack/react-query';
 
+import { useMobilePushConfig } from '../providers/mobile-push-provider.js';
+
 import type { MobilePushTokenResponse } from '@granit/notifications-mobile-push';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
-
-const DEFAULT_BASE_PATH = '/api/v1';
-
-/** Options accepted by useDeviceTokens. */
-export interface DeviceTokensOptions {
-  /** Axios instance used for API calls. */
-  readonly client: AxiosInstance;
-  /** Base path for the notifications API. Defaults to `/api/v1`. */
-  readonly basePath?: string;
-}
 
 /** Query key factory for device token queries. */
 export const deviceTokenKeys = {
@@ -24,15 +15,15 @@ export const deviceTokenKeys = {
 /**
  * Query hook that fetches all registered device tokens for the current user.
  *
+ * Must be used within a {@link MobilePushProvider}.
+ *
  * @example
  * ```tsx
- * const { data: tokens } = useDeviceTokens({ client: api });
+ * const { data: tokens } = useDeviceTokens();
  * ```
  */
-export function useDeviceTokens(
-  options: DeviceTokensOptions
-): UseQueryResult<readonly MobilePushTokenResponse[]> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+export function useDeviceTokens(): UseQueryResult<readonly MobilePushTokenResponse[]> {
+  const { client, basePath } = useMobilePushConfig();
 
   return useQuery({
     queryKey: deviceTokenKeys.list(),

--- a/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/hooks/use-mobile-push.ts
@@ -2,8 +2,9 @@ import { PushNotifications } from '@capacitor/push-notifications';
 import { registerDeviceToken, unregisterDeviceToken } from '@granit/notifications-mobile-push';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { useMobilePushConfig } from '../providers/mobile-push-provider.js';
+
 import type { MobilePlatform } from '@granit/notifications-mobile-push';
-import type { AxiosInstance } from 'axios';
 
 /**
  * Returns a promise that resolves with the device token once Capacitor
@@ -26,9 +27,7 @@ function waitForRegistrationToken(): Promise<string> {
   });
 }
 
-export interface MobilePushConfig {
-  readonly apiClient: AxiosInstance;
-  readonly basePath?: string;
+export interface MobilePushHookOptions {
   readonly platform: MobilePlatform;
 }
 
@@ -48,6 +47,8 @@ export interface UseMobilePushReturn {
 /**
  * Manages FCM/APNs device token registration for Capacitor apps.
  *
+ * Must be used within a {@link MobilePushProvider}.
+ *
  * This hook handles:
  * - Requesting push notification permissions via Capacitor
  * - Capturing the FCM/APNs token from the native layer
@@ -57,8 +58,8 @@ export interface UseMobilePushReturn {
  * Push payload display is handled by the native OS — the backend sends
  * wake-up only payloads (no PII in push payload, ISO 27001 compliant).
  */
-export function useMobilePush(config: MobilePushConfig): UseMobilePushReturn {
-  const basePath = config.basePath ?? '/api/v1';
+export function useMobilePush(options: MobilePushHookOptions): UseMobilePushReturn {
+  const { client: apiClient, basePath } = useMobilePushConfig();
 
   const [isRegistered, setIsRegistered] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -83,11 +84,11 @@ export function useMobilePush(config: MobilePushConfig): UseMobilePushReturn {
 
       try {
         if (oldToken) {
-          await unregisterDeviceToken(config.apiClient, basePath, oldToken);
+          await unregisterDeviceToken(apiClient, basePath, oldToken);
         }
-        await registerDeviceToken(config.apiClient, basePath, {
+        await registerDeviceToken(apiClient, basePath, {
           token: token.value,
-          platform: config.platform,
+          platform: options.platform,
         });
       } catch (err) {
         if (mountedRef.current) {
@@ -99,7 +100,7 @@ export function useMobilePush(config: MobilePushConfig): UseMobilePushReturn {
     return () => {
       listener.then((l) => l.remove());
     };
-  }, [isRegistered, config.apiClient, basePath, config.platform]);
+  }, [isRegistered, apiClient, basePath, options.platform]);
 
   const register = useCallback(async () => {
     setLoading(true);
@@ -121,9 +122,9 @@ export function useMobilePush(config: MobilePushConfig): UseMobilePushReturn {
       const token = await tokenPromise;
       tokenRef.current = token;
 
-      await registerDeviceToken(config.apiClient, basePath, {
+      await registerDeviceToken(apiClient, basePath, {
         token,
-        platform: config.platform,
+        platform: options.platform,
       });
 
       if (mountedRef.current) {
@@ -136,7 +137,7 @@ export function useMobilePush(config: MobilePushConfig): UseMobilePushReturn {
     } finally {
       if (mountedRef.current) setLoading(false);
     }
-  }, [config.apiClient, basePath, config.platform]);
+  }, [apiClient, basePath, options.platform]);
 
   const unregister = useCallback(async () => {
     setLoading(true);
@@ -144,7 +145,7 @@ export function useMobilePush(config: MobilePushConfig): UseMobilePushReturn {
 
     try {
       if (tokenRef.current) {
-        await unregisterDeviceToken(config.apiClient, basePath, tokenRef.current);
+        await unregisterDeviceToken(apiClient, basePath, tokenRef.current);
         tokenRef.current = null;
       }
 
@@ -158,7 +159,7 @@ export function useMobilePush(config: MobilePushConfig): UseMobilePushReturn {
     } finally {
       if (mountedRef.current) setLoading(false);
     }
-  }, [config.apiClient, basePath]);
+  }, [apiClient, basePath]);
 
   return { isRegistered, loading, error, register, unregister };
 }

--- a/packages/@granit/react-notifications-mobile-push/src/index.ts
+++ b/packages/@granit/react-notifications-mobile-push/src/index.ts
@@ -1,4 +1,8 @@
 export { useDeviceTokens, deviceTokenKeys } from './hooks/use-device-tokens.js';
-export type { DeviceTokensOptions } from './hooks/use-device-tokens.js';
 export { useMobilePush } from './hooks/use-mobile-push.js';
-export type { MobilePushConfig, UseMobilePushReturn } from './hooks/use-mobile-push.js';
+export type { MobilePushHookOptions, UseMobilePushReturn } from './hooks/use-mobile-push.js';
+export { MobilePushProvider, useMobilePushConfig } from './providers/mobile-push-provider.js';
+export type {
+  MobilePushProviderConfig,
+  MobilePushProviderProps,
+} from './providers/mobile-push-provider.js';

--- a/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
@@ -1,0 +1,45 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { MobilePlatform } from '@granit/notifications-mobile-push';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+/** Resolved configuration exposed by {@link useMobilePushConfig}. */
+export interface MobilePushProviderConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+}
+
+/** Props accepted by {@link MobilePushProvider}. `basePath` is optional — the default is applied by the provider. */
+export interface MobilePushProviderProps {
+  readonly config: Omit<MobilePushProviderConfig, 'basePath'> &
+    Partial<Pick<MobilePushProviderConfig, 'basePath'>>;
+  readonly children: ReactNode;
+}
+
+const MobilePushConfigContext = createContext<MobilePushProviderConfig | null>(null);
+
+/** Provides mobile push configuration to child components and hooks. */
+export function MobilePushProvider({ config, children }: Readonly<MobilePushProviderProps>) {
+  const value = useMemo<MobilePushProviderConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    }),
+    [config],
+  );
+  return <MobilePushConfigContext value={value}>{children}</MobilePushConfigContext>;
+}
+
+/** Returns the mobile push configuration from the nearest {@link MobilePushProvider}. */
+export function useMobilePushConfig(): MobilePushProviderConfig {
+  const ctx = useContext(MobilePushConfigContext);
+  if (!ctx) {
+    throw new Error('useMobilePushConfig must be used within a MobilePushProvider');
+  }
+  return ctx;
+}
+
+export type { MobilePlatform };

--- a/packages/@granit/react-notifications-web-push/src/__tests__/use-web-push.test.tsx
+++ b/packages/@granit/react-notifications-web-push/src/__tests__/use-web-push.test.tsx
@@ -2,9 +2,11 @@ import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useWebPush } from '../hooks/use-web-push.js';
+import { WebPushProvider } from '../providers/web-push-provider.js';
 
-import type { WebPushConfig } from '../hooks/use-web-push.js';
+import type { WebPushProviderProps } from '../providers/web-push-provider.js';
 import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
 
 const mockRegisterPushSubscription = vi.fn().mockResolvedValue(undefined);
 const mockUnregisterPushSubscription = vi.fn().mockResolvedValue(undefined);
@@ -24,11 +26,15 @@ function createMockAxios(): AxiosInstance {
   } as unknown as AxiosInstance;
 }
 
-function createConfig(overrides?: Partial<WebPushConfig>): WebPushConfig {
+function createWrapper(overrides?: Partial<WebPushProviderProps['config']>) {
+  const apiClient = overrides?.apiClient ?? createMockAxios();
+  const vapidPublicKey = overrides?.vapidPublicKey ?? 'test-vapid-key';
+  const config: WebPushProviderProps['config'] = { apiClient, vapidPublicKey, ...overrides };
   return {
-    vapidPublicKey: 'test-vapid-key',
-    apiClient: createMockAxios(),
-    ...overrides,
+    apiClient,
+    wrapper({ children }: { children: ReactNode }) {
+      return <WebPushProvider config={config}>{children}</WebPushProvider>;
+    },
   };
 }
 
@@ -104,7 +110,8 @@ describe('useWebPush', () => {
   // -- Unsupported environment tests --
 
   it('should detect when Web Push is not supported', () => {
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     expect(result.current.isSupported).toBe(false);
     expect(result.current.isSubscribed).toBe(false);
@@ -113,14 +120,16 @@ describe('useWebPush', () => {
   });
 
   it('should expose subscribe and unsubscribe functions', () => {
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     expect(typeof result.current.subscribe).toBe('function');
     expect(typeof result.current.unsubscribe).toBe('function');
   });
 
   it('should no-op subscribe when Web Push is not supported', async () => {
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await act(async () => {
       await result.current.subscribe();
@@ -131,7 +140,8 @@ describe('useWebPush', () => {
   });
 
   it('should no-op unsubscribe when Web Push is not supported', async () => {
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await act(async () => {
       await result.current.unsubscribe();
@@ -142,7 +152,8 @@ describe('useWebPush', () => {
   });
 
   it('should use default basePath and serviceWorkerPath', () => {
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     expect(result.current.error).toBeNull();
   });
@@ -151,7 +162,8 @@ describe('useWebPush', () => {
 
   it('should detect when Web Push is supported', () => {
     installWebPushGlobals();
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     expect(result.current.isSupported).toBe(true);
     expect(result.current.permission).toBe('default');
@@ -159,7 +171,8 @@ describe('useWebPush', () => {
 
   it('should detect existing subscription on mount', async () => {
     installWebPushGlobals({ existingSubscription: true });
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await vi.waitFor(() => {
       expect(result.current.isSubscribed).toBe(true);
@@ -168,8 +181,8 @@ describe('useWebPush', () => {
 
   it('should subscribe successfully', async () => {
     installWebPushGlobals();
-    const config = createConfig();
-    const { result } = renderHook(() => useWebPush(config));
+    const { wrapper, apiClient } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await act(async () => {
       await result.current.subscribe();
@@ -179,9 +192,9 @@ describe('useWebPush', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(mockRegisterPushSubscription).toHaveBeenCalledWith(
-      config.apiClient,
-      '/api/v1',
-      mockSubscription.toJSON()
+      apiClient,
+      '/api/v1/notifications',
+      mockSubscription.toJSON(),
     );
   });
 
@@ -189,7 +202,8 @@ describe('useWebPush', () => {
     installWebPushGlobals();
     vi.mocked(globalThis.Notification.requestPermission).mockResolvedValue('denied');
 
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await act(async () => {
       await result.current.subscribe();
@@ -205,7 +219,8 @@ describe('useWebPush', () => {
     installWebPushGlobals();
     mockRegisterPushSubscription.mockRejectedValueOnce(new Error('Network error'));
 
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await act(async () => {
       await result.current.subscribe();
@@ -218,8 +233,8 @@ describe('useWebPush', () => {
 
   it('should unsubscribe successfully', async () => {
     installWebPushGlobals({ existingSubscription: true });
-    const config = createConfig();
-    const { result } = renderHook(() => useWebPush(config));
+    const { wrapper, apiClient } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await vi.waitFor(() => {
       expect(result.current.isSubscribed).toBe(true);
@@ -233,9 +248,9 @@ describe('useWebPush', () => {
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBeNull();
     expect(mockUnregisterPushSubscription).toHaveBeenCalledWith(
-      config.apiClient,
-      '/api/v1',
-      mockSubscription.endpoint
+      apiClient,
+      '/api/v1/notifications',
+      mockSubscription.endpoint,
     );
     expect(mockSubscription.unsubscribe).toHaveBeenCalled();
   });
@@ -244,7 +259,8 @@ describe('useWebPush', () => {
     installWebPushGlobals({ existingSubscription: true });
     mockUnregisterPushSubscription.mockRejectedValueOnce(new Error('Server error'));
 
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await vi.waitFor(() => {
       expect(result.current.isSubscribed).toBe(true);
@@ -261,8 +277,11 @@ describe('useWebPush', () => {
 
   it('should use custom basePath and serviceWorkerPath', async () => {
     installWebPushGlobals();
-    const config = createConfig({ basePath: '/custom/api', serviceWorkerPath: '/custom-sw.js' });
-    const { result } = renderHook(() => useWebPush(config));
+    const { wrapper, apiClient } = createWrapper({
+      basePath: '/custom/api',
+      serviceWorkerPath: '/custom-sw.js',
+    });
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await act(async () => {
       await result.current.subscribe();
@@ -270,9 +289,9 @@ describe('useWebPush', () => {
 
     expect(navigator.serviceWorker.register).toHaveBeenCalledWith('/custom-sw.js');
     expect(mockRegisterPushSubscription).toHaveBeenCalledWith(
-      config.apiClient,
+      apiClient,
       '/custom/api',
-      expect.any(Object)
+      expect.any(Object),
     );
   });
 
@@ -280,7 +299,8 @@ describe('useWebPush', () => {
     installWebPushGlobals();
     mockRegisterPushSubscription.mockRejectedValueOnce('string error');
 
-    const { result } = renderHook(() => useWebPush(createConfig()));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useWebPush(), { wrapper });
 
     await act(async () => {
       await result.current.subscribe();

--- a/packages/@granit/react-notifications-web-push/src/constants.ts
+++ b/packages/@granit/react-notifications-web-push/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'notifications';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
+++ b/packages/@granit/react-notifications-web-push/src/hooks/use-web-push.ts
@@ -5,16 +5,7 @@ import {
 } from '@granit/notifications-web-push';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
-import type { AxiosInstance } from 'axios';
-
-export interface WebPushConfig {
-  /** VAPID public key (URL-safe Base64). */
-  readonly vapidPublicKey: string;
-  readonly apiClient: AxiosInstance;
-  readonly basePath?: string;
-  /** Path to the service worker. Default: '/sw.js'. */
-  readonly serviceWorkerPath?: string;
-}
+import { useWebPushConfig } from '../providers/web-push-provider.js';
 
 export interface UseWebPushReturn {
   /** Whether the browser supports Web Push. */
@@ -42,6 +33,8 @@ function isWebPushSupported(): boolean {
 /**
  * Manages Web Push VAPID subscription lifecycle.
  *
+ * Must be used within a {@link WebPushProvider}.
+ *
  * This hook handles:
  * - Requesting notification permission
  * - Registering/unregistering the service worker push subscription
@@ -50,9 +43,10 @@ function isWebPushSupported(): boolean {
  * The service worker itself (displaying notifications, handling clicks)
  * is app-level code — this hook only manages the subscription.
  */
-export function useWebPush(config: WebPushConfig): UseWebPushReturn {
-  const basePath = config.basePath ?? '/api/v1';
-  const swPath = config.serviceWorkerPath ?? '/sw.js';
+export function useWebPush(): UseWebPushReturn {
+  const config = useWebPushConfig();
+  const basePath = config.basePath;
+  const swPath = config.serviceWorkerPath;
 
   const [permission, setPermission] = useState<NotificationPermission>(
     isWebPushSupported() ? Notification.permission : 'default'

--- a/packages/@granit/react-notifications-web-push/src/index.ts
+++ b/packages/@granit/react-notifications-web-push/src/index.ts
@@ -1,2 +1,7 @@
 export { useWebPush } from './hooks/use-web-push.js';
-export type { UseWebPushReturn, WebPushConfig } from './hooks/use-web-push.js';
+export type { UseWebPushReturn } from './hooks/use-web-push.js';
+export { WebPushProvider, useWebPushConfig } from './providers/web-push-provider.js';
+export type {
+  WebPushProviderConfig,
+  WebPushProviderProps,
+} from './providers/web-push-provider.js';

--- a/packages/@granit/react-notifications-web-push/src/providers/web-push-provider.tsx
+++ b/packages/@granit/react-notifications-web-push/src/providers/web-push-provider.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+/** Resolved configuration exposed by {@link useWebPushConfig}. */
+export interface WebPushProviderConfig {
+  /** VAPID public key (URL-safe Base64). */
+  readonly vapidPublicKey: string;
+  readonly apiClient: AxiosInstance;
+  readonly basePath: string;
+  /** Path to the service worker. Default: '/sw.js'. */
+  readonly serviceWorkerPath: string;
+}
+
+/** Props accepted by {@link WebPushProvider}. `basePath` and `serviceWorkerPath` are optional. */
+export interface WebPushProviderProps {
+  readonly config: Omit<WebPushProviderConfig, 'basePath' | 'serviceWorkerPath'> &
+    Partial<Pick<WebPushProviderConfig, 'basePath' | 'serviceWorkerPath'>>;
+  readonly children: ReactNode;
+}
+
+const WebPushConfigContext = createContext<WebPushProviderConfig | null>(null);
+
+const DEFAULT_SERVICE_WORKER_PATH = '/sw.js';
+
+/** Provides web push configuration to child components and hooks. */
+export function WebPushProvider({ config, children }: Readonly<WebPushProviderProps>) {
+  const value = useMemo<WebPushProviderConfig>(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      serviceWorkerPath: config.serviceWorkerPath ?? DEFAULT_SERVICE_WORKER_PATH,
+    }),
+    [config],
+  );
+  return <WebPushConfigContext value={value}>{children}</WebPushConfigContext>;
+}
+
+/** Returns the web push configuration from the nearest {@link WebPushProvider}. */
+export function useWebPushConfig(): WebPushProviderConfig {
+  const ctx = useContext(WebPushConfigContext);
+  if (!ctx) {
+    throw new Error('useWebPushConfig must be used within a WebPushProvider');
+  }
+  return ctx;
+}

--- a/packages/@granit/react-notifications/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/test-utils.tsx
@@ -17,7 +17,7 @@ export function createWrapper(client: AxiosInstance, basePath = '/api/v1') {
 
 /**
  * Creates a wrapper where `basePath` is omitted from the config,
- * exercising the `?? '/api'` fallback in hooks.
+ * exercising the `?? API_BASE_PATH` fallback in hooks.
  */
 export function createWrapperWithoutBasePath(client: AxiosInstance) {
   return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/packages/@granit/react-notifications/src/constants.ts
+++ b/packages/@granit/react-notifications/src/constants.ts
@@ -1,0 +1,10 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'notifications';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+
+/**
+ * API-compatible base path for `@granit/notifications` functions.
+ * Those functions append `/${MODULE}` internally, so the base they
+ * receive must NOT include the module segment.
+ */
+export const API_BASE_PATH = `/api/${API_VERSION}`;

--- a/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-entity-activity-feed.ts
@@ -1,6 +1,7 @@
 import { fetchEntityActivityFeed } from '@granit/notifications';
 import { useCallback } from 'react';
 
+import { API_BASE_PATH } from '../constants.js';
 import { useNotificationContext } from '../providers/notification-provider.js';
 
 import { usePaginatedFetch } from './use-paginated-fetch.js';
@@ -34,7 +35,7 @@ export function useEntityActivityFeed(
 ): UseEntityActivityFeedReturn {
   const { entityType, entityId, pageSize = DEFAULT_PAGE_SIZE } = options;
   const { config } = useNotificationContext();
-  const basePath = config.basePath ?? '/api';
+  const basePath = config.basePath ?? API_BASE_PATH;
 
   const fetcher = useCallback(
     (page: number, ps: number) =>

--- a/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
@@ -1,6 +1,7 @@
 import { fetchPreferences, updatePreference } from '@granit/notifications';
 import { useCallback, useEffect, useOptimistic, useRef, useState, useTransition } from 'react';
 
+import { API_BASE_PATH } from '../constants.js';
 import { useNotificationContext } from '../providers/notification-provider.js';
 
 import type { NotificationPreference } from '@granit/notifications';
@@ -51,7 +52,7 @@ async function savePreference(
  */
 export function useNotificationPreferences(): UseNotificationPreferencesReturn {
   const { config } = useNotificationContext();
-  const basePath = config.basePath ?? '/api';
+  const basePath = config.basePath ?? API_BASE_PATH;
 
   const [preferences, setPreferences] = useState<NotificationPreference[]>([]);
   const [loading, setLoading] = useState(true);

--- a/packages/@granit/react-notifications/src/hooks/use-notifications.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notifications.ts
@@ -2,6 +2,7 @@ import { fetchNotifications, markAllAsRead, markAsRead } from '@granit/notificat
 import { toISODateString } from '@granit/types';
 import { useCallback } from 'react';
 
+import { API_BASE_PATH } from '../constants.js';
 import { useNotificationContext } from '../providers/notification-provider.js';
 
 import { usePaginatedFetch } from './use-paginated-fetch.js';
@@ -33,7 +34,7 @@ const DEFAULT_PAGE_SIZE = 20;
 export function useNotifications(options: UseNotificationsOptions = {}): UseNotificationsReturn {
   const { pageSize = DEFAULT_PAGE_SIZE } = options;
   const { config, setUnreadCount } = useNotificationContext();
-  const basePath = config.basePath ?? '/api';
+  const basePath = config.basePath ?? API_BASE_PATH;
 
   const fetcher = useCallback(
     (p: number, ps: number) =>

--- a/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-unread-count.ts
@@ -1,6 +1,7 @@
 import { fetchUnreadCount } from '@granit/notifications';
 import { useCallback, useEffect, useRef } from 'react';
 
+import { API_BASE_PATH } from '../constants.js';
 import { useNotificationContext } from '../providers/notification-provider.js';
 
 export interface UseUnreadCountOptions {
@@ -28,7 +29,7 @@ export function useUnreadCount(options: UseUnreadCountOptions = {}): UseUnreadCo
 
   const refresh = useCallback(async () => {
     try {
-      const count = await fetchUnreadCount(config.apiClient, config.basePath ?? '/api');
+      const count = await fetchUnreadCount(config.apiClient, config.basePath ?? API_BASE_PATH);
       if (mountedRef.current) {
         setUnreadCount(count);
       }

--- a/packages/@granit/react-notifications/src/testing/handlers.ts
+++ b/packages/@granit/react-notifications/src/testing/handlers.ts
@@ -2,6 +2,8 @@ import { noContent, notFound } from '@granit/testing/msw';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { API_BASE_PATH } from '../constants.js';
+
 import { mockNotificationPreferences, mockNotifications } from './data.js';
 
 import type {
@@ -18,7 +20,7 @@ import type { Mutable } from '@granit/testing';
  *
  * @param baseUrl - API base path (default: `/api/v1`)
  */
-export function createNotificationsHandlers(baseUrl = '/api/v1') {
+export function createNotificationsHandlers(baseUrl = API_BASE_PATH) {
   let notifications: Mutable<UserNotification>[] = [...mockNotifications];
   let preferences: Mutable<NotificationPreference>[] = [...mockNotificationPreferences];
 

--- a/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/openiddict-admin-provider.test.tsx
@@ -38,7 +38,7 @@ describe('OpenIddictAdminProvider', () => {
       wrapper: createWrapper(config),
     });
 
-    expect(result.current.basePath).toBe('/admin');
+    expect(result.current.basePath).toBe('/api/v1/admin');
   });
 
   it('should apply default queryKeyPrefix when not specified', () => {

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-groups.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-groups.test.tsx
@@ -66,7 +66,7 @@ describe('useAdminGroups', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listGroups).toHaveBeenCalledWith(expect.anything(), '/admin');
+    expect(listGroups).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin');
     expect(result.current.data).toEqual(mockGroups);
   });
 
@@ -95,7 +95,7 @@ describe('useCreateAdminGroup', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createGroup).toHaveBeenCalledWith(expect.anything(), '/admin', {
+    expect(createGroup).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
       name: 'Engineering',
       description: 'Engineering team',
     });
@@ -132,7 +132,7 @@ describe('useDeleteAdminGroup', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteGroup).toHaveBeenCalledWith(expect.anything(), '/admin', 'grp-001');
+    expect(deleteGroup).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'grp-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'groups'],
     });
@@ -165,7 +165,7 @@ describe('useAddGroupMember', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(addGroupMember).toHaveBeenCalledWith(expect.anything(), '/admin', 'grp-001', {
+    expect(addGroupMember).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'grp-001', {
       userId: 'usr-001',
     });
     expect(invalidateSpy).toHaveBeenCalledWith({
@@ -202,7 +202,7 @@ describe('useRemoveGroupMember', () => {
 
     expect(removeGroupMember).toHaveBeenCalledWith(
       expect.anything(),
-      '/admin',
+      '/api/v1/admin',
       'grp-001',
       'usr-001'
     );

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-roles.test.tsx
@@ -60,7 +60,7 @@ describe('useAdminRoles', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listRoles).toHaveBeenCalledWith(expect.anything(), '/admin');
+    expect(listRoles).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin');
     expect(result.current.data).toEqual(mockRoles);
   });
 
@@ -89,7 +89,7 @@ describe('useCreateAdminRole', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createRole).toHaveBeenCalledWith(expect.anything(), '/admin', {
+    expect(createRole).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
       name: 'admin',
       description: 'Administrator role',
     });
@@ -132,7 +132,7 @@ describe('useAdminRoleMembers', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getRoleMembers).toHaveBeenCalledWith(expect.anything(), '/admin', 'admin');
+    expect(getRoleMembers).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'admin');
     expect(result.current.data).toEqual(mockMembers);
   });
 
@@ -158,7 +158,7 @@ describe('useDeleteAdminRole', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteRole).toHaveBeenCalledWith(expect.anything(), '/admin', 'admin');
+    expect(deleteRole).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'admin');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'roles'],
     });

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
@@ -87,7 +87,7 @@ describe('useAdminUsers', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listUsers).toHaveBeenCalledWith(expect.anything(), '/admin', {
+    expect(listUsers).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
       search: 'admin',
       page: 1,
       pageSize: 10,
@@ -115,7 +115,7 @@ describe('useAdminUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(getUser).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
+    expect(getUser).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'usr-001');
     expect(result.current.data).toEqual(mockUser);
   });
 
@@ -141,7 +141,7 @@ describe('useCreateAdminUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createUser).toHaveBeenCalledWith(expect.anything(), '/admin', {
+    expect(createUser).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
       email: 'admin@example.com',
       firstName: 'Admin',
     });
@@ -178,7 +178,7 @@ describe('useDeleteAdminUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteUser).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
+    expect(deleteUser).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'usr-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'users'],
     });
@@ -215,7 +215,7 @@ describe('useImpersonateUser', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(impersonateUser).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
+    expect(impersonateUser).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'usr-001');
     expect(result.current.data).toEqual(mockImpersonation);
   });
 

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
@@ -63,7 +63,7 @@ describe('useOidcApplications', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listApplications).toHaveBeenCalledWith(expect.anything(), '/admin');
+    expect(listApplications).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin');
     expect(result.current.data).toEqual(mockApps);
   });
 
@@ -95,7 +95,7 @@ describe('useCreateOidcApplication', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createApplication).toHaveBeenCalledWith(expect.anything(), '/admin', {
+    expect(createApplication).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
       clientId: 'guava-front',
       displayName: 'Guava Frontend',
     });
@@ -132,7 +132,7 @@ describe('useDeleteOidcApplication', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteApplication).toHaveBeenCalledWith(expect.anything(), '/admin', 'guava-front');
+    expect(deleteApplication).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'guava-front');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'applications'],
     });
@@ -170,7 +170,7 @@ describe('useRotateApplicationSecret', () => {
 
     expect(rotateApplicationSecret).toHaveBeenCalledWith(
       expect.anything(),
-      '/admin',
+      '/api/v1/admin',
       'guava-front'
     );
     expect(result.current.data).toEqual(mockSecretResponse);

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
@@ -58,7 +58,7 @@ describe('useOidcAuthorizations', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/admin', undefined);
+    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', undefined);
     expect(result.current.data).toEqual(mockAuthorizations);
   });
 
@@ -70,7 +70,7 @@ describe('useOidcAuthorizations', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/admin', {
+    expect(listAuthorizations).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
       userId: 'usr-001',
     });
   });
@@ -100,7 +100,7 @@ describe('useRevokeAuthorization', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(revokeAuthorization).toHaveBeenCalledWith(expect.anything(), '/admin', 'auth-001');
+    expect(revokeAuthorization).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'auth-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'authorizations'],
     });
@@ -133,7 +133,7 @@ describe('useRevokeUserAuthorizations', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(revokeUserAuthorizations).toHaveBeenCalledWith(expect.anything(), '/admin', 'usr-001');
+    expect(revokeUserAuthorizations).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'usr-001');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'authorizations'],
     });

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
@@ -51,7 +51,7 @@ describe('useOidcScopes', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(listScopes).toHaveBeenCalledWith(expect.anything(), '/admin');
+    expect(listScopes).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin');
     expect(result.current.data).toEqual(mockScopes);
   });
 
@@ -84,7 +84,7 @@ describe('useCreateOidcScope', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(createScope).toHaveBeenCalledWith(expect.anything(), '/admin', {
+    expect(createScope).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', {
       name: 'api',
       displayName: 'API access',
       description: 'Grants API access',
@@ -122,7 +122,7 @@ describe('useDeleteOidcScope', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(deleteScope).toHaveBeenCalledWith(expect.anything(), '/admin', 'api');
+    expect(deleteScope).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'api');
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['openiddict-admin', 'oidc', 'scopes'],
     });

--- a/packages/@granit/react-openiddict-admin/src/constants.ts
+++ b/packages/@granit/react-openiddict-admin/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'admin';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
+++ b/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -14,7 +16,6 @@ export interface OpenIddictAdminProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/admin';
 const DEFAULT_KEY_PREFIX = ['openiddict-admin'] as const;
 
 const AdminContext = createContext<OpenIddictAdminConfig | null>(null);

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -1,6 +1,8 @@
 import { noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import {
   mockAdminGroups,
   mockAdminRoles,
@@ -23,9 +25,9 @@ import type {
  * Create stateful MSW handlers for OpenIddict admin endpoints.
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
  *
- * @param baseUrl - API base path (default: `/admin`)
+ * @param baseUrl - API base path (default: `/api/v1/admin`)
  */
-export function createOpenIddictAdminHandlers(baseUrl = '/admin') {
+export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // ── Users ────────────────────────────────────────────────────────────────
 

--- a/packages/@granit/react-payments/src/__tests__/payments-provider.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/payments-provider.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import {
   PaymentsProvider,
   buildPaymentsQueryKey,
@@ -13,7 +14,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: PaymentsConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/v1/payments',
+  basePath: DEFAULT_BASE_PATH,
 };
 
 function createWrapper(config: PaymentsConfig) {
@@ -29,7 +30,7 @@ describe('PaymentsProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/v1/payments');
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-payments/src/constants.ts
+++ b/packages/@granit/react-payments/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'payments';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-payments/src/hooks/use-payments.ts
+++ b/packages/@granit/react-payments/src/hooks/use-payments.ts
@@ -26,8 +26,6 @@ import type {
 } from '@granit/payments';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-const DEFAULT_BASE_PATH = '/api/v1/payments';
-
 /**
  * List all payment transactions.
  *
@@ -38,7 +36,7 @@ const DEFAULT_BASE_PATH = '/api/v1/payments';
  */
 export function usePaymentTransactions(): UseQueryResult<readonly PaymentTransactionResponse[]> {
   const config = usePaymentsConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildPaymentsQueryKey(config, 'transactions'),
@@ -58,7 +56,7 @@ export function usePaymentTransactions(): UseQueryResult<readonly PaymentTransac
  */
 export function usePaymentTransaction(id: string): UseQueryResult<PaymentTransactionResponse> {
   const config = usePaymentsConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildPaymentsQueryKey(config, 'transactions', id),
@@ -84,7 +82,7 @@ export function useInitiatePaymentCharge(): UseMutationResult<
 > {
   const config = usePaymentsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: PaymentChargeRequest) =>
@@ -114,7 +112,7 @@ export function useRequestPaymentRefund(): UseMutationResult<
 > {
   const config = usePaymentsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: PaymentRefundRequest) =>
@@ -143,7 +141,7 @@ export function useCreateCheckoutSession(): UseMutationResult<
   PaymentCheckoutRequest
 > {
   const config = usePaymentsConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: PaymentCheckoutRequest) =>
@@ -161,7 +159,7 @@ export function useCreateCheckoutSession(): UseMutationResult<
  */
 export function usePaymentMethods(): UseQueryResult<readonly PaymentMethodResponse[]> {
   const config = usePaymentsConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildPaymentsQueryKey(config, 'methods'),
@@ -181,7 +179,7 @@ export function useAvailablePaymentMethods(): UseQueryResult<
   readonly PaymentAvailableMethodResponse[]
 > {
   const config = usePaymentsConfig();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildPaymentsQueryKey(config, 'methods', 'available'),
@@ -206,7 +204,7 @@ export function useAttachPaymentMethod(): UseMutationResult<
 > {
   const config = usePaymentsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: PaymentAttachMethodRequest) =>
@@ -232,7 +230,7 @@ export function useAttachPaymentMethod(): UseMutationResult<
 export function useDetachPaymentMethod(): UseMutationResult<void, Error, string> {
   const config = usePaymentsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? DEFAULT_BASE_PATH;
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (id: string) => detachPaymentMethod(config.client, basePath, id),

--- a/packages/@granit/react-payments/src/providers/payments-provider.tsx
+++ b/packages/@granit/react-payments/src/providers/payments-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,7 +22,10 @@ const PaymentsConfigContext = createContext<PaymentsConfig | null>(null);
 
 /** Provides payments configuration to child components and hooks. */
 export function PaymentsProvider({ config, children }: Readonly<PaymentsProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
   return <PaymentsConfigContext value={value}>{children}</PaymentsConfigContext>;
 }
 

--- a/packages/@granit/react-payments/src/testing/handlers.ts
+++ b/packages/@granit/react-payments/src/testing/handlers.ts
@@ -2,6 +2,7 @@ import { noContent, notFound } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import {
   sampleAvailableMethods,
   sampleDisputes,
@@ -22,9 +23,9 @@ import type { CurrencyCode } from '@granit/types';
  * Create stateful MSW handlers for payments endpoints.
  * Handlers cover transactions, charges, refunds, payment methods, and checkout.
  *
- * @param baseUrl - API base path (default: `/api/v1/granit/payments`)
+ * @param baseUrl - API base path (default: `/api/v1/payments`)
  */
-export function createPaymentsHandlers(baseUrl = '/api/v1/granit/payments') {
+export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET all transactions
     http.get(`${baseUrl}/transactions`, () => {

--- a/packages/@granit/react-privacy/src/constants.ts
+++ b/packages/@granit/react-privacy/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'privacy';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
+++ b/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -14,7 +16,6 @@ export interface PrivacyProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_BASE_PATH = '/api/v1/privacy';
 const DEFAULT_KEY_PREFIX = ['privacy'] as const;
 
 const PrivacyContext = createContext<PrivacyConfig | null>(null);

--- a/packages/@granit/react-privacy/src/testing/handlers.ts
+++ b/packages/@granit/react-privacy/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import {
   mockAgreementHistory,
   mockAgreementStatuses,
@@ -28,7 +29,7 @@ type Mutable<T> = { -readonly [K in keyof T]: T[K] };
  *
  * @param baseUrl - API base path (default: `/api/v1/privacy`)
  */
-export function createPrivacyHandlers(baseUrl = '/api/v1/privacy') {
+export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const exports: Mutable<PrivacyExportStatusResponse>[] = mockExports.map((e) => ({ ...e }));
   const deletionRequests: Mutable<PrivacyDeletionResponse>[] = mockDeletionRequests.map((d) => ({
     ...d,

--- a/packages/@granit/react-scheduling/src/__tests__/scheduling-provider.test.tsx
+++ b/packages/@granit/react-scheduling/src/__tests__/scheduling-provider.test.tsx
@@ -1,0 +1,49 @@
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+import {
+  SchedulingProvider,
+  useSchedulingConfig,
+} from '../providers/scheduling-provider.js';
+
+import type { SchedulingConfig } from '../providers/scheduling-provider.js';
+import type { AxiosInstance } from 'axios';
+
+const mockConfig: SchedulingConfig = {
+  client: {} as AxiosInstance,
+  basePath: DEFAULT_BASE_PATH,
+};
+
+function createWrapper(config: SchedulingConfig) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <SchedulingProvider config={config}>{children}</SchedulingProvider>;
+  };
+}
+
+describe('SchedulingProvider', () => {
+  it('should provide config via useSchedulingConfig', () => {
+    const { result } = renderHook(() => useSchedulingConfig(), {
+      wrapper: createWrapper(mockConfig),
+    });
+
+    expect(result.current.client).toBe(mockConfig.client);
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
+  });
+
+  it('should apply default basePath when not provided', () => {
+    const config: SchedulingConfig = { client: {} as AxiosInstance };
+    const { result } = renderHook(() => useSchedulingConfig(), {
+      wrapper: createWrapper(config),
+    });
+
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
+  });
+
+  it('should throw when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useSchedulingConfig());
+    }).toThrow('useSchedulingConfig must be used within a SchedulingProvider');
+  });
+});

--- a/packages/@granit/react-scheduling/src/__tests__/use-scheduling.test.tsx
+++ b/packages/@granit/react-scheduling/src/__tests__/use-scheduling.test.tsx
@@ -1,0 +1,188 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useCancelScheduledAction,
+  useRescheduleScheduledAction,
+  useScheduledAction,
+  useScheduledActions,
+} from '../hooks/use-scheduling.js';
+import { SchedulingProvider } from '../providers/scheduling-provider.js';
+
+import type { SchedulingConfig } from '../providers/scheduling-provider.js';
+import type { PagedResult } from '@granit/query-engine';
+import type { ScheduledActionResponse } from '@granit/scheduling';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const sampleAction: ScheduledActionResponse = {
+  id: 'action-1',
+  payloadType: 'SendEmail',
+  executeAt: '2026-04-05T09:00:00Z',
+  correlationId: null,
+  status: 0,
+  executedAt: null,
+  cancelledBy: null,
+  failureReason: null,
+  createdAt: '2026-04-02T14:30:00Z',
+};
+
+const samplePagedResult: PagedResult<ScheduledActionResponse> = {
+  items: [sampleAction],
+  totalCount: 1,
+  page: 1,
+  pageSize: 20,
+  nextCursor: undefined,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: SchedulingConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <SchedulingProvider config={config}>{children}</SchedulingProvider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('use-scheduling', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useScheduledActions', () => {
+    it('fetches scheduled actions with default basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: samplePagedResult });
+
+      const { result } = renderHook(() => useScheduledActions(), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalled();
+      expect(result.current.data).toEqual(samplePagedResult);
+    });
+
+    it('fetches scheduled actions with custom basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: samplePagedResult });
+
+      const { result } = renderHook(() => useScheduledActions(), {
+        wrapper: createWrapper(client, '/custom/scheduling'),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalled();
+    });
+  });
+
+  describe('useScheduledAction', () => {
+    it('fetches a single scheduled action by ID', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleAction });
+
+      const { result } = renderHook(() => useScheduledAction('action-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data).toEqual(sampleAction);
+    });
+
+    it('is disabled when id is empty', () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useScheduledAction(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useCancelScheduledAction', () => {
+    it('cancels a scheduled action via DELETE', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useCancelScheduledAction(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('action-1');
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalled();
+    });
+
+    it('exposes error state on failure', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockRejectedValue(new Error('Not Found'));
+
+      const { result } = renderHook(() => useCancelScheduledAction(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('action-1');
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe('Not Found');
+    });
+  });
+
+  describe('useRescheduleScheduledAction', () => {
+    it('reschedules a scheduled action via PUT', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleAction });
+
+      const { result } = renderHook(() => useRescheduleScheduledAction(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({
+        id: 'action-1',
+        request: { newExecuteAt: '2026-04-10T09:00:00Z' },
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.put).toHaveBeenCalled();
+    });
+
+    it('exposes error state on failure', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockRejectedValue(new Error('Conflict'));
+
+      const { result } = renderHook(() => useRescheduleScheduledAction(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({
+        id: 'action-1',
+        request: { newExecuteAt: '2026-04-10T09:00:00Z' },
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(result.current.error?.message).toBe('Conflict');
+    });
+  });
+});

--- a/packages/@granit/react-scheduling/src/constants.ts
+++ b/packages/@granit/react-scheduling/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'scheduling';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
+++ b/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
@@ -6,23 +6,14 @@ import {
 } from '@granit/scheduling';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { useSchedulingConfig } from '../providers/scheduling-provider.js';
+
 import type { PagedResult, QueryRequest } from '@granit/query-engine';
 import type { RescheduleActionRequest, ScheduledActionResponse } from '@granit/scheduling';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
-const DEFAULT_BASE_PATH = '/api/v1/scheduling/scheduled-actions';
-
-/** Options accepted by all scheduling hooks. */
-export interface SchedulingOptions {
-  /** Axios instance used for all requests. */
-  readonly client: AxiosInstance;
-  /** Base URL for the scheduling API. Defaults to `/api/v1/scheduling/scheduled-actions`. */
-  readonly basePath?: string;
-}
-
-/** Options for the list hook, extending base options with QueryEngine params. */
-export interface SchedulingListOptions extends SchedulingOptions {
+/** Options for the list hook (query parameters and polling interval). */
+export interface SchedulingListOptions {
   /** QueryEngine request parameters (pagination, filters, sort, etc.). */
   readonly request?: QueryRequest;
   /** Auto-refetch interval in milliseconds. Defaults to `15_000` (15 s). Set to `false` to disable. */
@@ -49,18 +40,20 @@ export const schedulingKeys = {
  *
  * @example
  * ```tsx
- * const { data } = useScheduledActions({ client: api, request: { page: 1, pageSize: 20 } });
+ * const { data } = useScheduledActions({ request: { page: 1, pageSize: 20 } });
  * // data.items, data.totalCount
  * ```
  */
 export function useScheduledActions(
-  options: SchedulingListOptions
+  options?: SchedulingListOptions
 ): UseQueryResult<PagedResult<ScheduledActionResponse>> {
-  const { client, basePath = DEFAULT_BASE_PATH, request, refetchInterval = 15_000 } = options;
+  const config = useSchedulingConfig();
+  const actionsPath = `${config.basePath}/scheduled-actions`;
+  const { request, refetchInterval = 15_000 } = options ?? {};
 
   return useQuery({
     queryKey: schedulingKeys.list(request),
-    queryFn: () => fetchScheduledActions(client, basePath, request),
+    queryFn: () => fetchScheduledActions(config.client, actionsPath, request),
     refetchInterval,
   });
 }
@@ -72,18 +65,20 @@ export function useScheduledActions(
  *
  * @example
  * ```tsx
- * const { data: action } = useScheduledAction('550e8400-...', { client: api });
+ * const { data: action } = useScheduledAction('550e8400-...');
  * ```
  */
 export function useScheduledAction(
   id: string,
-  options: SchedulingOptions & { readonly refetchInterval?: number | false }
+  options?: { readonly refetchInterval?: number | false }
 ): UseQueryResult<ScheduledActionResponse> {
-  const { client, basePath = DEFAULT_BASE_PATH, refetchInterval = 15_000 } = options;
+  const config = useSchedulingConfig();
+  const actionsPath = `${config.basePath}/scheduled-actions`;
+  const { refetchInterval = 15_000 } = options ?? {};
 
   return useQuery({
     queryKey: schedulingKeys.detail(id),
-    queryFn: () => fetchScheduledActionById(client, basePath, id),
+    queryFn: () => fetchScheduledActionById(config.client, actionsPath, id),
     refetchInterval,
     enabled: id.length > 0,
   });
@@ -96,19 +91,18 @@ export function useScheduledAction(
  *
  * @example
  * ```tsx
- * const { mutate: cancel } = useCancelScheduledAction({ client: api });
+ * const { mutate: cancel } = useCancelScheduledAction();
  * cancel('550e8400-...');
  * ```
  */
-export function useCancelScheduledAction(
-  options: SchedulingOptions
-): UseMutationResult<void, Error, string> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+export function useCancelScheduledAction(): UseMutationResult<void, Error, string> {
+  const config = useSchedulingConfig();
+  const actionsPath = `${config.basePath}/scheduled-actions`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (id: string) => {
-      await cancelScheduledAction(client, basePath, id);
+      await cancelScheduledAction(config.client, actionsPath, id);
     },
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: schedulingKeys.all });
@@ -124,19 +118,18 @@ export function useCancelScheduledAction(
  *
  * @example
  * ```tsx
- * const { mutate: reschedule } = useRescheduleScheduledAction({ client: api });
+ * const { mutate: reschedule } = useRescheduleScheduledAction();
  * reschedule({ id: '550e8400-...', request: { newExecuteAt: '2026-04-10T09:00:00Z' } });
  * ```
  */
-export function useRescheduleScheduledAction(
-  options: SchedulingOptions
-): UseMutationResult<ScheduledActionResponse, Error, RescheduleVariables> {
-  const { client, basePath = DEFAULT_BASE_PATH } = options;
+export function useRescheduleScheduledAction(): UseMutationResult<ScheduledActionResponse, Error, RescheduleVariables> {
+  const config = useSchedulingConfig();
+  const actionsPath = `${config.basePath}/scheduled-actions`;
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async ({ id, request }: RescheduleVariables) =>
-      rescheduleScheduledAction(client, basePath, id, request),
+      rescheduleScheduledAction(config.client, actionsPath, id, request),
     onSuccess: async (_data, { id }) => {
       await queryClient.invalidateQueries({ queryKey: schedulingKeys.all });
       await queryClient.invalidateQueries({ queryKey: schedulingKeys.detail(id) });

--- a/packages/@granit/react-scheduling/src/index.ts
+++ b/packages/@granit/react-scheduling/src/index.ts
@@ -1,3 +1,10 @@
+// Provider
+export {
+  SchedulingProvider,
+  useSchedulingConfig,
+} from './providers/scheduling-provider.js';
+export type { SchedulingConfig, SchedulingProviderProps } from './providers/scheduling-provider.js';
+
 // Hooks
 export {
   schedulingKeys,
@@ -11,5 +18,4 @@ export {
 export type {
   RescheduleVariables,
   SchedulingListOptions,
-  SchedulingOptions,
 } from './hooks/use-scheduling.js';

--- a/packages/@granit/react-scheduling/src/providers/scheduling-provider.tsx
+++ b/packages/@granit/react-scheduling/src/providers/scheduling-provider.tsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+/** Configuration for the scheduling provider. */
+export interface SchedulingConfig {
+  readonly client: AxiosInstance;
+  /** Base path for scheduling endpoints (default: `/api/v1/scheduling`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface SchedulingProviderProps {
+  readonly config: SchedulingConfig;
+  readonly children: ReactNode;
+}
+
+const SchedulingConfigContext = createContext<SchedulingConfig | null>(null);
+
+/** Provides scheduling configuration to child components and hooks. */
+export function SchedulingProvider({ config, children }: Readonly<SchedulingProviderProps>) {
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
+  return <SchedulingConfigContext value={value}>{children}</SchedulingConfigContext>;
+}
+
+/** Returns the scheduling configuration from the nearest `SchedulingProvider`. */
+export function useSchedulingConfig(): SchedulingConfig {
+  const ctx = useContext(SchedulingConfigContext);
+  if (!ctx) {
+    throw new Error('useSchedulingConfig must be used within a SchedulingProvider');
+  }
+  return ctx;
+}

--- a/packages/@granit/react-scheduling/src/testing/handlers.ts
+++ b/packages/@granit/react-scheduling/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { ScheduledActionStatus } from '@granit/scheduling';
 import {
   applyDateFilter,
@@ -28,12 +29,14 @@ const statusPresetMap: Record<string, ScheduledActionStatus> = {
  * Create stateful MSW handlers for scheduled action endpoints.
  * Cancel and reschedule calls mutate the in-memory `mockScheduledActions` array.
  *
- * @param baseUrl - API base path (default: `/api/v1/scheduling/scheduled-actions`)
+ * @param baseUrl - API base path (default: `/api/v1/scheduling`)
  */
-export function createSchedulingHandlers(baseUrl = '/api/v1/scheduling/scheduled-actions') {
+export function createSchedulingHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  const actionsUrl = `${baseUrl}/scheduled-actions`;
+
   return [
     // GET list — supports @granit/query-engine serialized params
-    http.get(baseUrl, ({ request }) => {
+    http.get(actionsUrl, ({ request }) => {
       const url = new URL(request.url);
       const search = url.searchParams.get('search') ?? '';
 
@@ -89,14 +92,14 @@ export function createSchedulingHandlers(baseUrl = '/api/v1/scheduling/scheduled
     }),
 
     // GET by ID
-    http.get(`${baseUrl}/:id`, ({ params }) => {
+    http.get(`${actionsUrl}/:id`, ({ params }) => {
       const action = mockScheduledActions.find((a) => a.id === params.id);
       if (!action) return new HttpResponse(null, { status: 404 });
       return HttpResponse.json(action);
     }),
 
     // DELETE — cancel a pending action
-    http.delete(`${baseUrl}/:id`, ({ params }) => {
+    http.delete(`${actionsUrl}/:id`, ({ params }) => {
       const action = mockScheduledActions.find((a) => a.id === params.id);
       if (!action) {
         return HttpResponse.json(
@@ -121,7 +124,7 @@ export function createSchedulingHandlers(baseUrl = '/api/v1/scheduling/scheduled
     }),
 
     // PUT — reschedule a pending action
-    http.put(`${baseUrl}/:id/reschedule`, async ({ params, request }) => {
+    http.put(`${actionsUrl}/:id/reschedule`, async ({ params, request }) => {
       const action = mockScheduledActions.find((a) => a.id === params.id);
       if (!action) {
         return HttpResponse.json(

--- a/packages/@granit/react-subscriptions/src/constants.ts
+++ b/packages/@granit/react-subscriptions/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'subscriptions';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-subscriptions/src/hooks/use-plans.ts
+++ b/packages/@granit/react-subscriptions/src/hooks/use-plans.ts
@@ -34,7 +34,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function usePlans(): UseQueryResult<readonly PlanResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'plans'),
@@ -54,7 +54,7 @@ export function usePlans(): UseQueryResult<readonly PlanResponse[]> {
  */
 export function usePlan(id: string): UseQueryResult<PlanResponse> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'plans', id),
@@ -79,7 +79,7 @@ export type CreatePlanVariables = PlanCreateRequest;
 export function useCreatePlan(): UseMutationResult<PlanResponse, Error, CreatePlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: (request: CreatePlanVariables) => createPlan(config.client, basePath, request),
@@ -110,7 +110,7 @@ export type UpdatePlanVariables = {
 export function useUpdatePlan(): UseMutationResult<PlanResponse, Error, UpdatePlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ id, request }: UpdatePlanVariables) =>
@@ -141,7 +141,7 @@ export type PublishPlanVariables = {
 export function usePublishPlan(): UseMutationResult<void, Error, PublishPlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ id }: PublishPlanVariables) => publishPlan(config.client, basePath, id),
@@ -171,7 +171,7 @@ export type ArchivePlanVariables = {
 export function useArchivePlan(): UseMutationResult<void, Error, ArchivePlanVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ id }: ArchivePlanVariables) => archivePlan(config.client, basePath, id),
@@ -206,7 +206,7 @@ export function useCreatePriceVersion(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ planId, request }: CreatePriceVersionVariables) =>
@@ -231,7 +231,7 @@ export function useCreatePriceVersion(): UseMutationResult<
  */
 export function usePlanPriceHistory(planId: string): UseQueryResult<readonly PlanPriceResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'plans', planId, 'prices', 'history'),

--- a/packages/@granit/react-subscriptions/src/hooks/use-seats.ts
+++ b/packages/@granit/react-subscriptions/src/hooks/use-seats.ts
@@ -21,7 +21,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useSeats(subscriptionId: string): UseQueryResult<readonly SeatResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions', subscriptionId, 'seats'),
@@ -48,7 +48,7 @@ export function useAssignSeat(
 ): UseMutationResult<SeatResponse, Error, AssignSeatVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: (request: AssignSeatVariables) =>
@@ -81,7 +81,7 @@ export function useRevokeSeat(
 ): UseMutationResult<void, Error, RevokeSeatVariables> {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ userId }: RevokeSeatVariables) =>

--- a/packages/@granit/react-subscriptions/src/hooks/use-subscriptions.ts
+++ b/packages/@granit/react-subscriptions/src/hooks/use-subscriptions.ts
@@ -36,7 +36,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useSubscriptions(): UseQueryResult<readonly SubscriptionResponse[]> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions'),
@@ -54,7 +54,7 @@ export function useSubscriptions(): UseQueryResult<readonly SubscriptionResponse
  */
 export function useActiveSubscription(): UseQueryResult<SubscriptionResponse> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions', 'active'),
@@ -74,7 +74,7 @@ export function useActiveSubscription(): UseQueryResult<SubscriptionResponse> {
  */
 export function useSubscription(id: string): UseQueryResult<SubscriptionResponse> {
   const config = useSubscriptionsConfig();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useQuery({
     queryKey: buildSubscriptionsQueryKey(config, 'subscriptions', id),
@@ -103,7 +103,7 @@ export function useCreateSubscription(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: (request: CreateSubscriptionVariables) =>
@@ -139,7 +139,7 @@ export function useCancelSubscription(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ id, request }: CancelSubscriptionVariables) =>
@@ -175,7 +175,7 @@ export function useChangeSubscriptionPlan(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ id, request }: ChangeSubscriptionPlanVariables) =>
@@ -211,7 +211,7 @@ export function useMigrateSubscriptionPrice(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: ({ id, request }: MigrateSubscriptionPriceVariables) =>
@@ -244,7 +244,7 @@ export function useBulkMigrateSubscriptionPrice(): UseMutationResult<
 > {
   const config = useSubscriptionsConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath ?? '/api/v1/subscriptions';
+  const basePath = config.basePath;
 
   return useMutation({
     mutationFn: (request: BulkMigrateSubscriptionPriceVariables) =>

--- a/packages/@granit/react-subscriptions/src/index.ts
+++ b/packages/@granit/react-subscriptions/src/index.ts
@@ -5,6 +5,7 @@ export {
   useSubscriptionsConfig,
 } from './providers/subscriptions-provider.js';
 export type {
+  ResolvedSubscriptionsConfig,
   SubscriptionsConfig,
   SubscriptionsProviderProps,
 } from './providers/subscriptions-provider.js';

--- a/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
+++ b/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
@@ -3,6 +3,8 @@ import { createContext, useContext, useMemo } from 'react';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 /** Configuration for the subscriptions provider. */
 export interface SubscriptionsConfig {
   readonly client: AxiosInstance;
@@ -11,21 +13,29 @@ export interface SubscriptionsConfig {
   readonly queryKeyPrefix?: readonly string[];
 }
 
+/** Resolved configuration where all optional fields have defaults applied. */
+export interface ResolvedSubscriptionsConfig extends SubscriptionsConfig {
+  readonly basePath: string;
+}
+
 export interface SubscriptionsProviderProps {
   readonly config: SubscriptionsConfig;
   readonly children: ReactNode;
 }
 
-const SubscriptionsConfigContext = createContext<SubscriptionsConfig | null>(null);
+const SubscriptionsConfigContext = createContext<ResolvedSubscriptionsConfig | null>(null);
 
 /** Provides subscriptions configuration to child components and hooks. */
 export function SubscriptionsProvider({ config, children }: Readonly<SubscriptionsProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo<ResolvedSubscriptionsConfig>(
+    () => ({ ...config, basePath: config.basePath ?? DEFAULT_BASE_PATH }),
+    [config],
+  );
   return <SubscriptionsConfigContext value={value}>{children}</SubscriptionsConfigContext>;
 }
 
 /** Returns the subscriptions configuration from the nearest `SubscriptionsProvider`. */
-export function useSubscriptionsConfig(): SubscriptionsConfig {
+export function useSubscriptionsConfig(): ResolvedSubscriptionsConfig {
   const ctx = useContext(SubscriptionsConfigContext);
   if (!ctx) {
     throw new Error('useSubscriptionsConfig must be used within a SubscriptionsProvider');

--- a/packages/@granit/react-subscriptions/src/testing/handlers.ts
+++ b/packages/@granit/react-subscriptions/src/testing/handlers.ts
@@ -2,6 +2,7 @@ import { noContent, notFound } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockPlans, mockPriceHistory, mockSeats, mockSubscriptions } from './data.js';
 
 import type {
@@ -17,9 +18,9 @@ import type { CurrencyCode } from '@granit/types';
  * Covers plans, price versions, subscriptions, and seats — all mutations
  * persist in the in-memory data arrays.
  *
- * @param baseUrl - API base path (default: `/api/v1/granit/subscriptions`)
+ * @param baseUrl - API base path (default: `/api/v1/subscriptions`)
  */
-export function createSubscriptionsHandlers(baseUrl = '/api/v1/granit/subscriptions') {
+export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // ---------------------------------------------------------------------------
     // Plans

--- a/packages/@granit/react-tax/src/__tests__/tax-provider.test.tsx
+++ b/packages/@granit/react-tax/src/__tests__/tax-provider.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { TaxProvider, buildTaxQueryKey, useTaxConfig } from '../providers/tax-provider.js';
 
 import type { TaxConfig } from '../providers/tax-provider.js';
@@ -9,7 +10,7 @@ import type { AxiosInstance } from 'axios';
 
 const mockConfig: TaxConfig = {
   client: {} as AxiosInstance,
-  basePath: '/api/v1/tax',
+  basePath: DEFAULT_BASE_PATH,
 };
 
 function createWrapper(config: TaxConfig) {
@@ -25,7 +26,7 @@ describe('TaxProvider', () => {
     });
 
     expect(result.current.client).toBe(mockConfig.client);
-    expect(result.current.basePath).toBe('/api/v1/tax');
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-tax/src/constants.ts
+++ b/packages/@granit/react-tax/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'tax';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-tax/src/hooks/use-tax.ts
+++ b/packages/@granit/react-tax/src/hooks/use-tax.ts
@@ -23,7 +23,7 @@ export function useValidateTaxId(): UseMutationResult<
   TaxValidateRequest
 > {
   const config = useTaxConfig();
-  const basePath = config.basePath ?? '/api/v1/tax';
+  const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: TaxValidateRequest) => validateTaxId(config.client, basePath, request),
@@ -40,7 +40,7 @@ export function useValidateTaxId(): UseMutationResult<
  */
 export function useTaxRates(): UseQueryResult<readonly TaxRateResponse[]> {
   const config = useTaxConfig();
-  const basePath = config.basePath ?? '/api/v1/tax';
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildTaxQueryKey(config, 'rates'),
@@ -60,7 +60,7 @@ export function useTaxRates(): UseQueryResult<readonly TaxRateResponse[]> {
  */
 export function useTaxRateByCountry(countryCode: string): UseQueryResult<TaxRateResponse> {
   const config = useTaxConfig();
-  const basePath = config.basePath ?? '/api/v1/tax';
+  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildTaxQueryKey(config, 'rates', countryCode),

--- a/packages/@granit/react-tax/src/providers/tax-provider.tsx
+++ b/packages/@granit/react-tax/src/providers/tax-provider.tsx
@@ -1,5 +1,7 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -20,7 +22,10 @@ const TaxConfigContext = createContext<TaxConfig | null>(null);
 
 /** Provides tax configuration to child components and hooks. */
 export function TaxProvider({ config, children }: Readonly<TaxProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const value = useMemo(() => ({
+    ...config,
+    basePath: config.basePath ?? DEFAULT_BASE_PATH,
+  }), [config]);
   return <TaxConfigContext value={value}>{children}</TaxConfigContext>;
 }
 

--- a/packages/@granit/react-tax/src/testing/handlers.ts
+++ b/packages/@granit/react-tax/src/testing/handlers.ts
@@ -1,14 +1,15 @@
 import { notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { sampleTaxRates, sampleValidation } from './data.js';
 
 /**
  * Create MSW handlers for tax rate and VAT validation endpoints.
  *
- * @param baseUrl - API base path (default: `/api/v1/granit/tax`)
+ * @param baseUrl - API base path (default: `/api/v1/tax`)
  */
-export function createTaxHandlers(baseUrl = '/api/v1/granit/tax') {
+export function createTaxHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
     // GET /rates — all rates
     http.get(`${baseUrl}/rates`, () => HttpResponse.json(sampleTaxRates)),

--- a/packages/@granit/react-templating/src/__tests__/hooks.test.tsx
+++ b/packages/@granit/react-templating/src/__tests__/hooks.test.tsx
@@ -95,7 +95,7 @@ describe('useTemplates', () => {
     });
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
-    expect(client.get).toHaveBeenCalledWith('/api/v1/templates', { params });
+    expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates', { params });
   });
 
   it('should expose error state on failure', async () => {
@@ -165,7 +165,7 @@ describe('useTemplate', () => {
     });
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
-    expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice', {
+    expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates/Billing.Invoice', {
       params: { culture: 'fr-BE' },
     });
   });
@@ -204,7 +204,7 @@ describe('useTemplateMutations', () => {
     result.current.saveDraft.mutate({ name: 'Billing.Invoice', content: '<p>Hello</p>' });
 
     await waitFor(() => expect(result.current.saveDraft.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/api/v1/templates', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/templating/templates', {
       name: 'Billing.Invoice',
       content: '<p>Hello</p>',
     });
@@ -221,7 +221,7 @@ describe('useTemplateMutations', () => {
     result.current.publish.mutate({ name: 'Billing.Invoice' });
 
     await waitFor(() => expect(result.current.publish.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/publish', null, {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/templating/templates/Billing.Invoice/publish', null, {
       params: { culture: undefined },
     });
   });
@@ -237,7 +237,7 @@ describe('useTemplateMutations', () => {
     result.current.unpublish.mutate({ name: 'Billing.Invoice', culture: 'fr-BE' });
 
     await waitFor(() => expect(result.current.unpublish.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/unpublish', null, {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/templating/templates/Billing.Invoice/unpublish', null, {
       params: { culture: 'fr-BE' },
     });
   });
@@ -253,7 +253,7 @@ describe('useTemplateMutations', () => {
     result.current.deleteDraft.mutate({ name: 'Billing.Invoice' });
 
     await waitFor(() => expect(result.current.deleteDraft.isSuccess).toBe(true));
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/draft', {
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/templating/templates/Billing.Invoice/draft', {
       params: { culture: undefined },
     });
   });
@@ -273,7 +273,7 @@ describe('useTemplateMutations', () => {
     });
 
     await waitFor(() => expect(result.current.updateDraft.isSuccess).toBe(true));
-    expect(client.put).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice', {
+    expect(client.put).toHaveBeenCalledWith('/api/v1/templating/templates/Billing.Invoice', {
       name: 'Billing.Invoice',
       content: '<p>Updated</p>',
     });
@@ -499,7 +499,7 @@ describe('useTemplateRevision', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(revision);
-    expect(client.get).toHaveBeenCalledWith('/api/v1/templates/Billing.Invoice/history/rev-1');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates/Billing.Invoice/history/rev-1');
   });
 
   it('should not fetch when name is empty', () => {
@@ -601,7 +601,7 @@ describe('useTemplateBinaryPreview', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toBeInstanceOf(Blob);
     expect(client.post).toHaveBeenCalledWith(
-      '/api/v1/templates/Billing.Invoice/preview',
+      '/api/v1/templating/templates/Billing.Invoice/preview',
       { data: { total: 100 } },
       { responseType: 'blob' }
     );
@@ -732,7 +732,7 @@ describe('useTemplateLayouts', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(layouts);
-    expect(client.get).toHaveBeenCalledWith('/api/v1/templates/layouts');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/templating/templates/layouts');
   });
 
   it('should expose error state on failure', async () => {
@@ -774,7 +774,7 @@ describe('useTemplateCategoryMutations', () => {
     result.current.create.mutate({ name: 'Legal', sortOrder: 2 });
 
     await waitFor(() => expect(result.current.create.isSuccess).toBe(true));
-    expect(client.post).toHaveBeenCalledWith('/api/v1/templates/categories', {
+    expect(client.post).toHaveBeenCalledWith('/api/v1/templating/templates/categories', {
       name: 'Legal',
       sortOrder: 2,
     });
@@ -801,7 +801,7 @@ describe('useTemplateCategoryMutations', () => {
     });
 
     await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
-    expect(client.put).toHaveBeenCalledWith('/api/v1/templates/categories/cat-1', {
+    expect(client.put).toHaveBeenCalledWith('/api/v1/templating/templates/categories/cat-1', {
       name: 'Billing Updated',
       sortOrder: 1,
     });
@@ -819,7 +819,7 @@ describe('useTemplateCategoryMutations', () => {
     result.current.delete.mutate('cat-1');
 
     await waitFor(() => expect(result.current.delete.isSuccess).toBe(true));
-    expect(client.delete).toHaveBeenCalledWith('/api/v1/templates/categories/cat-1');
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/templating/templates/categories/cat-1');
   });
 
   it('should expose error state when create fails', async () => {

--- a/packages/@granit/react-templating/src/__tests__/provider.test.tsx
+++ b/packages/@granit/react-templating/src/__tests__/provider.test.tsx
@@ -9,11 +9,11 @@ describe('TemplatingProvider', () => {
   it('should provide config to children', () => {
     const client = createMockClient();
     const { result } = renderHook(() => useTemplatingConfig(), {
-      wrapper: createWrapper(client, '/api/v1', ['templates']),
+      wrapper: createWrapper(client, '/api/v1/templating', ['templates']),
     });
 
     expect(result.current.client).toBe(client);
-    expect(result.current.basePath).toBe('/api/v1');
+    expect(result.current.basePath).toBe('/api/v1/templating');
     expect(result.current.queryKeyPrefix).toEqual(['templates']);
   });
 
@@ -23,7 +23,7 @@ describe('TemplatingProvider', () => {
       wrapper: createWrapper(client),
     });
 
-    expect(result.current.basePath).toBe('/api/v1');
+    expect(result.current.basePath).toBe('/api/v1/templating');
     expect(result.current.queryKeyPrefix).toEqual(['templates']);
   });
 

--- a/packages/@granit/react-templating/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-templating/src/__tests__/test-utils.tsx
@@ -9,7 +9,7 @@ export { axiosResponse, createMockClient } from '@granit/testing';
 
 export function createWrapper(
   client: AxiosInstance,
-  basePath = '/api/v1',
+  basePath = '/api/v1/templating',
   queryKeyPrefix: readonly string[] = ['templates']
 ) {
   const queryClient = createTestQueryClient();

--- a/packages/@granit/react-templating/src/constants.ts
+++ b/packages/@granit/react-templating/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'templating';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-templating/src/providers/templating-provider.tsx
+++ b/packages/@granit/react-templating/src/providers/templating-provider.tsx
@@ -1,11 +1,12 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { TemplatingConfig } from '@granit/templating';
 import type { AxiosInstance } from 'axios';
 
 const TemplatingConfigContext = createContext<TemplatingConfig | null>(null);
 
-const DEFAULT_BASE_PATH = '/api/v1';
 const DEFAULT_QUERY_KEY_PREFIX = ['templates'] as const;
 
 export interface TemplatingProviderProps {

--- a/packages/@granit/react-templating/src/testing/handlers.ts
+++ b/packages/@granit/react-templating/src/testing/handlers.ts
@@ -2,6 +2,8 @@ import { TemplateLifecycleStatus } from '@granit/templating';
 import { noContent, notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import {
   mockTemplateCategories,
   mockTemplatesData,
@@ -18,7 +20,7 @@ import type { SaveTemplateCategoryRequest, TemplateCategory } from '@granit/temp
  *
  * @param baseUrl - API base path (default: `/api/v1/templating`)
  */
-export function createTemplatesHandlers(baseUrl = '/api/v1/templating') {
+export function createTemplatesHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const BASE = `${baseUrl}/templates`;
 
   let templates = [...mockTemplatesData];

--- a/packages/@granit/react-timeline/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/test-utils.tsx
@@ -1,10 +1,11 @@
 export { axiosResponse, createMockClient } from '@granit/testing';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { TimelineProvider } from '../providers/timeline-provider.js';
 
 import type { AxiosInstance } from 'axios';
 
-export function createWrapper(client: AxiosInstance, basePath = '/api/v1/timeline') {
+export function createWrapper(client: AxiosInstance, basePath = DEFAULT_BASE_PATH) {
   return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
     return (
       <TimelineProvider apiClient={client} basePath={basePath}>

--- a/packages/@granit/react-timeline/src/constants.ts
+++ b/packages/@granit/react-timeline/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'timeline';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-timeline/src/providers/timeline-provider.tsx
+++ b/packages/@granit/react-timeline/src/providers/timeline-provider.tsx
@@ -1,11 +1,11 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { TimelineConfig } from '@granit/timeline';
 import type { AxiosInstance } from 'axios';
 
 const TimelineConfigContext = createContext<TimelineConfig | null>(null);
-
-const DEFAULT_BASE_PATH = '/api/v1/timeline';
 
 export interface TimelineProviderProps {
   apiClient: AxiosInstance;

--- a/packages/@granit/react-timeline/src/testing/handlers.ts
+++ b/packages/@granit/react-timeline/src/testing/handlers.ts
@@ -2,6 +2,7 @@ import { noContent } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockTimelineEntries } from './data.js';
 
 import type { TimelineEntry, TimelineEntryPage } from '@granit/timeline';
@@ -11,7 +12,7 @@ import type { TimelineEntry, TimelineEntryPage } from '@granit/timeline';
  *
  * @param baseUrl - API base path (default: `/api/v1/timeline`)
  */
-export function createTimelineHandlers(baseUrl = '/api/v1/timeline') {
+export function createTimelineHandlers(baseUrl = DEFAULT_BASE_PATH) {
   let entries: TimelineEntry[] = [...mockTimelineEntries];
 
   return [

--- a/packages/@granit/react-webhooks/src/constants.ts
+++ b/packages/@granit/react-webhooks/src/constants.ts
@@ -1,3 +1,4 @@
-export const DEFAULT_BASE_PATH = '/api/v1/webhooks/subscriptions';
-
-export const DEFAULT_WEBHOOKS_BASE_PATH = '/api/v1/webhooks';
+export const API_VERSION = 'v1';
+export const MODULE = 'webhooks';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}/subscriptions`;
+export const DEFAULT_WEBHOOKS_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-webhooks/src/testing/handlers.ts
+++ b/packages/@granit/react-webhooks/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_WEBHOOKS_BASE_PATH } from '../constants.js';
 import {
   applyFilter,
   groupBy as groupByField,
@@ -70,7 +71,7 @@ function generateSecret(): string {
  *
  * @param baseUrl - API base path (default: `/api/v1/webhooks`)
  */
-export function createWebhooksHandlers(baseUrl = '/api/v1/webhooks') {
+export function createWebhooksHandlers(baseUrl = DEFAULT_WEBHOOKS_BASE_PATH) {
   let subscriptions = [...mockWebhookSubscriptions];
   const deliveryAttempts = [...mockWebhookDeliveryAttempts];
 

--- a/packages/@granit/react-workflow/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-workflow/src/__tests__/test-utils.tsx
@@ -1,10 +1,11 @@
 export { axiosResponse, createMockClient } from '@granit/testing';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { WorkflowProvider } from '../providers/workflow-provider.js';
 
 import type { AxiosInstance } from 'axios';
 
-export function createWrapper(client: AxiosInstance, basePath = '/api/v1/workflow') {
+export function createWrapper(client: AxiosInstance, basePath = DEFAULT_BASE_PATH) {
   return function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
     return (
       <WorkflowProvider apiClient={client} basePath={basePath}>

--- a/packages/@granit/react-workflow/src/constants.ts
+++ b/packages/@granit/react-workflow/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'workflow';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-workflow/src/providers/workflow-provider.tsx
+++ b/packages/@granit/react-workflow/src/providers/workflow-provider.tsx
@@ -1,11 +1,11 @@
 import { createContext, useContext, useMemo } from 'react';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
 import type { WorkflowConfig } from '@granit/workflow';
 import type { AxiosInstance } from 'axios';
 
 const WorkflowConfigContext = createContext<WorkflowConfig | null>(null);
-
-const DEFAULT_BASE_PATH = '/api/v1/workflow';
 
 export interface WorkflowProviderProps {
   apiClient: AxiosInstance;

--- a/packages/@granit/react-workflow/src/testing/handlers.ts
+++ b/packages/@granit/react-workflow/src/testing/handlers.ts
@@ -1,6 +1,7 @@
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
+import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockWorkflowHistory, mockWorkflowStatus } from './data.js';
 
 import type {
@@ -43,7 +44,7 @@ function resolveOutcome(
  *
  * @param baseUrl - API base path (default: `/api/v1/workflow`)
  */
-export function createWorkflowHandlers(baseUrl = '/api/v1/workflow') {
+export function createWorkflowHandlers(baseUrl = DEFAULT_BASE_PATH) {
   let currentStatus: WorkflowStatus = { ...mockWorkflowStatus };
   let history: TransitionHistory[] = [...mockWorkflowHistory];
 


### PR DESCRIPTION
## Summary

- Introduce `src/constants.ts` in 29 `@granit/react-*` packages with `API_VERSION`, `MODULE`, and `DEFAULT_BASE_PATH` — single source of truth for API route configuration
- All hooks, providers, testing handlers, and tests import from `constants.ts` instead of defining or hardcoding paths
- Providers resolve `basePath` default via `useMemo` so hooks no longer need fallback logic
- Add React providers for previously hook-only packages: `react-scheduling`, `react-background-jobs`, `react-notifications-mobile-push`, `react-notifications-web-push`
- Fix incorrect base paths: `/api/granit/*` → `/api/v1/*`, `/audit-log` → `/api/v1/auditing`, `/blobs` → `/api/v1/blob-storage`, `/account` → `/api/v1/account`, `/admin` → `/api/v1/admin`
- Hooks for sub-resource modules append entity path to `basePath` (e.g. `/api-keys`, `/blobs`, `/jobs`, `/scheduled-actions`, `/audit-entries`)

## Breaking changes

Packages with new providers have updated hook signatures:
- `useBackgroundJobs(params?)`, `usePauseJob()`, `useResumeJob()`, `useTriggerJob()` — no more options object
- `useScheduledActions(options?)`, `useCancelScheduledAction()`, `useRescheduleScheduledAction()` — no more client/basePath in options
- `useWebPush()`, `useDeviceTokens()` — no params, config from provider
- Removed types: `BackgroundJobsOptions`, `SchedulingOptions`, `DeviceTokensOptions`, `WebPushConfig` (from hooks)

## Test plan

- [x] Full test suite: 248 files, 1974 tests passing
- [x] TypeScript check: `pnpm tsc` clean
- [x] showcase-admin-react: `tsc --noEmit` clean
- [ ] Verify no remaining hardcoded paths outside `constants.ts`
- [ ] Smoke test showcase-admin-react in browser
