### PR TITLE
fix(quality): resolve SonarQube findings (data-lookup, localization, mobile-push)

### DIFF
--- a/packages/@granit/data-lookup/src/api/index.ts
+++ b/packages/@granit/data-lookup/src/api/index.ts
@@ -4,6 +4,7 @@ export {
   fetchLookupManifest,
   resolveLookup,
   searchLookup,
+  stringifyLookupValue,
 } from './lookup-client.js';
 export type { LookupClientOptions } from './lookup-client.js';
 export { findMissingScopeKey, isScopeSatisfied } from './scope-validation.js';

--- a/packages/@granit/data-lookup/src/api/lookup-client.ts
+++ b/packages/@granit/data-lookup/src/api/lookup-client.ts
@@ -71,11 +71,11 @@ export async function resolveLookup(
 
   const { client, signal } = options;
   const baseUrl = resolveLookupUrl(descriptor, options.basePath);
-  const resolveUrl = descriptor.endpoint ? `${baseUrl}/resolve` : `${baseUrl}/resolve`;
+  const resolveUrl = `${baseUrl}/resolve`;
 
   try {
     const { data } = await client.get<LookupItem>(resolveUrl, {
-      params: { value: String(value) },
+      params: { value: stringifyLookupValue(value) },
       signal,
     });
     return data;
@@ -123,6 +123,20 @@ export function buildSearchQuery(
   }
 
   return result;
+}
+
+/**
+ * Stringifies a lookup value for use as an HTTP query parameter. Object values
+ * are serialized as JSON to avoid the default `[object Object]` representation.
+ */
+export function stringifyLookupValue(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return String(value);
 }
 
 /** Resolves the URL for a lookup descriptor (registry name or custom endpoint). */

--- a/packages/@granit/data-lookup/src/index.ts
+++ b/packages/@granit/data-lookup/src/index.ts
@@ -22,5 +22,6 @@ export {
   isScopeSatisfied,
   resolveLookup,
   searchLookup,
+  stringifyLookupValue,
 } from './api/index.js';
 export type { LookupClientOptions } from './api/index.js';

--- a/packages/@granit/localization/src/unflatten-keys.ts
+++ b/packages/@granit/localization/src/unflatten-keys.ts
@@ -3,7 +3,7 @@
  * double-brace `{{Foo}}`, skipping values that already use double braces.
  */
 function toI18nextPlaceholders(value: string): string {
-  return value.replace(/(?<!\{)\{([A-Za-z]\w*)\}(?!\})/g, '{{$1}}');
+  return value.replaceAll(/(?<!\{)\{([A-Za-z]\w*)\}(?!\})/g, '{{$1}}');
 }
 
 /**

--- a/packages/@granit/react-data-lookup/src/components/lookup-badge.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-badge.tsx
@@ -1,3 +1,5 @@
+import { stringifyLookupValue } from '@granit/data-lookup';
+
 import { useLookupResolve } from '../hooks/use-lookup-resolve.js';
 
 import type { LookupDescriptor } from '@granit/data-lookup';
@@ -39,7 +41,7 @@ export function LookupBadge(props: LookupBadgeProps): ReactElement {
   const { descriptor, value, client, culture, basePath, fallback, render } = props;
   const query = useLookupResolve(descriptor, value, { client, basePath, culture });
 
-  const rawFallback = fallback ?? (value === null || value === undefined ? '' : String(value));
+  const rawFallback = fallback ?? stringifyLookupValue(value);
   const label = query.data?.label ?? rawFallback;
 
   if (render) {

--- a/packages/@granit/react-data-lookup/src/components/lookup-picker.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-picker.tsx
@@ -11,8 +11,8 @@ export interface LookupPickerRenderArgs {
   readonly search: string;
   readonly setSearch: (next: string) => void;
   /** Current value(s). String for `Eq`, array for `In`. */
-  readonly value: unknown | readonly unknown[];
-  readonly onChange: (next: unknown | readonly unknown[]) => void;
+  readonly value: unknown;
+  readonly onChange: (next: unknown) => void;
   /** Whether the picker is in multi-select mode (e.g., `In` filter operator). */
   readonly multi: boolean;
   /** Items matching the current search term. */
@@ -23,8 +23,8 @@ export interface LookupPickerRenderArgs {
 
 export interface LookupPickerProps {
   readonly descriptor: LookupDescriptor;
-  readonly value: unknown | readonly unknown[];
-  readonly onChange: (next: unknown | readonly unknown[]) => void;
+  readonly value: unknown;
+  readonly onChange: (next: unknown) => void;
   readonly client: AxiosInstance;
   readonly scope?: Readonly<Record<string, string | null | undefined>>;
   readonly culture?: string;

--- a/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
@@ -2,7 +2,6 @@ import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { MobilePlatform } from '@granit/notifications-mobile-push';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -28,7 +27,7 @@ export function MobilePushProvider({ config, children }: Readonly<MobilePushProv
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
     }),
-    [config],
+    [config]
   );
   return <MobilePushConfigContext value={value}>{children}</MobilePushConfigContext>;
 }
@@ -42,4 +41,4 @@ export function useMobilePushConfig(): MobilePushProviderConfig {
   return ctx;
 }
 
-export type { MobilePlatform };
+export type { MobilePlatform } from '@granit/notifications-mobile-push';


### PR DESCRIPTION
## Summary

Address SonarQube findings reported on `feature/saas-orb-alignment` and `@granit/localization`:

- **`data-lookup/lookup-client.ts`**
  - L74 (Bug, Major): drop the `descriptor.endpoint ? ... : ...` ternary — both branches were identical.
  - L78 (Code Smell, Minor): introduce a `stringifyLookupValue` helper so object values are JSON-serialized instead of stringified to `[object Object]`. Exported from the package public API.
- **`react-data-lookup/lookup-badge.tsx`** (L42, Code Smell): reuse `stringifyLookupValue` for the fallback label.
- **`react-data-lookup/lookup-picker.tsx`** (L14, L15, L26, L27, Code Smell): collapse redundant `unknown | readonly unknown[]` unions — `unknown` already covers the array case.
- **`localization/unflatten-keys.ts`** (L6, Code Smell): use `String#replaceAll` instead of `String#replace` (regex already had the `/g` flag).
- **`react-notifications-mobile-push/mobile-push-provider.tsx`** (L45, Code Smell): replace the type-import + `export type` pair with `export type { MobilePlatform } from '@granit/notifications-mobile-push'`.

No behavioral change for primitive lookup values — the new helper only diverges from `String(value)` when `value` is an object.

## Test plan

- [x] `pnpm tsc` — clean
- [x] `npx eslint` on the four touched packages — clean
- [x] `npx vitest run` on the four touched packages — 14 files / 103 tests passing