### PR TITLE
feat(parties): create-conflict 409 primitives + force / skipDuplicateCheck on createParty

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2574,6 +2574,12 @@
           "members": []
         },
         {
+          "name": "CreatePartyMutationVariables",
+          "kind": "interface",
+          "signature": "interface CreatePartyMutationVariables",
+          "members": []
+        },
+        {
           "name": "MergePartyFromDuplicateMutationVariables",
           "kind": "interface",
           "signature": "interface MergePartyFromDuplicateMutationVariables",

--- a/packages/@granit/parties/src/__tests__/parties-api.test.ts
+++ b/packages/@granit/parties/src/__tests__/parties-api.test.ts
@@ -134,8 +134,47 @@ describe('parties-api', () => {
 
       const result = await createParty(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith(basePath, request);
+      expect(client.post).toHaveBeenCalledWith(basePath, request, {
+        params: undefined,
+        headers: undefined,
+      });
       expect(result).toEqual(sampleParty);
+    });
+
+    it('forwards force=true as a query-string flag', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleParty });
+
+      const request: PartyCreateRequest = {
+        kind: 'Company',
+        name: 'Acme Corp',
+        defaultCurrency: 'EUR',
+      };
+
+      await createParty(client, basePath, request, { force: true });
+
+      expect(client.post).toHaveBeenCalledWith(basePath, request, {
+        params: { force: true },
+        headers: undefined,
+      });
+    });
+
+    it('forwards skipDuplicateCheck as the X-Skip-Duplicate-Check header', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleParty });
+
+      const request: PartyCreateRequest = {
+        kind: 'Company',
+        name: 'Acme Corp',
+        defaultCurrency: 'EUR',
+      };
+
+      await createParty(client, basePath, request, { skipDuplicateCheck: true });
+
+      expect(client.post).toHaveBeenCalledWith(basePath, request, {
+        params: undefined,
+        headers: { 'X-Skip-Duplicate-Check': 'true' },
+      });
     });
   });
 

