### PR TITLE
fix(data-exchange): align export API paths with backend sub-group routes

### DIFF
--- a/packages/@granit/data-exchange/src/__tests__/export/export-api.test.ts
+++ b/packages/@granit/data-exchange/src/__tests__/export/export-api.test.ts
@@ -10,7 +10,7 @@ import {
   fetchExportJobStatus,
 } from '../../export/api/export-api.js';
 
-const BASE = '/api/v1/data-exchange/export';
+const BASE = '/api/v1/data-exchange';
 
 describe('export-api', () => {
   it('fetchExportDefinitions calls GET /definitions', async () => {
@@ -18,7 +18,7 @@ describe('export-api', () => {
     const defs = [{ name: 'Test', entityType: 'Entity', supportedFormats: ['xlsx'] }];
     vi.mocked(client.get).mockResolvedValueOnce({ data: defs });
     const result = await fetchExportDefinitions(client, BASE);
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/definitions`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/metadata/definitions`);
     expect(result).toEqual(defs);
   });
 
@@ -36,7 +36,7 @@ describe('export-api', () => {
     ];
     vi.mocked(client.get).mockResolvedValueOnce({ data: fields });
     const result = await fetchExportFields(client, BASE, 'Test');
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/definitions/Test/fields`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/metadata/definitions/Test/fields`);
     expect(result).toEqual(fields);
   });
 
@@ -44,7 +44,7 @@ describe('export-api', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
     await fetchExportFields(client, BASE, 'My Export');
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/definitions/My%20Export/fields`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/metadata/definitions/My%20Export/fields`);
   });
 
   it('createExportJob calls POST /jobs', async () => {
@@ -62,7 +62,7 @@ describe('export-api', () => {
       search: null,
     };
     const result = await createExportJob(client, BASE, request);
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/jobs`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/export/jobs`, request);
     expect(result).toEqual(job);
   });
 
@@ -71,7 +71,7 @@ describe('export-api', () => {
     const job = { id: 'abc', status: 'Exporting' };
     vi.mocked(client.get).mockResolvedValueOnce({ data: job });
     const result = await fetchExportJobStatus(client, BASE, 'abc');
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/jobs/abc`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/export/jobs/abc`);
     expect(result).toEqual(job);
   });
 
@@ -83,7 +83,7 @@ describe('export-api', () => {
       headers: { 'content-disposition': 'attachment; filename="export.xlsx"' },
     });
     const result = await downloadExportFile(client, BASE, 'abc');
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/jobs/abc/download`, { responseType: 'blob' });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/export/jobs/abc/download`, { responseType: 'blob' });
     expect(result.blob).toBe(blob);
     expect(result.fileName).toBe('export.xlsx');
   });
@@ -101,7 +101,7 @@ describe('export-api', () => {
     const page = { items: [], totalCount: 0 };
     vi.mocked(client.get).mockResolvedValueOnce({ data: page });
     const result = await fetchExportJobs(client, BASE);
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/jobs`, { params: undefined });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/export/jobs`, { params: undefined });
     expect(result).toEqual(page);
   });
 
@@ -111,7 +111,7 @@ describe('export-api', () => {
     vi.mocked(client.get).mockResolvedValueOnce({ data: page });
     const params = { status: 'Completed', page: 1, pageSize: 10 };
     const result = await fetchExportJobs(client, BASE, params);
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/jobs`, { params });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/export/jobs`, { params });
     expect(result).toEqual(page);
   });
 });

--- a/packages/@granit/data-exchange/src/__tests__/export/preset-api.test.ts
+++ b/packages/@granit/data-exchange/src/__tests__/export/preset-api.test.ts
@@ -7,7 +7,7 @@ import {
   saveExportPreset,
 } from '../../export/api/preset-api.js';
 
