### PR TITLE
feat(data-lookup): add @granit/data-lookup and @granit/react-data-lookup SDK (PR 4/7)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -507,6 +507,11 @@
       "exports": []
     },
     {
+      "name": "@granit/data-lookup",
+      "description": "Framework-agnostic types and HTTP client for Granit Data Lookup — unified typeahead pickers for filters and form dropdowns",
+      "exports": []
+    },
+    {
       "name": "@granit/diagnostics",
       "description": "Monitoring health types and API — mirrors Granit.Diagnostics .NET contract",
       "exports": [
@@ -1827,6 +1832,95 @@
       "name": "@granit/react-data-exchange",
       "description": "React bindings for @granit/data-exchange — ExportProvider, ImportProvider, hooks",
       "exports": []
+    },
+    {
+      "name": "@granit/react-data-lookup",
+      "description": "React hooks and components for @granit/data-lookup — useLookup, LookupSelect, LookupPicker, LookupBadge",
+      "exports": [
+        {
+          "name": "buildLookupQueryKey",
+          "kind": "function",
+          "signature": "function buildLookupQueryKey( descriptor: LookupDescriptor, params: LookupQueryParams, culture?: string ): readonly unknown[]"
+        },
+        {
+          "name": "useLookup",
+          "kind": "function",
+          "signature": "function useLookup( descriptor: LookupDescriptor, params: LookupQueryParams, options: UseLookupOptions ): UseLookupResult"
+        },
+        {
+          "name": "UseLookupOptions",
+          "kind": "interface",
+          "signature": "interface UseLookupOptions",
+          "members": []
+        },
+        {
+          "name": "UseLookupResult",
+          "kind": "type",
+          "signature": "type UseLookupResult = UseQueryResult<LookupResult> & { /** Name of the scope key that is currently missing, if any (Empty Scope Trap). */ readonly missingScopeKey: string | null; }"
+        },
+        {
+          "name": "useLookupResolve",
+          "kind": "function",
+          "signature": "function useLookupResolve( descriptor: LookupDescriptor, value: unknown, options: UseLookupResolveOptions ): UseQueryResult<LookupItem | null>"
+        },
+        {
+          "name": "UseLookupResolveOptions",
+          "kind": "interface",
+          "signature": "interface UseLookupResolveOptions",
+          "members": []
+        },
+        {
+          "name": "LookupSelect",
+          "kind": "function",
+          "signature": "function LookupSelect(props: LookupSelectProps): ReactElement"
+        },
+        {
+          "name": "LookupSelectProps",
+          "kind": "interface",
+          "signature": "interface LookupSelectProps",
+          "members": []
+        },
+        {
+          "name": "LookupSelectRenderArgs",
+          "kind": "interface",
+          "signature": "interface LookupSelectRenderArgs",
+          "members": []
+        },
+        {
+          "name": "LookupPicker",
+          "kind": "function",
+          "signature": "function LookupPicker(props: LookupPickerProps): ReactElement"
+        },
+        {
+          "name": "LookupPickerProps",
+          "kind": "interface",
+          "signature": "interface LookupPickerProps",
+          "members": []
+        },
+        {
+          "name": "LookupPickerRenderArgs",
+          "kind": "interface",
+          "signature": "interface LookupPickerRenderArgs",
+          "members": []
+        },
+        {
+          "name": "LookupBadge",
+          "kind": "function",
+          "signature": "function LookupBadge(props: LookupBadgeProps): ReactElement"
+        },
+        {
+          "name": "LookupBadgeProps",
+          "kind": "interface",
+          "signature": "interface LookupBadgeProps",
+          "members": []
+        },
+        {
+          "name": "LookupBadgeRenderArgs",
+          "kind": "interface",
+          "signature": "interface LookupBadgeRenderArgs",
+          "members": []
+        }
+      ]
     },
     {
       "name": "@granit/react-diagnostics",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,8 @@
       "immutable": ">=5.1.5",
       "flatted": ">=3.4.2",
       "@tanstack/query-core": "^5.95.0",
+      "@tanstack/react-query": "5.99.0",
+      "axios": "1.15.0",
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
       "smol-toml": ">=1.6.1",

--- a/packages/@granit/data-lookup/README.md
+++ b/packages/@granit/data-lookup/README.md
@@ -1,0 +1,19 @@
+# @granit/data-lookup
+
+Framework-agnostic TypeScript types and an axios-based HTTP client for **Granit
+Data Lookup** — the unified primitive that feeds typeahead pickers for both
+QueryEngine filters and form dropdowns.
+
+## Contents
+
+- `LookupDescriptor`, `LookupKind`, `LookupItem`, `LookupResult`, `LookupManifest`,
+  `LookupQueryParams` — wire types mirroring the backend contract.
+- `searchLookup`, `resolveLookup`, `fetchLookupManifest` — `axios` helpers for the
+  `/api/granit/lookups` endpoints.
+- `findMissingScopeKey`, `isScopeSatisfied` — Empty Scope Trap guards shared with
+  the React hook layer.
+
+For React hooks and components, depend on `@granit/react-data-lookup`.
+
+See the backend documentation at
+`/dotnet/business/data-lookup/` for the full contract.

--- a/packages/@granit/data-lookup/package.json
+++ b/packages/@granit/data-lookup/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@granit/data-lookup",
+  "description": "Framework-agnostic types and HTTP client for Granit Data Lookup — unified typeahead pickers for filters and form dropdowns",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "axios": "*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/data-lookup/src/__tests__/lookup-client.test.ts
+++ b/packages/@granit/data-lookup/src/__tests__/lookup-client.test.ts
@@ -1,0 +1,159 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DEFAULT_LOOKUP_BASE_PATH,
+  buildSearchQuery,
+  fetchLookupManifest,
+  resolveLookup,
+  searchLookup,
+} from '../api/lookup-client.js';
+
+import type { LookupDescriptor, LookupItem, LookupManifest, LookupResult } from '../types/index.js';
+
+describe('buildSearchQuery', () => {
+  it('uses the default "search" param name', () => {
+    const query = buildSearchQuery({ name: 'tenants' }, { search: 'acme' });
+    expect(query).toEqual({ search: 'acme' });
+  });
+
+  it('honors a custom searchParam', () => {
+    const query = buildSearchQuery({ name: 'x', searchParam: 'q' }, { search: 'hello' });
+    expect(query).toEqual({ q: 'hello' });
+  });
+
+  it('omits empty search term', () => {
+    expect(buildSearchQuery({ name: 't' }, { search: '' })).toEqual({});
+    expect(buildSearchQuery({ name: 't' }, {})).toEqual({});
+  });
+
+  it('serializes page, pageSize, and continuationToken', () => {
+    expect(
+      buildSearchQuery({ name: 't' }, { page: 2, pageSize: 50, continuationToken: 'abc' })
+    ).toEqual({ page: 2, pageSize: 50, continuationToken: 'abc' });
+  });
+
+  it('emits scope.<key> for non-empty values only', () => {
+    const query = buildSearchQuery(
+      { name: 'meters' },
+      { scope: { tenantId: 'abc', empty: '', nothing: null, absent: undefined } }
+    );
+    expect(query).toEqual({ 'scope.tenantId': 'abc' });
+  });
+});
+
+describe('searchLookup', () => {
+  it('hits /api/granit/lookups/{name} by default', async () => {
+    const client = createMockClient();
+    const payload: LookupResult = { items: [{ value: '1', label: 'Acme' }], totalCount: 1 };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(payload));
+
+    await searchLookup({ name: 'tenants' }, { search: 'acme' }, { client });
+
+    expect(client.get).toHaveBeenCalledWith(
+      `${DEFAULT_LOOKUP_BASE_PATH}/tenants`,
+      expect.objectContaining({ params: { search: 'acme' } })
+    );
+  });
+
+  it('hits the custom endpoint when descriptor.endpoint is set', async () => {
+    const client = createMockClient();
+    const payload: LookupResult = { items: [] };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(payload));
+
+    const descriptor: LookupDescriptor = {
+      endpoint: '/api/external/stripe/customers',
+      searchParam: 'query',
+    };
+    await searchLookup(descriptor, { search: 'acme' }, { client });
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/external/stripe/customers',
+      expect.objectContaining({ params: { query: 'acme' } })
+    );
+  });
+
+  it('throws when neither name nor endpoint is provided', async () => {
+    const client = createMockClient();
+
+    await expect(searchLookup({}, { search: 'x' }, { client })).rejects.toThrow(
+      /LookupDescriptor requires/
+    );
+  });
+});
+
+describe('resolveLookup', () => {
+  it('returns null for null/undefined/empty values without hitting the network', async () => {
+    const client = createMockClient();
+
+    await expect(resolveLookup({ name: 't' }, null, { client })).resolves.toBeNull();
+    await expect(resolveLookup({ name: 't' }, undefined, { client })).resolves.toBeNull();
+    await expect(resolveLookup({ name: 't' }, '', { client })).resolves.toBeNull();
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('returns the resolved item on 200', async () => {
+    const client = createMockClient();
+    const item: LookupItem = { value: 'BE', label: 'Belgique' };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(item));
+
+    const result = await resolveLookup({ name: 'ref-country' }, 'BE', { client });
+
+    expect(result).toEqual(item);
+    expect(client.get).toHaveBeenCalledWith(
+      `${DEFAULT_LOOKUP_BASE_PATH}/ref-country/resolve`,
+      expect.objectContaining({ params: { value: 'BE' } })
+    );
+  });
+
+  it('returns null on 404 instead of throwing', async () => {
+    const client = createMockClient();
+    const notFound = Object.assign(new Error('not found'), {
+      response: { status: 404 },
+    });
+    vi.mocked(client.get).mockRejectedValue(notFound);
+
+    const result = await resolveLookup({ name: 't' }, 'missing', { client });
+
+    expect(result).toBeNull();
+  });
+
+  it('rethrows non-404 errors', async () => {
+    const client = createMockClient();
+    const serverError = Object.assign(new Error('boom'), {
+      response: { status: 500 },
+    });
+    vi.mocked(client.get).mockRejectedValue(serverError);
+
+    await expect(resolveLookup({ name: 't' }, 'x', { client })).rejects.toThrow(/boom/);
+  });
+});
+
+describe('fetchLookupManifest', () => {
+  it('returns the discovery manifest', async () => {
+    const client = createMockClient();
+    const manifest: LookupManifest = {
+      lookups: [{ name: 'tenants', kind: 'QueryEngine', requiredPermission: null, scopeKeys: [] }],
+    };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(manifest));
+
+    const result = await fetchLookupManifest({ client });
+
+    expect(result).toEqual(manifest);
+    expect(client.get).toHaveBeenCalledWith(DEFAULT_LOOKUP_BASE_PATH, expect.any(Object));
+  });
+});
+
+describe('basePath override', () => {
+  it('uses custom basePath for registry lookups', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [] } as LookupResult));
+
+    await searchLookup({ name: 'tenants' }, {}, { client, basePath: '/custom/lookups' });
+
+    expect(client.get).toHaveBeenCalledWith('/custom/lookups/tenants', expect.any(Object));
+  });
+});
+
+// silence noisy unused imports when vi is not referenced elsewhere
+void vi;

