### PR TITLE
feat(query-engine): wire FilterableField.lookup through useSmartFilter (PR 5/7)

### DIFF
--- a/packages/@granit/query-engine/package.json
+++ b/packages/@granit/query-engine/package.json
@@ -17,6 +17,7 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/data-lookup": "workspace:*",
     "@granit/utils": "workspace:*",
     "axios": "*"
   },

--- a/packages/@granit/query-engine/src/types/query-metadata.ts
+++ b/packages/@granit/query-engine/src/types/query-metadata.ts
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import type { FilterOperator } from './query-params.js';
+import type { LookupDescriptor } from '@granit/data-lookup';
 
 /** Column definition for display in data tables. */
 export interface ColumnDefinition {
@@ -30,6 +31,13 @@ export interface FilterableField {
   readonly operators: readonly FilterOperator[];
   /** Known values for enum-like fields (shown as suggestions in enterValue phase). */
   readonly enumValues?: readonly string[];
+  /**
+   * Optional descriptor pointing to a Granit.DataLookup source. When set, the
+   * SmartFilterBar routes the "enter value" phase to a server-backed typeahead
+   * picker (`<LookupPicker>` from `@granit/react-data-lookup`) instead of a
+   * free-text input.
+   */
+  readonly lookup?: LookupDescriptor;
 }
 
 /** Sortable field declaration. */

--- a/packages/@granit/react-query-engine/package.json
+++ b/packages/@granit/react-query-engine/package.json
@@ -13,6 +13,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/data-lookup": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/utils": "workspace:*",

--- a/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
+++ b/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
@@ -193,3 +193,77 @@ describe('useSmartFilter', () => {
     expect(qfSuggestion!.label).toBe('My Items');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lookup-backed fields — SmartFilter delegates to <LookupPicker>
+// ---------------------------------------------------------------------------
+
+const METADATA_WITH_LOOKUP: QueryMetadata = {
+  ...MOCK_METADATA,
+  filterableFields: [
+    {
+      name: 'TenantId',
+      type: 'Guid',
+      operators: ['Eq', 'In'],
+      lookup: {
+        name: 'tenants',
+        kind: 'QueryEngine',
+        requiredPermission: 'Platform.Tenants.Read',
+      },
+    },
+    {
+      name: 'MeterId',
+      type: 'Guid',
+      operators: ['Eq', 'In'],
+      lookup: {
+        name: 'meter-definitions',
+        scopeKeys: ['tenantId'],
+      },
+    },
+    ...MOCK_METADATA.filterableFields,
+  ],
+};
+
+describe('useSmartFilter — lookup-backed fields', () => {
+  it('exposes selectedFieldLookup when the selected field declares a lookup', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('TenantId'));
+
+    expect(result.current.selectedFieldLookup).toEqual({
+      name: 'tenants',
+      kind: 'QueryEngine',
+      requiredPermission: 'Platform.Tenants.Read',
+    });
+  });
+
+  it('exposes scopeKeys via selectedFieldLookup for scoped sources', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('MeterId'));
+
+    expect(result.current.selectedFieldLookup?.scopeKeys).toEqual(['tenantId']);
+  });
+
+  it('returns undefined selectedFieldLookup for fields without a lookup', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('LastName'));
+
+    expect(result.current.selectedFieldLookup).toBeUndefined();
+  });
+
+  it('emits NO inline value suggestions during enterValue for lookup-backed fields', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('TenantId'));
+    act(() => result.current.selectOperator('Eq'));
+
+    expect(result.current.phase).toBe('enterValue');
+    // No enum / boolean suggestions — the consumer renders <LookupPicker> instead.
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it('selectedFieldLookup is undefined in idle phase', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.selectedFieldLookup).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-query-engine/src/hooks/use-smart-filter.ts
+++ b/packages/@granit/react-query-engine/src/hooks/use-smart-filter.ts
@@ -4,6 +4,7 @@
 
 import { useCallback, useMemo, useReducer } from 'react';
 
