### PR TITLE
feat(parties): duplicates inbox + per-party badge

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2574,6 +2574,12 @@
           "members": []
         },
         {
+          "name": "MergePartyFromDuplicateMutationVariables",
+          "kind": "interface",
+          "signature": "interface MergePartyFromDuplicateMutationVariables",
+          "members": []
+        },
+        {
           "name": "MergeWizard",
           "kind": "function",
           "signature": "function MergeWizard("
@@ -2582,6 +2588,28 @@
           "name": "MergeWizardProps",
           "kind": "interface",
           "signature": "interface MergeWizardProps",
+          "members": []
+        },
+        {
+          "name": "DuplicatesInbox",
+          "kind": "function",
+          "signature": "function DuplicatesInbox(props: Readonly<DuplicatesInboxProps>)"
+        },
+        {
+          "name": "DuplicatesInboxProps",
+          "kind": "interface",
+          "signature": "interface DuplicatesInboxProps",
+          "members": []
+        },
+        {
+          "name": "PartyDuplicatesBadge",
+          "kind": "function",
+          "signature": "function PartyDuplicatesBadge("
+        },
+        {
+          "name": "PartyDuplicatesBadgeProps",
+          "kind": "interface",
+          "signature": "interface PartyDuplicatesBadgeProps",
           "members": []
         }
       ]

--- a/packages/@granit/parties/src/__tests__/parties-duplicates-api.test.ts
+++ b/packages/@granit/parties/src/__tests__/parties-duplicates-api.test.ts
@@ -1,0 +1,114 @@
+import { createMockClient } from '@granit/testing';
+import { toEntityId } from '@granit/types';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  dismissPartyDuplicate,
+  listDuplicatesForParty,
+  mergePartyFromDuplicate,
+} from '../api/parties-duplicates-api.js';
+
+import type {
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
+  PartyDuplicateMergeRequest,
+  PartyId,
+  PartyMergeResponse,
+} from '../types.js';
+
+const basePath = '/api/v1/parties';
+const partyId: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000001');
+const candidatePartyId: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000002');
+const duplicateRowId: PartyDuplicateCandidateId = toEntityId<'PartyDuplicateCandidate'>('dup-001');
+
+const sampleCandidate: PartyDuplicateCandidateResponse = {
+  id: duplicateRowId,
+  partyId,
+  candidateId: candidatePartyId,
+  score: 0.92,
+  tier: 'Deterministic',
+  signals: [{ kind: 'TaxIdEqual', score: 1.0 }],
+  dismissedAt: null,
+  createdAt: '2026-04-26T08:00:00Z',
+  updatedAt: '2026-04-27T02:00:00Z',
+};
+
+describe('parties-duplicates-api', () => {
+  describe('listDuplicatesForParty', () => {
+    it('GETs {basePath}/{id}/duplicate-candidates', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleCandidate] });
+
+      const result = await listDuplicatesForParty(client, basePath, partyId);
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/${partyId}/duplicate-candidates`);
+      expect(result).toEqual([sampleCandidate]);
+    });
+
+    it('returns an empty array when the party has no candidates', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      const result = await listDuplicatesForParty(client, basePath, partyId);
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('dismissPartyDuplicate', () => {
+    it('POSTs {basePath}/duplicates/{id}/dismiss with no body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+
+      await dismissPartyDuplicate(client, basePath, duplicateRowId);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/duplicates/${duplicateRowId}/dismiss`);
+    });
+  });
+
+  describe('mergePartyFromDuplicate', () => {
+    const mergeResponse: PartyMergeResponse = {
+      survivorId: partyId,
+      loserId: candidatePartyId,
+      conflicts: [],
+      rewriteCounts: { 'Invoice.PartyId': 5 },
+      dryRun: false,
+    };
+
+    it('POSTs the merge request without an Idempotency-Key by default', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: mergeResponse });
+
+      const request: PartyDuplicateMergeRequest = {
+        survivorId: partyId,
+        choices: { Name: 'Survivor' },
+        reason: 'Confirmed by ops review',
+      };
+
+      const result = await mergePartyFromDuplicate(client, basePath, duplicateRowId, request);
+
+      expect(client.post).toHaveBeenCalledWith(
+        `${basePath}/duplicates/${duplicateRowId}/merge`,
+        request,
+        undefined
+      );
+      expect(result).toEqual(mergeResponse);
+    });
+
+    it('forwards the Idempotency-Key header when provided', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: mergeResponse });
+
+      const idempotencyKey = '11111111-2222-4333-8444-555555555555';
+      const request: PartyDuplicateMergeRequest = { survivorId: partyId };
+
+      await mergePartyFromDuplicate(client, basePath, duplicateRowId, request, idempotencyKey);
+
+      expect(client.post).toHaveBeenCalledWith(
+        `${basePath}/duplicates/${duplicateRowId}/merge`,
+        request,
+        { headers: { 'Idempotency-Key': idempotencyKey } }
+      );
+    });
+  });
+});

--- a/packages/@granit/parties/src/api/parties-duplicates-api.ts
+++ b/packages/@granit/parties/src/api/parties-duplicates-api.ts
@@ -1,0 +1,68 @@
+import type {
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
+  PartyDuplicateMergeRequest,
+  PartyId,
+  PartyMergeResponse,
+} from '../types.js';
+import type { AxiosInstance } from 'axios';
+
+/**
+ * List pending duplicate-candidate pairs that involve the given party. Flat —
+ * no paging — backed by `GET /parties/{id}/duplicate-candidates`.
+ *
+ * For the paginated/filterable inbox view, use the QueryEngine endpoint at
+ * `GET /parties/duplicates` via `useQueryEndpoint` from
+ * `@granit/react-query-engine` instead — there is no dedicated wrapper here
+ * because the QueryEngine primitives already cover that surface.
+ *
+ * `GET {basePath}/{id}/duplicate-candidates`
+ */
+export async function listDuplicatesForParty(
+  client: AxiosInstance,
+  basePath: string,
+  partyId: PartyId
+): Promise<readonly PartyDuplicateCandidateResponse[]> {
+  const response = await client.get<readonly PartyDuplicateCandidateResponse[]>(
+    `${basePath}/${encodeURIComponent(partyId)}/duplicate-candidates`
+  );
+  return response.data;
+}
+
+/**
+ * Mark a candidate pair as "not a duplicate". Idempotent — repeated dismisses
+ * of the same row return 204; only a missing row returns 404.
+ *
+ * `POST {basePath}/duplicates/{id}/dismiss`
+ */
+export async function dismissPartyDuplicate(
+  client: AxiosInstance,
+  basePath: string,
+  id: PartyDuplicateCandidateId
+): Promise<void> {
+  await client.post(`${basePath}/duplicates/${encodeURIComponent(id)}/dismiss`);
+}
+
+/**
+ * One-click merge from a duplicate row. The loser is inferred server-side
+ * from the candidate pair (the other end of `partyId` / `candidateId`); 422 if
+ * `request.survivorId` is not part of that pair.
+ *
+ * Pass `idempotencyKey` (UUID v4 recommended) to make retries safe.
+ *
+ * `POST {basePath}/duplicates/{id}/merge` (with optional `Idempotency-Key` header)
+ */
+export async function mergePartyFromDuplicate(
+  client: AxiosInstance,
+  basePath: string,
+  id: PartyDuplicateCandidateId,
+  request: PartyDuplicateMergeRequest,
+  idempotencyKey?: string
+): Promise<PartyMergeResponse> {
+  const response = await client.post<PartyMergeResponse>(
+    `${basePath}/duplicates/${encodeURIComponent(id)}/merge`,
+    request,
+    idempotencyKey ? { headers: { 'Idempotency-Key': idempotencyKey } } : undefined
+  );
+  return response.data;
+}