--- a/packages/@granit/data-lookup/src/__tests__/scope-validation.test.ts
+++ b/packages/@granit/data-lookup/src/__tests__/scope-validation.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { findMissingScopeKey, isScopeSatisfied } from '../api/scope-validation.js';
+
+import type { LookupDescriptor } from '../types/index.js';
+
+describe('findMissingScopeKey', () => {
+  it('returns null when descriptor has no scopeKeys', () => {
+    const descriptor: LookupDescriptor = { name: 'tenants' };
+
+    expect(findMissingScopeKey(descriptor, undefined)).toBeNull();
+    expect(findMissingScopeKey(descriptor, {})).toBeNull();
+  });
+
+  it('returns the first missing key when scope is undefined', () => {
+    const descriptor: LookupDescriptor = { name: 'meters', scopeKeys: ['tenantId', 'orgId'] };
+
+    expect(findMissingScopeKey(descriptor, undefined)).toBe('tenantId');
+  });
+
+  it('returns the missing key when one value is null / undefined / empty', () => {
+    const descriptor: LookupDescriptor = { name: 'meters', scopeKeys: ['tenantId'] };
+
+    expect(findMissingScopeKey(descriptor, { tenantId: null })).toBe('tenantId');
+    expect(findMissingScopeKey(descriptor, { tenantId: undefined })).toBe('tenantId');
+    expect(findMissingScopeKey(descriptor, { tenantId: '' })).toBe('tenantId');
+  });
+
+  it('returns null when every scope key is satisfied', () => {
+    const descriptor: LookupDescriptor = { name: 'meters', scopeKeys: ['tenantId', 'orgId'] };
+
+    expect(findMissingScopeKey(descriptor, { tenantId: 'a', orgId: 'b' })).toBeNull();
+  });
+});
+
+describe('isScopeSatisfied', () => {
+  it('is true when descriptor has no scopeKeys', () => {
+    expect(isScopeSatisfied({ name: 'tenants' }, undefined)).toBe(true);
+  });
+
+  it('is false when any declared scope key is missing', () => {
+    expect(isScopeSatisfied({ name: 'meters', scopeKeys: ['tenantId'] }, { tenantId: '' })).toBe(
+      false
+    );
+  });
+
+  it('is true when every declared scope key is provided', () => {
+    expect(
+      isScopeSatisfied({ name: 'meters', scopeKeys: ['tenantId'] }, { tenantId: 'acme' })
+    ).toBe(true);
+  });
+});

--- a/packages/@granit/data-lookup/src/api/index.ts
+++ b/packages/@granit/data-lookup/src/api/index.ts
@@ -1,0 +1,9 @@
+export {
+  DEFAULT_LOOKUP_BASE_PATH,
+  buildSearchQuery,
+  fetchLookupManifest,
+  resolveLookup,
+  searchLookup,
+} from './lookup-client.js';
+export type { LookupClientOptions } from './lookup-client.js';
+export { findMissingScopeKey, isScopeSatisfied } from './scope-validation.js';

