### PR TITLE
feat!: align SaaS frontend with backend ORB phases (catalog, metering, customer-balance, invoicing)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -491,6 +491,17 @@
       ]
     },
     {
+      "name": "@granit/catalog",
+      "description": "Granit.Catalog — Product aggregate (shared billing item) types and API",
+      "exports": [
+        {
+          "name": "CatalogPermissions",
+          "kind": "const",
+          "signature": "const CatalogPermissions"
+        }
+      ]
+    },
+    {
       "name": "@granit/cookies",
       "description": "Cookie consent abstraction with React context and hooks",
       "exports": []
@@ -1829,6 +1840,24 @@
       ]
     },
     {
+      "name": "@granit/react-catalog",
+      "description": "React bindings for @granit/catalog — CatalogProvider and product hooks",
+      "exports": [
+        {
+          "name": "CatalogConfig",
+          "kind": "interface",
+          "signature": "interface CatalogConfig",
+          "members": []
+        },
+        {
+          "name": "CatalogProviderProps",
+          "kind": "interface",
+          "signature": "interface CatalogProviderProps",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-cookies",
       "description": "React bindings for @granit/cookies — CookieConsentProvider, useCookieConsent",
       "exports": [
@@ -2183,11 +2212,6 @@
           "kind": "interface",
           "signature": "interface MeteringProviderProps",
           "members": []
-        },
-        {
-          "name": "UpdateMeterDefinitionVariables",
-          "kind": "type",
-          "signature": "type UpdateMeterDefinitionVariables = { readonly id: string; readonly request: MeterDefinitionUpdateRequest; }"
         }
       ]
     },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ Ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- **@granit/catalog, @granit/react-catalog** : nouveau couple — types, API
+  client et hooks React pour le module `Granit.Catalog` (Product comme
+  agrégat partagé pour Metering / Subscriptions / Invoicing). Couvre la
+  CRUD `/products`, le lifecycle `Publish` / `Archive`, le bag `metadata`,
+  les `external-mappings` (Stripe / Avalara / Odoo), et la grille
+  QueryEngine `/product-records`. (2026-04-25)
+- **@granit/metering** : champs `lifecycleStatus` (`Draft` / `Published` /
+  `Archived`), `distinctProperty`, `productId` ; nouvelle valeur d'enum
+  `AggregationType.CountDistinct` ; nouveaux endpoints `publish` /
+  `archive` / `recompute` / `backfill` / `deprecate-event` exposés via
+  fonctions API + hooks React (`usePublishMeterDefinition`,
+  `useArchiveMeterDefinition`, `useRecomputeMeterUsage`,
+  `useBackfillUsageEvents`, `useDeprecateMeterEvent`). Permissions
+  `Metering.Events.{Manage,Backfill}` ajoutées. (2026-04-25)
+- **@granit/customer-balance, @granit/react-customer-balance** : nouvelle
+  fonction `debitCustomerBalance` + hook `useDebitCustomerBalance` pour
+  l'endpoint admin `POST /balance/debit` (drawdown manuel idempotent via
+  `referenceId`). Type `AdminDebitRequest` exposé. (2026-04-25)
+- **@granit/invoicing** : champ `productId` (soft reference vers
+  `Granit.Catalog.Product`) sur `InvoiceLineItemResponse` ; type
+  `InvoiceSourceType` exporté pour le typage strict de `sourceType`. (2026-04-25)
+- **@granit/subscriptions** : champ `productId` sur `PlanPriceResponse`
+  et `CreatePriceVersionRequest`. (2026-04-25)
 - **@granit/query-engine** : enrichissement de `useSmartFilter` avec support enum, boolean,
   field search et labels localisables (2026-03-07)
 - **@granit/query-engine** : ajout de `labelParts` aux tokens et exposition de
@@ -68,6 +91,18 @@ Ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
   (Granit dotnet PR #1209). Bump : identity 0.2.0 → 0.3.0,
   openiddict-admin 0.1.0 → 0.2.0, reference-data 0.2.0 → 0.3.0
   (idem pour les `react-*`). **Breaking** — voir `MIGRATION.md`. (2026-04-25)
+- **@granit/metering, @granit/react-metering** : `MeterDefinitionResponse.activated`
+  est désormais déprécié au profit de `lifecycleStatus`. Le hook
+  `useDeactivateMeterDefinition` est déprécié — utiliser
+  `useArchiveMeterDefinition`. Bump 0.1.0 → 0.2.0. **Breaking**
+  (voir `MIGRATION.md` pour la nouvelle shape). (2026-04-25)
+- **@granit/subscriptions, @granit/react-subscriptions** : champ
+  `productId` ajouté sur `PlanPriceResponse` (obligatoire dans la réponse
+  backend, peut être `null`). Bump 0.1.0 → 0.2.0. (2026-04-25)
+- **@granit/customer-balance, @granit/react-customer-balance,
+  @granit/invoicing, @granit/react-invoicing** : bump 0.1.0 → 0.2.0
+  (additions non-breaking côté DTOs ; alignement avec le backend Catalog
+  et ADR-036). (2026-04-25)
 - **@granit/query-engine** : adaptation de la pagination `skip`/`take` vers
   `page`/`pageSize` (`PagedResult<T>`) (2026-03-08)
 - **@granit/query-engine** : extraction des ternaires imbriqués et réduction de la

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,166 @@
 # Guide de migration
 
+## Alignement SaaS — Catalog + Metering hybride + Customer-Balance + Invoicing
+
+**Date** : 2026-04-25
+**Packages affectés** :
+
+- nouveaux : `@granit/catalog` (0.1.0), `@granit/react-catalog` (0.1.0)
+- mis à jour : `@granit/metering` (0.2.0) + `@granit/react-metering` (0.2.0),
+  `@granit/subscriptions` (0.2.0) + `@granit/react-subscriptions` (0.2.0),
+  `@granit/customer-balance` (0.2.0) + `@granit/react-customer-balance` (0.2.0),
+  `@granit/invoicing` (0.2.0) + `@granit/react-invoicing` (0.2.0)
+
+### Contexte
+
+Cinq phases d'alignement sur ORB ont atterri côté backend en `develop` :
+
+| Phase backend                                                                  | PR / scope                                                      |
+| ------------------------------------------------------------------------------ | --------------------------------------------------------------- |
+| 1. `Granit.Catalog` (Product comme agrégat partagé)                            | #1184                                                           |
+| 2. Metering hybride (lifecycle, CountDistinct, recompute, backfill, deprecate) | #1187 → #1196                                                   |
+| 3. Subscriptions overrides/phases/tiered (entités domaine internes)            | #1200, #1202 — pas d'endpoints HTTP, donc pas d'impact frontend |
+| 4. Customer-Balance — admin debit + pré-expiration                             | #1205, #1206                                                    |
+| 5. Invoicing — `productId` sur `InvoiceLineItem` (ADR-036)                     | #1208                                                           |
+
+Cette PR propage ces changements côté frontend.
+
+### `@granit/catalog` (nouveau)
+
+```diff
++ "@granit/catalog": "^0.1.0",
++ "@granit/react-catalog": "^0.1.0",
+```
+
+API : `listPublishedProducts`, `getProductById`, `getProductBySku`,
+`createProduct`, `updateProduct`, `updateProductMetadata`, `publishProduct`,
+`archiveProduct`, `addProductExternalMapping`, `removeProductExternalMapping`,
+`listProducts` (QueryEngine).
+
+Hooks React : `usePublishedProducts`, `useProduct`, `useProductBySku`,
+`useCreateProduct`, `useUpdateProduct`, `useUpdateProductMetadata`,
+`usePublishProduct`, `useArchiveProduct`, `useAddProductExternalMapping`,
+`useRemoveProductExternalMapping`.
+
+Permissions : `Catalog.Products.{Read,Manage}`.
+
+### `@granit/metering` (BREAKING)
+
+#### Lifecycle — `activated` déprécié au profit de `lifecycleStatus`
+
+```diff
+- if (meter.activated) { /* ... */ }
++ if (meter.lifecycleStatus === 'Published') { /* ... */ }
+```
+
+Le champ `activated` reste exposé pour une release de transition mais
+sera retiré au prochain MAJOR.
+
+#### `useDeactivateMeterDefinition` déprécié
+
+Le cycle de vie devient `Publish → Archive`. Migrer :
+
+```diff
+- const deactivate = useDeactivateMeterDefinition();
+- await deactivate.mutateAsync(meterId);
++ const archive = useArchiveMeterDefinition();
++ await archive.mutateAsync(meterId);
+```
+
+#### Nouveaux hooks et fonctions API
+
+- `usePublishMeterDefinition()` — fait passer un meter `Draft` à `Published`
+- `useArchiveMeterDefinition()` — `Published` → `Archived`
+- `useRecomputeMeterUsage()` — recalcul des agrégats sur une fenêtre
+- `useBackfillUsageEvents()` — ingestion historique (jusqu'à 365 jours)
+- `useDeprecateMeterEvent()` — soft-delete d'un événement individuel
+
+#### Nouvelle valeur d'enum `AggregationType.CountDistinct`
+
+Pour `CountDistinct`, `MeterDefinitionCreateRequest.distinctProperty` est
+**obligatoire** (le validateur backend rejette sinon).
+
+```ts
+const create = useCreateMeterDefinition();
+await create.mutateAsync({
+  name: 'Active Users',
+  unit: 'users',
+  aggregationType: 'CountDistinct',
+  distinctProperty: 'user_id',
+});
+```
+
+#### Nouveau champ `productId`
+
+Réponses des meters et `MeterDefinitionCreateRequest` portent désormais
+un `productId` optionnel (référence soft vers un `Granit.Catalog.Product`).
+Aucune action requise — le champ est accepté `null`.
+
+### `@granit/subscriptions`
+
+Ajout du champ `productId` sur `PlanPriceResponse` (obligatoire dans
+les réponses backend, peut être `null`) et `CreatePriceVersionRequest`
+(optionnel). Si tes fixtures ou mocks définissent un `PlanPriceResponse`
+manuellement, ajouter `productId: null`.
+
+### `@granit/customer-balance`
+
+Nouveau hook `useDebitCustomerBalance` pour `POST /balance/debit`.
+Permission backend : `CustomerBalance.Credits.Manage` (réutilisée pour
+les opérations de débit admin).
+
+```ts
+const debit = useDebitCustomerBalance();
+await debit.mutateAsync({
+  amount: 50,
+  currency: 'EUR',
+  reason: 'Manual correction',
+  referenceId: 'adj-2026-04-25-001', // optional, idempotent retries
+  referenceType: 'AdminAdjustment',
+});
+```
+
+### `@granit/invoicing`
+
+Nouveau champ `productId` sur `InvoiceLineItemResponse` (peut être
+`null`). Le type `sourceType` est désormais typé strictement comme
+`InvoiceSourceType` (`'Subscription' | 'Usage' | 'OneShot' | 'Credit'`)
+au lieu de `string`. Les fixtures qui posaient un `sourceType: 'X'`
+arbitraire compilent toujours tant que la chaîne est l'une des quatre
+valeurs autorisées.
+
+**Convention ADR-036** (enforced côté backend, pas côté front) :
+les lignes `Subscription` et `Usage` portent un `sourceId` au format
+Guid. Les fixtures fournies par `@granit/react-invoicing/testing` ont
+été ajustées pour respecter cette règle.
+
+### Bump `package.json`
+
+```diff
+- "@granit/metering": "^0.1.0",
++ "@granit/metering": "^0.2.0",
+- "@granit/react-metering": "^0.1.0",
++ "@granit/react-metering": "^0.2.0",
+- "@granit/subscriptions": "^0.1.0",
++ "@granit/subscriptions": "^0.2.0",
+- "@granit/react-subscriptions": "^0.1.0",
++ "@granit/react-subscriptions": "^0.2.0",
+- "@granit/customer-balance": "^0.1.0",
++ "@granit/customer-balance": "^0.2.0",
+- "@granit/react-customer-balance": "^0.1.0",
++ "@granit/react-customer-balance": "^0.2.0",
+- "@granit/invoicing": "^0.1.0",
++ "@granit/invoicing": "^0.2.0",
+- "@granit/react-invoicing": "^0.1.0",
++ "@granit/react-invoicing": "^0.2.0",
+```
+
+### Coordination déploiement
+
+Le backend ORB-aligned doit être déployé **avant** la mise en production
+du frontend, sinon les nouveaux hooks (`publish`, `archive`, `recompute`,
+`backfill`, `deprecate`, `debit`) recevront un `404` ou `405`.
+
 ## `extraProperties` → `metadata` (renommage framework-wide)
 
 **Date** : 2026-04-25

--- a/packages/@granit/catalog/package.json
+++ b/packages/@granit/catalog/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/catalog",
+  "description": "Granit.Catalog — Product aggregate (shared billing item) types and API",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
+    "axios": "*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/catalog/src/__tests__/catalog-api.test.ts
+++ b/packages/@granit/catalog/src/__tests__/catalog-api.test.ts
@@ -1,0 +1,245 @@
+import { createMockClient } from '@granit/testing';
+import { toEntityId, toISODateString } from '@granit/types';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  addProductExternalMapping,
+  archiveProduct,
+  createProduct,
+  getProductById,
+  getProductBySku,
+  listProducts,
+  listPublishedProducts,
+  publishProduct,
+  removeProductExternalMapping,
+  updateProduct,
+  updateProductMetadata,
+} from '../api/catalog-api.js';
+
+import type {
+  AddProductExternalMappingRequest,
+  Product,
+  ProductCreateRequest,
+  ProductExternalMappingResponse,
+  ProductResponse,
+  ProductUpdateRequest,
+  UpdateProductMetadataRequest,
+} from '../types.js';
+import type { PagedResult } from '@granit/query-engine';
+
+const basePath = '/api/granit/catalog';
+
+const sampleProduct: ProductResponse = {
+  id: toEntityId<'Product'>('prd-1'),
+  sku: 'API-CALLS',
+  name: 'API Calls',
+  description: 'Per-call billing for the public API.',
+  type: 'Metered',
+  unit: 'call',
+  lifecycleStatus: 'Published',
+  metadata: { tier: 'standard' },
+  externalMappings: [
+    {
+      id: toEntityId<'ProductExternalMapping'>('pem-1'),
+      providerName: 'Stripe',
+      externalId: 'prod_AbC123',
+    },
+  ],
+};
+
+describe('catalog-api', () => {
+  describe('listPublishedProducts', () => {
+    it('should GET {basePath}/products', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleProduct] });
+
+      const result = await listPublishedProducts(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith('/api/granit/catalog/products');
+      expect(result).toEqual([sampleProduct]);
+    });
+  });
+
+  describe('getProductById', () => {
+    it('should GET {basePath}/products/{id} and encode the id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleProduct });
+
+      await getProductById(client, basePath, 'prd id/with spaces');
+
+      expect(client.get).toHaveBeenCalledWith(
+        '/api/granit/catalog/products/prd%20id%2Fwith%20spaces'
+      );
+    });
+  });
+
+  describe('getProductBySku', () => {
+    it('should GET {basePath}/products/by-sku/{sku} and encode the sku', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleProduct });
+
+      await getProductBySku(client, basePath, 'API/CALLS PRO');
+
+      expect(client.get).toHaveBeenCalledWith(
+        '/api/granit/catalog/products/by-sku/API%2FCALLS%20PRO'
+      );
+    });
+  });
+
+  describe('createProduct', () => {
+    it('should POST {basePath}/products', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+
+      const request: ProductCreateRequest = {
+        sku: 'API-CALLS',
+        name: 'API Calls',
+        type: 'Metered',
+        unit: 'call',
+        description: 'Per-call billing for the public API.',
+      };
+
+      await createProduct(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/catalog/products', request);
+    });
+  });
+
+  describe('updateProduct', () => {
+    it('should PUT {basePath}/products/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleProduct });
+
+      const request: ProductUpdateRequest = {
+        name: 'API Calls v2',
+        description: null,
+        unit: 'call',
+      };
+
+      await updateProduct(client, basePath, 'prd-1', request);
+
+      expect(client.put).toHaveBeenCalledWith('/api/granit/catalog/products/prd-1', request);
+    });
+  });
+
+  describe('updateProductMetadata', () => {
+    it('should PUT {basePath}/products/{id}/metadata', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleProduct });
+
+      const request: UpdateProductMetadataRequest = {
+        metadata: { tier: 'premium', region: 'eu' },
+      };
+
+      await updateProductMetadata(client, basePath, 'prd-1', request);
+
+      expect(client.put).toHaveBeenCalledWith(
+        '/api/granit/catalog/products/prd-1/metadata',
+        request
+      );
+    });
+  });
+
+  describe('publishProduct', () => {
+    it('should POST {basePath}/products/{id}/publish', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+
+      await publishProduct(client, basePath, 'prd-1');
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/catalog/products/prd-1/publish');
+    });
+  });
+
+  describe('archiveProduct', () => {
+    it('should POST {basePath}/products/{id}/archive', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+
+      await archiveProduct(client, basePath, 'prd-1');
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/catalog/products/prd-1/archive');
+    });
+  });
+
+  describe('addProductExternalMapping', () => {
+    it('should POST {basePath}/products/{id}/external-mappings', async () => {
+      const client = createMockClient();
+      const mapping: ProductExternalMappingResponse = {
+        id: toEntityId<'ProductExternalMapping'>('pem-1'),
+        providerName: 'Stripe',
+        externalId: 'prod_AbC123',
+      };
+      vi.mocked(client.post).mockResolvedValue({ data: mapping });
+
+      const request: AddProductExternalMappingRequest = {
+        providerName: 'Stripe',
+        externalId: 'prod_AbC123',
+      };
+
+      const result = await addProductExternalMapping(client, basePath, 'prd-1', request);
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/api/granit/catalog/products/prd-1/external-mappings',
+        request
+      );
+      expect(result).toEqual(mapping);
+    });
+  });
+
+  describe('removeProductExternalMapping', () => {
+    it('should DELETE {basePath}/products/{id}/external-mappings/{mappingId}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      await removeProductExternalMapping(client, basePath, 'prd-1', 'pem-1');
+
+      expect(client.delete).toHaveBeenCalledWith(
+        '/api/granit/catalog/products/prd-1/external-mappings/pem-1'
+      );
+    });
+  });
+
+  describe('listProducts (QueryEngine)', () => {
+    it('should GET {basePath}/product-records with query string parameters', async () => {
+      const client = createMockClient();
+      const product: Product = {
+        id: toEntityId<'Product'>('prd-1'),
+        tenantId: null,
+        sku: 'API-CALLS',
+        name: 'API Calls',
+        description: null,
+        type: 'Metered',
+        unit: 'call',
+        lifecycleStatus: 'Published',
+        createdAt: toISODateString('2026-04-01T00:00:00Z'),
+        modifiedAt: toISODateString('2026-04-01T00:00:00Z'),
+      };
+      const page: PagedResult<Product> = {
+        items: [product],
+        totalCount: 1,
+      };
+      vi.mocked(client.get).mockResolvedValue({ data: page });
+
+      const result = await listProducts(client, basePath, { page: 1, pageSize: 25 });
+
+      expect(client.get).toHaveBeenCalledTimes(1);
+      const url = vi.mocked(client.get).mock.calls[0]?.[0] as string;
+      expect(url).toContain('/api/granit/catalog/product-records');
+      expect(url).toContain('page=1');
+      expect(url).toContain('pageSize=25');
+      expect(result).toEqual(page);
+    });
+
+    it('should GET {basePath}/product-records without parameters when omitted', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({
+        data: { items: [], totalCount: 0 },
+      });
+
+      await listProducts(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith('/api/granit/catalog/product-records');
+    });
+  });
+});