--- a/packages/@granit/parties/src/index.ts
+++ b/packages/@granit/parties/src/index.ts
@@ -1,6 +1,8 @@
 // Types
 export type {
   AddressKind,
+  DuplicateMatchSignalResponse,
+  DuplicateMatchTier,
   EvidenceBlobId,
   FieldConflictResponse,
   MergeWinner,
@@ -8,6 +10,9 @@ export type {
   PartyAddressRequest,
   PartyAddressResponse,
   PartyCreateRequest,
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
+  PartyDuplicateMergeRequest,
   PartyEmailId,
   PartyEmailRequest,
   PartyEmailResponse,
@@ -38,7 +43,7 @@ export type {
 // Permissions
 export { PartiesPermissions } from './permissions.js';
 
-// API
+// API — core
 export {
   activateParty,
   addPartyAddress,
@@ -64,3 +69,10 @@ export {
   suspendParty,
   updateParty,
 } from './api/parties-api.js';
+
+// API — duplicate detection
+export {
+  dismissPartyDuplicate,
+  listDuplicatesForParty,
+  mergePartyFromDuplicate,
+} from './api/parties-duplicates-api.js';

--- a/packages/@granit/parties/src/types.ts
+++ b/packages/@granit/parties/src/types.ts
@@ -18,6 +18,9 @@ export type PartyExternalMappingId = EntityId<'PartyExternalMapping'>;
 /** Branded identifier for an evidence blob attached to a tax status. */
 export type EvidenceBlobId = EntityId<'BlobReference'>;
 
+/** Branded identifier for a row in the duplicate-candidates review table. */
+export type PartyDuplicateCandidateId = EntityId<'PartyDuplicateCandidate'>;
+
 /** Nature of a {@link Party} entity. Mirrors the .NET `PartyKind` enum. */
 export type PartyKind = 'Individual' | 'Company' | 'Department';
 
@@ -295,4 +298,64 @@ export interface PartyMergeResponse {
   readonly rewriteCounts: Readonly<Record<string, number>>;
   /** `true` for previews and explicit dry-runs; `false` for committed merges. */
   readonly dryRun: boolean;
+}
+
+// ── Duplicate detection (3-tier pipeline) ────────────────────────────────
+
+/**
+ * Detection tier reported by the deduplication pipeline. Mirrors the .NET
+ * `DuplicateMatchTier` enum.
+ *
+ * - `Deterministic` — exact match on a discriminating identifier (TaxId, …).
+ * - `Blocking` — strong fuzzy match (e.g. same email domain + similar name).
+ * - `Fuzzy` — weaker similarity, surfaces only via the recurring scan.
+ */
+export type DuplicateMatchTier = 'Deterministic' | 'Blocking' | 'Fuzzy';
+
+/** A single weighted contribution surfaced under a candidate's signals list. */
+export interface DuplicateMatchSignalResponse {
+  /** Signal kind (e.g. `"TaxIdEqual"`, `"NameTrigram"`, `"EmailDomain"`). */
+  readonly kind: string;
+  /** Per-signal score in `[0, 1]`. */
+  readonly score: number;
+}
+
+/**
+ * Wire view of a row in the `parties_duplicate_candidates` review table.
+ * Returned by both `GET /parties/duplicates` (paged via QueryEngine) and
+ * `GET /parties/{id}/duplicate-candidates` (flat per-party listing).
+ */
+export interface PartyDuplicateCandidateResponse {
+  /** Stable id of the candidate-pair row — used to dismiss / merge. */
+  readonly id: PartyDuplicateCandidateId;
+  /** Lower id of the ordered pair. */
+  readonly partyId: PartyId;
+  /** Higher id of the ordered pair. */
+  readonly candidateId: PartyId;
+  /** Aggregated confidence in `[0, 1]`. */
+  readonly score: number;
+  readonly tier: DuplicateMatchTier;
+  /** Per-signal contributions, sorted by score descending. */
+  readonly signals: readonly DuplicateMatchSignalResponse[];
+  /** When an admin marked the pair as "not a duplicate"; `null` while pending. */
+  readonly dismissedAt: string | null;
+  /** When the pair was first detected. */
+  readonly createdAt: string;
+  /** When the pair was last refreshed by a re-scan; `null` on initial detection. */
+  readonly updatedAt: string | null;
+}
+
+/**
+ * Body of `POST /parties/duplicates/{id}/merge` — shortcut that resolves the
+ * candidate row to its (survivor, loser) pair and forwards to the merge
+ * orchestrator. The loser is inferred from the row (the other end of the
+ * pair); 422 if `survivorId` is not part of the pair.
+ */
+export interface PartyDuplicateMergeRequest {
+  /** Which end of the candidate pair survives. */
+  readonly survivorId: PartyId;
+  /** Per-field admin overrides — same semantics as {@link PartyMergeRequest.choices}. */
+  readonly choices?: Readonly<Record<string, MergeWinner>>;
+  /** Optional admin justification — captured in the audit log. */
+  readonly reason?: string | null;
 }

--- a/packages/@granit/react-parties/package.json
+++ b/packages/@granit/react-parties/package.json
@@ -16,6 +16,7 @@
   },
   "peerDependencies": {
     "@granit/parties": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "axios": "*",

--- a/packages/@granit/react-parties/src/__tests__/DuplicatesInbox.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/DuplicatesInbox.test.tsx
@@ -1,0 +1,180 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { toEntityId } from '@granit/types';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import i18next from 'i18next';
+import { initReactI18next, I18nextProvider } from 'react-i18next';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { DuplicatesInbox } from '../components/DuplicatesInbox.js';
+import { partiesTranslationsEn } from '../locales/en.js';
+import { PartiesProvider } from '../providers/parties-provider.js';
+
+import type { PartiesConfig } from '../providers/parties-provider.js';
+import type {
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
+  PartyId,
+} from '@granit/parties';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const partyA: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000001');
+const partyB: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000002');
+const partyC: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000003');
+const dupId1: PartyDuplicateCandidateId = toEntityId<'PartyDuplicateCandidate'>('dup-001');
+const dupId2: PartyDuplicateCandidateId = toEntityId<'PartyDuplicateCandidate'>('dup-002');
+
+const rows: PartyDuplicateCandidateResponse[] = [
+  {
+    id: dupId1,
+    partyId: partyA,
+    candidateId: partyB,
+    score: 0.97,
+    tier: 'Deterministic',
+    signals: [],
+    dismissedAt: null,
+    createdAt: '2026-04-25T08:00:00Z',
+    updatedAt: '2026-04-26T02:00:00Z',
+  },
+  {
+    id: dupId2,
+    partyId: partyB,
+    candidateId: partyC,
+    score: 0.62,
+    tier: 'Fuzzy',
+    signals: [],
+    dismissedAt: null,
+    createdAt: '2026-04-26T14:00:00Z',
+    updatedAt: null,
+  },
+];
+
+beforeAll(async () => {
+  if (!i18next.isInitialized) {
+    await i18next.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      ns: ['parties'],
+      defaultNS: 'parties',
+      resources: { en: { parties: partiesTranslationsEn } },
+      interpolation: { escapeValue: false },
+      returnNull: false,
+    });
+  }
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+function renderInbox(
+  client: AxiosInstance,
+  onMerge?: (row: PartyDuplicateCandidateResponse) => void
+) {
+  const queryClient = createTestQueryClient();
+  const config: PartiesConfig = { client };
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <I18nextProvider i18n={i18next}>
+        <QueryClientProvider client={queryClient}>
+          <PartiesProvider config={config}>{children}</PartiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+  }
+  return render(<DuplicatesInbox onMerge={onMerge} />, { wrapper: Wrapper });
+}
+
+describe('DuplicatesInbox', () => {
+  it('renders one table row per candidate after the QueryEngine call resolves', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: rows, totalCount: rows.length })
+    );
+
+    const { container } = renderInbox(client);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-slot="duplicate-row"]').length).toBe(rows.length)
+    );
+
+    // Tier badges show the right tone via data-tier attribute
+    const tierAttrs = Array.from(container.querySelectorAll('[data-slot="tier-badge"]')).map((el) =>
+      el.getAttribute('data-tier')
+    );
+    expect(tierAttrs).toEqual(['Deterministic', 'Fuzzy']);
+  });
+
+  it('shows the empty state when no candidates are pending', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [], totalCount: 0 }));
+
+    const { container } = renderInbox(client);
+
+    await waitFor(() =>
+      expect(screen.queryByText(partiesTranslationsEn.Duplicates.EmptyState)).not.toBeNull()
+    );
+    expect(container.querySelector('[data-slot="duplicate-row"]')).toBeNull();
+  });
+
+  it('dispatches the dismiss mutation when "Dismiss" is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: rows, totalCount: rows.length })
+    );
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const { container } = renderInbox(client);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-slot="duplicate-row"]').length).toBe(rows.length)
+    );
+
+    const dismissButtons = screen.getAllByRole('button', {
+      name: partiesTranslationsEn.Duplicates.Actions.Dismiss,
+    });
+    fireEvent.click(dismissButtons[0]!);
+
+    await waitFor(() =>
+      expect(client.post).toHaveBeenCalledWith(`/api/v1/parties/duplicates/${dupId1}/dismiss`)
+    );
+  });
+
+  it('forwards the row to onMerge when the consumer wires the callback', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: rows, totalCount: rows.length })
+    );
+
+    const onMerge = vi.fn();
+    const { container } = renderInbox(client, onMerge);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-slot="duplicate-row"]').length).toBe(rows.length)
+    );
+
+    const mergeButtons = screen.getAllByRole('button', {
+      name: partiesTranslationsEn.Duplicates.Actions.Merge,
+    });
+    fireEvent.click(mergeButtons[1]!);
+
+    expect(onMerge).toHaveBeenCalledWith(rows[1]);
+  });
+
+  it('does not render Merge buttons when onMerge is omitted', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: rows, totalCount: rows.length })
+    );
+
+    const { container } = renderInbox(client);
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-slot="duplicate-row"]').length).toBe(rows.length)
+    );
+
+    expect(
+      screen.queryAllByRole('button', { name: partiesTranslationsEn.Duplicates.Actions.Merge })
+    ).toHaveLength(0);
+  });
+});

