### PR TITLE
feat(identity): expose supportsGroupManagement capability

### DIFF
--- a/packages/@granit/identity/src/__tests__/identity-capabilities-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-capabilities-api.test.ts
@@ -14,6 +14,7 @@ const keycloakCapabilities: IdentityProviderCapabilities = {
   maxCustomAttributes: 2147483647,
   supportsCredentialVerification: true,
   supportsUserCreation: true,
+  supportsGroupManagement: true,
 };
 
 describe('identity-capabilities-api', () => {
@@ -46,6 +47,7 @@ describe('identity-capabilities-api', () => {
       maxCustomAttributes: 15,
       supportsCredentialVerification: true,
       supportsUserCreation: true,
+      supportsGroupManagement: false,
     };
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: entraCapabilities });

--- a/packages/@granit/identity/src/types/index.ts
+++ b/packages/@granit/identity/src/types/index.ts
@@ -40,4 +40,6 @@ export interface IdentityProviderCapabilities {
   readonly supportsCredentialVerification: boolean;
   /** Whether the provider supports creating new user accounts. */
   readonly supportsUserCreation: boolean;
+  /** Whether tenant admins can create, update, and delete groups via the API. */
+  readonly supportsGroupManagement: boolean;
 }

--- a/packages/@granit/react-identity/src/__tests__/use-identity-capabilities.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-capabilities.test.tsx
@@ -38,6 +38,7 @@ const mockCapabilities: IdentityProviderCapabilities = {
   maxCustomAttributes: 50,
   supportsCredentialVerification: true,
   supportsUserCreation: true,
+  supportsGroupManagement: false,
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/react-identity/src/testing/handlers.ts
+++ b/packages/@granit/react-identity/src/testing/handlers.ts
@@ -101,6 +101,7 @@ const capabilities: IdentityProviderCapabilities = {
   maxCustomAttributes: 20,
   supportsCredentialVerification: true,
   supportsUserCreation: true,
+  supportsGroupManagement: false,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add `supportsGroupManagement: boolean` to `IdentityProviderCapabilities`, mirroring the backend field introduced in [granit-fx/granit-dotnet#1040](https://github.com/granit-fx/granit-dotnet/issues/1040).
- Field is placed at the end of the interface to match the backend DTO order.
- Updated existing capability fixtures in `@granit/identity` tests and in `@granit/react-identity` (MSW handlers + hook tests) so the fixture shape stays exhaustive.

## Context

Backend now surfaces `supportsGroupManagement` via `GET /identity/capabilities`. It returns `false` for every provider today because the group CRUD endpoint is not implemented yet. Consumers (starting with showcase-admin-react) will gate group lifecycle UI on this flag.

## Test plan

- [x] `pnpm --filter @granit/identity build`
- [x] `pnpm vitest run packages/@granit/identity`
- [x] `pnpm vitest run packages/@granit/react-identity`
- [x] `pnpm tsc`
- [x] `pnpm lint`