--- a/packages/@granit/catalog/src/api/catalog-api.ts
+++ b/packages/@granit/catalog/src/api/catalog-api.ts
@@ -1,0 +1,301 @@
+import {
+  createSavedView,
+  deleteSavedView,
+  getPage,
+  getQueryMeta,
+  listSavedViews,
+  setDefaultSavedView,
+  updateSavedView,
+} from '@granit/query-engine';
+
+import type {
+  AddProductExternalMappingRequest,
+  Product,
+  ProductCreateRequest,
+  ProductExternalMappingResponse,
+  ProductListParams,
+  ProductPage,
+  ProductResponse,
+  ProductUpdateRequest,
+  UpdateProductMetadataRequest,
+} from '../types.js';
+import type {
+  CreateSavedViewRequest,
+  QueryMetadata,
+  SavedViewSummary,
+  UpdateSavedViewRequest,
+} from '@granit/query-engine';
+import type { AxiosInstance } from 'axios';
+
+const PRODUCT_RECORDS_SUBPATH = 'product-records';
+
+function productRecordsPath(basePath: string): string {
+  return `${basePath}/${PRODUCT_RECORDS_SUBPATH}`;
+}
+
+// ---------------------------------------------------------------------------
+// Read endpoints (business path: only Published products are listed)
+// ---------------------------------------------------------------------------
+
+/**
+ * List published products available for purchase.
+ *
+ * `GET {basePath}/products`
+ */
+export async function listPublishedProducts(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly ProductResponse[]> {
+  const response = await client.get<readonly ProductResponse[]>(`${basePath}/products`);
+  return response.data;
+}
+
+/**
+ * Get a product by its identifier (any lifecycle status).
+ *
+ * `GET {basePath}/products/{id}`
+ */
+export async function getProductById(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<ProductResponse> {
+  const response = await client.get<ProductResponse>(
+    `${basePath}/products/${encodeURIComponent(id)}`
+  );
+  return response.data;
+}
+
+/**
+ * Get a product by its stable business SKU.
+ *
+ * `GET {basePath}/products/by-sku/{sku}`
+ */
+export async function getProductBySku(
+  client: AxiosInstance,
+  basePath: string,
+  sku: string
+): Promise<ProductResponse> {
+  const response = await client.get<ProductResponse>(
+    `${basePath}/products/by-sku/${encodeURIComponent(sku)}`
+  );
+  return response.data;
+}
+
+// ---------------------------------------------------------------------------
+// Write endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new product in `Draft` status.
+ *
+ * `POST {basePath}/products`
+ */
+export async function createProduct(
+  client: AxiosInstance,
+  basePath: string,
+  request: ProductCreateRequest
+): Promise<ProductResponse> {
+  const response = await client.post<ProductResponse>(`${basePath}/products`, request);
+  return response.data;
+}
+
+/**
+ * Update editable fields of a `Draft` product.
+ *
+ * `PUT {basePath}/products/{id}`
+ */
+export async function updateProduct(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: ProductUpdateRequest
+): Promise<ProductResponse> {
+  const response = await client.put<ProductResponse>(
+    `${basePath}/products/${encodeURIComponent(id)}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Replace all metadata of a product (any lifecycle status).
+ *
+ * `PUT {basePath}/products/{id}/metadata`
+ */
+export async function updateProductMetadata(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: UpdateProductMetadataRequest
+): Promise<ProductResponse> {
+  const response = await client.put<ProductResponse>(
+    `${basePath}/products/${encodeURIComponent(id)}/metadata`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Publish a `Draft` product, making it available for purchase.
+ *
+ * `POST {basePath}/products/{id}/publish`
+ */
+export async function publishProduct(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<ProductResponse> {
+  const response = await client.post<ProductResponse>(
+    `${basePath}/products/${encodeURIComponent(id)}/publish`
+  );
+  return response.data;
+}
+
+/**
+ * Archive a `Published` product. Existing references are preserved for audit.
+ *
+ * `POST {basePath}/products/{id}/archive`
+ */
+export async function archiveProduct(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<ProductResponse> {
+  const response = await client.post<ProductResponse>(
+    `${basePath}/products/${encodeURIComponent(id)}/archive`
+  );
+  return response.data;
+}
+
+// ---------------------------------------------------------------------------
+// External mappings (provider sync — Stripe, Avalara, Odoo, ...)
+// ---------------------------------------------------------------------------
+
+/**
+ * Add an external provider mapping to a product.
+ *
+ * `POST {basePath}/products/{id}/external-mappings`
+ */
+export async function addProductExternalMapping(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: AddProductExternalMappingRequest
+): Promise<ProductExternalMappingResponse> {
+  const response = await client.post<ProductExternalMappingResponse>(
+    `${basePath}/products/${encodeURIComponent(id)}/external-mappings`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Remove an external provider mapping from a product.
+ *
+ * `DELETE {basePath}/products/{id}/external-mappings/{mappingId}`
+ */
+export async function removeProductExternalMapping(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  mappingId: string
+): Promise<void> {
+  await client.delete(
+    `${basePath}/products/${encodeURIComponent(id)}/external-mappings/${encodeURIComponent(mappingId)}`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// QueryEngine — admin grid (all lifecycle statuses, filterable, exportable)
+// ---------------------------------------------------------------------------
+
+/**
+ * List products via the QueryEngine endpoint (paginated, filterable).
+ *
+ * `GET {basePath}/product-records`
+ */
+export async function listProducts(
+  client: AxiosInstance,
+  basePath: string,
+  params?: ProductListParams
+): Promise<ProductPage> {
+  return getPage<Product>(client, productRecordsPath(basePath), params ?? {});
+}
+
+/**
+ * Get the QueryEngine metadata (columns, filterable fields, presets) for products.
+ *
+ * `GET {basePath}/product-records/meta`
+ */
+export async function getProductsQueryMeta(
+  client: AxiosInstance,
+  basePath: string
+): Promise<QueryMetadata> {
+  return getQueryMeta(client, productRecordsPath(basePath));
+}
+
+/**
+ * List saved views for the products query endpoint.
+ *
+ * `GET {basePath}/product-records/saved-views`
+ */
+export async function listProductsSavedViews(
+  client: AxiosInstance,
+  basePath: string
+): Promise<SavedViewSummary[]> {
+  return listSavedViews(client, productRecordsPath(basePath));
+}
+
+/**
+ * Create a saved view for the products query endpoint.
+ *
+ * `POST {basePath}/product-records/saved-views`
+ */
+export async function createProductsSavedView(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreateSavedViewRequest
+): Promise<SavedViewSummary> {
+  return createSavedView(client, productRecordsPath(basePath), request);
+}
+
+/**
+ * Update a saved view on the products query endpoint.
+ *
+ * `PUT {basePath}/product-records/saved-views/{id}`
+ */
+export async function updateProductsSavedView(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: UpdateSavedViewRequest
+): Promise<void> {
+  await updateSavedView(client, productRecordsPath(basePath), id, request);
+}
+
+/**
+ * Delete a saved view from the products query endpoint.
+ *
+ * `DELETE {basePath}/product-records/saved-views/{id}`
+ */
+export async function deleteProductsSavedView(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await deleteSavedView(client, productRecordsPath(basePath), id);
+}
+
+/**
+ * Set a saved view as the default for the products query endpoint.
+ *
+ * `POST {basePath}/product-records/saved-views/{id}/set-default`
+ */
+export async function setDefaultProductsSavedView(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await setDefaultSavedView(client, productRecordsPath(basePath), id);
+}

--- a/packages/@granit/catalog/src/index.ts
+++ b/packages/@granit/catalog/src/index.ts
@@ -1,0 +1,40 @@
+// Types
+export type {
+  AddProductExternalMappingRequest,
+  Product,
+  ProductCreateRequest,
+  ProductExternalMappingId,
+  ProductExternalMappingResponse,
+  ProductId,
+  ProductLifecycleStatus,
+  ProductListParams,
+  ProductPage,
+  ProductResponse,
+  ProductType,
+  ProductUpdateRequest,
+  UpdateProductMetadataRequest,
+} from './types.js';
+
+// Permissions
+export { CatalogPermissions } from './permissions.js';
+
+// API
+export {
+  addProductExternalMapping,
+  archiveProduct,
+  createProduct,
+  createProductsSavedView,
+  deleteProductsSavedView,
+  getProductById,
+  getProductBySku,
+  getProductsQueryMeta,
+  listProducts,
+  listProductsSavedViews,
+  listPublishedProducts,
+  publishProduct,
+  removeProductExternalMapping,
+  setDefaultProductsSavedView,
+  updateProduct,
+  updateProductMetadata,
+  updateProductsSavedView,
+} from './api/catalog-api.js';

--- a/packages/@granit/catalog/src/permissions.ts
+++ b/packages/@granit/catalog/src/permissions.ts
@@ -1,0 +1,6 @@
+export const CatalogPermissions = {
+  Products: {
+    Read: 'Catalog.Products.Read',
+    Manage: 'Catalog.Products.Manage',
+  },
+} as const;

--- a/packages/@granit/catalog/src/types.ts
+++ b/packages/@granit/catalog/src/types.ts
@@ -1,0 +1,99 @@
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
+import type { EntityId, ISODateString, TenantId } from '@granit/types';
+
+/** Branded identifier for a catalog product. */
+export type ProductId = EntityId<'Product'>;
+
+/** Branded identifier for a product's external provider mapping. */
+export type ProductExternalMappingId = EntityId<'ProductExternalMapping'>;
+
+/**
+ * Coarse classification of a product. Drives downstream behavior
+ * (tax codes, shipping, metering integration).
+ */
+export type ProductType = 'Service' | 'Metered' | 'Physical' | 'Digital';
+
+/** Workflow lifecycle status (mirrors Granit.Workflow). */
+export type ProductLifecycleStatus = 'Draft' | 'Published' | 'Archived';
+
+/**
+ * Optional reference to an external provider's product identifier
+ * (Stripe, Avalara, Odoo, ...). One row per provider.
+ */
+export interface ProductExternalMappingResponse {
+  readonly id: ProductExternalMappingId;
+  readonly providerName: string;
+  readonly externalId: string;
+}
+
+/** A catalog product as returned by the read endpoints. */
+export interface ProductResponse {
+  readonly id: ProductId;
+  readonly sku: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly type: ProductType;
+  readonly unit: string;
+  readonly lifecycleStatus: ProductLifecycleStatus;
+  readonly metadata: Readonly<Record<string, string>>;
+  readonly externalMappings: readonly ProductExternalMappingResponse[];
+}
+
+/** Request to create a new product in `Draft` status. */
+export interface ProductCreateRequest {
+  readonly sku: string;
+  readonly name: string;
+  readonly type: ProductType;
+  readonly unit: string;
+  readonly description?: string | null;
+}
+
+/** Request to update editable fields of a `Draft` product. */
+export interface ProductUpdateRequest {
+  readonly name: string;
+  readonly description: string | null;
+  readonly unit: string;
+}
+
+/**
+ * Request to replace all metadata of a product (any lifecycle status).
+ * Backend MUST NOT contain PII (audit logs and exports surface this content).
+ */
+export interface UpdateProductMetadataRequest {
+  readonly metadata: Readonly<Record<string, string>>;
+}
+
+/** Request to add an external provider mapping to a product. */
+export interface AddProductExternalMappingRequest {
+  readonly providerName: string;
+  readonly externalId: string;
+}
+
+// ---------------------------------------------------------------------------
+// QueryEngine entity (admin grid: filter / sort / paginate / export)
+// ---------------------------------------------------------------------------
+
+/**
+ * Product entity as returned by the QueryEngine endpoint
+ * (`GET /catalog/product-records`). Distinct from {@link ProductResponse}:
+ * the query endpoint returns the raw entity (including audit columns) without
+ * the `metadata` / `externalMappings` projections applied by the CRUD endpoints.
+ */
+export interface Product {
+  readonly id: ProductId;
+  readonly tenantId: TenantId | null;
+  readonly sku: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly type: ProductType;
+  readonly unit: string;
+  readonly lifecycleStatus: ProductLifecycleStatus;
+  readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString;
+}
+
+/** Paginated page of {@link Product} entities. */
+export type ProductPage = PagedResult<Product>;
+
+/** Query parameters accepted by `GET /catalog/product-records`. */
+export type ProductListParams = QueryRequest;

--- a/packages/@granit/catalog/tsconfig.json
+++ b/packages/@granit/catalog/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/catalog/tsup.config.ts
+++ b/packages/@granit/catalog/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/customer-balance/package.json
+++ b/packages/@granit/customer-balance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/customer-balance",
   "description": "Customer balance and credits — types and API functions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
+++ b/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   addAdminCredit,
+  debitCustomerBalance,
   getCustomerBalance,
   listBalanceTransactions,
 } from '../api/customer-balance-api.js';
 
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from '../types.js';
@@ -120,6 +122,42 @@ describe('customer-balance-api', () => {
       await addAdminCredit(client, basePath, request);
 
       expect(client.post).toHaveBeenCalledWith(`${basePath}/credit`, request);
+    });
+  });
+
+  describe('debitCustomerBalance', () => {
+    it('should POST {basePath}/balance/debit and return updated balance', async () => {
+      const client = createMockClient();
+      const updated: CustomerBalanceResponse = { ...sampleBalance, balance: 100.0 };
+      vi.mocked(client.post).mockResolvedValue({ data: updated });
+
+      const request: AdminDebitRequest = {
+        amount: 50.0,
+        currency: 'EUR',
+        reason: 'Manual correction',
+      };
+
+      const result = await debitCustomerBalance(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/balance/debit`, request);
+      expect(result).toEqual(updated);
+    });
+
+    it('should support optional referenceId / referenceType for idempotent retries', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
+
+      const request: AdminDebitRequest = {
+        amount: 10,
+        currency: 'EUR',
+        reason: 'Scheduled drawdown',
+        referenceId: '49a82c3e-1c50-4c0c-9d2e-4a9b7c0f6de2',
+        referenceType: 'AdminAdjustment',
+      };
+
+      await debitCustomerBalance(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/balance/debit`, request);
     });
   });
 });

--- a/packages/@granit/customer-balance/src/api/customer-balance-api.ts
+++ b/packages/@granit/customer-balance/src/api/customer-balance-api.ts
@@ -1,5 +1,6 @@
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from '../types.js';
@@ -44,4 +45,22 @@ export async function addAdminCredit(
   request: AdminCreditRequest
 ): Promise<void> {
   await client.post(`${basePath}/credit`, request);
+}
+
+/**
+ * Debit a tenant's balance manually — admin tooling for corrections,
+ * scheduled drawdowns, and non-invoice adjustments. Returns the updated
+ * balance state.
+ *
+ * `POST {basePath}/balance/debit`
+ *
+ * @returns the refreshed {@link CustomerBalanceResponse} after the debit.
+ */
+export async function debitCustomerBalance(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminDebitRequest
+): Promise<CustomerBalanceResponse> {
+  const response = await client.post<CustomerBalanceResponse>(`${basePath}/balance/debit`, request);
+  return response.data;
 }

--- a/packages/@granit/customer-balance/src/index.ts
+++ b/packages/@granit/customer-balance/src/index.ts
@@ -1,6 +1,7 @@
 // Types
 export type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from './types.js';
@@ -11,6 +12,7 @@ export { CustomerBalancePermissions } from './permissions.js';
 // API
 export {
   addAdminCredit,
+  debitCustomerBalance,
   getCustomerBalance,
   listBalanceTransactions,
 } from './api/customer-balance-api.js';

--- a/packages/@granit/customer-balance/src/types.ts
+++ b/packages/@granit/customer-balance/src/types.ts
@@ -7,6 +7,25 @@ export interface AdminCreditRequest {
   readonly expiresAt: string | null;
 }
 
+/**
+ * Request payload to debit a tenant's `BalanceAccount` manually — admin
+ * tooling for corrections, scheduled drawdowns, and non-invoice adjustments.
+ *
+ * When `referenceId` is set, a previous debit with the same
+ * `(referenceId, source = ManualAdjustment)` short-circuits the call —
+ * admin retries are safe.
+ */
+export interface AdminDebitRequest {
+  readonly amount: number;
+  readonly currency: string;
+  /** Free-text justification (audit trail; ≤ 500 chars; no PII per GDPR). */
+  readonly reason: string;
+  /** Optional external document reference (idempotency key). */
+  readonly referenceId?: string | null;
+  /** Type of the referenced document (e.g. `"AdminAdjustment"`). */
+  readonly referenceType?: string | null;
+}
+
 /** The current state of a customer's balance account. */
 export interface CustomerBalanceResponse {
   readonly balanceAccountId: string;

--- a/packages/@granit/invoicing/package.json
+++ b/packages/@granit/invoicing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/invoicing",
   "description": "Invoice lifecycle — types and API functions for invoices and credit notes",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
+++ b/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
@@ -19,9 +19,11 @@ const sampleLineItem = {
   taxRate: 0.21,
   taxAmount: 1029,
   sourceType: 'Subscription',
-  sourceId: 'sub-1',
+  // ADR-036: Subscription lines carry a Guid sourceId.
+  sourceId: '0a4d76b2-3d9f-4a6f-9fd8-9a92b9abf001',
   periodStart: '2026-03-01T00:00:00Z',
   periodEnd: '2026-04-01T00:00:00Z',
+  productId: null,
 } as const;
 
 const sampleInvoice: InvoiceResponse = {

--- a/packages/@granit/invoicing/src/index.ts
+++ b/packages/@granit/invoicing/src/index.ts
@@ -7,6 +7,7 @@ export type {
   InvoiceId,
   InvoiceLineItemResponse,
   InvoiceResponse,
+  InvoiceSourceType,
 } from './types.js';
 
 // Permissions

--- a/packages/@granit/invoicing/src/types.ts
+++ b/packages/@granit/invoicing/src/types.ts
@@ -30,6 +30,17 @@ export interface InvoiceCreateRequest {
   readonly periodEnd: string | null;
 }
 
+/**
+ * Origin of an invoice line item.
+ *
+ * Convention (see Granit dotnet ADR-036):
+ * - `Subscription` / `Usage` → {@link InvoiceLineItemResponse.sourceId} MUST be a
+ *   Guid string referencing the originating `Subscription.Id` / `PlanPrice.Id`
+ *   (Subscription) or `MeterDefinition.Id` (Usage).
+ * - `OneShot` / `Credit` → free-form (SKU, refund reference, or `null`).
+ */
+export type InvoiceSourceType = 'Subscription' | 'Usage' | 'OneShot' | 'Credit';
+
 /** A single line item within an invoice. */
 export interface InvoiceLineItemResponse {
   readonly id: string;
@@ -39,10 +50,18 @@ export interface InvoiceLineItemResponse {
   readonly amount: number;
   readonly taxRate: number | null;
   readonly taxAmount: number;
-  readonly sourceType: string;
+  readonly sourceType: InvoiceSourceType;
   readonly sourceId: string | null;
   readonly periodStart: string | null;
   readonly periodEnd: string | null;
+  /**
+   * Optional `Granit.Catalog.Product` identifier propagated from the upstream
+   * entity (`MeterDefinition.productId` for Usage, `PlanPrice.productId` for
+   * Subscription). Soft reference (no SQL FK across modules); survives meter
+   * or price renames so reporting stays attributable to a stable catalog item.
+   * See Granit dotnet ADR-036.
+   */
+  readonly productId: string | null;
 }
 
 /** Full invoice response from the API. */

--- a/packages/@granit/metering/package.json
+++ b/packages/@granit/metering/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/metering",
   "description": "Usage metering — meter definitions, events, and quota types and API functions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/metering/src/__tests__/metering-api.test.ts
+++ b/packages/@granit/metering/src/__tests__/metering-api.test.ts
@@ -2,6 +2,8 @@ import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  archiveMeterDefinition,
+  backfillUsageEvents,
   checkMeteringQuota,
   createMeterDefinition,
   createMeterDefinitionsSavedView,
@@ -9,6 +11,7 @@ import {
   deactivateMeterDefinition,
   deleteMeterDefinitionsSavedView,
   deleteUsageAggregatesSavedView,
+  deprecateMeterEvent,
   getMeterDefinition,
   getMeterDefinitionsQueryMeta,
   getUsageAggregatesQueryMeta,
@@ -18,6 +21,8 @@ import {
   listMeterDefinitionsSavedViews,
   listUsageAggregates,
   listUsageAggregatesSavedViews,
+  publishMeterDefinition,
+  recomputeMeterUsage,
   recordUsageEvents,
   setDefaultMeterDefinitionsSavedView,
   setDefaultUsageAggregatesSavedView,
@@ -53,6 +58,9 @@ const sampleMeter: MeterDefinitionResponse = {
   description: 'Number of API calls',
   aggregationType: 'Sum',
   activated: true,
+  productId: null,
+  lifecycleStatus: 'Published',
+  distinctProperty: null,
 };
 
 const sampleUsage: UsageAggregateResponse = {
@@ -262,6 +270,9 @@ const sampleMeterDefinition: MeterDefinition = {
   unit: 'calls',
   aggregationType: 'Sum',
   activated: true,
+  lifecycleStatus: 'Published',
+  distinctProperty: null,
+  productId: null,
   createdAt: '2026-04-01T00:00:00Z' as ISODateString,
   modifiedAt: '2026-04-01T00:00:00Z' as ISODateString,
 };
@@ -533,5 +544,106 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
     await listUsageAggregates(client, '/custom/metering');
 
     expect(client.get).toHaveBeenCalledWith('/custom/metering/usage-aggregates');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle + admin operations (publish/archive/recompute/backfill/deprecate)
+// ---------------------------------------------------------------------------
+
+describe('metering-api / lifecycle + admin operations', () => {
+  describe('publishMeterDefinition', () => {
+    it('should POST {basePath}/meters/{id}/publish', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleMeter });
+
+      const result = await publishMeterDefinition(client, basePath, 'meter-1');
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1/publish');
+      expect(result).toEqual(sampleMeter);
+    });
+  });
+
+  describe('archiveMeterDefinition', () => {
+    it('should POST {basePath}/meters/{id}/archive', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleMeter });
+
+      const result = await archiveMeterDefinition(client, basePath, 'meter-1');
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1/archive');
+      expect(result).toEqual(sampleMeter);
+    });
+  });
+
+  describe('recomputeMeterUsage', () => {
+    it('should POST {basePath}/meters/{id}/recompute with window', async () => {
+      const client = createMockClient();
+      const response = {
+        meterDefinitionId: 'meter-1',
+        windowStart: '2026-04-01T00:00:00Z',
+        windowEnd: '2026-04-02T00:00:00Z',
+        eventsScanned: 120,
+        aggregatesRebuilt: 24,
+        durationMilliseconds: 314,
+      };
+      vi.mocked(client.post).mockResolvedValue({ data: response });
+
+      const result = await recomputeMeterUsage(client, basePath, 'meter-1', {
+        from: '2026-04-01T00:00:00Z',
+        to: '2026-04-02T00:00:00Z',
+      });
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1/recompute', {
+        from: '2026-04-01T00:00:00Z',
+        to: '2026-04-02T00:00:00Z',
+      });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('backfillUsageEvents', () => {
+    it('should POST {basePath}/events/backfill', async () => {
+      const client = createMockClient();
+      const response = { eventsAccepted: 3, metersAffected: 1, aggregatesRebuilt: 5 };
+      vi.mocked(client.post).mockResolvedValue({ data: response });
+
+      const events = [
+        {
+          meterDefinitionId: 'meter-1',
+          idempotencyKey: 'k1',
+          quantity: 1,
+          timestamp: '2025-01-01T00:00:00Z',
+          metadata: null,
+        },
+      ];
+
+      const result = await backfillUsageEvents(client, basePath, { events });
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/events/backfill', { events });
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('deprecateMeterEvent', () => {
+    it('should POST {basePath}/events/{id}/deprecate', async () => {
+      const client = createMockClient();
+      const response = {
+        eventId: 'evt-1',
+        meterDefinitionId: 'meter-1',
+        deprecatedAt: '2026-04-25T08:00:00Z',
+        aggregatesRebuilt: 1,
+      };
+      vi.mocked(client.post).mockResolvedValue({ data: response });
+
+      const result = await deprecateMeterEvent(client, basePath, 'evt-1', {
+        reason: 'duplicate from retried client',
+      });
+
+      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/events/evt-1/deprecate', {
+        reason: 'duplicate from retried client',
+      });
+      expect(result).toEqual(response);
+    });
   });
 });

--- a/packages/@granit/metering/src/api/metering-api.ts
+++ b/packages/@granit/metering/src/api/metering-api.ts
@@ -9,6 +9,10 @@ import {
 } from '@granit/query-engine';
 
 import type {
+  BackfillUsageRequest,
+  BackfillUsageResponse,
+  DeprecateEventRequest,
+  DeprecateEventResponse,
   MeterDefinition,
   MeterDefinitionCreateRequest,
   MeterDefinitionListParams,
@@ -16,6 +20,8 @@ import type {
   MeterDefinitionResponse,
   MeterDefinitionUpdateRequest,
   MeteringQuotaStatusResponse,
+  RecomputeUsageRequest,
+  RecomputeUsageResponse,
   RecordUsageRequest,
   UsageAggregate,
   UsageAggregateListParams,
@@ -106,6 +112,10 @@ export async function updateMeterDefinition(
  * Deactivate a meter definition.
  *
  * `POST {basePath}/meters/{id}/deactivate`
+ *
+ * @deprecated Use {@link archiveMeterDefinition} instead. This endpoint
+ * remains a backend alias for one release; the lifecycle action is now
+ * `Publish → Archive` (see {@link MeterLifecycleStatus}).
  */
 export async function deactivateMeterDefinition(
   client: AxiosInstance,
@@ -113,6 +123,94 @@ export async function deactivateMeterDefinition(
   id: string
 ): Promise<void> {
   await client.post(`${basePath}/meters/${encodeURIComponent(id)}/deactivate`);
+}
+
+/**
+ * Publish a `Draft` meter definition. Only `Published` meters accept ingestion.
+ *
+ * `POST {basePath}/meters/{id}/publish`
+ */
+export async function publishMeterDefinition(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<MeterDefinitionResponse> {
+  const response = await client.post<MeterDefinitionResponse>(
+    `${basePath}/meters/${encodeURIComponent(id)}/publish`
+  );
+  return response.data;
+}
+
+/**
+ * Archive a `Published` meter definition. Existing aggregates remain readable;
+ * new event ingestion is rejected.
+ *
+ * `POST {basePath}/meters/{id}/archive`
+ */
+export async function archiveMeterDefinition(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<MeterDefinitionResponse> {
+  const response = await client.post<MeterDefinitionResponse>(
+    `${basePath}/meters/${encodeURIComponent(id)}/archive`
+  );
+  return response.data;
+}
+
+/**
+ * Recompute the usage aggregates for a meter over an arbitrary window.
+ * Window edges are snapped to hourly buckets server-side; the global ingestion
+ * watermark is never rewound — concurrent ingestion past `to` is unaffected.
+ *
+ * `POST {basePath}/meters/{id}/recompute`
+ */
+export async function recomputeMeterUsage(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: RecomputeUsageRequest
+): Promise<RecomputeUsageResponse> {
+  const response = await client.post<RecomputeUsageResponse>(
+    `${basePath}/meters/${encodeURIComponent(id)}/recompute`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Backfill historical events older than the standard 7-day ingestion window
+ * (up to 365 days). Triggers automatic recomputes on past `UsageAggregate` rows.
+ *
+ * `POST {basePath}/events/backfill`
+ */
+export async function backfillUsageEvents(
+  client: AxiosInstance,
+  basePath: string,
+  request: BackfillUsageRequest
+): Promise<BackfillUsageResponse> {
+  const response = await client.post<BackfillUsageResponse>(`${basePath}/events/backfill`, request);
+  return response.data;
+}
+
+/**
+ * Soft-deprecate an individual meter event. The event row is preserved
+ * (audit trail); the affected hourly aggregate is auto-rebuilt without the
+ * deprecated event's contribution.
+ *
+ * `POST {basePath}/events/{id}/deprecate`
+ */
+export async function deprecateMeterEvent(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: DeprecateEventRequest
+): Promise<DeprecateEventResponse> {
+  const response = await client.post<DeprecateEventResponse>(
+    `${basePath}/events/${encodeURIComponent(id)}/deprecate`,
+    request
+  );
+  return response.data;
 }
 
 /**

--- a/packages/@granit/metering/src/index.ts
+++ b/packages/@granit/metering/src/index.ts
@@ -2,6 +2,10 @@
 export type {
   AggregationPeriod,
   AggregationType,
+  BackfillUsageRequest,
+  BackfillUsageResponse,
+  DeprecateEventRequest,
+  DeprecateEventResponse,
   MeterDefinition,
   MeterDefinitionCreateRequest,
   MeterDefinitionListParams,
@@ -9,7 +13,10 @@ export type {
   MeterDefinitionResponse,
   MeterDefinitionUpdateRequest,
   MeterEventRequest,
+  MeterLifecycleStatus,
   MeteringQuotaStatusResponse,
+  RecomputeUsageRequest,
+  RecomputeUsageResponse,
   RecordUsageRequest,
   UsageAggregate,
   UsageAggregateListParams,
@@ -22,6 +29,8 @@ export { MeteringPermissions } from './permissions.js';
 
 // API
 export {
+  archiveMeterDefinition,
+  backfillUsageEvents,
   checkMeteringQuota,
   createMeterDefinition,
   createMeterDefinitionsSavedView,
@@ -29,6 +38,7 @@ export {
   deactivateMeterDefinition,
   deleteMeterDefinitionsSavedView,
   deleteUsageAggregatesSavedView,
+  deprecateMeterEvent,
   getMeterDefinition,
   getMeterDefinitionsQueryMeta,
   getUsageAggregatesQueryMeta,
@@ -38,6 +48,8 @@ export {
   listMeterDefinitionsSavedViews,
   listUsageAggregates,
   listUsageAggregatesSavedViews,
+  publishMeterDefinition,
+  recomputeMeterUsage,
   recordUsageEvents,
   setDefaultMeterDefinitionsSavedView,
   setDefaultUsageAggregatesSavedView,

--- a/packages/@granit/metering/src/permissions.ts
+++ b/packages/@granit/metering/src/permissions.ts
@@ -7,4 +7,17 @@ export const MeteringPermissions = {
     Read: 'Metering.Usage.Read',
     Record: 'Metering.Usage.Record',
   },
+  Events: {
+    /**
+     * Manage individual meter events (currently the soft-deprecation endpoint).
+     * Deliberately separated from `Usage.Record` because deprecation is destructive
+     * at the billing-data level (ISO 27001 A.9.4 — least privilege).
+     */
+    Manage: 'Metering.Events.Manage',
+    /**
+     * Backfill historical events older than the standard 7-day ingestion window
+     * (up to 365 days). Triggers automatic recomputes on past `UsageAggregate` rows.
+     */
+    Backfill: 'Metering.Events.Backfill',
+  },
 } as const;

--- a/packages/@granit/metering/src/types.ts
+++ b/packages/@granit/metering/src/types.ts
@@ -1,21 +1,39 @@
 import type { PagedResult, QueryRequest } from '@granit/query-engine';
 import type { ISODateString, TenantId } from '@granit/types';
 
-export type AggregationType = 'Sum' | 'Count' | 'Max' | 'Last';
+/**
+ * Supported aggregation strategies. `CountDistinct` requires
+ * {@link MeterDefinitionResponse.distinctProperty} to be set.
+ */
+export type AggregationType = 'Sum' | 'Count' | 'Max' | 'Last' | 'CountDistinct';
 
 export type AggregationPeriod = 'Hourly' | 'Daily' | 'BillingPeriod';
+
+/** Workflow lifecycle status of a meter definition (mirrors Granit.Workflow). */
+export type MeterLifecycleStatus = 'Draft' | 'Published' | 'Archived';
 
 export interface MeterDefinitionCreateRequest {
   readonly name: string;
   readonly unit: string;
   readonly aggregationType: AggregationType;
-  readonly description: string | null;
+  readonly description?: string | null;
+  /**
+   * Optional reference to a `Granit.Catalog.Product` identifier — the
+   * catalog item this meter measures. Soft reference (no SQL FK across modules).
+   */
+  readonly productId?: string | null;
+  /**
+   * JSON property name inside `MeterEvent.metadata` whose distinct values
+   * are counted. **Required** when `aggregationType === 'CountDistinct'`;
+   * must be omitted (or `null`) for any other aggregation type.
+   */
+  readonly distinctProperty?: string | null;
 }
 
 export interface MeterDefinitionUpdateRequest {
   readonly name: string;
   readonly unit: string;
-  readonly description: string | null;
+  readonly description?: string | null;
 }
 
 export interface MeterEventRequest {
@@ -36,7 +54,69 @@ export interface MeterDefinitionResponse {
   readonly unit: string;
   readonly description: string | null;
   readonly aggregationType: AggregationType;
+  /**
+   * @deprecated Removed in next major release.
+   * Use {@link lifecycleStatus} instead — `activated === true` iff
+   * `lifecycleStatus === 'Published'`.
+   */
   readonly activated: boolean;
+  /** Optional `Granit.Catalog.Product` reference (soft, no SQL FK). */
+  readonly productId: string | null;
+  /** Workflow lifecycle status. Only `Published` meters accept ingestion. */
+  readonly lifecycleStatus: MeterLifecycleStatus;
+  /** JSON property name counted distinctly when `aggregationType === 'CountDistinct'`. */
+  readonly distinctProperty: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Recompute / backfill / deprecate (admin operations on usage data)
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST {basePath}/meters/{id}/recompute`. */
+export interface RecomputeUsageRequest {
+  /** Inclusive lower bound of the recompute window (UTC, ISO 8601). */
+  readonly from: string;
+  /** Exclusive upper bound of the recompute window (UTC, ISO 8601). */
+  readonly to: string;
+}
+
+/** Response from a recompute invocation. */
+export interface RecomputeUsageResponse {
+  readonly meterDefinitionId: string;
+  readonly windowStart: string;
+  readonly windowEnd: string;
+  readonly eventsScanned: number;
+  readonly aggregatesRebuilt: number;
+  readonly durationMilliseconds: number;
+}
+
+/**
+ * Request body for `POST {basePath}/events/backfill` — same shape as
+ * {@link RecordUsageRequest} but accepts events up to 365 days old.
+ */
+export interface BackfillUsageRequest {
+  readonly events: readonly MeterEventRequest[];
+}
+
+/** Response from a backfill batch. */
+export interface BackfillUsageResponse {
+  readonly eventsAccepted: number;
+  readonly metersAffected: number;
+  readonly aggregatesRebuilt: number;
+}
+
+/** Request body for `POST {basePath}/events/{id}/deprecate`. */
+export interface DeprecateEventRequest {
+  /** Free-text justification (max 500 chars; audit log + admin UI). */
+  readonly reason: string;
+}
+
+/** Response from a successful event deprecation. */
+export interface DeprecateEventResponse {
+  readonly eventId: string;
+  readonly meterDefinitionId: string;
+  readonly deprecatedAt: string;
+  readonly aggregatesRebuilt: number;
 }
 
 export interface UsageAggregateResponse {
@@ -75,7 +155,11 @@ export interface MeterDefinition {
   readonly name: string;
   readonly unit: string;
   readonly aggregationType: AggregationType;
+  /** @deprecated Use {@link lifecycleStatus} — `activated === lifecycleStatus === 'Published'`. */
   readonly activated: boolean;
+  readonly lifecycleStatus: MeterLifecycleStatus;
+  readonly distinctProperty: string | null;
+  readonly productId: string | null;
   readonly createdAt: ISODateString;
   readonly modifiedAt: ISODateString;
 }

--- a/packages/@granit/react-catalog/package.json
+++ b/packages/@granit/react-catalog/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@granit/react-catalog",
+  "description": "React bindings for @granit/catalog — CatalogProvider and product hooks",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/catalog": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "axios": "*",
+    "msw": "^2.12.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  }
+}

--- a/packages/@granit/react-catalog/src/__tests__/use-catalog.test.tsx
+++ b/packages/@granit/react-catalog/src/__tests__/use-catalog.test.tsx
@@ -1,0 +1,210 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { toEntityId } from '@granit/types';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useArchiveProduct,
+  useCreateProduct,
+  useProduct,
+  useProductBySku,
+  usePublishProduct,
+  usePublishedProducts,
+  useUpdateProduct,
+  useUpdateProductMetadata,
+} from '../hooks/use-catalog.js';
+import { CatalogProvider } from '../providers/catalog-provider.js';
+
+import type { CatalogConfig } from '../providers/catalog-provider.js';
+import type {
+  ProductCreateRequest,
+  ProductResponse,
+  ProductUpdateRequest,
+  UpdateProductMetadataRequest,
+} from '@granit/catalog';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const sampleProduct: ProductResponse = {
+  id: toEntityId<'Product'>('prd_001'),
+  sku: 'API-CALLS',
+  name: 'API Calls',
+  description: 'Per-call billing for the public API.',
+  type: 'Metered',
+  unit: 'call',
+  lifecycleStatus: 'Published',
+  metadata: { tier: 'standard' },
+  externalMappings: [],
+};
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: CatalogConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <CatalogProvider config={config}>{children}</CatalogProvider>
+    );
+  };
+}
+
+describe('use-catalog', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('usePublishedProducts', () => {
+    it('fetches published products', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleProduct] });
+
+      const { result } = renderHook(() => usePublishedProducts(), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/api/v1/catalog/products');
+      expect(result.current.data).toEqual([sampleProduct]);
+    });
+
+    it('uses custom basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleProduct] });
+
+      const { result } = renderHook(() => usePublishedProducts(), {
+        wrapper: createWrapper(client, '/custom/catalog'),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/custom/catalog/products');
+    });
+  });
+
+  describe('useProduct', () => {
+    it('fetches a single product by id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleProduct });
+
+      const { result } = renderHook(() => useProduct('prd_001'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/api/v1/catalog/products/prd_001');
+    });
+
+    it('is disabled with empty id', () => {
+      const client = createMockClient();
+      const { result } = renderHook(() => useProduct(''), {
+        wrapper: createWrapper(client),
+      });
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useProductBySku', () => {
+    it('fetches a product by sku', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleProduct });
+
+      const { result } = renderHook(() => useProductBySku('API-CALLS'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/api/v1/catalog/products/by-sku/API-CALLS');
+    });
+  });
+
+  describe('useCreateProduct', () => {
+    it('creates a product and invalidates the products list', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+
+      const { result } = renderHook(() => useCreateProduct(), {
+        wrapper: createWrapper(client),
+      });
+
+      const request: ProductCreateRequest = {
+        sku: 'API-CALLS',
+        name: 'API Calls',
+        type: 'Metered',
+        unit: 'call',
+      };
+
+      await result.current.mutateAsync(request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/catalog/products', request);
+    });
+  });
+
+  describe('useUpdateProduct', () => {
+    it('updates a draft product', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleProduct });
+
+      const { result } = renderHook(() => useUpdateProduct(), {
+        wrapper: createWrapper(client),
+      });
+
+      const request: ProductUpdateRequest = {
+        name: 'API Calls v2',
+        description: null,
+        unit: 'call',
+      };
+
+      await result.current.mutateAsync({ id: 'prd_001', request });
+      expect(client.put).toHaveBeenCalledWith('/api/v1/catalog/products/prd_001', request);
+    });
+  });
+
+  describe('useUpdateProductMetadata', () => {
+    it('replaces product metadata', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleProduct });
+
+      const { result } = renderHook(() => useUpdateProductMetadata(), {
+        wrapper: createWrapper(client),
+      });
+
+      const request: UpdateProductMetadataRequest = {
+        metadata: { region: 'eu' },
+      };
+
+      await result.current.mutateAsync({ id: 'prd_001', request });
+      expect(client.put).toHaveBeenCalledWith('/api/v1/catalog/products/prd_001/metadata', request);
+    });
+  });
+
+  describe('usePublishProduct', () => {
+    it('publishes a draft product', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+
+      const { result } = renderHook(() => usePublishProduct(), {
+        wrapper: createWrapper(client),
+      });
+
+      await result.current.mutateAsync('prd_001');
+      expect(client.post).toHaveBeenCalledWith('/api/v1/catalog/products/prd_001/publish');
+    });
+  });
+
+  describe('useArchiveProduct', () => {
+    it('archives a published product', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+
+      const { result } = renderHook(() => useArchiveProduct(), {
+        wrapper: createWrapper(client),
+      });
+
+      await result.current.mutateAsync('prd_001');
+      expect(client.post).toHaveBeenCalledWith('/api/v1/catalog/products/prd_001/archive');
+    });
+  });
+});

