### PR TITLE
feat(idempotency): detect X-Idempotency-Tombstone and skip retries on 413

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -206,6 +206,22 @@
           "kind": "interface",
           "signature": "interface ValidationDetails",
           "members": []
+        },
+        {
+          "name": "isIdempotencyTombstoned",
+          "kind": "function",
+          "signature": "function isIdempotencyTombstoned(error: unknown): boolean"
+        },
+        {
+          "name": "readIdempotencyTombstone",
+          "kind": "function",
+          "signature": "function readIdempotencyTombstone(error: unknown): IdempotencyTombstoneInfo | undefined"
+        },
+        {
+          "name": "IdempotencyTombstoneInfo",
+          "kind": "interface",
+          "signature": "interface IdempotencyTombstoneInfo",
+          "members": []
         }
       ]
     },
@@ -611,6 +627,11 @@
           "name": "disableIdempotency",
           "kind": "function",
           "signature": "function disableIdempotency(): void"
+        },
+        {
+          "name": "shouldRetryIgnoringTombstone",
+          "kind": "function",
+          "signature": "function shouldRetryIgnoringTombstone( failureCount: number, error: unknown, maxAttempts = 3 ): boolean"
         }
       ]
     },

--- a/packages/@granit/api-client/src/__tests__/idempotency.test.ts
+++ b/packages/@granit/api-client/src/__tests__/idempotency.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { isIdempotencyTombstoned, readIdempotencyTombstone } from '../idempotency.js';
+
+// Builds an AxiosError-shaped object with the given response headers.
+// We intentionally do NOT use the real `AxiosError` constructor — the
+// helpers accept any error shape exposing `response.headers`, and this
+// test documents that contract.
+function errorWithHeaders(headers: Record<string, string>, status = 413): unknown {
+  return {
+    response: {
+      status,
+      statusText: 'Payload Too Large',
+      headers,
+    },
+    message: 'Request failed',
+  };
+}
+
+describe('readIdempotencyTombstone', () => {
+  it('returns the reason when the lowercase header is present', () => {
+    const err = errorWithHeaders({ 'x-idempotency-tombstone': 'ResponseTooLarge' });
+
+    expect(readIdempotencyTombstone(err)).toEqual({ reason: 'ResponseTooLarge' });
+  });
+
+  it('returns the reason when the canonical-cased header is present', () => {
+    // Axios normally lowercases headers, but a proxy or test fixture may not.
+    const err = errorWithHeaders({ 'X-Idempotency-Tombstone': 'ResponseTooLarge' });
+
+    expect(readIdempotencyTombstone(err)).toEqual({ reason: 'ResponseTooLarge' });
+  });
+
+  it('preserves unknown reasons so future backend values are not lost', () => {
+    // The backend may add new IdempotencyTombstoneReason variants (e.g.
+    // NonDeterministicResponse). The helper must not filter them.
+    const err = errorWithHeaders({ 'x-idempotency-tombstone': 'SomeFutureReason' });
+
+    expect(readIdempotencyTombstone(err)).toEqual({ reason: 'SomeFutureReason' });
+  });
+
+  it('returns undefined when the header is missing', () => {
+    const err = errorWithHeaders({ 'content-type': 'application/problem+json' });
+
+    expect(readIdempotencyTombstone(err)).toBeUndefined();
+  });
+
+  it('returns undefined when the header value is empty', () => {
+    const err = errorWithHeaders({ 'x-idempotency-tombstone': '' });
+
+    expect(readIdempotencyTombstone(err)).toBeUndefined();
+  });
+
+  it('returns undefined for non-error values', () => {
+    expect(readIdempotencyTombstone(null)).toBeUndefined();
+    expect(readIdempotencyTombstone(undefined)).toBeUndefined();
+    expect(readIdempotencyTombstone('some string')).toBeUndefined();
+    expect(readIdempotencyTombstone(new Error('plain error'))).toBeUndefined();
+    expect(readIdempotencyTombstone({})).toBeUndefined();
+  });
+
+  it('returns undefined when response is present but has no headers', () => {
+    const err = { response: { status: 413 } };
+
+    expect(readIdempotencyTombstone(err)).toBeUndefined();
+  });
+});
+
+describe('isIdempotencyTombstoned', () => {
+  it('is true when a reason is reported', () => {
+    const err = errorWithHeaders({ 'x-idempotency-tombstone': 'ResponseTooLarge' });
+
+    expect(isIdempotencyTombstoned(err)).toBe(true);
+  });
+
+  it('is false for a regular 413 without the tombstone header', () => {
+    // A plain Payload-Too-Large from a different source (e.g. Kestrel max
+    // request body) must NOT be misidentified as a tombstone.
+    const err = errorWithHeaders({ 'content-length': '0' });
+
+    expect(isIdempotencyTombstoned(err)).toBe(false);
+  });
+
+  it('is false for a 409 in-progress response', () => {
+    // The Idempotency middleware returns 409 on in-progress / race — those
+    // are retryable, unlike the 413 tombstone.
+    const err = errorWithHeaders({ 'retry-after': '30' }, 409);
+
+    expect(isIdempotencyTombstoned(err)).toBe(false);
+  });
+
+  it('is false for non-error input', () => {
+    expect(isIdempotencyTombstoned(null)).toBe(false);
+    expect(isIdempotencyTombstoned(new Error('network'))).toBe(false);
+  });
+});

