### PR TITLE
fix(subscriptions): return PagedResult from listSubscriptions via query-engine

### DIFF
--- a/packages/@granit/react-subscriptions/package.json
+++ b/packages/@granit/react-subscriptions/package.json
@@ -15,6 +15,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/query-engine": "workspace:*",
     "@granit/subscriptions": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",

--- a/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-subscriptions.test.tsx
@@ -18,6 +18,7 @@ import {
 import { SubscriptionsProvider } from '../providers/subscriptions-provider.js';
 
 import type { SubscriptionsConfig } from '../providers/subscriptions-provider.js';
+import type { PagedResult } from '@granit/query-engine';
 import type { BulkMigratePriceResponse, SubscriptionResponse } from '@granit/subscriptions';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -56,9 +57,13 @@ describe('use-subscriptions', () => {
   });
 
   describe('useSubscriptions', () => {
-    it('fetches all subscriptions', async () => {
+    it('fetches subscriptions as PagedResult', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleSubscription] });
+      const pagedResponse: PagedResult<SubscriptionResponse> = {
+        items: [sampleSubscription],
+        totalCount: 1,
+      };
+      vi.mocked(client.get).mockResolvedValue({ data: pagedResponse });
 
       const { result } = renderHook(() => useSubscriptions(), {
         wrapper: createWrapper(client),
@@ -66,7 +71,8 @@ describe('use-subscriptions', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.get).toHaveBeenCalledWith('/api/v1/subscriptions/subscriptions');
-      expect(result.current.data).toEqual([sampleSubscription]);
+      expect(result.current.data?.items).toEqual([sampleSubscription]);
+      expect(result.current.data?.totalCount).toBe(1);
     });
   });
 
@@ -216,7 +222,11 @@ describe('use-subscriptions', () => {
   describe('custom basePath', () => {
     it('uses custom basePath when provided', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleSubscription] });
+      const pagedResponse: PagedResult<SubscriptionResponse> = {
+        items: [sampleSubscription],
+        totalCount: 1,
+      };
+      vi.mocked(client.get).mockResolvedValue({ data: pagedResponse });
 
       const { result } = renderHook(() => useSubscriptions(), {
         wrapper: createWrapper(client, '/custom/path'),

--- a/packages/@granit/react-subscriptions/src/hooks/use-subscriptions.ts
+++ b/packages/@granit/react-subscriptions/src/hooks/use-subscriptions.ts
@@ -8,13 +8,14 @@ import {
   listSubscriptions,
   migrateSubscriptionPrice,
 } from '@granit/subscriptions';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
   buildSubscriptionsQueryKey,
   useSubscriptionsConfig,
 } from '../providers/subscriptions-provider.js';
 
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
 import type {
   BulkMigratePriceRequest,
   BulkMigratePriceResponse,
@@ -27,20 +28,27 @@ import type {
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /**
- * List all subscriptions.
+ * List subscriptions (paginated).
+ *
+ * Returns a {@link PagedResult} with `items` and `totalCount` — matches the
+ * backend `PagedResult<SubscriptionResponse>` shape.
  *
  * @example
  * ```tsx
- * const { data: subscriptions } = useSubscriptions();
+ * const { data } = useSubscriptions();
+ * const { items, totalCount } = data ?? { items: [], totalCount: 0 };
  * ```
  */
-export function useSubscriptions(): UseQueryResult<readonly SubscriptionResponse[]> {
+export function useSubscriptions(
+  params?: QueryRequest
+): UseQueryResult<PagedResult<SubscriptionResponse>> {
   const config = useSubscriptionsConfig();
   const basePath = config.basePath;
 
   return useQuery({
-    queryKey: buildSubscriptionsQueryKey(config, 'subscriptions'),
-    queryFn: () => listSubscriptions(config.client, basePath),
+    queryKey: buildSubscriptionsQueryKey(config, 'subscriptions', JSON.stringify(params ?? {})),
+    queryFn: () => listSubscriptions(config.client, basePath, params),
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/packages/@granit/react-subscriptions/src/testing/handlers.ts
+++ b/packages/@granit/react-subscriptions/src/testing/handlers.ts
@@ -120,17 +120,26 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // Subscriptions
     // ---------------------------------------------------------------------------
 
-    http.get(baseUrl, () => {
-      return HttpResponse.json(mockSubscriptions);
+    http.get(`${baseUrl}/subscriptions`, () => {
+      return HttpResponse.json({
+        items: mockSubscriptions,
+        totalCount: mockSubscriptions.length,
+      });
     }),
 
-    http.get(`${baseUrl}/:subscriptionId`, ({ params }) => {
+    http.get(`${baseUrl}/subscriptions/active`, ({ params: _params }) => {
+      const active = mockSubscriptions.find((s) => s.status === 'Active');
+      if (!active) return notFound();
+      return HttpResponse.json(active);
+    }),
+
+    http.get(`${baseUrl}/subscriptions/:subscriptionId`, ({ params }) => {
       const sub = mockSubscriptions.find((s) => s.id === params.subscriptionId);
       if (!sub) return notFound();
       return HttpResponse.json(sub);
     }),
 
-    http.post(baseUrl, async ({ request }) => {
+    http.post(`${baseUrl}/subscriptions`, async ({ request }) => {
       const body = (await request.json()) as {
         planId: string;
         currency: string;
@@ -160,7 +169,7 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(newSub, { status: 201 });
     }),
 
-    http.post(`${baseUrl}/:subscriptionId/cancel`, ({ params }) => {
+    http.post(`${baseUrl}/subscriptions/:subscriptionId/cancel`, ({ params }) => {
       const sub = mockSubscriptions.find((s) => s.id === params.subscriptionId);
       if (!sub) return notFound();
       sub.status = 'Canceled';
@@ -168,19 +177,22 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(sub);
     }),
 
-    http.post(`${baseUrl}/:subscriptionId/change-plan`, async ({ params, request }) => {
-      const body = (await request.json()) as { newPlanId: string };
-      const sub = mockSubscriptions.find((s) => s.id === params.subscriptionId);
-      if (!sub) return notFound();
-      sub.planId = toEntityId<'Plan'>(body.newPlanId);
-      return HttpResponse.json(sub);
-    }),
+    http.post(
+      `${baseUrl}/subscriptions/:subscriptionId/change-plan`,
+      async ({ params, request }) => {
+        const body = (await request.json()) as { newPlanId: string };
+        const sub = mockSubscriptions.find((s) => s.id === params.subscriptionId);
+        if (!sub) return notFound();
+        sub.planId = toEntityId<'Plan'>(body.newPlanId);
+        return HttpResponse.json(sub);
+      }
+    ),
 
-    http.post(`${baseUrl}/:subscriptionId/migrate-price`, () => {
+    http.post(`${baseUrl}/subscriptions/:subscriptionId/migrate-price`, () => {
       return noContent();
     }),
 
-    http.post(`${baseUrl}/bulk-migrate-price`, () => {
+    http.post(`${baseUrl}/subscriptions/bulk-migrate-price`, () => {
       return HttpResponse.json({ migratedCount: 3 });
     }),
 
@@ -188,12 +200,12 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // Seats
     // ---------------------------------------------------------------------------
 
-    http.get(`${baseUrl}/:subscriptionId/seats`, ({ params }) => {
+    http.get(`${baseUrl}/subscriptions/:subscriptionId/seats`, ({ params }) => {
       const seats = mockSeats[params.subscriptionId as string] ?? [];
       return HttpResponse.json(seats);
     }),
 
-    http.post(`${baseUrl}/:subscriptionId/seats`, async ({ params, request }) => {
+    http.post(`${baseUrl}/subscriptions/:subscriptionId/seats`, async ({ params, request }) => {
       const body = (await request.json()) as { userId: string };
       const subscriptionId = params.subscriptionId as string;
       mockSeats[subscriptionId] ??= [];
@@ -208,7 +220,7 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(newSeat, { status: 201 });
     }),
 
-    http.delete(`${baseUrl}/:subscriptionId/seats/:seatId`, ({ params }) => {
+    http.delete(`${baseUrl}/subscriptions/:subscriptionId/seats/:seatId`, ({ params }) => {
       const subscriptionId = params.subscriptionId as string;
       const seatId = params.seatId as string;
       if (mockSeats[subscriptionId]) {

--- a/packages/@granit/subscriptions/package.json
+++ b/packages/@granit/subscriptions/package.json
@@ -20,6 +20,7 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/query-engine": "workspace:*",
     "axios": "*"
   },
   "publishConfig": {

--- a/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
+++ b/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
@@ -30,6 +30,7 @@ import type {
   SeatResponse,
   SubscriptionResponse,
 } from '../types.js';
+import type { PagedResult } from '@granit/query-engine';
 
 const basePath = '/api/granit/subscriptions';
 
@@ -252,14 +253,34 @@ describe('subscriptions-api — Plans', () => {
 
 describe('subscriptions-api — Subscriptions', () => {
   describe('listSubscriptions', () => {
-    it('should GET {basePath}/subscriptions', async () => {
+    it('should GET {basePath}/subscriptions and return PagedResult', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleSubscription]));
+      const pagedResponse: PagedResult<SubscriptionResponse> = {
+        items: [sampleSubscription],
+        totalCount: 1,
+      };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(pagedResponse));
 
       const result = await listSubscriptions(client, basePath);
 
       expect(client.get).toHaveBeenCalledWith(`${basePath}/subscriptions`);
-      expect(result).toEqual([sampleSubscription]);
+      expect(result.items).toEqual([sampleSubscription]);
+      expect(result.totalCount).toBe(1);
+    });
+
+    it('should forward query params', async () => {
+      const client = createMockClient();
+      const pagedResponse: PagedResult<SubscriptionResponse> = {
+        items: [sampleSubscription],
+        totalCount: 1,
+      };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(pagedResponse));
+
+      await listSubscriptions(client, basePath, { page: 2, pageSize: 10 });
+
+      expect(client.get).toHaveBeenCalledWith(
+        expect.stringContaining(`${basePath}/subscriptions?`)
+      );
     });
   });
 

--- a/packages/@granit/subscriptions/src/api/subscriptions-api.ts
+++ b/packages/@granit/subscriptions/src/api/subscriptions-api.ts
@@ -1,3 +1,5 @@
+import { fetchPage } from '@granit/query-engine';
+
 import type {
   BulkMigratePriceRequest,
   BulkMigratePriceResponse,
@@ -14,6 +16,7 @@ import type {
   SubscriptionCreateRequest,
   SubscriptionResponse,
 } from '../types.js';
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
 import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
@@ -144,16 +147,19 @@ export async function getPlanPriceHistory(
 // ---------------------------------------------------------------------------
 
 /**
- * List all subscriptions.
+ * List subscriptions (paginated).
  *
  * `GET {basePath}/subscriptions`
+ *
+ * Delegates to {@link fetchPage} from `@granit/query-engine` so query
+ * parameters (page, pageSize, filters, sort, …) are serialized consistently.
  */
 export async function listSubscriptions(
   client: AxiosInstance,
-  basePath: string
-): Promise<readonly SubscriptionResponse[]> {
-  const response = await client.get<readonly SubscriptionResponse[]>(`${basePath}/subscriptions`);
-  return response.data;
+  basePath: string,
+  params?: QueryRequest
+): Promise<PagedResult<SubscriptionResponse>> {
+  return fetchPage<SubscriptionResponse>(client, `${basePath}/subscriptions`, params ?? {});
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1425,6 +1425,9 @@ importers:
 
   packages/@granit/react-subscriptions:
     dependencies:
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/subscriptions':
         specifier: workspace:*
         version: link:../subscriptions
@@ -1729,6 +1732,9 @@ importers:
 
   packages/@granit/subscriptions:
     dependencies:
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/types':
         specifier: workspace:*
         version: link:../types


### PR DESCRIPTION
## Summary

- **`listSubscriptions`** now delegates to `fetchPage` from `@granit/query-engine` and returns `PagedResult<SubscriptionResponse>` instead of a plain array — matching the backend `Granit.QueryEngine.PagedResult` contract
- **`useSubscriptions`** hook updated to return `UseQueryResult<PagedResult<…>>` with `keepPreviousData` for smooth pagination transitions; accepts optional `QueryRequest` params
- MSW handlers fixed: routes aligned to `{baseUrl}/subscriptions/…` and response wrapped in `PagedResult` shape
- `@granit/query-engine` added as peer dep to both `@granit/subscriptions` and `@granit/react-subscriptions`

Consumers needing full query engine features (filtering, sorting, grouping) can use `QueryProvider` + `useQueryEndpoint<SubscriptionResponse>()` directly, pointed at the subscriptions collection path.

## Test plan

- [x] `pnpm tsc` — no type errors
- [x] `npx vitest run packages/@granit/subscriptions packages/@granit/react-subscriptions` — 53 tests pass
- [x] ESLint — 0 warnings