--- a/packages/@granit/react-catalog/src/constants.ts
+++ b/packages/@granit/react-catalog/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'catalog';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-catalog/src/hooks/use-catalog.ts
+++ b/packages/@granit/react-catalog/src/hooks/use-catalog.ts
@@ -1,0 +1,248 @@
+import {
+  addProductExternalMapping,
+  archiveProduct,
+  createProduct,
+  getProductById,
+  getProductBySku,
+  listPublishedProducts,
+  publishProduct,
+  removeProductExternalMapping,
+  updateProduct,
+  updateProductMetadata,
+} from '@granit/catalog';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildCatalogQueryKey, useCatalogConfig } from '../providers/catalog-provider.js';
+
+import type {
+  AddProductExternalMappingRequest,
+  ProductCreateRequest,
+  ProductExternalMappingResponse,
+  ProductResponse,
+  ProductUpdateRequest,
+  UpdateProductMetadataRequest,
+} from '@granit/catalog';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * List all published products available for purchase.
+ *
+ * @example
+ * ```tsx
+ * const { data: products } = usePublishedProducts();
+ * ```
+ */
+export function usePublishedProducts(): UseQueryResult<readonly ProductResponse[]> {
+  const config = useCatalogConfig();
+  const basePath = config.basePath!;
+
+  return useQuery({
+    queryKey: buildCatalogQueryKey(config, 'products'),
+    queryFn: () => listPublishedProducts(config.client, basePath),
+  });
+}
+
+/**
+ * Get a product by its identifier (any lifecycle status).
+ * Disabled when `id` is empty.
+ */
+export function useProduct(id: string): UseQueryResult<ProductResponse> {
+  const config = useCatalogConfig();
+  const basePath = config.basePath!;
+
+  return useQuery({
+    queryKey: buildCatalogQueryKey(config, 'products', id),
+    queryFn: () => getProductById(config.client, basePath, id),
+    enabled: id.length > 0,
+  });
+}
+
+/**
+ * Get a product by its stable business SKU.
+ * Disabled when `sku` is empty.
+ */
+export function useProductBySku(sku: string): UseQueryResult<ProductResponse> {
+  const config = useCatalogConfig();
+  const basePath = config.basePath!;
+
+  return useQuery({
+    queryKey: buildCatalogQueryKey(config, 'products', 'by-sku', sku),
+    queryFn: () => getProductBySku(config.client, basePath, sku),
+    enabled: sku.length > 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new product in `Draft` status.
+ * Invalidates products queries on success.
+ */
+export function useCreateProduct(): UseMutationResult<
+  ProductResponse,
+  Error,
+  ProductCreateRequest
+> {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (request: ProductCreateRequest) => createProduct(config.client, basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products') });
+    },
+  });
+}
+
+/** Variables for `useUpdateProduct`. */
+export type UpdateProductVariables = {
+  readonly id: string;
+  readonly request: ProductUpdateRequest;
+};
+
+/**
+ * Update editable fields of a `Draft` product.
+ * Invalidates products queries on success.
+ */
+export function useUpdateProduct(): UseMutationResult<
+  ProductResponse,
+  Error,
+  UpdateProductVariables
+> {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }: UpdateProductVariables) =>
+      updateProduct(config.client, basePath, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products') });
+    },
+  });
+}
+
+/** Variables for `useUpdateProductMetadata`. */
+export type UpdateProductMetadataVariables = {
+  readonly id: string;
+  readonly request: UpdateProductMetadataRequest;
+};
+
+/**
+ * Replace all metadata of a product (any lifecycle status).
+ * Invalidates products queries on success.
+ */
+export function useUpdateProductMetadata(): UseMutationResult<
+  ProductResponse,
+  Error,
+  UpdateProductMetadataVariables
+> {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }: UpdateProductMetadataVariables) =>
+      updateProductMetadata(config.client, basePath, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products') });
+    },
+  });
+}
+
+/**
+ * Publish a `Draft` product, making it available for purchase.
+ * Invalidates products queries on success.
+ */
+export function usePublishProduct(): UseMutationResult<ProductResponse, Error, string> {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (id: string) => publishProduct(config.client, basePath, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products') });
+    },
+  });
+}
+
+/**
+ * Archive a `Published` product. Existing references are preserved for audit.
+ * Invalidates products queries on success.
+ */
+export function useArchiveProduct(): UseMutationResult<ProductResponse, Error, string> {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (id: string) => archiveProduct(config.client, basePath, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products') });
+    },
+  });
+}
+
+/** Variables for `useAddProductExternalMapping`. */
+export type AddProductExternalMappingVariables = {
+  readonly id: string;
+  readonly request: AddProductExternalMappingRequest;
+};
+
+/**
+ * Add an external provider mapping (Stripe, Avalara, Odoo, …) to a product.
+ * Invalidates the targeted product query on success.
+ */
+export function useAddProductExternalMapping(): UseMutationResult<
+  ProductExternalMappingResponse,
+  Error,
+  AddProductExternalMappingVariables
+> {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }: AddProductExternalMappingVariables) =>
+      addProductExternalMapping(config.client, basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products', id) });
+    },
+  });
+}
+
+/** Variables for `useRemoveProductExternalMapping`. */
+export type RemoveProductExternalMappingVariables = {
+  readonly id: string;
+  readonly mappingId: string;
+};
+
+/**
+ * Remove an external provider mapping from a product.
+ * Invalidates the targeted product query on success.
+ */
+export function useRemoveProductExternalMapping(): UseMutationResult<
+  void,
+  Error,
+  RemoveProductExternalMappingVariables
+> {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, mappingId }: RemoveProductExternalMappingVariables) =>
+      removeProductExternalMapping(config.client, basePath, id, mappingId),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products', id) });
+    },
+  });
+}

