### PR TITLE
feat!: rename extraProperties to metadata (align with Granit dotnet PR #1209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,12 @@ Ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Modifié
 
+- **@granit/identity, @granit/openiddict-admin, @granit/reference-data**
+  (et leurs `react-*`) : renommage du champ wire format
+  `extraProperties` → `metadata` pour s'aligner sur le renommage backend
+  (Granit dotnet PR #1209). Bump : identity 0.2.0 → 0.3.0,
+  openiddict-admin 0.1.0 → 0.2.0, reference-data 0.2.0 → 0.3.0
+  (idem pour les `react-*`). **Breaking** — voir `MIGRATION.md`. (2026-04-25)
 - **@granit/query-engine** : adaptation de la pagination `skip`/`take` vers
   `page`/`pageSize` (`PagedResult<T>`) (2026-03-08)
 - **@granit/query-engine** : extraction des ternaires imbriqués et réduction de la

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,60 @@
 # Guide de migration
 
+## `extraProperties` → `metadata` (renommage framework-wide)
+
+**Date** : 2026-04-25
+**Packages affectés** : `@granit/identity` (0.3.0),
+`@granit/openiddict-admin` (0.2.0), `@granit/reference-data` (0.3.0),
+et leurs `react-*` correspondants.
+
+### Contexte
+
+Le framework Granit aligne sa terminologie sur le standard de l'industrie
+(Stripe, ORB, AWS, Kubernetes, Shopify) : le champ d'extensibilité
+d'entité s'appelle désormais `metadata`. Voir
+[Granit dotnet PR #1209](https://github.com/granit-fx/granit-dotnet/pull/1209)
+pour le détail côté backend.
+
+Côté frontend, le wire format JSON change en conséquence : `extraProperties`
+n'existe plus, remplacé par `metadata` dans les types TypeScript exportés
+et toutes les fixtures de test.
+
+### Impact sur les consommateurs
+
+Sed mécanique sur le code applicatif :
+
+```bash
+git ls-files '*.ts' '*.tsx' '*.json' | xargs sed -i \
+  -e 's/extraProperties/metadata/g' \
+  -e 's/ExtraProperties/Metadata/g' \
+  -e 's/ExtraProperty/Metadata/g'
+```
+
+Et bumper les dépendances dans `package.json` :
+
+```diff
+- "@granit/identity": "^0.2.0",
++ "@granit/identity": "^0.3.0",
+- "@granit/openiddict-admin": "^0.1.0",
++ "@granit/openiddict-admin": "^0.2.0",
+- "@granit/reference-data": "^0.2.0",
++ "@granit/reference-data": "^0.3.0",
+- "@granit/react-identity": "^0.2.0",
++ "@granit/react-identity": "^0.3.0",
+- "@granit/react-openiddict-admin": "^0.1.0",
++ "@granit/react-openiddict-admin": "^0.2.0",
+- "@granit/react-reference-data": "^0.2.0",
++ "@granit/react-reference-data": "^0.3.0",
+```
+
+### Coordination avec le backend
+
+Le backend doit être déployé **avant** la mise en production du frontend :
+les anciens clients qui envoient `{ extraProperties: ... }` recevront un
+`400 Bad Request` (champ inconnu, pas de fallback de compatibilité).
+Idem dans l'autre sens : un nouveau client face à un ancien backend ne
+recevra pas le champ attendu.
+
 ## Pagination : migration vers `@granit/query-engine`
 
 **Date** : 2026-03-08

--- a/packages/@granit/identity/package.json
+++ b/packages/@granit/identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/identity",
   "description": "Identity provider capabilities — types and API for GET /identity/users/capabilities",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/identity/src/__tests__/identity-provider-role-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-role-api.test.ts
@@ -25,7 +25,7 @@ const sampleUser: IdentityUser = {
   firstName: 'John',
   lastName: 'Doe',
   enabled: true,
-  extraProperties: {},
+  metadata: {},
 };
 
 const basePath = '/identity/provider';

--- a/packages/@granit/identity/src/__tests__/identity-provider-user-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-user-api.test.ts
@@ -19,7 +19,7 @@ const sampleUser: IdentityUser = {
   firstName: 'John',
   lastName: 'Doe',
   enabled: true,
-  extraProperties: {},
+  metadata: {},
 };
 
 const basePath = '/identity/provider';

--- a/packages/@granit/identity/src/__tests__/identity-user-cache-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-user-cache-api.test.ts
@@ -28,7 +28,7 @@ const sampleUser: IdentityUser = {
   firstName: 'John',
   lastName: 'Doe',
   enabled: true,
-  extraProperties: { department: 'Engineering' },
+  metadata: { department: 'Engineering' },
 };
 
 const basePath = '/identity/users';

--- a/packages/@granit/identity/src/types/identity-provider-requests.ts
+++ b/packages/@granit/identity/src/types/identity-provider-requests.ts
@@ -13,7 +13,7 @@ export type IdentityUserUpdateRequest = {
   readonly email?: string;
   readonly firstName?: string;
   readonly lastName?: string;
-  readonly extraProperties?: Readonly<Record<string, string | null>>;
+  readonly metadata?: Readonly<Record<string, string | null>>;
 };
 
 /** Request body for `PATCH /identity/provider/users/{userId}/enabled`. */

--- a/packages/@granit/identity/src/types/identity-user.ts
+++ b/packages/@granit/identity/src/types/identity-user.ts
@@ -9,7 +9,7 @@ export type IdentityUser = {
   readonly firstName: string | null;
   readonly lastName: string | null;
   readonly enabled: boolean;
-  readonly extraProperties: Readonly<Record<string, string>>;
+  readonly metadata: Readonly<Record<string, string>>;
 };
 
 export type IdentityUserListParams = PaginationParams & {

--- a/packages/@granit/openiddict-admin/package.json
+++ b/packages/@granit/openiddict-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/openiddict-admin",
   "description": "OpenIddict admin management types and API functions — mirrors Granit.OpenIddict.Endpoints .NET contract",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-user-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-user-api.test.ts
@@ -14,7 +14,7 @@ const mockUser: AdminUser = {
   firstName: 'Alice',
   lastName: 'Doe',
   enabled: true,
-  extraProperties: {},
+  metadata: {},
 };
 
 const mockUserPage: AdminUserPage = {

--- a/packages/@granit/openiddict-admin/src/types/admin-user.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-user.ts
@@ -19,7 +19,7 @@ export interface AdminUser {
   readonly firstName: string | null;
   readonly lastName: string | null;
   readonly enabled: boolean;
-  readonly extraProperties: Readonly<Record<string, string>>;
+  readonly metadata: Readonly<Record<string, string>>;
 }
 
 /** Paginated list of admin users. */

--- a/packages/@granit/react-identity/package.json
+++ b/packages/@granit/react-identity/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-identity",
   "description": "React bindings for @granit/identity — IdentityProvider, useIdentityCapabilities",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-cache.test.tsx
@@ -45,7 +45,7 @@ const mockUsers: IdentityUser[] = [
     firstName: 'John',
     lastName: 'Doe',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
 ];
 

--- a/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-provider-users.test.tsx
@@ -27,7 +27,7 @@ const sampleUser: IdentityUser = {
   firstName: 'John',
   lastName: 'Doe',
   enabled: true,
-  extraProperties: {},
+  metadata: {},
 };
 
 function createWrapper(client: AxiosInstance, providerBasePath?: string) {

--- a/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-users.test.tsx
@@ -37,7 +37,7 @@ const mockUser: IdentityUser = {
   firstName: 'John',
   lastName: 'Doe',
   enabled: true,
-  extraProperties: {},
+  metadata: {},
 };
 
 const mockPage: IdentityUserPage = {

--- a/packages/@granit/react-identity/src/testing/data.ts
+++ b/packages/@granit/react-identity/src/testing/data.ts
@@ -10,7 +10,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Dupont',
     username: 'marie.dupont',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-002'),
@@ -19,7 +19,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Martin',
     username: 'jean.martin',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-003'),
@@ -28,7 +28,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Bernard',
     username: 'sophie.bernard',
     enabled: false,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-004'),
@@ -37,7 +37,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Leblanc',
     username: 'pierre.leblanc',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-005'),
@@ -46,7 +46,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Moreau',
     username: 'claire.moreau',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-006'),
@@ -55,7 +55,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Petit',
     username: 'thomas.petit',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-007'),
@@ -64,7 +64,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Robert',
     username: 'alice.robert',
     enabled: false,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-008'),
@@ -73,7 +73,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Simon',
     username: 'paul.simon',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-009'),
@@ -82,7 +82,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Garcia',
     username: 'nathalie.garcia',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-010'),
@@ -91,7 +91,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Lambert',
     username: 'francois.lambert',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-011'),
@@ -100,7 +100,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Rousseau',
     username: 'isabelle.rousseau',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-012'),
@@ -109,7 +109,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Fournier',
     username: 'marc.fournier',
     enabled: false,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-013'),
@@ -118,7 +118,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Girard',
     username: 'valerie.girard',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-014'),
@@ -127,7 +127,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Bonnet',
     username: 'luc.bonnet',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: toEntityId<'User'>('user-015'),
@@ -136,7 +136,7 @@ export const mockUsers: IdentityUser[] = [
     lastName: 'Dupuis',
     username: 'emilie.dupuis',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
 ];
 

--- a/packages/@granit/react-identity/src/testing/handlers.ts
+++ b/packages/@granit/react-identity/src/testing/handlers.ts
@@ -105,7 +105,7 @@ const capabilities: IdentityProviderCapabilities = {
 };
 
 // ---------------------------------------------------------------------------
-// Helper: map IdentityUser to response shape with extraProperties
+// Helper: map IdentityUser to response shape with metadata
 // ---------------------------------------------------------------------------
 
 function toIdentityUser(u: IdentityUser) {
@@ -116,7 +116,7 @@ function toIdentityUser(u: IdentityUser) {
     firstName: u.firstName,
     lastName: u.lastName,
     enabled: u.enabled,
-    extraProperties: { locale: 'fr', timezone: 'Europe/Brussels' },
+    metadata: { locale: 'fr', timezone: 'Europe/Brussels' },
   };
 }
 
@@ -237,7 +237,7 @@ export function createIdentityHandlers(
         firstName: body.firstName ?? null,
         lastName: body.lastName ?? null,
         enabled: body.enabled,
-        extraProperties: {},
+        metadata: {},
       };
       return HttpResponse.json(newUser, { status: 201 });
     }),

--- a/packages/@granit/react-openiddict-admin/package.json
+++ b/packages/@granit/react-openiddict-admin/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-openiddict-admin",
   "description": "React hooks for the admin module — QueryEngine user listing, impersonation, and OpenIddict (applications, scopes, authorizations)",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-admin-users.test.tsx
@@ -41,7 +41,7 @@ const mockUser: AdminUser = {
   firstName: 'Admin',
   lastName: 'User',
   enabled: true,
-  extraProperties: {},
+  metadata: {},
 };
 
 const mockPage: AdminUserPage = {

--- a/packages/@granit/react-openiddict-admin/src/testing/data.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/data.ts
@@ -19,7 +19,7 @@ export const mockAdminUsers: Mutable<AdminUser>[] = [
     firstName: 'Alice',
     lastName: 'Dupont',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: 'usr_01HZ9KQX0000000000002',
@@ -28,7 +28,7 @@ export const mockAdminUsers: Mutable<AdminUser>[] = [
     firstName: 'Bob',
     lastName: 'Martin',
     enabled: true,
-    extraProperties: {},
+    metadata: {},
   },
   {
     userId: 'usr_01HZ9KQX0000000000003',
@@ -37,7 +37,7 @@ export const mockAdminUsers: Mutable<AdminUser>[] = [
     firstName: 'Charlie',
     lastName: 'Leblanc',
     enabled: false,
-    extraProperties: { department: 'Engineering' },
+    metadata: { department: 'Engineering' },
   },
 ];
 

--- a/packages/@granit/react-reference-data/package.json
+++ b/packages/@granit/react-reference-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-reference-data",
   "description": "React hooks factory for @granit/reference-data — createReferenceDataHooks",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/react-reference-data/src/__tests__/create-reference-data-hooks.test.tsx
+++ b/packages/@granit/react-reference-data/src/__tests__/create-reference-data-hooks.test.tsx
@@ -35,7 +35,7 @@ const mockEntry: TestEntity = {
   validFrom: null,
   validTo: null,
   parentCode: null,
-  extraProperties: null,
+  metadata: null,
   extra: 'test-value',
 };
 

--- a/packages/@granit/reference-data/package.json
+++ b/packages/@granit/reference-data/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/reference-data",
   "description": "Generic reference data types and API — mirrors Granit.ReferenceData .NET",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/reference-data/src/__tests__/reference-data-api.test.ts
+++ b/packages/@granit/reference-data/src/__tests__/reference-data-api.test.ts
@@ -38,7 +38,7 @@ const mockEntry: ReferenceDataEntry = {
   validFrom: null,
   validTo: null,
   parentCode: null,
-  extraProperties: null,
+  metadata: null,
 };
 
 describe('listReferenceData', () => {

--- a/packages/@granit/reference-data/src/__tests__/reference-data-types.test.ts
+++ b/packages/@granit/reference-data/src/__tests__/reference-data-types.test.ts
@@ -49,10 +49,7 @@ describe('@granit/reference-data types', () => {
     });
 
     it('should have extra properties bag', () => {
-      expectTypeOf<ReferenceDataEntry['extraProperties']>().toEqualTypeOf<Record<
-        string,
-        string
-      > | null>();
+      expectTypeOf<ReferenceDataEntry['metadata']>().toEqualTypeOf<Record<string, string> | null>();
     });
 
     it('should have a unique id', () => {
@@ -92,11 +89,11 @@ describe('@granit/reference-data types', () => {
       >();
     });
 
-    it('should have optional parentCode and extraProperties', () => {
+    it('should have optional parentCode and metadata', () => {
       expectTypeOf<ReferenceDataCreateRequest['parentCode']>().toEqualTypeOf<
         string | null | undefined
       >();
-      expectTypeOf<ReferenceDataCreateRequest['extraProperties']>().toEqualTypeOf<
+      expectTypeOf<ReferenceDataCreateRequest['metadata']>().toEqualTypeOf<
         Record<string, string> | null | undefined
       >();
     });
@@ -119,11 +116,11 @@ describe('@granit/reference-data types', () => {
       expectTypeOf<ReferenceDataUpdateRequest['activated']>().toEqualTypeOf<boolean | undefined>();
     });
 
-    it('should have optional parentCode and extraProperties', () => {
+    it('should have optional parentCode and metadata', () => {
       expectTypeOf<ReferenceDataUpdateRequest['parentCode']>().toEqualTypeOf<
         string | null | undefined
       >();
-      expectTypeOf<ReferenceDataUpdateRequest['extraProperties']>().toEqualTypeOf<
+      expectTypeOf<ReferenceDataUpdateRequest['metadata']>().toEqualTypeOf<
         Record<string, string> | null | undefined
       >();
     });

--- a/packages/@granit/reference-data/src/types/index.ts
+++ b/packages/@granit/reference-data/src/types/index.ts
@@ -41,7 +41,7 @@ export interface ReferenceDataEntry extends ReferenceDataLabels {
   /** Parent code for hierarchical types (null for root entries). */
   readonly parentCode: string | null;
   /** Custom properties bag (all values are strings). */
-  readonly extraProperties: Record<string, string> | null;
+  readonly metadata: Record<string, string> | null;
 }
 
 /**
@@ -57,7 +57,7 @@ export interface ReferenceDataCreateRequest extends Partial<ReferenceDataLabels>
   readonly validFrom?: string | null;
   readonly validTo?: string | null;
   readonly parentCode?: string | null;
-  readonly extraProperties?: Record<string, string> | null;
+  readonly metadata?: Record<string, string> | null;
 }
 
 /**
@@ -73,7 +73,7 @@ export interface ReferenceDataUpdateRequest extends Partial<ReferenceDataLabels>
   readonly validFrom?: string | null;
   readonly validTo?: string | null;
   readonly parentCode?: string | null;
-  readonly extraProperties?: Record<string, string> | null;
+  readonly metadata?: Record<string, string> | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Aligns the frontend wire format with the backend rename done in
[Granit dotnet PR #1209](https://github.com/granit-fx/granit-dotnet/pull/1209)
(`IHasExtraProperties` → `IHasMetadata`, `ExtraPropertiesJson` → `MetadataJson`,
JSON wire format `extraProperties` → `metadata`).

The terminology now follows the industry standard (Stripe, ORB, AWS, Kubernetes,
Shopify, Square) instead of the legacy ABP-Framework `ExtraProperties` term.

## Packages bumped (BREAKING)

| Package | Before | After |
| ------- | ------ | ----- |
| `@granit/identity` | 0.2.0 | 0.3.0 |
| `@granit/openiddict-admin` | 0.1.0 | 0.2.0 |
| `@granit/reference-data` | 0.2.0 | 0.3.0 |
| `@granit/react-identity` | 0.2.0 | 0.3.0 |
| `@granit/react-openiddict-admin` | 0.1.0 | 0.2.0 |
| `@granit/react-reference-data` | 0.2.0 | 0.3.0 |

## Surface

- **Public types** : `IdentityUser.metadata`, `IdentityUserUpdateRequest.metadata`,
  `AdminUser.metadata`, `ReferenceDataResponse.metadata`,
  `ReferenceDataCreateRequest.metadata`, `ReferenceDataUpdateRequest.metadata`
- **Test fixtures + MSW handlers** : `testing/data.ts`, `testing/handlers.ts`
- **Unit tests** (vitest) : tous les packages affectés mis à jour

## Other Extra* names left untouched

`@granit/data-exchange` exporte `IExtraExportFieldProvider`,
`IExportExtraValueResolver`, etc. — concept distinct (extension de schéma
d'export, pas extensibilité d'entité). Non renommés, identique au backend.

## Migration consumer

`MIGRATION.md` ajouté avec sed mécanique + bump deps. Voir le diff de ce PR
ou le commit pour le détail.

## Coordination déploiement

Le backend doit être déployé **avant** la mise en production du frontend :
les anciens clients qui envoient `{ extraProperties: ... }` recevront un
`400 Bad Request` (pas de fallback de compatibilité côté backend).

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean (0 warnings, max-warnings 0)
- [x] `pnpm test --run` — 2129 / 2129 passed (262 fichiers)
- [x] `pnpm build` — succès sur tous les packages
- [x] `markdownlint MIGRATION.md CHANGELOG.md` — clean
- [ ] CI green