+import type { LookupDescriptor } from '@granit/data-lookup';
 import type {
   FilterEntry,
   FilterOperator,
@@ -376,6 +377,9 @@ function buildValueSuggestions(
 ): FilterSuggestion[] {
   const field = metadata.filterableFields.find((f) => f.name === state.selectedField);
   if (!field) return [];
+  // Lookup-backed fields delegate value input to <LookupPicker>. The hook stops
+  // emitting inline suggestions so the consumer renders the picker instead.
+  if (field.lookup) return [];
   if (field.type === 'Boolean') {
     return buildBooleanSuggestions(field, options?.booleanLabels);
   }
@@ -446,6 +450,12 @@ export interface UseSmartFilterReturn {
   readonly selectedOperator?: FilterOperator;
   /** Type of the currently selected field (during selectOperator / enterValue phases). */
   readonly selectedFieldType?: string;
+  /**
+   * Data-lookup descriptor for the currently selected field, if any. When set,
+   * the UI should render `<LookupPicker>` during the `enterValue` phase instead
+   * of the free-text / enum input. `undefined` for fields without a lookup source.
+   */
+  readonly selectedFieldLookup?: LookupDescriptor;
   /** Extracted FilterEntry array from current tokens (for useQueryEndpoint). */
   readonly filters: readonly FilterEntry[];
   /** Extracted search string from tokens. */
@@ -599,6 +609,11 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
     return options.metadata.filterableFields.find((f) => f.name === state.selectedField)?.type;
   }, [state.selectedField, options?.metadata]);
 
+  const selectedFieldLookup = useMemo(() => {
+    if (!state.selectedField || !options?.metadata) return undefined;
+    return options.metadata.filterableFields.find((f) => f.name === state.selectedField)?.lookup;
+  }, [state.selectedField, options?.metadata]);
+
   return {
     phase: state.phase,
     inputValue: state.inputValue,
@@ -606,6 +621,7 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
     suggestions,
     selectedOperator: state.selectedOperator,
     selectedFieldType,
+    selectedFieldLookup,
     filters,
     search,
     presets,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,9 @@ importers:
 
   packages/@granit/query-engine:
     dependencies:
+      '@granit/data-lookup':
+        specifier: workspace:*
+        version: link:../data-lookup
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1386,6 +1389,9 @@ importers:
 
   packages/@granit/react-query-engine:
     dependencies:
+      '@granit/data-lookup':
+        specifier: workspace:*
+        version: link:../data-lookup
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine


### PR DESCRIPTION
## Summary

Completes the wiring between the backend \`LookupDescriptor\` emitted on
\`FilterableField.lookup\` (granit-dotnet #1127 / PR 2) and the headless
\`useSmartFilter\` state machine. When a filterable field declares a lookup
source, the UI layer can now render \`<LookupPicker>\` (from #205 / PR 4)
instead of inline enum/boolean suggestions — no change required to the
caller other than the metadata itself.

Refs ADR-023. PR **5 of 7**.

## Changes

### \`@granit/query-engine\`

- \`FilterableField\` gains \`readonly lookup?: LookupDescriptor\`. Mirrors the
  .NET contract merged as granit-dotnet #1127 verbatim.
- New \`peerDependency\` on \`@granit/data-lookup\` (types only, zero runtime cost).

### \`@granit/react-query-engine\`

- \`useSmartFilter\` exposes \`selectedFieldLookup: LookupDescriptor | undefined\`
  in \`UseSmartFilterReturn\`. The consumer reads this to branch between the
  default suggestion list and \`<LookupPicker>\`.
- \`buildValueSuggestions\` short-circuits to \`[]\` when the selected field
  declares a lookup — the suggestion dropdown stays empty and the caller
  wires the picker directly.
- New \`peerDependency\` on \`@granit/data-lookup\`.

## Usage

Consumer (e.g., SmartFilterBar component in showcase-admin-react):

\`\`\`tsx
const {
  phase, selectedField, selectedFieldLookup, selectedOperator, confirmValue,
} = useSmartFilter({ metadata });

if (phase === 'enterValue' && selectedFieldLookup) {
  return (
    <LookupPicker
      descriptor={selectedFieldLookup}
      multi={selectedOperator === 'In'}
      onChange={(v) => confirmValue(String(v))}
      scope={formWatchedValues}
      client={axios}
      culture={i18n.resolvedLanguage}
      render={/* consumer UI */}
    />
  );
}
\`\`\`

## Test plan

- [x] \`pnpm -F @granit/query-engine exec tsc --noEmit\` + \`pnpm -F @granit/react-query-engine exec tsc --noEmit\` clean.
- [x] \`pnpm lint\` clean.
- [x] \`pnpm test --run packages/@granit/react-query-engine\` → **91 tests** (86 existing + **5 new**).
- [x] Zero regression across \`@granit/query-engine\`, \`@granit/data-lookup\`, \`@granit/react-data-lookup\` (98 tests total green).
- [x] \`pnpm -F @granit/query-engine build\` + \`pnpm -F @granit/react-query-engine build\` produce valid bundles.
- [ ] CI green.

## Dependencies

- **Depends on #205 (PR 4)** — base branch is \`feature/data-lookup-frontend-sdk\`
  so GitHub shows the incremental diff. Once #205 merges into \`develop\`, the
  base will auto-retarget to \`develop\`.
- Consumes \`LookupDescriptor\` types from \`@granit/data-lookup\` (PR 4).
- Consumes backend \`FilterableField.lookup\` from granit-dotnet #1127 (merged).

## Scope discipline

| ✅ In this PR | ❌ Deferred |
| --- | --- |
| \`FilterableField.lookup\` type + \`selectedFieldLookup\` hook surface | Showcase SmartFilterBar component wiring — out of this monorepo |
| 5 new unit tests | First backend adopters (Tenant/User/Meter \`.AsLookup\`) — PR 6 |
| Bypass of inline enum/boolean suggestions for lookup fields | \`<LookupSelect>\` migration in showcase edit forms — PR 7 |