--- a/packages/@granit/react-catalog/src/index.ts
+++ b/packages/@granit/react-catalog/src/index.ts
@@ -1,0 +1,27 @@
+// Provider
+export {
+  CatalogProvider,
+  buildCatalogQueryKey,
+  useCatalogConfig,
+} from './providers/catalog-provider.js';
+export type { CatalogConfig, CatalogProviderProps } from './providers/catalog-provider.js';
+
+// Hooks
+export {
+  useAddProductExternalMapping,
+  useArchiveProduct,
+  useCreateProduct,
+  useProduct,
+  useProductBySku,
+  usePublishProduct,
+  usePublishedProducts,
+  useRemoveProductExternalMapping,
+  useUpdateProduct,
+  useUpdateProductMetadata,
+} from './hooks/use-catalog.js';
+export type {
+  AddProductExternalMappingVariables,
+  RemoveProductExternalMappingVariables,
+  UpdateProductMetadataVariables,
+  UpdateProductVariables,
+} from './hooks/use-catalog.js';

--- a/packages/@granit/react-catalog/src/providers/catalog-provider.tsx
+++ b/packages/@granit/react-catalog/src/providers/catalog-provider.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+/** Configuration for the catalog provider. */
+export interface CatalogConfig {
+  readonly client: AxiosInstance;
+  /** Base path for catalog endpoints (default: `/api/v1/catalog`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface CatalogProviderProps {
+  readonly config: CatalogConfig;
+  readonly children: ReactNode;
+}
+
+const CatalogConfigContext = createContext<CatalogConfig | null>(null);
+
+/** Provides catalog configuration to child components and hooks. */
+export function CatalogProvider({ config, children }: Readonly<CatalogProviderProps>) {
+  const value = useMemo(
+    () => ({
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+    }),
+    [config]
+  );
+  return <CatalogConfigContext value={value}>{children}</CatalogConfigContext>;
+}
+
+/** Returns the catalog configuration from the nearest `CatalogProvider`. */
+export function useCatalogConfig(): CatalogConfig {
+  const ctx = useContext(CatalogConfigContext);
+  if (!ctx) {
+    throw new Error('useCatalogConfig must be used within a CatalogProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for catalog operations. */
+export function buildCatalogQueryKey(
+  config: CatalogConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? ['catalog'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-catalog/src/testing/data.ts
+++ b/packages/@granit/react-catalog/src/testing/data.ts
@@ -1,0 +1,47 @@
+import { toEntityId } from '@granit/types';
+
+import type { ProductResponse } from '@granit/catalog';
+
+type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+export const sampleProducts: Mutable<ProductResponse>[] = [
+  {
+    id: toEntityId<'Product'>('prd_001'),
+    sku: 'API-CALLS',
+    name: 'API Calls',
+    description: 'Per-call billing for the public API.',
+    type: 'Metered',
+    unit: 'call',
+    lifecycleStatus: 'Published',
+    metadata: { tier: 'standard' },
+    externalMappings: [
+      {
+        id: toEntityId<'ProductExternalMapping'>('pem_001'),
+        providerName: 'Stripe',
+        externalId: 'prod_AbC123',
+      },
+    ],
+  },
+  {
+    id: toEntityId<'Product'>('prd_002'),
+    sku: 'STORAGE-GB',
+    name: 'Object Storage',
+    description: 'Per-GB monthly storage.',
+    type: 'Metered',
+    unit: 'GB',
+    lifecycleStatus: 'Published',
+    metadata: {},
+    externalMappings: [],
+  },
+  {
+    id: toEntityId<'Product'>('prd_003'),
+    sku: 'ONBOARDING',
+    name: 'Onboarding Service',
+    description: 'White-glove onboarding (one-off).',
+    type: 'Service',
+    unit: 'session',
+    lifecycleStatus: 'Draft',
+    metadata: {},
+    externalMappings: [],
+  },
+];

--- a/packages/@granit/react-catalog/src/testing/handlers.ts
+++ b/packages/@granit/react-catalog/src/testing/handlers.ts
@@ -1,0 +1,154 @@
+import { noContent, notFound } from '@granit/testing/msw';
+import { toEntityId } from '@granit/types';
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import { sampleProducts } from './data.js';
+
+import type {
+  AddProductExternalMappingRequest,
+  ProductCreateRequest,
+  ProductExternalMappingResponse,
+  ProductResponse,
+  ProductUpdateRequest,
+  UpdateProductMetadataRequest,
+} from '@granit/catalog';
+
+/**
+ * Create stateful MSW handlers for catalog endpoints.
+ * Product mutations (create / update / publish / archive / metadata / external-mappings)
+ * persist in the in-memory list.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/catalog`)
+ */
+export function createCatalogHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  let products = [...sampleProducts];
+
+  return [
+    // GET list published products
+    http.get(`${baseUrl}/products`, () => {
+      return HttpResponse.json(products.filter((p) => p.lifecycleStatus === 'Published'));
+    }),
+
+    // GET product by id
+    http.get(`${baseUrl}/products/:id`, ({ params }) => {
+      const product = products.find((p) => p.id === params.id);
+      if (!product) return notFound();
+      return HttpResponse.json(product);
+    }),
+
+    // GET product by SKU
+    http.get(`${baseUrl}/products/by-sku/:sku`, ({ params }) => {
+      const product = products.find((p) => p.sku === params.sku);
+      if (!product) return notFound();
+      return HttpResponse.json(product);
+    }),
+
+    // POST create product
+    http.post(`${baseUrl}/products`, async ({ request }) => {
+      const body = (await request.json()) as ProductCreateRequest;
+      const newProduct: ProductResponse = {
+        id: toEntityId<'Product'>(`prd_${String(products.length + 1).padStart(3, '0')}`),
+        sku: body.sku,
+        name: body.name,
+        description: body.description ?? null,
+        type: body.type,
+        unit: body.unit,
+        lifecycleStatus: 'Draft',
+        metadata: {},
+        externalMappings: [],
+      };
+      products = [...products, newProduct];
+      return HttpResponse.json(newProduct, { status: 201 });
+    }),
+
+    // PUT update product
+    http.put(`${baseUrl}/products/:id`, async ({ params, request }) => {
+      const id = params.id as string;
+      const body = (await request.json()) as ProductUpdateRequest;
+      const existing = products.find((p) => p.id === id);
+      if (!existing) return notFound();
+
+      const updated: ProductResponse = {
+        ...existing,
+        name: body.name,
+        description: body.description,
+        unit: body.unit,
+      };
+      products = products.map((p) => (p.id === id ? updated : p));
+      return HttpResponse.json(updated);
+    }),
+
+    // PUT product metadata
+    http.put(`${baseUrl}/products/:id/metadata`, async ({ params, request }) => {
+      const id = params.id as string;
+      const body = (await request.json()) as UpdateProductMetadataRequest;
+      const existing = products.find((p) => p.id === id);
+      if (!existing) return notFound();
+
+      const updated: ProductResponse = { ...existing, metadata: body.metadata };
+      products = products.map((p) => (p.id === id ? updated : p));
+      return HttpResponse.json(updated);
+    }),
+
+    // POST publish
+    http.post(`${baseUrl}/products/:id/publish`, ({ params }) => {
+      const id = params.id as string;
+      const existing = products.find((p) => p.id === id);
+      if (!existing) return notFound();
+
+      const updated: ProductResponse = { ...existing, lifecycleStatus: 'Published' };
+      products = products.map((p) => (p.id === id ? updated : p));
+      return HttpResponse.json(updated);
+    }),
+
+    // POST archive
+    http.post(`${baseUrl}/products/:id/archive`, ({ params }) => {
+      const id = params.id as string;
+      const existing = products.find((p) => p.id === id);
+      if (!existing) return notFound();
+
+      const updated: ProductResponse = { ...existing, lifecycleStatus: 'Archived' };
+      products = products.map((p) => (p.id === id ? updated : p));
+      return HttpResponse.json(updated);
+    }),
+
+    // POST external mapping
+    http.post(`${baseUrl}/products/:id/external-mappings`, async ({ params, request }) => {
+      const id = params.id as string;
+      const body = (await request.json()) as AddProductExternalMappingRequest;
+      const existing = products.find((p) => p.id === id);
+      if (!existing) return notFound();
+
+      const mapping: ProductExternalMappingResponse = {
+        id: toEntityId<'ProductExternalMapping'>(
+          `pem_${String(existing.externalMappings.length + 1).padStart(3, '0')}`
+        ),
+        providerName: body.providerName,
+        externalId: body.externalId,
+      };
+      const updated: ProductResponse = {
+        ...existing,
+        externalMappings: [...existing.externalMappings, mapping],
+      };
+      products = products.map((p) => (p.id === id ? updated : p));
+      return HttpResponse.json(mapping, { status: 201 });
+    }),
+
+    // DELETE external mapping
+    http.delete(`${baseUrl}/products/:id/external-mappings/:mappingId`, ({ params }) => {
+      const id = params.id as string;
+      const mappingId = params.mappingId as string;
+      const existing = products.find((p) => p.id === id);
+      if (!existing) return notFound();
+
+      const updated: ProductResponse = {
+        ...existing,
+        externalMappings: existing.externalMappings.filter((m) => m.id !== mappingId),
+      };
+      products = products.map((p) => (p.id === id ? updated : p));
+      return noContent();
+    }),
+  ];
+}

--- a/packages/@granit/react-catalog/src/testing/index.ts
+++ b/packages/@granit/react-catalog/src/testing/index.ts
@@ -1,0 +1,2 @@
+export { sampleProducts } from './data.js';
+export { createCatalogHandlers } from './handlers.js';

--- a/packages/@granit/react-catalog/tsconfig.json
+++ b/packages/@granit/react-catalog/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/catalog": ["../catalog/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-catalog/tsup.config.ts
+++ b/packages/@granit/react-catalog/tsup.config.ts
@@ -1,0 +1,6 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  external: [/^@granit\//, 'msw'],
+});

--- a/packages/@granit/react-customer-balance/package.json
+++ b/packages/@granit/react-customer-balance/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-customer-balance",
   "description": "React bindings for @granit/customer-balance — CustomerBalanceProvider and hooks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
@@ -9,12 +9,14 @@ import {
   useAddAdminCredit,
   useBalanceTransactions,
   useCustomerBalance,
+  useDebitCustomerBalance,
 } from '../hooks/use-customer-balance.js';
 import { CustomerBalanceProvider } from '../providers/customer-balance-provider.js';
 
 import type { CustomerBalanceConfig } from '../providers/customer-balance-provider.js';
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from '@granit/customer-balance';
@@ -154,6 +156,30 @@ describe('use-customer-balance', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.post).toHaveBeenCalledWith('/custom/balance/credit', request);
+    });
+  });
+
+  describe('useDebitCustomerBalance', () => {
+    it('posts a debit and returns the updated balance', async () => {
+      const client = createMockClient();
+      const updated: CustomerBalanceResponse = { ...sampleBalance, balance: 100.0 };
+      vi.mocked(client.post).mockResolvedValue({ data: updated });
+
+      const request: AdminDebitRequest = {
+        amount: 50.0,
+        currency: 'EUR',
+        reason: 'Manual correction',
+      };
+
+      const { result } = renderHook(() => useDebitCustomerBalance(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate(request);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/customer-balance/balance/debit', request);
+      expect(result.current.data).toEqual(updated);
     });
   });
 });

