### PR TITLE
feat(query-engine): wire FilterableField.lookup through useSmartFilter (re-submit of #206)

### DIFF
--- a/packages/@granit/query-engine/package.json
+++ b/packages/@granit/query-engine/package.json
@@ -17,6 +17,7 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/data-lookup": "workspace:*",
     "@granit/utils": "workspace:*",
     "axios": "*"
   },

--- a/packages/@granit/query-engine/src/types/query-metadata.ts
+++ b/packages/@granit/query-engine/src/types/query-metadata.ts
@@ -4,6 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import type { FilterOperator } from './query-params.js';
+import type { LookupDescriptor } from '@granit/data-lookup';
 
 /** Column definition for display in data tables. */
 export interface ColumnDefinition {
@@ -30,6 +31,13 @@ export interface FilterableField {
   readonly operators: readonly FilterOperator[];
   /** Known values for enum-like fields (shown as suggestions in enterValue phase). */
   readonly enumValues?: readonly string[];
+  /**
+   * Optional descriptor pointing to a Granit.DataLookup source. When set, the
+   * SmartFilterBar routes the "enter value" phase to a server-backed typeahead
+   * picker (`<LookupPicker>` from `@granit/react-data-lookup`) instead of a
+   * free-text input.
+   */
+  readonly lookup?: LookupDescriptor;
 }
 
 /** Sortable field declaration. */

--- a/packages/@granit/react-query-engine/package.json
+++ b/packages/@granit/react-query-engine/package.json
@@ -13,6 +13,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/data-lookup": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/utils": "workspace:*",

--- a/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
+++ b/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
@@ -193,3 +193,77 @@ describe('useSmartFilter', () => {
     expect(qfSuggestion!.label).toBe('My Items');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Lookup-backed fields — SmartFilter delegates to <LookupPicker>
+// ---------------------------------------------------------------------------
+
+const METADATA_WITH_LOOKUP: QueryMetadata = {
+  ...MOCK_METADATA,
+  filterableFields: [
+    {
+      name: 'TenantId',
+      type: 'Guid',
+      operators: ['Eq', 'In'],
+      lookup: {
+        name: 'tenants',
+        kind: 'QueryEngine',
+        requiredPermission: 'Platform.Tenants.Read',
+      },
+    },
+    {
+      name: 'MeterId',
+      type: 'Guid',
+      operators: ['Eq', 'In'],
+      lookup: {
+        name: 'meter-definitions',
+        scopeKeys: ['tenantId'],
+      },
+    },
+    ...MOCK_METADATA.filterableFields,
+  ],
+};
+
+describe('useSmartFilter — lookup-backed fields', () => {
+  it('exposes selectedFieldLookup when the selected field declares a lookup', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('TenantId'));
+
+    expect(result.current.selectedFieldLookup).toEqual({
+      name: 'tenants',
+      kind: 'QueryEngine',
+      requiredPermission: 'Platform.Tenants.Read',
+    });
+  });
+
+  it('exposes scopeKeys via selectedFieldLookup for scoped sources', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('MeterId'));
+
+    expect(result.current.selectedFieldLookup?.scopeKeys).toEqual(['tenantId']);
+  });
+
+  it('returns undefined selectedFieldLookup for fields without a lookup', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('LastName'));
+
+    expect(result.current.selectedFieldLookup).toBeUndefined();
+  });
+
+  it('emits NO inline value suggestions during enterValue for lookup-backed fields', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+    act(() => result.current.selectField('TenantId'));
+    act(() => result.current.selectOperator('Eq'));
+
+    expect(result.current.phase).toBe('enterValue');
+    // No enum / boolean suggestions — the consumer renders <LookupPicker> instead.
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it('selectedFieldLookup is undefined in idle phase', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: METADATA_WITH_LOOKUP }));
+
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.selectedFieldLookup).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-query-engine/src/hooks/use-smart-filter.ts
+++ b/packages/@granit/react-query-engine/src/hooks/use-smart-filter.ts
@@ -4,6 +4,7 @@
 
 import { useCallback, useMemo, useReducer } from 'react';
 
+import type { LookupDescriptor } from '@granit/data-lookup';
 import type {
   FilterEntry,
   FilterOperator,
@@ -376,6 +377,9 @@ function buildValueSuggestions(
 ): FilterSuggestion[] {
   const field = metadata.filterableFields.find((f) => f.name === state.selectedField);
   if (!field) return [];
+  // Lookup-backed fields delegate value input to <LookupPicker>. The hook stops
+  // emitting inline suggestions so the consumer renders the picker instead.
+  if (field.lookup) return [];
   if (field.type === 'Boolean') {
     return buildBooleanSuggestions(field, options?.booleanLabels);
   }
@@ -446,6 +450,12 @@ export interface UseSmartFilterReturn {
   readonly selectedOperator?: FilterOperator;
   /** Type of the currently selected field (during selectOperator / enterValue phases). */
   readonly selectedFieldType?: string;
+  /**
+   * Data-lookup descriptor for the currently selected field, if any. When set,
+   * the UI should render `<LookupPicker>` during the `enterValue` phase instead
+   * of the free-text / enum input. `undefined` for fields without a lookup source.
+   */
+  readonly selectedFieldLookup?: LookupDescriptor;
   /** Extracted FilterEntry array from current tokens (for useQueryEndpoint). */
   readonly filters: readonly FilterEntry[];
   /** Extracted search string from tokens. */
@@ -599,6 +609,11 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
     return options.metadata.filterableFields.find((f) => f.name === state.selectedField)?.type;
   }, [state.selectedField, options?.metadata]);
 
+  const selectedFieldLookup = useMemo(() => {
+    if (!state.selectedField || !options?.metadata) return undefined;
+    return options.metadata.filterableFields.find((f) => f.name === state.selectedField)?.lookup;
+  }, [state.selectedField, options?.metadata]);
+
   return {
     phase: state.phase,
     inputValue: state.inputValue,
@@ -606,6 +621,7 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
     suggestions,
     selectedOperator: state.selectedOperator,
     selectedFieldType,
+    selectedFieldLookup,
     filters,
     search,
     presets,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -562,6 +562,9 @@ importers:
 
   packages/@granit/query-engine:
     dependencies:
+      '@granit/data-lookup':
+        specifier: workspace:*
+        version: link:../data-lookup
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1386,6 +1389,9 @@ importers:
 
   packages/@granit/react-query-engine:
     dependencies:
+      '@granit/data-lookup':
+        specifier: workspace:*
+        version: link:../data-lookup
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine


### PR DESCRIPTION
## Summary

Re-submits the changes from PR #206 that ended up orphaned.

PR #206 was merged into its stacked base (`feature/data-lookup-frontend-sdk`)
rather than `develop`, so the commits never landed on `develop`. This PR
cherry-picks the single commit (`c39c93c`) onto a fresh branch cut from
today's `develop`, restoring the wiring.

## What this enables

Without these changes, `FilterableField.lookup` declared on the backend
(granit-dotnet ADR-028, PR #1127) has no effect on the React SmartFilterBar:
fields with a `Lookup(...)` fall back to free-text input, defeating the whole
point of the Data Lookup feature on admin grids.

With this PR:

- `FilterableField.lookup?: LookupDescriptor` is exposed on the query metadata type.
- `useSmartFilter` returns `selectedFieldLookup` and stops emitting inline suggestions when the field is lookup-backed.
- Consumers can render `<LookupPicker>` (from `@granit/react-data-lookup`) during the `enterValue` phase.

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test run packages/@granit/react-query-engine` — 91/91 passing
- [x] Clean cherry-pick from `c39c93c`; no conflicts.