--- a/packages/@granit/api-client/src/idempotency.ts
+++ b/packages/@granit/api-client/src/idempotency.ts
@@ -1,0 +1,89 @@
+// ---------------------------------------------------------------------------
+// Idempotency tombstone detection helpers.
+//
+// The Granit backend (Granit.Http.Idempotency) marks a completed idempotency
+// entry as "tombstoned" when the original response cannot be cached for replay
+// (e.g. exceeded MaxResponseSizeBytes). On every subsequent retry with the
+// same key, the server returns HTTP 413 with:
+//
+//   X-Idempotency-Tombstone: ResponseTooLarge
+//
+// Retrying with the same key will NEVER succeed — the server cannot
+// reconstruct the original response. Clients must generate a new idempotency
+// key to try again. These helpers let consumers (React Query `retry`,
+// custom retry wrappers, error dashboards) detect the tombstone and stop.
+// ---------------------------------------------------------------------------
+
+const TOMBSTONE_HEADER = 'x-idempotency-tombstone';
+
+/** Reason reported by the backend for the tombstoned response. */
+export interface IdempotencyTombstoneInfo {
+  /**
+   * Machine-readable reason as emitted by the backend. Current values:
+   * - `"ResponseTooLarge"` — response exceeded `MaxResponseSizeBytes`.
+   *
+   * New reasons may be added by the backend without a frontend breaking
+   * change; callers should treat unknown values as generic "not replayable".
+   */
+  readonly reason: string;
+}
+
+// Minimal shape test for an AxiosError-like object without taking a direct
+// dependency on axios's error constructor. This lets the helper accept either
+// a raw AxiosError or a framework-specific error wrapper that preserves
+// `response.headers`.
+interface ErrorWithResponseHeaders {
+  response?: {
+    headers?: Readonly<Record<string, unknown>>;
+  };
+}
+
+function hasResponseHeaders(error: unknown): error is ErrorWithResponseHeaders {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    typeof (error as { response?: unknown }).response === 'object' &&
+    (error as { response?: unknown }).response !== null
+  );
+}
+
+/**
+ * Inspect an error thrown from an HTTP call and return the tombstone info
+ * if the response carried the `X-Idempotency-Tombstone` header. Returns
+ * `undefined` for any non-tombstoned error (network error, regular 4xx/5xx,
+ * or a response without the header).
+ *
+ * Accepts any error shape that exposes `response.headers` — AxiosError
+ * natively, plus the `HttpError` thrown by framework-specific adapters
+ * when they preserve the original response headers.
+ */
+export function readIdempotencyTombstone(error: unknown): IdempotencyTombstoneInfo | undefined {
+  if (!hasResponseHeaders(error)) {
+    return undefined;
+  }
+
+  const headers = error.response?.headers;
+  if (!headers) {
+    return undefined;
+  }
+
+  // Axios lowercases response headers by default, but some adapters preserve
+  // the original casing — check both.
+  const raw = headers[TOMBSTONE_HEADER] ?? headers['X-Idempotency-Tombstone'];
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return undefined;
+  }
+
+  return { reason: raw };
+}
+
+/**
+ * Convenience predicate — `true` when the error indicates the server
+ * already executed the original request and its response is permanently
+ * unavailable for replay. Retrying with the same idempotency key will
+ * always produce the same 413 response.
+ */
+export function isIdempotencyTombstoned(error: unknown): boolean {
+  return readIdempotencyTombstone(error) !== undefined;
+}

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -219,3 +219,7 @@ export function buildApiUrl(basePath: string, ...segments: string[]): string {
 
 export { HttpError, TimeoutError, ValidationError } from './errors.js';
 export type { ProblemDetailsPayload, ValidationDetails } from './errors.js';
+
+// Idempotency tombstone helpers — see ./idempotency.ts.
+export { isIdempotencyTombstoned, readIdempotencyTombstone } from './idempotency.js';
+export type { IdempotencyTombstoneInfo } from './idempotency.js';

--- a/packages/@granit/idempotency/src/__tests__/idempotency.test.ts
+++ b/packages/@granit/idempotency/src/__tests__/idempotency.test.ts
@@ -176,3 +176,68 @@ describe('disableIdempotency', () => {
     expect(r2.config.headers['Idempotency-Key']).toBeUndefined();
   });
 });