--- a/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
+++ b/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
@@ -1,5 +1,6 @@
 import {
   addAdminCredit,
+  debitCustomerBalance,
   getCustomerBalance,
   listBalanceTransactions,
 } from '@granit/customer-balance';
@@ -12,6 +13,7 @@ import {
 
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from '@granit/customer-balance';
@@ -70,6 +72,46 @@ export function useAddAdminCredit(): UseMutationResult<void, Error, AdminCreditR
 
   return useMutation({
     mutationFn: (request: AdminCreditRequest) => addAdminCredit(config.client, basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildCustomerBalanceQueryKey(config, 'balance'),
+      });
+      queryClient.invalidateQueries({
+        queryKey: buildCustomerBalanceQueryKey(config, 'transactions'),
+      });
+    },
+  });
+}
+
+/**
+ * Debit a tenant's balance manually — admin tooling for corrections,
+ * scheduled drawdowns, and non-invoice adjustments. Invalidates balance
+ * and transaction queries on success.
+ *
+ * @example
+ * ```tsx
+ * const debit = useDebitCustomerBalance();
+ * await debit.mutateAsync({
+ *   amount: 50,
+ *   currency: 'EUR',
+ *   reason: 'Correction after manual reconciliation',
+ *   referenceId: 'adj-2026-04-25-001',
+ *   referenceType: 'AdminAdjustment',
+ * });
+ * ```
+ */
+export function useDebitCustomerBalance(): UseMutationResult<
+  CustomerBalanceResponse,
+  Error,
+  AdminDebitRequest
+> {
+  const config = useCustomerBalanceConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (request: AdminDebitRequest) =>
+      debitCustomerBalance(config.client, basePath, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildCustomerBalanceQueryKey(config, 'balance'),

--- a/packages/@granit/react-customer-balance/src/index.ts
+++ b/packages/@granit/react-customer-balance/src/index.ts
@@ -14,4 +14,5 @@ export {
   useAddAdminCredit,
   useBalanceTransactions,
   useCustomerBalance,
+  useDebitCustomerBalance,
 } from './hooks/use-customer-balance.js';

--- a/packages/@granit/react-customer-balance/src/testing/handlers.ts
+++ b/packages/@granit/react-customer-balance/src/testing/handlers.ts
@@ -5,7 +5,7 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 
 import { sampleBalance, sampleTransactions } from './data.js';
 
-import type { AdminCreditRequest } from '@granit/customer-balance';
+import type { AdminCreditRequest, AdminDebitRequest } from '@granit/customer-balance';
 
 /**
  * Create stateful MSW handlers for customer balance endpoints.
@@ -31,6 +31,14 @@ export function createCustomerBalanceHandlers(baseUrl = DEFAULT_BASE_PATH) {
       sampleBalance.balance = sampleBalance.balance + body.amount;
       sampleBalance.updatedAt = toISODateString(new Date().toISOString());
       return HttpResponse.json({ ...sampleBalance }, { status: 201 });
+    }),
+
+    // POST admin debit
+    http.post(`${baseUrl}/balance/debit`, async ({ request }) => {
+      const body = (await request.json()) as AdminDebitRequest;
+      sampleBalance.balance = sampleBalance.balance - body.amount;
+      sampleBalance.updatedAt = toISODateString(new Date().toISOString());
+      return HttpResponse.json({ ...sampleBalance });
     }),
   ];
 }

--- a/packages/@granit/react-invoicing/package.json
+++ b/packages/@granit/react-invoicing/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-invoicing",
   "description": "React bindings for @granit/invoicing — InvoicingProvider and hooks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/react-invoicing/src/testing/data.ts
+++ b/packages/@granit/react-invoicing/src/testing/data.ts
@@ -14,9 +14,11 @@ export const sampleInvoiceLineItems: Mutable<InvoiceLineItemResponse>[] = [
     taxRate: 21,
     taxAmount: 1029,
     sourceType: 'Subscription',
-    sourceId: null,
+    // ADR-036: Subscription lines carry a Guid sourceId.
+    sourceId: '0a4d76b2-3d9f-4a6f-9fd8-9a92b9abf001',
     periodStart: toISODateString('2026-03-01T00:00:00Z'),
     periodEnd: toISODateString('2026-03-31T23:59:59Z'),
+    productId: null,
   },
   {
     id: toEntityId<'InvoiceLineItem'>('li_002'),
@@ -26,10 +28,12 @@ export const sampleInvoiceLineItems: Mutable<InvoiceLineItemResponse>[] = [
     amount: 1000,
     taxRate: 21,
     taxAmount: 210,
-    sourceType: 'Subscription',
-    sourceId: null,
+    sourceType: 'Usage',
+    // ADR-036: Usage lines carry a Guid sourceId (the MeterDefinition.Id).
+    sourceId: '7e9f2c1d-44ab-4f12-a05c-d1fa8b2e7c10',
     periodStart: toISODateString('2026-03-01T00:00:00Z'),
     periodEnd: toISODateString('2026-03-31T23:59:59Z'),
+    productId: null,
   },
 ];
 

--- a/packages/@granit/react-metering/package.json
+++ b/packages/@granit/react-metering/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-metering",
   "description": "React bindings for @granit/metering — MeteringProvider and hooks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
+++ b/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
@@ -49,6 +49,9 @@ const sampleMeter: MeterDefinitionResponse = {
   description: 'Number of API calls',
   aggregationType: 'Sum',
   activated: true,
+  productId: null,
+  lifecycleStatus: 'Published',
+  distinctProperty: null,
 };
 
 const sampleUsage: UsageAggregateResponse = {

--- a/packages/@granit/react-metering/src/hooks/use-metering.ts
+++ b/packages/@granit/react-metering/src/hooks/use-metering.ts
@@ -1,10 +1,15 @@
 import {
+  archiveMeterDefinition,
+  backfillUsageEvents,
   checkMeteringQuota,
   createMeterDefinition,
   deactivateMeterDefinition,
+  deprecateMeterEvent,
   getMeterDefinition,
   getUsageForPeriod,
   listActiveMeters,
+  publishMeterDefinition,
+  recomputeMeterUsage,
   recordUsageEvents,
   updateMeterDefinition,
 } from '@granit/metering';
@@ -13,10 +18,16 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { buildMeteringQueryKey, useMeteringConfig } from '../providers/metering-provider.js';
 
 import type {
+  BackfillUsageRequest,
+  BackfillUsageResponse,
+  DeprecateEventRequest,
+  DeprecateEventResponse,
   MeterDefinitionCreateRequest,
   MeterDefinitionResponse,
   MeterDefinitionUpdateRequest,
   MeteringQuotaStatusResponse,
+  RecomputeUsageRequest,
+  RecomputeUsageResponse,
   RecordUsageRequest,
   UsageAggregateResponse,
 } from '@granit/metering';
@@ -178,11 +189,9 @@ export function useUpdateMeterDefinition(): UseMutationResult<
  * Deactivate a meter definition.
  * Invalidates meters queries on success.
  *
- * @example
- * ```tsx
- * const deactivate = useDeactivateMeterDefinition();
- * await deactivate.mutateAsync('meter-1');
- * ```
+ * @deprecated Use {@link useArchiveMeterDefinition} instead — the lifecycle action is
+ * now `Publish → Archive`. The backend keeps the deactivate endpoint as an alias for
+ * one release; this hook will be removed in the next major version.
  */
 export function useDeactivateMeterDefinition(): UseMutationResult<void, Error, string> {
   const config = useMeteringConfig();
@@ -195,6 +204,132 @@ export function useDeactivateMeterDefinition(): UseMutationResult<void, Error, s
       queryClient.invalidateQueries({
         queryKey: buildMeteringQueryKey(config, 'meters'),
       });
+    },
+  });
+}
+
+/**
+ * Publish a `Draft` meter definition. Only `Published` meters accept ingestion.
+ * Invalidates meters queries on success.
+ */
+export function usePublishMeterDefinition(): UseMutationResult<
+  MeterDefinitionResponse,
+  Error,
+  string
+> {
+  const config = useMeteringConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (id: string) => publishMeterDefinition(config.client, basePath, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'meters') });
+    },
+  });
+}
+
+/**
+ * Archive a `Published` meter definition. Existing aggregates remain readable;
+ * new event ingestion is rejected.
+ * Invalidates meters queries on success.
+ */
+export function useArchiveMeterDefinition(): UseMutationResult<
+  MeterDefinitionResponse,
+  Error,
+  string
+> {
+  const config = useMeteringConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (id: string) => archiveMeterDefinition(config.client, basePath, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'meters') });
+    },
+  });
+}
+
+/** Variables for `useRecomputeMeterUsage`. */
+export type RecomputeMeterUsageVariables = {
+  readonly id: string;
+  readonly request: RecomputeUsageRequest;
+};
+
+/**
+ * Recompute the usage aggregates of a meter for an arbitrary time window.
+ * Invalidates usage and quota queries on success.
+ */
+export function useRecomputeMeterUsage(): UseMutationResult<
+  RecomputeUsageResponse,
+  Error,
+  RecomputeMeterUsageVariables
+> {
+  const config = useMeteringConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }: RecomputeMeterUsageVariables) =>
+      recomputeMeterUsage(config.client, basePath, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'usage') });
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'quota') });
+    },
+  });
+}
+
+/**
+ * Backfill historical events older than the standard 7-day ingestion window
+ * (up to 365 days). Triggers automatic recomputes; invalidates usage and quota
+ * queries on success.
+ */
+export function useBackfillUsageEvents(): UseMutationResult<
+  BackfillUsageResponse,
+  Error,
+  BackfillUsageRequest
+> {
+  const config = useMeteringConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (request: BackfillUsageRequest) =>
+      backfillUsageEvents(config.client, basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'usage') });
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'quota') });
+    },
+  });
+}
+
+/** Variables for `useDeprecateMeterEvent`. */
+export type DeprecateMeterEventVariables = {
+  readonly id: string;
+  readonly request: DeprecateEventRequest;
+};
+
+/**
+ * Soft-deprecate an individual meter event. The event is preserved (audit
+ * trail); the affected aggregate is auto-rebuilt without the deprecated
+ * event's contribution. Invalidates usage and quota queries on success.
+ */
+export function useDeprecateMeterEvent(): UseMutationResult<
+  DeprecateEventResponse,
+  Error,
+  DeprecateMeterEventVariables
+> {
+  const config = useMeteringConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }: DeprecateMeterEventVariables) =>
+      deprecateMeterEvent(config.client, basePath, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'usage') });
+      queryClient.invalidateQueries({ queryKey: buildMeteringQueryKey(config, 'quota') });
     },
   });
 }