--- a/packages/@granit/react-parties/src/__tests__/PartyDuplicatesBadge.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/PartyDuplicatesBadge.test.tsx
@@ -1,0 +1,152 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { toEntityId } from '@granit/types';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, waitFor } from '@testing-library/react';
+import i18next from 'i18next';
+import { initReactI18next, I18nextProvider } from 'react-i18next';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { PartyDuplicatesBadge } from '../components/PartyDuplicatesBadge.js';
+import { partiesTranslationsEn } from '../locales/en.js';
+import { PartiesProvider } from '../providers/parties-provider.js';
+
+import type { PartiesConfig } from '../providers/parties-provider.js';
+import type {
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
+  PartyId,
+} from '@granit/parties';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const partyA: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000001');
+const partyB: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000002');
+
+const candidateBuilder = (
+  overrides: Partial<PartyDuplicateCandidateResponse>
+): PartyDuplicateCandidateResponse => ({
+  id: toEntityId<'PartyDuplicateCandidate'>('dup-x') as PartyDuplicateCandidateId,
+  partyId: partyA,
+  candidateId: partyB,
+  score: 0.8,
+  tier: 'Blocking',
+  signals: [],
+  dismissedAt: null,
+  createdAt: '2026-04-26T08:00:00Z',
+  updatedAt: null,
+  ...overrides,
+});
+
+beforeAll(async () => {
+  if (!i18next.isInitialized) {
+    await i18next.use(initReactI18next).init({
+      lng: 'en',
+      fallbackLng: 'en',
+      ns: ['parties'],
+      defaultNS: 'parties',
+      resources: { en: { parties: partiesTranslationsEn } },
+      interpolation: { escapeValue: false },
+      returnNull: false,
+    });
+  }
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+function renderBadge(client: AxiosInstance, props?: { href?: string }) {
+  const queryClient = createTestQueryClient();
+  const config: PartiesConfig = { client };
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <I18nextProvider i18n={i18next}>
+        <QueryClientProvider client={queryClient}>
+          <PartiesProvider config={config}>{children}</PartiesProvider>
+        </QueryClientProvider>
+      </I18nextProvider>
+    );
+  }
+  return render(<PartyDuplicatesBadge partyId={partyA} href={props?.href} />, {
+    wrapper: Wrapper,
+  });
+}
+
+describe('PartyDuplicatesBadge', () => {
+  it('renders the count when the party has pending candidates', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse([
+        candidateBuilder({ tier: 'Deterministic' }),
+        candidateBuilder({
+          id: toEntityId<'PartyDuplicateCandidate'>('dup-y') as PartyDuplicateCandidateId,
+          tier: 'Fuzzy',
+        }),
+      ])
+    );
+
+    const { container } = renderBadge(client);
+
+    const badge = await waitFor(() => {
+      const el = container.querySelector('[data-slot="party-duplicates-badge"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    expect(badge.textContent).toMatch(/Potential duplicates \(2\)/);
+    // At least one non-Fuzzy → amber tone
+    expect(badge.getAttribute('data-tone')).toBe('amber');
+  });
+
+  it('uses the muted tone when only Fuzzy candidates are pending', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([candidateBuilder({ tier: 'Fuzzy' })]));
+
+    const { container } = renderBadge(client);
+    const badge = await waitFor(() => {
+      const el = container.querySelector('[data-slot="party-duplicates-badge"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    expect(badge.getAttribute('data-tone')).toBe('muted');
+  });
+
+  it('renders nothing when there are no pending candidates', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    const { container } = renderBadge(client);
+
+    // Wait for the query to settle then assert no pill
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(container.querySelector('[data-slot="party-duplicates-badge"]')).toBeNull();
+  });
+
+  it('hides dismissed-only rows', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse([candidateBuilder({ dismissedAt: '2026-04-26T10:00:00Z' })])
+    );
+
+    const { container } = renderBadge(client);
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(container.querySelector('[data-slot="party-duplicates-badge"]')).toBeNull();
+  });
+
+  it('renders as an anchor when href is supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse([candidateBuilder({ tier: 'Deterministic' })])
+    );
+
+    const { container } = renderBadge(client, { href: '/admin/parties/duplicates?filter=…' });
+    const badge = await waitFor(() => {
+      const el = container.querySelector('[data-slot="party-duplicates-badge"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+    expect(badge.tagName).toBe('A');
+    expect((badge as HTMLAnchorElement).getAttribute('href')).toBe(
+      '/admin/parties/duplicates?filter=…'
+    );
+  });
+});