+
+describe('shouldRetryIgnoringTombstone', () => {
+  interface RetryModule {
+    shouldRetryIgnoringTombstone: (
+      failureCount: number,
+      error: unknown,
+      maxAttempts?: number
+    ) => boolean;
+  }
+
+  let idempotencyMod: RetryModule;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    idempotencyMod = (await import('../index.ts')) as unknown as RetryModule;
+  });
+
+  function tombstoneError(reason = 'ResponseTooLarge'): unknown {
+    return {
+      response: {
+        status: 413,
+        headers: { 'x-idempotency-tombstone': reason },
+      },
+      message: 'Payload Too Large',
+    };
+  }
+
+  it('returns false for tombstoned errors regardless of failure count', () => {
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(0, tombstoneError())).toBe(false);
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(1, tombstoneError())).toBe(false);
+  });
+
+  it('returns true below the default max-attempts bound for non-tombstoned errors', () => {
+    const transientError = new Error('network failure');
+
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(0, transientError)).toBe(true);
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(2, transientError)).toBe(true);
+  });
+
+  it('returns false at or above the max-attempts bound', () => {
+    const transientError = new Error('network failure');
+
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(3, transientError)).toBe(false);
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(99, transientError)).toBe(false);
+  });
+
+  it('respects a custom max-attempts value', () => {
+    const transientError = new Error('network failure');
+
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(1, transientError, 1)).toBe(false);
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(0, transientError, 1)).toBe(true);
+  });
+
+  it('returns true for a non-tombstoned 413 (different cause)', () => {
+    // A 413 from Kestrel's max-request-body limit has no tombstone header —
+    // retrying a smaller payload could succeed, so we do not block retries
+    // just because the status was 413.
+    const plain413: unknown = {
+      response: { status: 413, headers: { 'content-length': '0' } },
+      message: 'Payload Too Large',
+    };
+
+    expect(idempotencyMod.shouldRetryIgnoringTombstone(0, plain413)).toBe(true);
+  });
+});

--- a/packages/@granit/idempotency/src/index.ts
+++ b/packages/@granit/idempotency/src/index.ts
@@ -1,6 +1,11 @@
-import { setIdempotencyKeyGenerator } from '@granit/api-client';
+import { isIdempotencyTombstoned, setIdempotencyKeyGenerator } from '@granit/api-client';
 
 import type { InternalAxiosRequestConfig } from 'axios';
+
+// Re-export the tombstone helpers so consumers only need to depend on
+// `@granit/idempotency` to handle idempotency end-to-end (generation + retry).
+export { isIdempotencyTombstoned, readIdempotencyTombstone } from '@granit/api-client';
+export type { IdempotencyTombstoneInfo } from '@granit/api-client';
 
 // ---------------------------------------------------------------------------
 // Configuration