-const BASE = '/api/v1/data-exchange/export';
+const BASE = '/api/v1/data-exchange';
 
 describe('preset-api', () => {
   it('fetchExportPresets calls GET /presets/{definitionName}', async () => {
@@ -23,7 +23,7 @@ describe('preset-api', () => {
     ];
     vi.mocked(client.get).mockResolvedValueOnce({ data: presets });
     const result = await fetchExportPresets(client, BASE, 'Test');
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/presets/Test`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/metadata/presets/Test`);
     expect(result).toEqual(presets);
   });
 
@@ -37,18 +37,18 @@ describe('preset-api', () => {
       includeIdForImport: true,
     };
     await saveExportPreset(client, BASE, request);
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/presets`, request);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/metadata/presets`, request);
   });
 
   it('deleteExportPreset calls DELETE /presets/{definitionName}/{presetName}', async () => {
     const client = createMockClient();
     await deleteExportPreset(client, BASE, 'Test', 'Monthly');
-    expect(client.delete).toHaveBeenCalledWith(`${BASE}/presets/Test/Monthly`);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/metadata/presets/Test/Monthly`);
   });
 
   it('deleteExportPreset encodes names', async () => {
     const client = createMockClient();
     await deleteExportPreset(client, BASE, 'My Export', 'Monthly Report');
-    expect(client.delete).toHaveBeenCalledWith(`${BASE}/presets/My%20Export/Monthly%20Report`);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/metadata/presets/My%20Export/Monthly%20Report`);
   });
 });