--- a/packages/@granit/react-parties/src/__tests__/use-party-duplicates.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-party-duplicates.test.tsx
@@ -1,0 +1,176 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { toEntityId } from '@granit/types';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useDismissPartyDuplicateMutation,
+  useMergePartyFromDuplicateMutation,
+  usePartyDuplicateCandidatesForPartyQuery,
+} from '../hooks/use-party-duplicates.js';
+import { PartiesProvider } from '../providers/parties-provider.js';
+
+import type { PartiesConfig } from '../providers/parties-provider.js';
+import type {
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
+  PartyId,
+  PartyMergeResponse,
+} from '@granit/parties';
+import type { QueryClient } from '@tanstack/react-query';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const partyA: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000001');
+const partyB: PartyId = toEntityId<'Party'>('00000000-0000-0000-0000-000000000002');
+const dupId: PartyDuplicateCandidateId = toEntityId<'PartyDuplicateCandidate'>('dup-001');
+
+const candidate: PartyDuplicateCandidateResponse = {
+  id: dupId,
+  partyId: partyA,
+  candidateId: partyB,
+  score: 0.92,
+  tier: 'Deterministic',
+  signals: [{ kind: 'TaxIdEqual', score: 1.0 }],
+  dismissedAt: null,
+  createdAt: '2026-04-26T08:00:00Z',
+  updatedAt: null,
+};
+
+function makeWrapper(client: AxiosInstance, queryClient: QueryClient = createTestQueryClient()) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const config: PartiesConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <PartiesProvider config={config}>{children}</PartiesProvider>
+    );
+  };
+}
+
+describe('usePartyDuplicateCandidatesForPartyQuery', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('GETs the per-party candidates endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([candidate]));
+
+    const { result } = renderHook(() => usePartyDuplicateCandidatesForPartyQuery(partyA), {
+      wrapper: makeWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(`/api/v1/parties/${partyA}/duplicate-candidates`);
+    expect(result.current.data).toEqual([candidate]);
+  });
+
+  it('does not fetch when partyId is null', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => usePartyDuplicateCandidatesForPartyQuery(null), {
+      wrapper: makeWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDismissPartyDuplicateMutation', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('POSTs the dismiss endpoint and invalidates the duplicates cache', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDismissPartyDuplicateMutation(), {
+      wrapper: makeWrapper(client, queryClient),
+    });
+
+    result.current.mutate({ id: dupId });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.post).toHaveBeenCalledWith(`/api/v1/parties/duplicates/${dupId}/dismiss`);
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      ([filters]) => filters?.queryKey as readonly unknown[]
+    );
+    expect(invalidatedKeys).toContainEqual(['parties', 'duplicates']);
+  });
+});
+
+describe('useMergePartyFromDuplicateMutation', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const mergeResponse: PartyMergeResponse = {
+    survivorId: partyA,
+    loserId: partyB,
+    conflicts: [],
+    rewriteCounts: { 'Invoice.PartyId': 5 },
+    dryRun: false,
+  };
+
+  it('POSTs with auto-generated Idempotency-Key and invalidates duplicates + parties caches', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(mergeResponse));
+
+    const queryClient = createTestQueryClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useMergePartyFromDuplicateMutation(), {
+      wrapper: makeWrapper(client, queryClient),
+    });
+
+    result.current.mutate({
+      id: dupId,
+      request: { survivorId: partyA, reason: 'Confirmed by ops review' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const call = vi.mocked(client.post).mock.calls[0]!;
+    expect(call[0]).toBe(`/api/v1/parties/duplicates/${dupId}/merge`);
+    expect(call[1]).toEqual({ survivorId: partyA, reason: 'Confirmed by ops review' });
+    expect(call[2]).toMatchObject({
+      headers: expect.objectContaining({
+        'Idempotency-Key': expect.stringMatching(/^[0-9a-f-]{36}$/i),
+      }),
+    });
+
+    const invalidatedKeys = invalidateSpy.mock.calls.map(
+      ([filters]) => filters?.queryKey as readonly unknown[]
+    );
+    expect(invalidatedKeys).toContainEqual(['parties', 'duplicates']);
+    expect(invalidatedKeys).toContainEqual(['parties', 'list']);
+    expect(invalidatedKeys).toContainEqual(['parties', 'detail', partyA]);
+    expect(invalidatedKeys).toContainEqual(['parties', 'detail', partyB]);
+  });
+
+  it('uses an explicit idempotencyKey when supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(mergeResponse));
+
+    const { result } = renderHook(() => useMergePartyFromDuplicateMutation(), {
+      wrapper: makeWrapper(client),
+    });
+
+    const explicitKey = '11111111-2222-4333-8444-555555555555';
+    result.current.mutate({
+      id: dupId,
+      request: { survivorId: partyA },
+      idempotencyKey: explicitKey,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.post).toHaveBeenCalledWith(
+      `/api/v1/parties/duplicates/${dupId}/merge`,
+      { survivorId: partyA },
+      { headers: { 'Idempotency-Key': explicitKey } }
+    );
+  });
+});