@@ -86,4 +91,43 @@ export function disableIdempotency(): void {
 
 function defaultKeyGenerator(_config: InternalAxiosRequestConfig): string {
   return crypto.randomUUID();
+}
+
+// ---------------------------------------------------------------------------
+// React Query retry helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Retry predicate compatible with TanStack Query's `retry` option.
+ *
+ * Returns `false` immediately when the error is a tombstoned idempotency
+ * response — retrying with the same key will always return HTTP 413, so the
+ * default retry-on-error strategy would burn attempts for no benefit.
+ *
+ * For any other error, falls back to the usual `failureCount < maxAttempts`
+ * bound (default 3).
+ *
+ * @example
+ * ```ts
+ * import { shouldRetryIgnoringTombstone } from '@granit/idempotency';
+ *
+ * const queryClient = new QueryClient({
+ *   defaultOptions: {
+ *     mutations: {
+ *       retry: (failureCount, error) =>
+ *         shouldRetryIgnoringTombstone(failureCount, error),
+ *     },
+ *   },
+ * });
+ * ```
+ */
+export function shouldRetryIgnoringTombstone(
+  failureCount: number,
+  error: unknown,
+  maxAttempts = 3
+): boolean {
+  if (isIdempotencyTombstoned(error)) {
+    return false;
+  }
+  return failureCount < maxAttempts;
 }


### PR DESCRIPTION
## Summary

Follow-up to [granit-fx/granit-dotnet#1151](https://github.com/granit-fx/granit-dotnet/pull/1151) (security audit VULN-201). The .NET backend now stores an `IdempotencyState.Tombstoned` entry when the original response cannot be cached for replay (e.g. exceeded `MaxResponseSizeBytes`). On every subsequent retry with the same key, the backend returns:

```http
HTTP/1.1 413 Payload Too Large
X-Idempotency-Tombstone: ResponseTooLarge
content-type: application/problem+json
```

Retrying the same key will **never** succeed — the server has already executed the original request but cannot reconstruct its response. Default retry strategies (React Query's exponential back-off, ad-hoc try/catch loops) would burn attempts to no effect and surface a misleading 413 error to the user.

This PR surfaces the tombstone so consumers can short-circuit retries.

### API additions

**`@granit/api-client`** — new named exports:

```ts
import { isIdempotencyTombstoned, readIdempotencyTombstone } from '@granit/api-client';

if (isIdempotencyTombstoned(error)) {
  // Request already executed once; don't retry with the same key.
  toast.error('This operation was already performed. Reload to see the result.');
}

const info = readIdempotencyTombstone(error);
if (info?.reason === 'ResponseTooLarge') {
  // Guide the user to retry with a fresh key.
}
```

Both helpers accept any error shape that exposes `response.headers` — `AxiosError` natively, or a framework-specific `HttpError` that preserves headers. They read both lowercase (`x-idempotency-tombstone`) and canonical (`X-Idempotency-Tombstone`) casings.

**`@granit/idempotency`** — re-exports the helpers + adds a TanStack Query retry predicate:

```ts
import { shouldRetryIgnoringTombstone } from '@granit/idempotency';

const queryClient = new QueryClient({
  defaultOptions: {
    mutations: {
      retry: (failureCount, error) => shouldRetryIgnoringTombstone(failureCount, error),
    },
  },
});
```

Signature: `(failureCount, error, maxAttempts = 3) => boolean`. Returns `false` immediately on a tombstoned error; falls back to the usual `failureCount < maxAttempts` bound otherwise.

### Design decisions

- **Forward-compatible reason**: the helper preserves unknown reason strings so new backend variants (e.g. `NonDeterministicResponse`) surface to consumers without a frontend release.
- **Plain 413 stays retryable**: a 413 from Kestrel's max-request-body limit (no `X-Idempotency-Tombstone` header) is not tagged. Only the explicit tombstone short-circuits.
- **No AxiosError coupling**: the helper checks a structural shape (`{ response: { headers: {…} } }`) so it works on both raw Axios errors and any wrapper that preserves response headers.

## Test plan

- [x] `npx vitest run packages/@granit/api-client packages/@granit/idempotency` — 71 tests pass (5 suites)
- [x] `npx eslint … --max-warnings 0` — clean
- [x] `tsc --noEmit` on both packages — clean
- [x] `prettier --check` — clean
- [x] `pnpm build` — dist artifacts produced, `@granit/idempotency` dist.js +1.15 KB, .d.ts +2.63 KB
- [ ] Wire `shouldRetryIgnoringTombstone` into a consuming app's `QueryClient` as a smoke test (e.g. in `granit-showcase-admin-react`)

## New tests

- `api-client/src/__tests__/idempotency.test.ts` — 10 cases covering casing variants, unknown reasons, missing headers, non-axios shapes, plain 413 not flagged.
- `idempotency/src/__tests__/idempotency.test.ts` (extended) — 5 cases on the retry predicate.