--- a/packages/@granit/data-exchange/src/export/api/export-api.ts
+++ b/packages/@granit/data-exchange/src/export/api/export-api.ts
@@ -11,20 +11,20 @@ export type ExportJobListParams = PaginationParams & {
 /**
  * Fetches all registered export definitions.
  *
- * `GET {basePath}/definitions`
+ * `GET {basePath}/metadata/definitions`
  */
 export async function fetchExportDefinitions(
   client: AxiosInstance,
   basePath: string
 ): Promise<readonly ExportDefinitionResponse[]> {
-  const response = await client.get<ExportDefinitionResponse[]>(`${basePath}/definitions`);
+  const response = await client.get<ExportDefinitionResponse[]>(`${basePath}/metadata/definitions`);
   return response.data;
 }
 
 /**
  * Fetches the available fields for a given export definition.
  *
- * `GET {basePath}/definitions/{name}/fields`
+ * `GET {basePath}/metadata/definitions/{name}/fields`
  */
 export async function fetchExportFields(
   client: AxiosInstance,
@@ -32,7 +32,7 @@ export async function fetchExportFields(
   definitionName: string
 ): Promise<readonly ExportField[]> {
   const response = await client.get<ExportField[]>(
-    `${basePath}/definitions/${encodeURIComponent(definitionName)}/fields`
+    `${basePath}/metadata/definitions/${encodeURIComponent(definitionName)}/fields`
   );
   return response.data;
 }
@@ -40,21 +40,21 @@ export async function fetchExportFields(
 /**
  * Creates an export job.
  *
- * `POST {basePath}/jobs`
+ * `POST {basePath}/export/jobs`
  */
 export async function createExportJob(
   client: AxiosInstance,
   basePath: string,
   request: CreateExportJobRequest
 ): Promise<ExportJobResponse> {
-  const response = await client.post<ExportJobResponse>(`${basePath}/jobs`, request);
+  const response = await client.post<ExportJobResponse>(`${basePath}/export/jobs`, request);
   return response.data;
 }
 
 /**
  * Fetches the current status of an export job.
  *
- * `GET {basePath}/jobs/{jobId}`
+ * `GET {basePath}/export/jobs/{jobId}`
  */
 export async function fetchExportJobStatus(
   client: AxiosInstance,
@@ -62,7 +62,7 @@ export async function fetchExportJobStatus(
   jobId: string
 ): Promise<ExportJobResponse> {
   const response = await client.get<ExportJobResponse>(
-    `${basePath}/jobs/${encodeURIComponent(jobId)}`
+    `${basePath}/export/jobs/${encodeURIComponent(jobId)}`
   );
   return response.data;
 }
@@ -70,14 +70,14 @@ export async function fetchExportJobStatus(
 /**
  * Fetches a paginated list of export jobs.
  *
- * `GET {basePath}/jobs`
+ * `GET {basePath}/export/jobs`
  */
 export async function fetchExportJobs(
   client: AxiosInstance,
   basePath: string,
   params?: ExportJobListParams
 ): Promise<PagedResult<ExportJobResponse>> {
-  const response = await client.get<PagedResult<ExportJobResponse>>(`${basePath}/jobs`, {
+  const response = await client.get<PagedResult<ExportJobResponse>>(`${basePath}/export/jobs`, {
     params,
   });
   return response.data;
@@ -86,7 +86,7 @@ export async function fetchExportJobs(
 /**
  * Downloads the generated export file.
  *
- * `GET {basePath}/jobs/{jobId}/download`
+ * `GET {basePath}/export/jobs/{jobId}/download`
  */
 export async function downloadExportFile(
   client: AxiosInstance,
@@ -94,7 +94,7 @@ export async function downloadExportFile(
   jobId: string
 ): Promise<{ blob: Blob; fileName: string }> {
   const response = await client.get<Blob>(
-    `${basePath}/jobs/${encodeURIComponent(jobId)}/download`,
+    `${basePath}/export/jobs/${encodeURIComponent(jobId)}/download`,
     { responseType: 'blob' }
   );
 

--- a/packages/@granit/data-exchange/src/export/api/preset-api.ts
+++ b/packages/@granit/data-exchange/src/export/api/preset-api.ts
@@ -4,7 +4,7 @@ import type { AxiosInstance } from 'axios';
 /**
  * Fetches saved export presets for a given definition.
  *
- * `GET {basePath}/presets/{definitionName}`
+ * `GET {basePath}/metadata/presets/{definitionName}`
  */
 export async function fetchExportPresets(
   client: AxiosInstance,
@@ -12,7 +12,7 @@ export async function fetchExportPresets(
   definitionName: string
 ): Promise<readonly ExportPresetResponse[]> {
   const response = await client.get<ExportPresetResponse[]>(
-    `${basePath}/presets/${encodeURIComponent(definitionName)}`
+    `${basePath}/metadata/presets/${encodeURIComponent(definitionName)}`
   );
   return response.data;
 }
@@ -20,20 +20,20 @@ export async function fetchExportPresets(
 /**
  * Saves or updates an export preset.
  *
- * `POST {basePath}/presets`
+ * `POST {basePath}/metadata/presets`
  */
 export async function saveExportPreset(
   client: AxiosInstance,
   basePath: string,
   request: SaveExportPresetRequest
 ): Promise<void> {
-  await client.post(`${basePath}/presets`, request);
+  await client.post(`${basePath}/metadata/presets`, request);
 }
 
 /**
  * Deletes a saved export preset.
  *
- * `DELETE {basePath}/presets/{definitionName}/{presetName}`
+ * `DELETE {basePath}/metadata/presets/{definitionName}/{presetName}`
  */
 export async function deleteExportPreset(
   client: AxiosInstance,
@@ -42,6 +42,6 @@ export async function deleteExportPreset(
   presetName: string
 ): Promise<void> {
   await client.delete(
-    `${basePath}/presets/${encodeURIComponent(definitionName)}/${encodeURIComponent(presetName)}`
+    `${basePath}/metadata/presets/${encodeURIComponent(definitionName)}/${encodeURIComponent(presetName)}`
   );
 }

--- a/packages/@granit/react-data-exchange/src/__tests__/export/export-provider.test.tsx
+++ b/packages/@granit/react-data-exchange/src/__tests__/export/export-provider.test.tsx
@@ -14,7 +14,7 @@ import type { ReactNode } from 'react';
 function createConfig(overrides?: Partial<ExportConfig>): ExportConfig {
   return {
     client: axios.create(),
-    basePath: '/api/v1/data-exchange/metadata',
+    basePath: '/api/v1/data-exchange',
     ...overrides,
   };
 }
@@ -31,7 +31,7 @@ describe('ExportProvider', () => {
     const { result } = renderHook(() => useExportConfig(), {
       wrapper: wrapper(config),
     });
-    expect(result.current.basePath).toBe('/api/v1/data-exchange/metadata');
+    expect(result.current.basePath).toBe('/api/v1/data-exchange');
     expect(result.current.client).toBe(config.client);
   });
 

--- a/packages/@granit/react-data-exchange/src/__tests__/export/use-export-definition.test.tsx
+++ b/packages/@granit/react-data-exchange/src/__tests__/export/use-export-definition.test.tsx
@@ -14,7 +14,7 @@ const mockClient = axios.create();
 
 const mockConfig: ExportConfig = {
   client: mockClient,
-  basePath: '/api/v1/data-exchange/metadata',
+  basePath: '/api/v1/data-exchange',
 };
 
 function createWrapper() {

--- a/packages/@granit/react-data-exchange/src/__tests__/export/use-export-job.test.tsx
+++ b/packages/@granit/react-data-exchange/src/__tests__/export/use-export-job.test.tsx
@@ -14,7 +14,7 @@ const mockClient = axios.create();
 
 const mockConfig: ExportConfig = {
   client: mockClient,
-  basePath: '/api/v1/data-exchange/metadata',
+  basePath: '/api/v1/data-exchange',
 };
 
 function createWrapper() {

--- a/packages/@granit/react-data-exchange/src/__tests__/export/use-export-jobs.test.tsx
+++ b/packages/@granit/react-data-exchange/src/__tests__/export/use-export-jobs.test.tsx
@@ -14,7 +14,7 @@ const mockClient = axios.create();
 
 const mockConfig: ExportConfig = {
   client: mockClient,
-  basePath: '/api/v1/data-exchange/metadata',
+  basePath: '/api/v1/data-exchange',
 };
 
 function createWrapper() {
@@ -55,7 +55,7 @@ describe('useExportJobs', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.items).toHaveLength(1);
     expect(result.current.data?.totalCount).toBe(1);
-    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/data-exchange/metadata/jobs', {
+    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/data-exchange/export/jobs', {
       params: undefined,
     });
   });
@@ -71,7 +71,7 @@ describe('useExportJobs', () => {
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/data-exchange/metadata/jobs', {
+    expect(mockClient.get).toHaveBeenCalledWith('/api/v1/data-exchange/export/jobs', {
       params: { status: 'Failed', page: 2, pageSize: 10 },
     });
   });

--- a/packages/@granit/react-data-exchange/src/__tests__/export/use-export-presets.test.tsx
+++ b/packages/@granit/react-data-exchange/src/__tests__/export/use-export-presets.test.tsx
@@ -14,7 +14,7 @@ const mockClient = axios.create();
 
 const mockConfig: ExportConfig = {
   client: mockClient,
-  basePath: '/api/v1/data-exchange/metadata',
+  basePath: '/api/v1/data-exchange',
 };
 
 function createWrapper() {

--- a/packages/@granit/react-data-exchange/src/testing/handlers.ts
+++ b/packages/@granit/react-data-exchange/src/testing/handlers.ts
@@ -310,12 +310,12 @@ let importJobCounter = 0;
  *
  * @param metadataBase   - Export metadata base path (default: `/api/v1/data-exchange/metadata`)
  * @param importBase     - Import base path (default: `/api/v1/data-exchange`)
- * @param exportJobsBase - Export jobs base path (default: `/api/v1/data-exchange/metadata/jobs`)
+ * @param exportJobsBase - Export jobs base path (default: `/api/v1/data-exchange/export/jobs`)
  */
 export function createDataExchangeHandlers(
   metadataBase = `${DEFAULT_BASE_PATH}/metadata`,
   importBase = DEFAULT_BASE_PATH,
-  exportJobsBase = `${DEFAULT_BASE_PATH}/metadata/jobs`
+  exportJobsBase = `${DEFAULT_BASE_PATH}/export/jobs`
 ) {
   return [
     // Export: definitions
@@ -369,7 +369,7 @@ export function createDataExchangeHandlers(
     }),
 
     // Export: create job
-    http.post(`${metadataBase}/jobs`, async ({ request }) => {
+    http.post(exportJobsBase, async ({ request }) => {
       const body = (await request.json()) as { definitionName: string; format: string };
       const job = {
         id: crypto.randomUUID(),
@@ -386,7 +386,7 @@ export function createDataExchangeHandlers(
     }),
 
     // Export: job status
-    http.get(`${metadataBase}/jobs/:jobId`, () => {
+    http.get(`${exportJobsBase}/:jobId`, () => {
       return HttpResponse.json({
         id: 'mock',
         definitionName: 'countries',
@@ -401,7 +401,7 @@ export function createDataExchangeHandlers(
     }),
 
     // Export: download file
-    http.get(`${metadataBase}/jobs/:jobId/download`, () => {
+    http.get(`${exportJobsBase}/:jobId/download`, () => {
       const csv =
         'code,alpha3,labelEn,labelFr,region,isActive\nBE,BEL,Belgium,Belgique,Europe,true\n';
       return new HttpResponse(csv, {


### PR DESCRIPTION
## Summary

- Prefix export definition/field API calls with `/metadata/` and job API calls with `/export/` to match the backend `Granit.DataExchange.Endpoints` sub-group structure
- Update preset API paths to use `/metadata/presets/...`
- Fix MSW test handlers to route export job endpoints via `exportJobsBase` instead of `metadataBase`
- Update all test assertions and `basePath` configs to use the root `/api/v1/data-exchange`

## Test plan

- [x] `vitest --run` on `@granit/data-exchange` export tests (9 tests pass)
- [x] `vitest --run` on `@granit/react-data-exchange` export tests (24 tests pass)