### PR TITLE
fix(privacy,deps): pluralize privacy routes + patch protobufjs CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
       "smol-toml": ">=1.6.1",
-      "brace-expansion": ">=5.0.5"
+      "brace-expansion": ">=5.0.5",
+      "protobufjs": "^7.5.5"
     }
   },
   "lint-staged": {

--- a/packages/@granit/privacy/src/__tests__/privacy-api.test.ts
+++ b/packages/@granit/privacy/src/__tests__/privacy-api.test.ts
@@ -35,20 +35,20 @@ describe('privacy-api', () => {
   // ── Data Export ──────────────────────────────────────────────────────────
 
   describe('requestExport', () => {
-    it('sends POST to /export', async () => {
+    it('sends POST to /exports', async () => {
       const client = createMockClient();
       const response = { requestId: 'req-1', requestedAt: '2026-03-21T10:00:00Z' };
       vi.mocked(client.post).mockResolvedValueOnce({ data: response });
 
       const result = await requestExport(client, BASE);
 
-      expect(client.post).toHaveBeenCalledWith(`${BASE}/export`);
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/exports`);
       expect(result).toEqual(response);
     });
   });
 
   describe('getExportStatus', () => {
-    it('sends GET to /export/{requestId}', async () => {
+    it('sends GET to /exports/{requestId}', async () => {
       const client = createMockClient();
       const response: PrivacyExportStatusResponse = {
         requestId: 'req-1',
@@ -62,20 +62,20 @@ describe('privacy-api', () => {
 
       const result = await getExportStatus(client, BASE, 'req-1');
 
-      expect(client.get).toHaveBeenCalledWith(`${BASE}/export/req-1`);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/exports/req-1`);
       expect(result).toEqual(response);
     });
   });
 
   describe('listExports', () => {
-    it('sends GET to /export', async () => {
+    it('sends GET to /exports', async () => {
       const client = createMockClient();
       const response: PrivacyExportStatusResponse[] = [];
       vi.mocked(client.get).mockResolvedValueOnce({ data: response });
 
       const result = await listExports(client, BASE);
 
-      expect(client.get).toHaveBeenCalledWith(`${BASE}/export`);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/exports`);
       expect(result).toEqual(response);
     });
   });
@@ -83,7 +83,7 @@ describe('privacy-api', () => {
   // ── Data Deletion ───────────────────────────────────────────────────────
 
   describe('requestDeletion', () => {
-    it('sends POST to /deletion with reason', async () => {
+    it('sends POST to /deletions with reason', async () => {
       const client = createMockClient();
       const response: PrivacyDeletionResponse = {
         requestId: 'del-1',
@@ -98,13 +98,13 @@ describe('privacy-api', () => {
         reason: 'User requested account deletion',
       });
 
-      expect(client.post).toHaveBeenCalledWith(`${BASE}/deletion`, {
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/deletions`, {
         reason: 'User requested account deletion',
       });
       expect(result).toEqual(response);
     });
 
-    it('sends POST to /deletion with defer flag', async () => {
+    it('sends POST to /deletions with defer flag', async () => {
       const client = createMockClient();
       const response: PrivacyDeletionResponse = {
         requestId: 'del-2',
@@ -121,7 +121,7 @@ describe('privacy-api', () => {
         defer: true,
       });
 
-      expect(client.post).toHaveBeenCalledWith(`${BASE}/deletion`, {
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/deletions`, {
         reason: 'Closing account',
         defer: true,
       });
@@ -130,7 +130,7 @@ describe('privacy-api', () => {
   });
 
   describe('listDeletions', () => {
-    it('sends GET to /deletion', async () => {
+    it('sends GET to /deletions', async () => {
       const client = createMockClient();
       const response: PrivacyDeletionResponse[] = [
         {
@@ -146,13 +146,13 @@ describe('privacy-api', () => {
 
       const result = await listDeletions(client, BASE);
 
-      expect(client.get).toHaveBeenCalledWith(`${BASE}/deletion`);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/deletions`);
       expect(result).toEqual(response);
     });
   });
 
   describe('getDeletionStatus', () => {
-    it('sends GET to /deletion/{requestId}', async () => {
+    it('sends GET to /deletions/{requestId}', async () => {
       const client = createMockClient();
       const response: PrivacyDeletionResponse = {
         requestId: 'del-1',
@@ -166,19 +166,19 @@ describe('privacy-api', () => {
 
       const result = await getDeletionStatus(client, BASE, 'del-1');
 
-      expect(client.get).toHaveBeenCalledWith(`${BASE}/deletion/del-1`);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/deletions/del-1`);
       expect(result).toEqual(response);
     });
   });
 
   describe('cancelDeletion', () => {
-    it('sends POST to /deletion/{requestId}/cancel', async () => {
+    it('sends POST to /deletions/{requestId}/cancel', async () => {
       const client = createMockClient();
       vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
       await cancelDeletion(client, BASE, 'del-1');
 
-      expect(client.post).toHaveBeenCalledWith(`${BASE}/deletion/del-1/cancel`);
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/deletions/del-1/cancel`);
     });
   });
 

--- a/packages/@granit/privacy/src/api/privacy-api.ts
+++ b/packages/@granit/privacy/src/api/privacy-api.ts
@@ -19,20 +19,20 @@ import type { AxiosInstance } from 'axios';
 /**
  * Request a GDPR data export. Returns 202 with the request ID.
  *
- * `POST {basePath}/export`
+ * `POST {basePath}/exports`
  */
 export async function requestExport(
   client: AxiosInstance,
   basePath: string
 ): Promise<PrivacyExportRequestResponse> {
-  const { data } = await client.post<PrivacyExportRequestResponse>(`${basePath}/export`);
+  const { data } = await client.post<PrivacyExportRequestResponse>(`${basePath}/exports`);
   return data;
 }
 
 /**
  * Get the status of a data export request.
  *
- * `GET {basePath}/export/{requestId}`
+ * `GET {basePath}/exports/{requestId}`
  */
 export async function getExportStatus(
   client: AxiosInstance,
@@ -40,7 +40,7 @@ export async function getExportStatus(
   requestId: string
 ): Promise<PrivacyExportStatusResponse> {
   const { data } = await client.get<PrivacyExportStatusResponse>(
-    `${basePath}/export/${encodeURIComponent(requestId)}`
+    `${basePath}/exports/${encodeURIComponent(requestId)}`
   );
   return data;
 }
@@ -48,13 +48,13 @@ export async function getExportStatus(
 /**
  * List all data export requests for the current user.
  *
- * `GET {basePath}/export`
+ * `GET {basePath}/exports`
  */
 export async function listExports(
   client: AxiosInstance,
   basePath: string
 ): Promise<PrivacyExportStatusResponse[]> {
-  const { data } = await client.get<PrivacyExportStatusResponse[]>(`${basePath}/export`);
+  const { data } = await client.get<PrivacyExportStatusResponse[]>(`${basePath}/exports`);
   return data;
 }
 
@@ -66,34 +66,34 @@ export async function listExports(
  * When `defer` is `true`, the deletion is scheduled after a cooling-off
  * period and can be cancelled via {@link cancelDeletion}.
  *
- * `POST {basePath}/deletion`
+ * `POST {basePath}/deletions`
  */
 export async function requestDeletion(
   client: AxiosInstance,
   basePath: string,
   request: PrivacyDeletionRequest
 ): Promise<PrivacyDeletionResponse> {
-  const { data } = await client.post<PrivacyDeletionResponse>(`${basePath}/deletion`, request);
+  const { data } = await client.post<PrivacyDeletionResponse>(`${basePath}/deletions`, request);
   return data;
 }
 
 /**
  * List all deletion requests for the current user.
  *
- * `GET {basePath}/deletion`
+ * `GET {basePath}/deletions`
  */
 export async function listDeletions(
   client: AxiosInstance,
   basePath: string
 ): Promise<PrivacyDeletionResponse[]> {
-  const { data } = await client.get<PrivacyDeletionResponse[]>(`${basePath}/deletion`);
+  const { data } = await client.get<PrivacyDeletionResponse[]>(`${basePath}/deletions`);
   return data;
 }
 
 /**
  * Get the status of a specific deletion request.
  *
- * `GET {basePath}/deletion/{requestId}`
+ * `GET {basePath}/deletions/{requestId}`
  */
 export async function getDeletionStatus(
   client: AxiosInstance,
@@ -101,7 +101,7 @@ export async function getDeletionStatus(
   requestId: string
 ): Promise<PrivacyDeletionResponse> {
   const { data } = await client.get<PrivacyDeletionResponse>(
-    `${basePath}/deletion/${encodeURIComponent(requestId)}`
+    `${basePath}/deletions/${encodeURIComponent(requestId)}`
   );
   return data;
 }
@@ -111,14 +111,14 @@ export async function getDeletionStatus(
  *
  * Returns 409 if the request is already executed or already cancelled.
  *
- * `POST {basePath}/deletion/{requestId}/cancel`
+ * `POST {basePath}/deletions/{requestId}/cancel`
  */
 export async function cancelDeletion(
   client: AxiosInstance,
   basePath: string,
   requestId: string
 ): Promise<void> {
-  await client.post(`${basePath}/deletion/${encodeURIComponent(requestId)}/cancel`);
+  await client.post(`${basePath}/deletions/${encodeURIComponent(requestId)}/cancel`);
 }
 
 // ── Legal Agreements (GDPR Art. 7) ───────────────────────────────────────────

--- a/packages/@granit/react-privacy/src/__tests__/privacy-hooks.test.tsx
+++ b/packages/@granit/react-privacy/src/__tests__/privacy-hooks.test.tsx
@@ -80,9 +80,9 @@ describe('PrivacyProvider', () => {
     const wrapper = ({ children }: { children: ReactNode }) =>
       React.createElement(QueryClientProvider, { client: queryClient }, children);
 
-    expect(() =>
-      renderHook(() => usePrivacyConfig(), { wrapper })
-    ).toThrow('usePrivacyConfig must be used within a PrivacyProvider');
+    expect(() => renderHook(() => usePrivacyConfig(), { wrapper })).toThrow(
+      'usePrivacyConfig must be used within a PrivacyProvider'
+    );
   });
 });
 
@@ -158,9 +158,7 @@ describe('useAgreementStatuses', () => {
 describe('useAgreementHistory', () => {
   it('should fetch agreement history', async () => {
     const client = createMockClient();
-    const history = [
-      { documentId: 'doc-1', action: 'accepted', performedAt: '2025-01-02' },
-    ];
+    const history = [{ documentId: 'doc-1', action: 'accepted', performedAt: '2025-01-02' }];
     vi.mocked(client.get).mockResolvedValue(axiosResponse(history));
 
     const { result } = renderHook(() => useAgreementHistory(), {
@@ -241,7 +239,7 @@ describe('useRequestDeletion', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/privacy/deletion', {
+    expect(client.post).toHaveBeenCalledWith('/api/privacy/deletions', {
       reason: 'I want my data deleted',
     });
     expect(result.current.data).toEqual(response);
@@ -268,7 +266,7 @@ describe('useRequestDeletion', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/privacy/deletion', {
+    expect(client.post).toHaveBeenCalledWith('/api/privacy/deletions', {
       reason: 'Closing account',
       defer: true,
     });
@@ -317,7 +315,7 @@ describe('useDeletionRequests', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/privacy/deletion');
+    expect(client.get).toHaveBeenCalledWith('/api/privacy/deletions');
     expect(result.current.data).toEqual(deletions);
   });
 });
@@ -344,7 +342,7 @@ describe('useDeletionStatus', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/privacy/deletion/del-1');
+    expect(client.get).toHaveBeenCalledWith('/api/privacy/deletions/del-1');
     expect(result.current.data).toEqual(status);
   });
 
@@ -379,7 +377,7 @@ describe('useCancelDeletion', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/privacy/deletion/del-1/cancel');
+    expect(client.post).toHaveBeenCalledWith('/api/privacy/deletions/del-1/cancel');
   });
 
   it('should expose error when cancellation fails (409 conflict)', async () => {
@@ -406,9 +404,7 @@ describe('useCancelDeletion', () => {
 describe('usePrivacyExports', () => {
   it('should fetch all export requests', async () => {
     const client = createMockClient();
-    const exports = [
-      { requestId: 'exp-1', status: 'completed', requestedAt: '2025-01-01' },
-    ];
+    const exports = [{ requestId: 'exp-1', status: 'completed', requestedAt: '2025-01-01' }];
     vi.mocked(client.get).mockResolvedValue(axiosResponse(exports));
 
     const { result } = renderHook(() => usePrivacyExports(), {
@@ -417,7 +413,7 @@ describe('usePrivacyExports', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/privacy/export');
+    expect(client.get).toHaveBeenCalledWith('/api/privacy/exports');
     expect(result.current.data).toEqual(exports);
   });
 });
@@ -438,7 +434,7 @@ describe('usePrivacyExportStatus', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/privacy/export/exp-1');
+    expect(client.get).toHaveBeenCalledWith('/api/privacy/exports/exp-1');
     expect(result.current.data).toEqual(status);
   });
 
@@ -474,7 +470,7 @@ describe('useRequestExport', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.post).toHaveBeenCalledWith('/api/privacy/export');
+    expect(client.post).toHaveBeenCalledWith('/api/privacy/exports');
     expect(result.current.data).toEqual(response);
   });
 

--- a/packages/@granit/react-privacy/src/testing/handlers.ts
+++ b/packages/@granit/react-privacy/src/testing/handlers.ts
@@ -48,8 +48,8 @@ export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const legalBase = `${baseUrl}/legal-documents`;
 
   return [
-    // POST /export — request a new data export
-    http.post(`${baseUrl}/export`, () => {
+    // POST /exports — request a new data export
+    http.post(`${baseUrl}/exports`, () => {
       exportCounter++;
       const requestId = `exp-${String(exportCounter).padStart(3, '0')}`;
       const requestedAt = new Date().toISOString();
@@ -65,20 +65,20 @@ export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json({ requestId, requestedAt }, { status: 202 });
     }),
 
-    // GET /export — list all exports
-    http.get(`${baseUrl}/export`, () => {
+    // GET /exports — list all exports
+    http.get(`${baseUrl}/exports`, () => {
       return HttpResponse.json(exports);
     }),
 
-    // GET /export/:requestId — get status of a specific export
-    http.get(`${baseUrl}/export/:requestId`, ({ params }) => {
+    // GET /exports/:requestId — get status of a specific export
+    http.get(`${baseUrl}/exports/:requestId`, ({ params }) => {
       const exportItem = exports.find((e) => e.requestId === params.requestId);
       if (!exportItem) return notFound();
       return HttpResponse.json(exportItem);
     }),
 
-    // POST /deletion — request account deletion
-    http.post(`${baseUrl}/deletion`, async ({ request }) => {
+    // POST /deletions — request account deletion
+    http.post(`${baseUrl}/deletions`, async ({ request }) => {
       const body = (await request.json()) as { reason: string; defer?: boolean };
       deletionCounter++;
       const requestId = `del-${String(deletionCounter).padStart(3, '0')}`;
@@ -97,20 +97,20 @@ export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(response, { status: 202 });
     }),
 
-    // GET /deletion — list all deletion requests
-    http.get(`${baseUrl}/deletion`, () => {
+    // GET /deletions — list all deletion requests
+    http.get(`${baseUrl}/deletions`, () => {
       return HttpResponse.json(deletionRequests);
     }),
 
-    // GET /deletion/:requestId — get status of a specific deletion request
-    http.get(`${baseUrl}/deletion/:requestId`, ({ params }) => {
+    // GET /deletions/:requestId — get status of a specific deletion request
+    http.get(`${baseUrl}/deletions/:requestId`, ({ params }) => {
       const item = deletionRequests.find((r) => r.requestId === params.requestId);
       if (!item) return notFound();
       return HttpResponse.json(item);
     }),
 
-    // POST /deletion/:requestId/cancel — cancel a deferred deletion
-    http.post(`${baseUrl}/deletion/:requestId/cancel`, ({ params }) => {
+    // POST /deletions/:requestId/cancel — cancel a deferred deletion
+    http.post(`${baseUrl}/deletions/:requestId/cancel`, ({ params }) => {
       const item = deletionRequests.find((r) => r.requestId === params.requestId);
       if (!item) return notFound();
       if (item.status !== 'Deferred') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   yaml: '>=2.8.3'
   smol-toml: '>=1.6.1'
   brace-expansion: '>=5.0.5'
+  protobufjs: ^7.5.5
 
 importers:
 
@@ -3030,36 +3031,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -3148,36 +3155,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-3fPzdREH806oRLxpTWW1Gt4tQHs0TitZFOECB2xzCFLPKnSOy90gwA7P29cksYilFO6XVRY1kzga0cL2nRjKPg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-EKwI1tSrLs7YVw+JPJT/G2dJQ1jl9qlTTTEG0V2Ok/RdOenRfBw2PQdLPyjhIu58ocdBfP7vIRN/pvMsPxs/AQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-Uknladnb3Sxqu6SEcqBldQyJUpk8NleooZEc0MbRBJ4inEhRYWZX0NJu12vNf2mqAq7gsofAxHrGghiUYjhaLQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.16':
     resolution: {integrity: sha512-FIb8+uG49sZBtLTn+zt1AJ20TqVcqWeSIyoVt0or7uAWesgKaHbiBh6OpA/k9v0LTt+PTrb1Lao133kP4uVxkg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.16':
     resolution: {integrity: sha512-RuERhF9/EgWxZEXYWCOaViUWHIboceK4/ivdtQ3R0T44NjLkIIlGIAVAuCddFxsZ7vnRHtNQUrt2vR2n2slB2w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.16':
     resolution: {integrity: sha512-mXcXnvd9GpazCxeUCCnZ2+YF7nut+ZOEbE4GtaiPtyY6AkhZWbK70y1KK3j+RDhjVq5+U8FySkKRb/+w0EeUwA==}
@@ -3242,66 +3255,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -3436,9 +3462,6 @@ packages:
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
-  '@types/node@25.5.2':
-    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
-
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
@@ -3556,41 +3579,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4605,24 +4636,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5030,16 +5065,8 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
-  protobufjs@7.5.4:
-    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
-    engines: {node: '>=12.0.0'}
-
   protobufjs@7.5.5:
     resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
-    engines: {node: '>=12.0.0'}
-
-  protobufjs@8.0.1:
-    resolution: {integrity: sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==}
     engines: {node: '>=12.0.0'}
 
   proxy-from-env@2.1.0:
@@ -5450,9 +5477,6 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
-
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
@@ -6844,7 +6868,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.6.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.6.0(@opentelemetry/api@1.9.1)
-      protobufjs: 7.5.4
+      protobufjs: 7.5.5
 
   '@opentelemetry/otlp-transformer@0.215.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -6855,7 +6879,7 @@ snapshots:
       '@opentelemetry/sdk-logs': 0.215.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.7.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-trace-base': 2.7.0(@opentelemetry/api@1.9.1)
-      protobufjs: 8.0.1
+      protobufjs: 7.5.5
 
   '@opentelemetry/resources@2.6.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -7256,10 +7280,6 @@ snapshots:
   '@types/katex@0.16.8': {}
 
   '@types/ms@2.1.0': {}
-
-  '@types/node@25.5.2':
-    dependencies:
-      undici-types: 7.18.2
 
   '@types/node@25.6.0':
     dependencies:
@@ -9000,37 +9020,7 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
-  protobufjs@7.5.4:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.5.2
-      long: 5.3.2
-
   protobufjs@7.5.5:
-    dependencies:
-      '@protobufjs/aspromise': 1.1.2
-      '@protobufjs/base64': 1.1.2
-      '@protobufjs/codegen': 2.0.4
-      '@protobufjs/eventemitter': 1.1.0
-      '@protobufjs/fetch': 1.1.0
-      '@protobufjs/float': 1.0.2
-      '@protobufjs/inquire': 1.1.0
-      '@protobufjs/path': 1.1.2
-      '@protobufjs/pool': 1.1.0
-      '@protobufjs/utf8': 1.1.0
-      '@types/node': 25.6.0
-      long: 5.3.2
-
-  protobufjs@8.0.1:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -9441,8 +9431,6 @@ snapshots:
   uc.micro@2.1.0: {}
 
   ufo@1.6.3: {}
-
-  undici-types@7.18.2: {}
 
   undici-types@7.19.2: {}
 


### PR DESCRIPTION
## Summary

- **refactor(privacy)** — pluralize `@granit/privacy` route segments (`/export` → `/exports`, `/deletion` → `/deletions`) to match the backend sub-group convention used elsewhere in the framework. MSW test handlers updated in lockstep.
- **fix(deps)** — pin `protobufjs` to `^7.5.5` via `pnpm.overrides` to patch [GHSA-xq3m-2v4x-88gg](https://github.com/advisories/GHSA-xq3m-2v4x-88gg) / CVE-2026-41242 (critical, CVSS 9.4 — arbitrary code execution through crafted protobuf descriptors). The package is a transitive dep of `@opentelemetry/exporter-trace-otlp-http` and was resolved to the vulnerable `7.5.4`.

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm why protobufjs` → `7.5.5` (patched, single version)
- [ ] CI green