--- a/packages/@granit/react-metering/src/index.ts
+++ b/packages/@granit/react-metering/src/index.ts
@@ -9,12 +9,21 @@ export type { MeteringConfig, MeteringProviderProps } from './providers/metering
 // Hooks
 export {
   useActiveMeters,
+  useArchiveMeterDefinition,
+  useBackfillUsageEvents,
   useCreateMeterDefinition,
   useDeactivateMeterDefinition,
+  useDeprecateMeterEvent,
   useMeterDefinition,
   useMeteringQuota,
+  usePublishMeterDefinition,
+  useRecomputeMeterUsage,
   useRecordUsageEvents,
   useUpdateMeterDefinition,
   useUsageForPeriod,
 } from './hooks/use-metering.js';
-export type { UpdateMeterDefinitionVariables } from './hooks/use-metering.js';
+export type {
+  DeprecateMeterEventVariables,
+  RecomputeMeterUsageVariables,
+  UpdateMeterDefinitionVariables,
+} from './hooks/use-metering.js';

--- a/packages/@granit/react-metering/src/testing/data.ts
+++ b/packages/@granit/react-metering/src/testing/data.ts
@@ -16,6 +16,9 @@ export const sampleMeters: Mutable<MeterDefinitionResponse>[] = [
     aggregationType: 'Count',
     unit: 'calls',
     activated: true,
+    productId: null,
+    lifecycleStatus: 'Published',
+    distinctProperty: null,
   },
   {
     id: toEntityId<'MeterDefinition'>('mtr_002'),
@@ -24,6 +27,9 @@ export const sampleMeters: Mutable<MeterDefinitionResponse>[] = [
     aggregationType: 'Sum',
     unit: 'bytes',
     activated: true,
+    productId: null,
+    lifecycleStatus: 'Published',
+    distinctProperty: null,
   },
   {
     id: toEntityId<'MeterDefinition'>('mtr_003'),
@@ -32,6 +38,9 @@ export const sampleMeters: Mutable<MeterDefinitionResponse>[] = [
     aggregationType: 'Sum',
     unit: 'minutes',
     activated: true,
+    productId: null,
+    lifecycleStatus: 'Published',
+    distinctProperty: null,
   },
 ];
 

--- a/packages/@granit/react-metering/src/testing/handlers.ts
+++ b/packages/@granit/react-metering/src/testing/handlers.ts
@@ -30,7 +30,7 @@ export function createMeteringHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(meter);
     }),
 