--- a/packages/@granit/react-parties/src/components/DuplicatesInbox.tsx
+++ b/packages/@granit/react-parties/src/components/DuplicatesInbox.tsx
@@ -1,0 +1,258 @@
+import { QueryProvider, useQueryEndpoint } from '@granit/react-query-engine';
+import { useTranslation } from 'react-i18next';
+
+import { useDismissPartyDuplicateMutation } from '../hooks/use-party-duplicates.js';
+import { usePartiesConfig } from '../providers/parties-provider.js';
+
+import type { DuplicateMatchTier, PartyDuplicateCandidateResponse } from '@granit/parties';
+import type { ReactNode } from 'react';
+
+const PARTIES_NAMESPACE = 'parties';
+
+/** Internal key prefix that lets the dismiss / merge mutations invalidate the inbox. */
+const INBOX_QUERY_KEY_PREFIX = ['parties', 'duplicates', 'inbox'] as const;
+
+export interface DuplicatesInboxProps {
+  /**
+   * Called when the user clicks "Merge…" on a row. The consumer is expected to
+   * open its own merge UI (typically the existing `<MergeWizard>` from #1294
+   * wrapped in a Dialog / Drawer with a survivor picker), pre-filled with the
+   * row's `partyId` and `candidateId`.
+   *
+   * The candidate row is exposed as-is so the consumer can extract whichever
+   * id pair it needs.
+   */
+  readonly onMerge?: (candidate: PartyDuplicateCandidateResponse) => void;
+  /**
+   * Override page size for the underlying QueryEngine call. Defaults to 20.
+   */
+  readonly pageSize?: number;
+  /**
+   * Render-prop for linking a Party id to its detail page. When omitted, the
+   * Party A / Party B columns render plain text. Useful when the consumer's
+   * router exposes a typed `<Link>` component.
+   */
+  readonly renderPartyLink?: (partyId: string) => ReactNode;
+}
+
+/**
+ * Paginated review surface for pending duplicate-candidate pairs. Wraps itself
+ * in a `<QueryProvider>` so the consumer only needs to provide the parent
+ * `<PartiesProvider>` upstream.
+ *
+ * Permission gating is delegated to the consumer — wrap with your own guard
+ * checking `PartiesPermissions.Parties.Read` for the inbox itself,
+ * `…Manage` for dismiss, and `…Merge` for the merge shortcut.
+ *
+ * @example
+ * ```tsx
+ * <DuplicatesInbox onMerge={(row) => openMergeDialog(row)} />
+ * ```
+ */
+export function DuplicatesInbox(props: Readonly<DuplicatesInboxProps>) {
+  const config = usePartiesConfig();
+  const basePath = config.basePath!;
+
+  return (
+    <QueryProvider
+      config={{
+        client: config.client,
+        basePath: `${basePath}/duplicates`,
+        queryKeyPrefix: [...INBOX_QUERY_KEY_PREFIX],
+      }}
+    >
+      <DuplicatesInboxBody {...props} />
+    </QueryProvider>
+  );
+}
+
+function DuplicatesInboxBody({
+  onMerge,
+  pageSize,
+  renderPartyLink,
+}: Readonly<DuplicatesInboxProps>) {
+  const { t } = useTranslation(PARTIES_NAMESPACE);
+  const dismissMutation = useDismissPartyDuplicateMutation();
+
+  const { params, query, setPage } = useQueryEndpoint<PartyDuplicateCandidateResponse>({
+    initialParams: { page: 1, pageSize: pageSize ?? 20 },
+  });
+
+  const items = query.data?.items ?? [];
+  const totalCount = query.data?.totalCount ?? 0;
+  const currentPage = params.page ?? 1;
+  const currentPageSize = params.pageSize ?? 20;
+  const totalPages = Math.max(1, Math.ceil(totalCount / currentPageSize));
+
+  return (
+    <div data-slot="duplicates-inbox" className="space-y-4">
+      <header>
+        <h2 className="text-2xl font-semibold">{t('Duplicates.Inbox.Title')}</h2>
+        <p className="mt-1 text-sm text-muted-foreground">{t('Duplicates.Inbox.Subtitle')}</p>
+      </header>
+
+      <div className="rounded-md border">
+        <table className="w-full text-sm">
+          <thead className="border-b bg-muted/30 text-left">
+            <tr>
+              <th className="px-3 py-2 font-medium">{t('Duplicates.Columns.Score')}</th>
+              <th className="px-3 py-2 font-medium">{t('Duplicates.Columns.Tier')}</th>
+              <th className="px-3 py-2 font-medium">{t('Duplicates.Columns.PartyA')}</th>
+              <th className="px-3 py-2 font-medium">{t('Duplicates.Columns.PartyB')}</th>
+              <th className="px-3 py-2 font-medium">{t('Duplicates.Columns.Detected')}</th>
+              <th className="px-3 py-2 font-medium">{t('Duplicates.Columns.Refreshed')}</th>
+              <th className="px-3 py-2 font-medium text-right">
+                {t('Duplicates.Columns.Actions')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {query.isLoading ? (
+              <tr>
+                <td colSpan={7} className="px-3 py-8 text-center text-muted-foreground">
+                  {t('Duplicates.LoadingState')}
+                </td>
+              </tr>
+            ) : query.isError ? (
+              <tr>
+                <td colSpan={7} role="alert" className="px-3 py-8 text-center text-destructive">
+                  {t('Duplicates.ErrorState')}
+                </td>
+              </tr>
+            ) : items.length === 0 ? (
+              <tr>
+                <td colSpan={7} className="px-3 py-8 text-center text-muted-foreground">
+                  {t('Duplicates.EmptyState')}
+                </td>
+              </tr>
+            ) : (
+              items.map((row) => (
+                <DuplicateRow
+                  key={row.id}
+                  row={row}
+                  onDismiss={() => dismissMutation.mutate({ id: row.id })}
+                  onMerge={onMerge ? () => onMerge(row) : undefined}
+                  renderPartyLink={renderPartyLink}
+                  dismissDisabled={dismissMutation.isPending}
+                  dismissLabel={t('Duplicates.Actions.Dismiss')}
+                  mergeLabel={t('Duplicates.Actions.Merge')}
+                  tierLabels={{
+                    Deterministic: t('Duplicates.Tier.Deterministic'),
+                    Blocking: t('Duplicates.Tier.Blocking'),
+                    Fuzzy: t('Duplicates.Tier.Fuzzy'),
+                  }}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {totalCount > currentPageSize && (
+        <div className="flex items-center justify-between text-sm">
+          <span className="text-muted-foreground">
+            {t('Duplicates.Pagination.PageOfTotal', { page: currentPage, total: totalPages })}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              className="rounded-md border border-input bg-background px-3 py-1 text-sm font-medium disabled:opacity-50"
+              onClick={() => setPage(currentPage - 1)}
+              disabled={currentPage <= 1}
+            >
+              {t('Duplicates.Pagination.Previous')}
+            </button>
+            <button
+              type="button"
+              className="rounded-md border border-input bg-background px-3 py-1 text-sm font-medium disabled:opacity-50"
+              onClick={() => setPage(currentPage + 1)}
+              disabled={currentPage >= totalPages}
+            >
+              {t('Duplicates.Pagination.Next')}
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface DuplicateRowProps {
+  readonly row: PartyDuplicateCandidateResponse;
+  readonly onDismiss: () => void;
+  readonly onMerge?: () => void;
+  readonly renderPartyLink?: (partyId: string) => ReactNode;
+  readonly dismissDisabled: boolean;
+  readonly dismissLabel: string;
+  readonly mergeLabel: string;
+  readonly tierLabels: Record<DuplicateMatchTier, string>;
+}
+
+const TIER_TONES: Record<DuplicateMatchTier, string> = {
+  Deterministic: 'bg-green-100 text-green-800 border-green-300',
+  Blocking: 'bg-yellow-100 text-yellow-800 border-yellow-300',
+  Fuzzy: 'bg-blue-100 text-blue-800 border-blue-300',
+};
+
+function DuplicateRow({
+  row,
+  onDismiss,
+  onMerge,
+  renderPartyLink,
+  dismissDisabled,
+  dismissLabel,
+  mergeLabel,
+  tierLabels,
+}: Readonly<DuplicateRowProps>) {
+  return (
+    <tr data-slot="duplicate-row" data-row-id={row.id} className="border-b last:border-b-0">
+      <td className="px-3 py-2 font-mono">{row.score.toFixed(2)}</td>
+      <td className="px-3 py-2">
+        <span
+          data-slot="tier-badge"
+          data-tier={row.tier}
+          className={`inline-flex rounded-full border px-2 py-0.5 text-xs font-medium ${TIER_TONES[row.tier]}`}
+        >
+          {tierLabels[row.tier]}
+        </span>
+      </td>
+      <td className="px-3 py-2 font-mono text-xs">
+        {renderPartyLink ? renderPartyLink(row.partyId) : row.partyId}
+      </td>
+      <td className="px-3 py-2 font-mono text-xs">
+        {renderPartyLink ? renderPartyLink(row.candidateId) : row.candidateId}
+      </td>
+      <td className="px-3 py-2 text-muted-foreground">{formatDate(row.createdAt)}</td>
+      <td className="px-3 py-2 text-muted-foreground">{formatDate(row.updatedAt)}</td>
+      <td className="px-3 py-2 text-right">
+        <div className="inline-flex gap-2">
+          <button
+            type="button"
+            onClick={onDismiss}
+            disabled={dismissDisabled}
+            className="rounded-md border border-input bg-background px-2 py-1 text-xs font-medium disabled:opacity-50"
+          >
+            {dismissLabel}
+          </button>
+          {onMerge && (
+            <button
+              type="button"
+              onClick={onMerge}
+              className="rounded-md bg-primary px-2 py-1 text-xs font-medium text-primary-foreground"
+            >
+              {mergeLabel}
+            </button>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+function formatDate(value: string | null | undefined): string {
+  if (!value) return '—';
+  // Plain ISO display — consumers are expected to inject locale-aware
+  // formatting via their own theming layer if needed. The framework package
+  // intentionally avoids pulling in date-fns / Intl here.
+  return value.slice(0, 10);
+}

--- a/packages/@granit/react-parties/src/components/PartyDuplicatesBadge.tsx
+++ b/packages/@granit/react-parties/src/components/PartyDuplicatesBadge.tsx
@@ -1,0 +1,101 @@
+import { useTranslation } from 'react-i18next';
+
+import { usePartyDuplicateCandidatesForPartyQuery } from '../hooks/use-party-duplicates.js';
+
+import type { PartyId } from '@granit/parties';
+import type { ReactNode } from 'react';
+
+const PARTIES_NAMESPACE = 'parties';
+
+export interface PartyDuplicatesBadgeProps {
+  /** Party whose pending candidate pairs we surface. */
+  readonly partyId: PartyId;
+  /**
+   * URL to navigate to on click. Typically the duplicates inbox URL with a
+   * filter applied to this party — `/admin/parties/duplicates?filter=…`.
+   * When omitted, the badge renders as a plain `<span>`.
+   */
+  readonly href?: string;
+  /** Optional render-prop wrapper (consumer-supplied router `<Link>` etc.). */
+  readonly renderLink?: (props: { href: string; children: ReactNode }) => ReactNode;
+  /** Optional className appended to the pill — for theme integration. */
+  readonly className?: string;
+}
+
+/**
+ * Small inline pill that surfaces the count of pending duplicate candidates
+ * involving a given party. Hidden when the party has no candidates (or while
+ * the query is still loading) to keep the detail page calm.
+ *
+ * Coloured amber when at least one pair contains a non-Fuzzy (i.e. stronger)
+ * signal; muted gray when only Tier-3 fuzzy pairs are present.
+ */
+export function PartyDuplicatesBadge({
+  partyId,
+  href,
+  renderLink,
+  className,
+}: Readonly<PartyDuplicatesBadgeProps>) {
+  const { t } = useTranslation(PARTIES_NAMESPACE);
+  const query = usePartyDuplicateCandidatesForPartyQuery(partyId);
+
+  const candidates = query.data ?? [];
+  const pending = candidates.filter((c) => c.dismissedAt == null);
+
+  if (pending.length === 0) return null;
+
+  const hasNonFuzzy = pending.some((c) => c.tier !== 'Fuzzy');
+  const tone = hasNonFuzzy
+    ? 'bg-amber-100 text-amber-800 border-amber-300'
+    : 'bg-muted text-muted-foreground border-border';
+
+  const label = t('Duplicates.Badge.PerParty', {
+    count: pending.length,
+    defaultValue: 'Potential duplicates ({{count}})',
+  });
+
+  const pillClass = [
+    'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium',
+    tone,
+    className ?? '',
+  ]
+    .join(' ')
+    .trim();
+
+  if (href) {
+    if (renderLink) {
+      return renderLink({
+        href,
+        children: (
+          <span
+            data-slot="party-duplicates-badge"
+            data-tone={hasNonFuzzy ? 'amber' : 'muted'}
+            className={pillClass}
+          >
+            {label}
+          </span>
+        ),
+      });
+    }
+    return (
+      <a
+        data-slot="party-duplicates-badge"
+        data-tone={hasNonFuzzy ? 'amber' : 'muted'}
+        href={href}
+        className={pillClass}
+      >
+        {label}
+      </a>
+    );
+  }
+
+  return (
+    <span
+      data-slot="party-duplicates-badge"
+      data-tone={hasNonFuzzy ? 'amber' : 'muted'}
+      className={pillClass}
+    >
+      {label}
+    </span>
+  );
+}

--- a/packages/@granit/react-parties/src/hooks/use-party-duplicates.ts
+++ b/packages/@granit/react-parties/src/hooks/use-party-duplicates.ts
@@ -1,0 +1,143 @@
+import {
+  dismissPartyDuplicate,
+  listDuplicatesForParty,
+  mergePartyFromDuplicate,
+} from '@granit/parties';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildPartiesQueryKey, usePartiesConfig } from '../providers/parties-provider.js';
+
+import type {
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
+  PartyDuplicateMergeRequest,
+  PartyId,
+  PartyMergeResponse,
+} from '@granit/parties';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Generate a fresh idempotency key for a duplicate-shortcut merge.
+ * Same fallback as `useMergePartyMutation` — kept private to avoid coupling
+ * the two hooks via a shared util module.
+ */
+function newIdempotencyKey(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * List the pending duplicate-candidate pairs that involve a specific party.
+ * Powers the per-Party "Potential duplicates" badge on the detail page.
+ *
+ * Cached under `[parties, 'duplicates', 'for-party', partyId]` so the badge
+ * and any inline panel share a single cache entry.
+ *
+ * @example
+ * ```tsx
+ * const { data: candidates } = usePartyDuplicateCandidatesForPartyQuery(party.id);
+ * if (candidates && candidates.length > 0) return <PartyDuplicatesBadge ... />;
+ * ```
+ */
+export function usePartyDuplicateCandidatesForPartyQuery(
+  partyId: PartyId | null | undefined
+): UseQueryResult<readonly PartyDuplicateCandidateResponse[]> {
+  const config = usePartiesConfig();
+  const basePath = config.basePath!;
+
+  return useQuery({
+    queryKey: buildPartiesQueryKey(config, 'duplicates', 'for-party', partyId),
+    queryFn: () => listDuplicatesForParty(config.client, basePath, partyId as PartyId),
+    enabled: partyId != null,
+  });
+}
+
+/**
+ * Mark a candidate pair as "not a duplicate". Idempotent server-side. On
+ * success, invalidates the inbox list (via `useQueryEndpoint`'s
+ * `[parties, 'list', …]` keys), every per-party candidates cache, and any
+ * cached merge preview that touched the involved parties.
+ */
+export function useDismissPartyDuplicateMutation(): UseMutationResult<
+  void,
+  Error,
+  { readonly id: PartyDuplicateCandidateId }
+> {
+  const config = usePartiesConfig();
+  const basePath = config.basePath!;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id }) => dismissPartyDuplicate(config.client, basePath, id),
+    onSuccess: () => {
+      // Covers both the per-party badge (`[parties, 'duplicates', 'for-party', …]`)
+      // and the inbox grid when its `<QueryProvider>` is configured with
+      // `queryKeyPrefix: ['parties', 'duplicates', 'inbox']` — the default
+      // <DuplicatesInbox> below wires that automatically.
+      void queryClient.invalidateQueries({
+        queryKey: buildPartiesQueryKey(config, 'duplicates'),
+      });
+    },
+  });
+}
+
+/**
+ * Variables for {@link useMergePartyFromDuplicateMutation} — the candidate row
+ * id plus the standard merge body. `idempotencyKey` is auto-generated when
+ * omitted so retries are safe.
+ */
+export interface MergePartyFromDuplicateMutationVariables {
+  readonly id: PartyDuplicateCandidateId;
+  readonly request: PartyDuplicateMergeRequest;
+  readonly idempotencyKey?: string;
+}
+
+/**
+ * Execute the duplicate-row merge shortcut. The loser is inferred server-side
+ * from the candidate pair (the other end of `partyId` / `candidateId`); 422 if
+ * `survivorId` is not part of the pair.
+ *
+ * On success, invalidates: the duplicates cache (per-party + inbox), both
+ * party detail caches, and the parties list — same coverage as the standard
+ * merge mutation since the same orchestrator runs underneath.
+ */
+export function useMergePartyFromDuplicateMutation(): UseMutationResult<
+  PartyMergeResponse,
+  Error,
+  MergePartyFromDuplicateMutationVariables
+> {
+  const config = usePartiesConfig();
+  const basePath = config.basePath!;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request, idempotencyKey }) =>
+      mergePartyFromDuplicate(
+        config.client,
+        basePath,
+        id,
+        request,
+        idempotencyKey ?? newIdempotencyKey()
+      ),
+    onSuccess: (data, { request }) => {
+      void queryClient.invalidateQueries({
+        queryKey: buildPartiesQueryKey(config, 'duplicates'),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: buildPartiesQueryKey(config, 'list'),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: buildPartiesQueryKey(config, 'detail', request.survivorId),
+      });
+      void queryClient.invalidateQueries({
+        queryKey: buildPartiesQueryKey(config, 'detail', data.loserId),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-parties/src/index.ts
+++ b/packages/@granit/react-parties/src/index.ts
@@ -34,9 +34,21 @@ export {
 export { useMergePartyMutation, useMergePartyPreviewQuery } from './hooks/use-party-merge.js';
 export type { MergePartyMutationVariables } from './hooks/use-party-merge.js';
 
+// Hooks — duplicate detection
+export {
+  useDismissPartyDuplicateMutation,
+  useMergePartyFromDuplicateMutation,
+  usePartyDuplicateCandidatesForPartyQuery,
+} from './hooks/use-party-duplicates.js';
+export type { MergePartyFromDuplicateMutationVariables } from './hooks/use-party-duplicates.js';
+
 // Components
 export { MergeWizard } from './components/MergeWizard.js';
 export type { MergeWizardProps } from './components/MergeWizard.js';
+export { DuplicatesInbox } from './components/DuplicatesInbox.js';
+export type { DuplicatesInboxProps } from './components/DuplicatesInbox.js';
+export { PartyDuplicatesBadge } from './components/PartyDuplicatesBadge.js';
+export type { PartyDuplicatesBadgeProps } from './components/PartyDuplicatesBadge.js';
 
 // i18n bundles
 export { partiesTranslationsEn, partiesTranslationsFr } from './locales/index.js';

--- a/packages/@granit/react-parties/src/locales/en.ts
+++ b/packages/@granit/react-parties/src/locales/en.ts
@@ -51,4 +51,43 @@ export const partiesTranslationsEn = {
     },
     ValueEmpty: '(empty)',
   },
+  Duplicates: {
+    Inbox: {
+      Title: 'Potential duplicates',
+      Subtitle:
+        'Review pairs flagged by the recurring scan. Dismiss false positives or merge confirmed duplicates.',
+    },
+    Columns: {
+      Score: 'Score',
+      Tier: 'Tier',
+      PartyA: 'Party A',
+      PartyB: 'Party B',
+      Detected: 'Detected',
+      Refreshed: 'Refreshed',
+      Actions: 'Actions',
+    },
+    Tier: {
+      Deterministic: 'Deterministic',
+      Blocking: 'Blocking',
+      Fuzzy: 'Fuzzy',
+    },
+    Actions: {
+      Dismiss: 'Dismiss',
+      Merge: 'Merge…',
+      DismissedToast: 'Pair dismissed.',
+      MergedToast: 'Parties merged.',
+    },
+    EmptyState: 'No pending duplicates.',
+    LoadingState: 'Loading duplicates…',
+    ErrorState: 'Could not load duplicates.',
+    Pagination: {
+      Previous: 'Previous',
+      Next: 'Next',
+      PageOfTotal: 'Page {{page}} of {{total}}',
+    },
+    Badge: {
+      PerParty_one: 'Potential duplicate ({{count}})',
+      PerParty_other: 'Potential duplicates ({{count}})',
+    },
+  },
 } as const;

--- a/packages/@granit/react-parties/src/locales/fr.ts
+++ b/packages/@granit/react-parties/src/locales/fr.ts
@@ -52,4 +52,43 @@ export const partiesTranslationsFr = {
     },
     ValueEmpty: '(vide)',
   },
+  Duplicates: {
+    Inbox: {
+      Title: 'Doublons potentiels',
+      Subtitle:
+        'Examinez les paires détectées par le scan récurrent. Rejetez les faux positifs ou fusionnez les doublons confirmés.',
+    },
+    Columns: {
+      Score: 'Score',
+      Tier: 'Niveau',
+      PartyA: 'Tiers A',
+      PartyB: 'Tiers B',
+      Detected: 'Détecté',
+      Refreshed: 'Rafraîchi',
+      Actions: 'Actions',
+    },
+    Tier: {
+      Deterministic: 'Déterministe',
+      Blocking: 'Bloquant',
+      Fuzzy: 'Approximatif',
+    },
+    Actions: {
+      Dismiss: 'Rejeter',
+      Merge: 'Fusionner…',
+      DismissedToast: 'Paire rejetée.',
+      MergedToast: 'Tiers fusionnés.',
+    },
+    EmptyState: 'Aucun doublon en attente.',
+    LoadingState: 'Chargement des doublons…',
+    ErrorState: 'Impossible de charger les doublons.',
+    Pagination: {
+      Previous: 'Précédent',
+      Next: 'Suivant',
+      PageOfTotal: 'Page {{page}} sur {{total}}',
+    },
+    Badge: {
+      PerParty_one: 'Doublon potentiel ({{count}})',
+      PerParty_other: 'Doublons potentiels ({{count}})',
+    },
+  },
 } as const;

--- a/packages/@granit/react-parties/src/testing/data.ts
+++ b/packages/@granit/react-parties/src/testing/data.ts
@@ -2,6 +2,8 @@ import { toEntityId } from '@granit/types';
 
 import type {
   PartyAddressId,
+  PartyDuplicateCandidateId,
+  PartyDuplicateCandidateResponse,
   PartyEmailId,
   PartyExternalMappingId,
   PartyId,
@@ -372,6 +374,67 @@ export const sampleParties: Mutable<PartyResponse>[] = [
   starkRD,
   bobDupont,
   ngoHelpers,
+];
+
+// ── Duplicate candidates ──────────────────────────────────────────────────
+
+const duplicateId = (suffix: string): PartyDuplicateCandidateId =>
+  toEntityId<'PartyDuplicateCandidate'>(`dup-${suffix}`);
+
+/**
+ * In-memory duplicates store used by the MSW handlers. Each row references two
+ * existing parties from {@link sampleParties} so the showcase can dogfood the
+ * inbox + per-party badge end-to-end.
+ *
+ * Demo storyline: Alice Martin (Lead) looks like a duplicate of two other
+ * parties — a strong deterministic match against an existing customer and a
+ * weaker fuzzy match against a different one — so opening her detail page
+ * shows an amber badge, and the inbox grid shows three pending pairs covering
+ * every tier.
+ */
+export const sampleDuplicates: Mutable<PartyDuplicateCandidateResponse>[] = [
+  {
+    id: duplicateId('001'),
+    partyId: id(1),
+    candidateId: id(2),
+    score: 0.97,
+    tier: 'Deterministic',
+    signals: [
+      { kind: 'TaxIdEqual', score: 1.0 },
+      { kind: 'NameTrigram', score: 0.74 },
+    ],
+    dismissedAt: null,
+    createdAt: '2026-04-25T08:30:00Z',
+    updatedAt: '2026-04-27T02:00:00Z',
+  },
+  {
+    id: duplicateId('002'),
+    partyId: id(2),
+    candidateId: id(3),
+    score: 0.81,
+    tier: 'Blocking',
+    signals: [
+      { kind: 'EmailDomainEqual', score: 0.85 },
+      { kind: 'NameTrigram', score: 0.78 },
+    ],
+    dismissedAt: null,
+    createdAt: '2026-04-26T14:15:00Z',
+    updatedAt: null,
+  },
+  {
+    id: duplicateId('003'),
+    partyId: id(4),
+    candidateId: id(8),
+    score: 0.62,
+    tier: 'Fuzzy',
+    signals: [
+      { kind: 'NameTrigram', score: 0.62 },
+      { kind: 'CountryEqual', score: 1.0 },
+    ],
+    dismissedAt: null,
+    createdAt: '2026-04-27T03:00:00Z',
+    updatedAt: null,
+  },
 ];
 
 /** Project a {@link PartyResponse} to its list-item shape. */

--- a/packages/@granit/react-parties/src/testing/handlers.ts
+++ b/packages/@granit/react-parties/src/testing/handlers.ts
@@ -3,13 +3,14 @@ import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import { sampleParties, toListItem } from './data.js';
+import { sampleDuplicates, sampleParties, toListItem } from './data.js';
 
 import type {
   FieldConflictResponse,
   PartyAddressId,
   PartyAddressRequest,
   PartyCreateRequest,
+  PartyDuplicateMergeRequest,
   PartyEmailId,
   PartyEmailRequest,
   PartyExternalMappingId,
@@ -66,6 +67,73 @@ export function createPartiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
           )
         : sampleParties;
       return HttpResponse.json(items.map(toListItem));
+    }),
+
+    // ── Duplicate candidates: paged inbox (QueryEngine shape) ────────
+    // MUST appear before the `/:id` catch-all below so the literal segment
+    // "duplicates" is not interpreted as a party id.
+    http.get(`${baseUrl}/duplicates`, ({ request }) => {
+      const url = new URL(request.url);
+      const page = Number(url.searchParams.get('page') ?? '1');
+      const pageSize = Number(url.searchParams.get('pageSize') ?? '20');
+      const pending = sampleDuplicates.filter((d) => d.dismissedAt == null);
+      const start = (page - 1) * pageSize;
+      const items = pending.slice(start, start + pageSize);
+      return HttpResponse.json({ items, totalCount: pending.length });
+    }),
+
+    // ── Duplicate candidates: per-party flat list ────────────────────
+    http.get(`${baseUrl}/:id/duplicate-candidates`, ({ params }) => {
+      const partyId = params.id as string;
+      const rows = sampleDuplicates.filter(
+        (d) => (d.partyId === partyId || d.candidateId === partyId) && d.dismissedAt == null
+      );
+      return HttpResponse.json(rows);
+    }),
+
+    // ── Duplicate candidates: dismiss ────────────────────────────────
+    http.post(`${baseUrl}/duplicates/:id/dismiss`, ({ params }) => {
+      const row = sampleDuplicates.find((d) => d.id === params.id);
+      if (!row) return notFound();
+      row.dismissedAt = new Date().toISOString();
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    // ── Duplicate candidates: merge shortcut ─────────────────────────
+    http.post(`${baseUrl}/duplicates/:id/merge`, async ({ params, request }) => {
+      const row = sampleDuplicates.find((d) => d.id === params.id);
+      if (!row) return notFound();
+
+      const body = (await request.json()) as PartyDuplicateMergeRequest;
+      let loserId: string;
+      if (body.survivorId === row.partyId) {
+        loserId = row.candidateId;
+      } else if (body.survivorId === row.candidateId) {
+        loserId = row.partyId;
+      } else {
+        return HttpResponse.json(
+          { detail: 'survivorId is not part of the candidate pair on the supplied id.' },
+          { status: 422 }
+        );
+      }
+
+      const survivor = findById(body.survivorId);
+      const loser = findById(loserId);
+      if (!survivor || !loser) return notFound();
+
+      // Reuse the same merge response shape — apply minimal demo mutations
+      // so the inbox refresh + party detail refresh both observe the change.
+      loser.status = 'Archived';
+      row.dismissedAt = new Date().toISOString();
+
+      const response: PartyMergeResponse = {
+        survivorId: survivor.id,
+        loserId: loser.id,
+        conflicts: computeConflicts(survivor, loser),
+        rewriteCounts: rewriteCountsFor(loser),
+        dryRun: false,
+      };
+      return HttpResponse.json(response);
     }),
 
     // ── GET detail ───────────────────────────────────────────────────

--- a/packages/@granit/react-parties/src/testing/index.ts
+++ b/packages/@granit/react-parties/src/testing/index.ts
@@ -2,5 +2,5 @@
 // @granit/react-parties/testing — Mock data & MSW handlers
 // ---------------------------------------------------------------------------
 
-export { sampleParties, sampleParty, samplePartyId, toListItem } from './data.js';
+export { sampleDuplicates, sampleParties, sampleParty, samplePartyId, toListItem } from './data.js';
 export { createPartiesHandlers } from './handlers.js';

--- a/packages/@granit/react-parties/tsconfig.json
+++ b/packages/@granit/react-parties/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/parties": ["../parties/src/index.ts"]
+      "@granit/parties": ["../parties/src/index.ts"],
+      "@granit/react-query-engine": ["../react-query-engine/src/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1349,6 +1349,9 @@ importers:
       '@granit/parties':
         specifier: workspace:*
         version: link:../parties
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -7640,7 +7643,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
     optional: true
 
   '@vitest/coverage-v8@4.1.5(vitest@4.1.5)':


### PR DESCRIPTION
## Summary

Implements **Story #1304** (last in Feature #1280, Epic #1278). Wires the new backend duplicate-detection surface (granit-fx/granit-dotnet stories #1297–#1302):

| Method | Path | Auth |
|---|---|---|
| `GET` | `/parties/duplicates` (paged, QueryEngine) | `Parties.Parties.Read` |
| `GET` | `/parties/{id}/duplicate-candidates` | `Parties.Parties.Read` |
| `POST` | `/parties/duplicates/{id}/dismiss` | `Parties.Parties.Manage` |
| `POST` | `/parties/duplicates/{id}/merge` (Idempotency-Key) | `Parties.Parties.Merge` |

## What landed

### `@granit/parties`

- Types: `PartyDuplicateCandidateId`, `PartyDuplicateCandidateResponse`, `DuplicateMatchTier`, `DuplicateMatchSignalResponse`, `PartyDuplicateMergeRequest`.
- Axios functions in `src/api/parties-duplicates-api.ts`: `listDuplicatesForParty`, `dismissPartyDuplicate`, `mergePartyFromDuplicate`.
- The paged inbox endpoint is consumed via **`@granit/react-query-engine`'s `useQueryEndpoint`** — no per-endpoint client wrapper added (the QueryEngine primitives already cover that surface).

### `@granit/react-parties`

- `usePartyDuplicateCandidatesForPartyQuery(partyId)` — TanStack Query hook for the per-party flat list.
- `useDismissPartyDuplicateMutation()` — invalidates `[parties, 'duplicates']` which prefix-matches both the per-party cache and the inbox grid.
- `useMergePartyFromDuplicateMutation()` — auto-generates a UUID v4 `Idempotency-Key` per submission, invalidates duplicates + parties list + both detail caches.
- **`<DuplicatesInbox onMerge?>`** — paged table built on `useQueryEndpoint`. Columns: Score, Tier (color-coded badge), Party A, Party B, Detected, Refreshed, Actions. Internally wraps itself in a `<QueryProvider>` with a stable `queryKeyPrefix` so mutations invalidate it without consumer wiring. Merge button surfaces the row via `onMerge` callback so the consumer composes its own merge UI (typically the `<MergeWizard>` from #1294 with a survivor picker).
- **`<PartyDuplicatesBadge partyId href? renderLink?>`** — small inline pill for the party detail page. Amber when at least one non-Fuzzy candidate is pending, muted gray when only Tier-3 fuzzy. Hidden when zero pending pairs.
- `partiesTranslationsEn` / `partiesTranslationsFr` extended with the `Duplicates.*` namespace (EN + FR with "Tiers" terminology, ICU plural on the badge).
- New peer dep: `@granit/react-query-engine`.

### Mock harness

- `sampleDuplicates` exposes 3 demo rows covering each tier so the showcase mock mode renders a populated inbox + an amber badge on Acme's detail page out of the box.
- `createPartiesHandlers()` extended with the four new endpoints (paged inbox in QueryEngine shape, per-party list, dismiss with mutation, merge shortcut with 422 on bad `survivorId`).

## Convention deviations from the original spec

The original prompt referenced several primitives that don't exist in this monorepo (`useGranitQuery`, `<GranitDataGrid>`, `@granit/react-mergeable`, `<RequirePermission>`, audit-inbox in `@granit/react-auditing`). Verified against develop and adjusted:

- Used the **actual** QueryEngine primitive: `useQueryEndpoint` from `@granit/react-query-engine`.
- Built the table inline with HTML + Tailwind utilities (same convention as `<MergeWizard>`) instead of a non-existent framework `<DataGrid>`. The showcase can wrap in its own grid library if richer ergonomics are needed; a follow-up framework `<GranitDataGrid>` would be welcome but is out of scope here.
- Permission gating delegated to the consumer (same convention as `<MergeWizard>`) since `<RequirePermission>` doesn't exist. JSDoc lists which permission applies to which action.

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — zero warnings
- [x] `pnpm -r build` — both packages emit ESM + d.ts
- [x] `npx vitest run` — **271 files / 2210 tests** pass (+20 in this PR)
- [ ] showcase-admin-react integration (route + dialog wrapping) — separate PR

## Out of scope (per story)

- Online-detection 409 wiring on the create form (Story #1302 follow-up).
- Bulk dismiss (multi-row selection) — single-row actions only in v1.

Refs: granit-fx/granit-dotnet#1304 (story) · #1280 (feature) · #1278 (epic) · depends on this repo's #221 + #223 (already merged on develop)
