### PR TITLE
refactor(api-client): route every consumer through @granit/api-client

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -43,7 +43,7 @@
         {
           "name": "sessionHeartbeat",
           "kind": "function",
-          "signature": "async function sessionHeartbeat( client: AxiosInstance, basePath: string ): Promise<void>"
+          "signature": "async function sessionHeartbeat(client: AxiosInstance, basePath: string): Promise<void>"
         },
         {
           "name": "getAccountSettings",
@@ -1212,7 +1212,7 @@
         {
           "name": "useAIConfig",
           "kind": "function",
-          "signature": "function useAIConfig(): AIConfig"
+          "signature": "function useAIConfig(): ResolvedAIConfig"
         },
         {
           "name": "AIConfig",
@@ -1353,7 +1353,7 @@
         {
           "name": "useAuditLogConfig",
           "kind": "function",
-          "signature": "function useAuditLogConfig(): AuditLogConfig"
+          "signature": "function useAuditLogConfig(): ResolvedAuditLogConfig"
         },
         {
           "name": "AuditLogConfig",
@@ -2468,7 +2468,7 @@
         {
           "name": "useMobilePushConfig",
           "kind": "function",
-          "signature": "function useMobilePushConfig(): MobilePushProviderConfig"
+          "signature": "function useMobilePushConfig(): ResolvedMobilePushProviderConfig"
         }
       ]
     },
@@ -2906,7 +2906,7 @@
         {
           "name": "useTaxConfig",
           "kind": "function",
-          "signature": "function useTaxConfig(): TaxConfig"
+          "signature": "function useTaxConfig(): ResolvedTaxConfig"
         },
         {
           "name": "TaxConfig",

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ This file lists the third-party libraries used by the **granit-front** project
 along with their respective licenses. It is updated whenever an external
 dependency is added or modified.
 
-Last updated: 2026-04-27
+Last updated: 2026-04-28
 
 ---
 
@@ -35,7 +35,7 @@ Last updated: 2026-04-27
 | @eslint/js                      | 10.0.1  | OpenJS Foundation                          |
 | @microsoft/fetch-event-source   | 2.0.1   | Copyright (c) Microsoft Corporation        |
 | @microsoft/signalr              | 10.0.0  | Copyright (c) .NET Foundation              |
-| @tanstack/react-query           | 5.99.0  | Copyright (c) Tanner Linsley               |
+| @tanstack/react-query           | 5.100.5 | Copyright (c) Tanner Linsley               |
 | @tanstack/react-virtual         | 3.13.24 | Copyright (c) Tanner Linsley               |
 | @testing-library/jest-dom       | 6.9.1   | Copyright (c) Testing Library Contributors |
 | @testing-library/react          | 16.3.2  | Copyright (c) Testing Library Contributors |
@@ -57,7 +57,7 @@ Last updated: 2026-04-27
 | prettier                        | 3.8.3   | Copyright (c) James Long                   |
 | react                           | 19.2.5  | Copyright (c) Meta Platforms, Inc.         |
 | react-dom                       | 19.2.5  | Copyright (c) Meta Platforms, Inc.         |
-| react-hook-form                 | 7.72.1  | Copyright (c) react-hook-form Contributors |
+| react-hook-form                 | 7.74.0  | Copyright (c) react-hook-form Contributors |
 | react-i18next                   | 17.0.4  | Copyright (c) i18next Contributors         |
 | tailwind-merge                  | 3.5.0   | Copyright (c) Dany Castillo                |
 | tsup                            | 8.5.1   | Copyright (c) EGOIST                       |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,21 @@ export default tseslint.config(
           alphabetize: { order: 'asc', caseInsensitive: true },
         },
       ],
+      // All Granit packages MUST go through @granit/api-client for HTTP client
+      // types and instance creation. Direct `axios` imports bypass the framework
+      // façade (interceptors, auth, CSRF, ProblemDetails) and are forbidden
+      // outside the allow-list below.
+      'no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'axios',
+              message: "Import Axios types from '@granit/api-client' instead. The api-client package owns the HTTP client façade (createApiClient, AxiosInstance re-export, interceptors).",
+            },
+          ],
+        },
+      ],
     },
   },
 