--- a/packages/@granit/parties/src/api/parties-api.ts
+++ b/packages/@granit/parties/src/api/parties-api.ts
@@ -1,4 +1,5 @@
 import type {
+  CreatePartyOptions,
   PartyAddressId,
   PartyAddressRequest,
   PartyCreateRequest,
@@ -55,14 +56,26 @@ export async function getPartyById(
 /**
  * Create a new party.
  *
- * `POST {basePath}`
+ * `POST {basePath}` — returns the created party on 200/201.
+ *
+ * On a Tier-1 (Deterministic) duplicate match the server returns 409 with a
+ * {@link PartyCreateConflictResponse} body in `error.response.data`. Callers
+ * that want to suppress the check on a per-call basis can pass
+ * `options.force: true` (URL flag) or `options.skipDuplicateCheck: true`
+ * (header) — see {@link CreatePartyOptions}.
  */
 export async function createParty(
   client: AxiosInstance,
   basePath: string,
-  request: PartyCreateRequest
+  request: PartyCreateRequest,
+  options?: CreatePartyOptions
 ): Promise<PartyResponse> {
-  const response = await client.post<PartyResponse>(basePath, request);
+  const params = options?.force ? { force: true } : undefined;
+  const headers = options?.skipDuplicateCheck ? { 'X-Skip-Duplicate-Check': 'true' } : undefined;
+  const response = await client.post<PartyResponse>(basePath, request, {
+    params,
+    headers,
+  });
   return response.data;
 }
 

--- a/packages/@granit/parties/src/index.ts
+++ b/packages/@granit/parties/src/index.ts
@@ -1,6 +1,7 @@
 // Types
 export type {
   AddressKind,
+  CreatePartyOptions,
   DuplicateMatchSignalResponse,
   DuplicateMatchTier,
   EvidenceBlobId,
@@ -9,6 +10,7 @@ export type {
   PartyAddressId,
   PartyAddressRequest,
   PartyAddressResponse,
+  PartyCreateConflictResponse,
   PartyCreateRequest,
   PartyDuplicateCandidateId,
   PartyDuplicateCandidateResponse,

--- a/packages/@granit/parties/src/types.ts
+++ b/packages/@granit/parties/src/types.ts
@@ -161,6 +161,41 @@ export interface PartyCreateRequest {
   readonly internalNotes?: string | null;
 }
 
+/**
+ * Optional knobs on {@link createParty}. Carry the per-call duplicate-check
+ * bypass flags surfaced by the admin endpoints.
+ *
+ * - `force` translates to `?force=true` on the URL — UI flow ("Create anyway"
+ *   button on the conflict dialog).
+ * - `skipDuplicateCheck` translates to the `X-Skip-Duplicate-Check: true`
+ *   header — bulk-import flow where the caller has already de-duplicated
+ *   upstream and doesn't want the per-row Tier-1 check to run.
+ *
+ * Both are independent and can be combined (header wins server-side).
+ */
+export interface CreatePartyOptions {
+  readonly force?: boolean;
+  readonly skipDuplicateCheck?: boolean;
+}
+
+/**
+ * 409 response body returned by `POST {basePath}` when the server's Tier-1
+ * (Deterministic) duplicate detector matches the inbound payload against an
+ * existing party. The client typically renders a "potential duplicates"
+ * dialog letting the operator pick: use the existing party, retry with
+ * `force: true`, or merge into the matched party.
+ *
+ * `candidates` carries the lightweight summary for each match (max 5 rows).
+ * `tier` always equals `'Deterministic'` today — the `Blocking` and `Fuzzy`
+ * tiers run asynchronously via the scan job and never short-circuit a create.
+ */
+export interface PartyCreateConflictResponse {
+  readonly title: string;
+  readonly detail: string;
+  readonly tier: DuplicateMatchTier;
+  readonly candidates: readonly PartyListItemResponse[];
+}
+
 /** Request payload to update a party's identity fields. */
 export interface PartyUpdateRequest {
   readonly name: string;

--- a/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
@@ -172,10 +172,39 @@ describe('use-parties', () => {
         wrapper: createWrapper(client),
       });
 
-      result.current.mutate(request);
+      result.current.mutate({ request });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/v1/parties', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/parties', request, {
+        params: undefined,
+        headers: undefined,
+      });
+    });
+
+    it('forwards force + skipDuplicateCheck options to the request', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleParty });
+
+      const request: PartyCreateRequest = {
+        kind: 'Company',
+        name: 'Acme',
+        defaultCurrency: 'EUR',
+      };
+
+      const { result } = renderHook(() => useCreatePartyMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({
+        request,
+        options: { force: true, skipDuplicateCheck: true },
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/parties', request, {
+        params: { force: true },
+        headers: { 'X-Skip-Duplicate-Check': 'true' },
+      });
     });
   });
 

--- a/packages/@granit/react-parties/src/hooks/use-parties.ts
+++ b/packages/@granit/react-parties/src/hooks/use-parties.ts
@@ -25,6 +25,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { buildPartiesQueryKey, usePartiesConfig } from '../providers/parties-provider.js';
 
 import type {
+  CreatePartyOptions,
   PartyAddressId,
   PartyAddressRequest,
   PartyCreateRequest,
@@ -109,18 +110,33 @@ function useInvalidator() {
   };
 }
 
+/**
+ * Variables for {@link useCreatePartyMutation}. Carries the request body plus
+ * optional per-call duplicate-check bypass flags ({@link CreatePartyOptions}).
+ *
+ * On a Tier-1 duplicate match the server returns 409; the AxiosError surfaces
+ * a {@link PartyCreateConflictResponse} body in `error.response.data` so the
+ * UI can render the "potential duplicates" dialog (use existing / create
+ * anyway / merge into existing).
+ */
+export interface CreatePartyMutationVariables {
+  readonly request: PartyCreateRequest;
+  readonly options?: CreatePartyOptions;
+}
+
 /** Create a new party. Invalidates the list query on success. */
 export function useCreatePartyMutation(): UseMutationResult<
   PartyResponse,
   Error,