-    // POST create meter
+    // POST create meter (Draft)
     http.post(`${baseUrl}/meters`, async ({ request }) => {
       const body = (await request.json()) as Partial<MeterDefinitionResponse>;
       const newMeter: MeterDefinitionResponse = {
@@ -39,10 +39,78 @@ export function createMeteringHandlers(baseUrl = DEFAULT_BASE_PATH) {
         description: body.description ?? '',
         aggregationType: body.aggregationType ?? 'Count',
         unit: body.unit ?? '',
-        activated: true,
+        activated: false,
+        productId: body.productId ?? null,
+        lifecycleStatus: 'Draft',
+        distinctProperty: body.distinctProperty ?? null,
       };
       meters = [...meters, newMeter];
       return HttpResponse.json(newMeter, { status: 201 });
+    }),
+
+    // POST publish
+    http.post(`${baseUrl}/meters/:id/publish`, ({ params }) => {
+      const id = params.id as string;
+      const existing = meters.find((m) => m.id === id);
+      if (!existing) return notFound();
+      const updated: MeterDefinitionResponse = {
+        ...existing,
+        activated: true,
+        lifecycleStatus: 'Published',
+      };
+      meters = meters.map((m) => (m.id === id ? updated : m));
+      return HttpResponse.json(updated);
+    }),
+
+    // POST archive
+    http.post(`${baseUrl}/meters/:id/archive`, ({ params }) => {
+      const id = params.id as string;
+      const existing = meters.find((m) => m.id === id);
+      if (!existing) return notFound();
+      const updated: MeterDefinitionResponse = {
+        ...existing,
+        activated: false,
+        lifecycleStatus: 'Archived',
+      };
+      meters = meters.map((m) => (m.id === id ? updated : m));
+      return HttpResponse.json(updated);
+    }),
+
+    // POST recompute
+    http.post(`${baseUrl}/meters/:id/recompute`, async ({ params, request }) => {
+      const id = params.id as string;
+      const existing = meters.find((m) => m.id === id);
+      if (!existing) return notFound();
+      const body = (await request.json()) as { from: string; to: string };
+      return HttpResponse.json({
+        meterDefinitionId: id,
+        windowStart: body.from,
+        windowEnd: body.to,
+        eventsScanned: 0,
+        aggregatesRebuilt: 0,
+        durationMilliseconds: 0,
+      });
+    }),
+
+    // POST backfill
+    http.post(`${baseUrl}/events/backfill`, async ({ request }) => {
+      const body = (await request.json()) as { events: readonly unknown[] };
+      return HttpResponse.json({
+        eventsAccepted: body.events.length,
+        metersAffected: 1,
+        aggregatesRebuilt: body.events.length,
+      });
+    }),
+
+    // POST event deprecate
+    http.post(`${baseUrl}/events/:id/deprecate`, async ({ params }) => {
+      const id = params.id as string;
+      return HttpResponse.json({
+        eventId: id,
+        meterDefinitionId: meters[0]?.id ?? 'mtr_001',
+        deprecatedAt: new Date().toISOString(),
+        aggregatesRebuilt: 1,
+      });
     }),
 
     // PUT update meter
@@ -61,13 +129,15 @@ export function createMeteringHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(updated);
     }),
 