@@ -29,6 +44,24 @@ export default tseslint.config(
   {
     files: ['packages/@granit/logger/**/*.ts'],
     rules: { 'no-console': 'off' },
+  },
+
+  // The api-client package IS the façade — it must import from axios.
+  // The allow-list below covers infra packages that legitimately sit below
+  // the axios client in the dependency graph (auth bootstrap, telemetry,
+  // Fetch-API-bound transports). Tests can mock axios freely.
+  {
+    files: [
+      'packages/@granit/api-client/**/*.{ts,tsx}',
+      'packages/@granit/bff/**/*.{ts,tsx}',
+      'packages/@granit/react-bff/**/*.{ts,tsx}',
+      'packages/@granit/logger-otlp/**/*.{ts,tsx}',
+      'packages/@granit/react-tracing/**/*.{ts,tsx}',
+      'packages/@granit/notifications-sse/**/*.{ts,tsx}',
+      '**/__tests__/**/*.{ts,tsx}',
+      '**/*.test.{ts,tsx}',
+    ],
+    rules: { 'no-restricted-imports': 'off' },
   },
 
   // Test files — relax some rules

--- a/packages/@granit/account/package.json
+++ b/packages/@granit/account/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/account/src/api/account-deletion-api.ts
+++ b/packages/@granit/account/src/api/account-deletion-api.ts
@@ -1,5 +1,5 @@
 import type { AccountDeleteRequest } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Request account deletion (GDPR Art. 17). Deletion is asynchronous.

--- a/packages/@granit/account/src/api/account-email-api.ts
+++ b/packages/@granit/account/src/api/account-email-api.ts
@@ -2,7 +2,7 @@ import type {
   AccountChangeEmailRequest,
   AccountConfirmEmailChangeRequest,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Request an email change (authenticated).

--- a/packages/@granit/account/src/api/account-external-login-api.ts
+++ b/packages/@granit/account/src/api/account-external-login-api.ts
@@ -2,7 +2,7 @@ import type {
   AccountExternalLoginCallbackResponse,
   AccountExternalLoginInfo,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List linked external login providers for the current user.

--- a/packages/@granit/account/src/api/account-passkey-api.ts
+++ b/packages/@granit/account/src/api/account-passkey-api.ts
@@ -4,7 +4,7 @@ import type {
   AccountPasskeyRegistrationRequest,
   AccountPasskeyRenameRequest,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all registered passkeys for the current user.

--- a/packages/@granit/account/src/api/account-password-api.ts
+++ b/packages/@granit/account/src/api/account-password-api.ts
@@ -3,7 +3,7 @@ import type {
   AccountPasswordChangeRequest,
   AccountPasswordResetRequest,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Change the current user's password (authenticated).

--- a/packages/@granit/account/src/api/account-profile-api.ts
+++ b/packages/@granit/account/src/api/account-profile-api.ts
@@ -1,8 +1,5 @@
-import type {
-  AccountProfileResponse,
-  AccountProfileUpdateRequest,
-} from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AccountProfileResponse, AccountProfileUpdateRequest } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Get the current user's profile.

--- a/packages/@granit/account/src/api/account-registration-api.ts
+++ b/packages/@granit/account/src/api/account-registration-api.ts
@@ -1,5 +1,5 @@
 import type { AccountRegisterRequest, AccountRegisterResponse } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Register a new user account.

--- a/packages/@granit/account/src/api/account-session-api.ts
+++ b/packages/@granit/account/src/api/account-session-api.ts
@@ -1,5 +1,5 @@
 import type { AccountImpersonationResult } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Send a session heartbeat to prevent idle timeout.
@@ -7,10 +7,7 @@ import type { AxiosInstance } from 'axios';
  *
  * `POST {basePath}/session/heartbeat`
  */
-export async function sessionHeartbeat(
-  client: AxiosInstance,
-  basePath: string
-): Promise<void> {
+export async function sessionHeartbeat(client: AxiosInstance, basePath: string): Promise<void> {
   await client.post(`${basePath}/session/heartbeat`);
 }
 

--- a/packages/@granit/account/src/api/account-settings-api.ts
+++ b/packages/@granit/account/src/api/account-settings-api.ts
@@ -1,5 +1,5 @@
 import type { AccountSettingsResponse } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Fetch the public account configuration (anonymous).

--- a/packages/@granit/account/src/api/account-two-factor-api.ts
+++ b/packages/@granit/account/src/api/account-two-factor-api.ts
@@ -5,7 +5,7 @@ import type {
   AccountTwoFactorEnableResponse,
   AccountTwoFactorStatusResponse,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Get the current user's 2FA status.
@@ -57,10 +57,7 @@ export async function enableTwoFactor(
  *
  * `POST {basePath}/two-factor/disable`
  */
-export async function disableTwoFactor(
-  client: AxiosInstance,
-  basePath: string
-): Promise<void> {
+export async function disableTwoFactor(client: AxiosInstance, basePath: string): Promise<void> {
   await client.post(`${basePath}/two-factor/disable`);
 }
 

--- a/packages/@granit/ai/package.json
+++ b/packages/@granit/ai/package.json
@@ -14,11 +14,12 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/ai/src/api/ai-chat-api.ts
+++ b/packages/@granit/ai/src/api/ai-chat-api.ts
@@ -11,7 +11,7 @@ import type {
   AIChatStreamChunk,
   AIChatStreamUsage,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Send a chat completion request and return the full response.

--- a/packages/@granit/ai/src/api/ai-embeddings-api.ts
+++ b/packages/@granit/ai/src/api/ai-embeddings-api.ts
@@ -4,7 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import type { AIEmbeddingRequest, AIEmbeddingResponse } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Generate embeddings for a batch of text inputs.

--- a/packages/@granit/ai/src/api/ai-providers-api.ts
+++ b/packages/@granit/ai/src/api/ai-providers-api.ts
@@ -4,7 +4,7 @@
 // ---------------------------------------------------------------------------
 
 import type { AIProviderModelResponse, AIProviderResponse } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all registered AI providers.

--- a/packages/@granit/ai/src/api/ai-workspaces-api.ts
+++ b/packages/@granit/ai/src/api/ai-workspaces-api.ts
@@ -9,7 +9,7 @@ import type {
   AIWorkspaceResponse,
   AIWorkspaceUpdateRequest,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all AI workspaces.

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -223,3 +223,21 @@ export type { ProblemDetailsPayload, ValidationDetails } from './errors.js';
 // Idempotency tombstone helpers — see ./idempotency.ts.
 export { isIdempotencyTombstoned, readIdempotencyTombstone } from './idempotency.js';
 export type { IdempotencyTombstoneInfo } from './idempotency.js';
+
+// ---------------------------------------------------------------------------
+// Axios type façade — single entry point for the framework
+// ---------------------------------------------------------------------------
+// All Granit packages MUST import these types from `@granit/api-client`,
+// never directly from `axios`. This keeps the HTTP client implementation
+// behind a single seam: future swaps, branding, or interceptor contracts can
+// land here without touching every consumer.
+//
+// The ESLint rule `no-restricted-imports` enforces this — see eslint.config.mjs.
+
+export type {
+  AxiosError,
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';

--- a/packages/@granit/auditing/package.json
+++ b/packages/@granit/auditing/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/auditing/src/api/audit-log-api.ts
+++ b/packages/@granit/auditing/src/api/audit-log-api.ts
@@ -1,6 +1,6 @@
 import type { AuditEntryDetail, AuditListParams, AuditPage } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PaginationParams } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 /**
  * List audit log entries with optional filters and pagination.

--- a/packages/@granit/authentication-local/package.json
+++ b/packages/@granit/authentication-local/package.json
@@ -14,9 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/authentication-local/src/api/account-login-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-login-api.ts
@@ -1,5 +1,5 @@
 import type { AccountLoginRequest, AccountLoginResponse } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Authenticate a user via local credentials (email/username + password).

--- a/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
@@ -2,7 +2,7 @@ import type {
   AccountLoginResponse,
   AccountPasskeyAssertionCompleteRequest,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Begin a WebAuthn assertion ceremony for passkey login (anonymous).

--- a/packages/@granit/authentication-local/src/api/account-two-factor-login-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-two-factor-login-api.ts
@@ -1,5 +1,5 @@
 import type { AccountLoginResponse, AccountTwoFactorLoginRequest } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Complete a two-factor login after the initial login returned

--- a/packages/@granit/authorization/package.json
+++ b/packages/@granit/authorization/package.json
@@ -14,7 +14,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {
@@ -24,5 +24,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/authorization/src/types/index.ts
+++ b/packages/@granit/authorization/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 // ---------------------------------------------------------------------------
 // Permissions (usePermissions hook)

--- a/packages/@granit/background-jobs/package.json
+++ b/packages/@granit/background-jobs/package.json
@@ -14,11 +14,12 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/background-jobs/src/api/background-jobs-api.ts
+++ b/packages/@granit/background-jobs/src/api/background-jobs-api.ts
@@ -1,6 +1,6 @@
 import type { BackgroundJobListParams, BackgroundJobStatus } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 /**
  * List a paginated collection of all background jobs.

--- a/packages/@granit/blob-storage/package.json
+++ b/packages/@granit/blob-storage/package.json
@@ -14,9 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/blob-storage/src/api/blob-storage-api.ts
+++ b/packages/@granit/blob-storage/src/api/blob-storage-api.ts
@@ -9,7 +9,7 @@ import type {
   BlobUploadInitiateRequest,
   BlobUploadInitiateResponse,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Initiate a direct-to-cloud upload and get a pre-signed URL.

--- a/packages/@granit/customer-balance/package.json
+++ b/packages/@granit/customer-balance/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
+++ b/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
@@ -32,7 +32,7 @@ const sampleTransaction: BalanceTransactionResponse = {
   createdAt: '2026-04-01T10:00:00Z',
 };
 
-const basePath = '/api/granit/customer-balance';
+const basePath = '/customer-balance';
 
 describe('customer-balance-api', () => {
   describe('getCustomerBalance', () => {

--- a/packages/@granit/customer-balance/src/api/customer-balance-api.ts
+++ b/packages/@granit/customer-balance/src/api/customer-balance-api.ts
@@ -3,7 +3,7 @@ import type {
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Fetch the current customer balance.

--- a/packages/@granit/data-exchange/package.json
+++ b/packages/@granit/data-exchange/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/utils": "workspace:*",
-    "axios": "*"
+    "@granit/utils": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/data-exchange/src/export/api/export-api.ts
+++ b/packages/@granit/data-exchange/src/export/api/export-api.ts
@@ -1,7 +1,7 @@
 import type { ExportDefinitionResponse, ExportField } from '../types/export-definition.js';
 import type { CreateExportJobRequest, ExportJobResponse } from '../types/export-job.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult, PaginationParams } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 /** Query parameters for listing export jobs. */
 export type ExportJobListParams = PaginationParams & {

--- a/packages/@granit/data-exchange/src/export/api/preset-api.ts
+++ b/packages/@granit/data-exchange/src/export/api/preset-api.ts
@@ -1,5 +1,5 @@
 import type { ExportPresetResponse, SaveExportPresetRequest } from '../types/export-preset.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Lists saved export presets for a given definition.

--- a/packages/@granit/data-exchange/src/import/api/import-api.ts
+++ b/packages/@granit/data-exchange/src/import/api/import-api.ts
@@ -1,8 +1,8 @@
 import type { ImportJobResponse } from '../types/import-job.js';
 import type { ConfirmMappingsRequest, ImportPreviewResponse } from '../types/import-preview.js';
 import type { ImportReportResponse } from '../types/import-report.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult, PaginationParams } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 /** Query parameters for listing import jobs. */
 export type ImportJobListParams = PaginationParams & {
@@ -98,7 +98,9 @@ export async function getImportJob(
   basePath: string,
   jobId: string
 ): Promise<ImportJobResponse> {
-  const response = await client.get<ImportJobResponse>(`${basePath}/import/${encodeURIComponent(jobId)}`);
+  const response = await client.get<ImportJobResponse>(
+    `${basePath}/import/${encodeURIComponent(jobId)}`
+  );
   return response.data;
 }
 

--- a/packages/@granit/data-lookup/README.md
+++ b/packages/@granit/data-lookup/README.md
@@ -9,7 +9,7 @@ QueryEngine filters and form dropdowns.
 - `LookupDescriptor`, `LookupKind`, `LookupItem`, `LookupResult`, `LookupManifest`,
   `LookupQueryParams` — wire types mirroring the backend contract.
 - `searchLookup`, `resolveLookup`, `fetchLookupManifest` — `axios` helpers for the
-  `/api/granit/lookups` endpoints.
+  `/lookups` endpoints.
 - `findMissingScopeKey`, `isScopeSatisfied` — Empty Scope Trap guards shared with
   the React hook layer.
 

--- a/packages/@granit/data-lookup/package.json
+++ b/packages/@granit/data-lookup/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/data-lookup/src/__tests__/lookup-client.test.ts
+++ b/packages/@granit/data-lookup/src/__tests__/lookup-client.test.ts
@@ -43,7 +43,7 @@ describe('buildSearchQuery', () => {
 });
 
 describe('searchLookup', () => {
-  it('hits /api/granit/lookups/{name} by default', async () => {
+  it('hits /lookups/{name} by default', async () => {
     const client = createMockClient();
     const payload: LookupResult = { items: [{ value: '1', label: 'Acme' }], totalCount: 1 };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(payload));

--- a/packages/@granit/data-lookup/src/api/lookup-client.ts
+++ b/packages/@granit/data-lookup/src/api/lookup-client.ts
@@ -8,7 +8,7 @@ import type {
 import type { AxiosInstance } from 'axios';
 
 /** Default route prefix used by the backend `MapGranitDataLookups()` extension. */
-export const DEFAULT_LOOKUP_BASE_PATH = '/api/granit/lookups';
+export const DEFAULT_LOOKUP_BASE_PATH = '/lookups';
 
 /** Options for {@link searchLookup} and {@link resolveLookup}. */
 export interface LookupClientOptions {

--- a/packages/@granit/data-lookup/src/api/lookup-client.ts
+++ b/packages/@granit/data-lookup/src/api/lookup-client.ts
@@ -5,7 +5,7 @@ import type {
   LookupQueryParams,
   LookupResult,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /** Default route prefix used by the backend `MapGranitDataLookups()` extension. */
 export const DEFAULT_LOOKUP_BASE_PATH = '/lookups';

--- a/packages/@granit/data-lookup/src/types/lookup-descriptor.ts
+++ b/packages/@granit/data-lookup/src/types/lookup-descriptor.ts
@@ -11,7 +11,7 @@ export type LookupKind = 'QueryEngine' | 'Simple' | 'ReferenceData' | 'Enum';
  * the frontend to render a typeahead picker.
  *
  * Exactly one of `name` or `endpoint` must be provided:
- * - `name`: resolved against the central `/api/granit/lookups/{name}` registry
+ * - `name`: resolved against the central `/lookups/{name}` registry
  *   (preferred).
  * - `endpoint`: absolute or relative URL for a bespoke source that returns the
  *   canonical {@link LookupResult} shape.

--- a/packages/@granit/data-lookup/src/types/lookup-item.ts
+++ b/packages/@granit/data-lookup/src/types/lookup-item.ts
@@ -28,7 +28,7 @@ export interface LookupResult {
 
 /**
  * Public metadata about a registered lookup source, returned by
- * `GET /api/granit/lookups`.
+ * `GET /lookups`.
  */
 export interface LookupManifestEntry {
   readonly name: string;
@@ -37,7 +37,7 @@ export interface LookupManifestEntry {
   readonly scopeKeys: readonly string[];
 }
 
-/** Response shape of `GET /api/granit/lookups`. */
+/** Response shape of `GET /lookups`. */
 export interface LookupManifest {
   readonly lookups: readonly LookupManifestEntry[];
 }

--- a/packages/@granit/diagnostics/package.json
+++ b/packages/@granit/diagnostics/package.json
@@ -14,9 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/diagnostics/src/api/diagnostics-api.ts
+++ b/packages/@granit/diagnostics/src/api/diagnostics-api.ts
@@ -1,5 +1,5 @@
 import type { MonitoringHealthResponse } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /** Default base path for the diagnostics API. */
 export const DEFAULT_DIAGNOSTICS_BASE_PATH = '/api/v1/diagnostics';

--- a/packages/@granit/features/package.json
+++ b/packages/@granit/features/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/features/src/__tests__/features-api.test.ts
+++ b/packages/@granit/features/src/__tests__/features-api.test.ts
@@ -11,7 +11,7 @@ import {
 
 import type { FeatureGroupResponse, FeatureValueResponse } from '../types.js';
 
-const basePath = '/api/granit/features';
+const basePath = '/features';
 
 const sampleGroup: FeatureGroupResponse = {
   name: 'ui',

--- a/packages/@granit/features/src/api/features-api.ts
+++ b/packages/@granit/features/src/api/features-api.ts
@@ -3,7 +3,7 @@ import type {
   FeatureValueResponse,
   SetFeatureOverrideRequest,
 } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Fetch all feature definitions grouped by category.

--- a/packages/@granit/idempotency/package.json
+++ b/packages/@granit/idempotency/package.json
@@ -14,8 +14,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*",
-    "axios": "^1.0.0"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {
@@ -25,5 +24,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/idempotency/src/index.ts
+++ b/packages/@granit/idempotency/src/index.ts
@@ -1,6 +1,6 @@
 import { isIdempotencyTombstoned, setIdempotencyKeyGenerator } from '@granit/api-client';
 
-import type { InternalAxiosRequestConfig } from 'axios';
+import type { InternalAxiosRequestConfig } from '@granit/api-client';
 
 // Re-export the tombstone helpers so consumers only need to depend on
 // `@granit/idempotency` to handle idempotency end-to-end (generation + retry).

--- a/packages/@granit/identity/package.json
+++ b/packages/@granit/identity/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/identity/src/api/identity-capabilities-api.ts
+++ b/packages/@granit/identity/src/api/identity-capabilities-api.ts
@@ -1,5 +1,5 @@
 import type { IdentityProviderCapabilities } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Get the active identity provider's capabilities.

--- a/packages/@granit/identity/src/api/identity-provider-group-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-group-api.ts
@@ -1,6 +1,6 @@
 import type { IdentityGroup } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { UserId } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 /**
  * List all groups from the identity provider.

--- a/packages/@granit/identity/src/api/identity-provider-password-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-password-api.ts
@@ -1,6 +1,6 @@
 import type { IdentityPasswordChangedAtResponse } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { UserId } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 /**
  * Get the last password change timestamp for a user.

--- a/packages/@granit/identity/src/api/identity-provider-role-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-role-api.ts
@@ -1,6 +1,6 @@
 import type { IdentityRole, IdentityUser } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { UserId } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 /**
  * List all roles from the identity provider.

--- a/packages/@granit/identity/src/api/identity-provider-session-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-session-api.ts
@@ -1,6 +1,6 @@
 import type { IdentityDeviceActivity, IdentitySession, IdentitySessionId } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { UserId } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 /**
  * List active sessions for a user.

--- a/packages/@granit/identity/src/api/identity-provider-user-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-user-api.ts
@@ -3,8 +3,8 @@ import type {
   IdentityUserCreateRequest,
   IdentityUserUpdateRequest,
 } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { UserId } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 export type IdentityProviderUserListParams = {
   readonly search?: string;

--- a/packages/@granit/identity/src/api/identity-user-cache-api.ts
+++ b/packages/@granit/identity/src/api/identity-user-cache-api.ts
@@ -6,8 +6,8 @@ import type {
   IdentityUserListParams,
   IdentityUserPage,
 } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { UserId } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 /**
  * Search cached identity users with optional filtering and pagination.

--- a/packages/@granit/invoicing/package.json
+++ b/packages/@granit/invoicing/package.json
@@ -14,11 +14,12 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
+++ b/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
@@ -54,9 +54,9 @@ describe('invoicing-api', () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: [sampleInvoice] });
 
-      const result = await listInvoices(client, '/api/granit/invoicing');
+      const result = await listInvoices(client, '/invoicing');
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/invoicing/invoices');
+      expect(client.get).toHaveBeenCalledWith('/invoicing/invoices');
       expect(result).toEqual([sampleInvoice]);
     });
 
@@ -75,9 +75,9 @@ describe('invoicing-api', () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: sampleInvoice });
 
-      const result = await getInvoiceById(client, '/api/granit/invoicing', 'inv-1');
+      const result = await getInvoiceById(client, '/invoicing', 'inv-1');
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/invoicing/invoices/inv-1');
+      expect(client.get).toHaveBeenCalledWith('/invoicing/invoices/inv-1');
       expect(result).toEqual(sampleInvoice);
     });
 
@@ -85,10 +85,10 @@ describe('invoicing-api', () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: sampleInvoice });
 
-      await getInvoiceById(client, '/api/granit/invoicing', 'inv/special&id');
+      await getInvoiceById(client, '/invoicing', 'inv/special&id');
 
       expect(client.get).toHaveBeenCalledWith(
-        `/api/granit/invoicing/invoices/${encodeURIComponent('inv/special&id')}`
+        `/invoicing/invoices/${encodeURIComponent('inv/special&id')}`
       );
     });
   });
@@ -99,9 +99,9 @@ describe('invoicing-api', () => {
       const pdfBlob = new Blob(['%PDF-1.4'], { type: 'application/pdf' });
       vi.mocked(client.get).mockResolvedValue({ data: pdfBlob });
 
-      const result = await downloadInvoicePdf(client, '/api/granit/invoicing', 'inv-1');
+      const result = await downloadInvoicePdf(client, '/invoicing', 'inv-1');
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/invoicing/invoices/inv-1/pdf', {
+      expect(client.get).toHaveBeenCalledWith('/invoicing/invoices/inv-1/pdf', {
         responseType: 'blob',
       });
       expect(result).toBe(pdfBlob);
@@ -112,10 +112,10 @@ describe('invoicing-api', () => {
       const pdfBlob = new Blob(['%PDF-1.4'], { type: 'application/pdf' });
       vi.mocked(client.get).mockResolvedValue({ data: pdfBlob });
 
-      await downloadInvoicePdf(client, '/api/granit/invoicing', 'inv/special&id');
+      await downloadInvoicePdf(client, '/invoicing', 'inv/special&id');
 
       expect(client.get).toHaveBeenCalledWith(
-        `/api/granit/invoicing/invoices/${encodeURIComponent('inv/special&id')}/pdf`,
+        `/invoicing/invoices/${encodeURIComponent('inv/special&id')}/pdf`,
         { responseType: 'blob' }
       );
     });
@@ -137,9 +137,9 @@ describe('invoicing-api', () => {
         periodEnd: '2026-04-01T00:00:00Z',
       };
 
-      const result = await createInvoice(client, '/api/granit/invoicing', request);
+      const result = await createInvoice(client, '/invoicing', request);
 
-      expect(client.post).toHaveBeenCalledWith('/api/granit/invoicing/invoices', request);
+      expect(client.post).toHaveBeenCalledWith('/invoicing/invoices', request);
       expect(result).toEqual(sampleInvoice);
     });
 
@@ -166,7 +166,7 @@ describe('invoicing-api', () => {
         periodEnd: null,
       };
 
-      const result = await createInvoice(client, '/api/granit/invoicing', request);
+      const result = await createInvoice(client, '/invoicing', request);
 
       expect(result.documentType).toBe('CreditNote');
       expect(result.parentInvoiceId).toBe('inv-1');

--- a/packages/@granit/invoicing/src/api/invoicing-api.ts
+++ b/packages/@granit/invoicing/src/api/invoicing-api.ts
@@ -1,5 +1,5 @@
 import type { InvoiceCreateRequest, InvoiceResponse } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all invoices.

--- a/packages/@granit/localization/package.json
+++ b/packages/@granit/localization/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/storage": "workspace:*",
     "@granit/types": "workspace:*",
-    "axios": "*",
     "i18next": "^25.0.0"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/localization/src/api/localization-admin-api.ts
+++ b/packages/@granit/localization/src/api/localization-admin-api.ts
@@ -1,5 +1,5 @@
 import type { AdminLanguage } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all languages with admin status.

--- a/packages/@granit/metering/package.json
+++ b/packages/@granit/metering/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/metering/src/__tests__/metering-api.test.ts
+++ b/packages/@granit/metering/src/__tests__/metering-api.test.ts
@@ -44,7 +44,7 @@ import type {
 } from '@granit/query-engine';
 import type { ISODateString, TenantId } from '@granit/types';
 
-const basePath = '/api/granit/metering';
+const basePath = '/metering';
 
 const sampleMeter: MeterDefinitionResponse = {
   id: 'meter-1',
@@ -81,7 +81,7 @@ describe('metering-api', () => {
 
       const result = await listActiveMeters(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meters');
+      expect(client.get).toHaveBeenCalledWith('/metering/meters');
       expect(result).toEqual([sampleMeter]);
     });
   });
@@ -93,7 +93,7 @@ describe('metering-api', () => {
 
       const result = await getMeterDefinition(client, basePath, 'meter-1');
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1');
+      expect(client.get).toHaveBeenCalledWith('/metering/meters/meter-1');
       expect(result).toEqual(sampleMeter);
     });
 
@@ -103,7 +103,7 @@ describe('metering-api', () => {
 
       await getMeterDefinition(client, basePath, 'meter/special');
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meters/meter%2Fspecial');
+      expect(client.get).toHaveBeenCalledWith('/metering/meters/meter%2Fspecial');
     });
   });
 
@@ -121,7 +121,7 @@ describe('metering-api', () => {
 
       const result = await createMeterDefinition(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/meters', request);
+      expect(client.post).toHaveBeenCalledWith('/metering/meters', request);
       expect(result).toEqual(sampleMeter);
     });
   });
@@ -140,7 +140,7 @@ describe('metering-api', () => {
 
       const result = await updateMeterDefinition(client, basePath, 'meter-1', request);
 
-      expect(client.put).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1', request);
+      expect(client.put).toHaveBeenCalledWith('/metering/meters/meter-1', request);
       expect(result).toEqual(updated);
     });
 
@@ -156,10 +156,7 @@ describe('metering-api', () => {
 
       await updateMeterDefinition(client, basePath, 'meter/special', request);
 
-      expect(client.put).toHaveBeenCalledWith(
-        '/api/granit/metering/meters/meter%2Fspecial',
-        request
-      );
+      expect(client.put).toHaveBeenCalledWith('/metering/meters/meter%2Fspecial', request);
     });
   });
 
@@ -170,7 +167,7 @@ describe('metering-api', () => {
 
       await deactivateMeterDefinition(client, basePath, 'meter-1');
 
-      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/meters/meter-1/deactivate');
+      expect(client.post).toHaveBeenCalledWith('/metering/meters/meter-1/deactivate');
     });
 
     it('should encode the id', async () => {
@@ -179,9 +176,7 @@ describe('metering-api', () => {
 
       await deactivateMeterDefinition(client, basePath, 'meter/special');
 
-      expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/metering/meters/meter%2Fspecial/deactivate'
-      );
+      expect(client.post).toHaveBeenCalledWith('/metering/meters/meter%2Fspecial/deactivate');
     });
   });
 
@@ -192,7 +187,7 @@ describe('metering-api', () => {
 
       const result = await getUsageForPeriod(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/usage');
+      expect(client.get).toHaveBeenCalledWith('/metering/usage');
       expect(result).toEqual([sampleUsage]);
     });
   });
@@ -204,7 +199,7 @@ describe('metering-api', () => {
 
       const result = await checkMeteringQuota(client, basePath, 'meter-1');
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/quota/meter-1');
+      expect(client.get).toHaveBeenCalledWith('/metering/quota/meter-1');
       expect(result).toEqual(sampleQuota);
     });
 
@@ -214,7 +209,7 @@ describe('metering-api', () => {
 
       await checkMeteringQuota(client, basePath, 'meter/special');
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/quota/meter%2Fspecial');
+      expect(client.get).toHaveBeenCalledWith('/metering/quota/meter%2Fspecial');
     });
   });
 
@@ -237,7 +232,7 @@ describe('metering-api', () => {
 
       await recordUsageEvents(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith('/api/granit/metering/events', request);
+      expect(client.post).toHaveBeenCalledWith('/metering/events', request);
     });
   });
 
@@ -303,7 +298,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
 
       expect(client.get).toHaveBeenCalledTimes(1);
       const url = vi.mocked(client.get).mock.calls[0]?.[0] as string;
-      expect(url).toContain('/api/granit/metering/meter-definitions');
+      expect(url).toContain('/metering/meter-definitions');
       expect(url).toContain('page=1');
       expect(url).toContain('pageSize=25');
       expect(result).toEqual(page);
@@ -315,7 +310,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
 
       await listMeterDefinitions(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meter-definitions');
+      expect(client.get).toHaveBeenCalledWith('/metering/meter-definitions');
     });
   });
 
@@ -326,7 +321,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
 
       const result = await getMeterDefinitionsQueryMeta(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meter-definitions/meta');
+      expect(client.get).toHaveBeenCalledWith('/metering/meter-definitions/meta');
       expect(result).toEqual(sampleMeta);
     });
   });
@@ -338,7 +333,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
 
       const result = await listMeterDefinitionsSavedViews(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/meter-definitions/saved-views');
+      expect(client.get).toHaveBeenCalledWith('/metering/meter-definitions/saved-views');
       expect(result).toEqual([sampleSavedView]);
     });
   });
@@ -355,10 +350,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
 
       const result = await createMeterDefinitionsSavedView(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/metering/meter-definitions/saved-views',
-        request
-      );
+      expect(client.post).toHaveBeenCalledWith('/metering/meter-definitions/saved-views', request);
       expect(result).toEqual(sampleSavedView);
     });
   });
@@ -375,7 +367,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
       await updateMeterDefinitionsSavedView(client, basePath, 'sv-1', request);
 
       expect(client.put).toHaveBeenCalledWith(
-        '/api/granit/metering/meter-definitions/saved-views/sv-1',
+        '/metering/meter-definitions/saved-views/sv-1',
         request
       );
     });
@@ -388,9 +380,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
 
       await deleteMeterDefinitionsSavedView(client, basePath, 'sv-1');
 
-      expect(client.delete).toHaveBeenCalledWith(
-        '/api/granit/metering/meter-definitions/saved-views/sv-1'
-      );
+      expect(client.delete).toHaveBeenCalledWith('/metering/meter-definitions/saved-views/sv-1');
     });
   });
 
@@ -402,7 +392,7 @@ describe('metering-api / QueryEngine — meter definitions', () => {
       await setDefaultMeterDefinitionsSavedView(client, basePath, 'sv-1');
 
       expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/metering/meter-definitions/saved-views/sv-1/set-default'
+        '/metering/meter-definitions/saved-views/sv-1/set-default'
       );
     });
   });
@@ -423,7 +413,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
 
       expect(client.get).toHaveBeenCalledTimes(1);
       const url = vi.mocked(client.get).mock.calls[0]?.[0] as string;
-      expect(url).toContain('/api/granit/metering/usage-aggregates');
+      expect(url).toContain('/metering/usage-aggregates');
       expect(url).toContain('sort=-periodStart');
       expect(result).toEqual(page);
     });
@@ -434,7 +424,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
 
       await listUsageAggregates(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/usage-aggregates');
+      expect(client.get).toHaveBeenCalledWith('/metering/usage-aggregates');
     });
   });
 
@@ -445,7 +435,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
 
       const result = await getUsageAggregatesQueryMeta(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/usage-aggregates/meta');
+      expect(client.get).toHaveBeenCalledWith('/metering/usage-aggregates/meta');
       expect(result).toEqual(sampleMeta);
     });
   });
@@ -457,7 +447,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
 
       const result = await listUsageAggregatesSavedViews(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith('/api/granit/metering/usage-aggregates/saved-views');
+      expect(client.get).toHaveBeenCalledWith('/metering/usage-aggregates/saved-views');
       expect(result).toEqual([sampleSavedView]);
     });
   });
@@ -474,10 +464,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
 
       const result = await createUsageAggregatesSavedView(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/metering/usage-aggregates/saved-views',
-        request
-      );
+      expect(client.post).toHaveBeenCalledWith('/metering/usage-aggregates/saved-views', request);
       expect(result).toEqual(sampleSavedView);
     });
   });
@@ -494,7 +481,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
       await updateUsageAggregatesSavedView(client, basePath, 'sv-1', request);
 
       expect(client.put).toHaveBeenCalledWith(
-        '/api/granit/metering/usage-aggregates/saved-views/sv-1',
+        '/metering/usage-aggregates/saved-views/sv-1',
         request
       );
     });
@@ -507,9 +494,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
 
       await deleteUsageAggregatesSavedView(client, basePath, 'sv-1');
 
-      expect(client.delete).toHaveBeenCalledWith(
-        '/api/granit/metering/usage-aggregates/saved-views/sv-1'
-      );
+      expect(client.delete).toHaveBeenCalledWith('/metering/usage-aggregates/saved-views/sv-1');
     });
   });
 
@@ -521,7 +506,7 @@ describe('metering-api / QueryEngine — usage aggregates', () => {
       await setDefaultUsageAggregatesSavedView(client, basePath, 'sv-1');
 
       expect(client.post).toHaveBeenCalledWith(
-        '/api/granit/metering/usage-aggregates/saved-views/sv-1/set-default'
+        '/metering/usage-aggregates/saved-views/sv-1/set-default'
       );
     });
   });

--- a/packages/@granit/metering/src/api/metering-api.ts
+++ b/packages/@granit/metering/src/api/metering-api.ts
@@ -22,13 +22,13 @@ import type {
   UsageAggregatePage,
   UsageAggregateResponse,
 } from '../types.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type {
   CreateSavedViewRequest,
   QueryMetadata,
   SavedViewSummary,
   UpdateSavedViewRequest,
 } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 const METER_DEFINITIONS_SUBPATH = 'meter-definitions';
 const USAGE_AGGREGATES_SUBPATH = 'usage-aggregates';

--- a/packages/@granit/multi-tenancy/package.json
+++ b/packages/@granit/multi-tenancy/package.json
@@ -14,8 +14,8 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {
@@ -25,5 +25,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/multi-tenancy/src/api/tenant-admin-api.ts
+++ b/packages/@granit/multi-tenancy/src/api/tenant-admin-api.ts
@@ -3,7 +3,7 @@ import type {
   CreateTenantRequest,
   UpdateTenantRequest,
 } from '../types/admin-tenant.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all tenants.

--- a/packages/@granit/notifications-mobile-push/package.json
+++ b/packages/@granit/notifications-mobile-push/package.json
@@ -14,7 +14,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/notifications-mobile-push/src/api/mobile-push-api.ts
+++ b/packages/@granit/notifications-mobile-push/src/api/mobile-push-api.ts
@@ -1,6 +1,6 @@
 import { buildApiUrl } from '@granit/api-client';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 export type MobilePlatform = 'android' | 'ios';
 

--- a/packages/@granit/notifications-web-push/package.json
+++ b/packages/@granit/notifications-web-push/package.json
@@ -18,7 +18,7 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/notifications-web-push/src/api/web-push-api.ts
+++ b/packages/@granit/notifications-web-push/src/api/web-push-api.ts
@@ -1,6 +1,6 @@
 import { buildApiUrl } from '@granit/api-client';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 export async function registerPushSubscription(
   client: AxiosInstance,

--- a/packages/@granit/notifications/package.json
+++ b/packages/@granit/notifications/package.json
@@ -17,9 +17,9 @@
     "@granit/api-client": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/notifications/src/api/notification-api.ts
+++ b/packages/@granit/notifications/src/api/notification-api.ts
@@ -5,8 +5,8 @@ import type {
   UserNotificationPage,
   NotificationPreference,
 } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PaginationParams } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
 // Notifications (inbox)

--- a/packages/@granit/notifications/src/types/index.ts
+++ b/packages/@granit/notifications/src/types/index.ts
@@ -1,6 +1,6 @@
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
 import type { EntityId, ISODateString, UserId } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
 // Notification types — aligned with Granit.Notifications .NET backend

--- a/packages/@granit/openiddict-admin/package.json
+++ b/packages/@granit/openiddict-admin/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/query-engine": "workspace:*",
-    "axios": "*"
+    "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
@@ -3,7 +3,7 @@ import type {
   AdminOidcApplicationCreateRequest,
   AdminOidcApplicationSecretResponse,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 // ── OIDC Application CRUD ────────────────────────────────────────────────────
 
@@ -49,9 +49,7 @@ export async function deleteApplication(
   basePath: string,
   clientId: string
 ): Promise<void> {
-  await client.delete(
-    `${basePath}/oidc/applications/${encodeURIComponent(clientId)}`
-  );
+  await client.delete(`${basePath}/oidc/applications/${encodeURIComponent(clientId)}`);
 }
 
 /**

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-authorization-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-authorization-api.ts
@@ -1,8 +1,5 @@
-import type {
-  AdminOidcAuthorization,
-  AdminOidcAuthorizationListParams,
-} from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AdminOidcAuthorization, AdminOidcAuthorizationListParams } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 
 // ── OIDC Authorization management ────────────────────────────────────────────
 
@@ -33,9 +30,7 @@ export async function revokeAuthorization(
   basePath: string,
   id: string
 ): Promise<void> {
-  await client.delete(
-    `${basePath}/oidc/authorizations/${encodeURIComponent(id)}`
-  );
+  await client.delete(`${basePath}/oidc/authorizations/${encodeURIComponent(id)}`);
 }
 
 /**
@@ -48,7 +43,5 @@ export async function revokeUserAuthorizations(
   basePath: string,
   userId: string
 ): Promise<void> {
-  await client.delete(
-    `${basePath}/oidc/authorizations/user/${encodeURIComponent(userId)}`
-  );
+  await client.delete(`${basePath}/oidc/authorizations/user/${encodeURIComponent(userId)}`);
 }

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
@@ -1,8 +1,5 @@
-import type {
-  AdminOidcScope,
-  AdminOidcScopeCreateRequest,
-} from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AdminOidcScope, AdminOidcScopeCreateRequest } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 
 // ── OIDC Scope CRUD ──────────────────────────────────────────────────────────
 
@@ -15,9 +12,7 @@ export async function listScopes(
   client: AxiosInstance,
   basePath: string
 ): Promise<readonly AdminOidcScope[]> {
-  const { data } = await client.get<readonly AdminOidcScope[]>(
-    `${basePath}/oidc/scopes`
-  );
+  const { data } = await client.get<readonly AdminOidcScope[]>(`${basePath}/oidc/scopes`);
   return data;
 }
 
@@ -31,10 +26,7 @@ export async function createScope(
   basePath: string,
   request: AdminOidcScopeCreateRequest
 ): Promise<AdminOidcScope> {
-  const { data } = await client.post<AdminOidcScope>(
-    `${basePath}/oidc/scopes`,
-    request
-  );
+  const { data } = await client.post<AdminOidcScope>(`${basePath}/oidc/scopes`, request);
   return data;
 }
 
@@ -48,7 +40,5 @@ export async function deleteScope(
   basePath: string,
   scopeName: string
 ): Promise<void> {
-  await client.delete(
-    `${basePath}/oidc/scopes/${encodeURIComponent(scopeName)}`
-  );
+  await client.delete(`${basePath}/oidc/scopes/${encodeURIComponent(scopeName)}`);
 }

--- a/packages/@granit/openiddict-admin/src/api/admin-user-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-user-api.ts
@@ -3,7 +3,7 @@ import type {
   AdminUserListParams,
   AdminUserPage,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List admin users via the QueryEngine-backed admin endpoint.

--- a/packages/@granit/parties/package.json
+++ b/packages/@granit/parties/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/parties/src/api/parties-api.ts
+++ b/packages/@granit/parties/src/api/parties-api.ts
@@ -21,7 +21,7 @@ import type {
   PartyTaxStatusRequest,
   PartyUpdateRequest,
 } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List parties in the active scope, optionally filtered by role flag.

--- a/packages/@granit/parties/src/api/parties-duplicates-api.ts
+++ b/packages/@granit/parties/src/api/parties-duplicates-api.ts
@@ -5,7 +5,7 @@ import type {
   PartyId,
   PartyMergeResponse,
 } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List pending duplicate-candidate pairs that involve the given party. Flat —

--- a/packages/@granit/payments/package.json
+++ b/packages/@granit/payments/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/payments/src/__tests__/payments-api.test.ts
+++ b/packages/@granit/payments/src/__tests__/payments-api.test.ts
@@ -34,7 +34,7 @@ import type {
   PaymentTransactionResponse,
 } from '../types.js';
 
-const basePath = '/api/granit/payments';
+const basePath = '/payments';
 
 const sampleTransaction: PaymentTransactionResponse = {
   id: 'txn-1',

--- a/packages/@granit/payments/src/api/payments-api.ts
+++ b/packages/@granit/payments/src/api/payments-api.ts
@@ -13,7 +13,7 @@ import type {
   PaymentRefundResponse,
   PaymentTransactionResponse,
 } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all payment transactions.

--- a/packages/@granit/privacy/package.json
+++ b/packages/@granit/privacy/package.json
@@ -14,9 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/privacy/src/api/privacy-api.ts
+++ b/packages/@granit/privacy/src/api/privacy-api.ts
@@ -12,7 +12,7 @@ import type {
   PrivacyExportRequestResponse,
   PrivacyExportStatusResponse,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 // ── Data Export (GDPR Art. 15/20) ────────────────────────────────────────────
 

--- a/packages/@granit/query-engine/package.json
+++ b/packages/@granit/query-engine/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/data-lookup": "workspace:*",
-    "@granit/utils": "workspace:*",
-    "axios": "*"
+    "@granit/utils": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/query-engine/src/api/query-api.ts
+++ b/packages/@granit/query-engine/src/api/query-api.ts
@@ -7,7 +7,7 @@ import { serializeQueryRequest } from './query-param-serializer.js';
 import type { QueryMetadata } from '../types/query-metadata.js';
 import type { QueryRequest } from '../types/query-params.js';
 import type { GroupedResult, PagedResult } from '../types/query-results.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Get a paginated page of results.

--- a/packages/@granit/query-engine/src/api/saved-views-api.ts
+++ b/packages/@granit/query-engine/src/api/saved-views-api.ts
@@ -7,7 +7,7 @@ import type {
   SavedViewSummary,
   UpdateSavedViewRequest,
 } from '../types/saved-views.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List all saved views for the current entity type.

--- a/packages/@granit/query-engine/src/config.ts
+++ b/packages/@granit/query-engine/src/config.ts
@@ -1,4 +1,4 @@
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /** Configuration for a single query endpoint. */
 export interface QueryConfig {

--- a/packages/@granit/react-account/package.json
+++ b/packages/@granit/react-account/package.json
@@ -16,8 +16,9 @@
   },
   "peerDependencies": {
     "@granit/account": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -27,6 +28,8 @@
     }
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-account/src/providers/account-provider.tsx
+++ b/packages/@granit/react-account/src/providers/account-provider.tsx
@@ -1,14 +1,23 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 export interface AccountConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * AccountConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedAccountConfig extends AccountConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface AccountProviderProps {
@@ -18,9 +27,9 @@ export interface AccountProviderProps {
 
 const DEFAULT_KEY_PREFIX = ['account'] as const;
 
-const AccountContext = createContext<AccountConfig | null>(null);
+const AccountContext = createContext<ResolvedAccountConfig | null>(null);
 
-export function useAccountConfig(): AccountConfig {
+export function useAccountConfig(): ResolvedAccountConfig {
   const config = useContext(AccountContext);
   if (!config) throw new Error('useAccountConfig must be used within an AccountProvider');
   return config;
@@ -34,14 +43,21 @@ export function buildAccountQueryKey(
 }
 
 export function AccountProvider({ config, children }: AccountProviderProps) {
-  const value = useMemo<AccountConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'AccountProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
 
   return <AccountContext value={value}>{children}</AccountContext>;
 }

--- a/packages/@granit/react-ai/package.json
+++ b/packages/@granit/react-ai/package.json
@@ -16,8 +16,9 @@
   },
   "peerDependencies": {
     "@granit/ai": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -40,7 +41,9 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-ai/src/providers/ai-provider.tsx
+++ b/packages/@granit/react-ai/src/providers/ai-provider.tsx
@@ -2,21 +2,30 @@
 // AI context provider — supplies Axios client and config to all AI hooks.
 // ---------------------------------------------------------------------------
 
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the AI provider. */
 export interface AIConfig {
   /** Axios client with auth and tenant interceptors. */
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for AI endpoints (default: `/api/v1/ai`). */
   readonly basePath?: string;
   /** Custom React Query key prefix (default: `['ai']`). */
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * AIConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedAIConfig extends AIConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface AIProviderProps {
@@ -24,22 +33,29 @@ export interface AIProviderProps {
   readonly children: ReactNode;
 }
 
-const AIConfigContext = createContext<AIConfig | null>(null);
+const AIConfigContext = createContext<ResolvedAIConfig | null>(null);
 
 /** Provides AI configuration to child components and hooks. */
 export function AIProvider({ config, children }: Readonly<AIProviderProps>) {
-  const value = useMemo(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedAIConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'AIProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
   return <AIConfigContext value={value}>{children}</AIConfigContext>;
 }
 
 /** Returns the AI configuration from the nearest `AIProvider`. */
-export function useAIConfig(): AIConfig {
+export function useAIConfig(): ResolvedAIConfig {
   const ctx = useContext(AIConfigContext);
   if (!ctx) {
     throw new Error('useAIConfig must be used within an AIProvider');

--- a/packages/@granit/react-api-client/package.json
+++ b/packages/@granit/react-api-client/package.json
@@ -9,10 +9,11 @@
   },
   "scripts": {},
   "peerDependencies": {
-    "axios": "*",
+    "@granit/api-client": "workspace:*",
     "react": "^19.0.0"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   },

--- a/packages/@granit/react-api-client/src/providers/granit-client-provider.tsx
+++ b/packages/@granit/react-api-client/src/providers/granit-client-provider.tsx
@@ -1,6 +1,6 @@
 import { createContext, useContext } from 'react';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 const GranitClientContext = createContext<AxiosInstance | null>(null);

--- a/packages/@granit/react-auditing/package.json
+++ b/packages/@granit/react-auditing/package.json
@@ -15,15 +15,18 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/auditing": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
+++ b/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the audit log provider. */
 export interface AuditLogConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path prefix (default: `/api/v1/auditing`). */
   readonly basePath: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * AuditLogConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedAuditLogConfig extends AuditLogConfig {
+  readonly client: AxiosInstance;
 }
 
 /** Props accepted by {@link AuditLogProvider}. `basePath` is optional — the default is applied by the provider. */
@@ -19,24 +28,31 @@ export interface AuditLogProviderProps {
   readonly children: ReactNode;
 }
 
-const AuditLogConfigContext = createContext<AuditLogConfig | null>(null);
+const AuditLogConfigContext = createContext<ResolvedAuditLogConfig | null>(null);
 
 const DEFAULT_QUERY_KEY_PREFIX = ['audit-log'] as const;
 
 /** Provides audit log configuration to child components and hooks. */
 export function AuditLogProvider({ config, children }: Readonly<AuditLogProviderProps>) {
-  const value = useMemo<AuditLogConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'AuditLogProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
   return <AuditLogConfigContext value={value}>{children}</AuditLogConfigContext>;
 }
 
 /** Returns the audit log configuration from the nearest `AuditLogProvider`. */
-export function useAuditLogConfig(): AuditLogConfig {
+export function useAuditLogConfig(): ResolvedAuditLogConfig {
   const ctx = useContext(AuditLogConfigContext);
   if (!ctx) {
     throw new Error('useAuditLogConfig must be used within an AuditLogProvider');

--- a/packages/@granit/react-authentication-api-keys/package.json
+++ b/packages/@granit/react-authentication-api-keys/package.json
@@ -15,14 +15,15 @@
     "build": "tsup"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
+    "@granit/api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/authentication-api-keys": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
@@ -2,9 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { ApiKeyResponse } from '@granit/authentication-api-keys';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/@granit/react-authentication-cognito/package.json
+++ b/packages/@granit/react-authentication-cognito/package.json
@@ -29,5 +29,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-entraid/package.json
+++ b/packages/@granit/react-authentication-entraid/package.json
@@ -29,5 +29,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-google-cloud/package.json
+++ b/packages/@granit/react-authentication-google-cloud/package.json
@@ -29,5 +29,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-keycloak/package.json
+++ b/packages/@granit/react-authentication-keycloak/package.json
@@ -29,5 +29,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-local/package.json
+++ b/packages/@granit/react-authentication-local/package.json
@@ -15,9 +15,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/authentication-local": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -27,6 +28,8 @@
     }
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   },

--- a/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
+++ b/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
@@ -1,8 +1,9 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 export interface LocalAuthConfig {
@@ -11,9 +12,17 @@ export interface LocalAuthConfig {
    * Must have `withCredentials: true` — the login endpoint sets an
    * ASP.NET Core Identity session cookie (not a token).
    */
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * LocalAuthConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedLocalAuthConfig extends LocalAuthConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface LocalAuthProviderProps {
@@ -23,9 +32,9 @@ export interface LocalAuthProviderProps {
 
 const DEFAULT_KEY_PREFIX = ['authentication-local'] as const;
 
-const LocalAuthContext = createContext<LocalAuthConfig | null>(null);
+const LocalAuthContext = createContext<ResolvedLocalAuthConfig | null>(null);
 
-export function useLocalAuthConfig(): LocalAuthConfig {
+export function useLocalAuthConfig(): ResolvedLocalAuthConfig {
   const config = useContext(LocalAuthContext);
   if (!config) throw new Error('useLocalAuthConfig must be used within a LocalAuthProvider');
   return config;
@@ -39,14 +48,21 @@ export function buildLocalAuthQueryKey(
 }
 
 export function LocalAuthProvider({ config, children }: LocalAuthProviderProps) {
-  const value = useMemo<LocalAuthConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'LocalAuthProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
 
   return <LocalAuthContext value={value}>{children}</LocalAuthContext>;
 }

--- a/packages/@granit/react-background-jobs/package.json
+++ b/packages/@granit/react-background-jobs/package.json
@@ -15,10 +15,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/background-jobs": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -41,8 +42,10 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
+++ b/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the background jobs provider. */
 export interface BackgroundJobsConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for background-jobs endpoints (default: `/api/v1/background-jobs`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * BackgroundJobsConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedBackgroundJobsConfig extends BackgroundJobsConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface BackgroundJobsProviderProps {
@@ -18,19 +27,32 @@ export interface BackgroundJobsProviderProps {
   readonly children: ReactNode;
 }
 
-const BackgroundJobsConfigContext = createContext<BackgroundJobsConfig | null>(null);
+const BackgroundJobsConfigContext = createContext<ResolvedBackgroundJobsConfig | null>(null);
 
 /** Provides background jobs configuration to child components and hooks. */
-export function BackgroundJobsProvider({ config, children }: Readonly<BackgroundJobsProviderProps>) {
-  const value = useMemo(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-  }), [config]);
+export function BackgroundJobsProvider({
+  config,
+  children,
+}: Readonly<BackgroundJobsProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedBackgroundJobsConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'BackgroundJobsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
   return <BackgroundJobsConfigContext value={value}>{children}</BackgroundJobsConfigContext>;
 }
 
 /** Returns the background jobs configuration from the nearest `BackgroundJobsProvider`. */
-export function useBackgroundJobsConfig(): BackgroundJobsConfig {
+export function useBackgroundJobsConfig(): ResolvedBackgroundJobsConfig {
   const ctx = useContext(BackgroundJobsConfigContext);
   if (!ctx) {
     throw new Error('useBackgroundJobsConfig must be used within a BackgroundJobsProvider');

--- a/packages/@granit/react-blob-storage/package.json
+++ b/packages/@granit/react-blob-storage/package.json
@@ -15,9 +15,9 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/blob-storage": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -27,9 +27,10 @@
     }
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-testing": "workspace:*",
-    "@granit/query-engine": "workspace:*"
+    "@granit/testing": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { BlobDescriptorResponse } from '@granit/blob-storage';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 /** Options accepted by all blob-storage hooks. */
 export interface BlobStorageOptions {

--- a/packages/@granit/react-customer-balance/package.json
+++ b/packages/@granit/react-customer-balance/package.json
@@ -15,10 +15,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/customer-balance": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -41,6 +42,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
+++ b/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the customer-balance provider. */
 export interface CustomerBalanceConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for customer-balance endpoints (default: `/api/v1/customer-balance`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * CustomerBalanceConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedCustomerBalanceConfig extends CustomerBalanceConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface CustomerBalanceProviderProps {
@@ -18,22 +27,32 @@ export interface CustomerBalanceProviderProps {
   readonly children: ReactNode;
 }
 
-const CustomerBalanceConfigContext = createContext<CustomerBalanceConfig | null>(null);
+const CustomerBalanceConfigContext = createContext<ResolvedCustomerBalanceConfig | null>(null);
 
 /** Provides customer-balance configuration to child components and hooks. */
 export function CustomerBalanceProvider({
   config,
   children,
 }: Readonly<CustomerBalanceProviderProps>) {
-  const value = useMemo(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-  }), [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedCustomerBalanceConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'CustomerBalanceProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
   return <CustomerBalanceConfigContext value={value}>{children}</CustomerBalanceConfigContext>;
 }
 
 /** Returns the customer-balance configuration from the nearest `CustomerBalanceProvider`. */
-export function useCustomerBalanceConfig(): CustomerBalanceConfig {
+export function useCustomerBalanceConfig(): ResolvedCustomerBalanceConfig {
   const ctx = useContext(CustomerBalanceConfigContext);
   if (!ctx) {
     throw new Error('useCustomerBalanceConfig must be used within a CustomerBalanceProvider');

--- a/packages/@granit/react-data-exchange/package.json
+++ b/packages/@granit/react-data-exchange/package.json
@@ -15,12 +15,12 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/react-api-client": "workspace:*",
+    "@granit/api-client": "workspace:*",
     "@granit/data-exchange": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
@@ -44,7 +44,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   }
 }

--- a/packages/@granit/react-data-exchange/src/export/providers/export-provider.tsx
+++ b/packages/@granit/react-data-exchange/src/export/providers/export-provider.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /**

--- a/packages/@granit/react-data-exchange/src/import/providers/import-provider.tsx
+++ b/packages/@granit/react-data-exchange/src/import/providers/import-provider.tsx
@@ -3,7 +3,7 @@ import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /**

--- a/packages/@granit/react-data-exchange/src/providers/data-exchange-provider.tsx
+++ b/packages/@granit/react-data-exchange/src/providers/data-exchange-provider.tsx
@@ -5,7 +5,7 @@ import { ImportProvider } from '../import/providers/import-provider.js';
 
 import type { ExportConfig } from '../export/providers/export-provider.js';
 import type { ImportConfig } from '../import/providers/import-provider.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /**
@@ -51,14 +51,15 @@ const EMPTY_CONFIG: DataExchangeConfig = {};
  * </DataExchangeProvider>
  * ```
  */
-export function DataExchangeProvider({ config = EMPTY_CONFIG, children }: Readonly<DataExchangeProviderProps>) {
+export function DataExchangeProvider({
+  config = EMPTY_CONFIG,
+  children,
+}: Readonly<DataExchangeProviderProps>) {
   const exportConfig = useMemo<ExportConfig>(
     () => ({
       client: config.client,
       basePath: config.basePath,
-      ...(config.queryKeyPrefix
-        ? { queryKeyPrefix: [...config.queryKeyPrefix, 'export'] }
-        : {}),
+      ...(config.queryKeyPrefix ? { queryKeyPrefix: [...config.queryKeyPrefix, 'export'] } : {}),
     }),
     [config]
   );
@@ -67,9 +68,7 @@ export function DataExchangeProvider({ config = EMPTY_CONFIG, children }: Readon
     () => ({
       client: config.client,
       basePath: config.basePath,
-      ...(config.queryKeyPrefix
-        ? { queryKeyPrefix: [...config.queryKeyPrefix, 'import'] }
-        : {}),
+      ...(config.queryKeyPrefix ? { queryKeyPrefix: [...config.queryKeyPrefix, 'import'] } : {}),
     }),
     [config]
   );

--- a/packages/@granit/react-data-lookup/package.json
+++ b/packages/@granit/react-data-lookup/package.json
@@ -14,9 +14,9 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/data-lookup": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "react": "^19.0.0"
   },
   "publishConfig": {
@@ -29,7 +29,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   }
 }

--- a/packages/@granit/react-data-lookup/src/components/lookup-badge.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-badge.tsx
@@ -2,8 +2,8 @@ import { stringifyLookupValue } from '@granit/data-lookup';
 
 import { useLookupResolve } from '../hooks/use-lookup-resolve.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { LookupDescriptor } from '@granit/data-lookup';
-import type { AxiosInstance } from 'axios';
 import type { ReactElement } from 'react';
 
 /** Render-prop signature. */

--- a/packages/@granit/react-data-lookup/src/components/lookup-picker.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-picker.tsx
@@ -2,8 +2,8 @@ import { useMemo, useState } from 'react';
 
 import { useLookup } from '../hooks/use-lookup.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { LookupDescriptor, LookupItem } from '@granit/data-lookup';
-import type { AxiosInstance } from 'axios';
 import type { ReactElement } from 'react';
 
 /** Render-prop signature for the SmartFilterBar typeahead. */

--- a/packages/@granit/react-data-lookup/src/components/lookup-select.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-select.tsx
@@ -40,7 +40,7 @@ export interface LookupSelectProps {
   readonly scope?: Readonly<Record<string, string | null | undefined>>;
   /** Current UI culture — passed to both hooks so caches are per-language. */
   readonly culture?: string;
-  /** Override the base path. Defaults to `/api/granit/lookups`. */
+  /** Override the base path. Defaults to `/lookups`. */
   readonly basePath?: string;
   /** Page size passed to the search query. Default: `25`. */
   readonly pageSize?: number;

--- a/packages/@granit/react-data-lookup/src/components/lookup-select.tsx
+++ b/packages/@granit/react-data-lookup/src/components/lookup-select.tsx
@@ -3,8 +3,8 @@ import { useMemo, useState } from 'react';
 import { useLookupResolve } from '../hooks/use-lookup-resolve.js';
 import { useLookup } from '../hooks/use-lookup.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { LookupDescriptor, LookupItem } from '@granit/data-lookup';
-import type { AxiosInstance } from 'axios';
 import type { ReactElement } from 'react';
 
 /** Render-prop signature for custom UIs. Callers bring their own combobox primitive. */

--- a/packages/@granit/react-data-lookup/src/hooks/use-lookup-resolve.ts
+++ b/packages/@granit/react-data-lookup/src/hooks/use-lookup-resolve.ts
@@ -1,9 +1,9 @@
 import { resolveLookup } from '@granit/data-lookup';
 import { useQuery } from '@tanstack/react-query';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { LookupDescriptor, LookupItem } from '@granit/data-lookup';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 /** Options accepted by {@link useLookupResolve}. */
 export interface UseLookupResolveOptions {

--- a/packages/@granit/react-data-lookup/src/hooks/use-lookup-resolve.ts
+++ b/packages/@granit/react-data-lookup/src/hooks/use-lookup-resolve.ts
@@ -18,7 +18,7 @@ export interface UseLookupResolveOptions {
  * (e.g., when loading a form previously saved with a foreign-key value — the
  * label must be fetched to show a human-readable picker state).
  *
- * `GET /api/granit/lookups/{name}/resolve?value=…` → {@link LookupItem} | `null`.
+ * `GET /lookups/{name}/resolve?value=…` → {@link LookupItem} | `null`.
  *
  * Returns `data: null` when the value cannot be resolved (404) rather than
  * raising — callers typically show the raw value as a fallback.

--- a/packages/@granit/react-data-lookup/src/hooks/use-lookup.ts
+++ b/packages/@granit/react-data-lookup/src/hooks/use-lookup.ts
@@ -33,7 +33,7 @@ export type UseLookupResult = UseQueryResult<LookupResult> & {
 };
 
 /**
- * Fetches a page of items from a lookup source via `GET /api/granit/lookups/{name}`.
+ * Fetches a page of items from a lookup source via `GET /lookups/{name}`.
  *
  * **Empty Scope Trap mitigation** — when the descriptor declares
  * `scopeKeys: ["tenantId"]` and the provided `scope` is missing the value,

--- a/packages/@granit/react-data-lookup/src/hooks/use-lookup.ts
+++ b/packages/@granit/react-data-lookup/src/hooks/use-lookup.ts
@@ -1,9 +1,9 @@
 import { findMissingScopeKey, searchLookup } from '@granit/data-lookup';
 import { useQuery } from '@tanstack/react-query';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { LookupDescriptor, LookupQueryParams, LookupResult } from '@granit/data-lookup';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 /** Options accepted by {@link useLookup}. */
 export interface UseLookupOptions {

--- a/packages/@granit/react-diagnostics/package.json
+++ b/packages/@granit/react-diagnostics/package.json
@@ -15,9 +15,9 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/diagnostics": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -40,7 +40,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   }
 }

--- a/packages/@granit/react-diagnostics/src/hooks/use-monitoring-health.ts
+++ b/packages/@granit/react-diagnostics/src/hooks/use-monitoring-health.ts
@@ -1,9 +1,9 @@
 import { DEFAULT_DIAGNOSTICS_BASE_PATH, getMonitoringHealth } from '@granit/diagnostics';
 import { useQuery } from '@tanstack/react-query';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { MonitoringHealthResponse } from '@granit/diagnostics';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 /** Options accepted by the useMonitoringHealth hook. */
 export interface MonitoringHealthOptions {

--- a/packages/@granit/react-features/package.json
+++ b/packages/@granit/react-features/package.json
@@ -15,9 +15,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/features": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -40,7 +41,9 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   }
 }

--- a/packages/@granit/react-features/src/providers/features-provider.tsx
+++ b/packages/@granit/react-features/src/providers/features-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the features provider. */
 export interface FeaturesConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for features endpoints (default: `/api/v1/features`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * FeaturesConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedFeaturesConfig extends FeaturesConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface FeaturesProviderProps {
@@ -18,19 +27,29 @@ export interface FeaturesProviderProps {
   readonly children: ReactNode;
 }
 
-const FeaturesConfigContext = createContext<FeaturesConfig | null>(null);
+const FeaturesConfigContext = createContext<ResolvedFeaturesConfig | null>(null);
 
 /** Provides features configuration to child components and hooks. */
 export function FeaturesProvider({ config, children }: Readonly<FeaturesProviderProps>) {
-  const value = useMemo(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-  }), [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedFeaturesConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'FeaturesProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
   return <FeaturesConfigContext value={value}>{children}</FeaturesConfigContext>;
 }
 
 /** Returns the features configuration from the nearest `FeaturesProvider`. */
-export function useFeaturesConfig(): FeaturesConfig {
+export function useFeaturesConfig(): ResolvedFeaturesConfig {
   const ctx = useContext(FeaturesConfigContext);
   if (!ctx) {
     throw new Error('useFeaturesConfig must be used within a FeaturesProvider');

--- a/packages/@granit/react-identity/package.json
+++ b/packages/@granit/react-identity/package.json
@@ -15,9 +15,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/identity": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -40,6 +41,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-identity/src/providers/identity-provider.tsx
+++ b/packages/@granit/react-identity/src/providers/identity-provider.tsx
@@ -1,18 +1,27 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH, DEFAULT_PROVIDER_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the identity provider. */
 export interface IdentityConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for user cache endpoints (default: `/api/v1/identity/users`). */
   readonly basePath: string;
   /** Base path for identity provider endpoints (default: `/api/v1/identity/provider`). */
   readonly providerBasePath: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * IdentityConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedIdentityConfig extends IdentityConfig {
+  readonly client: AxiosInstance;
 }
 
 /** Props accepted by {@link IdentityProvider}. Paths are optional — defaults are applied by the provider. */
@@ -22,23 +31,30 @@ export interface IdentityProviderProps {
   readonly children: ReactNode;
 }
 
-const IdentityConfigContext = createContext<IdentityConfig | null>(null);
+const IdentityConfigContext = createContext<ResolvedIdentityConfig | null>(null);
 
 /** Provides identity configuration to child components and hooks. */
 export function IdentityProvider({ config, children }: Readonly<IdentityProviderProps>) {
-  const value = useMemo<IdentityConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'IdentityProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       providerBasePath: config.providerBasePath ?? DEFAULT_PROVIDER_BASE_PATH,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
   return <IdentityConfigContext value={value}>{children}</IdentityConfigContext>;
 }
 
 /** Returns the identity configuration from the nearest `IdentityProvider`. */
-export function useIdentityConfig(): IdentityConfig {
+export function useIdentityConfig(): ResolvedIdentityConfig {
   const ctx = useContext(IdentityConfigContext);
   if (!ctx) {
     throw new Error('useIdentityConfig must be used within an IdentityProvider');

--- a/packages/@granit/react-invoicing/package.json
+++ b/packages/@granit/react-invoicing/package.json
@@ -15,10 +15,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/invoicing": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -41,6 +42,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-invoicing/src/providers/invoicing-provider.tsx
+++ b/packages/@granit/react-invoicing/src/providers/invoicing-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the invoicing provider. */
 export interface InvoicingConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for invoicing endpoints (default: `/api/v1/invoicing`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * InvoicingConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedInvoicingConfig extends InvoicingConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface InvoicingProviderProps {
@@ -18,19 +27,29 @@ export interface InvoicingProviderProps {
   readonly children: ReactNode;
 }
 
-const InvoicingConfigContext = createContext<InvoicingConfig | null>(null);
+const InvoicingConfigContext = createContext<ResolvedInvoicingConfig | null>(null);
 
 /** Provides invoicing configuration to child components and hooks. */
 export function InvoicingProvider({ config, children }: Readonly<InvoicingProviderProps>) {
-  const value = useMemo(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-  }), [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedInvoicingConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'InvoicingProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
   return <InvoicingConfigContext value={value}>{children}</InvoicingConfigContext>;
 }
 
 /** Returns the invoicing configuration from the nearest `InvoicingProvider`. */
-export function useInvoicingConfig(): InvoicingConfig {
+export function useInvoicingConfig(): ResolvedInvoicingConfig {
   const ctx = useContext(InvoicingConfigContext);
   if (!ctx) {
     throw new Error('useInvoicingConfig must be used within an InvoicingProvider');

--- a/packages/@granit/react-localization/package.json
+++ b/packages/@granit/react-localization/package.json
@@ -14,14 +14,14 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@date-fns/tz": "^1.0.0",
+    "@granit/api-client": "workspace:*",
     "@granit/localization": "workspace:*",
     "@granit/storage": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
+    "date-fns": "^4.0.0",
     "i18next": "^25.0.0",
     "msw": "^2.12.0",
-    "@date-fns/tz": "^1.0.0",
-    "date-fns": "^4.0.0",
     "react": "^19.0.0",
     "react-i18next": "^16.0.0"
   },
@@ -44,6 +44,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   }

--- a/packages/@granit/react-localization/src/hooks/use-admin-localization.ts
+++ b/packages/@granit/react-localization/src/hooks/use-admin-localization.ts
@@ -6,9 +6,9 @@ import {
 } from '@granit/localization';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { AdminLanguage } from '@granit/localization';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 export interface LocalizationAdminOptions {
   readonly client: AxiosInstance;

--- a/packages/@granit/react-metering/package.json
+++ b/packages/@granit/react-metering/package.json
@@ -15,10 +15,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/metering": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -41,6 +42,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-metering/src/providers/metering-provider.tsx
+++ b/packages/@granit/react-metering/src/providers/metering-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the metering provider. */
 export interface MeteringConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for metering endpoints (default: `/api/v1/metering`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * MeteringConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedMeteringConfig extends MeteringConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface MeteringProviderProps {
@@ -18,19 +27,29 @@ export interface MeteringProviderProps {
   readonly children: ReactNode;
 }
 
-const MeteringConfigContext = createContext<MeteringConfig | null>(null);
+const MeteringConfigContext = createContext<ResolvedMeteringConfig | null>(null);
 
 /** Provides metering configuration to child components and hooks. */
 export function MeteringProvider({ config, children }: Readonly<MeteringProviderProps>) {
-  const value = useMemo(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-  }), [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedMeteringConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'MeteringProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
   return <MeteringConfigContext value={value}>{children}</MeteringConfigContext>;
 }
 
 /** Returns the metering configuration from the nearest `MeteringProvider`. */
-export function useMeteringConfig(): MeteringConfig {
+export function useMeteringConfig(): ResolvedMeteringConfig {
   const ctx = useContext(MeteringConfigContext);
   if (!ctx) {
     throw new Error('useMeteringConfig must be used within a MeteringProvider');

--- a/packages/@granit/react-multi-tenancy/package.json
+++ b/packages/@granit/react-multi-tenancy/package.json
@@ -17,8 +17,8 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/multi-tenancy": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -39,5 +39,9 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*"
   }
 }

--- a/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
+++ b/packages/@granit/react-multi-tenancy/src/providers/tenant-admin-provider.tsx
@@ -1,14 +1,23 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 export interface TenantAdminConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * TenantAdminConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedTenantAdminConfig extends TenantAdminConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface TenantAdminProviderProps {
@@ -18,9 +27,9 @@ export interface TenantAdminProviderProps {
 
 const DEFAULT_KEY_PREFIX = ['tenant-admin'] as const;
 
-const TenantAdminContext = createContext<TenantAdminConfig | null>(null);
+const TenantAdminContext = createContext<ResolvedTenantAdminConfig | null>(null);
 
-export function useTenantAdminConfig(): TenantAdminConfig {
+export function useTenantAdminConfig(): ResolvedTenantAdminConfig {
   const config = useContext(TenantAdminContext);
   if (!config) throw new Error('useTenantAdminConfig must be used within a TenantAdminProvider');
   return config;
@@ -34,14 +43,21 @@ export function buildTenantAdminQueryKey(
 }
 
 export function TenantAdminProvider({ config, children }: TenantAdminProviderProps) {
-  const value = useMemo<TenantAdminConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'TenantAdminProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
 
   return <TenantAdminContext value={value}>{children}</TenantAdminContext>;
 }

--- a/packages/@granit/react-notifications-mobile-push/package.json
+++ b/packages/@granit/react-notifications-mobile-push/package.json
@@ -15,15 +15,18 @@
   },
   "peerDependencies": {
     "@capacitor/push-notifications": ">=6.0.0",
+    "@granit/api-client": "workspace:*",
     "@granit/notifications-mobile-push": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "react": "^19.0.0"
   },
   "devDependencies": {
     "@capacitor/push-notifications": "^8.0.3",
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
+++ b/packages/@granit/react-notifications-mobile-push/src/providers/mobile-push-provider.tsx
@@ -1,14 +1,23 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Resolved configuration exposed by {@link useMobilePushConfig}. */
 export interface MobilePushProviderConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   readonly basePath: string;
+}
+
+/**
+ * MobilePushProviderConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedMobilePushProviderConfig extends MobilePushProviderConfig {
+  readonly client: AxiosInstance;
 }
 
 /** Props accepted by {@link MobilePushProvider}. `basePath` is optional — the default is applied by the provider. */
@@ -18,22 +27,29 @@ export interface MobilePushProviderProps {
   readonly children: ReactNode;
 }
 
-const MobilePushConfigContext = createContext<MobilePushProviderConfig | null>(null);
+const MobilePushConfigContext = createContext<ResolvedMobilePushProviderConfig | null>(null);
 
 /** Provides mobile push configuration to child components and hooks. */
 export function MobilePushProvider({ config, children }: Readonly<MobilePushProviderProps>) {
-  const value = useMemo<MobilePushProviderConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'MobilePushProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
   return <MobilePushConfigContext value={value}>{children}</MobilePushConfigContext>;
 }
 
 /** Returns the mobile push configuration from the nearest {@link MobilePushProvider}. */
-export function useMobilePushConfig(): MobilePushProviderConfig {
+export function useMobilePushConfig(): ResolvedMobilePushProviderConfig {
   const ctx = useContext(MobilePushConfigContext);
   if (!ctx) {
     throw new Error('useMobilePushConfig must be used within a MobilePushProvider');

--- a/packages/@granit/react-notifications-web-push/package.json
+++ b/packages/@granit/react-notifications-web-push/package.json
@@ -14,8 +14,9 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/notifications-web-push": "workspace:*",
-    "axios": "*",
+    "@granit/react-api-client": "workspace:*",
     "react": "^19.0.0"
   },
   "publishConfig": {
@@ -26,5 +27,9 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*"
   }
 }

--- a/packages/@granit/react-notifications-web-push/src/providers/web-push-provider.tsx
+++ b/packages/@granit/react-notifications-web-push/src/providers/web-push-provider.tsx
@@ -1,8 +1,9 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Resolved configuration exposed by {@link useWebPushConfig}. */
@@ -15,10 +16,14 @@ export interface WebPushProviderConfig {
   readonly serviceWorkerPath: string;
 }
 
-/** Props accepted by {@link WebPushProvider}. `basePath` and `serviceWorkerPath` are optional. */
+/**
+ * Props accepted by {@link WebPushProvider}. `apiClient`, `basePath`, and
+ * `serviceWorkerPath` are optional — the provider falls back to the nearest
+ * `<GranitClientProvider>` for `apiClient` and applies defaults otherwise.
+ */
 export interface WebPushProviderProps {
-  readonly config: Omit<WebPushProviderConfig, 'basePath' | 'serviceWorkerPath'> &
-    Partial<Pick<WebPushProviderConfig, 'basePath' | 'serviceWorkerPath'>>;
+  readonly config: Omit<WebPushProviderConfig, 'apiClient' | 'basePath' | 'serviceWorkerPath'> &
+    Partial<Pick<WebPushProviderConfig, 'apiClient' | 'basePath' | 'serviceWorkerPath'>>;
   readonly children: ReactNode;
 }
 
@@ -28,14 +33,21 @@ const DEFAULT_SERVICE_WORKER_PATH = '/sw.js';
 
 /** Provides web push configuration to child components and hooks. */
 export function WebPushProvider({ config, children }: Readonly<WebPushProviderProps>) {
-  const value = useMemo<WebPushProviderConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<WebPushProviderConfig>(() => {
+    const apiClient = config.apiClient ?? contextClient;
+    if (!apiClient) {
+      throw new Error(
+        'WebPushProvider requires an Axios client. Provide it via config.apiClient or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
+      apiClient,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       serviceWorkerPath: config.serviceWorkerPath ?? DEFAULT_SERVICE_WORKER_PATH,
-    }),
-    [config],
-  );
+    };
+  }, [config, contextClient]);
   return <WebPushConfigContext value={value}>{children}</WebPushConfigContext>;
 }
 

--- a/packages/@granit/react-notifications/package.json
+++ b/packages/@granit/react-notifications/package.json
@@ -15,11 +15,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/notifications": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -42,6 +42,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   }

--- a/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-preferences.ts
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useOptimistic, useRef, useState, useTransition 
 import { API_BASE_PATH } from '../constants.js';
 import { useNotificationConfig } from '../providers/notification-provider.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { NotificationPreference } from '@granit/notifications';
-import type { AxiosInstance } from 'axios';
 
 export interface UseNotificationPreferencesReturn {
   preferences: NotificationPreference[];

--- a/packages/@granit/react-openiddict-admin/package.json
+++ b/packages/@granit/react-openiddict-admin/package.json
@@ -15,9 +15,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/openiddict-admin": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -27,8 +28,10 @@
     }
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
+++ b/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
@@ -1,14 +1,23 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 export interface OpenIddictAdminConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * OpenIddictAdminConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedOpenIddictAdminConfig extends OpenIddictAdminConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface OpenIddictAdminProviderProps {
@@ -18,9 +27,9 @@ export interface OpenIddictAdminProviderProps {
 
 const DEFAULT_KEY_PREFIX = ['openiddict-admin'] as const;
 
-const AdminContext = createContext<OpenIddictAdminConfig | null>(null);
+const AdminContext = createContext<ResolvedOpenIddictAdminConfig | null>(null);
 
-export function useAdminConfig(): OpenIddictAdminConfig {
+export function useAdminConfig(): ResolvedOpenIddictAdminConfig {
   const config = useContext(AdminContext);
   if (!config) throw new Error('useAdminConfig must be used within an OpenIddictAdminProvider');
   return config;
@@ -34,14 +43,21 @@ export function buildAdminQueryKey(
 }
 
 export function OpenIddictAdminProvider({ config, children }: OpenIddictAdminProviderProps) {
-  const value = useMemo<OpenIddictAdminConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'OpenIddictAdminProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
 
   return <AdminContext value={value}>{children}</AdminContext>;
 }

--- a/packages/@granit/react-parties/package.json
+++ b/packages/@granit/react-parties/package.json
@@ -15,11 +15,12 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/parties": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0",
     "react-i18next": "^16.0.0 || ^17.0.0"
@@ -43,6 +44,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-parties/src/components/MergeWizard.tsx
+++ b/packages/@granit/react-parties/src/components/MergeWizard.tsx
@@ -4,8 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { usePartyQuery } from '../hooks/use-parties.js';
 import { useMergePartyMutation, useMergePartyPreviewQuery } from '../hooks/use-party-merge.js';
 
+import type { AxiosError } from '@granit/api-client';
 import type { FieldConflictResponse, MergeWinner, PartyId, PartyResponse } from '@granit/parties';
-import type { AxiosError } from 'axios';
 
 const REASON_MAX_LENGTH = 1000;
 const PARTIES_NAMESPACE = 'parties';

--- a/packages/@granit/react-parties/src/providers/parties-provider.tsx
+++ b/packages/@granit/react-parties/src/providers/parties-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the parties provider. */
 export interface PartiesConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for parties endpoints (default: `/api/v1/parties`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * PartiesConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedPartiesConfig extends PartiesConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface PartiesProviderProps {
@@ -18,22 +27,29 @@ export interface PartiesProviderProps {
   readonly children: ReactNode;
 }
 
-const PartiesConfigContext = createContext<PartiesConfig | null>(null);
+const PartiesConfigContext = createContext<ResolvedPartiesConfig | null>(null);
 
 /** Provides parties configuration to child components and hooks. */
 export function PartiesProvider({ config, children }: Readonly<PartiesProviderProps>) {
-  const value = useMemo(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedPartiesConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'PartiesProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
   return <PartiesConfigContext value={value}>{children}</PartiesConfigContext>;
 }
 
 /** Returns the parties configuration from the nearest `PartiesProvider`. */
-export function usePartiesConfig(): PartiesConfig {
+export function usePartiesConfig(): ResolvedPartiesConfig {
   const ctx = useContext(PartiesConfigContext);
   if (!ctx) {
     throw new Error('usePartiesConfig must be used within a PartiesProvider');

--- a/packages/@granit/react-payments/package.json
+++ b/packages/@granit/react-payments/package.json
@@ -15,10 +15,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/payments": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "lucide-react": "^1.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
@@ -42,6 +43,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-payments/src/providers/payments-provider.tsx
+++ b/packages/@granit/react-payments/src/providers/payments-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the payments provider. */
 export interface PaymentsConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for payment endpoints (default: `/api/v1/payments`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * PaymentsConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedPaymentsConfig extends PaymentsConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface PaymentsProviderProps {
@@ -18,22 +27,29 @@ export interface PaymentsProviderProps {
   readonly children: ReactNode;
 }
 
-const PaymentsConfigContext = createContext<PaymentsConfig | null>(null);
+const PaymentsConfigContext = createContext<ResolvedPaymentsConfig | null>(null);
 
 /** Provides payments configuration to child components and hooks. */
 export function PaymentsProvider({ config, children }: Readonly<PaymentsProviderProps>) {
-  const value = useMemo(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedPaymentsConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'PaymentsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
   return <PaymentsConfigContext value={value}>{children}</PaymentsConfigContext>;
 }
 
 /** Returns the payments configuration from the nearest `PaymentsProvider`. */
-export function usePaymentsConfig(): PaymentsConfig {
+export function usePaymentsConfig(): ResolvedPaymentsConfig {
   const ctx = useContext(PaymentsConfigContext);
   if (!ctx) {
     throw new Error('usePaymentsConfig must be used within a PaymentsProvider');

--- a/packages/@granit/react-privacy/package.json
+++ b/packages/@granit/react-privacy/package.json
@@ -15,9 +15,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/privacy": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -27,8 +28,10 @@
     }
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
+++ b/packages/@granit/react-privacy/src/providers/privacy-provider.tsx
@@ -1,14 +1,23 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 export interface PrivacyConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * PrivacyConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedPrivacyConfig extends PrivacyConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface PrivacyProviderProps {
@@ -18,9 +27,9 @@ export interface PrivacyProviderProps {
 
 const DEFAULT_KEY_PREFIX = ['privacy'] as const;
 
-const PrivacyContext = createContext<PrivacyConfig | null>(null);
+const PrivacyContext = createContext<ResolvedPrivacyConfig | null>(null);
 
-export function usePrivacyConfig(): PrivacyConfig {
+export function usePrivacyConfig(): ResolvedPrivacyConfig {
   const config = useContext(PrivacyContext);
   if (!config) throw new Error('usePrivacyConfig must be used within a PrivacyProvider');
   return config;
@@ -34,14 +43,21 @@ export function buildPrivacyQueryKey(
 }
 
 export function PrivacyProvider({ config, children }: PrivacyProviderProps) {
-  const value = useMemo<PrivacyConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'PrivacyProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
-    }),
-    [config]
-  );
+      client,
+    };
+  }, [config, contextClient]);
 
   return <PrivacyContext value={value}>{children}</PrivacyContext>;
 }

--- a/packages/@granit/react-reference-data/package.json
+++ b/packages/@granit/react-reference-data/package.json
@@ -14,11 +14,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/reference-data": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "react": "^19.0.0"
   },
   "publishConfig": {
@@ -31,7 +31,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   }
 }

--- a/packages/@granit/react-reference-data/src/hooks/create-reference-data-hooks.ts
+++ b/packages/@granit/react-reference-data/src/hooks/create-reference-data-hooks.ts
@@ -8,6 +8,7 @@ import {
 } from '@granit/reference-data';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
 import type {
   ReferenceDataCreateRequest,
@@ -16,7 +17,6 @@ import type {
   ReferenceDataUpdateRequest,
 } from '@granit/reference-data';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
 // Public option types

--- a/packages/@granit/react-scheduling/package.json
+++ b/packages/@granit/react-scheduling/package.json
@@ -15,10 +15,11 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/scheduling": "workspace:*",
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/scheduling": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -41,8 +42,10 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/react-scheduling/src/providers/scheduling-provider.tsx
+++ b/packages/@granit/react-scheduling/src/providers/scheduling-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the scheduling provider. */
 export interface SchedulingConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for scheduling endpoints (default: `/api/v1/scheduling`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * SchedulingConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedSchedulingConfig extends SchedulingConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface SchedulingProviderProps {
@@ -18,19 +27,29 @@ export interface SchedulingProviderProps {
   readonly children: ReactNode;
 }
 
-const SchedulingConfigContext = createContext<SchedulingConfig | null>(null);
+const SchedulingConfigContext = createContext<ResolvedSchedulingConfig | null>(null);
 
 /** Provides scheduling configuration to child components and hooks. */
 export function SchedulingProvider({ config, children }: Readonly<SchedulingProviderProps>) {
-  const value = useMemo(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-  }), [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedSchedulingConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'SchedulingProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
   return <SchedulingConfigContext value={value}>{children}</SchedulingConfigContext>;
 }
 
 /** Returns the scheduling configuration from the nearest `SchedulingProvider`. */
-export function useSchedulingConfig(): SchedulingConfig {
+export function useSchedulingConfig(): ResolvedSchedulingConfig {
   const ctx = useContext(SchedulingConfigContext);
   if (!ctx) {
     throw new Error('useSchedulingConfig must be used within a SchedulingProvider');

--- a/packages/@granit/react-settings/package.json
+++ b/packages/@granit/react-settings/package.json
@@ -15,9 +15,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/settings": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -40,7 +41,9 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   }
 }

--- a/packages/@granit/react-settings/src/providers/settings-provider.tsx
+++ b/packages/@granit/react-settings/src/providers/settings-provider.tsx
@@ -1,14 +1,23 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the settings provider. */
 export interface SettingsConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path prefix before `/settings/...` (default: empty string). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * SettingsConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedSettingsConfig extends SettingsConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface SettingsProviderProps {
@@ -16,16 +25,25 @@ export interface SettingsProviderProps {
   readonly children: ReactNode;
 }
 
-const SettingsConfigContext = createContext<SettingsConfig | null>(null);
+const SettingsConfigContext = createContext<ResolvedSettingsConfig | null>(null);
 
 /** Provides settings configuration to child components and hooks. */
 export function SettingsProvider({ config, children }: Readonly<SettingsProviderProps>) {
-  const value = useMemo(() => config, [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedSettingsConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'SettingsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return { ...config, client };
+  }, [config, contextClient]);
   return <SettingsConfigContext value={value}>{children}</SettingsConfigContext>;
 }
 
 /** Returns the settings configuration from the nearest `SettingsProvider`. */
-export function useSettingsConfig(): SettingsConfig {
+export function useSettingsConfig(): ResolvedSettingsConfig {
   const ctx = useContext(SettingsConfigContext);
   if (!ctx) {
     throw new Error('useSettingsConfig must be used within a SettingsProvider');

--- a/packages/@granit/react-subscriptions/package.json
+++ b/packages/@granit/react-subscriptions/package.json
@@ -15,11 +15,12 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/subscriptions": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -42,6 +43,8 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"

--- a/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
+++ b/packages/@granit/react-subscriptions/src/providers/subscriptions-provider.tsx
@@ -1,13 +1,14 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the subscriptions provider. */
 export interface SubscriptionsConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for subscriptions endpoints (default: `/api/v1/subscriptions`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -15,6 +16,7 @@ export interface SubscriptionsConfig {
 
 /** Resolved configuration where all optional fields have defaults applied. */
 export interface ResolvedSubscriptionsConfig extends SubscriptionsConfig {
+  readonly client: AxiosInstance;
   readonly basePath: string;
 }
 
@@ -27,10 +29,16 @@ const SubscriptionsConfigContext = createContext<ResolvedSubscriptionsConfig | n
 
 /** Provides subscriptions configuration to child components and hooks. */
 export function SubscriptionsProvider({ config, children }: Readonly<SubscriptionsProviderProps>) {
-  const value = useMemo<ResolvedSubscriptionsConfig>(
-    () => ({ ...config, basePath: config.basePath ?? DEFAULT_BASE_PATH }),
-    [config]
-  );
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedSubscriptionsConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'SubscriptionsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
+  }, [config, contextClient]);
   return <SubscriptionsConfigContext value={value}>{children}</SubscriptionsConfigContext>;
 }
 

--- a/packages/@granit/react-tax/package.json
+++ b/packages/@granit/react-tax/package.json
@@ -15,9 +15,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/tax": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -40,8 +41,10 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/react-tax/src/providers/tax-provider.tsx
+++ b/packages/@granit/react-tax/src/providers/tax-provider.tsx
@@ -1,16 +1,25 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the tax provider. */
 export interface TaxConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for tax endpoints (default: `/api/v1/tax`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * TaxConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedTaxConfig extends TaxConfig {
+  readonly client: AxiosInstance;
 }
 
 export interface TaxProviderProps {
@@ -18,19 +27,29 @@ export interface TaxProviderProps {
   readonly children: ReactNode;
 }
 
-const TaxConfigContext = createContext<TaxConfig | null>(null);
+const TaxConfigContext = createContext<ResolvedTaxConfig | null>(null);
 
 /** Provides tax configuration to child components and hooks. */
 export function TaxProvider({ config, children }: Readonly<TaxProviderProps>) {
-  const value = useMemo(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-  }), [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedTaxConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'TaxProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
   return <TaxConfigContext value={value}>{children}</TaxConfigContext>;
 }
 
 /** Returns the tax configuration from the nearest `TaxProvider`. */
-export function useTaxConfig(): TaxConfig {
+export function useTaxConfig(): ResolvedTaxConfig {
   const ctx = useContext(TaxConfigContext);
   if (!ctx) {
     throw new Error('useTaxConfig must be used within a TaxProvider');

--- a/packages/@granit/react-templating/package.json
+++ b/packages/@granit/react-templating/package.json
@@ -17,15 +17,17 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
     "@granit/templating": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/templating": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-templating/src/providers/templating-provider.tsx
+++ b/packages/@granit/react-templating/src/providers/templating-provider.tsx
@@ -1,13 +1,14 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { TemplatingConfig as ResolvedTemplatingConfig } from '@granit/templating';
-import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
 export interface TemplatingConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
@@ -22,14 +23,21 @@ const DEFAULT_QUERY_KEY_PREFIX = ['templates'] as const;
 const TemplatingConfigContext = createContext<ResolvedTemplatingConfig | null>(null);
 
 export function TemplatingProvider({ config, children }: TemplatingProviderProps) {
-  const value = useMemo<ResolvedTemplatingConfig>(
-    () => ({
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedTemplatingConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'TemplatingProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
       ...config,
+      client,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
       queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
-    }),
-    [config]
-  );
+    };
+  }, [config, contextClient]);
 
   return <TemplatingConfigContext value={value}>{children}</TemplatingConfigContext>;
 }

--- a/packages/@granit/react-timeline/package.json
+++ b/packages/@granit/react-timeline/package.json
@@ -16,16 +16,18 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/timeline": "workspace:*",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-timeline/src/providers/timeline-provider.tsx
+++ b/packages/@granit/react-timeline/src/providers/timeline-provider.tsx
@@ -1,16 +1,17 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { TimelineConfig } from '@granit/timeline';
-import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
 const TimelineConfigContext = createContext<TimelineConfig | null>(null);
 
 /** Configuration for the timeline provider. */
 export interface TimelineProviderConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for timeline endpoints (default: `/api/v1/timeline`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -23,11 +24,21 @@ export interface TimelineProviderProps {
 
 /** Provides timeline configuration to child components and hooks. */
 export function TimelineProvider({ config, children }: Readonly<TimelineProviderProps>) {
-  const value = useMemo<TimelineConfig>(() => ({
-    ...config,
-    basePath: config.basePath ?? DEFAULT_BASE_PATH,
-    queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
-  }), [config]);
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<TimelineConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'TimelineProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      client,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+    };
+  }, [config, contextClient]);
 
   return <TimelineConfigContext value={value}>{children}</TimelineConfigContext>;
 }

--- a/packages/@granit/react-validation/package.json
+++ b/packages/@granit/react-validation/package.json
@@ -14,13 +14,14 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/validation": "workspace:*",
-    "axios": "*",
     "react": "^19.0.0"
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
-    "@granit/react-testing": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-validation/src/use-server-validation.ts
+++ b/packages/@granit/react-validation/src/use-server-validation.ts
@@ -2,8 +2,8 @@ import { validateField, validateFieldServer } from '@granit/validation';
 import { useEffect, useRef, useState } from 'react';
 
 import type { TranslateFunction } from './create-constraints-resolver.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { FieldConstraint } from '@granit/validation';
-import type { AxiosInstance } from 'axios';
 
 export interface ServerValidationState {
   readonly status: 'idle' | 'validating' | 'valid' | 'invalid' | 'error';

--- a/packages/@granit/react-webhooks/package.json
+++ b/packages/@granit/react-webhooks/package.json
@@ -15,9 +15,9 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/webhooks": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -27,8 +27,9 @@
     }
   },
   "devDependencies": {
-    "@granit/testing": "workspace:*",
+    "@granit/api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/react-webhooks/src/hooks/use-event-types.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-event-types.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_WEBHOOKS_BASE_PATH } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { WebhookEventTypeResponse } from '@granit/webhooks';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 export interface EventTypesOptions {
   readonly client: AxiosInstance;

--- a/packages/@granit/react-webhooks/src/hooks/use-retry-delivery.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-retry-delivery.ts
@@ -3,8 +3,8 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { DEFAULT_WEBHOOKS_BASE_PATH } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { UseMutationResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 export interface RetryDeliveryOptions {
   readonly client: AxiosInstance;

--- a/packages/@granit/react-webhooks/src/hooks/use-subscription.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-subscription.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { WebhookSubscriptionResponse } from '@granit/webhooks';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 /** Options accepted by all webhook hooks. */
 export interface WebhooksOptions {

--- a/packages/@granit/react-webhooks/src/hooks/use-webhook-config.ts
+++ b/packages/@granit/react-webhooks/src/hooks/use-webhook-config.ts
@@ -3,9 +3,9 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_WEBHOOKS_BASE_PATH } from '../constants.js';
 
+import type { AxiosInstance } from '@granit/api-client';
 import type { WebhookModuleConfig } from '@granit/webhooks';
 import type { UseQueryResult } from '@tanstack/react-query';
-import type { AxiosInstance } from 'axios';
 
 export interface WebhookConfigOptions {
   readonly client: AxiosInstance;

--- a/packages/@granit/react-workflow/package.json
+++ b/packages/@granit/react-workflow/package.json
@@ -16,15 +16,17 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/workflow": "workspace:*",
-    "axios": "*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-workflow/src/providers/workflow-provider.tsx
+++ b/packages/@granit/react-workflow/src/providers/workflow-provider.tsx
@@ -1,13 +1,14 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
 
 /** Configuration for the workflow provider. */
 export interface WorkflowConfig {
-  readonly client: AxiosInstance;
+  readonly client?: AxiosInstance;
   /** Base path for workflow endpoints (default: `/api/v1/workflow`). */
   readonly basePath?: string;
   readonly queryKeyPrefix?: readonly string[];
@@ -15,6 +16,7 @@ export interface WorkflowConfig {
 
 /** Resolved configuration where all optional fields have defaults applied. */
 export interface ResolvedWorkflowConfig extends WorkflowConfig {
+  readonly client: AxiosInstance;
   readonly basePath: string;
 }
 
@@ -27,10 +29,16 @@ const WorkflowConfigContext = createContext<ResolvedWorkflowConfig | null>(null)
 
 /** Provides workflow configuration to child components and hooks. */
 export function WorkflowProvider({ config, children }: Readonly<WorkflowProviderProps>) {
-  const value = useMemo<ResolvedWorkflowConfig>(
-    () => ({ ...config, basePath: config.basePath ?? DEFAULT_BASE_PATH }),
-    [config],
-  );
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedWorkflowConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'WorkflowProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return { ...config, client, basePath: config.basePath ?? DEFAULT_BASE_PATH };
+  }, [config, contextClient]);
   return <WorkflowConfigContext value={value}>{children}</WorkflowConfigContext>;
 }
 

--- a/packages/@granit/reference-data/package.json
+++ b/packages/@granit/reference-data/package.json
@@ -14,11 +14,12 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/reference-data/src/api/reference-data-api.ts
+++ b/packages/@granit/reference-data/src/api/reference-data-api.ts
@@ -4,8 +4,8 @@ import type {
   ReferenceDataQuery,
   ReferenceDataUpdateRequest,
 } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 /**
  * List reference data entries (paginated).

--- a/packages/@granit/scheduling/package.json
+++ b/packages/@granit/scheduling/package.json
@@ -14,11 +14,12 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/scheduling/src/api/scheduling-api.ts
+++ b/packages/@granit/scheduling/src/api/scheduling-api.ts
@@ -1,8 +1,8 @@
 import { getPage } from '@granit/query-engine';
 
 import type { RescheduleActionRequest, ScheduledActionResponse } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult, QueryRequest } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 /**
  * Get a scheduled action by ID.

--- a/packages/@granit/settings/package.json
+++ b/packages/@granit/settings/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/settings/src/api/settings-api.ts
+++ b/packages/@granit/settings/src/api/settings-api.ts
@@ -6,7 +6,7 @@ import type {
   SettingsMap,
   UpdateSettingValueRequest,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /** Scopes that expose admin bulk endpoints. `user` is per-user and has no bulk form. */
 export type AdminSettingsScope = 'global' | 'tenant';

--- a/packages/@granit/settings/src/types/index.ts
+++ b/packages/@granit/settings/src/types/index.ts
@@ -61,7 +61,8 @@ export type BulkSettingOutcome = 'Updated' | 'NotFound' | 'ProviderNotAllowed' |
  * Per-entry result returned by `PUT /settings/{scope}/bulk`.
  *
  * `errorCode` is a machine-readable i18n key (e.g. `"Granit:Settings:NotFound"`)
- * resolvable via `GET /api/granit/localization`. It is `null` iff `outcome === "Updated"`.
+ * resolvable via the host's localization endpoint (`GET /localization` by default,
+ * mounted under whatever prefix the host configures). `null` iff `outcome === "Updated"`.
  */
 export interface BulkSettingResult {
   readonly key: string;

--- a/packages/@granit/subscriptions/package.json
+++ b/packages/@granit/subscriptions/package.json
@@ -14,12 +14,13 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
+++ b/packages/@granit/subscriptions/src/__tests__/subscriptions-api.test.ts
@@ -32,7 +32,7 @@ import type {
 } from '../types.js';
 import type { PagedResult } from '@granit/query-engine';
 
-const basePath = '/api/granit/subscriptions';
+const basePath = '/subscriptions';
 
 const samplePlan: PlanResponse = {
   id: 'plan-1',

--- a/packages/@granit/subscriptions/src/api/subscriptions-api.ts
+++ b/packages/@granit/subscriptions/src/api/subscriptions-api.ts
@@ -16,8 +16,8 @@ import type {
   SubscriptionCreateRequest,
   SubscriptionResponse,
 } from '../types.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult, QueryRequest } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 // ---------------------------------------------------------------------------
 // Plans

--- a/packages/@granit/tax/package.json
+++ b/packages/@granit/tax/package.json
@@ -14,10 +14,11 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/tax/src/__tests__/tax-api.test.ts
+++ b/packages/@granit/tax/src/__tests__/tax-api.test.ts
@@ -52,9 +52,9 @@ describe('validateTaxId', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValue({ data: mockValidateResponse });
 
-    const result = await validateTaxId(client, '/api/granit/tax', mockValidateRequest);
+    const result = await validateTaxId(client, '/tax', mockValidateRequest);
 
-    expect(client.post).toHaveBeenCalledWith('/api/granit/tax/ids/validate', mockValidateRequest);
+    expect(client.post).toHaveBeenCalledWith('/tax/ids/validate', mockValidateRequest);
     expect(result).toEqual(mockValidateResponse);
   });
 
@@ -79,7 +79,7 @@ describe('validateTaxId', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValue({ data: invalid });
 
-    const result = await validateTaxId(client, '/api/granit/tax', mockValidateRequest);
+    const result = await validateTaxId(client, '/tax', mockValidateRequest);
 
     expect(result.isValid).toBe(false);
     expect(result.companyName).toBeNull();
@@ -96,9 +96,9 @@ describe('getTaxRates', () => {
     const rates = [mockBelgiumRate, mockLuxembourgRate];
     vi.mocked(client.get).mockResolvedValue({ data: rates });
 
-    const result = await getTaxRates(client, '/api/granit/tax');
+    const result = await getTaxRates(client, '/tax');
 
-    expect(client.get).toHaveBeenCalledWith('/api/granit/tax/rates');
+    expect(client.get).toHaveBeenCalledWith('/tax/rates');
     expect(result).toEqual(rates);
     expect(result).toHaveLength(2);
   });
@@ -116,7 +116,7 @@ describe('getTaxRates', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: [] });
 
-    const result = await getTaxRates(client, '/api/granit/tax');
+    const result = await getTaxRates(client, '/tax');
 
     expect(result).toEqual([]);
   });
@@ -131,9 +131,9 @@ describe('getTaxRateByCountry', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: mockBelgiumRate });
 
-    const result = await getTaxRateByCountry(client, '/api/granit/tax', 'BE');
+    const result = await getTaxRateByCountry(client, '/tax', 'BE');
 
-    expect(client.get).toHaveBeenCalledWith('/api/granit/tax/rates/BE');
+    expect(client.get).toHaveBeenCalledWith('/tax/rates/BE');
     expect(result).toEqual(mockBelgiumRate);
   });
 
@@ -141,9 +141,9 @@ describe('getTaxRateByCountry', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: mockBelgiumRate });
 
-    await getTaxRateByCountry(client, '/api/granit/tax', 'GB/NI');
+    await getTaxRateByCountry(client, '/tax', 'GB/NI');
 
-    expect(client.get).toHaveBeenCalledWith('/api/granit/tax/rates/GB%2FNI');
+    expect(client.get).toHaveBeenCalledWith('/tax/rates/GB%2FNI');
   });
 
   it('should work with custom basePath', async () => {

--- a/packages/@granit/tax/src/api/tax-api.ts
+++ b/packages/@granit/tax/src/api/tax-api.ts
@@ -1,5 +1,5 @@
 import type { TaxRateResponse, TaxValidateRequest, TaxValidateResponse } from '../types.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * Validate a tax ID (e.g. VAT number) against the configured tax service.

--- a/packages/@granit/templating/package.json
+++ b/packages/@granit/templating/package.json
@@ -17,9 +17,9 @@
     "@granit/api-client": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/templating/src/api/templates-api.ts
+++ b/packages/@granit/templating/src/api/templates-api.ts
@@ -14,8 +14,8 @@ import type {
   TemplateRevision,
   TemplateVariables,
 } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult, PaginationParams } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 function templateUrl(basePath: string, name: string, ...segments: string[]): string {
   return buildApiUrl(basePath, 'templates', encodeURIComponent(name), ...segments);

--- a/packages/@granit/templating/src/types/template-types.ts
+++ b/packages/@granit/templating/src/types/template-types.ts
@@ -1,6 +1,6 @@
+import type { AxiosInstance } from '@granit/api-client';
 import type { PaginationParams } from '@granit/query-engine';
 import type { EntityId, ISODateString } from '@granit/types';
-import type { AxiosInstance } from 'axios';
 
 // ── Template lifecycle status (mirrors .NET Granit.Templating.Domain.TemplateLifecycleStatus) ──
 

--- a/packages/@granit/testing/package.json
+++ b/packages/@granit/testing/package.json
@@ -15,7 +15,7 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*",
+    "@granit/api-client": "workspace:*",
     "msw": "^2.12.0",
     "vitest": "^4.0.0"
   },
@@ -36,5 +36,8 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
   }
 }

--- a/packages/@granit/testing/src/mock-client.ts
+++ b/packages/@granit/testing/src/mock-client.ts
@@ -1,6 +1,6 @@
 import { vi } from 'vitest';
 
-import type { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import type { AxiosInstance, AxiosResponse, InternalAxiosRequestConfig } from '@granit/api-client';
 
 /**
  * Create a fully mocked AxiosInstance with vi.fn() stubs for all methods.

--- a/packages/@granit/timeline/package.json
+++ b/packages/@granit/timeline/package.json
@@ -18,9 +18,9 @@
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/timeline/src/api/timeline-api.ts
+++ b/packages/@granit/timeline/src/api/timeline-api.ts
@@ -6,7 +6,7 @@ import type {
   TimelineEntry,
   TimelineEntryPage,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 function buildEntityUrl(
   basePath: string,

--- a/packages/@granit/timeline/src/types/config.ts
+++ b/packages/@granit/timeline/src/types/config.ts
@@ -1,4 +1,4 @@
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 // --- Provider config ---
 

--- a/packages/@granit/validation/package.json
+++ b/packages/@granit/validation/package.json
@@ -14,9 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {

--- a/packages/@granit/validation/src/api/server-validation-api.ts
+++ b/packages/@granit/validation/src/api/server-validation-api.ts
@@ -4,7 +4,7 @@ import type {
   ServerValidationResult,
   ValidationStatus,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 const DEFAULT_BASE_PATH = '/api/v1/validation';
 

--- a/packages/@granit/webhooks/package.json
+++ b/packages/@granit/webhooks/package.json
@@ -14,9 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "axios": "*"
+    "@granit/api-client": "workspace:*"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },

--- a/packages/@granit/webhooks/src/api/webhooks-api.ts
+++ b/packages/@granit/webhooks/src/api/webhooks-api.ts
@@ -11,7 +11,7 @@ import type {
   WebhookSubscriptionTestPingResponse,
   WebhookSubscriptionUpdateRequest,
 } from '../types/index.js';
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 // ── Subscription CRUD ───────────────────────────────────────────────────────
 

--- a/packages/@granit/workflow/package.json
+++ b/packages/@granit/workflow/package.json
@@ -17,9 +17,9 @@
     "@granit/api-client": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*",
-    "axios": "*"
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/workflow/src/api/workflow-api.ts
+++ b/packages/@granit/workflow/src/api/workflow-api.ts
@@ -6,8 +6,8 @@ import type {
   WorkflowTransitionResult,
   WorkflowStatus,
 } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult, PaginationParams } from '@granit/query-engine';
-import type { AxiosInstance } from 'axios';
 
 function buildEntityUrl(
   basePath: string,

--- a/packages/@granit/workflow/src/types/config.ts
+++ b/packages/@granit/workflow/src/types/config.ts
@@ -1,4 +1,4 @@
-import type { AxiosInstance } from 'axios';
+import type { AxiosInstance } from '@granit/api-client';
 
 /** Configuration for the workflow provider context. */
 export interface WorkflowConfig {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,10 +161,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -174,10 +174,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -200,10 +200,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -253,20 +253,19 @@ importers:
         version: 26.2.3
 
   packages/@granit/authentication-local:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/authorization:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
 
   packages/@granit/background-jobs:
     dependencies:
@@ -276,10 +275,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -291,11 +290,10 @@ importers:
         version: link:../types
 
   packages/@granit/blob-storage:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -312,11 +310,10 @@ importers:
         version: 0.7.21(@babel/core@7.29.0)(eslint@10.2.1(jiti@2.6.1))
 
   packages/@granit/customer-balance:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -329,30 +326,28 @@ importers:
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/data-lookup:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/diagnostics:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -360,23 +355,19 @@ importers:
   packages/@granit/error-boundary: {}
 
   packages/@granit/features:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/idempotency:
-    dependencies:
+    devDependencies:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
 
   packages/@granit/identity:
     dependencies:
@@ -386,10 +377,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -399,10 +390,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -415,13 +406,13 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       i18next:
         specifier: ^25.0.0
         version: 25.8.14(typescript@5.9.3)
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -442,10 +433,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -455,9 +446,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
 
   packages/@granit/notifications:
     dependencies:
@@ -467,19 +459,12 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
 
   packages/@granit/notifications-mobile-push:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -515,10 +500,6 @@ importers:
         version: 2.0.1
 
   packages/@granit/notifications-web-push:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -532,20 +513,19 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/parties:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -554,21 +534,19 @@ importers:
         version: link:../types
 
   packages/@granit/payments:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/privacy:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -581,10 +559,10 @@ importers:
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -597,9 +575,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -607,6 +582,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -625,9 +606,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -635,9 +613,15 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -650,13 +634,13 @@ importers:
 
   packages/@granit/react-api-client:
     dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       react:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -675,9 +659,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -685,6 +666,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -722,9 +709,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -732,6 +716,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -744,9 +731,6 @@ importers:
 
   packages/@granit/react-authentication-cognito:
     dependencies:
-      '@granit/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@granit/authentication':
         specifier: workspace:*
         version: link:../authentication
@@ -762,15 +746,16 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
 
   packages/@granit/react-authentication-entraid:
     dependencies:
       '@azure/msal-browser':
         specifier: '>=3.0.0'
         version: 5.6.2
-      '@granit/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@granit/authentication':
         specifier: workspace:*
         version: link:../authentication
@@ -783,12 +768,13 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
-
-  packages/@granit/react-authentication-google-cloud:
-    dependencies:
+    devDependencies:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+
+  packages/@granit/react-authentication-google-cloud:
+    dependencies:
       '@granit/authentication':
         specifier: workspace:*
         version: link:../authentication
@@ -804,12 +790,13 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
-
-  packages/@granit/react-authentication-keycloak:
-    dependencies:
+    devDependencies:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+
+  packages/@granit/react-authentication-keycloak:
+    dependencies:
       '@granit/authentication':
         specifier: workspace:*
         version: link:../authentication
@@ -825,6 +812,10 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
 
   packages/@granit/react-authentication-local:
     dependencies:
@@ -834,9 +825,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -844,6 +832,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -887,9 +881,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -897,6 +888,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -924,9 +921,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -934,6 +928,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
@@ -965,9 +962,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -975,6 +969,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1002,9 +1002,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1015,6 +1012,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5(react@19.2.5)
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1030,13 +1030,13 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       react:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1052,9 +1052,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1062,6 +1059,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1089,9 +1089,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1099,6 +1096,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1114,9 +1117,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1124,6 +1124,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1142,9 +1148,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1152,6 +1155,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1176,9 +1185,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       date-fns:
         specifier: ^4.0.0
         version: 4.1.0
@@ -1195,6 +1201,9 @@ importers:
         specifier: ^16.0.0
         version: 16.5.4(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@5.9.3)
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1210,9 +1219,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1220,6 +1226,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1232,24 +1244,25 @@ importers:
 
   packages/@granit/react-multi-tenancy:
     dependencies:
-      '@granit/api-client':
-        specifier: workspace:*
-        version: link:../api-client
       '@granit/multi-tenancy':
         specifier: workspace:*
         version: link:../multi-tenancy
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
 
   packages/@granit/react-notifications:
     dependencies:
@@ -1265,9 +1278,6 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1275,6 +1285,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1290,9 +1303,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1300,6 +1310,12 @@ importers:
       '@capacitor/push-notifications':
         specifier: ^8.0.3
         version: 8.0.3(@capacitor/core@8.2.0)
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1312,12 +1328,16 @@ importers:
       '@granit/notifications-web-push':
         specifier: workspace:*
         version: link:../notifications-web-push
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       react:
         specifier: ^19.0.0
         version: 19.2.5
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
 
   packages/@granit/react-openiddict-admin:
     dependencies:
@@ -1327,9 +1347,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1337,6 +1354,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1355,9 +1378,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.4(@types/node@25.6.0)(typescript@6.0.3)
@@ -1368,6 +1388,12 @@ importers:
         specifier: ^16.0.0 || ^17.0.0
         version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1386,9 +1412,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       lucide-react:
         specifier: ^1.0.0
         version: 1.8.0(react@19.2.5)
@@ -1399,6 +1422,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1417,9 +1446,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1427,6 +1453,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1482,13 +1514,13 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       react:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1507,9 +1539,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1517,6 +1546,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1535,9 +1570,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1545,6 +1577,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1572,9 +1610,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1582,6 +1617,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1600,9 +1641,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1610,6 +1648,12 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1625,9 +1669,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1641,6 +1682,9 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1684,9 +1728,6 @@ importers:
       '@granit/timeline':
         specifier: workspace:*
         version: link:../timeline
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1697,6 +1738,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1748,13 +1792,13 @@ importers:
       '@granit/validation':
         specifier: workspace:*
         version: link:../validation
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       react:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1770,9 +1814,6 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1780,6 +1821,9 @@ importers:
         specifier: ^19.0.0
         version: 19.2.5
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1801,9 +1845,6 @@ importers:
       '@granit/workflow':
         specifier: workspace:*
         version: link:../workflow
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
@@ -1814,6 +1855,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1832,10 +1876,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1848,20 +1892,19 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/settings:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1876,20 +1919,19 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/tax:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1902,9 +1944,6 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -1912,15 +1951,16 @@ importers:
 
   packages/@granit/testing:
     dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
       msw:
         specifier: ^2.12.0
         version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.0.0
         version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
 
   packages/@granit/timeline:
     dependencies:
@@ -1930,9 +1970,6 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -1968,21 +2005,19 @@ importers:
         version: 3.5.0
 
   packages/@granit/validation:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
 
   packages/@granit/webhooks:
-    dependencies:
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1998,9 +2033,6 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
-      axios:
-        specifier: 1.15.2
-        version: 1.15.2
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

This branch bundles four cleanup commits that arrived after PR #226 was merged. The big-ticket item is the **api-client façade refactor** (last commit); the other three are small follow-ups from the granit-dotnet `/api/granit` prefix removal.

### Commits

1. **chore(deps): refresh THIRD-PARTY-NOTICES with current installed versions** — keeps the notices file in sync with `pnpm-lock.yaml`.
2. **fix(data-lookup): align client base path with /lookups (no /api/granit prefix)** — pairs with the granit-dotnet change that flipped the C# default from `api/granit/lookups` to `lookups`.
3. **docs(settings): drop /api/granit prefix from localization route reference** — same theme, doc-only fix.
4. **refactor(api-client): route every consumer through @granit/api-client** — the main refactor (see below).

### `@granit/api-client` becomes the single seam

No domain or React package may import from `axios` directly anymore — types and instance creation flow through the façade.

- `@granit/api-client` re-exports `AxiosInstance`, `AxiosError`, `AxiosRequestConfig`, `AxiosResponse`, `InternalAxiosRequestConfig`. Consumers depend on `@granit/api-client`, not `axios`, for HTTP types.
- **113 source files migrated**: 58 `*-api.ts` (domain) + 26 React providers + ~29 hooks/components/types now import Axios types from `@granit/api-client`.
- **75 `package.json` updated**: `axios` peer dep dropped (now transitive via api-client), `@granit/api-client` added as peer + dev dep where missing.
- **ESLint `no-restricted-imports`** forbids `from 'axios'` outside the façade. Allow-list: `api-client` itself, `bff`, `react-bff`, `logger-otlp`, `react-tracing`, `notifications-sse`, and tests.

### React provider wiring unified

`config.client` is now **optional** in 24 providers (account, ai, auditing, authentication-local, background-jobs, customer-balance, features, identity, invoicing, metering, multi-tenancy, notifications-mobile-push, openiddict-admin, parties, payments, privacy, scheduling, settings, subscriptions, tax, templating, timeline, workflow, web-push). Each provider falls back to `useOptionalGranitClient()` when `config.client` is omitted, throwing a clear error if neither is supplied. A `Resolved<X>Config` exposes the post-resolution shape with `client` guaranteed.

**Backward-compatible**: existing consumers passing `config.client` keep working unchanged.

## Test plan

- [x] `pnpm tsc` — clean (105 projects)
- [x] `pnpm lint --max-warnings 0` — clean
- [x] `pnpm test --run` — **2213/2213** tests passing (271 files)
- [ ] Verify showcase-admin-react builds against the updated framework
- [ ] Smoke-test one feature in the showcase (e.g. parties duplicates inbox) to confirm no runtime regression