-  PartyCreateRequest
+  CreatePartyMutationVariables
 > {
   const config = usePartiesConfig();
   const basePath = config.basePath!;
   const { invalidateList } = useInvalidator();
 
   return useMutation({
-    mutationFn: (request: PartyCreateRequest) => createParty(config.client, basePath, request),
+    mutationFn: ({ request, options }: CreatePartyMutationVariables) =>
+      createParty(config.client, basePath, request, options),
     onSuccess: () => {
       void invalidateList();
     },

--- a/packages/@granit/react-parties/src/index.ts
+++ b/packages/@granit/react-parties/src/index.ts
@@ -33,6 +33,7 @@ export {
 // Hooks — merge
 export { useMergePartyMutation, useMergePartyPreviewQuery } from './hooks/use-party-merge.js';
 export type { MergePartyMutationVariables } from './hooks/use-party-merge.js';
+export type { CreatePartyMutationVariables } from './hooks/use-parties.js';
 
 // Hooks — duplicate detection
 export {

--- a/packages/@granit/react-parties/src/testing/handlers.ts
+++ b/packages/@granit/react-parties/src/testing/handlers.ts
@@ -9,6 +9,7 @@ import type {
   FieldConflictResponse,
   PartyAddressId,
   PartyAddressRequest,
+  PartyCreateConflictResponse,
   PartyCreateRequest,
   PartyDuplicateMergeRequest,
   PartyEmailId,
@@ -145,6 +146,31 @@ export function createPartiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // ── POST create ──────────────────────────────────────────────────
     http.post(baseUrl, async ({ request }) => {
       const body = (await request.json()) as PartyCreateRequest;
+
+      // Tier-1 (Deterministic) duplicate detection: case-insensitive name
+      // match against active parties. Bypassable via `?force=true` (URL flag)
+      // or `X-Skip-Duplicate-Check: true` (header) — mirrors the production
+      // contract surfaced by `createParty` / `CreatePartyOptions`.
+      const url = new URL(request.url);
+      const forceFlag = url.searchParams.get('force') === 'true';
+      const skipHeader = request.headers.get('x-skip-duplicate-check') === 'true';
+      if (!forceFlag && !skipHeader) {
+        const needle = body.name.trim().toLowerCase();
+        const matches = sampleParties
+          .filter((p) => p.status !== 'Archived' && p.name.toLowerCase() === needle)
+          .map(toListItem)
+          .slice(0, 5);
+        if (matches.length > 0) {
+          const conflict: PartyCreateConflictResponse = {
+            title: 'Duplicate party detected',
+            detail: `A ${matches.length === 1 ? 'party' : 'few parties'} with the name "${body.name}" already exist. Pick how to proceed.`,
+            tier: 'Deterministic',
+            candidates: matches,
+          };
+          return HttpResponse.json(conflict, { status: 409 });
+        }
+      }
+
       createCounter += 1;
       const newParty: Mutable<PartyResponse> = {
         id: toEntityId<'Party'>(


### PR DESCRIPTION
## Summary

Adds the missing primitive that the showcase admin's "Potential duplicate detected" dialog needs to consume the existing backend `POST /parties` 409 contract. Pre-requisite of the showcase's parties-duplicates-inbox PR.

### \`@granit/parties\`

- New \`CreatePartyOptions\` interface — \`{ force?: boolean; skipDuplicateCheck?: boolean }\`.
- New \`PartyCreateConflictResponse\` body shape returned on 409 from \`POST {basePath}\` — \`{ title, detail, tier, candidates: PartyListItemResponse[] }\`.
- \`createParty(client, basePath, request, options?)\` — fourth arg threads \`?force=true\` onto the URL and/or \`X-Skip-Duplicate-Check: true\` onto the headers.

### \`@granit/react-parties\`

- \`useCreatePartyMutation\` variables change from \`PartyCreateRequest\` to \`{ request, options? }\` (new exported \`CreatePartyMutationVariables\` type). On 409 the AxiosError \`response.data\` is typed as \`PartyCreateConflictResponse\`.
- \`createPartiesHandlers\` POST handler now emits 409 when an inbound \`name\` matches an existing active party (case-insensitive). Honors \`?force=true\` and the \`X-Skip-Duplicate-Check\` header to bypass the check — exercises the same contract production exposes.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` (parties + react-parties) — clean
- [x] \`pnpm exec eslint packages/@granit/parties/src packages/@granit/react-parties/src --max-warnings 0\` — clean
- [x] \`pnpm vitest run packages/@granit/parties packages/@granit/react-parties\` — 84/84 passing (+3 new tests for the option-flag wiring)

## Breaking change

\`useCreatePartyMutation\`'s variables shape. The only consumer is granit-fx/granit-showcase-admin-react and the showcase update ships in lockstep — there's a companion PR there that targets \`develop\` (will be opened after this lands).