-    // DELETE deactivate meter
-    http.delete(`${baseUrl}/meters/:id`, ({ params }) => {
+    // POST deactivate (deprecated alias — backend keeps it for one release;
+    // mirrors the legacy behavior so existing integration tests keep passing).
+    http.post(`${baseUrl}/meters/:id/deactivate`, ({ params }) => {
       const id = params.id as string;
-      const index = meters.findIndex((m) => m.id === id);
-      if (index === -1) return notFound();
-
-      meters = meters.map((m) => (m.id === id ? { ...m, activated: false } : m));
+      const existing = meters.find((m) => m.id === id);
+      if (!existing) return notFound();
+      meters = meters.map((m) =>
+        m.id === id ? { ...m, activated: false, lifecycleStatus: 'Archived' } : m
+      );
       return noContent();
     }),
 

--- a/packages/@granit/react-subscriptions/package.json
+++ b/packages/@granit/react-subscriptions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/react-subscriptions",
   "description": "React bindings for @granit/subscriptions — SubscriptionsProvider and hooks",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
+++ b/packages/@granit/react-subscriptions/src/__tests__/use-plans.test.tsx
@@ -44,6 +44,7 @@ const samplePrice: PlanPriceResponse = {
   isCurrent: true,
   replacedByPriceId: null,
   replacedAt: null,
+  productId: null,
 };
 
 function createWrapper(client: AxiosInstance, basePath?: string) {

--- a/packages/@granit/react-subscriptions/src/testing/data.ts
+++ b/packages/@granit/react-subscriptions/src/testing/data.ts
@@ -41,6 +41,7 @@ export const mockPlans: Mutable<PlanResponse>[] = [
         isCurrent: false,
         replacedByPriceId: toEntityId<'PlanPrice'>('price-002-2'),
         replacedAt: toISODateString('2026-01-01T00:00:00Z'),
+        productId: null,
       },
       {
         id: toEntityId<'PlanPrice'>('price-002-2'),
@@ -51,6 +52,7 @@ export const mockPlans: Mutable<PlanResponse>[] = [
         isCurrent: false,
         replacedByPriceId: toEntityId<'PlanPrice'>('price-002-3'),
         replacedAt: toISODateString('2026-03-01T00:00:00Z'),
+        productId: null,
       },
       {
         id: toEntityId<'PlanPrice'>('price-002-3'),
@@ -61,6 +63,7 @@ export const mockPlans: Mutable<PlanResponse>[] = [
         isCurrent: true,
         replacedByPriceId: null,
         replacedAt: null,
+        productId: null,
       },
     ],
   },
@@ -84,6 +87,7 @@ export const mockPlans: Mutable<PlanResponse>[] = [
         isCurrent: false,
         replacedByPriceId: null,
         replacedAt: null,
+        productId: null,
       },
     ],
   },
@@ -100,6 +104,7 @@ export const mockPriceHistory: Record<string, Mutable<PlanPriceResponse>[]> = {
       isCurrent: false,
       replacedByPriceId: toEntityId<'PlanPrice'>('price-002-2'),
       replacedAt: toISODateString('2026-01-01T00:00:00Z'),
+      productId: null,
     },
     {
       id: toEntityId<'PlanPrice'>('price-002-2'),
@@ -110,6 +115,7 @@ export const mockPriceHistory: Record<string, Mutable<PlanPriceResponse>[]> = {
       isCurrent: false,
       replacedByPriceId: toEntityId<'PlanPrice'>('price-002-3'),
       replacedAt: toISODateString('2026-03-01T00:00:00Z'),
+      productId: null,
     },
     {
       id: toEntityId<'PlanPrice'>('price-002-3'),
@@ -120,6 +126,7 @@ export const mockPriceHistory: Record<string, Mutable<PlanPriceResponse>[]> = {
       isCurrent: true,
       replacedByPriceId: null,
       replacedAt: null,
+      productId: null,
     },
   ],
   'plan-003': [
@@ -132,6 +139,7 @@ export const mockPriceHistory: Record<string, Mutable<PlanPriceResponse>[]> = {
       isCurrent: false,
       replacedByPriceId: null,
       replacedAt: null,
+      productId: null,
     },
   ],
 };

--- a/packages/@granit/react-subscriptions/src/testing/handlers.ts
+++ b/packages/@granit/react-subscriptions/src/testing/handlers.ts
@@ -87,6 +87,7 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
         currency: string;
         interval: string;
         effectiveFrom: string;
+        productId?: string | null;
       };
       const planId = params.planId as string;
       mockPriceHistory[planId] ??= [];
@@ -111,6 +112,7 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
         isCurrent: true,
         replacedByPriceId: null,
         replacedAt: null,
+        productId: body.productId ?? null,
       };
       existing.push(newPrice);
       return HttpResponse.json(newPrice, { status: 201 });

--- a/packages/@granit/subscriptions/package.json
+++ b/packages/@granit/subscriptions/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/subscriptions",
   "description": "Plan catalog, subscription lifecycle, price versioning, and seat management — types and API functions",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
+++ b/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
@@ -56,6 +56,7 @@ const samplePrice: PlanPriceResponse = {
   isCurrent: true,
   replacedByPriceId: null,
   replacedAt: null,
+  productId: null,
 };
 
 const sampleSubscription: SubscriptionResponse = {

--- a/packages/@granit/subscriptions/src/types.ts
+++ b/packages/@granit/subscriptions/src/types.ts
@@ -33,6 +33,11 @@ export interface CreatePriceVersionRequest {
   readonly amount: number;
   readonly currency: string;
   readonly interval: BillingInterval;
+  /**
+   * Optional `Granit.Catalog.Product` identifier — the catalog item this price
+   * tarifs. Soft reference (no SQL FK).
+   */
+  readonly productId?: string | null;
 }
 
 export interface SubscriptionCreateRequest {
@@ -86,6 +91,12 @@ export interface PlanPriceResponse {
   readonly isCurrent: boolean;
   readonly replacedByPriceId: string | null;
   readonly replacedAt: string | null;
+  /**
+   * Optional reference to a `Granit.Catalog.Product` identifier — the catalog
+   * item this price tarifs. Soft reference (no SQL FK across modules);
+   * preserved across price versions.
+   */
+  readonly productId: string | null;
 }
 
 export interface SubscriptionResponse {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,22 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/catalog:
+    dependencies:
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+      axios:
+        specifier: 1.15.0
+        version: 1.15.0
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/cookies: {}
 
   packages/@granit/cookies-klaro:
@@ -930,6 +946,34 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+
+  packages/@granit/react-catalog:
+    dependencies:
+      '@granit/catalog':
+        specifier: workspace:*
+        version: link:../catalog
+      '@tanstack/react-query':
+        specifier: 5.99.0
+        version: 5.99.0(react@19.2.5)
+      axios:
+        specifier: 1.15.0
+        version: 1.15.0
+      msw:
+        specifier: ^2.12.0
+        version: 2.13.4(@types/node@25.6.0)(typescript@6.0.3)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-cookies:
     dependencies:


### PR DESCRIPTION
## Summary

Propagates the backend ORB-alignment program (EPIC #1155, granit-dotnet
develop) to the frontend SDK.

**Stacked on PR #210** (metadata rename) — the new `Granit.Catalog.Product` DTO carries a `metadata` field; reviewing this on top of #210 keeps the diff focused.

## What ships in one PR

### New packages

| Package | Version | Purpose |
| ------- | ------- | ------- |
| `@granit/catalog` | 0.1.0 | Types + API client for `Granit.Catalog` (Product) |
| `@granit/react-catalog` | 0.1.0 | Provider + 10 React Query hooks + MSW handlers |

### Updated packages (BREAKING — bump 0.1.0 → 0.2.0)

| Package | What changed |
| ------- | ------------ |
| `@granit/metering` + `react-metering` | `lifecycleStatus`, `productId`, `distinctProperty` on responses ; `CountDistinct` aggregation ; new `publish` / `archive` / `recompute` / `backfill` / `deprecate-event` API + hooks ; `deactivate*` deprecated ; new permissions `Metering.Events.{Manage,Backfill}` |
| `@granit/subscriptions` + `react-subscriptions` | `productId` on `PlanPriceResponse` + `CreatePriceVersionRequest` |
| `@granit/customer-balance` + `react-customer-balance` | `debitCustomerBalance` API + `useDebitCustomerBalance` hook + `AdminDebitRequest` type |
| `@granit/invoicing` + `react-invoicing` | `productId` on `InvoiceLineItemResponse` ; `sourceType` typed strictly via `InvoiceSourceType` ; fixtures honor ADR-036 (Subscription/Usage Guid sourceId) |

## Phase 3 explicitly out of scope

Backend Phase 3 (`PricingTier`, `SubscriptionPhase`, `SubscriptionDiscount`, `SubscriptionPriceOverride` per #1200, #1202) added domain entities only — no HTTP surface yet. No frontend work needed; will be revisited when the backend ships endpoints.

## Verification

- ✅ `pnpm tsc` — clean across the workspace
- ✅ `pnpm lint` — clean (max-warnings 0)
- ✅ `pnpm test --run` — **2159 / 2159** passed (264 files; +30 new tests vs `develop`)
- ✅ `pnpm build` — all packages built (DTS + ESM)
- ✅ `npx markdownlint-cli2 CHANGELOG.md MIGRATION.md` — clean

## Migration

Full guide added to `MIGRATION.md` (sed snippets, breaking-change diffs, deployment ordering). The `CHANGELOG.md` Unreleased section enumerates every package change with date stamps.

## Coordination déploiement

Deploy backend (`granit-dotnet` `develop` already merged: #1184, #1187 → #1196, #1205, #1206, #1208 ; **PR #1209** metadata rename must merge first since the Catalog Product DTO depends on the wire format) **before** shipping this frontend bundle. Otherwise the new hooks (`publish`, `archive`, `recompute`, `backfill`, `deprecate-event`, `debit`) will return 404/405.

## Test plan

- [ ] CI green (tsc + lint + test + build)
- [ ] Re-target to `develop` once PR #210 merges (currently base is `feature/rename-extra-properties-to-metadata`)
- [ ] Downstream `granit-showcase-admin-react` regenerates the API + sed pass once published