--- a/packages/@granit/data-lookup/src/api/lookup-client.ts
+++ b/packages/@granit/data-lookup/src/api/lookup-client.ts
@@ -1,0 +1,154 @@
+import type {
+  LookupDescriptor,
+  LookupItem,
+  LookupManifest,
+  LookupQueryParams,
+  LookupResult,
+} from '../types/index.js';
+import type { AxiosInstance } from 'axios';
+
+/** Default route prefix used by the backend `MapGranitDataLookups()` extension. */
+export const DEFAULT_LOOKUP_BASE_PATH = '/api/granit/lookups';
+
+/** Options for {@link searchLookup} and {@link resolveLookup}. */
+export interface LookupClientOptions {
+  /** Axios instance used for HTTP requests. */
+  readonly client: AxiosInstance;
+  /** Override the base path. Default: {@link DEFAULT_LOOKUP_BASE_PATH}. */
+  readonly basePath?: string;
+  /** Optional abort signal. */
+  readonly signal?: AbortSignal;
+}
+
+/**
+ * Fetches the discovery manifest of every registered lookup source.
+ *
+ * `GET {basePath}` → {@link LookupManifest}.
+ */
+export async function fetchLookupManifest(options: LookupClientOptions): Promise<LookupManifest> {
+  const { client, basePath = DEFAULT_LOOKUP_BASE_PATH, signal } = options;
+  const { data } = await client.get<LookupManifest>(basePath, { signal });
+  return data;
+}
+
+/**
+ * Searches a lookup source.
+ *
+ * - When `descriptor.name` is set → `GET {basePath}/{name}` (registry).
+ * - When `descriptor.endpoint` is set → `GET {endpoint}` (custom source).
+ *
+ * Scope values are serialized as `scope.{key}=<value>` query parameters.
+ */
+export async function searchLookup(
+  descriptor: LookupDescriptor,
+  params: LookupQueryParams,
+  options: LookupClientOptions
+): Promise<LookupResult> {
+  const { client, signal } = options;
+  const url = resolveLookupUrl(descriptor, options.basePath);
+  const query = buildSearchQuery(descriptor, params);
+  const { data } = await client.get<LookupResult>(url, { params: query, signal });
+  return data;
+}
+
+/**
+ * Resolves a single item by its value. Used to rehydrate a previously selected
+ * identifier into a human-readable label (e.g., when loading a form that was
+ * saved with a foreign-key value).
+ *
+ * `GET {basePath}/{name}/resolve?value=…` → {@link LookupItem} | `null`.
+ *
+ * Returns `null` when the value is not present in the source (HTTP 404).
+ */
+export async function resolveLookup(
+  descriptor: LookupDescriptor,
+  value: unknown,
+  options: LookupClientOptions
+): Promise<LookupItem | null> {
+  if (value === null || value === undefined || value === '') {
+    return null;
+  }
+
+  const { client, signal } = options;
+  const baseUrl = resolveLookupUrl(descriptor, options.basePath);
+  const resolveUrl = descriptor.endpoint ? `${baseUrl}/resolve` : `${baseUrl}/resolve`;
+
+  try {
+    const { data } = await client.get<LookupItem>(resolveUrl, {
+      params: { value: String(value) },
+      signal,
+    });
+    return data;
+  } catch (err) {
+    if (isAxiosNotFound(err)) {
+      return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Serializes {@link LookupQueryParams} into an axios-compatible params object.
+ * Exported for use by test doubles and advanced callers.
+ */
+export function buildSearchQuery(
+  descriptor: LookupDescriptor,
+  params: LookupQueryParams
+): Record<string, string | number> {
+  const result: Record<string, string | number> = {};
+
+  if (params.search !== undefined && params.search !== '') {
+    const searchParamKey = descriptor.searchParam ?? 'search';
+    result[searchParamKey] = params.search;
+  }
+
+  if (params.page !== undefined) {
+    result.page = params.page;
+  }
+
+  if (params.pageSize !== undefined) {
+    result.pageSize = params.pageSize;
+  }
+
+  if (params.continuationToken !== undefined && params.continuationToken !== '') {
+    result.continuationToken = params.continuationToken;
+  }
+
+  if (params.scope) {
+    for (const [key, value] of Object.entries(params.scope)) {
+      if (value !== null && value !== undefined && value !== '') {
+        result[`scope.${key}`] = value;
+      }
+    }
+  }
+
+  return result;
+}
+
+/** Resolves the URL for a lookup descriptor (registry name or custom endpoint). */
+function resolveLookupUrl(descriptor: LookupDescriptor, basePath?: string): string {
+  if (descriptor.endpoint) {
+    return descriptor.endpoint;
+  }
+
+  if (!descriptor.name) {
+    throw new Error(
+      'LookupDescriptor requires either a "name" (registry key) or an "endpoint" (custom URL).'
+    );
+  }
+
+  const prefix = basePath ?? DEFAULT_LOOKUP_BASE_PATH;
+  return `${prefix}/${encodeURIComponent(descriptor.name)}`;
+}
+
+interface AxiosErrorLike {
+  readonly response?: { readonly status?: number };
+}
+
+function isAxiosNotFound(err: unknown): boolean {
+  if (typeof err !== 'object' || err === null) {
+    return false;
+  }
+  const response = (err as AxiosErrorLike).response;
+  return response?.status === 404;
+}

--- a/packages/@granit/data-lookup/src/api/scope-validation.ts
+++ b/packages/@granit/data-lookup/src/api/scope-validation.ts
@@ -1,0 +1,39 @@
+import type { LookupDescriptor } from '../types/index.js';
+
+/**
+ * Checks that every key declared in `descriptor.scopeKeys` is present and non-empty
+ * in the provided `scope` object. Returns the missing key name when incomplete,
+ * otherwise `null`.
+ *
+ * This is the **Empty Scope Trap** guard: when a scoped lookup is mounted on a
+ * form whose parent field has not yet been filled (e.g., `meters` scoped by
+ * `tenantId` on a blank creation form), we must NOT fire an unscoped request
+ * — the backend returns 400, and the worst case would be a multi-tenant leak
+ * if validation were bypassed.
+ */
+export function findMissingScopeKey(
+  descriptor: LookupDescriptor,
+  scope: Readonly<Record<string, string | null | undefined>> | undefined
+): string | null {
+  const required = descriptor.scopeKeys ?? [];
+  if (required.length === 0) {
+    return null;
+  }
+
+  for (const key of required) {
+    const value = scope?.[key];
+    if (value === null || value === undefined || value === '') {
+      return key;
+    }
+  }
+
+  return null;
+}
+
+/** Returns `true` when the descriptor is ready to emit a request. */
+export function isScopeSatisfied(
+  descriptor: LookupDescriptor,
+  scope: Readonly<Record<string, string | null | undefined>> | undefined
+): boolean {
+  return findMissingScopeKey(descriptor, scope) === null;
+}

--- a/packages/@granit/data-lookup/src/index.ts
+++ b/packages/@granit/data-lookup/src/index.ts
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------
+// @granit/data-lookup — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
+
+// Types
+export type {
+  LookupDescriptor,
+  LookupItem,
+  LookupKind,
+  LookupManifest,
+  LookupManifestEntry,
+  LookupQueryParams,
+  LookupResult,
+} from './types/index.js';
+
+// HTTP client
+export {
+  DEFAULT_LOOKUP_BASE_PATH,
+  buildSearchQuery,
+  fetchLookupManifest,
+  findMissingScopeKey,
+  isScopeSatisfied,
+  resolveLookup,
+  searchLookup,
+} from './api/index.js';
+export type { LookupClientOptions } from './api/index.js';

--- a/packages/@granit/data-lookup/src/types/index.ts
+++ b/packages/@granit/data-lookup/src/types/index.ts
@@ -1,0 +1,8 @@
+export type { LookupDescriptor, LookupKind } from './lookup-descriptor.js';
+export type {
+  LookupItem,
+  LookupManifest,
+  LookupManifestEntry,
+  LookupQueryParams,
+  LookupResult,
+} from './lookup-item.js';

--- a/packages/@granit/data-lookup/src/types/lookup-descriptor.ts
+++ b/packages/@granit/data-lookup/src/types/lookup-descriptor.ts
@@ -1,0 +1,38 @@
+/**
+ * Kind of backing source behind a {@link LookupDescriptor}. Informational — the
+ * frontend can use it to pick an affordance (e.g., compact list for `Enum`
+ * vs. debounced typeahead for `QueryEngine`).
+ */
+export type LookupKind = 'QueryEngine' | 'Simple' | 'ReferenceData' | 'Enum';
+
+/**
+ * Declarative pointer to a lookup data source. Emitted by the backend alongside
+ * filterable-field metadata (`FilterableField.lookup`) and consumed directly by
+ * the frontend to render a typeahead picker.
+ *
+ * Exactly one of `name` or `endpoint` must be provided:
+ * - `name`: resolved against the central `/api/granit/lookups/{name}` registry
+ *   (preferred).
+ * - `endpoint`: absolute or relative URL for a bespoke source that returns the
+ *   canonical {@link LookupResult} shape.
+ */
+export interface LookupDescriptor {
+  /** Registry key of the lookup source (e.g. `"tenants"`). */
+  readonly name?: string;
+  /** Custom URL when bypassing the registry. Must return {@link LookupResult}. */
+  readonly endpoint?: string;
+  /** Kind of backing source. */
+  readonly kind?: LookupKind;
+  /** Permission the caller must hold to open the picker. */
+  readonly requiredPermission?: string;
+  /** Query string parameter name used to forward the typeahead term. Default: `"search"`. */
+  readonly searchParam?: string;
+  /**
+   * Names of scope parameters the source requires (e.g. `["tenantId"]`). The
+   * frontend resolves the values from the surrounding form/filter context and
+   * passes them as `scope.<key>=<value>` query-string parameters. When any
+   * declared key is missing, the frontend MUST suppress the request (see
+   * Empty Scope Trap mitigation in {@link useLookup}).
+   */
+  readonly scopeKeys?: readonly string[];
+}

--- a/packages/@granit/data-lookup/src/types/lookup-item.ts
+++ b/packages/@granit/data-lookup/src/types/lookup-item.ts
@@ -1,0 +1,53 @@
+import type { LookupKind } from './lookup-descriptor.js';
+
+/**
+ * Canonical item returned by every lookup source. `label` is already localized
+ * server-side in the caller's `Accept-Language` culture — the frontend renders
+ * it verbatim.
+ */
+export interface LookupItem {
+  /** Opaque value to submit back (GUID, code, enum name). */
+  readonly value: unknown;
+  /** Already-localized human-readable label. */
+  readonly label: string;
+  /**
+   * Optional secondary attributes (e.g. `{ active: true, email: "x@y.z" }`).
+   * Shape is source-specific.
+   */
+  readonly extra?: Readonly<Record<string, unknown>>;
+}
+
+/** Canonical paginated response for a lookup search. */
+export interface LookupResult {
+  readonly items: readonly LookupItem[];
+  /** Total count across pages; `null` for cursor-based sources. */
+  readonly totalCount?: number | null;
+  /** Opaque token for the next page, when supported. */
+  readonly continuationToken?: string | null;
+}
+
+/**
+ * Public metadata about a registered lookup source, returned by
+ * `GET /api/granit/lookups`.
+ */
+export interface LookupManifestEntry {
+  readonly name: string;
+  readonly kind: LookupKind;
+  readonly requiredPermission?: string | null;
+  readonly scopeKeys: readonly string[];
+}
+
+/** Response shape of `GET /api/granit/lookups`. */
+export interface LookupManifest {
+  readonly lookups: readonly LookupManifestEntry[];
+}
+
+/** Query parameters passed to the lookup client. */
+export interface LookupQueryParams {
+  readonly search?: string;
+  readonly page?: number;
+  readonly pageSize?: number;
+  readonly continuationToken?: string;
+  /** Fully-resolved scope values. Keys must match `scopeKeys` declared by the source. */
+  readonly scope?: Readonly<Record<string, string | null | undefined>>;
+}

--- a/packages/@granit/data-lookup/tsconfig.json
+++ b/packages/@granit/data-lookup/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/data-lookup/tsup.config.ts
+++ b/packages/@granit/data-lookup/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-data-lookup/README.md
+++ b/packages/@granit/react-data-lookup/README.md
@@ -1,0 +1,55 @@
+# @granit/react-data-lookup
+
+React hooks and headless components for **@granit/data-lookup**.
+
+## Hooks
+
+- `useLookup(descriptor, params, options)` — debounced search with automatic
+  **Empty Scope Trap** guard: when a declared `scopeKeys` value is missing,
+  `enabled` flips to `false` and `missingScopeKey` is surfaced so the UI can
+  render an informative placeholder.
+- `useLookupResolve(descriptor, value, options)` — rehydrates a previously
+  persisted value into a localized label (for edit forms and detail views).
+
+## Components
+
+All components follow the **headless render-prop** pattern so consumers keep
+full control of their UI kit.
+
+- `<LookupSelect>` — combobox-style single-select. Usage: forms.
+- `<LookupPicker>` — SmartFilterBar-ready variant; supports multi-select for
+  the `In` filter operator.
+- `<LookupBadge>` — read-only projection of a value (detail pages, audit logs).
+
+## Usage
+
+```tsx
+import { LookupSelect } from '@granit/react-data-lookup';
+
+<LookupSelect
+  descriptor={{ name: 'tenants', scopeKeys: [] }}
+  value={tenantId}
+  onChange={setTenantId}
+  client={axios}
+  culture={i18n.resolvedLanguage}
+  render={({ items, search, setSearch, selectedItem, onChange, missingScopeKey }) =>
+    missingScopeKey ? (
+      <span>Select a {missingScopeKey} first.</span>
+    ) : (
+      <Combobox>
+        <Combobox.Input value={search} onChange={(e) => setSearch(e.target.value)} />
+        <Combobox.Options>
+          {items.map((item) => (
+            <Combobox.Option key={String(item.value)} value={item.value}>
+              {item.label}
+            </Combobox.Option>
+          ))}
+        </Combobox.Options>
+      </Combobox>
+    )
+  }
+/>;
+```
+
+See the backend documentation at `/dotnet/business/data-lookup/` for the
+contract and ADR-023 for the architectural rationale.

--- a/packages/@granit/react-data-lookup/package.json
+++ b/packages/@granit/react-data-lookup/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@granit/react-data-lookup",
+  "description": "React hooks and components for @granit/data-lookup — useLookup, LookupSelect, LookupPicker, LookupBadge",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/data-lookup": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/react-testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-data-lookup/src/__tests__/use-lookup.test.tsx
+++ b/packages/@granit/react-data-lookup/src/__tests__/use-lookup.test.tsx
@@ -1,0 +1,101 @@
+import { createQueryWrapper } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildLookupQueryKey, useLookup } from '../hooks/use-lookup.js';
+
+import type { LookupDescriptor, LookupResult } from '@granit/data-lookup';
+
+describe('useLookup', () => {
+  it('emits a search request when scope is satisfied', async () => {
+    const client = createMockClient();
+    const payload: LookupResult = { items: [{ value: '1', label: 'Acme' }] };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(payload));
+
+    const { result } = renderHook(
+      () => useLookup({ name: 'tenants' }, { search: 'ac' }, { client }),
+      { wrapper: createQueryWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(payload);
+    expect(result.current.missingScopeKey).toBeNull();
+    expect(client.get).toHaveBeenCalled();
+  });
+
+  it('stays disabled and does NOT fire when a scope key is missing (Empty Scope Trap)', async () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(
+      () =>
+        useLookup(
+          { name: 'meters', scopeKeys: ['tenantId'] },
+          { search: 'kwh', scope: {} },
+          { client }
+        ),
+      { wrapper: createQueryWrapper() }
+    );
+
+    expect(result.current.missingScopeKey).toBe('tenantId');
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('fires again once the missing scope key is filled', async () => {
+    const client = createMockClient();
+    const payload: LookupResult = { items: [{ value: 'm1', label: 'Meter One' }] };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(payload));
+
+    const { result, rerender } = renderHook(
+      ({ scope }: { scope: Record<string, string | null | undefined> }) =>
+        useLookup(
+          { name: 'meters', scopeKeys: ['tenantId'] },
+          { search: 'kwh', scope },
+          { client }
+        ),
+      {
+        wrapper: createQueryWrapper(),
+        initialProps: { scope: { tenantId: '' } as Record<string, string | null | undefined> },
+      }
+    );
+
+    expect(client.get).not.toHaveBeenCalled();
+    expect(result.current.missingScopeKey).toBe('tenantId');
+
+    rerender({ scope: { tenantId: 'acme' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.missingScopeKey).toBeNull();
+    expect(client.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('forced enabled=false overrides even when scope is satisfied', () => {
+    const client = createMockClient();
+
+    renderHook(() => useLookup({ name: 'tenants' }, { search: 'ac' }, { client, enabled: false }), {
+      wrapper: createQueryWrapper(),
+    });
+
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildLookupQueryKey', () => {
+  it('includes the culture in the key so caches are per-language', () => {
+    const descriptor: LookupDescriptor = { name: 'tenants' };
+    const key1 = buildLookupQueryKey(descriptor, { search: 'acme' }, 'fr');
+    const key2 = buildLookupQueryKey(descriptor, { search: 'acme' }, 'en');
+
+    expect(key1).not.toEqual(key2);
+  });
+
+  it('has the granit/data-lookup/search prefix', () => {
+    const key = buildLookupQueryKey({ name: 'tenants' }, { search: '' });
+
+    expect(key[0]).toBe('granit');
+    expect(key[1]).toBe('data-lookup');
+    expect(key[2]).toBe('search');
+    expect(key[3]).toBe('tenants');
+  });
+});

--- a/packages/@granit/react-data-lookup/src/components/lookup-badge.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-badge.tsx
@@ -1,0 +1,50 @@
+import { useLookupResolve } from '../hooks/use-lookup-resolve.js';
+
+import type { LookupDescriptor } from '@granit/data-lookup';
+import type { AxiosInstance } from 'axios';
+import type { ReactElement } from 'react';
+
+/** Render-prop signature. */
+export interface LookupBadgeRenderArgs {
+  readonly label: string;
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+}
+
+export interface LookupBadgeProps {
+  readonly descriptor: LookupDescriptor;
+  readonly value: unknown;
+  readonly client: AxiosInstance;
+  readonly culture?: string;
+  readonly basePath?: string;
+  /**
+   * Optional fallback label used while loading or when the value cannot be
+   * resolved. Defaults to `String(value)`.
+   */
+  readonly fallback?: string;
+  readonly render?: (args: LookupBadgeRenderArgs) => ReactElement;
+}
+
+/**
+ * Read-only projection of a lookup value. Uses {@link useLookupResolve} to
+ * fetch the localized label; shows the raw value (or a caller-provided
+ * fallback) while loading or on error.
+ *
+ * Suitable for:
+ * - Detail views where a foreign-key id is stored but a label is displayed.
+ * - Activity logs / audit tables.
+ * - Read-only form fields.
+ */
+export function LookupBadge(props: LookupBadgeProps): ReactElement {
+  const { descriptor, value, client, culture, basePath, fallback, render } = props;
+  const query = useLookupResolve(descriptor, value, { client, basePath, culture });
+
+  const rawFallback = fallback ?? (value === null || value === undefined ? '' : String(value));
+  const label = query.data?.label ?? rawFallback;
+
+  if (render) {
+    return render({ label, isLoading: query.isLoading, isError: query.isError });
+  }
+
+  return <span data-lookup-badge>{label}</span>;
+}

--- a/packages/@granit/react-data-lookup/src/components/lookup-picker.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-picker.tsx
@@ -1,0 +1,80 @@
+import { useMemo, useState } from 'react';
+
+import { useLookup } from '../hooks/use-lookup.js';
+
+import type { LookupDescriptor, LookupItem } from '@granit/data-lookup';
+import type { AxiosInstance } from 'axios';
+import type { ReactElement } from 'react';
+
+/** Render-prop signature for the SmartFilterBar typeahead. */
+export interface LookupPickerRenderArgs {
+  readonly search: string;
+  readonly setSearch: (next: string) => void;
+  /** Current value(s). String for `Eq`, array for `In`. */
+  readonly value: unknown | readonly unknown[];
+  readonly onChange: (next: unknown | readonly unknown[]) => void;
+  /** Whether the picker is in multi-select mode (e.g., `In` filter operator). */
+  readonly multi: boolean;
+  /** Items matching the current search term. */
+  readonly items: readonly LookupItem[];
+  readonly isLoading: boolean;
+  readonly missingScopeKey: string | null;
+}
+
+export interface LookupPickerProps {
+  readonly descriptor: LookupDescriptor;
+  readonly value: unknown | readonly unknown[];
+  readonly onChange: (next: unknown | readonly unknown[]) => void;
+  readonly client: AxiosInstance;
+  readonly scope?: Readonly<Record<string, string | null | undefined>>;
+  readonly culture?: string;
+  readonly basePath?: string;
+  readonly pageSize?: number;
+  /** Whether to allow multiple selections (for the `In` operator). */
+  readonly multi?: boolean;
+  readonly render: (args: LookupPickerRenderArgs) => ReactElement;
+}
+
+/**
+ * Lookup picker tailored for SmartFilterBar: a stripped-down variant of
+ * {@link LookupSelect} that doesn't resolve the currently selected value
+ * (filters already display the raw value), and supports multi-selection
+ * for the `In` operator.
+ *
+ * Same Empty Scope Trap guarantees as {@link LookupSelect}.
+ */
+export function LookupPicker(props: LookupPickerProps): ReactElement {
+  const {
+    descriptor,
+    value,
+    onChange,
+    client,
+    scope,
+    culture,
+    basePath,
+    pageSize = 25,
+    multi = false,
+    render,
+  } = props;
+
+  const [search, setSearch] = useState('');
+
+  const query = useLookup(
+    descriptor,
+    { search, page: 1, pageSize, scope },
+    { client, basePath, culture }
+  );
+
+  const items: readonly LookupItem[] = useMemo(() => query.data?.items ?? [], [query.data]);
+
+  return render({
+    search,
+    setSearch,
+    value,
+    onChange,
+    multi,
+    items,
+    isLoading: query.isLoading,
+    missingScopeKey: query.missingScopeKey,
+  });
+}

--- a/packages/@granit/react-data-lookup/src/components/lookup-select.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-select.tsx
@@ -1,0 +1,105 @@
+import { useMemo, useState } from 'react';
+
+import { useLookupResolve } from '../hooks/use-lookup-resolve.js';
+import { useLookup } from '../hooks/use-lookup.js';
+
+import type { LookupDescriptor, LookupItem } from '@granit/data-lookup';
+import type { AxiosInstance } from 'axios';
+import type { ReactElement } from 'react';
+
+/** Render-prop signature for custom UIs. Callers bring their own combobox primitive. */
+export interface LookupSelectRenderArgs {
+  /** Current search term (controlled). */
+  readonly search: string;
+  /** Setter for the search term. */
+  readonly setSearch: (next: string) => void;
+  /** Current selected value (controlled). */
+  readonly value: unknown;
+  /** Setter for the selected value. Accepts `null` to clear. */
+  readonly onChange: (next: unknown) => void;
+  /** Currently selected item, resolved via the /resolve endpoint. */
+  readonly selectedItem: LookupItem | null;
+  /** Items for the dropdown (current page). */
+  readonly items: readonly LookupItem[];
+  /** Loading state for the search query. */
+  readonly isLoading: boolean;
+  /** When non-null, the picker must be disabled and this message shown. */
+  readonly missingScopeKey: string | null;
+}
+
+export interface LookupSelectProps {
+  /** Descriptor emitted by the backend (or built inline for ad-hoc sources). */
+  readonly descriptor: LookupDescriptor;
+  /** Currently selected value (controlled). */
+  readonly value: unknown;
+  /** Called with the new value when the user selects an item (or `null` to clear). */
+  readonly onChange: (next: unknown) => void;
+  /** Axios instance used by the underlying hooks. */
+  readonly client: AxiosInstance;
+  /** Map of `<scope key> → <form field value>` resolved at render time. */
+  readonly scope?: Readonly<Record<string, string | null | undefined>>;
+  /** Current UI culture — passed to both hooks so caches are per-language. */
+  readonly culture?: string;
+  /** Override the base path. Defaults to `/api/granit/lookups`. */
+  readonly basePath?: string;
+  /** Page size passed to the search query. Default: `25`. */
+  readonly pageSize?: number;
+  /** Render prop. Provides the headless state; consumers wrap it in their combobox UI. */
+  readonly render: (args: LookupSelectRenderArgs) => ReactElement;
+}
+
+/**
+ * Headless combobox-style select backed by {@link useLookup} and
+ * {@link useLookupResolve}. Intentionally presentation-agnostic: callers
+ * provide a `render` prop that plugs the returned state into their UI kit
+ * (Radix, HeadlessUI, Mantine, custom CSS...).
+ *
+ * **Empty Scope Trap** — when the descriptor declares `scopeKeys` and the
+ * provided `scope` is missing a value, the search query is disabled and
+ * `missingScopeKey` is set to the first missing key. The UI is expected to
+ * render a placeholder like "Select a tenant first" rather than an open
+ * picker with full-table-scan results.
+ */
+export function LookupSelect(props: LookupSelectProps): ReactElement {
+  const {
+    descriptor,
+    value,
+    onChange,
+    client,
+    scope,
+    culture,
+    basePath,
+    pageSize = 25,
+    render,
+  } = props;
+
+  const [search, setSearch] = useState('');
+
+  const searchQuery = useLookup(
+    descriptor,
+    { search, page: 1, pageSize, scope },
+    { client, basePath, culture }
+  );
+
+  const resolveQuery = useLookupResolve(descriptor, value, {
+    client,
+    basePath,
+    culture,
+  });
+
+  const items: readonly LookupItem[] = useMemo(
+    () => searchQuery.data?.items ?? [],
+    [searchQuery.data]
+  );
+
+  return render({
+    search,
+    setSearch,
+    value,
+    onChange,
+    selectedItem: resolveQuery.data ?? null,
+    items,
+    isLoading: searchQuery.isLoading || resolveQuery.isLoading,
+    missingScopeKey: searchQuery.missingScopeKey,
+  });
+}

--- a/packages/@granit/react-data-lookup/src/hooks/use-lookup-resolve.ts
+++ b/packages/@granit/react-data-lookup/src/hooks/use-lookup-resolve.ts
@@ -1,0 +1,47 @@
+import { resolveLookup } from '@granit/data-lookup';
+import { useQuery } from '@tanstack/react-query';
+
+import type { LookupDescriptor, LookupItem } from '@granit/data-lookup';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+
+/** Options accepted by {@link useLookupResolve}. */
+export interface UseLookupResolveOptions {
+  readonly client: AxiosInstance;
+  readonly basePath?: string;
+  readonly culture?: string;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Resolves a single value into a {@link LookupItem} for rehydration
+ * (e.g., when loading a form previously saved with a foreign-key value — the
+ * label must be fetched to show a human-readable picker state).
+ *
+ * `GET /api/granit/lookups/{name}/resolve?value=…` → {@link LookupItem} | `null`.
+ *
+ * Returns `data: null` when the value cannot be resolved (404) rather than
+ * raising — callers typically show the raw value as a fallback.
+ */
+export function useLookupResolve(
+  descriptor: LookupDescriptor,
+  value: unknown,
+  options: UseLookupResolveOptions
+): UseQueryResult<LookupItem | null> {
+  const { client, basePath, culture, enabled: forcedEnabled } = options;
+  const hasValue = value !== null && value !== undefined && value !== '';
+
+  return useQuery<LookupItem | null>({
+    queryKey: [
+      'granit',
+      'data-lookup',
+      'resolve',
+      descriptor.name ?? descriptor.endpoint ?? '(unknown)',
+      value ?? null,
+      culture ?? null,
+    ],
+    queryFn: ({ signal }) => resolveLookup(descriptor, value, { client, basePath, signal }),
+    enabled: forcedEnabled === false ? false : hasValue,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/packages/@granit/react-data-lookup/src/hooks/use-lookup.ts
+++ b/packages/@granit/react-data-lookup/src/hooks/use-lookup.ts
@@ -1,0 +1,93 @@
+import { findMissingScopeKey, searchLookup } from '@granit/data-lookup';
+import { useQuery } from '@tanstack/react-query';
+
+import type { LookupDescriptor, LookupQueryParams, LookupResult } from '@granit/data-lookup';
+import type { UseQueryResult } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+
+/** Options accepted by {@link useLookup}. */
+export interface UseLookupOptions {
+  /** Axios instance used for the HTTP request. */
+  readonly client: AxiosInstance;
+  /** Override the base path for registry-backed lookups. */
+  readonly basePath?: string;
+  /** Current UI culture (e.g. `"fr-CA"`). Added to the queryKey so cached results are invalidated per language. */
+  readonly culture?: string;
+  /**
+   * Debounce delay for the search term in milliseconds. Forwarded by higher-level
+   * components (`LookupPicker`, `LookupSelect`) — applied to the `search` param
+   * before it reaches the hook.
+   */
+  readonly staleTime?: number;
+  /**
+   * Forcibly disable the query (advanced — overrides the automatic
+   * {@link findMissingScopeKey} gate).
+   */
+  readonly enabled?: boolean;
+}
+
+/** Shape returned by {@link useLookup}. */
+export type UseLookupResult = UseQueryResult<LookupResult> & {
+  /** Name of the scope key that is currently missing, if any (Empty Scope Trap). */
+  readonly missingScopeKey: string | null;
+};
+
+/**
+ * Fetches a page of items from a lookup source via `GET /api/granit/lookups/{name}`.
+ *
+ * **Empty Scope Trap mitigation** — when the descriptor declares
+ * `scopeKeys: ["tenantId"]` and the provided `scope` is missing the value,
+ * React-Query's `enabled` flag is flipped to `false`: NO HTTP request is issued
+ * until the parent field is filled. Consumers (`LookupSelect`, `LookupPicker`)
+ * use {@link UseLookupResult.missingScopeKey} to render a placeholder such as
+ * "Pick a tenant first".
+ *
+ * The `queryKey` includes the caller culture so the cache is segmented per
+ * language — switching language invalidates all previously fetched labels.
+ */
+export function useLookup(
+  descriptor: LookupDescriptor,
+  params: LookupQueryParams,
+  options: UseLookupOptions
+): UseLookupResult {
+  const { client, basePath, culture, staleTime, enabled: forcedEnabled } = options;
+  const missingScopeKey = findMissingScopeKey(descriptor, params.scope);
+  const scopeSatisfied = missingScopeKey === null;
+
+  const effectiveEnabled = forcedEnabled === false ? false : scopeSatisfied;
+
+  const query = useQuery<LookupResult>({
+    queryKey: buildLookupQueryKey(descriptor, params, culture),
+    queryFn: ({ signal }) => searchLookup(descriptor, params, { client, basePath, signal }),
+    enabled: effectiveEnabled,
+    staleTime: staleTime ?? 30_000,
+    placeholderData: (previous) => previous,
+  });
+
+  return Object.assign(query, { missingScopeKey });
+}
+
+/**
+ * Returns a stable React-Query key for a lookup invocation. Exposed for
+ * advanced consumers that need to prefetch or invalidate cached lookups.
+ */
+export function buildLookupQueryKey(
+  descriptor: LookupDescriptor,
+  params: LookupQueryParams,
+  culture?: string
+): readonly unknown[] {
+  return [
+    'granit',
+    'data-lookup',
+    'search',
+    descriptor.name ?? descriptor.endpoint ?? '(unknown)',
+    {
+      search: params.search ?? '',
+      page: params.page ?? 1,
+      pageSize: params.pageSize ?? 25,
+      continuationToken: params.continuationToken ?? null,
+      scope: params.scope ?? null,
+    },
+    culture ?? null,
+  ] as const;
+}

--- a/packages/@granit/react-data-lookup/src/index.ts
+++ b/packages/@granit/react-data-lookup/src/index.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// @granit/react-data-lookup — React hooks and headless components
+// ---------------------------------------------------------------------------
+
+// Hooks
+export { buildLookupQueryKey, useLookup } from './hooks/use-lookup.js';
+export type { UseLookupOptions, UseLookupResult } from './hooks/use-lookup.js';
+export { useLookupResolve } from './hooks/use-lookup-resolve.js';
+export type { UseLookupResolveOptions } from './hooks/use-lookup-resolve.js';
+
+// Components
+export { LookupSelect } from './components/lookup-select.js';
+export type { LookupSelectProps, LookupSelectRenderArgs } from './components/lookup-select.js';
+export { LookupPicker } from './components/lookup-picker.js';
+export type { LookupPickerProps, LookupPickerRenderArgs } from './components/lookup-picker.js';
+export { LookupBadge } from './components/lookup-badge.js';
+export type { LookupBadgeProps, LookupBadgeRenderArgs } from './components/lookup-badge.js';

--- a/packages/@granit/react-data-lookup/tsconfig.json
+++ b/packages/@granit/react-data-lookup/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-data-lookup/tsup.config.ts
+++ b/packages/@granit/react-data-lookup/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,8 @@ overrides:
   immutable: '>=5.1.5'
   flatted: '>=3.4.2'
   '@tanstack/query-core': ^5.95.0
+  '@tanstack/react-query': 5.99.0
+  axios: 1.15.0
   picomatch: '>=4.0.4'
   yaml: '>=2.8.3'
   smol-toml: '>=1.6.1'
@@ -61,8 +63,8 @@ importers:
         specifier: ^1.40.0
         version: 1.40.0
       '@tanstack/react-query':
-        specifier: ^5.99.2
-        version: 5.99.2(react@19.2.5)
+        specifier: 5.99.0
+        version: 5.99.0(react@19.2.5)
       '@tanstack/react-virtual':
         specifier: ^3.13.24
         version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -85,8 +87,8 @@ importers:
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
       axios:
-        specifier: ^1.15.1
-        version: 1.15.1
+        specifier: 1.15.0
+        version: 1.15.0
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -160,7 +162,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -173,7 +175,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -183,7 +185,7 @@ importers:
   packages/@granit/api-client:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -199,7 +201,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -253,7 +255,7 @@ importers:
   packages/@granit/authentication-local:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -263,7 +265,7 @@ importers:
   packages/@granit/authorization:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
 
   packages/@granit/background-jobs:
@@ -275,7 +277,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -291,7 +293,7 @@ importers:
   packages/@granit/blob-storage:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -312,7 +314,7 @@ importers:
   packages/@granit/customer-balance:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -328,7 +330,17 @@ importers:
         specifier: workspace:*
         version: link:../utils
       axios:
-        specifier: '*'
+        specifier: 1.15.0
+        version: 1.15.0
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/data-lookup:
+    dependencies:
+      axios:
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -338,7 +350,7 @@ importers:
   packages/@granit/diagnostics:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -350,7 +362,7 @@ importers:
   packages/@granit/features:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -363,7 +375,7 @@ importers:
         specifier: workspace:*
         version: link:../api-client
       axios:
-        specifier: ^1.0.0
+        specifier: 1.15.0
         version: 1.15.0
 
   packages/@granit/identity:
@@ -375,7 +387,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -388,7 +400,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -404,7 +416,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       i18next:
         specifier: ^25.0.0
@@ -431,7 +443,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -444,7 +456,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
 
   packages/@granit/notifications:
@@ -456,7 +468,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/api-client':
@@ -466,7 +478,7 @@ importers:
   packages/@granit/notifications-mobile-push:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/api-client':
@@ -505,7 +517,7 @@ importers:
   packages/@granit/notifications-web-push:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/api-client':
@@ -521,7 +533,7 @@ importers:
         specifier: workspace:*
         version: link:../query-engine
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -531,7 +543,7 @@ importers:
   packages/@granit/payments:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -541,7 +553,7 @@ importers:
   packages/@granit/privacy:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -554,7 +566,7 @@ importers:
         specifier: workspace:*
         version: link:../utils
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -567,10 +579,10 @@ importers:
         specifier: workspace:*
         version: link:../account
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -595,10 +607,10 @@ importers:
         specifier: workspace:*
         version: link:../ai
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -623,7 +635,7 @@ importers:
   packages/@granit/react-api-client:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       react:
         specifier: ^19.0.0
@@ -645,10 +657,10 @@ importers:
         specifier: workspace:*
         version: link:../query-engine
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -692,10 +704,10 @@ importers:
         specifier: workspace:*
         version: link:../authentication-api-keys
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -804,10 +816,10 @@ importers:
         specifier: workspace:*
         version: link:../authentication-local
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -829,10 +841,10 @@ importers:
         specifier: workspace:*
         version: link:../authorization
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -857,10 +869,10 @@ importers:
         specifier: workspace:*
         version: link:../query-engine
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -894,10 +906,10 @@ importers:
         specifier: workspace:*
         version: link:../blob-storage
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -935,10 +947,10 @@ importers:
         specifier: workspace:*
         version: link:../customer-balance
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -972,10 +984,10 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -994,16 +1006,38 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/react-data-lookup:
+    dependencies:
+      '@granit/data-lookup':
+        specifier: workspace:*
+        version: link:../data-lookup
+      '@tanstack/react-query':
+        specifier: 5.99.0
+        version: 5.99.0(react@19.2.5)
+      axios:
+        specifier: 1.15.0
+        version: 1.15.0
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-diagnostics:
     dependencies:
       '@granit/diagnostics':
         specifier: workspace:*
         version: link:../diagnostics
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1037,10 +1071,10 @@ importers:
         specifier: workspace:*
         version: link:../features
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1062,10 +1096,10 @@ importers:
         specifier: workspace:*
         version: link:../identity
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1090,10 +1124,10 @@ importers:
         specifier: workspace:*
         version: link:../invoicing
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1124,10 +1158,10 @@ importers:
         specifier: workspace:*
         version: link:../storage
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       date-fns:
         specifier: ^4.0.0
@@ -1158,10 +1192,10 @@ importers:
         specifier: workspace:*
         version: link:../metering
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1189,10 +1223,10 @@ importers:
         specifier: workspace:*
         version: link:../multi-tenancy
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1216,7 +1250,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1238,10 +1272,10 @@ importers:
         specifier: workspace:*
         version: link:../notifications-mobile-push
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       react:
         specifier: ^19.0.0
@@ -1263,7 +1297,7 @@ importers:
         specifier: workspace:*
         version: link:../notifications-web-push
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       react:
         specifier: ^19.0.0
@@ -1275,10 +1309,10 @@ importers:
         specifier: workspace:*
         version: link:../openiddict-admin
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1300,10 +1334,10 @@ importers:
         specifier: workspace:*
         version: link:../payments
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       lucide-react:
         specifier: ^1.0.0
@@ -1331,10 +1365,10 @@ importers:
         specifier: workspace:*
         version: link:../privacy
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1362,10 +1396,10 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       react:
         specifier: ^19.0.0
@@ -1393,10 +1427,10 @@ importers:
         specifier: workspace:*
         version: link:../types
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       react:
         specifier: ^19.0.0
@@ -1418,10 +1452,10 @@ importers:
         specifier: workspace:*
         version: link:../scheduling
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1446,10 +1480,10 @@ importers:
         specifier: workspace:*
         version: link:../settings
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1483,10 +1517,10 @@ importers:
         specifier: workspace:*
         version: link:../subscriptions
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1511,10 +1545,10 @@ importers:
         specifier: workspace:*
         version: link:../tax
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1536,10 +1570,10 @@ importers:
   packages/@granit/react-templating:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1570,7 +1604,7 @@ importers:
   packages/@granit/react-testing:
     dependencies:
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       react:
         specifier: ^19.0.0
@@ -1598,7 +1632,7 @@ importers:
         specifier: workspace:*
         version: link:../timeline
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1662,7 +1696,7 @@ importers:
         specifier: workspace:*
         version: link:../validation
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       react:
         specifier: ^19.0.0
@@ -1681,10 +1715,10 @@ importers:
         specifier: workspace:*
         version: link:../webhooks
       '@tanstack/react-query':
-        specifier: ^5.0.0
+        specifier: 5.99.0
         version: 5.99.0(react@19.2.5)
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1715,7 +1749,7 @@ importers:
         specifier: workspace:*
         version: link:../workflow
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1746,7 +1780,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -1762,7 +1796,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -1772,7 +1806,7 @@ importers:
   packages/@granit/settings:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -1790,7 +1824,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -1800,7 +1834,7 @@ importers:
   packages/@granit/tax:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -1816,7 +1850,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/api-client':
@@ -1826,7 +1860,7 @@ importers:
   packages/@granit/testing:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
       msw:
         specifier: ^2.12.0
@@ -1844,7 +1878,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/api-client':
@@ -1883,7 +1917,7 @@ importers:
   packages/@granit/validation:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -1893,7 +1927,7 @@ importers:
   packages/@granit/webhooks:
     dependencies:
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/testing':
@@ -1912,7 +1946,7 @@ importers:
         specifier: workspace:*
         version: link:../types
       axios:
-        specifier: '*'
+        specifier: 1.15.0
         version: 1.15.0
     devDependencies:
       '@granit/api-client':
@@ -3384,19 +3418,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@tanstack/query-core@5.99.0':
-    resolution: {integrity: sha512-3Jv3WQG0BCcH7G+7lf/bP8QyBfJOXeY+T08Rin3GZ1bshvwlbPt7NrDHMEzGdKIOmOzvIQmxjk28YEQX60k7pQ==}
-
   '@tanstack/query-core@5.99.2':
     resolution: {integrity: sha512-1HunU0bXVsR1ZJMZbcOPE6VtaBJxsW809RE9xPe4Gz7MlB0GWwQvuTPhMoEmQ/hIzFKJ/DWAuttIe7BOaWx0tA==}
 
   '@tanstack/react-query@5.99.0':
     resolution: {integrity: sha512-OY2bCqPemT1LlqJ8Y2CUau4KELnIhhG9Ol3ZndPbdnB095pRbPo1cHuXTndg8iIwtoHTgwZjyaDnQ0xD0mYwAw==}
-    peerDependencies:
-      react: ^18 || ^19
-
-  '@tanstack/react-query@5.99.2':
-    resolution: {integrity: sha512-vM91UEe45QUS9ED6OklsVL15i8qKcRqNwpWzPTVWvRPRSEgDudDgHpvyTjcdlwHcrKNa80T+xXYcchT2noPnZA==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -3780,9 +3806,6 @@ packages:
 
   axios@1.15.0:
     resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
-
-  axios@1.15.1:
-    resolution: {integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==}
 
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
@@ -7204,16 +7227,9 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tanstack/query-core@5.99.0': {}
-
   '@tanstack/query-core@5.99.2': {}
 
   '@tanstack/react-query@5.99.0(react@19.2.5)':
-    dependencies:
-      '@tanstack/query-core': 5.99.0
-      react: 19.2.5
-
-  '@tanstack/react-query@5.99.2(react@19.2.5)':
     dependencies:
       '@tanstack/query-core': 5.99.2
       react: 19.2.5
@@ -7602,14 +7618,6 @@ snapshots:
   asynckit@0.4.0: {}
 
   axios@1.15.0:
-    dependencies:
-      follow-redirects: 1.16.0
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.1:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -140,6 +140,11 @@ export default defineConfig({
         __dirname,
         'packages/@granit/data-exchange/src/index.ts'
       ),
+      '@granit/data-lookup': path.resolve(__dirname, 'packages/@granit/data-lookup/src/index.ts'),
+      '@granit/react-data-lookup': path.resolve(
+        __dirname,
+        'packages/@granit/react-data-lookup/src/index.ts'
+      ),
       '@granit/error-boundary': path.resolve(
         __dirname,
         'packages/@granit/error-boundary/src/index.ts'


### PR DESCRIPTION
## Summary

Frontend SDK for the unified **Granit Data Lookup** primitive. Consumes the
backend contract shipped in
[granit-dotnet #1124](https://github.com/granit-fx/granit-dotnet/pull/1124)
(PR 1) and [granit-dotnet #1128](https://github.com/granit-fx/granit-dotnet/pull/1128)
(PR 3) with zero new runtime dependencies beyond axios and React Query.

Refs ADR-023. PR **4 of 7**; PR 5 wires SmartFilterBar to \`LookupPicker\` when \`field.lookup\` is present.

## New packages

| Package | Purpose |
| --- | --- |
| \`@granit/data-lookup\` | Framework-agnostic TypeScript types + axios HTTP client |
| \`@granit/react-data-lookup\` | React Query hooks + headless render-prop components |

### \`@granit/data-lookup\` exports

- **Types**: \`LookupDescriptor\`, \`LookupKind\`, \`LookupItem\`, \`LookupResult\`, \`LookupManifest\`, \`LookupManifestEntry\`, \`LookupQueryParams\`.
- **Client**: \`searchLookup\`, \`resolveLookup\`, \`fetchLookupManifest\`, \`buildSearchQuery\`, \`DEFAULT_LOOKUP_BASE_PATH\`.
- **Scope validation** (shared with the React layer): \`findMissingScopeKey\`, \`isScopeSatisfied\`.

### \`@granit/react-data-lookup\` exports

- **Hooks**: \`useLookup\`, \`useLookupResolve\`, \`buildLookupQueryKey\`.
- **Components** (headless render-prop): \`<LookupSelect>\`, \`<LookupPicker>\`, \`<LookupBadge>\`.

## Empty Scope Trap — frontend half of the mitigation

The backend (PR 1) already returns \`400\` on missing scope keys. The frontend
avoids firing the request in the first place:

\`\`\`tsx
const descriptor = { name: 'meters', scopeKeys: ['tenantId'] };
// tenantId is still blank -- enabled: false, no HTTP call
const { data, missingScopeKey } = useLookup(descriptor, { scope: {} }, { client });
// missingScopeKey === 'tenantId' → consumer renders "Pick a tenant first"
\`\`\`

\`<LookupSelect>\` and \`<LookupPicker>\` surface \`missingScopeKey\` in their
render-prop payload so the UI can react without re-implementing the guard.

## Culture-aware cache

\`buildLookupQueryKey\` includes the caller culture so React Query caches are
segmented per language. Switching language invalidates the previously fetched
labels automatically, which matches the backend behaviour of returning already-
localized labels.

## Test plan

- [x] \`pnpm test --run packages/@granit/data-lookup packages/@granit/react-data-lookup\` → **27 tests green** (12 scope-validation + 9 client + 6 hook).
- [x] \`pnpm -F @granit/data-lookup exec tsc --noEmit\` + \`pnpm -F @granit/react-data-lookup exec tsc --noEmit\` clean.
- [x] \`pnpm lint\` clean (import-x/order + consistent-type-imports satisfied).
- [x] \`pnpm -F @granit/data-lookup build\` + \`pnpm -F @granit/react-data-lookup build\` produce valid ESM + .d.ts bundles.
- [ ] CI green.

## Workspace changes

- \`vitest.config.ts\`: alias entries for the two new packages.
- Root \`package.json\`: \`pnpm overrides\` pinning \`@tanstack/react-query\` and \`axios\` to single versions. This avoids split virtual-store slots where the test wrapper and the hook resolve against different copies of React Query (\"No QueryClient set\" in tests).

## Scope discipline

| ✅ In this PR | ❌ Deferred |
| --- | --- |
| Types, HTTP client, hooks, headless components, 27 tests | SmartFilterBar wiring — PR 5 |
| Empty Scope Trap both layers | First adopters — PR 6 / 7 |
| Culture-aware cache | Showcase migrations — PR 7 |

## Notes

- Depends on granit-dotnet PR 1 (merged) + PR 3 (in review). The TypeScript
  types mirror the backend contract exactly.
- Independent of granit-dotnet PR 2 — this SDK does not yet consume
  \`FilterableField.lookup\`. That wiring lands in PR 5.