### PR TITLE
feat(dashboards): scaffold dashboards / charts / analytics framework + arch proposals

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2058,14 +2058,9 @@
           "members": []
         },
         {
-          "name": "DashboardContextProvider",
+          "name": "useEffectiveTimeWindow",
           "kind": "function",
-          "signature": "function DashboardContextProvider("
-        },
-        {
-          "name": "useDashboardContext",
-          "kind": "function",
-          "signature": "function useDashboardContext(): DashboardContextValue | null"
+          "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"
         },
         {
           "name": "WidgetRenderer",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1988,6 +1988,16 @@
           "members": []
         },
         {
+          "name": "DashboardContextProvider",
+          "kind": "function",
+          "signature": "function DashboardContextProvider("
+        },
+        {
+          "name": "useDashboardContext",
+          "kind": "function",
+          "signature": "function useDashboardContext(): DashboardContextValue | null"
+        },
+        {
           "name": "WidgetRenderer",
           "kind": "function",
           "signature": "function WidgetRenderer("
@@ -2028,6 +2038,16 @@
           "name": "defaultWidgetRegistry",
           "kind": "const",
           "signature": "const defaultWidgetRegistry: WidgetRegistry"
+        },
+        {
+          "name": "WidgetRegistryProvider",
+          "kind": "function",
+          "signature": "function WidgetRegistryProvider("
+        },
+        {
+          "name": "useWidgetRegistry",
+          "kind": "function",
+          "signature": "function useWidgetRegistry(): WidgetRegistry"
         },
         {
           "name": "WidgetRegistryProviderProps",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -491,6 +491,35 @@
       ]
     },
     {
+      "name": "@granit/charts",
+      "description": "Framework-agnostic chart primitives for Granit — typed series shapes, ECharts theme builder from Tailwind tokens, locale-aware tick formatters",
+      "exports": [
+        {
+          "name": "ChartAxis",
+          "kind": "interface",
+          "signature": "interface ChartAxis",
+          "members": []
+        },
+        {
+          "name": "ChartDataPoint",
+          "kind": "type",
+          "signature": "type ChartDataPoint<X = number | string, Y = number> = readonly [X, Y]"
+        },
+        {
+          "name": "ChartDimensions",
+          "kind": "interface",
+          "signature": "interface ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "ChartSeries",
+          "kind": "interface",
+          "signature": "interface ChartSeries<X = number | string, Y = number>",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/cookies",
       "description": "Cookie consent abstraction with React context and hooks",
       "exports": []
@@ -516,6 +545,11 @@
           "signature": "const CustomerBalancePermissions"
         }
       ]
+    },
+    {
+      "name": "@granit/dashboards",
+      "description": "Framework-agnostic types and registry contracts for Granit dashboards — DashboardDefinition, WidgetDefinition discriminated union, layout primitives, and built-in presentation widgets (Markdown / Image / Text)",
+      "exports": []
     },
     {
       "name": "@granit/data-exchange",
@@ -1840,6 +1874,84 @@
       ]
     },
     {
+      "name": "@granit/react-charts",
+      "description": "React chart primitives for Granit — typed <LineChart>, <BarChart>, <PieChart>, <SparklineChart> built on Apache ECharts (modular tree-shaken imports), plus <Chart> escape hatch for raw ECharts options",
+      "exports": [
+        {
+          "name": "Chart",
+          "kind": "function",
+          "signature": "function Chart("
+        },
+        {
+          "name": "ChartProps",
+          "kind": "interface",
+          "signature": "interface ChartProps",
+          "members": []
+        },
+        {
+          "name": "LineChart",
+          "kind": "function",
+          "signature": "function LineChart("
+        },
+        {
+          "name": "LineChartProps",
+          "kind": "interface",
+          "signature": "interface LineChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "BarChart",
+          "kind": "function",
+          "signature": "function BarChart("
+        },
+        {
+          "name": "BarChartProps",
+          "kind": "interface",
+          "signature": "interface BarChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "PieChart",
+          "kind": "function",
+          "signature": "function PieChart("
+        },
+        {
+          "name": "PieChartProps",
+          "kind": "interface",
+          "signature": "interface PieChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "PieDatum",
+          "kind": "interface",
+          "signature": "interface PieDatum",
+          "members": []
+        },
+        {
+          "name": "SparklineChart",
+          "kind": "function",
+          "signature": "function SparklineChart("
+        },
+        {
+          "name": "SparklineChartProps",
+          "kind": "interface",
+          "signature": "interface SparklineChartProps extends ChartDimensions",
+          "members": []
+        },
+        {
+          "name": "useEChartsTheme",
+          "kind": "function",
+          "signature": "function useEChartsTheme(options: UseEChartsThemeOptions): string"
+        },
+        {
+          "name": "UseEChartsThemeOptions",
+          "kind": "interface",
+          "signature": "interface UseEChartsThemeOptions",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-cookies",
       "description": "React bindings for @granit/cookies — CookieConsentProvider, useCookieConsent",
       "exports": [
@@ -1859,6 +1971,76 @@
       "name": "@granit/react-customer-balance",
       "description": "React bindings for @granit/customer-balance — CustomerBalanceProvider and hooks",
       "exports": []
+    },
+    {
+      "name": "@granit/react-dashboards",
+      "description": "React renderer for @granit/dashboards — Dashboard layout component, WidgetRegistry provider, and built-in renderers for Markdown / Image / Text widgets",
+      "exports": [
+        {
+          "name": "Dashboard",
+          "kind": "function",
+          "signature": "function Dashboard("
+        },
+        {
+          "name": "DashboardProps",
+          "kind": "interface",
+          "signature": "interface DashboardProps",
+          "members": []
+        },
+        {
+          "name": "WidgetRenderer",
+          "kind": "function",
+          "signature": "function WidgetRenderer("
+        },
+        {
+          "name": "WidgetRendererProps",
+          "kind": "interface",
+          "signature": "interface WidgetRendererProps",
+          "members": []
+        },
+        {
+          "name": "WidgetCard",
+          "kind": "function",
+          "signature": "function WidgetCard("
+        },
+        {
+          "name": "WidgetCardProps",
+          "kind": "interface",
+          "signature": "interface WidgetCardProps",
+          "members": []
+        },
+        {
+          "name": "ImageWidget",
+          "kind": "function",
+          "signature": "function ImageWidget("
+        },
+        {
+          "name": "MarkdownWidget",
+          "kind": "function",
+          "signature": "function MarkdownWidget("
+        },
+        {
+          "name": "TextWidget",
+          "kind": "function",
+          "signature": "function TextWidget("
+        },
+        {
+          "name": "defaultWidgetRegistry",
+          "kind": "const",
+          "signature": "const defaultWidgetRegistry: WidgetRegistry"
+        },
+        {
+          "name": "WidgetRegistryProviderProps",
+          "kind": "interface",
+          "signature": "interface WidgetRegistryProviderProps",
+          "members": []
+        },
+        {
+          "name": "composeRegistries",
+          "kind": "function",
+          "signature": "function composeRegistries(...registries: readonly WidgetRegistry[]): WidgetRegistry"
+        }
+      ]
     },
     {
       "name": "@granit/react-data-exchange",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -99,6 +99,11 @@
       ]
     },
     {
+      "name": "@granit/analytics",
+      "description": "Framework-agnostic types for Granit.Analytics — MetricResponse runtime envelopes plus KPI / Chart / Table / Pivot widget definitions consumed by @granit/dashboards",
+      "exports": []
+    },
+    {
       "name": "@granit/api-client",
       "description": "Axios factory with Bearer token interceptor and shared response types",
       "exports": [
@@ -1367,6 +1372,71 @@
               "signature": "request: AIEmbeddingRequest"
             }
           ]
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-analytics",
+      "description": "React hooks and renderers for @granit/analytics — useMetric hook plus KpiTile widget renderer registered into the @granit/dashboards widget registry",
+      "exports": [
+        {
+          "name": "normalizeMetricRequest",
+          "kind": "function",
+          "signature": "function normalizeMetricRequest(request: MetricRequest): MetricRequest"
+        },
+        {
+          "name": "useMetric",
+          "kind": "function",
+          "signature": "function useMetric( metricName: string, request: MetricRequest, options: UseMetricOptions ="
+        },
+        {
+          "name": "UseMetricOptions",
+          "kind": "interface",
+          "signature": "interface UseMetricOptions",
+          "members": []
+        },
+        {
+          "name": "KpiTile",
+          "kind": "function",
+          "signature": "function KpiTile("
+        },
+        {
+          "name": "KpiTileProps",
+          "kind": "interface",
+          "signature": "interface KpiTileProps",
+          "members": []
+        },
+        {
+          "name": "KpiTileView",
+          "kind": "function",
+          "signature": "function KpiTileView("
+        },
+        {
+          "name": "KpiTileViewProps",
+          "kind": "interface",
+          "signature": "interface KpiTileViewProps",
+          "members": []
+        },
+        {
+          "name": "defaultAnalyticsWidgetRegistry",
+          "kind": "const",
+          "signature": "const defaultAnalyticsWidgetRegistry: WidgetRegistry"
+        },
+        {
+          "name": "formatDeltaRatio",
+          "kind": "function",
+          "signature": "function formatDeltaRatio( ratio: number | null, locale?: string, fallback: string = NO_VALUE ): string"
+        },
+        {
+          "name": "formatMetricValue",
+          "kind": "function",
+          "signature": "function formatMetricValue("
+        },
+        {
+          "name": "FormatMetricValueArgs",
+          "kind": "interface",
+          "signature": "interface FormatMetricValueArgs",
+          "members": []
         }
       ]
     },

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -12,8 +12,8 @@ Last updated: 2026-04-28
 
 | License      | Package count |
 | ------------ | ------------- |
-| MIT          | 36            |
-| Apache-2.0   | 13            |
+| MIT          | 37            |
+| Apache-2.0   | 14            |
 | BSD-3-Clause | 1             |
 
 ---
@@ -46,6 +46,7 @@ Last updated: 2026-04-28
 | axios                           | 1.15.0  | Copyright (c) Matt Zabriskie               |
 | clsx                            | 2.1.1   | Copyright (c) Luke Edwards                 |
 | date-fns                        | 4.1.0   | Copyright (c) Sasha Koss                   |
+| echarts-for-react               | 3.0.6   | Copyright (c) hustcc                       |
 | eslint                          | 10.2.1  | OpenJS Foundation                          |
 | eslint-plugin-import-x          | 4.16.2  | eslint-plugin-import-x Contributors        |
 | husky                           | 9.1.7   | Copyright (c) typicode                     |
@@ -79,6 +80,7 @@ Last updated: 2026-04-28
 | @opentelemetry/resources                        | 2.7.0   | Copyright The OpenTelemetry Authors |
 | @opentelemetry/sdk-trace-web                    | 2.7.0   | Copyright The OpenTelemetry Authors |
 | @opentelemetry/semantic-conventions             | 1.40.0  | Copyright The OpenTelemetry Authors |
+| echarts                                         | 6.0.0   | Copyright Apache ECharts Authors    |
 | firebase                                        | 12.x    | Copyright Google LLC                |
 | keycloak-js                                     | 26.2.3  | Copyright Red Hat, Inc.             |
 | typescript                                      | 6.0.3   | Copyright (c) Microsoft Corporation |

--- a/docs/dashboards-architecture-proposals.md
+++ b/docs/dashboards-architecture-proposals.md
@@ -1,0 +1,1116 @@
+# Dashboards architecture — proposals from frontend implementation
+
+This document consolidates feedback gathered while scaffolding `@granit/dashboards`,
+`@granit/react-dashboards`, `@granit/charts`, `@granit/react-charts`, and after
+analyzing ThingsBoard's reference architecture for IoT-grade dashboards.
+
+The goal is to enrich `Granit.Dashboards.Abstractions` (and downstream
+`Granit.Analytics`, future `Granit.IoT.Dashboards`) **before stories B2/B3/B4
+land**, so the persisted aggregate, endpoints, and the live-streaming surface
+all share a coherent model from day one rather than retrofitting.
+
+Proposals are graded by priority:
+
+- 🔴 **P1** — needed before story B2 (persisted Dashboard aggregate)
+- 🟠 **P2** — needed before story C (drill-down / streaming widgets)
+- 🟡 **P3** — quality-of-life, can land independently
+
+---
+
+## P1.1 — JSON polymorphism discriminator
+
+**Current**: `WidgetDefinition.cs` is `abstract record` with concrete records
+inheriting (Markdown / Image / Text / Kpi / Chart / Table / Pivot). No
+`[JsonPolymorphic]` attribute is set, so System.Text.Json defaults to
+`"$type": "Granit.Dashboards.Widgets.MarkdownWidgetDefinition, Granit.Dashboards.Abstractions"` —
+verbose, CLR-coupled, and brittle to renames.
+
+**Proposal**: pin a clean discriminator name and short type IDs.
+
+```csharp
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]
+[JsonDerivedType(typeof(MarkdownWidgetDefinition), "markdown")]
+[JsonDerivedType(typeof(ImageWidgetDefinition), "image")]
+[JsonDerivedType(typeof(TextWidgetDefinition), "text")]
+public abstract record WidgetDefinition(...);
+```
+
+Same pattern for `Granit.Analytics`:
+
+```csharp
+[JsonDerivedType(typeof(KpiWidgetDefinition), "kpi")]
+[JsonDerivedType(typeof(ChartWidgetDefinition), "chart")]
+[JsonDerivedType(typeof(TableWidgetDefinition), "table")]
+[JsonDerivedType(typeof(PivotWidgetDefinition), "pivot")]
+```
+
+**Frontend impact**: TypeScript discriminated unions on `type` (idiomatic JSON,
+maps 1:1). Without this, every consumer has to translate `$type` → enum tag.
+
+---
+
+## P1.2 — Optional `Fit?` on ImageWidgetDefinition
+
+**Current**: `ImageWidgetDefinition` has `Source` + `AltLocalizationKey` but no
+display-fit hint. The frontend has to pick a default (`contain` is reasonable
+but not always right).
+
+**Proposal**:
+
+```csharp
+public sealed record ImageWidgetDefinition(
+    string Slug,
+    string Source,
+    string AltLocalizationKey,
+    int Position,
+    WidgetSize? Size = null,
+    ImageFit Fit = ImageFit.Contain)
+    : WidgetDefinition(Slug, Position, Size ?? WidgetSize.MediaTile);
+
+public enum ImageFit
+{
+    /// <summary>Preserve aspect ratio, letterbox to fit.</summary>
+    Contain = 0,
+    /// <summary>Fill the cell, crop to maintain aspect.</summary>
+    Cover = 1,
+    /// <summary>Stretch to fill (rarely correct).</summary>
+    Fill = 2,
+}
+```
+
+**Why**: "logo widget" wants `Contain` (no cropping); "banner photo widget"
+wants `Cover` (no whitespace). Two distinct UX intents, not solvable by
+preprocessing the asset.
+
+---
+
+## P1.3 — `DashboardTimeWindow` + per-widget override
+
+**Current**: each data widget carries its own period spec via the `MetricRequest`
+body or the `QueryDefinition` filter. Eight KPIs sharing "last 30 days" means
+duplicating the period eight times. The user can't change the dashboard-wide
+range without editing every widget.
+
+**Proposal**: ship a default time window on the definition, propagate via a
+runtime `DashboardContext`, allow per-widget override. **Wraps the existing
+`PeriodSpec` from A2/A3** (with DAX-style tokens `mtd`/`ytd`/`previous_period`/...)
+rather than introducing a parallel time-range model — calendar-aware bounds
+matter (MTD ≠ "last 30 days") and we already shipped the right primitive.
+
+```csharp
+namespace Granit.Dashboards;
+
+using Granit.Analytics.Metrics;  // PeriodSpec, CompareSpec — existing types
+
+/// <summary>
+/// Time window applied to every data-bound widget on a dashboard. The frontend
+/// surfaces it as a top-of-dashboard control (e.g. "Last 30 days ▾"); user
+/// changes propagate to all widgets that don't carry their own override.
+///
+/// Wraps the existing <see cref="PeriodSpec"/> (token OR absolute range) so
+/// dashboard-level windows align with the metric-level period model already
+/// shipped in A2/A3 — no parallel concept on the wire.
+/// </summary>
+public sealed record DashboardTimeWindow(
+    /// <summary>The actual period — token-based (`last_30d`, `mtd`, `ytd`, ...) or absolute range.</summary>
+    PeriodSpec Period,
+    /// <summary>Refresh semantics: History (frozen, refetch on range change) vs Realtime (sliding window).</summary>
+    TimeWindowKind Kind = TimeWindowKind.History,
+    /// <summary>Optional comparison window (e.g. previous_period). Same model as MetricRequest.</summary>
+    CompareSpec? CompareTo = null,
+    /// <summary>Bucket size for time-series aggregation. When null, the widget's data source picks a default.</summary>
+    TimeSpan? Aggregation = null)
+{
+    public static DashboardTimeWindow Last24Hours => new(PeriodSpec.Token("last_24h"));
+    public static DashboardTimeWindow Last7Days => new(PeriodSpec.Token("last_7d"));
+    public static DashboardTimeWindow Last30Days => new(PeriodSpec.Token("last_30d"));
+    public static DashboardTimeWindow Mtd => new(PeriodSpec.Token("mtd"));
+    public static DashboardTimeWindow Ytd => new(PeriodSpec.Token("ytd"));
+    public static DashboardTimeWindow RealtimeLast5Minutes =>
+        new(PeriodSpec.Token("last_5m"), Kind: TimeWindowKind.Realtime);
+}
+
+public enum TimeWindowKind
+{
+    /// <summary>Frozen window — query once per range change.</summary>
+    History = 0,
+    /// <summary>Sliding window — refreshes continuously, suitable for telemetry.</summary>
+    Realtime = 1,
+}
+
+public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
+{
+    // ... existing members
+    public virtual DashboardTimeWindow? DefaultTimeWindow => null;
+}
+
+public abstract record WidgetDefinition(
+    string Slug,
+    int Position,
+    WidgetSize Size,
+    string? RequiredPermission = null,
+    /// <summary>
+    /// Override the dashboard's time window for this widget specifically.
+    /// Useful when (a) the widget is rendered standalone outside a dashboard,
+    /// or (b) the widget needs a different range than the rest of the dashboard
+    /// (e.g. a "year-to-date" KPI next to "last 30 days" widgets).
+    /// </summary>
+    DashboardTimeWindow? TimeWindowOverride = null);
+```
+
+**Standalone-rendered widgets**: when a widget is dropped into a non-dashboard
+page (e.g. a KPI tile above an invoice list), the frontend uses
+`TimeWindowOverride` directly. No `DashboardContext` required.
+
+**Frontend impact**: `<DashboardProvider timeWindow={...}>` propagates via React
+context. `useMetric` reads the context (or the prop override), composes the
+final `PeriodSpec` for the underlying `MetricRequest` — same shape it already
+takes today.
+
+---
+
+## P1.4 — Responsive layouts (per-breakpoint overrides)
+
+**Current**: `DashboardLayout` is a single grid configuration with no
+breakpoint awareness.
+
+**Proposal**: `DashboardLayout` carries a base configuration plus optional
+per-breakpoint overrides — same model ThingsBoard ships
+(`shared/models/dashboard.models.ts:114-142`). Mobile / tablet / desktop
+re-arrangements share the widget pool and only override what changes.
+
+```csharp
+public sealed record DashboardLayout(
+    int Columns,
+    int RowHeight,
+    /// <summary>
+    /// Per-widget size overrides keyed by widget Slug. Empty = use the widget's
+    /// default Size from its definition.
+    /// </summary>
+    IReadOnlyDictionary<string, WidgetSize>? WidgetSizes = null,
+    /// <summary>
+    /// Optional Slug ordering — when present, overrides the widget's `Position`
+    /// for this layout only. Widgets not listed are appended in their declared
+    /// Position order.
+    /// </summary>
+    IReadOnlyList<string>? WidgetOrder = null,
+    /// <summary>
+    /// Per-breakpoint overrides. Each entry is a partial layout that replaces
+    /// the matching fields on the base layout when the viewport hits the
+    /// breakpoint. `default` is reserved for the base — no entry needed for it.
+    /// </summary>
+    IReadOnlyDictionary<DashboardBreakpoint, DashboardLayoutOverride>? Breakpoints = null)
+{
+    public static DashboardLayout Default => new(12, 80);
+}
+
+public enum DashboardBreakpoint { Xs, Sm, Md, Lg, Xl }
+
+public sealed record DashboardLayoutOverride(
+    int? Columns = null,
+    int? RowHeight = null,
+    IReadOnlyDictionary<string, WidgetSize>? WidgetSizes = null,
+    IReadOnlyList<string>? WidgetOrder = null,
+    /// <summary>Slugs to hide at this breakpoint. The widgets remain in the pool but the layout drops them.</summary>
+    IReadOnlySet<string>? HiddenWidgets = null);
+```
+
+Combined with auto-flow positioning, a layout = base grid + per-breakpoint
+deltas. A typical mobile override expands every KPI tile to full-width and
+hides decorative widgets:
+
+```csharp
+public override DashboardLayout Layout => DashboardLayout.Default with
+{
+    Breakpoints = new Dictionary<DashboardBreakpoint, DashboardLayoutOverride>
+    {
+        [DashboardBreakpoint.Xs] = new(
+            Columns: 4,
+            WidgetSizes: new Dictionary<string, WidgetSize>
+            {
+                ["UnpaidCount"] = new(4, 1),    // full row on xs
+                ["UnpaidTotal"] = new(4, 1),
+            },
+            HiddenWidgets: new HashSet<string> { "Banner" }),
+    },
+};
+```
+
+**Why nested overrides instead of separate `MobileLayout`**: a single
+`DashboardLayout` payload owning the full responsive ladder reads better in
+the JSON dump, makes drift between breakpoints local rather than scattered,
+and matches the convention React/Tailwind/Bootstrap users already know. TB
+proves this scales to 5+ breakpoints with custom keys.
+
+**Frontend impact**: `<Dashboard>` resolves the active breakpoint via
+`useMediaQuery`, merges `Breakpoints[active]` into the base layout, then
+renders. The widget pool stays constant; only sizes/order/visibility shift.
+
+### Deferred to v2 — dual-pane container (`main` / `right`)
+
+ThingsBoard splits each state's layout into two parallel columns: a `main`
+pane and an optional `right` sidebar pane (`DashboardStateLayouts` at
+`shared/models/dashboard.models.ts`). Useful for "always-visible status
+sidebar alongside the main content" patterns (alarm panel, device summary).
+
+**Not in v1**: a single grid covers 95% of cases. If a story justifies
+the dual-pane shape later, it lands as `Layout` becoming
+`{ Main: DashboardLayout, Right?: DashboardLayout }` — the existing `Layout`
+field becomes implicitly the `Main` pane, fully backward-compatible.
+
+---
+
+## P1.5 — Action descriptors
+
+**Current**: widgets are pure render targets. Click behavior is implicit (a KPI
+clicks open... what? The frontend doesn't know).
+
+**Proposal**: declarative actions. No code injection — only descriptors that
+the frontend dispatches to known handlers.
+
+```csharp
+public abstract record WidgetDefinition(
+    string Slug,
+    int Position,
+    WidgetSize Size,
+    string? RequiredPermission = null,
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null);
+
+public sealed record WidgetAction(
+    WidgetActionTrigger Trigger,
+    WidgetActionKind Kind,
+    /// <summary>
+    /// Target identifier — interpretation depends on Kind:
+    /// - Navigate: a frontend route ("/invoicing?status=unpaid")
+    /// - OpenDashboardState: a `state` name on the same dashboard
+    /// - OpenDashboard: a `Dashboard.Name`
+    /// - ExportData: an `ExportDefinition.Name`
+    /// </summary>
+    string Target,
+    /// <summary>
+    /// Static parameters merged with the dynamic data row at dispatch time
+    /// (e.g. params="customerId={row.customerId}" + static={status:"unpaid"}).
+    /// </summary>
+    IReadOnlyDictionary<string, string>? Params = null);
+
+public enum WidgetActionTrigger
+{
+    /// <summary>Clicking the widget body or KPI value.</summary>
+    Click = 0,
+    /// <summary>Clicking a row inside a Table/Pivot widget.</summary>
+    RowClick = 1,
+    /// <summary>Clicking a series segment inside a Chart widget.</summary>
+    SeriesClick = 2,
+    /// <summary>Clicking a legend item.</summary>
+    LegendClick = 3,
+}
+
+public enum WidgetActionKind
+{
+    /// <summary>Frontend route navigation (preserves dashboard context if possible).</summary>
+    Navigate = 0,
+    /// <summary>Switch to another `state` of the current dashboard (see P2.1 below).</summary>
+    OpenDashboardState = 1,
+    /// <summary>Navigate to another full dashboard.</summary>
+    OpenDashboard = 2,
+    /// <summary>Trigger an export via `Granit.DataExchange`.</summary>
+    ExportData = 3,
+    /// <summary>Open a side drawer with the row's full detail (table widgets).</summary>
+    OpenDetail = 4,
+}
+```
+
+---
+
+## P2.1 — Views (intra-dashboard navigation)
+
+**Naming note**: the original draft called this concept `DashboardState`. It
+collides with `DashboardStatus` (Draft/Published/Archived) already shipped in
+B2 — two semantically distinct concepts sharing "Status/State" guarantees
+autocomplete confusion. Renamed to **`DashboardView`** throughout. The
+URL pattern, transitions, and runtime behavior are unchanged.
+
+**Goal**: a dashboard becomes a **navigable container** with multiple internal
+views, sharing TimeWindow / aliases / breadcrumb context. ThingsBoard's killer
+feature for IoT drill-down (their "states", but the renaming avoids the
+status-vs-state ambiguity in our codebase).
+
+**Proposal**:
+
+```csharp
+public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
+{
+    /// <summary>
+    /// Named views — separate widget arrangements within the same dashboard.
+    /// Default view is the entry point. Transitions are triggered by widget
+    /// actions (Kind = OpenDashboardView).
+    /// </summary>
+    public virtual IReadOnlyList<DashboardView>? Views => null;
+
+    /// <summary>
+    /// When `Views` is non-null, this is the entry-point view name.
+    /// When `Views` is null, the dashboard is single-view and the
+    /// `Widgets` collection is the implicit "default" view.
+    /// </summary>
+    public virtual string? DefaultView => null;
+}
+
+public sealed record DashboardView(
+    /// <summary>
+    /// View identifier, unique within the dashboard. Lowercase, dot-separated
+    /// (e.g. "list", "detail", "history.heatmap"). Used in URLs.
+    /// </summary>
+    string Name,
+    /// <summary>Widgets shipped by this view, in declared order.</summary>
+    IReadOnlyList<WidgetDefinition> Widgets,
+    /// <summary>
+    /// Layout override for this view. When null, falls back to the dashboard's
+    /// `Layout` (with all its breakpoint overrides). The override may itself
+    /// declare breakpoints — they merge per the standard cascade.
+    /// </summary>
+    DashboardLayout? Layout = null,
+    /// <summary>
+    /// Localization key for the view's display label, used in breadcrumbs.
+    /// Defaults to "Dashboard:{DashboardName}.View.{ViewName}".
+    /// </summary>
+    string? DisplayNameLocalizationKey = null);
+```
+
+The corresponding action kind (P1.5) becomes `OpenDashboardView`; routing
+artefacts read `DashboardViewRouter`, `DashboardViewParams`, etc.
+
+**URL convention**: `/dashboards/{Name}/view/{viewName}` with optional
+parameters propagated via query string (entity IDs, time window override).
+_See P2.1.1 below for the param encoding — we rejected TB's base64 array._
+
+**Frontend impact**: `<DashboardViewRouter>` component manages the active
+view, propagates entity-alias resolution and TimeWindow into the view's
+widgets via the same `DashboardContext` provider.
+
+**Migration note for module-shipped definitions without views**: the existing
+`DashboardDefinition.Widgets` becomes the implicit default view — backward
+compatible. Most dashboards stay single-view; views are opt-in for drill-down.
+
+### P2.1.1 — Param encoding for view navigation
+
+ThingsBoard encodes the navigation stack as `?state=<base64-encoded-array>`
+(`shared/models/dashboard.models.ts` + `default-state-controller.component.ts:207`).
+That choice is opaque to URL inspection, breaks at length limits, and doesn't
+survive being shared in chat / docs.
+
+**We reject base64-encoded stacks**. Use plain query string with named
+parameters and a single `view` selector:
+
+```text
+/dashboards/Granit.Iot.FleetOverview/view/detail?entityId=device-abc-123&since=2026-04-01
+```
+
+The view router maintains the breadcrumb stack in memory (back-button history
+via `history.state`), not in the URL. URL stays inspectable, shareable, and
+short. If a story justifies multi-level back navigation across deep links,
+that's a per-app router concern, not a framework requirement.
+
+---
+
+## P2.2 — Datasource abstraction
+
+**Goal**: decouple a widget from how its data arrives. Current
+`KpiWidgetDefinition.MetricName: string` ties a KPI to the metric source
+specifically; can't bind a KPI to a query aggregate or to an IoT telemetry
+average.
+
+**Proposal**:
+
+```csharp
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(MetricDatasource), "metric")]
+[JsonDerivedType(typeof(QueryAggregateDatasource), "query-aggregate")]
+[JsonDerivedType(typeof(TelemetryDatasource), "iot-telemetry")]
+public abstract record Datasource;
+
+public sealed record MetricDatasource(string MetricName) : Datasource;
+
+public sealed record QueryAggregateDatasource(
+    string QueryName,
+    AggregateFunction Aggregation,
+    string? Field) : Datasource;
+
+public sealed record TelemetryDatasource(
+    /// <summary>Entity alias name (see P2.3) — resolves to a device id at render time.</summary>
+    string EntityAlias,
+    /// <summary>Telemetry key (e.g. "temperature", "pressure", "rpm").</summary>
+    string TelemetryKey,
+    /// <summary>Aggregation applied over the dashboard's time window.</summary>
+    TelemetryAggregation Aggregation = TelemetryAggregation.Last) : Datasource;
+
+public enum TelemetryAggregation { Last, Avg, Sum, Min, Max, Count }
+```
+
+Then widgets switch from a typed-name field to a `Datasource`:
+
+```csharp
+public sealed record KpiWidgetDefinition(
+    string Slug,
+    Datasource Datasource,    // was: string MetricName
+    int Position,
+    WidgetSize? Size = null,
+    string? RequiredPermission = null,
+    DashboardTimeWindow? TimeWindowOverride = null,
+    IReadOnlyList<WidgetAction>? Actions = null)
+    : WidgetDefinition(...);
+```
+
+**Why**: a "Daily Active Users" KPI tile can be backed by a metric
+(`MetricDatasource`) on the analytics dashboard, AND by a query aggregate
+(`QueryAggregateDatasource`) on an ad-hoc admin page — same widget, different
+source. IoT gauges naturally bind via `TelemetryDatasource`.
+
+**Tradeoff**: more verbose at definition site. Mitigated by static factories:
+
+```csharp
+new KpiWidgetDefinition("UnpaidCount",
+    Datasource.Metric("Granit.Invoicing.UnpaidInvoiceCountMetric"),
+    Position: 1);
+```
+
+### Per-DataKey formatting (color / units / decimals)
+
+ThingsBoard attaches color, units, and decimal precision to **each `DataKey`**
+(one per series), not to the widget as a whole. This is genuinely better than
+our current sketch: a chart with multiple series can color each independently,
+a KPI with a comparison can format reference and current value differently,
+units travel with the data instead of being baked into the chart config.
+
+```csharp
+public abstract record Datasource;
+
+public sealed record QueryAggregateDatasource(
+    string QueryName,
+    AggregateFunction Aggregation,
+    string? Field,
+    /// <summary>
+    /// Per-series presentation hints. When the chart has multiple series,
+    /// each entry's `Key` matches a series identifier (e.g. group-by value).
+    /// </summary>
+    IReadOnlyList<DataKeyFormat>? KeyFormats = null) : Datasource;
+
+public sealed record DataKeyFormat(
+    /// <summary>Series identifier — matches the GroupBy value or the Field name.</summary>
+    string Key,
+    /// <summary>Localization key for the display label (legend, tooltip).</summary>
+    string? LabelLocalizationKey = null,
+    /// <summary>Hex color override. Falls back to the theme palette by series index.</summary>
+    string? Color = null,
+    /// <summary>Unit suffix (e.g. "°C", "kWh", "€"). Resolved via i18n if prefixed `Unit:`.</summary>
+    string? Unit = null,
+    /// <summary>Decimal places for numeric formatting. Falls back to the widget config or 2.</summary>
+    int? Decimals = null);
+```
+
+**Why on the datasource and not the widget**: the same chart widget can be
+reused with different data shapes. A "Revenue by Region" chart and a
+"Revenue by Product" chart are the same `ChartWidgetDefinition` with
+different datasources — colors and units belong to the data binding, not
+the visual.
+
+**Frontend impact**: chart primitives (`<LineChart>`, `<BarChart>`) read
+`KeyFormats` from the resolved datasource and apply them as series-level
+overrides on top of the active theme palette. KPI tile reads them for
+its own value + comparison formatting.
+
+---
+
+## P2.3 — Entity aliases (parameterized dashboards)
+
+**Goal**: render the same dashboard for different entities (devices, customers,
+products) without duplicating the definition.
+
+**Proposal**:
+
+```csharp
+public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
+{
+    /// <summary>
+    /// Aliases declared by this dashboard. Each alias gets resolved to a
+    /// concrete entity (or set of entities) at render time, by an
+    /// `EntityAliasResolver` registered for its kind.
+    /// </summary>
+    public virtual IReadOnlyList<EntityAlias>? Aliases => null;
+}
+
+public sealed record EntityAlias(
+    /// <summary>Alias identifier referenced from datasources (e.g. "currentDevice").</summary>
+    string Name,
+    /// <summary>What kind of entity this alias points to.</summary>
+    string EntityType,                 // "Device", "Customer", "Invoice", ...
+    EntityAliasResolver Resolver);
+
+[JsonPolymorphic(TypeDiscriminatorPropertyName = "kind")]
+[JsonDerivedType(typeof(RouteParamResolver), "route-param")]
+[JsonDerivedType(typeof(StateEntityResolver), "state-entity")]
+[JsonDerivedType(typeof(TenantContextResolver), "tenant-context")]
+[JsonDerivedType(typeof(UserSelectionResolver), "user-selection")]
+[JsonDerivedType(typeof(StaticEntityResolver), "static")]
+public abstract record EntityAliasResolver;
+
+/// <summary>Pulls the entity id from a URL/route parameter.</summary>
+public sealed record RouteParamResolver(string ParamName) : EntityAliasResolver;
+
+/// <summary>
+/// Pulls the entity id from the current dashboard state's parameters — the
+/// bridge between the URL state stack (P2.1) and aliases. When a row click
+/// in a list state pushes a new state onto the stack with `entityId` in
+/// `StateParams`, the alias re-resolves automatically and downstream widgets
+/// re-fetch with the new entity. ThingsBoard's killer drill-down feature.
+/// </summary>
+public sealed record StateEntityResolver(
+    /// <summary>Slot name in `StateParams` carrying the entity id.</summary>
+    string ParamName = "entityId") : EntityAliasResolver;
+
+/// <summary>Resolves to the current authenticated tenant — single entity.</summary>
+public sealed record TenantContextResolver() : EntityAliasResolver;
+
+/// <summary>Renders a picker; user selects one (or many) entities at runtime.</summary>
+public sealed record UserSelectionResolver(
+    /// <summary>Granit.DataLookup name backing the picker.</summary>
+    string LookupName,
+    bool MultiSelect = false) : EntityAliasResolver;
+
+/// <summary>Hardcoded entity (mostly for testing or "global" widgets).</summary>
+public sealed record StaticEntityResolver(string EntityId) : EntityAliasResolver;
+```
+
+**Why 4 resolver kinds instead of TB's 15**: TB has separate
+`assetSearchQuery`, `deviceSearchQuery`, `edgeSearchQuery`,
+`entityViewSearchQuery` that all do the same traversal with a different
+entity-type filter. The `*Type` resolvers collapse into parameters to
+`UserSelectionResolver` (a lookup typed against an entity type). 4 resolvers
+cover every applicational use case currently on the roadmap.
+
+**Deferred — `RelationGraphResolver`**: TB's "find all sensors related to the
+current device" pattern requires an entity-relation graph that doesn't yet
+exist in Granit. Building it is a project of its own (a new
+`Granit.EntityRelations` aggregate plus traversal in `Granit.QueryEngine`)
+and should land via a dedicated ADR if a concrete IoT story justifies it.
+For now, the same outcome can be approximated by a `UserSelectionResolver`
+backed by a lookup that returns the related entities — explicit but
+adequate.
+
+**Datasource integration**: `TelemetryDatasource.EntityAlias` (and any other
+entity-bound datasource) references `EntityAlias.Name`. The runtime substitutes
+the resolved id when fetching data.
+
+**Frontend impact**: `<DashboardProvider>` resolves aliases up-front (route
+params synchronously, lookups via `useLookup`), exposes a resolver function
+through context. Widget renderers call `useEntityAlias("currentDevice")` to
+get the resolved id when assembling their data fetch.
+
+---
+
+## P2.4 — SSE subscription for `realtime` widgets
+
+**Goal**: replace polling with push for widgets whose data is `RefreshHint.Realtime`.
+
+**Decision**: **SSE** as the transport, with a server-side abstraction
+(`IMetricStreamProducer`) that lets the implementation evolve without leaking
+to widget renderers. Two endpoints — per-metric (simple) and per-dashboard
+(multiplexed, the production path).
+
+### Server-side abstraction — one producer per subscription
+
+```csharp
+namespace Granit.Analytics.Subscriptions;
+
+/// <summary>
+/// Produces a stream of `MetricResponse` envelopes for a single subscription
+/// (one metric + one set of params). One producer instance per subscription —
+/// the dashboard endpoint multiplexes N producers internally, the per-metric
+/// endpoint creates one. This is the right granularity: a producer's job is
+/// "watch this metric with these inputs and emit when the value changes",
+/// nothing more.
+///
+/// The default implementation polls the underlying `MetricEvaluator` on a
+/// timer keyed by the metric's `RefreshHint`; future implementations may
+/// push from a hot source (event bus, database notification triggers, IoT
+/// telemetry pipeline) without changing the consumer surface.
+/// </summary>
+public interface IMetricStreamProducer
+{
+    IAsyncEnumerable<MetricResponse> Subscribe(
+        MetricSubscriptionRequest request,
+        CancellationToken cancellationToken);
+}
+
+public sealed record MetricSubscriptionRequest(
+    string MetricName,
+    DashboardTimeWindow TimeWindow,
+    /// <summary>
+    /// Owning tenant id. Pinned explicitly on the request rather than read
+    /// from an ambient `ICurrentTenant` so the producer keying never collapses
+    /// cross-tenant — two tenants subscribing to the same metric with the same
+    /// params get distinct producer instances. This is non-negotiable for
+    /// multi-tenant isolation; the runtime asserts it on the way in.
+    /// </summary>
+    string TenantId,
+    /// <summary>Resolved entity alias values (see P2.3) — server uses these to scope the underlying query.</summary>
+    IReadOnlyDictionary<string, string>? ResolvedAliases = null);
+```
+
+**Producer scoping** — a producer is created per subscription, not per
+dashboard. Two consequences:
+
+- Standalone widgets (KPI tile above a non-dashboard page) reuse the same
+  producer abstraction with no special-casing.
+- Identical subscription requests across users / dashboards can share a
+  single producer instance (DI scoping concern handled separately) — natural
+  fan-in caching at the source rather than per-endpoint.
+
+The endpoints are thin SSE adapters that consume one or more producers; the
+multiplexing is HTTP-layer orchestration, not a separate abstraction.
+
+### Two endpoints
+
+```text
+GET /analytics/metrics/{name}/stream
+    ?window=last_5m&entity=device-123
+    → single MetricResponse stream, simplest case
+
+GET /analytics/dashboards/{name}/stream
+    ?widgets=w1,w2,w3&window=last_5m&entity=device-123
+    → multiplexed stream, fans out internally to N producers,
+      tags each event with the originating widget slug
+```
+
+**Per-metric stream** — the simple path. Used when a widget renders standalone
+(KPI tile above an invoice list, no parent dashboard). One subscription, one
+connection, one envelope shape.
+
+**Per-dashboard multiplexed stream** — the production path. The frontend opens
+**one** SSE connection per dashboard regardless of how many real-time widgets
+the dashboard contains. Server fans out internally to the relevant
+`IMetricStreamProducer` instances; events are tagged with the originating
+widget slug and routed to the correct subscriber on the client.
+
+This solves the "10 widgets × 50 reconnects on alias change" problem honestly
+— there's exactly one reconnect on param change, not N.
+
+### Wire format — initial snapshot + incremental deltas
+
+Two event types per stream:
+
+- `metric-snapshot` — emitted once at subscription time (or after reconnect)
+  carrying the full current `MetricResponse`. The frontend renders this as
+  the initial state before any deltas arrive.
+- `metric-update` — emitted on subsequent value changes carrying the new
+  `MetricResponse`. `sequence` is monotonic so consumers can detect gaps.
+
+This `data` (initial) + `update` (incremental) split mirrors ThingsBoard's
+`DataUpdateMsg<T>` shape (`telemetry.models.ts:440`). Without it, late
+subscribers either render empty until the next change or have to call the
+one-shot endpoint separately to bootstrap — both annoying.
+
+Per-metric stream — `Last-Event-ID` resumes from the last seen sequence.
+
+```text
+id: 0
+event: metric-snapshot
+data: {"name":"...","snapshot":{...},"sequence":0,"emittedAt":"...","refreshHint":"realtime"}
+
+id: 42
+event: metric-update
+data: {"name":"...","snapshot":{...},"sequence":42,"emittedAt":"...","refreshHint":"realtime"}
+
+event: heartbeat
+data: {}
+```
+
+Per-dashboard multiplexed stream — same two event types, with a routing
+wrapper that identifies the widget on the dashboard:
+
+```text
+id: 0
+event: metric-snapshot
+data: {"widgetSlug":"UnpaidCount","metric":{"name":"...","snapshot":{...},"sequence":0,"emittedAt":"...","refreshHint":"realtime"}}
+
+id: 42
+event: metric-update
+data: {"widgetSlug":"UnpaidCount","metric":{"name":"...","snapshot":{...},"sequence":42,"emittedAt":"...","refreshHint":"realtime"}}
+```
+
+The server retains a short replay buffer per producer so reconnecting clients
+with `Last-Event-ID` don't miss state.
+
+**Buffer sizing — bounded both in time and count**:
+
+```csharp
+public sealed record SseReplayBufferOptions(
+    /// <summary>Time window kept in the replay buffer. Default 30 seconds.</summary>
+    TimeSpan Window = default,
+    /// <summary>
+    /// Hard cap on envelope count per producer. Drops the oldest when exceeded
+    /// even if they're still inside the time window — protects against
+    /// runaway high-churn producers (e.g. a misbehaving IoT device pushing 1
+    /// kHz updates). Default 100.
+    /// </summary>
+    int MaxEnvelopes = 100);
+```
+
+Both are configurable per producer (so a "rapid IoT telemetry" producer can
+opt for a smaller window + larger count, while a "billing snapshot" producer
+keeps a wider window) with a hard global cap to prevent memory blow-up under
+adversarial conditions.
+
+### Param-change semantics
+
+When the user changes the dashboard's `TimeWindow` or an alias resolves to a
+new entity, the frontend:
+
+1. Closes the current `EventSource`
+2. Opens a new one with the updated query string
+
+For per-dashboard streams, this is **one** reconnect that re-establishes all
+widget subscriptions atomically. The TCP connection itself is reused via HTTP
+keep-alive; only the SSE stream is dropped and re-opened. Latency is bounded
+by one HTTP request RTT.
+
+### Frontend integration
+
+`useMetric` switches transparently based on `refreshHint` and the surrounding
+dashboard context:
+
+```typescript
+const { data } = useMetric('Granit.Invoicing.UnpaidInvoiceCountMetric', request);
+// - refreshHint=static    → fetched once, cached forever
+// - refreshHint=dynamic   → polled every 60s
+// - refreshHint=realtime, no DashboardContext  → per-metric SSE
+// - refreshHint=realtime, inside <DashboardProvider>  → joins the dashboard's
+//                                                      multiplexed SSE stream
+```
+
+The hook self-discriminates — no `<MetricSubscriptionProvider transport={...}>`
+wrapping, no transport context propagation. Widget renderers know nothing
+about the wire.
+
+### Why SSE, why not SignalR
+
+| Criterion                  | **SSE** ✅ chosen                                                                  | **SignalR** considered, rejected                   |
+| -------------------------- | ---------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Throughput per connection  | Higher — no WebSocket framing, no multiplex bookkeeping                            | Lower for sustained one-way pushes                 |
+| Frontend dep weight        | 0 KB (native `EventSource`)                                                        | ~30 KB gz (`@microsoft/signalr`)                   |
+| Proxy / firewall traversal | Plain HTTP/1.1 GET — works everywhere                                              | Needs WebSocket upgrade (or long-polling fallback) |
+| Reconnect / resume         | Native via `Last-Event-ID` + server replay buffer                                  | Built-in but heavier                               |
+| Multiplexing               | Per-dashboard endpoint (see above)                                                 | Native via hub channels                            |
+| Granit infra alignment     | Reuses `Granit.Notifications.SSE` (already shipped)                                | Would parallel the existing path                   |
+| Observability              | Each subscription is an HTTP request → standard tracing, CDN logs, gateway metrics | Opaque hub frames                                  |
+| Implementation surface     | Two endpoints fronting one producer interface                                      | A hub + invocation methods + lifecycle             |
+
+### Will SSE be sufficient? — honest assessment
+
+**Yes, for the roadmap we can see.** The multiplexing concern (one reconnect
+per param change instead of N) is solved by the per-dashboard endpoint without
+moving to WebSockets. The remaining SignalR-only superpower is **bidirectional
+command-and-control**, and that's a separate concern by design — see below.
+
+**Where SSE genuinely loses to SignalR**:
+
+- **Bidirectional command surface** ("send a command to device X, await ack on
+  the same channel"): SSE is server→client only. We solve commands with a
+  regular POST + correlation id, _not_ by carrying them on the subscription
+  channel. Conflating "subscribe to live data" with "command-and-control"
+  is precisely what makes SignalR architectures hard to audit later.
+- **Multi-user collaborative editing** (admin pushes a widget change to all
+  connected viewers): SSE can do this via a separate broadcast endpoint. If
+  we ever ship collaborative dashboards (no concrete story), we add it then.
+
+**Where SSE is fine but worth flagging**:
+
+- **HTTP/1.1 deployments** are limited to ~6 concurrent streams per origin.
+  Mitigated by the per-dashboard multiplexed endpoint (one connection per
+  dashboard). HTTP/2 lifts this to 100+ streams transparently — modern infra.
+- **Server-side resource cost**: each SSE stream is a long-lived task. With
+  per-dashboard multiplexing, this is N dashboards × M users instead of
+  N widgets × M users. Manageable up to thousands of concurrent connections
+  per Kestrel instance.
+
+### What about future transport needs?
+
+If a concrete story justifies a different transport — collaborative editing,
+true bidirectional IoT command surfaces — it lands as a **parallel
+mechanism**, not a refactor of the subscription path. The
+`IMetricStreamProducer` server-side abstraction makes this safe: a SignalR
+hub or WebSocket endpoint becomes another consumer of the same producer
+interface, the `MetricResponse` envelope is locked, and widget renderers
+don't notice.
+
+What we explicitly **do not** ship:
+
+- A frontend `<MetricSubscriptionProvider transport={...}>` context.
+- Multiple frontend transport packages (`@granit/react-analytics-subscriptions-sse`
+  vs `@granit/react-analytics-subscriptions-signalr`).
+- Per-host transport DI on the frontend.
+
+The abstraction lives where it matters (server-side producer interface);
+the frontend stays simple.
+
+---
+
+## P2.5 — Dashboard-level filters (toolbar-exposed)
+
+**Goal**: ship reusable, dashboard-scoped filter sets — separate from the
+per-datasource filters that widgets carry internally. ThingsBoard distinguishes
+the two and exposes some filters to the toolbar via `editable: true` so end
+users can refine the entire dashboard at runtime
+(`shared/models/query/query.models.ts:400`).
+
+**Use cases**:
+
+- Finance dashboard: a single "Customer = X" filter that all 12 widgets
+  respect (unpaid invoices, revenue, payments, etc.).
+- IoT dashboard: a "Site = Plant 3" filter narrowing every device-bound
+  widget to one location.
+- Audit dashboard: a "Severity ≥ Warning" filter trimming noise across
+  every audit-event widget.
+
+**Proposal**:
+
+```csharp
+public abstract class DashboardDefinition : IDashboardDefinitionDescriptor
+{
+    /// <summary>
+    /// Filters declared by this dashboard. Each filter is referenced by name
+    /// from any datasource; toolbar-exposed filters become user-editable
+    /// controls at the top of the dashboard.
+    /// </summary>
+    public virtual IReadOnlyList<DashboardFilter>? Filters => null;
+}
+
+public sealed record DashboardFilter(
+    /// <summary>Filter identifier referenced from datasources (e.g. "currentCustomer").</summary>
+    string Name,
+    /// <summary>Localization key for the toolbar label when `Editable = true`.</summary>
+    string LabelLocalizationKey,
+    /// <summary>Filter clauses combined by `Operation`.</summary>
+    IReadOnlyList<DashboardFilterClause> Clauses,
+    DashboardFilterOperation Operation = DashboardFilterOperation.And,
+    /// <summary>
+    /// When true, the filter is rendered as a toolbar control so end users
+    /// can change its value at runtime. The widget renders the appropriate
+    /// input (date picker, lookup, text, etc.) based on the clause shape.
+    /// </summary>
+    bool Editable = false);
+
+public sealed record DashboardFilterClause(
+    /// <summary>Field path (e.g. "customer.id", "issuedAt", "status").</summary>
+    string Field,
+    DashboardFilterOperator Op,
+    /// <summary>Static value or `${var}` expression resolved against StateParams / aliases.</summary>
+    object? Value);
+
+public enum DashboardFilterOperator { Eq, Ne, Gt, Gte, Lt, Lte, In, Contains, StartsWith }
+public enum DashboardFilterOperation { And, Or }
+```
+
+**Datasource integration**: `QueryAggregateDatasource` and `TelemetryDatasource`
+gain an optional `DashboardFilters: IReadOnlyList<string>?` field listing the
+filter names to apply. The runtime AND-merges those with whatever the widget
+itself declares.
+
+**Frontend impact**: the dashboard renderer surfaces `Editable = true` filters
+as a toolbar above the grid. Each control's value lives in `DashboardContext`;
+changes invalidate the affected widget queries (same key composition includes
+filter values). Non-editable filters are applied silently — useful for
+"current user", "current tenant" scoping.
+
+**Why this and not just key-filters per datasource**: dashboard filters are
+shared across widgets, get UI representation, and propagate consistently. A
+per-datasource filter is widget-local — fine for "this chart only ever shows
+unpaid invoices", but breaks down for "this whole dashboard is now scoped to
+March 2026".
+
+---
+
+## P3.1 — `Dashboard:{Name}.Description` localization key
+
+**Current**: `DashboardDefinition` has no description. The catalog UI
+(import dialog) shows only the localized title.
+
+**Proposal**: document the convention in `IDashboardDefinitionDescriptor`:
+
+```csharp
+public interface IDashboardDefinitionDescriptor
+{
+    // ... existing members
+
+    /// <summary>
+    /// The descriptor exposes only the wire identifier; user-facing strings are
+    /// resolved from localization:
+    ///
+    ///   <c>Dashboard:{Name}</c>             — title (required)
+    ///   <c>Dashboard:{Name}.Description</c> — secondary description (optional)
+    ///   <c>Widget:{DashboardName}.{Slug}</c> — widget content (per widget convention)
+    ///
+    /// Modules ship the keys for their default cultures; tenants override them
+    /// via `Granit.Localization.Overrides`.
+    /// </summary>
+}
+```
+
+No code change — just contractual clarity so consumers don't reinvent the convention.
+
+---
+
+## P3.2 — Per-instance config overrides (layer over B2)
+
+**Context**: ThingsBoard widgets have rich per-instance overrides — title,
+color, units, thresholds, decimals. We don't need them on the **definition**
+(module-shipped, fixed) but the **persisted Dashboard** aggregate should
+accept them.
+
+**Status update**: B2 (#1453) ships `WidgetInstance` with the data-binding
+fields inlined directly (`MetricName`, `ConfigJson`, etc.). That's correct
+for "values pinned at import time". This proposal layers a separate
+`Overrides: WidgetInstanceConfig?` field for **runtime user customization**
+(admin renames a widget, recolors a series, adjusts decimals). The two are
+distinct concerns — pinned import-time values vs editable user overrides.
+
+**Sketch** (follow-up over B2, not blocking the merge):
+
+```csharp
+namespace Granit.Dashboards;  // in Granit.Dashboards (impl), not Abstractions
+
+public sealed class DashboardWidgetInstance
+{
+    public Guid Id { get; set; }
+    public string DefinitionWidgetSlug { get; set; }    // links back to the WidgetDefinition.Slug
+    public WidgetInstanceConfig? Overrides { get; set; }
+}
+
+public sealed record WidgetInstanceConfig(
+    string? TitleOverrideLocalizationKey = null,
+    string? ColorOverride = null,                // hex
+    string? UnitOverride = null,
+    int? DecimalsOverride = null,
+    IReadOnlyList<WidgetThreshold>? Thresholds = null);
+
+public sealed record WidgetThreshold(
+    decimal Value,
+    string Color,
+    /// <summary>"&gt;=" | "&lt;=" | "==" — applied left-to-right.</summary>
+    string Operator);
+```
+
+The persisted aggregate carries instance config; the definition stays minimal.
+
+---
+
+## P3.3 — `${variable}` substitution syntax (no JS)
+
+**Goal**: parameterise widget titles, action params, filter values, and
+similar strings using a tiny declarative substitution syntax. ThingsBoard
+uses `${variableName}` regex-driven replacement throughout
+(`core/utils.ts:39, 456, 470`). It's a useful pattern — but they pair it
+with full JS evaluation in other places, which we explicitly reject.
+
+**Proposal**: ship `${variable}` and only `${variable}`. No code, no `eval`,
+no expression evaluator. A small hardened resolver matches `\${([^}]+)}` and
+substitutes against a typed context.
+
+**Substitution context** (composition order — later wins):
+
+1. **State parameters** — `${entityId}`, `${entityName}` from the active
+   `StateParams` (P2.1).
+2. **Resolved aliases** — `${alias.currentDevice}` from `EntityAlias` resolution.
+3. **Time window** — `${timeWindow.from}`, `${timeWindow.to}`,
+   `${timeWindow.span}`.
+4. **Row data** (in row-click action contexts) — `${row.customerId}`,
+   `${row.amount}`.
+5. **Series / data-key data** (in series-click action contexts) —
+   `${series.name}`, `${series.value}`.
+
+**Where it applies**:
+
+- `WidgetAction.Params` values → resolved at dispatch time against the
+  triggering row / series.
+- `DashboardFilterClause.Value` → resolved against state params + aliases at
+  query-build time.
+- Widget title overrides on persisted instances (story B2) → resolved against
+  state params + aliases at render time.
+
+**Implementation** (server-side):
+
+```csharp
+public interface IVariableSubstituter
+{
+    string Substitute(string template, IReadOnlyDictionary<string, object?> context);
+}
+
+// Default implementation — pure regex, no scripting.
+//   "Customer ${entityName} — invoices unpaid"
+//   + { entityName = "Acme Corp" }
+//   = "Customer Acme Corp — invoices unpaid"
+//
+// Unknown variables: replaced with empty string AND surfaced as a structured
+// log warning. We never throw — broken templates degrade visibly but don't
+// break the dashboard.
+```
+
+**What we explicitly reject**: any expression syntax beyond simple variable
+lookup. No `${1+1}`, no `${entity.name | uppercase}`, no `${if status...}`.
+If a widget needs computed values, the computation lives in the data pipeline
+(metric definition, query) — not in a template literal.
+
+---
+
+## Anti-patterns explicitly NOT inherited from ThingsBoard
+
+| TB feature                                          | Why not                                                             |
+| --------------------------------------------------- | ------------------------------------------------------------------- |
+| **Inline JS hooks** in widget config                | XSS, untestable, untyped. Declarative descriptors only.             |
+| **Schemaless `settings: {}` blob**                  | Drift guaranteed. Strongly-typed records per widget variant.        |
+| **Marketplace / dynamically loaded widget bundles** | Module-shipped only — auditable supply chain.                       |
+| **WebSocket bidirectional for everything**          | `RefreshHint` discriminates. Only `realtime` gets a push transport. |
+| **Mandatory state machine**                         | Optional via `States?` — single-state dashboards stay simple.       |
+
+---
+
+## Phasing summary
+
+B0 / B1 / B2 are already shipped or in review on `granit-dotnet`. The
+phasing below maps to the actual story IDs rather than abstract milestones.
+
+| Real story                           | Proposals                                                                                                                                     | When                                                                                                                                                    |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pre-merge fix on B2 #1453**        | **P1.1 JsonPolymorphic**                                                                                                                      | **Urgent — must land before B2 merges**. The default `$type` shape is CLR-coupled and would persist into every imported dashboard JSON.                 |
+| **B1.5 follow-up** (after B2 merges) | P1.2 ImageFit + P1.3 TimeWindow (PeriodSpec-aligned) + P1.4 Responsive layouts + P3.1 description doc + P3.3 `${var}` substituter             | Frontend can refactor `@granit/dashboards` types and ship `<DashboardProvider>` against the existing model right now; the additions land progressively. |
+| **B3 #1384 (per-kind validators)**   | P1.5 Actions + P3.2 WidgetInstance overrides                                                                                                  | Originally scoped to validators; widen to actions + the runtime override layer over B2's inlined config.                                                |
+| **B4 #1385**                         | P2.1 Views (renamed from `DashboardState`) + P2.5 Dashboard filters                                                                           | Already a busy story — may need to split filters out into B4.5 if it grows.                                                                             |
+| **B5 (frontend-led)**                | P2.3 EntityAliases (4 resolver kinds, no RelationGraph) + P2.2 Datasource migration                                                           | Datasource migration is a breaking change to KpiWidgetDefinition (drop `MetricName` shorthand, replace with `Datasource`). Front + back coordinated.    |
+| **B6+ — dedicated ticket**           | P2.4 SSE subscriptions (per-metric + per-dashboard multiplexed, snapshot+update events, tenant-pinned producer keying, bounded replay buffer) | New ticket separate from #1387. Endpoint design is a project of its own.                                                                                |
+
+Frontend work that can proceed **immediately** (no backend dependency): the
+type alignment to current shipped `Granit.Dashboards.Abstractions`
+(`Slug`/`Position`/`Size`/`RequiredPermission`/localization keys/`IsSystem`/
+`Version`/full `DashboardCategory` enum, drop layout-items, drop description),
+plus the `<Dashboard>` auto-flow grid and i18n-resolving widget renderers.
+The proposed extensions slot in cleanly as backend ships them.
+
+P1 items unblock the frontend refactor immediately. P2/P3 can land progressively
+without breaking the wire format if discriminated unions are pinned now.
+
+---
+
+## Frontend status (for awareness)
+
+These TypeScript packages were scaffolded in `granit-front`, all uncommitted
+(awaiting alignment with the items above):
+
+- `@granit/dashboards` — types mirroring `Granit.Dashboards.Abstractions`
+- `@granit/react-dashboards` — Dashboard renderer, registry, framework widgets
+- `@granit/charts` — Apache ECharts theme builder + locale-aware formatters
+- `@granit/react-charts` — typed `<LineChart>`, `<BarChart>`, `<PieChart>`,
+  `<SparklineChart>` + escape hatch `<Chart>`, ECharts modular imports
+
+Once the P1 items land in `Granit.Dashboards.Abstractions` and we settle on
+the JsonPolymorphic discriminators, the frontend refactor is ~1h of mechanical
+type updates.

--- a/docs/dashboards-architecture-proposals.md
+++ b/docs/dashboards-architecture-proposals.md
@@ -930,6 +930,164 @@ March 2026".
 
 ---
 
+## P2.6 — Editable persisted dashboards via react-grid-layout
+
+**Goal**: ship the ThingsBoard-grade UX for arranging widgets — drag,
+resize, per-breakpoint layouts, persistence — without forcing the bundle
+weight onto every dashboard view.
+
+### Three layers, one mental model
+
+| Layer                                                        | Source                                                    | Layout strategy                                                                  | Lib                 |
+| ------------------------------------------------------------ | --------------------------------------------------------- | -------------------------------------------------------------------------------- | ------------------- |
+| **Definition** (catalogue, module-shipped)                   | `DashboardDefinition`                                     | Auto-flow CSS grid (`grid-auto-flow: dense`) over `position: int` + `WidgetSize` | none                |
+| **Persisted read-only** (story B2 — imported, end-user view) | `Dashboard` aggregate, explicit `WidgetInstance.Position` | CSS grid with explicit `grid-row`/`grid-column` per widget                       | none                |
+| **Persisted edit** (admin mode — drag/resize)                | Same `Dashboard` aggregate, in edit mode                  | `react-grid-layout` (`<ResponsiveReactGridLayout>`)                              | `react-grid-layout` |
+
+The user-facing components match the layer:
+
+- `<Dashboard definition={...}>` — already shipped. Auto-flow only.
+- `<Dashboard instance={...} mode="readonly">` — new. CSS grid with explicit positions.
+- `<DashboardEditor instance={...}>` — new. `React.lazy()` over `react-grid-layout`,
+  loaded only when the admin enters edit mode.
+
+### Backend additions (B2 follow-up, NOT blocking the merge)
+
+```csharp
+namespace Granit.Dashboards;
+
+public sealed record WidgetInstancePosition(int X, int Y, int Width, int Height);
+
+public class WidgetInstance
+{
+    // ... existing inlined config (B2)
+
+    /// <summary>Default placement on the standard (desktop) breakpoint.</summary>
+    public WidgetInstancePosition Position { get; set; }
+
+    /// <summary>
+    /// Per-breakpoint position overrides keyed by `DashboardBreakpoint`.
+    /// Empty / null = use the default `Position`.
+    /// </summary>
+    public IReadOnlyDictionary<DashboardBreakpoint, WidgetInstancePosition>? PositionOverrides { get; set; }
+}
+```
+
+When the admin imports a `DashboardDefinition`, the framework computes initial
+positions by walking the definition's auto-flow (`position: int` + `size`),
+populates `WidgetInstance.Position`, and lets the admin drag/resize from there.
+
+### Frontend — bundle isolation strategy
+
+`@granit/react-dashboards` ships **read-only rendering** with zero new deps:
+
+```tsx
+// Internal to <Dashboard instance>
+function PersistedDashboard({ instance }: { instance: PersistedDashboard }) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: ..., gridAutoRows: ... }}>
+      {instance.widgets.map((w) => (
+        <div
+          key={w.slug}
+          style={{
+            gridColumn: `${w.position.x + 1} / span ${w.position.width}`,
+            gridRow: `${w.position.y + 1} / span ${w.position.height}`,
+          }}
+        >
+          <WidgetRenderer widget={w.definition} />
+        </div>
+      ))}
+    </div>
+  );
+}
+```
+
+The editor lives behind a lazy boundary in the same package:
+
+```tsx
+const DashboardEditor = React.lazy(() => import('./DashboardEditor.js'));
+
+export function Dashboard({ instance, mode }: DashboardProps) {
+  if (mode !== 'edit') return <PersistedDashboard instance={instance} />;
+  return (
+    <Suspense fallback={<DashboardEditorSkeleton />}>
+      <DashboardEditor instance={instance} />
+    </Suspense>
+  );
+}
+```
+
+**Bundle math** — `react-grid-layout` (~30 KB gz) + `react-resizable` (~3 KB gz)
+load only when an admin clicks "Edit dashboard". End-user views stay light.
+
+### `react-grid-layout` configuration mapping
+
+```tsx
+import { Responsive, WidthProvider } from 'react-grid-layout';
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+<ResponsiveGridLayout
+  className="dashboard-editor"
+  layouts={layoutsByBreakpoint} // { lg: WidgetLayout[], md: ..., sm: ..., xs: ... }
+  breakpoints={{ lg: 1200, md: 996, sm: 768, xs: 480, xxs: 0 }}
+  cols={{ lg: 12, md: 10, sm: 6, xs: 4, xxs: 2 }}
+  rowHeight={instance.layout.rowHeight}
+  draggableHandle=".widget-drag-handle" // explicit handle prevents accidental drags
+  isDraggable={true}
+  isResizable={true}
+  onLayoutChange={(_, all) => persistLayouts(all)}
+>
+  {instance.widgets.map((w) => (
+    <div key={w.slug} data-grid={dataGridFromInstance(w)}>
+      <WidgetRenderer widget={w.definition} />
+    </div>
+  ))}
+</ResponsiveGridLayout>;
+```
+
+The `WidgetLayout[]` shape r-g-l consumes maps 1:1 onto our
+`WidgetInstancePosition` + breakpoint key — no impedance mismatch.
+
+### What `react-grid-layout` covers vs leaves to us
+
+| ThingsBoard UX                    | r-g-l native?                                                     |
+| --------------------------------- | ----------------------------------------------------------------- |
+| Drag widgets                      | ✅                                                                |
+| Resize from corners               | ✅                                                                |
+| Per-breakpoint layouts            | ✅ (`Responsive` wrapper)                                         |
+| Static (non-editable) widgets     | ✅ (`static: true` per layout entry)                              |
+| Persistence                       | ✅ (`onLayoutChange` callback — we wire it to a backend mutation) |
+| Multiple states / dashboard views | ❌ — handled by P2.1 routing layer                                |
+| Widget actions / drill-down       | ❌ — handled by P1.5                                              |
+
+### Risks logged
+
+- **a11y** — drag-and-drop has weak keyboard / screen-reader support. The
+  editor mode is admin-only; if WCAG 2.2 AA matters for end users, the
+  read-only `<Dashboard instance>` (CSS grid only) is fully accessible
+  already, and the editor stays gated behind a permission flag.
+- **Performance > 50 widgets per state** — r-g-l can sluggish under heavy
+  loads. Validate via prototype if/when a real IoT dashboard exceeds 50
+  widgets per active state. Alternative: virtualize the off-screen widgets
+  (manual, not r-g-l-native).
+- **Maintenance posture** — r-g-l is mature (10 k+ stars, MIT) but commits
+  are modest. We accept that risk; the alternative (dnd-kit + custom layout
+  engine) is multi-week effort with marginal benefit.
+
+### Story phasing
+
+| Step                                                                    | Where                                               |
+| ----------------------------------------------------------------------- | --------------------------------------------------- |
+| Add `WidgetInstance.Position` + `PositionOverrides` to B2 aggregate     | granit-dotnet, follow-up to #1453                   |
+| Computation of initial positions from auto-flow on import               | granit-dotnet (story B4 #1385 — import endpoint)    |
+| `<Dashboard instance mode="readonly">` CSS grid renderer                | `@granit/react-dashboards`, no new deps             |
+| `<DashboardEditor>` lazy boundary + `react-grid-layout` integration     | `@granit/react-dashboards`, dep added (lazy-loaded) |
+| `onLayoutChange` → backend mutation via `useUpdateDashboardLayout` hook | `@granit/react-dashboards`                          |
+| Admin-only edit toggle UI (button + permission gate)                    | consuming app (showcase first)                      |
+
+---
+
 ## P3.1 — `Dashboard:{Name}.Description` localization key
 
 **Current**: `DashboardDefinition` has no description. The catalog UI
@@ -1079,14 +1237,15 @@ If a widget needs computed values, the computation lives in the data pipeline
 B0 / B1 / B2 are already shipped or in review on `granit-dotnet`. The
 phasing below maps to the actual story IDs rather than abstract milestones.
 
-| Real story                           | Proposals                                                                                                                                     | When                                                                                                                                                    |
-| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Pre-merge fix on B2 #1453**        | **P1.1 JsonPolymorphic**                                                                                                                      | **Urgent — must land before B2 merges**. The default `$type` shape is CLR-coupled and would persist into every imported dashboard JSON.                 |
-| **B1.5 follow-up** (after B2 merges) | P1.2 ImageFit + P1.3 TimeWindow (PeriodSpec-aligned) + P1.4 Responsive layouts + P3.1 description doc + P3.3 `${var}` substituter             | Frontend can refactor `@granit/dashboards` types and ship `<DashboardProvider>` against the existing model right now; the additions land progressively. |
-| **B3 #1384 (per-kind validators)**   | P1.5 Actions + P3.2 WidgetInstance overrides                                                                                                  | Originally scoped to validators; widen to actions + the runtime override layer over B2's inlined config.                                                |
-| **B4 #1385**                         | P2.1 Views (renamed from `DashboardState`) + P2.5 Dashboard filters                                                                           | Already a busy story — may need to split filters out into B4.5 if it grows.                                                                             |
-| **B5 (frontend-led)**                | P2.3 EntityAliases (4 resolver kinds, no RelationGraph) + P2.2 Datasource migration                                                           | Datasource migration is a breaking change to KpiWidgetDefinition (drop `MetricName` shorthand, replace with `Datasource`). Front + back coordinated.    |
-| **B6+ — dedicated ticket**           | P2.4 SSE subscriptions (per-metric + per-dashboard multiplexed, snapshot+update events, tenant-pinned producer keying, bounded replay buffer) | New ticket separate from #1387. Endpoint design is a project of its own.                                                                                |
+| Real story                           | Proposals                                                                                                                                                        | When                                                                                                                                                                  |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Pre-merge fix on B2 #1453**        | **P1.1 JsonPolymorphic**                                                                                                                                         | **Urgent — must land before B2 merges**. The default `$type` shape is CLR-coupled and would persist into every imported dashboard JSON.                               |
+| **B1.5 follow-up** (after B2 merges) | P1.2 ImageFit + P1.3 TimeWindow (PeriodSpec-aligned) + P1.4 Responsive layouts + P3.1 description doc + P3.3 `${var}` substituter                                | Frontend can refactor `@granit/dashboards` types and ship `<DashboardProvider>` against the existing model right now; the additions land progressively.               |
+| **B3 #1384 (per-kind validators)**   | P1.5 Actions + P3.2 WidgetInstance overrides                                                                                                                     | Originally scoped to validators; widen to actions + the runtime override layer over B2's inlined config.                                                              |
+| **B4 #1385**                         | P2.1 Views (renamed from `DashboardState`) + P2.5 Dashboard filters                                                                                              | Already a busy story — may need to split filters out into B4.5 if it grows.                                                                                           |
+| **B5 (frontend-led)**                | P2.3 EntityAliases (4 resolver kinds, no RelationGraph) + P2.2 Datasource migration                                                                              | Datasource migration is a breaking change to KpiWidgetDefinition (drop `MetricName` shorthand, replace with `Datasource`). Front + back coordinated.                  |
+| **B6+ — dedicated ticket**           | P2.4 SSE subscriptions (per-metric + per-dashboard multiplexed, snapshot+update events, tenant-pinned producer keying, bounded replay buffer)                    | New ticket separate from #1387. Endpoint design is a project of its own.                                                                                              |
+| **B6+ — dedicated ticket**           | P2.6 `WidgetInstance.Position` (X, Y, W, H) + per-breakpoint `PositionOverrides` on B2 aggregate; auto-flow → explicit position computation on import (B4 #1385) | `<Dashboard instance mode="readonly">` CSS-grid renderer (zero new deps); `<DashboardEditor>` lazy boundary loading `react-grid-layout` (~33 KB gz only on edit mode) |
 
 Frontend work that can proceed **immediately** (no backend dependency): the
 type alignment to current shipped `Granit.Dashboards.Abstractions`

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "axios": "^1.15.2",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "eslint": "^10.2.1",
     "eslint-plugin-import-x": "^4.16.2",
     "husky": "^9.1.7",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "jsdom": "^29.1.0",
     "keycloak-js": "^26.2.4",
     "lint-staged": "^16.4.0",
+    "lucide-react": "^1.8.0",
     "markdownlint-cli2": "^0.22.1",
     "msw": "^2.13.6",
     "prettier": "^3.8.3",

--- a/packages/@granit/analytics/package.json
+++ b/packages/@granit/analytics/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@granit/analytics",
+  "description": "Framework-agnostic types for Granit.Analytics — MetricResponse runtime envelopes plus KPI / Chart / Table / Pivot widget definitions consumed by @granit/dashboards",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/dashboards": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/dashboards": "workspace:*"
+  }
+}

--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------
+// @granit/analytics — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
+
+// Metrics — runtime evaluation envelopes
+export type {
+  CompareSpec,
+  CompareToken,
+  MetricPreviousPayload,
+  MetricRequest,
+  MetricResponse,
+  MetricSnapshotPayload,
+  PeriodSpec,
+  PeriodToken,
+  RefreshHint,
+  Trend,
+  ValueKind,
+} from './metrics/index.js';
+
+// Widgets — catalog declarations consumed by @granit/dashboards
+export type {
+  AggregateFunction,
+  AnalyticsWidgetDefinition,
+  ChartType,
+  ChartWidgetDefinition,
+  KpiWidgetDefinition,
+  PivotWidgetDefinition,
+  TableWidgetDefinition,
+} from './widgets/index.js';

--- a/packages/@granit/analytics/src/metrics/index.ts
+++ b/packages/@granit/analytics/src/metrics/index.ts
@@ -1,0 +1,13 @@
+export type {
+  CompareSpec,
+  CompareToken,
+  MetricPreviousPayload,
+  MetricRequest,
+  MetricResponse,
+  MetricSnapshotPayload,
+  PeriodSpec,
+  PeriodToken,
+  RefreshHint,
+  Trend,
+  ValueKind,
+} from './metric-response.js';

--- a/packages/@granit/analytics/src/metrics/metric-response.ts
+++ b/packages/@granit/analytics/src/metrics/metric-response.ts
@@ -1,0 +1,73 @@
+/**
+ * Public contract for `Granit.Analytics` metric evaluation responses.
+ *
+ * Mirrors the v1 backend response envelope. Hand-curated rather than imported
+ * from Orval — packages downstream of `@granit/analytics` consume these types
+ * directly without depending on a generated client.
+ */
+
+export type ValueKind = 'count' | 'currency' | 'percentage' | 'duration' | 'date' | 'number';
+
+export type Trend = 'up' | 'down' | 'flat';
+
+export type RefreshHint = 'static' | 'dynamic' | 'realtime';
+
+/**
+ * Calendar-aware period token. Backend (`Granit.Analytics.Metrics.PeriodSpec`)
+ * supports more (`last_60s`, `last_5m`, `mtd`, `qtd`, `ytd`, ...); the frontend
+ * type stays open as `string` so new tokens land without requiring a client
+ * type bump.
+ */
+export type PeriodToken =
+  | 'today'
+  | 'yesterday'
+  | 'last_60s'
+  | 'last_5m'
+  | 'last_7d'
+  | 'last_30d'
+  | 'mtd'
+  | 'qtd'
+  | 'ytd'
+  | (string & {});
+
+export type CompareToken = 'previous_period' | (string & {});
+
+export type PeriodSpec =
+  | { readonly token: PeriodToken }
+  | { readonly from: string; readonly to: string };
+
+export type CompareSpec = { readonly token: CompareToken };
+
+export interface MetricRequest {
+  readonly period: PeriodSpec;
+  readonly compareTo?: CompareSpec;
+}
+
+export interface MetricPreviousPayload {
+  readonly value: number | null;
+  /** Ratio (current − previous) / |previous|. Null when previous is 0 or current is null. */
+  readonly deltaRatio: number | null;
+  readonly trend: Trend;
+  /** Drives green/red. Null when delta is undefined. */
+  readonly isFavorable: boolean | null;
+}
+
+export interface MetricSnapshotPayload {
+  readonly value: number | null;
+  readonly valueKind: ValueKind;
+  /** ISO 4217 currency code when `valueKind === 'currency'`. Null otherwise. */
+  readonly currency: string | null;
+  readonly isHigherBetter: boolean;
+  readonly noData: boolean;
+  readonly previous: MetricPreviousPayload | null;
+}
+
+export interface MetricResponse {
+  readonly name: string;
+  readonly snapshot: MetricSnapshotPayload;
+  /** Monotonic counter — future-proofs streaming transport (P2.4). */
+  readonly sequence: number;
+  /** ISO 8601 UTC timestamp the backend emitted the snapshot. */
+  readonly emittedAt: string;
+  readonly refreshHint: RefreshHint;
+}

--- a/packages/@granit/analytics/src/widgets/aggregation.ts
+++ b/packages/@granit/analytics/src/widgets/aggregation.ts
@@ -1,0 +1,5 @@
+/**
+ * Aggregation operators. Mirrors `Granit.QueryEngine.Filtering.AggregateFunction`
+ * — the same enum used for metric definitions on the backend.
+ */
+export type AggregateFunction = 'count' | 'sum' | 'avg' | 'min' | 'max';

--- a/packages/@granit/analytics/src/widgets/chart-widget.ts
+++ b/packages/@granit/analytics/src/widgets/chart-widget.ts
@@ -1,0 +1,27 @@
+import type { AggregateFunction } from './aggregation.js';
+import type { WidgetDefinitionBase } from '@granit/dashboards';
+
+/**
+ * Visual hint for chart widgets, interpreted by the frontend renderer. Mirrors
+ * `Granit.Analytics.Dashboards.Widgets.ChartType`.
+ */
+export type ChartType = 'bar' | 'horizontalBar' | 'line' | 'area' | 'pie' | 'donut';
+
+/**
+ * Aggregated chart bound to a `QueryDefinition`. Mirrors
+ * `Granit.Analytics.Dashboards.Widgets.ChartWidgetDefinition`.
+ *
+ * Unlike a KPI, a chart owns its aggregation (sum / average / count over a
+ * chosen field) so the same query can power multiple distinct charts.
+ */
+export interface ChartWidgetDefinition extends WidgetDefinitionBase {
+  readonly type: 'chart';
+  /** The `QueryDefinition.Name` backing this chart. */
+  readonly queryName: string;
+  /** Field used as the chart's category axis (e.g. `IssuedAtMonth`). */
+  readonly groupBy: string;
+  readonly aggregation: AggregateFunction;
+  /** Field aggregated. Null when `aggregation === 'count'`. */
+  readonly field: string | null;
+  readonly chartType: ChartType;
+}

--- a/packages/@granit/analytics/src/widgets/index.ts
+++ b/packages/@granit/analytics/src/widgets/index.ts
@@ -1,0 +1,21 @@
+export type { AggregateFunction } from './aggregation.js';
+export type { ChartType, ChartWidgetDefinition } from './chart-widget.js';
+export type { KpiWidgetDefinition } from './kpi-widget.js';
+export type { PivotWidgetDefinition } from './pivot-widget.js';
+export type { TableWidgetDefinition } from './table-widget.js';
+
+import type { ChartWidgetDefinition } from './chart-widget.js';
+import type { KpiWidgetDefinition } from './kpi-widget.js';
+import type { PivotWidgetDefinition } from './pivot-widget.js';
+import type { TableWidgetDefinition } from './table-widget.js';
+
+/**
+ * Closed union of every analytics widget shipped by `Granit.Analytics`. Used
+ * by the frontend dispatcher to refine `WidgetDefinition` to a known analytics
+ * variant when registering renderers.
+ */
+export type AnalyticsWidgetDefinition =
+  | KpiWidgetDefinition
+  | ChartWidgetDefinition
+  | TableWidgetDefinition
+  | PivotWidgetDefinition;

--- a/packages/@granit/analytics/src/widgets/kpi-widget.ts
+++ b/packages/@granit/analytics/src/widgets/kpi-widget.ts
@@ -1,0 +1,15 @@
+import type { WidgetDefinitionBase } from '@granit/dashboards';
+
+/**
+ * Single-value KPI tile bound to a `MetricDefinition`. Mirrors
+ * `Granit.Analytics.Dashboards.Widgets.KpiWidgetDefinition`.
+ *
+ * The widget renders the metric's current value plus an optional comparison
+ * delta with favorable / unfavorable color (driven by
+ * `MetricSnapshotPayload.previous.isFavorable`).
+ */
+export interface KpiWidgetDefinition extends WidgetDefinitionBase {
+  readonly type: 'kpi';
+  /** The `MetricDefinition.Name` this KPI surfaces (e.g. `Granit.Invoicing.UnpaidInvoiceCountMetric`). */
+  readonly metricName: string;
+}

--- a/packages/@granit/analytics/src/widgets/pivot-widget.ts
+++ b/packages/@granit/analytics/src/widgets/pivot-widget.ts
@@ -1,0 +1,19 @@
+import type { AggregateFunction } from './aggregation.js';
+import type { WidgetDefinitionBase } from '@granit/dashboards';
+
+/**
+ * Pivot-table widget — rows × columns × value cells. Classic OLAP shape.
+ * Mirrors `Granit.Analytics.Dashboards.Widgets.PivotWidgetDefinition`.
+ */
+export interface PivotWidgetDefinition extends WidgetDefinitionBase {
+  readonly type: 'pivot';
+  /** The `QueryDefinition.Name` backing this pivot. */
+  readonly queryName: string;
+  /** Fields used as row dimensions (in order). */
+  readonly rowFields: readonly string[];
+  /** Fields used as column dimensions (in order). */
+  readonly columnFields: readonly string[];
+  /** Field aggregated in each cell. Null when `valueAggregation === 'count'`. */
+  readonly valueField: string | null;
+  readonly valueAggregation: AggregateFunction;
+}

--- a/packages/@granit/analytics/src/widgets/table-widget.ts
+++ b/packages/@granit/analytics/src/widgets/table-widget.ts
@@ -1,0 +1,16 @@
+import type { WidgetDefinitionBase } from '@granit/dashboards';
+
+/**
+ * Tabular widget bound to a `QueryDefinition`. Mirrors
+ * `Granit.Analytics.Dashboards.Widgets.TableWidgetDefinition`.
+ *
+ * Renders a paginated grid of rows using the query's filter / sort surface.
+ */
+export interface TableWidgetDefinition extends WidgetDefinitionBase {
+  readonly type: 'table';
+  /** The `QueryDefinition.Name` backing this table. */
+  readonly queryName: string;
+  /** Subset of the query's columns to surface, in order. Null = render all. */
+  readonly visibleColumns: readonly string[] | null;
+  readonly pageSize: number;
+}

--- a/packages/@granit/analytics/tsconfig.json
+++ b/packages/@granit/analytics/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/analytics/tsup.config.ts
+++ b/packages/@granit/analytics/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/charts/package.json
+++ b/packages/@granit/charts/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/charts",
+  "description": "Framework-agnostic chart primitives for Granit — typed series shapes, ECharts theme builder from Tailwind tokens, locale-aware tick formatters",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/charts/src/__tests__/build-echarts-theme.test.ts
+++ b/packages/@granit/charts/src/__tests__/build-echarts-theme.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildEChartsTheme } from '../theme/build-echarts-theme.js';
+
+interface ExpectedShape {
+  readonly color: readonly string[];
+  readonly textStyle: { readonly color: string; readonly fontFamily: string };
+}
+
+const TOKENS = {
+  background: '#ffffff',
+  foreground: '#0f172a',
+  muted: '#64748b',
+  border: '#e2e8f0',
+  palette: ['#3b82f6', '#10b981', '#f59e0b'] as const,
+};
+
+describe('buildEChartsTheme', () => {
+  it('returns the categorical palette as the top-level color array', () => {
+    const theme = buildEChartsTheme(TOKENS) as unknown as ExpectedShape;
+    expect(theme.color).toEqual([...TOKENS.palette]);
+  });
+
+  it('threads the foreground token into textStyle.color', () => {
+    const theme = buildEChartsTheme(TOKENS) as unknown as ExpectedShape;
+    expect(theme.textStyle.color).toBe(TOKENS.foreground);
+  });
+
+  it('returns a frozen object so consumers can not mutate shared state', () => {
+    const theme = buildEChartsTheme(TOKENS);
+    expect(Object.isFrozen(theme)).toBe(true);
+  });
+
+  it('falls back to inherited font family when none is provided', () => {
+    const theme = buildEChartsTheme(TOKENS) as unknown as ExpectedShape;
+    expect(theme.textStyle.fontFamily).toBe('inherit');
+  });
+
+  it('respects an explicit fontFamily token', () => {
+    const theme = buildEChartsTheme({
+      ...TOKENS,
+      fontFamily: 'Inter, sans-serif',
+    }) as unknown as ExpectedShape;
+    expect(theme.textStyle.fontFamily).toBe('Inter, sans-serif');
+  });
+});

--- a/packages/@granit/charts/src/__tests__/format-axis-tick.test.ts
+++ b/packages/@granit/charts/src/__tests__/format-axis-tick.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatAxisTick } from '../format/format-axis-tick.js';
+
+const normalize = (s: string) => s.replace(/[\u0020\u00A0\u202F]+/g, ' ');
+
+describe('formatAxisTick', () => {
+  it('formats numbers with locale grouping', () => {
+    const fmt = formatAxisTick({ locale: 'en-US' });
+    expect(fmt(1234)).toBe('1,234');
+  });
+
+  it('formats currency with the chosen ISO 4217 code', () => {
+    const fmt = formatAxisTick({ kind: 'currency', currency: 'EUR', locale: 'fr-FR' });
+    expect(normalize(fmt(12450.5))).toBe('12 450,50 €');
+  });
+
+  it('throws when currency kind is requested without a currency code', () => {
+    expect(() => formatAxisTick({ kind: 'currency' })).toThrow(/currency is required/);
+  });
+
+  it('formats percentage values', () => {
+    const fmt = formatAxisTick({ kind: 'percent', locale: 'en-US' });
+    expect(fmt(0.1507)).toBe('15.07%');
+  });
+
+  it('coerces string inputs to numbers', () => {
+    const fmt = formatAxisTick({ locale: 'en-US' });
+    expect(fmt('1234')).toBe('1,234');
+  });
+
+  it('formats time-of-day with a date input as Unix ms', () => {
+    const fmt = formatAxisTick({ kind: 'time', locale: 'en-US' });
+    const ts = Date.UTC(2026, 0, 15, 13, 5);
+    // We don't assert the exact string because the runtime's TZ varies — just
+    // confirm it produced an HH:MM-like shape.
+    expect(fmt(ts)).toMatch(/\d{1,2}[:.]\d{2}/);
+  });
+});

--- a/packages/@granit/charts/src/format/format-axis-tick.ts
+++ b/packages/@granit/charts/src/format/format-axis-tick.ts
@@ -1,0 +1,74 @@
+/**
+ * Locale-aware axis tick formatter factory.
+ *
+ * ECharts axis labels accept either a string template or a function. Our
+ * primitives plug a function in by default so we get proper Intl-driven
+ * grouping and currency rendering — the platform's default `toString()`
+ * doesn't respect locale and produces "1234" where users expect "1,234".
+ */
+export interface FormatAxisTickOptions {
+  /** BCP 47 tag. Defaults to runtime default (`undefined`). */
+  readonly locale?: string;
+  /** Formatting kind. Drives which `Intl` formatter is used. */
+  readonly kind?: 'number' | 'currency' | 'percent' | 'time' | 'date';
+  /** Required when `kind === 'currency'`. ISO 4217. */
+  readonly currency?: string;
+  /** Maximum fraction digits. Defaults to 2 for number/currency/percent, 0 for count-like. */
+  readonly maximumFractionDigits?: number;
+}
+
+/**
+ * Returns a function suitable for `axisLabel.formatter`.
+ *
+ * @example
+ *   formatAxisTick({ kind: 'currency', currency: 'EUR', locale: 'fr-FR' })(12450.5)
+ *   // → "12 450,50 €"
+ */
+export function formatAxisTick(
+  options: FormatAxisTickOptions = {}
+): (value: number | string) => string {
+  const { locale, kind = 'number', currency, maximumFractionDigits } = options;
+
+  switch (kind) {
+    case 'currency': {
+      if (!currency) {
+        throw new Error('formatAxisTick: currency is required when kind="currency"');
+      }
+      const fmt = new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency,
+        maximumFractionDigits: maximumFractionDigits ?? 2,
+      });
+      return (v) => fmt.format(toNumber(v));
+    }
+    case 'percent': {
+      const fmt = new Intl.NumberFormat(locale, {
+        style: 'percent',
+        maximumFractionDigits: maximumFractionDigits ?? 2,
+      });
+      return (v) => fmt.format(toNumber(v));
+    }
+    case 'time': {
+      const fmt = new Intl.DateTimeFormat(locale, {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+      return (v) => fmt.format(new Date(toNumber(v)));
+    }
+    case 'date': {
+      const fmt = new Intl.DateTimeFormat(locale);
+      return (v) => fmt.format(new Date(toNumber(v)));
+    }
+    case 'number':
+    default: {
+      const fmt = new Intl.NumberFormat(locale, {
+        maximumFractionDigits: maximumFractionDigits ?? 0,
+      });
+      return (v) => fmt.format(toNumber(v));
+    }
+  }
+}
+
+function toNumber(value: number | string): number {
+  return typeof value === 'number' ? value : Number(value);
+}

--- a/packages/@granit/charts/src/format/index.ts
+++ b/packages/@granit/charts/src/format/index.ts
@@ -1,0 +1,2 @@
+export { formatAxisTick } from './format-axis-tick.js';
+export type { FormatAxisTickOptions } from './format-axis-tick.js';

--- a/packages/@granit/charts/src/index.ts
+++ b/packages/@granit/charts/src/index.ts
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------
+// @granit/charts — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
+
+// Types
+export type { ChartAxis, ChartDataPoint, ChartDimensions, ChartSeries } from './types.js';
+
+// Theme
+export { buildEChartsTheme } from './theme/index.js';
+export type { ChartThemeTokens } from './theme/index.js';
+
+// Formatters
+export { formatAxisTick } from './format/index.js';
+export type { FormatAxisTickOptions } from './format/index.js';

--- a/packages/@granit/charts/src/theme/build-echarts-theme.ts
+++ b/packages/@granit/charts/src/theme/build-echarts-theme.ts
@@ -1,0 +1,64 @@
+/**
+ * Inputs for {@link buildEChartsTheme} — derived from the host app's Tailwind
+ * design tokens. Only the values ECharts actually reads are required; the
+ * builder fills in sensible fallbacks for the rest.
+ */
+export interface ChartThemeTokens {
+  readonly background: string;
+  readonly foreground: string;
+  readonly muted: string;
+  readonly border: string;
+  /** Categorical palette — used to color individual series in order. */
+  readonly palette: readonly string[];
+  /** Font family used for axis labels, legends, tooltips. */
+  readonly fontFamily?: string;
+}
+
+/**
+ * Builds an ECharts theme object from a small set of Tailwind-aligned design
+ * tokens. The returned object can be registered via `echarts.registerTheme(...)`
+ * and then referenced by name in `<Chart theme="granit-light" />`.
+ *
+ * Kept framework-agnostic on purpose: this module never imports `echarts`. It
+ * returns a plain JSON object whose shape matches what ECharts consumes.
+ */
+export function buildEChartsTheme(tokens: ChartThemeTokens): Readonly<Record<string, unknown>> {
+  const fontFamily = tokens.fontFamily ?? 'inherit';
+  const textStyle = { color: tokens.foreground, fontFamily };
+
+  return Object.freeze({
+    color: [...tokens.palette],
+    backgroundColor: tokens.background,
+    textStyle,
+    title: {
+      textStyle: { color: tokens.foreground, fontFamily, fontWeight: 600 },
+      subtextStyle: { color: tokens.muted, fontFamily },
+    },
+    legend: {
+      textStyle,
+      inactiveColor: tokens.muted,
+    },
+    tooltip: {
+      backgroundColor: tokens.background,
+      borderColor: tokens.border,
+      textStyle,
+    },
+    categoryAxis: axisStyle(tokens),
+    valueAxis: axisStyle(tokens),
+    timeAxis: axisStyle(tokens),
+    logAxis: axisStyle(tokens),
+    grid: { borderColor: tokens.border },
+    line: { lineStyle: { width: 2 }, symbolSize: 6, smooth: false },
+    bar: { itemStyle: { borderRadius: 2 } },
+    pie: { itemStyle: { borderColor: tokens.background, borderWidth: 1 } },
+  });
+}
+
+function axisStyle(tokens: ChartThemeTokens) {
+  return {
+    axisLine: { show: true, lineStyle: { color: tokens.border } },
+    axisTick: { show: false },
+    axisLabel: { color: tokens.muted, fontFamily: tokens.fontFamily ?? 'inherit' },
+    splitLine: { lineStyle: { color: tokens.border, type: 'dashed' } },
+  };
+}

--- a/packages/@granit/charts/src/theme/index.ts
+++ b/packages/@granit/charts/src/theme/index.ts
@@ -1,0 +1,2 @@
+export { buildEChartsTheme } from './build-echarts-theme.js';
+export type { ChartThemeTokens } from './build-echarts-theme.js';

--- a/packages/@granit/charts/src/types.ts
+++ b/packages/@granit/charts/src/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Tuple representation of a single chart point — the same shape ECharts and
+ * most plotting libraries consume natively. Keeping the wire format aligned
+ * with ECharts means our wrappers don't have to re-shape data on every render.
+ */
+export type ChartDataPoint<X = number | string, Y = number> = readonly [X, Y];
+
+/**
+ * One series (line, bar, etc.) of a chart. Series have a stable `id` so the
+ * renderer can keep visual continuity (color, animation) when data updates.
+ */
+export interface ChartSeries<X = number | string, Y = number> {
+  /** Stable identifier — drives ECharts series-key matching across re-renders. */
+  readonly id: string;
+  /** Display name shown in legends and tooltips. */
+  readonly name: string;
+  readonly data: readonly ChartDataPoint<X, Y>[];
+  /**
+   * Override color. When omitted, the chart palette assigns a color from the
+   * theme's categorical scale.
+   */
+  readonly color?: string;
+}
+
+/**
+ * Coarse axis configuration. Concrete chart components extend this with
+ * primitive-specific options (e.g. category axes for bar charts).
+ */
+export interface ChartAxis {
+  readonly type?: 'category' | 'time' | 'value' | 'log';
+  readonly label?: string;
+  /** Hard min — when omitted, ECharts auto-fits. */
+  readonly min?: number;
+  /** Hard max — when omitted, ECharts auto-fits. */
+  readonly max?: number;
+}
+
+/** Common dimension props applicable to every chart primitive. */
+export interface ChartDimensions {
+  readonly height?: number | string;
+  readonly width?: number | string;
+}

--- a/packages/@granit/charts/tsconfig.json
+++ b/packages/@granit/charts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/charts/tsup.config.ts
+++ b/packages/@granit/charts/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/dashboards/package.json
+++ b/packages/@granit/dashboards/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/dashboards",
+  "description": "Framework-agnostic types and registry contracts for Granit dashboards — DashboardDefinition, WidgetDefinition discriminated union, layout primitives, and built-in presentation widgets (Markdown / Image / Text)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -2,18 +2,21 @@
 // @granit/dashboards — public API (framework-agnostic)
 // ---------------------------------------------------------------------------
 
-export { DEFAULT_DASHBOARD_LAYOUT, WIDGET_SIZE } from './types/index.js';
+export { DASHBOARD_TIME_WINDOW, DEFAULT_DASHBOARD_LAYOUT, WIDGET_SIZE } from './types/index.js';
 export type {
   DashboardCategory,
   DashboardDefinition,
   DashboardDefinitionDescriptor,
   DashboardDefinitionRegistry,
   DashboardLayout,
+  DashboardPeriod,
+  DashboardTimeWindow,
   FrameworkWidgetDefinition,
   ImageWidgetDefinition,
   MarkdownWidgetDefinition,
   TextWidgetDefinition,
   TextWidgetStyle,
+  TimeWindowKind,
   WidgetDefinition,
   WidgetDefinitionBase,
   WidgetSize,

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------------
+// @granit/dashboards — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
+
+export type {
+  DashboardCategory,
+  DashboardDefinition,
+  DashboardDefinitionDescriptor,
+  DashboardDefinitionRegistry,
+  DashboardLayout,
+  DashboardLayoutItem,
+  DashboardWidgetPosition,
+  FrameworkWidgetDefinition,
+  ImageWidgetDefinition,
+  MarkdownWidgetDefinition,
+  TextWidgetDefinition,
+  WidgetDefinition,
+  WidgetDefinitionBase,
+  WidgetSize,
+} from './types/index.js';

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -2,18 +2,18 @@
 // @granit/dashboards — public API (framework-agnostic)
 // ---------------------------------------------------------------------------
 
+export { DEFAULT_DASHBOARD_LAYOUT, WIDGET_SIZE } from './types/index.js';
 export type {
   DashboardCategory,
   DashboardDefinition,
   DashboardDefinitionDescriptor,
   DashboardDefinitionRegistry,
   DashboardLayout,
-  DashboardLayoutItem,
-  DashboardWidgetPosition,
   FrameworkWidgetDefinition,
   ImageWidgetDefinition,
   MarkdownWidgetDefinition,
   TextWidgetDefinition,
+  TextWidgetStyle,
   WidgetDefinition,
   WidgetDefinitionBase,
   WidgetSize,

--- a/packages/@granit/dashboards/src/types/dashboard-category.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-category.ts
@@ -1,0 +1,14 @@
+/**
+ * Coarse classification used by the dashboard catalog UI to group dashboards.
+ *
+ * Kept as a plain union (not an enum) so consumers can extend it via TypeScript
+ * declaration merging or simply pass any string the host has registered.
+ */
+export type DashboardCategory =
+  | 'business'
+  | 'operations'
+  | 'iot'
+  | 'compliance'
+  | 'finance'
+  | 'general'
+  | (string & {});

--- a/packages/@granit/dashboards/src/types/dashboard-category.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-category.ts
@@ -1,14 +1,23 @@
 /**
- * Coarse classification used by the dashboard catalog UI to group dashboards.
+ * Coarse classification shipped on every {@link DashboardDefinition}.
+ * Drives the catalogue ordering surfaced by the dashboard registry and the
+ * section grouping in the admin import dialog.
  *
- * Kept as a plain union (not an enum) so consumers can extend it via TypeScript
- * declaration merging or simply pass any string the host has registered.
+ * Mirrors `Granit.Dashboards.DashboardCategory` (numeric enum). Backend ships
+ * via `JsonStringEnumConverter` so the wire is the lowercase form here.
  */
 export type DashboardCategory =
-  | 'business'
-  | 'operations'
-  | 'iot'
-  | 'compliance'
-  | 'finance'
+  /** Default — uncategorised. Use only when the others genuinely do not fit. */
   | 'general'
-  | (string & {});
+  /** Invoicing, payments, subscriptions, customer balance, tax. */
+  | 'finance'
+  /** AI usage, blob storage, background jobs, webhooks, observability. */
+  | 'operations'
+  /** Identity, authorization, auditing. */
+  | 'security'
+  /** Privacy / GDPR (export requests, erasure, retention). */
+  | 'compliance'
+  /** Multi-tenancy, platform-level admin (tenant lifecycle, feature flags). */
+  | 'platform'
+  /** IoT / real-time telemetry — sensors, alarms, video feeds. */
+  | 'iot';

--- a/packages/@granit/dashboards/src/types/dashboard-definition-descriptor.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-definition-descriptor.ts
@@ -1,0 +1,29 @@
+import type { DashboardCategory } from './dashboard-category.js';
+import type { DashboardDefinition } from './dashboard-definition.js';
+
+/**
+ * Lightweight descriptor returned by the dashboard registry's discovery
+ * endpoint. Lists every dashboard the host knows about without dragging in
+ * the full {@link DashboardDefinition} payload — useful for catalog screens
+ * (left rail, picker) where only metadata matters.
+ *
+ * Matches `IDashboardDefinitionDescriptor` on the backend.
+ */
+export interface DashboardDefinitionDescriptor {
+  readonly id: string;
+  readonly name: string;
+  readonly category: DashboardCategory;
+  readonly description?: string;
+}
+
+/**
+ * Frontend-facing analogue of `IDashboardDefinitionRegistry`. Hosts plug in
+ * their preferred fetching strategy (REST, embedded JSON, GraphQL) behind
+ * this contract; the React layer consumes only the interface.
+ */
+export interface DashboardDefinitionRegistry {
+  /** Returns descriptors for every dashboard the host exposes to the caller. */
+  list(signal?: AbortSignal): Promise<readonly DashboardDefinitionDescriptor[]>;
+  /** Returns the full definition (widgets + layout) for one dashboard, or null when unknown. */
+  get(id: string, signal?: AbortSignal): Promise<DashboardDefinition | null>;
+}

--- a/packages/@granit/dashboards/src/types/dashboard-definition-descriptor.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-definition-descriptor.ts
@@ -1,19 +1,32 @@
 import type { DashboardCategory } from './dashboard-category.js';
 import type { DashboardDefinition } from './dashboard-definition.js';
+import type { DashboardLayout } from './dashboard-layout.js';
+import type { WidgetDefinition } from './widget-definition.js';
 
 /**
- * Lightweight descriptor returned by the dashboard registry's discovery
+ * Lightweight descriptor returned by the dashboard registry's catalogue
  * endpoint. Lists every dashboard the host knows about without dragging in
- * the full {@link DashboardDefinition} payload — useful for catalog screens
- * (left rail, picker) where only metadata matters.
+ * widget payloads — useful for catalog screens (left rail, picker) where
+ * only metadata matters.
  *
- * Matches `IDashboardDefinitionDescriptor` on the backend.
+ * Mirrors `IDashboardDefinitionDescriptor` on the backend.
+ *
+ * User-facing strings are resolved from localization:
+ *
+ * - `Dashboard:{name}` — title (required)
+ * - `Dashboard:{name}.Description` — secondary description (optional, P3.1)
+ * - `Widget:{dashboardName}.{slug}` — widget content (per widget convention)
+ *
+ * Modules ship the keys for their default cultures; tenants override them
+ * via `Granit.Localization.Overrides`.
  */
 export interface DashboardDefinitionDescriptor {
-  readonly id: string;
   readonly name: string;
   readonly category: DashboardCategory;
-  readonly description?: string;
+  readonly isSystem: boolean;
+  readonly version: string;
+  readonly layout: DashboardLayout;
+  readonly widgets: readonly WidgetDefinition[];
 }
 
 /**
@@ -24,6 +37,6 @@ export interface DashboardDefinitionDescriptor {
 export interface DashboardDefinitionRegistry {
   /** Returns descriptors for every dashboard the host exposes to the caller. */
   list(signal?: AbortSignal): Promise<readonly DashboardDefinitionDescriptor[]>;
-  /** Returns the full definition (widgets + layout) for one dashboard, or null when unknown. */
-  get(id: string, signal?: AbortSignal): Promise<DashboardDefinition | null>;
+  /** Returns the full definition for one dashboard, or null when unknown. */
+  get(name: string, signal?: AbortSignal): Promise<DashboardDefinition | null>;
 }

--- a/packages/@granit/dashboards/src/types/dashboard-definition.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-definition.ts
@@ -1,0 +1,22 @@
+import type { DashboardCategory } from './dashboard-category.js';
+import type { DashboardLayout } from './dashboard-layout.js';
+import type { WidgetDefinition } from './widget-definition.js';
+
+/**
+ * Top-level descriptor of a dashboard — name, classification, the widgets it
+ * contains, and how they are laid out. This is the JSON shape the backend
+ * registry exposes and the frontend renders.
+ *
+ * Widgets and layout are intentionally separate fields so a single widget can
+ * be reused across multiple layouts (compact / detailed) and so layout edits
+ * never require re-emitting widget content.
+ */
+export interface DashboardDefinition {
+  readonly id: string;
+  readonly name: string;
+  readonly category: DashboardCategory;
+  readonly description?: string;
+  /** Catalog of widgets, keyed by `id`. References from `layout.items.widgetId`. */
+  readonly widgets: readonly WidgetDefinition[];
+  readonly layout: DashboardLayout;
+}

--- a/packages/@granit/dashboards/src/types/dashboard-definition.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-definition.ts
@@ -3,20 +3,38 @@ import type { DashboardLayout } from './dashboard-layout.js';
 import type { WidgetDefinition } from './widget-definition.js';
 
 /**
- * Top-level descriptor of a dashboard — name, classification, the widgets it
- * contains, and how they are laid out. This is the JSON shape the backend
- * registry exposes and the frontend renders.
+ * Top-level descriptor of a dashboard — a declarative catalogue entry shipped
+ * by a Granit module. Mirrors `Granit.Dashboards.DashboardDefinition`.
  *
- * Widgets and layout are intentionally separate fields so a single widget can
- * be reused across multiple layouts (compact / detailed) and so layout edits
- * never require re-emitting widget content.
+ * The definition is pure declaration: no runtime, no persistence. When an
+ * admin imports a definition (story B4), the framework deep-copies it into a
+ * persisted `Dashboard` aggregate (story B2). Module upgrades do NOT retro-edit
+ * imported dashboards — drift is surfaced via {@link version} and an
+ * admin-driven re-sync action (ADR-038 §3).
  */
 export interface DashboardDefinition {
-  readonly id: string;
+  /**
+   * Unique wire identifier — `Granit.{Module}.{DashboardName}`, PascalCase,
+   * dot-separated. Used as the resource key for the dashboard's localized
+   * title (`Dashboard:{Name}`) and as the import endpoint parameter.
+   */
   readonly name: string;
+  /** Catalogue grouping. Drives section ordering in the import dialog. */
   readonly category: DashboardCategory;
-  readonly description?: string;
-  /** Catalog of widgets, keyed by `id`. References from `layout.items.widgetId`. */
-  readonly widgets: readonly WidgetDefinition[];
+  /**
+   * Whether this dashboard is mandated by the platform operator. When true,
+   * imported instances cannot be deleted by tenant admins (only re-synced).
+   * Defaults to false on the backend — framework modules ship suggestions,
+   * not impositions (ADR-038 §5).
+   */
+  readonly isSystem: boolean;
+  /**
+   * Semver of the definition shape. Bumped when the widget set changes in a
+   * breaking way; surfaced to admins as drift after import (ADR-038 §3).
+   */
+  readonly version: string;
+  /** Grid layout configuration. */
   readonly layout: DashboardLayout;
+  /** Widgets shipped by this dashboard, in declared order. */
+  readonly widgets: readonly WidgetDefinition[];
 }

--- a/packages/@granit/dashboards/src/types/dashboard-layout.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-layout.ts
@@ -1,0 +1,41 @@
+import type { WidgetSize } from './widget-size.js';
+
+/**
+ * Position of a widget on the dashboard grid.
+ *
+ * Coordinates are 0-based, top-left origin. A widget at `{ x: 0, y: 0, width: 6, height: 2 }`
+ * spans the leftmost 6 columns and the top 2 rows.
+ */
+export interface DashboardWidgetPosition extends WidgetSize {
+  readonly x: number;
+  readonly y: number;
+}
+
+/**
+ * One item in a dashboard's layout — references a widget by id and tells the
+ * renderer where to place it. Decoupling layout from widget definition makes
+ * it possible to share a single widget across multiple dashboards or to swap
+ * layouts (compact / detailed) without touching widget content.
+ */
+export interface DashboardLayoutItem {
+  /** Matches a {@link WidgetDefinition.id} in the dashboard's `widgets` collection. */
+  readonly widgetId: string;
+  readonly position: DashboardWidgetPosition;
+}
+
+/**
+ * The grid layout of a dashboard.
+ *
+ * `columns` defaults to 12 — same convention as Bootstrap and react-grid-layout —
+ * and is the basis for responsive recomputation when the viewport narrows.
+ * `rowHeight` is hinted in pixels so the host can convert grid rows to a CSS
+ * dimension; the renderer falls back to a sensible default when omitted.
+ */
+export interface DashboardLayout {
+  /** Number of columns in the grid. Defaults to 12 when serialized without it. */
+  readonly columns: number;
+  /** Hint for the renderer — pixel height of one grid row. */
+  readonly rowHeight?: number;
+  /** Placements. The order has no semantic meaning; positions own placement. */
+  readonly items: readonly DashboardLayoutItem[];
+}

--- a/packages/@granit/dashboards/src/types/dashboard-layout.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-layout.ts
@@ -1,41 +1,18 @@
-import type { WidgetSize } from './widget-size.js';
-
 /**
- * Position of a widget on the dashboard grid.
- *
- * Coordinates are 0-based, top-left origin. A widget at `{ x: 0, y: 0, width: 6, height: 2 }`
- * spans the leftmost 6 columns and the top 2 rows.
- */
-export interface DashboardWidgetPosition extends WidgetSize {
-  readonly x: number;
-  readonly y: number;
-}
-
-/**
- * One item in a dashboard's layout — references a widget by id and tells the
- * renderer where to place it. Decoupling layout from widget definition makes
- * it possible to share a single widget across multiple dashboards or to swap
- * layouts (compact / detailed) without touching widget content.
- */
-export interface DashboardLayoutItem {
-  /** Matches a {@link WidgetDefinition.id} in the dashboard's `widgets` collection. */
-  readonly widgetId: string;
-  readonly position: DashboardWidgetPosition;
-}
-
-/**
- * The grid layout of a dashboard.
- *
- * `columns` defaults to 12 — same convention as Bootstrap and react-grid-layout —
- * and is the basis for responsive recomputation when the viewport narrows.
- * `rowHeight` is hinted in pixels so the host can convert grid rows to a CSS
- * dimension; the renderer falls back to a sensible default when omitted.
+ * Coarse layout configuration applied to a dashboard's widget grid. Mirrors
+ * `Granit.Dashboards.DashboardLayout`. Per ADR-038, the layout is intentionally
+ * minimal at the declarative level — the persisted Dashboard aggregate (story
+ * B2) and the frontend composer (story B5) own the fine-grained layout.
  */
 export interface DashboardLayout {
-  /** Number of columns in the grid. Defaults to 12 when serialized without it. */
+  /** Number of grid columns. Default 12 (standard responsive grid). */
   readonly columns: number;
-  /** Hint for the renderer — pixel height of one grid row. */
-  readonly rowHeight?: number;
-  /** Placements. The order has no semantic meaning; positions own placement. */
-  readonly items: readonly DashboardLayoutItem[];
+  /** Row height in CSS pixels. Default 80. */
+  readonly rowHeight: number;
 }
+
+/** Conventional 12-column responsive grid with 80 px row height. */
+export const DEFAULT_DASHBOARD_LAYOUT: DashboardLayout = Object.freeze({
+  columns: 12,
+  rowHeight: 80,
+});

--- a/packages/@granit/dashboards/src/types/dashboard-time-window.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-time-window.ts
@@ -1,0 +1,48 @@
+/**
+ * Time window applied to every data-bound widget on a dashboard. Mirrors the
+ * proposed `Granit.Dashboards.DashboardTimeWindow` (proposals doc P1.3).
+ *
+ * The frontend surfaces it as a top-of-dashboard control ("Last 30 days ▾");
+ * user changes propagate to all widgets that don't carry their own override.
+ *
+ * Period shape is intentionally structurally compatible with
+ * `@granit/analytics`'s `PeriodSpec` (token-based or absolute range) without
+ * a hard type-level dependency — keeps the dashboards package free of
+ * analytics concerns at the type system level.
+ */
+export interface DashboardTimeWindow {
+  readonly period: DashboardPeriod;
+  /** Refresh semantics: `history` (frozen, refetch on range change) vs `realtime` (sliding window). */
+  readonly kind?: TimeWindowKind;
+  /** Optional comparison window (e.g. `previous_period`). */
+  readonly compareTo?: { readonly token: string };
+  /**
+   * Bucket size for time-series aggregation, in milliseconds. When omitted,
+   * the widget's data source picks a default.
+   */
+  readonly aggregationMs?: number;
+}
+
+export type TimeWindowKind = 'history' | 'realtime';
+
+/**
+ * Period selector — token-based (`last_30d`, `mtd`, `ytd`, `last_5m`, ...) or
+ * an absolute ISO 8601 range. Token strings stay open so backend additions
+ * don't require a frontend type bump.
+ */
+export type DashboardPeriod =
+  | { readonly token: string }
+  | { readonly from: string; readonly to: string };
+
+/** Convenience constants matching the conventional tokens. */
+export const DASHBOARD_TIME_WINDOW = Object.freeze({
+  Last24Hours: { period: { token: 'last_24h' }, kind: 'history' } satisfies DashboardTimeWindow,
+  Last7Days: { period: { token: 'last_7d' }, kind: 'history' } satisfies DashboardTimeWindow,
+  Last30Days: { period: { token: 'last_30d' }, kind: 'history' } satisfies DashboardTimeWindow,
+  Mtd: { period: { token: 'mtd' }, kind: 'history' } satisfies DashboardTimeWindow,
+  Ytd: { period: { token: 'ytd' }, kind: 'history' } satisfies DashboardTimeWindow,
+  RealtimeLast5Minutes: {
+    period: { token: 'last_5m' },
+    kind: 'realtime',
+  } satisfies DashboardTimeWindow,
+});

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -4,17 +4,16 @@ export type {
   DashboardDefinitionRegistry,
 } from './dashboard-definition-descriptor.js';
 export type { DashboardDefinition } from './dashboard-definition.js';
-export type {
-  DashboardLayout,
-  DashboardLayoutItem,
-  DashboardWidgetPosition,
-} from './dashboard-layout.js';
+export { DEFAULT_DASHBOARD_LAYOUT } from './dashboard-layout.js';
+export type { DashboardLayout } from './dashboard-layout.js';
 export type {
   FrameworkWidgetDefinition,
   ImageWidgetDefinition,
   MarkdownWidgetDefinition,
   TextWidgetDefinition,
+  TextWidgetStyle,
   WidgetDefinition,
   WidgetDefinitionBase,
 } from './widget-definition.js';
+export { WIDGET_SIZE } from './widget-size.js';
 export type { WidgetSize } from './widget-size.js';

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -1,0 +1,20 @@
+export type { DashboardCategory } from './dashboard-category.js';
+export type {
+  DashboardDefinitionDescriptor,
+  DashboardDefinitionRegistry,
+} from './dashboard-definition-descriptor.js';
+export type { DashboardDefinition } from './dashboard-definition.js';
+export type {
+  DashboardLayout,
+  DashboardLayoutItem,
+  DashboardWidgetPosition,
+} from './dashboard-layout.js';
+export type {
+  FrameworkWidgetDefinition,
+  ImageWidgetDefinition,
+  MarkdownWidgetDefinition,
+  TextWidgetDefinition,
+  WidgetDefinition,
+  WidgetDefinitionBase,
+} from './widget-definition.js';
+export type { WidgetSize } from './widget-size.js';

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -1,4 +1,10 @@
 export type { DashboardCategory } from './dashboard-category.js';
+export { DASHBOARD_TIME_WINDOW } from './dashboard-time-window.js';
+export type {
+  DashboardPeriod,
+  DashboardTimeWindow,
+  TimeWindowKind,
+} from './dashboard-time-window.js';
 export type {
   DashboardDefinitionDescriptor,
   DashboardDefinitionRegistry,

--- a/packages/@granit/dashboards/src/types/widget-definition.ts
+++ b/packages/@granit/dashboards/src/types/widget-definition.ts
@@ -1,0 +1,65 @@
+/**
+ * Common shape every widget definition shares — what's needed by the renderer
+ * to dispatch and identify the widget regardless of its content.
+ *
+ * Specific widget definitions extend this with their own payload (a Markdown
+ * widget carries `content`, an Image widget carries `src`, an Analytics KPI
+ * carries `metric` + `period`, etc.).
+ *
+ * The `type` discriminator is a string rather than a closed enum so packages
+ * downstream of `@granit/dashboards` (analytics, IoT, custom apps) can register
+ * their own widget types without modifying the framework's union.
+ */
+export interface WidgetDefinitionBase {
+  /** Stable identifier — referenced by `DashboardLayoutItem.widgetId`. */
+  readonly id: string;
+  /** Discriminator. Built-ins: `markdown` | `image` | `text`. Extensions add their own. */
+  readonly type: string;
+  /** Optional title rendered above the widget body by `<WidgetCard>`. */
+  readonly title?: string;
+}
+
+/**
+ * Renders Markdown content. The framework ships a minimal pre-formatted
+ * fallback renderer; consuming apps can register a richer renderer (e.g.
+ * react-markdown with custom remark plugins) via the {@link WidgetRegistry}.
+ */
+export interface MarkdownWidgetDefinition extends WidgetDefinitionBase {
+  readonly type: 'markdown';
+  readonly content: string;
+}
+
+/** Renders a static image — typically a logo or visual divider. */
+export interface ImageWidgetDefinition extends WidgetDefinitionBase {
+  readonly type: 'image';
+  readonly src: string;
+  readonly alt?: string;
+  /** CSS object-fit value. Defaults to `'contain'`. */
+  readonly fit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+}
+
+/** Renders a single block of plain text. Whitespace is preserved. */
+export interface TextWidgetDefinition extends WidgetDefinitionBase {
+  readonly type: 'text';
+  readonly content: string;
+}
+
+/**
+ * Closed union of every widget type the framework itself knows how to render.
+ * Downstream packages add their own variants and feed them through the
+ * generic {@link WidgetDefinition} below.
+ */
+export type FrameworkWidgetDefinition =
+  | MarkdownWidgetDefinition
+  | ImageWidgetDefinition
+  | TextWidgetDefinition;
+
+/**
+ * Open-ended widget definition — accepts any `type` string plus arbitrary extra
+ * fields. This is what dashboard payloads are typed as on the wire (a host can
+ * persist Analytics widgets, IoT widgets, etc., and the framework treats them
+ * uniformly until a registered renderer is found for the `type`).
+ */
+export type WidgetDefinition =
+  | FrameworkWidgetDefinition
+  | (WidgetDefinitionBase & Readonly<Record<string, unknown>>);

--- a/packages/@granit/dashboards/src/types/widget-definition.ts
+++ b/packages/@granit/dashboards/src/types/widget-definition.ts
@@ -1,47 +1,69 @@
+import type { WidgetSize } from './widget-size.js';
+
 /**
- * Common shape every widget definition shares — what's needed by the renderer
- * to dispatch and identify the widget regardless of its content.
+ * Common shape every widget definition shares. Mirrors
+ * `Granit.Dashboards.WidgetDefinition` (abstract record). Concrete widget
+ * variants extend this with their kind-specific configuration; downstream
+ * packages register their own renderers via the `WidgetRegistry`.
  *
- * Specific widget definitions extend this with their own payload (a Markdown
- * widget carries `content`, an Image widget carries `src`, an Analytics KPI
- * carries `metric` + `period`, etc.).
- *
- * The `type` discriminator is a string rather than a closed enum so packages
- * downstream of `@granit/dashboards` (analytics, IoT, custom apps) can register
- * their own widget types without modifying the framework's union.
+ * The `type` discriminator is the JSON polymorphism marker exposed by the
+ * backend's `[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]`
+ * attribute (proposed in P1.1 of the architecture doc).
  */
 export interface WidgetDefinitionBase {
-  /** Stable identifier — referenced by `DashboardLayoutItem.widgetId`. */
-  readonly id: string;
-  /** Discriminator. Built-ins: `markdown` | `image` | `text`. Extensions add their own. */
+  /**
+   * Widget-local identifier (PascalCase, unique within the dashboard).
+   * Composes the localization key `Widget:{DashboardName}.{Slug}` for the
+   * widget's display content, and stays stable across reorder operations.
+   */
+  readonly slug: string;
+  /** JSON discriminator. Built-ins: `markdown` | `image` | `text`. */
   readonly type: string;
-  /** Optional title rendered above the widget body by `<WidgetCard>`. */
-  readonly title?: string;
+  /** Dense-ranked grid order — 0-based, contiguous within the dashboard. */
+  readonly position: number;
+  /** Width / height in grid cells. */
+  readonly size: WidgetSize;
+  /**
+   * Optional override of the permission gating this widget at render time.
+   * When omitted, the runtime resolves the effective permission from the
+   * underlying data source (metric / query / IoT topic). Presentation-only
+   * widgets ignore this field.
+   */
+  readonly requiredPermission?: string;
 }
 
 /**
- * Renders Markdown content. The framework ships a minimal pre-formatted
- * fallback renderer; consuming apps can register a richer renderer (e.g.
- * react-markdown with custom remark plugins) via the {@link WidgetRegistry}.
+ * Renders Markdown content. The content lives behind a localization key
+ * resolved at render time via `useTranslation()` — this gives multi-tenant
+ * i18n + per-tenant overrides for free.
  */
 export interface MarkdownWidgetDefinition extends WidgetDefinitionBase {
   readonly type: 'markdown';
-  readonly content: string;
+  /** Localization key resolving to the Markdown body. */
+  readonly contentLocalizationKey: string;
 }
 
 /** Renders a static image — typically a logo or visual divider. */
 export interface ImageWidgetDefinition extends WidgetDefinitionBase {
   readonly type: 'image';
-  readonly src: string;
-  readonly alt?: string;
-  /** CSS object-fit value. Defaults to `'contain'`. */
-  readonly fit?: 'contain' | 'cover' | 'fill' | 'none' | 'scale-down';
+  /** URL or blob reference (`blob:logo-banner`, `https://cdn...`). */
+  readonly source: string;
+  /** Localization key for the alt text (accessibility). */
+  readonly altLocalizationKey: string;
 }
 
-/** Renders a single block of plain text. Whitespace is preserved. */
+/** Visual style hint for `TextWidgetDefinition`. */
+export type TextWidgetStyle = 'body' | 'heading' | 'subheading' | 'caption';
+
+/**
+ * Plain text tile — short label or heading without markdown formatting.
+ * Lighter alternative to `MarkdownWidgetDefinition` for stable interface
+ * labels (page titles, section headers).
+ */
 export interface TextWidgetDefinition extends WidgetDefinitionBase {
   readonly type: 'text';
-  readonly content: string;
+  readonly contentLocalizationKey: string;
+  readonly style: TextWidgetStyle;
 }
 
 /**
@@ -55,10 +77,10 @@ export type FrameworkWidgetDefinition =
   | TextWidgetDefinition;
 
 /**
- * Open-ended widget definition — accepts any `type` string plus arbitrary extra
- * fields. This is what dashboard payloads are typed as on the wire (a host can
- * persist Analytics widgets, IoT widgets, etc., and the framework treats them
- * uniformly until a registered renderer is found for the `type`).
+ * Open-ended widget definition — accepts any `type` string plus arbitrary
+ * extra fields. This is what dashboard payloads are typed as on the wire
+ * (a host can persist Analytics widgets, IoT widgets, etc., and the framework
+ * treats them uniformly until a registered renderer is found for the `type`).
  */
 export type WidgetDefinition =
   | FrameworkWidgetDefinition

--- a/packages/@granit/dashboards/src/types/widget-size.ts
+++ b/packages/@granit/dashboards/src/types/widget-size.ts
@@ -1,0 +1,13 @@
+/**
+ * Logical size of a widget in dashboard grid units.
+ *
+ * The grid is column-and-row based — `width: 6` means "span 6 columns of the
+ * dashboard layout grid". The dashboard layout owns the column count (default 12);
+ * widgets are resized by adjusting these spans, never by pixel dimensions.
+ */
+export interface WidgetSize {
+  /** Number of grid columns the widget spans. Must be ≥ 1 and ≤ layout.columns. */
+  readonly width: number;
+  /** Number of grid rows the widget spans. Must be ≥ 1. */
+  readonly height: number;
+}

--- a/packages/@granit/dashboards/src/types/widget-size.ts
+++ b/packages/@granit/dashboards/src/types/widget-size.ts
@@ -1,13 +1,27 @@
 /**
- * Logical size of a widget in dashboard grid units.
- *
- * The grid is column-and-row based — `width: 6` means "span 6 columns of the
- * dashboard layout grid". The dashboard layout owns the column count (default 12);
- * widgets are resized by adjusting these spans, never by pixel dimensions.
+ * Width / height of a widget on the dashboard grid, expressed in grid cells.
+ * The grid is conventionally 12 columns wide; widget heights are typically
+ * 1–6 rows. Mirrors `Granit.Dashboards.Abstractions.WidgetSize`.
  */
 export interface WidgetSize {
-  /** Number of grid columns the widget spans. Must be ≥ 1 and ≤ layout.columns. */
+  /** Grid columns occupied by the widget. Must be > 0. */
   readonly width: number;
-  /** Number of grid rows the widget spans. Must be ≥ 1. */
+  /** Grid rows occupied by the widget. Must be > 0. */
   readonly height: number;
 }
+
+/**
+ * Conventional sizes mirroring the static factories on `WidgetSize`. Use
+ * these for parity with backend-shipped definitions (`WidgetSize.SmallKpi` ↔
+ * `WIDGET_SIZE.SMALL_KPI`); custom sizes are fine via plain object literals.
+ */
+export const WIDGET_SIZE = Object.freeze({
+  /** A small KPI card — 3×1 (a quarter row). */
+  SMALL_KPI: { width: 3, height: 1 } satisfies WidgetSize,
+  /** A standard chart — half a row, two rows tall (6×2). */
+  STANDARD_CHART: { width: 6, height: 2 } satisfies WidgetSize,
+  /** A full-width content widget (12×1) — typical for markdown banners. */
+  FULL_WIDTH_ROW: { width: 12, height: 1 } satisfies WidgetSize,
+  /** A square media tile (4×4) — typical default for image / video widgets. */
+  MEDIA_TILE: { width: 4, height: 4 } satisfies WidgetSize,
+});

--- a/packages/@granit/dashboards/tsconfig.json
+++ b/packages/@granit/dashboards/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/dashboards/tsup.config.ts
+++ b/packages/@granit/dashboards/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-analytics/package.json
+++ b/packages/@granit/react-analytics/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@granit/react-analytics",
+  "description": "React hooks and renderers for @granit/analytics — useMetric hook plus KpiTile widget renderer registered into the @granit/dashboards widget registry",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/analytics": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "lucide-react": "^1.0.0",
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/analytics": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-analytics/src/__tests__/format-metric-value.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/format-metric-value.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatDeltaRatio, formatMetricValue } from '../lib/format-metric-value.js';
+
+import type { ValueKind } from '@granit/analytics';
+
+const normalize = (s: string) => s.replace(/[\u0020\u00A0\u202F]+/g, ' ');
+
+describe('formatMetricValue', () => {
+  it('returns the fallback when the value is null', () => {
+    expect(formatMetricValue({ value: null, valueKind: 'count', locale: 'en-US' })).toBe('—');
+  });
+
+  it('returns a custom fallback when provided', () => {
+    expect(
+      formatMetricValue({ value: null, valueKind: 'count', locale: 'en-US', fallback: 'N/A' })
+    ).toBe('N/A');
+  });
+
+  it.each<{ kind: ValueKind; value: number; en: string; fr: string; currency?: string }>([
+    { kind: 'count', value: 1234, en: '1,234', fr: '1 234' },
+    { kind: 'currency', value: 12450.5, currency: 'EUR', en: '€12,450.50', fr: '12 450,50 €' },
+    { kind: 'percentage', value: 0.1507, en: '15.07%', fr: '15,07 %' },
+    { kind: 'number', value: 3.14159, en: '3.14', fr: '3,14' },
+  ])('formats $kind=$value across en-US / fr-FR', ({ kind, value, en, fr, currency }) => {
+    expect(
+      normalize(formatMetricValue({ value, valueKind: kind, currency, locale: 'en-US' }))
+    ).toBe(normalize(en));
+    expect(
+      normalize(formatMetricValue({ value, valueKind: kind, currency, locale: 'fr-FR' }))
+    ).toBe(normalize(fr));
+  });
+
+  it('formats sub-minute durations as seconds', () => {
+    expect(formatMetricValue({ value: 42, valueKind: 'duration', locale: 'en-US' })).toBe('42s');
+  });
+
+  it('formats minute-and-second durations', () => {
+    expect(formatMetricValue({ value: 125, valueKind: 'duration', locale: 'en-US' })).toBe('2m 5s');
+  });
+});
+
+describe('formatDeltaRatio', () => {
+  it('always shows a sign', () => {
+    expect(formatDeltaRatio(0.1428, 'en-US')).toBe('+14.28%');
+    expect(formatDeltaRatio(-0.1428, 'en-US')).toBe('-14.28%');
+  });
+
+  it('returns the fallback when ratio is null', () => {
+    expect(formatDeltaRatio(null, 'en-US')).toBe('—');
+  });
+});

--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
@@ -1,0 +1,138 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { KpiTileView } from '../components/kpi-tile-view.js';
+
+import type { MetricResponse } from '@granit/analytics';
+
+function makeResponse(overrides: Partial<MetricResponse['snapshot']> = {}): MetricResponse {
+  return {
+    name: 'Test.Metric',
+    sequence: 1,
+    emittedAt: '2026-04-28T12:00:00Z',
+    refreshHint: 'dynamic',
+    snapshot: {
+      value: 12,
+      valueKind: 'count',
+      currency: null,
+      isHigherBetter: true,
+      noData: false,
+      previous: null,
+      ...overrides,
+    },
+  };
+}
+
+describe('KpiTileView', () => {
+  it('renders the title above the body', () => {
+    render(<KpiTileView title="Unpaid invoices" data={undefined} isLoading error={null} />);
+    expect(screen.getByText('Unpaid invoices')).toBeInTheDocument();
+  });
+
+  it('shows skeletons while loading and no data', () => {
+    const { container } = render(<KpiTileView title="X" data={undefined} isLoading error={null} />);
+    expect(container.querySelector('[data-slot="kpi-tile-skeleton"]')).toBeInTheDocument();
+    expect(container.querySelector('[data-slot="kpi-tile-value"]')).toBeNull();
+  });
+
+  it('renders the formatted value once data is available', () => {
+    render(
+      <KpiTileView
+        title="X"
+        data={makeResponse({ value: 1234 })}
+        isLoading={false}
+        error={null}
+        locale="en-US"
+      />
+    );
+    expect(screen.getByText('1,234')).toBeInTheDocument();
+  });
+
+  it('renders an em dash when noData is true', () => {
+    render(
+      <KpiTileView
+        title="X"
+        data={makeResponse({ value: null, noData: true })}
+        isLoading={false}
+        error={null}
+        locale="en-US"
+      />
+    );
+    expect(screen.getByText('—')).toBeInTheDocument();
+  });
+
+  it('hides the delta when no previous payload', () => {
+    const { container } = render(
+      <KpiTileView title="X" data={makeResponse()} isLoading={false} error={null} locale="en-US" />
+    );
+    expect(container.querySelector('[data-slot="kpi-tile-delta"]')).toBeNull();
+  });
+
+  it('renders a favorable delta in the success colour', () => {
+    const { container } = render(
+      <KpiTileView
+        title="X"
+        data={makeResponse({
+          value: 12,
+          previous: { value: 14, deltaRatio: -0.1428, trend: 'down', isFavorable: true },
+        })}
+        isLoading={false}
+        error={null}
+        locale="en-US"
+      />
+    );
+    const delta = container.querySelector('[data-slot="kpi-tile-delta"]');
+    expect(delta).toHaveClass('text-success-600');
+    expect(delta?.textContent).toContain('-14.28%');
+  });
+
+  it('renders an unfavorable delta in the destructive colour', () => {
+    const { container } = render(
+      <KpiTileView
+        title="X"
+        data={makeResponse({
+          value: 18,
+          previous: { value: 14, deltaRatio: 0.2857, trend: 'up', isFavorable: false },
+        })}
+        isLoading={false}
+        error={null}
+        locale="en-US"
+      />
+    );
+    const delta = container.querySelector('[data-slot="kpi-tile-delta"]');
+    expect(delta).toHaveClass('text-destructive');
+  });
+
+  it('invokes onRetry when the error retry button is clicked', async () => {
+    const { default: userEvent } = await import('@testing-library/user-event');
+    const onRetry = vi.fn();
+    render(
+      <KpiTileView
+        title="X"
+        data={undefined}
+        isLoading={false}
+        error={new Error('boom')}
+        onRetry={onRetry}
+        errorTitle="Failed"
+        errorRetryLabel="Try again"
+      />
+    );
+    expect(screen.getByText('Failed')).toBeInTheDocument();
+    await userEvent.setup().click(screen.getByRole('button', { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it('renders the trendVisual slot when provided', () => {
+    const { container } = render(
+      <KpiTileView
+        title="X"
+        data={makeResponse()}
+        isLoading={false}
+        error={null}
+        trendVisual={<svg data-testid="sparkline" />}
+      />
+    );
+    expect(container.querySelector('[data-slot="kpi-tile-trend"]')).toBeInTheDocument();
+    expect(screen.getByTestId('sparkline')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-analytics/src/__tests__/use-metric.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/use-metric.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeMetricRequest } from '../api/use-metric.js';
+
+import type { MetricRequest } from '@granit/analytics';
+
+describe('normalizeMetricRequest', () => {
+  it('keeps a token-based period intact', () => {
+    const input: MetricRequest = { period: { token: 'last_30d' } };
+    expect(normalizeMetricRequest(input)).toEqual({ period: { token: 'last_30d' } });
+  });
+
+  it('keeps a custom range intact', () => {
+    const input: MetricRequest = {
+      period: { from: '2026-04-01T00:00:00Z', to: '2026-04-28T00:00:00Z' },
+    };
+    expect(normalizeMetricRequest(input)).toEqual({
+      period: { from: '2026-04-01T00:00:00Z', to: '2026-04-28T00:00:00Z' },
+    });
+  });
+
+  it('drops an undefined compareTo so the cache key collapses', () => {
+    const a: MetricRequest = { period: { token: 'last_30d' } };
+    const b: MetricRequest = { period: { token: 'last_30d' }, compareTo: undefined };
+    expect(JSON.stringify(normalizeMetricRequest(a))).toBe(
+      JSON.stringify(normalizeMetricRequest(b))
+    );
+  });
+
+  it('produces JSON-stable output regardless of input key order', () => {
+    const a: MetricRequest = {
+      period: { token: 'last_30d' },
+      compareTo: { token: 'previous_period' },
+    };
+    const b: MetricRequest = {
+      compareTo: { token: 'previous_period' },
+      period: { token: 'last_30d' },
+    };
+    expect(JSON.stringify(normalizeMetricRequest(a))).toBe(
+      JSON.stringify(normalizeMetricRequest(b))
+    );
+  });
+});

--- a/packages/@granit/react-analytics/src/api/use-metric.ts
+++ b/packages/@granit/react-analytics/src/api/use-metric.ts
@@ -1,0 +1,110 @@
+import { HttpError } from '@granit/api-client';
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type Query, type UseQueryResult } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+import type { MetricRequest, MetricResponse } from '@granit/analytics';
+
+const METRIC_PATH = '/analytics/metrics';
+
+const POLLING_INTERVAL_MS: Readonly<Record<MetricResponse['refreshHint'], number | false>> = {
+  static: false,
+  dynamic: false,
+  realtime: 5_000,
+};
+
+export interface UseMetricOptions {
+  /** Disable the request — useful when the parent isn't ready (e.g. tenant pending). */
+  readonly enabled?: boolean;
+  /**
+   * Force a polling interval, overriding the timing the response's
+   * `refreshHint` would otherwise dictate. `false` disables polling entirely.
+   * Once SSE subscriptions land (proposals doc P2.4), this option becomes
+   * less relevant — the hook self-discriminates between polling, SSE, and
+   * dashboard-multiplexed streams.
+   */
+  readonly refetchInterval?: number | false;
+}
+
+/**
+ * Evaluates a `MetricDefinition` and returns a TanStack Query result.
+ *
+ * Cache key shape — `['analytics', 'metric', metricName, normalizedRequest]` —
+ * IS the future subscription identity (see proposals doc, invariant on P2.4).
+ * Any push transport will reuse the same composition to address subscriptions.
+ *
+ * The polling cadence is derived from the response's `refreshHint` on every
+ * tick (TanStack v5 `refetchInterval` accepts a query-aware function), so a
+ * `static` snapshot stops polling itself, a `dynamic` one stays cached, and a
+ * `realtime` one polls until SSE replaces polling per P2.4.
+ *
+ * Retry policy: never retry on 4xx (the metric is unknown, the period spec is
+ * malformed, or the tenant is forbidden — none of these recover by retrying).
+ */
+export function useMetric(
+  metricName: string,
+  request: MetricRequest,
+  options: UseMetricOptions = {}
+): UseQueryResult<MetricResponse> {
+  const api = useGranitClient();
+  const normalizedRequest = useMemo(() => normalizeRequest(request), [request]);
+
+  const queryKey = useMemo(
+    () => ['analytics', 'metric', metricName, normalizedRequest] as const,
+    [metricName, normalizedRequest]
+  );
+
+  return useQuery({
+    queryKey,
+    queryFn: async ({ signal }) => {
+      const { data } = await api.post<MetricResponse>(
+        `${METRIC_PATH}/${encodeURIComponent(metricName)}`,
+        normalizedRequest,
+        { signal }
+      );
+      return data;
+    },
+    enabled: options.enabled ?? true,
+    retry: shouldRetry,
+    staleTime: 60_000,
+    refetchInterval: options.refetchInterval ?? refetchIntervalFromResponse,
+  });
+}
+
+function shouldRetry(failureCount: number, error: unknown): boolean {
+  // 4xx are deterministic (bad request / not found / forbidden) — never retry.
+  // The `@granit/api-client` interceptors normalize Axios errors to HttpError,
+  // so we check that contract instead of importing axios directly.
+  if (error instanceof HttpError && error.status >= 400 && error.status < 500) {
+    return false;
+  }
+  return failureCount < 2;
+}
+
+function refetchIntervalFromResponse(
+  query: Query<MetricResponse, Error, MetricResponse, readonly unknown[]>
+): number | false {
+  const data = query.state.data;
+  if (!data) return false;
+  return POLLING_INTERVAL_MS[data.refreshHint];
+}
+
+/**
+ * Produces a canonical request shape so semantically-equivalent inputs collapse
+ * to the same query key (and therefore the same cache entry, in-flight
+ * request, and — once streaming lands — subscription identity).
+ *
+ * Exported for testing. Consumers go through {@link useMetric}.
+ */
+export function normalizeMetricRequest(request: MetricRequest): MetricRequest {
+  const period =
+    'token' in request.period
+      ? { token: request.period.token }
+      : { from: request.period.from, to: request.period.to };
+
+  return request.compareTo ? { period, compareTo: { token: request.compareTo.token } } : { period };
+}
+
+function normalizeRequest(request: MetricRequest): MetricRequest {
+  return normalizeMetricRequest(request);
+}

--- a/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
@@ -1,0 +1,200 @@
+import { Minus, TrendingDown, TrendingUp } from 'lucide-react';
+
+import { formatDeltaRatio, formatMetricValue } from '../lib/format-metric-value.js';
+
+import type { MetricResponse } from '@granit/analytics';
+import type { ComponentType, ReactNode } from 'react';
+
+const NO_VALUE = '—';
+
+const TREND_ICON: Record<
+  MetricResponse['snapshot']['previous'] extends infer P
+    ? P extends { trend: infer T }
+      ? T extends string
+        ? T
+        : never
+      : never
+    : never,
+  ComponentType<{ readonly className?: string; readonly 'aria-hidden'?: boolean }>
+> = {
+  up: TrendingUp,
+  down: TrendingDown,
+  flat: Minus,
+};
+
+export interface KpiTileViewProps {
+  readonly title?: string;
+  readonly data: MetricResponse | undefined;
+  readonly isLoading: boolean;
+  readonly error: unknown;
+  readonly onRetry?: () => void;
+  /** BCP 47 tag for value/delta formatting. Defaults to runtime default. */
+  readonly locale?: string;
+  /** Localised text for the no-data hover hint. */
+  readonly noDataLabel?: string;
+  readonly errorTitle?: string;
+  readonly errorRetryLabel?: string;
+  readonly className?: string;
+  /**
+   * Optional slot for a sparkline / mini-chart rendered next to the value —
+   * consumers wire this with `@granit/react-charts`'s `<SparklineChart>`.
+   * Kept as a slot rather than a built-in dep so packages that ship a KPI
+   * without trend visualization don't pull in the chart bundle.
+   */
+  readonly trendVisual?: ReactNode;
+}
+
+/**
+ * Pure presentational KPI tile. Decoupled from data fetching so Storybook
+ * stories drive it directly with fixtures (no QueryClient required) and the
+ * smart wrapper {@link KpiTile} handles loading / error / success transitions.
+ */
+export function KpiTileView({
+  title,
+  data,
+  isLoading,
+  error,
+  onRetry,
+  locale,
+  noDataLabel = 'No data for this period',
+  errorTitle = 'Failed to load metric',
+  errorRetryLabel = 'Retry',
+  className,
+  trendVisual,
+}: KpiTileViewProps) {
+  return (
+    <div
+      data-slot="kpi-tile"
+      className={joinClasses(
+        'flex h-full flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm',
+        className
+      )}
+    >
+      {title ? (
+        <header data-slot="kpi-tile-header">
+          <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
+        </header>
+      ) : null}
+      <div data-slot="kpi-tile-body" className="flex-1 min-h-0">
+        {isLoading && !data ? (
+          <Skeleton />
+        ) : error ? (
+          <ErrorState title={errorTitle} retryLabel={errorRetryLabel} onRetry={onRetry} />
+        ) : data ? (
+          <Body data={data} locale={locale} noDataLabel={noDataLabel} trendVisual={trendVisual} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function Skeleton() {
+  return (
+    <div data-slot="kpi-tile-skeleton" className="space-y-2">
+      <div className="h-8 w-24 animate-pulse rounded-md bg-accent" />
+      <div className="h-4 w-16 animate-pulse rounded-md bg-accent" />
+    </div>
+  );
+}
+
+function ErrorState({
+  title,
+  retryLabel,
+  onRetry,
+}: {
+  readonly title: string;
+  readonly retryLabel: string;
+  readonly onRetry?: () => void;
+}) {
+  return (
+    <div
+      data-slot="kpi-tile-error"
+      className="flex flex-col gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive"
+    >
+      <span>{title}</span>
+      {onRetry ? (
+        <button
+          type="button"
+          onClick={onRetry}
+          className="self-start rounded-md border border-destructive/40 bg-background px-2 py-1 font-medium hover:bg-destructive/10"
+        >
+          {retryLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function Body({
+  data,
+  locale,
+  noDataLabel,
+  trendVisual,
+}: {
+  readonly data: MetricResponse;
+  readonly locale: string | undefined;
+  readonly noDataLabel: string;
+  readonly trendVisual: ReactNode;
+}) {
+  const { snapshot } = data;
+  const formattedValue = snapshot.noData
+    ? NO_VALUE
+    : formatMetricValue({
+        value: snapshot.value,
+        valueKind: snapshot.valueKind,
+        currency: snapshot.currency,
+        locale,
+      });
+
+  return (
+    <div className="flex h-full items-end justify-between gap-3">
+      <div className="space-y-1">
+        <span
+          data-slot="kpi-tile-value"
+          title={snapshot.noData ? noDataLabel : undefined}
+          className="text-2xl font-semibold tracking-tight"
+        >
+          {formattedValue}
+        </span>
+        <Delta previous={snapshot.previous} locale={locale} />
+      </div>
+      {trendVisual ? (
+        <div data-slot="kpi-tile-trend" className="w-24 shrink-0">
+          {trendVisual}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function Delta({
+  previous,
+  locale,
+}: {
+  readonly previous: MetricResponse['snapshot']['previous'];
+  readonly locale: string | undefined;
+}) {
+  if (!previous || previous.deltaRatio === null) return null;
+
+  const Icon = TREND_ICON[previous.trend];
+  const colourClass =
+    previous.isFavorable === true
+      ? 'text-success-600'
+      : previous.isFavorable === false
+        ? 'text-destructive'
+        : 'text-muted-foreground';
+
+  return (
+    <div
+      data-slot="kpi-tile-delta"
+      className={joinClasses('flex items-center gap-1 text-xs font-medium', colourClass)}
+    >
+      <Icon className="h-3.5 w-3.5" aria-hidden />
+      <span>{formatDeltaRatio(previous.deltaRatio, locale)}</span>
+    </div>
+  );
+}
+
+function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -1,0 +1,55 @@
+import { useDashboardContext } from '@granit/react-dashboards';
+import { useTranslation } from 'react-i18next';
+
+import { useMetric } from '../api/use-metric.js';
+
+import { KpiTileView } from './kpi-tile-view.js';
+
+import type { KpiWidgetDefinition, MetricRequest } from '@granit/analytics';
+
+const DEFAULT_PERIOD: MetricRequest = {
+  period: { token: 'last_30d' },
+  compareTo: { token: 'previous_period' },
+};
+
+/**
+ * Smart KPI tile — registered as the renderer for `KpiWidgetDefinition`
+ * (`type: 'kpi'`) in the analytics widget registry. Reads dashboard context
+ * for breadcrumb data, fetches the metric snapshot via {@link useMetric},
+ * delegates rendering to {@link KpiTileView}.
+ *
+ * v1 uses a hardcoded `last_30d / previous_period` request shape — the
+ * runtime `DashboardTimeWindow` (proposals doc P1.3) will replace this once
+ * `Granit.Dashboards.DashboardTimeWindow` ships and is propagated via
+ * dashboard context.
+ */
+export interface KpiTileProps {
+  readonly widget: KpiWidgetDefinition;
+}
+
+export function KpiTile({ widget }: KpiTileProps) {
+  const { t, i18n } = useTranslation();
+  const dashboardCtx = useDashboardContext();
+
+  const titleKey = dashboardCtx
+    ? `Widget:${dashboardCtx.dashboardName}.${widget.slug}.Title`
+    : `Widget:${widget.slug}.Title`;
+  const translated = t(titleKey, { defaultValue: '' });
+  const title = translated || widget.metricName;
+
+  const query = useMetric(widget.metricName, DEFAULT_PERIOD);
+
+  return (
+    <KpiTileView
+      title={title}
+      data={query.data}
+      isLoading={query.isLoading}
+      error={query.error}
+      onRetry={() => void query.refetch()}
+      locale={i18n.language}
+      noDataLabel={t('Analytics.NoData', { defaultValue: 'No data for this period' })}
+      errorTitle={t('Analytics.Error.Title', { defaultValue: 'Failed to load metric' })}
+      errorRetryLabel={t('Analytics.Error.Retry', { defaultValue: 'Retry' })}
+    />
+  );
+}

--- a/packages/@granit/react-analytics/src/index.ts
+++ b/packages/@granit/react-analytics/src/index.ts
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------------
+// @granit/react-analytics — public API
+// ---------------------------------------------------------------------------
+
+// Hook
+export { normalizeMetricRequest, useMetric } from './api/use-metric.js';
+export type { UseMetricOptions } from './api/use-metric.js';
+
+// Widget renderers
+export { KpiTile } from './components/kpi-tile.js';
+export type { KpiTileProps } from './components/kpi-tile.js';
+export { KpiTileView } from './components/kpi-tile-view.js';
+export type { KpiTileViewProps } from './components/kpi-tile-view.js';
+
+// Registry
+export { defaultAnalyticsWidgetRegistry } from './registry/default-analytics-widget-registry.js';
+
+// Formatters (re-exported for convenience — also available standalone)
+export { formatDeltaRatio, formatMetricValue } from './lib/format-metric-value.js';
+export type { FormatMetricValueArgs } from './lib/format-metric-value.js';

--- a/packages/@granit/react-analytics/src/lib/format-metric-value.ts
+++ b/packages/@granit/react-analytics/src/lib/format-metric-value.ts
@@ -1,0 +1,91 @@
+import type { ValueKind } from '@granit/analytics';
+
+/**
+ * Locale-aware formatter for a metric's primary value. Pure function — no
+ * React, no i18n. The locale is passed explicitly so callers can drive it
+ * from `useTranslation().i18n.language` (or any other source).
+ */
+export interface FormatMetricValueArgs {
+  readonly value: number | null;
+  readonly valueKind: ValueKind;
+  /** ISO 4217 currency code. Required when `valueKind === 'currency'`. */
+  readonly currency?: string | null;
+  /** BCP 47 tag. Defaults to runtime default (`undefined` → host default). */
+  readonly locale?: string;
+  /** Rendered when value is null. Defaults to em dash. */
+  readonly fallback?: string;
+}
+
+const NO_VALUE = '—';
+
+export function formatMetricValue({
+  value,
+  valueKind,
+  currency,
+  locale,
+  fallback = NO_VALUE,
+}: FormatMetricValueArgs): string {
+  if (value === null || Number.isNaN(value)) return fallback;
+
+  switch (valueKind) {
+    case 'count':
+      return new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(value);
+
+    case 'currency': {
+      if (!currency) return new Intl.NumberFormat(locale).format(value);
+      return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value);
+    }
+
+    case 'percentage':
+      return new Intl.NumberFormat(locale, {
+        style: 'percent',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(value);
+
+    case 'duration':
+      return formatDuration(value, locale);
+
+    case 'date':
+      return new Intl.DateTimeFormat(locale).format(new Date(value));
+
+    case 'number':
+      return new Intl.NumberFormat(locale, {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      }).format(value);
+
+    default:
+      return new Intl.NumberFormat(locale).format(value);
+  }
+}
+
+/**
+ * Formats a delta ratio as a signed percentage (e.g. `-14.28%`, `+3.50%`).
+ * Returns the fallback when the ratio is null (delta undefined).
+ */
+export function formatDeltaRatio(
+  ratio: number | null,
+  locale?: string,
+  fallback: string = NO_VALUE
+): string {
+  if (ratio === null || Number.isNaN(ratio)) return fallback;
+  return new Intl.NumberFormat(locale, {
+    style: 'percent',
+    signDisplay: 'always',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(ratio);
+}
+
+function formatDuration(seconds: number, locale?: string): string {
+  if (seconds < 60) {
+    return new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(seconds) + 's';
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remaining = Math.floor(seconds % 60);
+  const fmt = new Intl.NumberFormat(locale, { maximumFractionDigits: 0 });
+  return remaining === 0
+    ? `${fmt.format(minutes)}m`
+    : `${fmt.format(minutes)}m ${fmt.format(remaining)}s`;
+}

--- a/packages/@granit/react-analytics/src/registry/default-analytics-widget-registry.ts
+++ b/packages/@granit/react-analytics/src/registry/default-analytics-widget-registry.ts
@@ -1,0 +1,20 @@
+import { KpiTile } from '../components/kpi-tile.js';
+
+import type { WidgetRegistry, WidgetRendererFn } from '@granit/react-dashboards';
+
+/**
+ * Analytics widget renderers, keyed by their `type` discriminator. Compose
+ * with the framework default registry via `composeRegistries(default, analytics)`
+ * at the app root so dashboards rendering analytics widgets resolve their
+ * renderers without per-app re-registration.
+ *
+ * v1 only ships `kpi`. `chart`, `table`, `pivot` land as the query-engine
+ * integration is wired (see proposals doc P2.2).
+ */
+export const defaultAnalyticsWidgetRegistry: WidgetRegistry = Object.freeze({
+  // The cast goes through `unknown` because TypeScript can't relate
+  // `KpiTile`'s narrow `KpiWidgetDefinition` prop to the registry's open
+  // `WidgetDefinition` type — the dispatcher's runtime contract guarantees
+  // that the widget passed in matches the registered key (`'kpi'` here).
+  kpi: KpiTile as unknown as WidgetRendererFn,
+});

--- a/packages/@granit/react-analytics/tsconfig.json
+++ b/packages/@granit/react-analytics/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-analytics/tsup.config.ts
+++ b/packages/@granit/react-analytics/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-charts/package.json
+++ b/packages/@granit/react-charts/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@granit/react-charts",
+  "description": "React chart primitives for Granit — typed <LineChart>, <BarChart>, <PieChart>, <SparklineChart> built on Apache ECharts (modular tree-shaken imports), plus <Chart> escape hatch for raw ECharts options",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/charts": "workspace:*",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/charts": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-charts/src/__tests__/line-chart.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/line-chart.test.tsx
@@ -1,0 +1,98 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BarChart } from '../components/bar-chart.js';
+import { LineChart } from '../components/line-chart.js';
+import { PieChart } from '../components/pie-chart.js';
+import { SparklineChart } from '../components/sparkline-chart.js';
+
+import type { ChartSeries } from '@granit/charts';
+
+// jsdom doesn't implement Canvas; ECharts queries it on init. Stub the call.
+vi.mock('echarts-for-react/lib/core', () => ({
+  default: ({ option }: { readonly option: unknown }) => (
+    <div data-testid="echarts-mock" data-option={JSON.stringify(option)} />
+  ),
+}));
+
+const sampleSeries: ChartSeries[] = [
+  {
+    id: 's1',
+    name: 'A',
+    data: [
+      ['Mon', 1],
+      ['Tue', 3],
+      ['Wed', 2],
+    ],
+  },
+  {
+    id: 's2',
+    name: 'B',
+    data: [
+      ['Mon', 2],
+      ['Tue', 1],
+      ['Wed', 4],
+    ],
+  },
+];
+
+describe('chart primitives', () => {
+  it('LineChart passes a line series to the underlying ECharts component', () => {
+    const { getByTestId } = render(<LineChart series={sampleSeries} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series).toHaveLength(2);
+    expect(opt.series[0].type).toBe('line');
+    expect(opt.series[0].id).toBe('s1');
+  });
+
+  it('LineChart hides the legend when only one series is provided', () => {
+    const { getByTestId } = render(<LineChart series={[sampleSeries[0]!]} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.legend).toBeUndefined();
+  });
+
+  it('BarChart applies the stack identifier when stacked is true', () => {
+    const { getByTestId } = render(<BarChart series={sampleSeries} stacked />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].stack).toBe('total');
+    expect(opt.series[1].stack).toBe('total');
+  });
+
+  it('BarChart swaps axes when horizontal is true', () => {
+    const { getByTestId } = render(<BarChart series={sampleSeries} horizontal />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.xAxis.type).toBe('value');
+    expect(opt.yAxis.type).toBe('category');
+  });
+
+  it('PieChart maps innerRadiusRatio to a percentage radius', () => {
+    const { getByTestId } = render(
+      <PieChart
+        data={[
+          { id: 'a', name: 'A', value: 1 },
+          { id: 'b', name: 'B', value: 2 },
+        ]}
+        innerRadiusRatio={0.5}
+      />
+    );
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].radius).toEqual(['35%', '70%']);
+  });
+
+  it('SparklineChart hides axes and applies smooth by default', () => {
+    const { getByTestId } = render(
+      <SparklineChart
+        data={[
+          ['t1', 1],
+          ['t2', 2],
+          ['t3', 3],
+        ]}
+      />
+    );
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.xAxis.show).toBe(false);
+    expect(opt.yAxis.show).toBe(false);
+    expect(opt.series[0].smooth).toBe(true);
+    expect(opt.series[0].showSymbol).toBe(false);
+  });
+});

--- a/packages/@granit/react-charts/src/components/bar-chart.tsx
+++ b/packages/@granit/react-charts/src/components/bar-chart.tsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart.js';
+
+import type { ChartAxis, ChartDimensions, ChartSeries } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface BarChartProps extends ChartDimensions {
+  readonly series: readonly ChartSeries[];
+  readonly xAxis?: ChartAxis;
+  readonly yAxis?: ChartAxis;
+  /** Stack series on top of each other. Each stacked series joins the same group. */
+  readonly stacked?: boolean;
+  /** Render bars horizontally (swaps x and y axis roles). */
+  readonly horizontal?: boolean;
+  readonly showLegend?: boolean;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed bar chart wrapper. Honors {@link BarChartProps.stacked} for stacked
+ * compositions and {@link BarChartProps.horizontal} for category-on-y layouts
+ * (useful when category labels are long).
+ */
+export function BarChart({
+  series,
+  xAxis,
+  yAxis,
+  stacked = false,
+  horizontal = false,
+  showLegend,
+  height,
+  width,
+  className,
+  theme,
+}: BarChartProps) {
+  const options = useMemo<EChartsOption>(() => {
+    const wantLegend = showLegend ?? series.length > 1;
+    const categoryAxis = {
+      type: 'category' as const,
+      name: xAxis?.label,
+    };
+    const valueAxis = {
+      type: 'value' as const,
+      name: yAxis?.label,
+      min: yAxis?.min,
+      max: yAxis?.max,
+    };
+    return {
+      tooltip: { trigger: 'axis', axisPointer: { type: 'shadow' } },
+      legend: wantLegend ? { data: series.map((s) => s.name), top: 0 } : undefined,
+      grid: {
+        left: 8,
+        right: 16,
+        top: wantLegend ? 32 : 8,
+        bottom: 8,
+        containLabel: true,
+      },
+      xAxis: horizontal ? valueAxis : categoryAxis,
+      yAxis: horizontal ? categoryAxis : valueAxis,
+      series: series.map((s) => ({
+        id: s.id,
+        name: s.name,
+        type: 'bar',
+        // ECharts' option types want mutable arrays; spread to drop readonly.
+        data: s.data.map((p) => [...p]) as (number | string)[][],
+        stack: stacked ? 'total' : undefined,
+        itemStyle: s.color ? { color: s.color } : undefined,
+      })),
+    };
+  }, [series, xAxis, yAxis, stacked, horizontal, showLegend]);
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/components/chart.tsx
+++ b/packages/@granit/react-charts/src/components/chart.tsx
@@ -1,0 +1,49 @@
+import EChartsReactCore from 'echarts-for-react/lib/core';
+
+import { echarts } from '../echarts-instance.js';
+
+import type { EChartsOption } from 'echarts';
+
+/**
+ * Escape hatch for advanced charts not yet wrapped by a typed primitive.
+ *
+ * Accepts raw ECharts options. Prefer the typed primitives (`<LineChart>`,
+ * `<BarChart>`, `<PieChart>`, `<SparklineChart>`) for everything they cover —
+ * they keep the framework decoupled from the underlying chart library.
+ *
+ * Reach for `<Chart>` only when the typed primitives are insufficient
+ * (custom series compositions, advanced axis configs, etc.). Each call site is
+ * a maintenance debt that has to migrate if ECharts is ever swapped.
+ */
+export interface ChartProps {
+  readonly options: EChartsOption;
+  /** Pixel height or any CSS dimension. Defaults to `320`. */
+  readonly height?: number | string;
+  readonly className?: string;
+  /**
+   * Theme name (must have been registered via `echarts.registerTheme()`) or
+   * a theme object. Hosts typically register a single theme and pass its name.
+   */
+  readonly theme?: string | object;
+  /**
+   * Notification that the underlying ECharts instance was created. Use this
+   * to access imperative APIs (`getDataURL`, `dispatchAction`, etc.) that
+   * the typed primitives intentionally hide.
+   */
+  readonly onChartReady?: (instance: unknown) => void;
+}
+
+export function Chart({ options, height = 320, className, theme, onChartReady }: ChartProps) {
+  return (
+    <EChartsReactCore
+      echarts={echarts}
+      option={options}
+      style={{ height, width: '100%' }}
+      className={className}
+      theme={theme}
+      onChartReady={onChartReady}
+      notMerge={false}
+      lazyUpdate
+    />
+  );
+}

--- a/packages/@granit/react-charts/src/components/line-chart.tsx
+++ b/packages/@granit/react-charts/src/components/line-chart.tsx
@@ -1,0 +1,80 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart.js';
+
+import type { ChartAxis, ChartDimensions, ChartSeries } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface LineChartProps extends ChartDimensions {
+  readonly series: readonly ChartSeries[];
+  readonly xAxis?: ChartAxis;
+  readonly yAxis?: ChartAxis;
+  /** Smooth out the line interpolation. Defaults to `false` for fidelity. */
+  readonly smooth?: boolean;
+  /** Show the legend above the plot area. Defaults to `true` when >1 series. */
+  readonly showLegend?: boolean;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed line chart wrapper. Accepts a list of {@link ChartSeries} plus axis
+ * configuration; everything else (palette, font, grid spacing, tooltip
+ * trigger) is inherited from the active ECharts theme.
+ *
+ * Stays narrow on purpose: power users wanting access to dataZoom, brush,
+ * markLine, etc. should drop down to `<Chart>` rather than expanding this
+ * surface — the wrapper only covers the 80% case.
+ */
+export function LineChart({
+  series,
+  xAxis,
+  yAxis,
+  smooth = false,
+  showLegend,
+  height,
+  width,
+  className,
+  theme,
+}: LineChartProps) {
+  const options = useMemo<EChartsOption>(() => {
+    const wantLegend = showLegend ?? series.length > 1;
+    return {
+      tooltip: { trigger: 'axis' },
+      legend: wantLegend ? { data: series.map((s) => s.name), top: 0 } : undefined,
+      grid: {
+        left: 8,
+        right: 16,
+        top: wantLegend ? 32 : 8,
+        bottom: 8,
+        containLabel: true,
+      },
+      xAxis: {
+        type: xAxis?.type ?? 'category',
+        name: xAxis?.label,
+        min: xAxis?.min,
+        max: xAxis?.max,
+      },
+      yAxis: {
+        type: yAxis?.type ?? 'value',
+        name: yAxis?.label,
+        min: yAxis?.min,
+        max: yAxis?.max,
+      },
+      series: series.map((s) => ({
+        id: s.id,
+        name: s.name,
+        type: 'line',
+        // ECharts' option types want mutable arrays; spread to drop readonly.
+        data: s.data.map((p) => [...p]) as (number | string)[][],
+        smooth,
+        itemStyle: s.color ? { color: s.color } : undefined,
+        lineStyle: s.color ? { color: s.color } : undefined,
+      })),
+    };
+  }, [series, xAxis, yAxis, smooth, showLegend]);
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/components/pie-chart.tsx
+++ b/packages/@granit/react-charts/src/components/pie-chart.tsx
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart.js';
+
+import type { ChartDimensions } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface PieDatum {
+  readonly id: string;
+  readonly name: string;
+  readonly value: number;
+  readonly color?: string;
+}
+
+export interface PieChartProps extends ChartDimensions {
+  readonly data: readonly PieDatum[];
+  /**
+   * When set (e.g. `0.5`), renders a donut with the inner radius at this
+   * fraction of the outer radius. Default `0` produces a solid pie.
+   */
+  readonly innerRadiusRatio?: number;
+  readonly showLegend?: boolean;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Typed pie / donut chart wrapper. Pass `innerRadiusRatio` (0–1) to get a
+ * donut — common for Odoo-style "X out of total" KPIs.
+ */
+export function PieChart({
+  data,
+  innerRadiusRatio = 0,
+  showLegend = true,
+  height,
+  width,
+  className,
+  theme,
+}: PieChartProps) {
+  const options = useMemo<EChartsOption>(() => {
+    const outerRadius = '70%';
+    const innerRadius = innerRadiusRatio > 0 ? `${Math.round(innerRadiusRatio * 70)}%` : '0%';
+    return {
+      tooltip: { trigger: 'item' },
+      legend: showLegend ? { orient: 'vertical', left: 'left' } : undefined,
+      series: [
+        {
+          type: 'pie',
+          radius: [innerRadius, outerRadius],
+          data: data.map((d) => ({
+            id: d.id,
+            name: d.name,
+            value: d.value,
+            itemStyle: d.color ? { color: d.color } : undefined,
+          })),
+          emphasis: {
+            itemStyle: { shadowBlur: 10, shadowOffsetX: 0, shadowColor: 'rgba(0, 0, 0, 0.2)' },
+          },
+        },
+      ],
+    };
+  }, [data, innerRadiusRatio, showLegend]);
+
+  return (
+    <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />
+  );
+}

--- a/packages/@granit/react-charts/src/components/sparkline-chart.tsx
+++ b/packages/@granit/react-charts/src/components/sparkline-chart.tsx
@@ -1,0 +1,57 @@
+import { useMemo } from 'react';
+
+import { Chart } from './chart.js';
+
+import type { ChartDataPoint, ChartDimensions } from '@granit/charts';
+import type { EChartsOption } from 'echarts';
+
+export interface SparklineChartProps extends ChartDimensions {
+  readonly data: readonly ChartDataPoint[];
+  /** Override the line color. Defaults to the theme's first palette entry. */
+  readonly color?: string;
+  /** Render as area (filled below the line) rather than a plain line. */
+  readonly area?: boolean;
+  /** Smooth interpolation. Defaults to `true` for sparklines (visual softness). */
+  readonly smooth?: boolean;
+  readonly className?: string;
+  readonly theme?: string | object;
+}
+
+/**
+ * Inline mini line chart — no axes, no grid, no legend. Suitable for KPI tile
+ * trend hints, table cell trends, or dashboard tickers. Defaults to a small
+ * fixed height so it slots into list rows without layout surgery.
+ */
+export function SparklineChart({
+  data,
+  color,
+  area = false,
+  smooth = true,
+  height = 40,
+  className,
+  theme,
+}: SparklineChartProps) {
+  const options = useMemo<EChartsOption>(
+    () => ({
+      grid: { left: 0, right: 0, top: 0, bottom: 0 },
+      xAxis: { type: 'category', show: false, boundaryGap: false },
+      yAxis: { type: 'value', show: false },
+      tooltip: { trigger: 'axis', axisPointer: { type: 'line' } },
+      series: [
+        {
+          type: 'line',
+          // ECharts' option types want mutable arrays; spread to drop readonly.
+          data: data.map((p) => [...p]) as (number | string)[][],
+          smooth,
+          showSymbol: false,
+          lineStyle: color ? { color, width: 2 } : { width: 2 },
+          itemStyle: color ? { color } : undefined,
+          areaStyle: area ? (color ? { color, opacity: 0.2 } : { opacity: 0.2 }) : undefined,
+        },
+      ],
+    }),
+    [data, color, area, smooth]
+  );
+
+  return <Chart options={options} height={height} className={className} theme={theme} />;
+}

--- a/packages/@granit/react-charts/src/echarts-instance.ts
+++ b/packages/@granit/react-charts/src/echarts-instance.ts
@@ -1,0 +1,38 @@
+/**
+ * Single ECharts instance configured with only the chart types and components
+ * the framework's primitives use. Tree-shakes everything else out of consumer
+ * bundles — pulling `echarts/core` instead of `echarts` cuts ~70% of the bundle
+ * weight on apps that only render line / bar / pie / gauge widgets.
+ *
+ * Add a chart type or component here when you ship a new primitive. The cost
+ * is paid once, in a single shared module — primitive components import from
+ * here, never directly from `echarts/charts` or `echarts/components`.
+ */
+import { BarChart, GaugeChart, LineChart, PieChart } from 'echarts/charts';
+import {
+  DataZoomComponent,
+  GridComponent,
+  LegendComponent,
+  TitleComponent,
+  TooltipComponent,
+} from 'echarts/components';
+import * as echarts from 'echarts/core';
+import { CanvasRenderer } from 'echarts/renderers';
+
+echarts.use([
+  // Charts
+  LineChart,
+  BarChart,
+  PieChart,
+  GaugeChart,
+  // Components
+  GridComponent,
+  TooltipComponent,
+  TitleComponent,
+  LegendComponent,
+  DataZoomComponent,
+  // Renderer
+  CanvasRenderer,
+]);
+
+export { echarts };

--- a/packages/@granit/react-charts/src/hooks/use-echarts-theme.ts
+++ b/packages/@granit/react-charts/src/hooks/use-echarts-theme.ts
@@ -1,0 +1,87 @@
+import { buildEChartsTheme } from '@granit/charts';
+import { useEffect, useMemo, useState } from 'react';
+
+import { echarts } from '../echarts-instance.js';
+
+import type { ChartThemeTokens } from '@granit/charts';
+
+export interface UseEChartsThemeOptions {
+  readonly lightTokens: ChartThemeTokens;
+  readonly darkTokens?: ChartThemeTokens;
+  /**
+   * Selector or media-query strategy used to detect dark mode. Defaults to
+   * `'class'` (matches the Tailwind/`dark:` convention — looks for a `.dark`
+   * ancestor on the document element).
+   */
+  readonly darkModeStrategy?: 'class' | 'media';
+  /**
+   * Theme name pair used when registering. Defaults to `granit-light` /
+   * `granit-dark`. Apps that compose multiple themes can override these.
+   */
+  readonly themeNames?: readonly [light: string, dark: string];
+}
+
+/**
+ * Registers light + dark ECharts themes from Tailwind tokens and returns the
+ * name of the theme currently in effect. Pass that name to a chart's `theme`
+ * prop:
+ *
+ *   const theme = useEChartsTheme({ lightTokens, darkTokens });
+ *   return <LineChart series={...} theme={theme} />;
+ *
+ * The hook re-runs when the dark-mode signal changes — for the `class`
+ * strategy, that's a `MutationObserver` on `<html>`'s `class` attribute; for
+ * the `media` strategy, a `prefers-color-scheme` media query.
+ */
+export function useEChartsTheme(options: UseEChartsThemeOptions): string {
+  const {
+    lightTokens,
+    darkTokens,
+    darkModeStrategy = 'class',
+    themeNames = ['granit-light', 'granit-dark'],
+  } = options;
+
+  const [lightName, darkName] = themeNames;
+
+  const lightTheme = useMemo(() => buildEChartsTheme(lightTokens), [lightTokens]);
+  const darkTheme = useMemo(
+    () => (darkTokens ? buildEChartsTheme(darkTokens) : null),
+    [darkTokens]
+  );
+
+  // Register themes on the shared ECharts instance — `registerTheme` is
+  // idempotent for the same name, so re-registration on token change is fine.
+  useEffect(() => {
+    echarts.registerTheme(lightName, lightTheme);
+    if (darkTheme) echarts.registerTheme(darkName, darkTheme);
+  }, [lightName, lightTheme, darkName, darkTheme]);
+
+  const [isDark, setIsDark] = useState(() => detectDarkMode(darkModeStrategy));
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+
+    if (darkModeStrategy === 'media') {
+      const mq = window.matchMedia('(prefers-color-scheme: dark)');
+      const onChange = () => setIsDark(mq.matches);
+      mq.addEventListener('change', onChange);
+      return () => mq.removeEventListener('change', onChange);
+    }
+
+    // class strategy
+    const root = document.documentElement;
+    const observer = new MutationObserver(() => setIsDark(root.classList.contains('dark')));
+    observer.observe(root, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, [darkModeStrategy]);
+
+  return isDark && darkTheme ? darkName : lightName;
+}
+
+function detectDarkMode(strategy: 'class' | 'media'): boolean {
+  if (typeof window === 'undefined') return false;
+  if (strategy === 'media') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches;
+  }
+  return document.documentElement.classList.contains('dark');
+}

--- a/packages/@granit/react-charts/src/index.ts
+++ b/packages/@granit/react-charts/src/index.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// @granit/react-charts — public API
+// ---------------------------------------------------------------------------
+
+// Escape hatch
+export { Chart } from './components/chart.js';
+export type { ChartProps } from './components/chart.js';
+
+// Typed primitives
+export { LineChart } from './components/line-chart.js';
+export type { LineChartProps } from './components/line-chart.js';
+export { BarChart } from './components/bar-chart.js';
+export type { BarChartProps } from './components/bar-chart.js';
+export { PieChart } from './components/pie-chart.js';
+export type { PieChartProps, PieDatum } from './components/pie-chart.js';
+export { SparklineChart } from './components/sparkline-chart.js';
+export type { SparklineChartProps } from './components/sparkline-chart.js';
+
+// Theming
+export { useEChartsTheme } from './hooks/use-echarts-theme.js';
+export type { UseEChartsThemeOptions } from './hooks/use-echarts-theme.js';

--- a/packages/@granit/react-charts/tsconfig.json
+++ b/packages/@granit/react-charts/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-charts/tsup.config.ts
+++ b/packages/@granit/react-charts/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-dashboards/package.json
+++ b/packages/@granit/react-dashboards/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@granit/react-dashboards",
+  "description": "React renderer for @granit/dashboards — Dashboard layout component, WidgetRegistry provider, and built-in renderers for Markdown / Image / Text widgets",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/dashboards": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-dashboards/package.json
+++ b/packages/@granit/react-dashboards/package.json
@@ -15,7 +15,8 @@
   },
   "peerDependencies": {
     "@granit/dashboards": "workspace:*",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
@@ -1,4 +1,6 @@
 import { render, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
 import { describe, expect, it } from 'vitest';
 
 import { Dashboard } from '../components/dashboard.js';
@@ -7,91 +9,132 @@ import { WidgetRegistryProvider } from '../registry/widget-registry-context.js';
 
 import type { DashboardDefinition } from '@granit/dashboards';
 
+// Bootstraps a minimal i18next instance so Markdown / Text / Image widgets can
+// resolve their localization keys to the English fixture content used below.
+//
+// `nsSeparator: false` and `keySeparator: false` disable i18next's default
+// `namespace:key` and `key.subkey` parsing — Granit uses flat keys with `:`
+// and `.` as plain characters (e.g. `Widget:DashboardName.Slug.Title`).
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        'Widget:Test.Hello': 'World',
+        'Widget:Test.Heading': '# Heading',
+        'Widget:Test.Caption': 'Read me',
+        'Widget:Test.Logo.Alt': 'Granit logo',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
 function renderDashboard(definition: DashboardDefinition) {
   return render(
-    <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
-      <Dashboard definition={definition} />
-    </WidgetRegistryProvider>
+    <I18nextProvider i18n={testI18n}>
+      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
+        <Dashboard definition={definition} />
+      </WidgetRegistryProvider>
+    </I18nextProvider>
   );
 }
 
 describe('Dashboard', () => {
-  it('renders widgets at their grid positions', () => {
+  it('renders widgets in `position` order with their declared size', () => {
     const { container } = renderDashboard({
-      id: 'test',
       name: 'Test',
       category: 'general',
+      isSystem: false,
+      version: '1.0.0',
+      layout: { columns: 12, rowHeight: 80 },
       widgets: [
-        { id: 'w1', type: 'text', title: 'Hello', content: 'World' },
-        { id: 'w2', type: 'markdown', content: '# Heading' },
+        {
+          slug: 'Hello',
+          type: 'text',
+          position: 1,
+          size: { width: 6, height: 1 },
+          contentLocalizationKey: 'Widget:Test.Hello',
+          style: 'body',
+        },
+        {
+          slug: 'Heading',
+          type: 'markdown',
+          position: 0,
+          size: { width: 6, height: 1 },
+          contentLocalizationKey: 'Widget:Test.Heading',
+        },
       ],
-      layout: {
-        columns: 12,
-        items: [
-          { widgetId: 'w1', position: { x: 0, y: 0, width: 6, height: 1 } },
-          { widgetId: 'w2', position: { x: 6, y: 0, width: 6, height: 1 } },
-        ],
-      },
     });
 
     expect(screen.getByText('World')).toBeInTheDocument();
     expect(screen.getByText('# Heading')).toBeInTheDocument();
-    expect(container.querySelectorAll('[data-slot="dashboard-cell"]')).toHaveLength(2);
-  });
 
-  it('skips layout items with no matching widget', () => {
-    const { container } = renderDashboard({
-      id: 'test',
-      name: 'Test',
-      category: 'general',
-      widgets: [{ id: 'w1', type: 'text', content: 'Only one' }],
-      layout: {
-        columns: 12,
-        items: [
-          { widgetId: 'w1', position: { x: 0, y: 0, width: 6, height: 1 } },
-          { widgetId: 'ghost', position: { x: 6, y: 0, width: 6, height: 1 } },
-        ],
-      },
-    });
-    expect(container.querySelectorAll('[data-slot="dashboard-cell"]')).toHaveLength(1);
-  });
-
-  it('renders an unknown-widget placeholder when the type has no registered renderer', () => {
-    render(
-      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
-        <Dashboard
-          definition={{
-            id: 'test',
-            name: 'Test',
-            category: 'general',
-            widgets: [
-              {
-                id: 'w1',
-                type: 'analytics-kpi',
-                metric: 'foo',
-              } as never,
-            ],
-            layout: {
-              columns: 12,
-              items: [{ widgetId: 'w1', position: { x: 0, y: 0, width: 6, height: 1 } }],
-            },
-          }}
-        />
-      </WidgetRegistryProvider>
-    );
-    expect(screen.getByText(/Unknown widget type/i)).toBeInTheDocument();
-    expect(screen.getByText(/analytics-kpi/)).toBeInTheDocument();
+    const cells = container.querySelectorAll('[data-slot="dashboard-cell"]');
+    expect(cells).toHaveLength(2);
+    // The cell with `position: 0` (Heading) renders first in DOM.
+    expect(cells[0]?.getAttribute('data-widget-slug')).toBe('Heading');
+    expect(cells[1]?.getAttribute('data-widget-slug')).toBe('Hello');
   });
 
   it('applies grid-template-columns from layout.columns', () => {
     const { container } = renderDashboard({
-      id: 'test',
-      name: 'Test',
+      name: 'Empty',
       category: 'general',
+      isSystem: false,
+      version: '1.0.0',
+      layout: { columns: 8, rowHeight: 80 },
       widgets: [],
-      layout: { columns: 8, items: [] },
     });
     const dashboard = container.querySelector('[data-slot="dashboard"]');
     expect(dashboard).toHaveStyle({ gridTemplateColumns: 'repeat(8, minmax(0, 1fr))' });
+  });
+
+  it('renders an unknown-widget placeholder when the type has no registered renderer', () => {
+    renderDashboard({
+      name: 'Test',
+      category: 'general',
+      isSystem: false,
+      version: '1.0.0',
+      layout: { columns: 12, rowHeight: 80 },
+      widgets: [
+        {
+          slug: 'Foo',
+          type: 'analytics-kpi',
+          position: 0,
+          size: { width: 3, height: 1 },
+          metric: 'foo',
+        } as never,
+      ],
+    });
+    expect(screen.getByText(/Unknown widget type/i)).toBeInTheDocument();
+    expect(screen.getByText(/analytics-kpi/)).toBeInTheDocument();
+  });
+
+  it('renders the TextWidget with style-aware HTML element', () => {
+    const { container } = renderDashboard({
+      name: 'Test',
+      category: 'general',
+      isSystem: false,
+      version: '1.0.0',
+      layout: { columns: 12, rowHeight: 80 },
+      widgets: [
+        {
+          slug: 'Caption',
+          type: 'text',
+          position: 0,
+          size: { width: 6, height: 1 },
+          contentLocalizationKey: 'Widget:Test.Caption',
+          style: 'caption',
+        },
+      ],
+    });
+    const text = container.querySelector('[data-slot="text-widget"]');
+    expect(text?.tagName).toBe('P');
+    expect(text?.getAttribute('data-style')).toBe('caption');
   });
 });

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Dashboard } from '../components/dashboard.js';
+import { defaultWidgetRegistry } from '../registry/default-widget-registry.js';
+import { WidgetRegistryProvider } from '../registry/widget-registry-context.js';
+
+import type { DashboardDefinition } from '@granit/dashboards';
+
+function renderDashboard(definition: DashboardDefinition) {
+  return render(
+    <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
+      <Dashboard definition={definition} />
+    </WidgetRegistryProvider>
+  );
+}
+
+describe('Dashboard', () => {
+  it('renders widgets at their grid positions', () => {
+    const { container } = renderDashboard({
+      id: 'test',
+      name: 'Test',
+      category: 'general',
+      widgets: [
+        { id: 'w1', type: 'text', title: 'Hello', content: 'World' },
+        { id: 'w2', type: 'markdown', content: '# Heading' },
+      ],
+      layout: {
+        columns: 12,
+        items: [
+          { widgetId: 'w1', position: { x: 0, y: 0, width: 6, height: 1 } },
+          { widgetId: 'w2', position: { x: 6, y: 0, width: 6, height: 1 } },
+        ],
+      },
+    });
+
+    expect(screen.getByText('World')).toBeInTheDocument();
+    expect(screen.getByText('# Heading')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="dashboard-cell"]')).toHaveLength(2);
+  });
+
+  it('skips layout items with no matching widget', () => {
+    const { container } = renderDashboard({
+      id: 'test',
+      name: 'Test',
+      category: 'general',
+      widgets: [{ id: 'w1', type: 'text', content: 'Only one' }],
+      layout: {
+        columns: 12,
+        items: [
+          { widgetId: 'w1', position: { x: 0, y: 0, width: 6, height: 1 } },
+          { widgetId: 'ghost', position: { x: 6, y: 0, width: 6, height: 1 } },
+        ],
+      },
+    });
+    expect(container.querySelectorAll('[data-slot="dashboard-cell"]')).toHaveLength(1);
+  });
+
+  it('renders an unknown-widget placeholder when the type has no registered renderer', () => {
+    render(
+      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
+        <Dashboard
+          definition={{
+            id: 'test',
+            name: 'Test',
+            category: 'general',
+            widgets: [
+              {
+                id: 'w1',
+                type: 'analytics-kpi',
+                metric: 'foo',
+              } as never,
+            ],
+            layout: {
+              columns: 12,
+              items: [{ widgetId: 'w1', position: { x: 0, y: 0, width: 6, height: 1 } }],
+            },
+          }}
+        />
+      </WidgetRegistryProvider>
+    );
+    expect(screen.getByText(/Unknown widget type/i)).toBeInTheDocument();
+    expect(screen.getByText(/analytics-kpi/)).toBeInTheDocument();
+  });
+
+  it('applies grid-template-columns from layout.columns', () => {
+    const { container } = renderDashboard({
+      id: 'test',
+      name: 'Test',
+      category: 'general',
+      widgets: [],
+      layout: { columns: 8, items: [] },
+    });
+    const dashboard = container.querySelector('[data-slot="dashboard"]');
+    expect(dashboard).toHaveStyle({ gridTemplateColumns: 'repeat(8, minmax(0, 1fr))' });
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/use-effective-time-window.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-effective-time-window.test.tsx
@@ -1,0 +1,53 @@
+import { DASHBOARD_TIME_WINDOW, type DashboardTimeWindow } from '@granit/dashboards';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DashboardContextProvider } from '../components/dashboard-context.js';
+import { useEffectiveTimeWindow } from '../hooks/use-effective-time-window.js';
+
+import type { ReactNode } from 'react';
+
+describe('useEffectiveTimeWindow', () => {
+  it('falls back to the framework default outside any provider', () => {
+    const { result } = renderHook(() => useEffectiveTimeWindow());
+    expect(result.current).toBe(DASHBOARD_TIME_WINDOW.Last30Days);
+  });
+
+  it('returns the dashboard timeWindow when the context provides one', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DashboardContextProvider
+        value={{ dashboardName: 'Test', timeWindow: DASHBOARD_TIME_WINDOW.Last7Days }}
+      >
+        {children}
+      </DashboardContextProvider>
+    );
+    const { result } = renderHook(() => useEffectiveTimeWindow(), { wrapper });
+    expect(result.current).toBe(DASHBOARD_TIME_WINDOW.Last7Days);
+  });
+
+  it('prefers an explicit override over the dashboard timeWindow', () => {
+    const override: DashboardTimeWindow = {
+      period: { token: 'mtd' },
+      kind: 'history',
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DashboardContextProvider
+        value={{ dashboardName: 'Test', timeWindow: DASHBOARD_TIME_WINDOW.Last7Days }}
+      >
+        {children}
+      </DashboardContextProvider>
+    );
+    const { result } = renderHook(() => useEffectiveTimeWindow(override), { wrapper });
+    expect(result.current).toBe(override);
+  });
+
+  it('falls back to the framework default when the provider has no timeWindow', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DashboardContextProvider value={{ dashboardName: 'Test' }}>
+        {children}
+      </DashboardContextProvider>
+    );
+    const { result } = renderHook(() => useEffectiveTimeWindow(), { wrapper });
+    expect(result.current).toBe(DASHBOARD_TIME_WINDOW.Last30Days);
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/widget-registry.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/widget-registry.test.tsx
@@ -1,0 +1,47 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { defaultWidgetRegistry } from '../registry/default-widget-registry.js';
+import { WidgetRegistryProvider, useWidgetRegistry } from '../registry/widget-registry-context.js';
+import { composeRegistries, type WidgetRegistry } from '../registry/widget-registry.js';
+
+describe('composeRegistries', () => {
+  it('merges entries from later registries over earlier ones', () => {
+    const A: WidgetRegistry = { foo: () => null };
+    const B: WidgetRegistry = { bar: () => null };
+    const composed = composeRegistries(A, B);
+    expect(Object.keys(composed)).toEqual(expect.arrayContaining(['foo', 'bar']));
+  });
+
+  it('lets later registries override earlier renderers for the same type', () => {
+    const fallback = () => null;
+    const override = () => null;
+    const composed = composeRegistries({ foo: fallback }, { foo: override });
+    expect(composed.foo).toBe(override);
+  });
+
+  it('returns a frozen object', () => {
+    const composed = composeRegistries({ foo: () => null });
+    expect(Object.isFrozen(composed)).toBe(true);
+  });
+});
+
+describe('useWidgetRegistry', () => {
+  it('throws when used outside a provider', () => {
+    expect(() => renderHook(() => useWidgetRegistry())).toThrow(
+      /must be used inside a <WidgetRegistryProvider>/
+    );
+  });
+
+  it('returns the composed registry from the provider', () => {
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>
+        {children}
+      </WidgetRegistryProvider>
+    );
+    const { result } = renderHook(() => useWidgetRegistry(), { wrapper });
+    expect(result.current.markdown).toBeDefined();
+    expect(result.current.image).toBeDefined();
+    expect(result.current.text).toBeDefined();
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
@@ -1,17 +1,37 @@
-import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type Dispatch,
+  type ReactNode,
+  type SetStateAction,
+} from 'react';
+
+import type { DashboardTimeWindow } from '@granit/dashboards';
 
 /**
  * Read-only ambient context for a rendered dashboard. Surfaces the dashboard
- * identity so renderers (and future hooks for TimeWindow / aliases / filters)
- * have a stable handle without prop-drilling.
+ * identity plus the active time window so renderers (and future hooks for
+ * aliases / filters) have a stable handle without prop-drilling.
  *
- * Today the only field is `dashboardName`; the type is the extension point
- * where TimeWindow / EntityAlias / DashboardFilters land in later stories
- * (see proposals doc P1.3 / P2.3 / P2.5).
+ * The shape grows progressively as proposals land: TimeWindow today (P1.3),
+ * EntityAlias and DashboardFilters next (P2.3 / P2.5).
  */
 export interface DashboardContextValue {
   /** Wire identifier of the active dashboard, e.g. `"Granit.Invoicing.FinanceOverview"`. */
   readonly dashboardName: string;
+  /**
+   * Active time window. When omitted the dashboard has no time-window control
+   * (data widgets fall back to their own `TimeWindowOverride` or per-call period).
+   */
+  readonly timeWindow?: DashboardTimeWindow;
+  /**
+   * Setter the toolbar control wires to a state hook so user changes propagate
+   * through context. When omitted the time window is read-only — useful for
+   * embedded / preview / printable dashboards.
+   */
+  readonly setTimeWindow?: Dispatch<SetStateAction<DashboardTimeWindow | undefined>>;
 }
 
 const DashboardContext = createContext<DashboardContextValue | null>(null);
@@ -22,7 +42,12 @@ export interface DashboardContextProviderProps {
 }
 
 export function DashboardContextProvider({ value, children }: DashboardContextProviderProps) {
-  const memoised = useMemo(() => value, [value.dashboardName]);
+  const memoised = useMemo<DashboardContextValue>(
+    () => value,
+    // Identity-stable on the primitive fields; the setter is assumed stable
+    // (typically returned from useState).
+    [value.dashboardName, value.timeWindow, value.setTimeWindow]
+  );
   return <DashboardContext.Provider value={memoised}>{children}</DashboardContext.Provider>;
 }
 
@@ -33,4 +58,27 @@ export function DashboardContextProvider({ value, children }: DashboardContextPr
  */
 export function useDashboardContext(): DashboardContextValue | null {
   return useContext(DashboardContext);
+}
+
+/**
+ * State hook intended for the `<Dashboard>` component itself — exposes a
+ * `[timeWindow, setTimeWindow]` pair the toolbar control binds to, kept in
+ * React state so user changes propagate via context to every widget.
+ *
+ * Usage inside `<Dashboard>`:
+ * ```tsx
+ * const [timeWindow, setTimeWindow] = useDashboardTimeWindowState(
+ *   definition.defaultTimeWindow
+ * );
+ *
+ * <DashboardContextProvider
+ *   value={{ dashboardName: definition.name, timeWindow, setTimeWindow }}
+ * >
+ *   <DashboardToolbar />
+ *   <Grid>{...}</Grid>
+ * </DashboardContextProvider>
+ * ```
+ */
+export function useDashboardTimeWindowState(initial?: DashboardTimeWindow) {
+  return useState<DashboardTimeWindow | undefined>(initial);
 }

--- a/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-context.tsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+/**
+ * Read-only ambient context for a rendered dashboard. Surfaces the dashboard
+ * identity so renderers (and future hooks for TimeWindow / aliases / filters)
+ * have a stable handle without prop-drilling.
+ *
+ * Today the only field is `dashboardName`; the type is the extension point
+ * where TimeWindow / EntityAlias / DashboardFilters land in later stories
+ * (see proposals doc P1.3 / P2.3 / P2.5).
+ */
+export interface DashboardContextValue {
+  /** Wire identifier of the active dashboard, e.g. `"Granit.Invoicing.FinanceOverview"`. */
+  readonly dashboardName: string;
+}
+
+const DashboardContext = createContext<DashboardContextValue | null>(null);
+
+export interface DashboardContextProviderProps {
+  readonly value: DashboardContextValue;
+  readonly children: ReactNode;
+}
+
+export function DashboardContextProvider({ value, children }: DashboardContextProviderProps) {
+  const memoised = useMemo(() => value, [value.dashboardName]);
+  return <DashboardContext.Provider value={memoised}>{children}</DashboardContext.Provider>;
+}
+
+/**
+ * Reads the active {@link DashboardContextValue}. Returns `null` outside a
+ * provider — useful for renderers that gracefully degrade when used
+ * standalone (a KPI tile rendered above an invoice list, for instance).
+ */
+export function useDashboardContext(): DashboardContextValue | null {
+  return useContext(DashboardContext);
+}

--- a/packages/@granit/react-dashboards/src/components/dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard.tsx
@@ -1,89 +1,85 @@
+import { useMemo, type CSSProperties } from 'react';
+
+import { DashboardContextProvider } from './dashboard-context.js';
 import { WidgetRenderer } from './widget-renderer.js';
 
-import type {
-  DashboardDefinition,
-  DashboardLayoutItem,
-  WidgetDefinition,
-} from '@granit/dashboards';
-import type { CSSProperties } from 'react';
-
-const DEFAULT_ROW_HEIGHT_PX = 80;
+import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
 
 export interface DashboardProps {
   readonly definition: DashboardDefinition;
   readonly className?: string;
   /**
-   * Override the row height (in pixels). Falls back to `definition.layout.rowHeight`
-   * and finally to {@link DEFAULT_ROW_HEIGHT_PX}. The grid columns scale to
-   * available width; only row height is fixed so widget heights remain stable
-   * across viewport changes.
+   * Override the row height (in pixels). Falls back to
+   * `definition.layout.rowHeight`. The grid columns scale to available width;
+   * only row height is fixed so widget heights remain stable across viewport
+   * changes.
    */
   readonly rowHeight?: number;
 }
 
 /**
- * Renders a {@link DashboardDefinition} as a CSS grid.
+ * Renders a {@link DashboardDefinition} as a CSS auto-flow grid.
  *
- * v1 implementation — static grid, no drag/drop, no responsive recomputation
- * (the browser's native `repeat(N, 1fr)` already handles width scaling). v2 will
- * swap this for `react-grid-layout` to enable drag/resize/persist; the public
- * API (just pass a `definition`) remains stable across that swap.
+ * v1 implementation — widgets fill the grid in `position` order, each taking
+ * its declared `size.width × size.height`. The browser handles placement via
+ * `grid-auto-flow: dense`. v2 will swap this for `react-grid-layout` to
+ * enable drag/resize/persist; the public API (just pass a `definition`)
+ * remains stable across that swap.
  *
- * Widgets whose layout item has no matching `WidgetDefinition.id` are silently
- * skipped — that's the cheap path for backend-driven layouts where a widget
- * was deleted but its layout item lingers in transit.
+ * Wraps children in a {@link DashboardContextProvider} so widget renderers
+ * (and future TimeWindow / alias hooks) have a stable handle on the active
+ * dashboard.
  */
 export function Dashboard({ definition, className, rowHeight }: DashboardProps) {
-  const widgetsById = indexWidgetsById(definition.widgets);
-  const effectiveRowHeight = rowHeight ?? definition.layout.rowHeight ?? DEFAULT_ROW_HEIGHT_PX;
+  const orderedWidgets = useMemo(() => sortByPosition(definition.widgets), [definition.widgets]);
+  const effectiveRowHeight = rowHeight ?? definition.layout.rowHeight;
 
   const gridStyle: CSSProperties = {
     display: 'grid',
+    gridAutoFlow: 'dense',
     gridTemplateColumns: `repeat(${definition.layout.columns}, minmax(0, 1fr))`,
     gridAutoRows: `${effectiveRowHeight}px`,
     gap: '1rem',
   };
 
   return (
-    <div
-      data-slot="dashboard"
-      data-dashboard-id={definition.id}
-      className={className}
-      style={gridStyle}
-    >
-      {definition.layout.items.map((item) => {
-        const widget = widgetsById.get(item.widgetId);
-        if (!widget) return null;
-        return (
-          <DashboardCell key={item.widgetId} item={item}>
+    <DashboardContextProvider value={{ dashboardName: definition.name }}>
+      <div
+        data-slot="dashboard"
+        data-dashboard-name={definition.name}
+        className={className}
+        style={gridStyle}
+      >
+        {orderedWidgets.map((widget) => (
+          <DashboardCell key={widget.slug} widget={widget}>
             <WidgetRenderer widget={widget} />
           </DashboardCell>
-        );
-      })}
-    </div>
+        ))}
+      </div>
+    </DashboardContextProvider>
   );
 }
 
 function DashboardCell({
-  item,
+  widget,
   children,
 }: {
-  readonly item: DashboardLayoutItem;
+  readonly widget: WidgetDefinition;
   readonly children: React.ReactNode;
 }) {
   const cellStyle: CSSProperties = {
-    gridColumn: `${item.position.x + 1} / span ${item.position.width}`,
-    gridRow: `${item.position.y + 1} / span ${item.position.height}`,
+    gridColumn: `span ${widget.size.width}`,
+    gridRow: `span ${widget.size.height}`,
   };
   return (
-    <div data-slot="dashboard-cell" style={cellStyle}>
+    <div data-slot="dashboard-cell" data-widget-slug={widget.slug} style={cellStyle}>
       {children}
     </div>
   );
 }
 
-function indexWidgetsById(widgets: readonly WidgetDefinition[]): Map<string, WidgetDefinition> {
-  const map = new Map<string, WidgetDefinition>();
-  for (const widget of widgets) map.set(widget.id, widget);
-  return map;
+function sortByPosition(widgets: readonly WidgetDefinition[]): readonly WidgetDefinition[] {
+  // Stable sort on `position` so authors can declare widgets in any order in
+  // their definition and the renderer respects the explicit `Position`.
+  return [...widgets].sort((a, b) => a.position - b.position);
 }

--- a/packages/@granit/react-dashboards/src/components/dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard.tsx
@@ -1,0 +1,89 @@
+import { WidgetRenderer } from './widget-renderer.js';
+
+import type {
+  DashboardDefinition,
+  DashboardLayoutItem,
+  WidgetDefinition,
+} from '@granit/dashboards';
+import type { CSSProperties } from 'react';
+
+const DEFAULT_ROW_HEIGHT_PX = 80;
+
+export interface DashboardProps {
+  readonly definition: DashboardDefinition;
+  readonly className?: string;
+  /**
+   * Override the row height (in pixels). Falls back to `definition.layout.rowHeight`
+   * and finally to {@link DEFAULT_ROW_HEIGHT_PX}. The grid columns scale to
+   * available width; only row height is fixed so widget heights remain stable
+   * across viewport changes.
+   */
+  readonly rowHeight?: number;
+}
+
+/**
+ * Renders a {@link DashboardDefinition} as a CSS grid.
+ *
+ * v1 implementation — static grid, no drag/drop, no responsive recomputation
+ * (the browser's native `repeat(N, 1fr)` already handles width scaling). v2 will
+ * swap this for `react-grid-layout` to enable drag/resize/persist; the public
+ * API (just pass a `definition`) remains stable across that swap.
+ *
+ * Widgets whose layout item has no matching `WidgetDefinition.id` are silently
+ * skipped — that's the cheap path for backend-driven layouts where a widget
+ * was deleted but its layout item lingers in transit.
+ */
+export function Dashboard({ definition, className, rowHeight }: DashboardProps) {
+  const widgetsById = indexWidgetsById(definition.widgets);
+  const effectiveRowHeight = rowHeight ?? definition.layout.rowHeight ?? DEFAULT_ROW_HEIGHT_PX;
+
+  const gridStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: `repeat(${definition.layout.columns}, minmax(0, 1fr))`,
+    gridAutoRows: `${effectiveRowHeight}px`,
+    gap: '1rem',
+  };
+
+  return (
+    <div
+      data-slot="dashboard"
+      data-dashboard-id={definition.id}
+      className={className}
+      style={gridStyle}
+    >
+      {definition.layout.items.map((item) => {
+        const widget = widgetsById.get(item.widgetId);
+        if (!widget) return null;
+        return (
+          <DashboardCell key={item.widgetId} item={item}>
+            <WidgetRenderer widget={widget} />
+          </DashboardCell>
+        );
+      })}
+    </div>
+  );
+}
+
+function DashboardCell({
+  item,
+  children,
+}: {
+  readonly item: DashboardLayoutItem;
+  readonly children: React.ReactNode;
+}) {
+  const cellStyle: CSSProperties = {
+    gridColumn: `${item.position.x + 1} / span ${item.position.width}`,
+    gridRow: `${item.position.y + 1} / span ${item.position.height}`,
+  };
+  return (
+    <div data-slot="dashboard-cell" style={cellStyle}>
+      {children}
+    </div>
+  );
+}
+
+function indexWidgetsById(widgets: readonly WidgetDefinition[]): Map<string, WidgetDefinition> {
+  const map = new Map<string, WidgetDefinition>();
+  for (const widget of widgets) map.set(widget.id, widget);
+  return map;
+}

--- a/packages/@granit/react-dashboards/src/components/widget-card.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-card.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Visual frame for every dashboard widget — title row + body slot.
+ *
+ * Decoupled from `<WidgetRenderer>` so consumers can opt out of the frame
+ * (an Image widget that should bleed to the edges of its grid cell, for
+ * instance) by rendering the body directly. Default styling matches the
+ * shadcn `<Card>` aesthetic without taking a hard dep on it.
+ */
+export interface WidgetCardProps {
+  readonly title?: string;
+  readonly children: ReactNode;
+  readonly className?: string;
+}
+
+export function WidgetCard({ title, children, className }: WidgetCardProps) {
+  const root = ['flex h-full flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm', className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div data-slot="widget-card" className={root}>
+      {title ? (
+        <header data-slot="widget-card-header">
+          <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
+        </header>
+      ) : null}
+      <div data-slot="widget-card-body" className="flex-1 min-h-0">
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
@@ -1,5 +1,8 @@
+import { useTranslation } from 'react-i18next';
+
 import { useWidgetRegistry } from '../registry/widget-registry-context.js';
 
+import { useDashboardContext } from './dashboard-context.js';
 import { WidgetCard } from './widget-card.js';
 
 import type { WidgetDefinition } from '@granit/dashboards';
@@ -8,8 +11,9 @@ export interface WidgetRendererProps {
   readonly widget: WidgetDefinition;
   /**
    * When `true` (default), the widget body is wrapped in a {@link WidgetCard}
-   * with the widget's title rendered above it. Set to `false` to render only
-   * the body — useful for image widgets that should bleed to the edges.
+   * with the widget's title resolved from
+   * `Widget:{dashboardName}.{slug}.Title`. Set to `false` to render only the
+   * body — useful for image widgets that should bleed to the edges.
    */
   readonly framed?: boolean;
 }
@@ -20,14 +24,18 @@ export interface WidgetRendererProps {
  * placeholder so the dashboard surfaces missing-renderer issues visibly
  * rather than silently dropping widgets.
  *
- * The dispatcher is intentionally generic — the active registry is read from
- * context, so the same `<WidgetRenderer>` works for framework, analytics, IoT,
- * and app-specific widget types depending on what's been registered upstream.
+ * Title resolution: composes `Widget:{dashboardName}.{slug}.Title` from the
+ * active {@link useDashboardContext} and resolves via `useTranslation()`. When
+ * no dashboard context is present (standalone widget), the prefix collapses to
+ * `Widget:{slug}.Title`. An empty translation skips the title row entirely —
+ * widgets that don't want a frame title just leave the key unset.
  */
 export function WidgetRenderer({ widget, framed = true }: WidgetRendererProps) {
   const registry = useWidgetRegistry();
-  const Renderer = registry[widget.type];
+  const { t } = useTranslation();
+  const dashboardCtx = useDashboardContext();
 
+  const Renderer = registry[widget.type];
   const body = Renderer ? (
     <Renderer widget={widget} />
   ) : (
@@ -35,7 +43,13 @@ export function WidgetRenderer({ widget, framed = true }: WidgetRendererProps) {
   );
 
   if (!framed) return body;
-  return <WidgetCard title={widget.title}>{body}</WidgetCard>;
+
+  const titleKey = dashboardCtx
+    ? `Widget:${dashboardCtx.dashboardName}.${widget.slug}.Title`
+    : `Widget:${widget.slug}.Title`;
+  const title = t(titleKey, { defaultValue: '' });
+
+  return <WidgetCard title={title || undefined}>{body}</WidgetCard>;
 }
 
 function UnknownWidgetFallback({ type }: { readonly type: string }) {

--- a/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-renderer.tsx
@@ -1,0 +1,50 @@
+import { useWidgetRegistry } from '../registry/widget-registry-context.js';
+
+import { WidgetCard } from './widget-card.js';
+
+import type { WidgetDefinition } from '@granit/dashboards';
+
+export interface WidgetRendererProps {
+  readonly widget: WidgetDefinition;
+  /**
+   * When `true` (default), the widget body is wrapped in a {@link WidgetCard}
+   * with the widget's title rendered above it. Set to `false` to render only
+   * the body — useful for image widgets that should bleed to the edges.
+   */
+  readonly framed?: boolean;
+}
+
+/**
+ * Dispatches a {@link WidgetDefinition} to the renderer registered for its
+ * `type` discriminator. If no renderer is registered, falls back to a small
+ * placeholder so the dashboard surfaces missing-renderer issues visibly
+ * rather than silently dropping widgets.
+ *
+ * The dispatcher is intentionally generic — the active registry is read from
+ * context, so the same `<WidgetRenderer>` works for framework, analytics, IoT,
+ * and app-specific widget types depending on what's been registered upstream.
+ */
+export function WidgetRenderer({ widget, framed = true }: WidgetRendererProps) {
+  const registry = useWidgetRegistry();
+  const Renderer = registry[widget.type];
+
+  const body = Renderer ? (
+    <Renderer widget={widget} />
+  ) : (
+    <UnknownWidgetFallback type={widget.type} />
+  );
+
+  if (!framed) return body;
+  return <WidgetCard title={widget.title}>{body}</WidgetCard>;
+}
+
+function UnknownWidgetFallback({ type }: { readonly type: string }) {
+  return (
+    <div
+      data-slot="widget-unknown"
+      className="flex h-full items-center justify-center rounded-md border border-dashed border-destructive/40 p-3 text-xs text-destructive"
+    >
+      Unknown widget type: <code className="ml-1 font-mono">{type}</code>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
@@ -1,3 +1,5 @@
+import { useTranslation } from 'react-i18next';
+
 import type { ImageWidgetDefinition } from '@granit/dashboards';
 
 /**
@@ -7,15 +9,21 @@ import type { ImageWidgetDefinition } from '@granit/dashboards';
  * widget remains usable in environments without a router-aware image loader
  * (Storybook, plain CRA, embed scenarios). `loading="lazy"` keeps off-screen
  * widgets cheap on long dashboards.
+ *
+ * The `source` field accepts either a plain URL or a `blob:<id>` reference
+ * resolved by the host's blob storage adapter — apps that ship blob support
+ * register a richer renderer overriding this default.
  */
 export function ImageWidget({ widget }: { readonly widget: ImageWidgetDefinition }) {
+  const { t } = useTranslation();
+  const alt = t(widget.altLocalizationKey);
   return (
     <div data-slot="image-widget" className="flex h-full w-full items-center justify-center">
       <img
-        src={widget.src}
-        alt={widget.alt ?? ''}
+        src={widget.source}
+        alt={alt}
         loading="lazy"
-        style={{ objectFit: widget.fit ?? 'contain' }}
+        style={{ objectFit: 'contain' }}
         className="h-full w-full"
       />
     </div>

--- a/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
@@ -1,0 +1,23 @@
+import type { ImageWidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Built-in renderer for `ImageWidgetDefinition`.
+ *
+ * Uses native `<img>` rather than a framework-specific image component so the
+ * widget remains usable in environments without a router-aware image loader
+ * (Storybook, plain CRA, embed scenarios). `loading="lazy"` keeps off-screen
+ * widgets cheap on long dashboards.
+ */
+export function ImageWidget({ widget }: { readonly widget: ImageWidgetDefinition }) {
+  return (
+    <div data-slot="image-widget" className="flex h-full w-full items-center justify-center">
+      <img
+        src={widget.src}
+        alt={widget.alt ?? ''}
+        loading="lazy"
+        style={{ objectFit: widget.fit ?? 'contain' }}
+        className="h-full w-full"
+      />
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widgets/markdown-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/markdown-widget.tsx
@@ -1,0 +1,21 @@
+import type { MarkdownWidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Built-in renderer for `MarkdownWidgetDefinition`.
+ *
+ * v1 ships a minimal pre-formatted fallback — content renders verbatim with
+ * whitespace preserved. To enable full Markdown rendering (headings, lists,
+ * code blocks, links), apps register their own renderer in the registry,
+ * typically backed by `react-markdown`. Keeping the fallback dependency-free
+ * means `@granit/react-dashboards` doesn't drag react-markdown into bundles
+ * that never use it.
+ */
+export function MarkdownWidget({ widget }: { readonly widget: MarkdownWidgetDefinition }) {
+  return (
+    <div data-slot="markdown-widget" className="prose prose-sm max-w-none">
+      <pre className="whitespace-pre-wrap break-words font-sans text-sm text-foreground">
+        {widget.content}
+      </pre>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widgets/markdown-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/markdown-widget.tsx
@@ -1,20 +1,28 @@
+import { useTranslation } from 'react-i18next';
+
 import type { MarkdownWidgetDefinition } from '@granit/dashboards';
 
 /**
  * Built-in renderer for `MarkdownWidgetDefinition`.
  *
- * v1 ships a minimal pre-formatted fallback — content renders verbatim with
- * whitespace preserved. To enable full Markdown rendering (headings, lists,
- * code blocks, links), apps register their own renderer in the registry,
- * typically backed by `react-markdown`. Keeping the fallback dependency-free
- * means `@granit/react-dashboards` doesn't drag react-markdown into bundles
- * that never use it.
+ * v1 ships a minimal pre-formatted fallback — the resolved Markdown renders
+ * verbatim with whitespace preserved. To enable full Markdown rendering
+ * (headings, lists, code blocks, links), apps register their own renderer in
+ * the registry, typically backed by `react-markdown`. Keeping the fallback
+ * dependency-free means `@granit/react-dashboards` doesn't drag react-markdown
+ * into bundles that never use it.
+ *
+ * The widget's `contentLocalizationKey` is resolved directly via
+ * `useTranslation()` — the backend ships the key fully composed
+ * (`Widget:{DashboardName}.{Slug}`).
  */
 export function MarkdownWidget({ widget }: { readonly widget: MarkdownWidgetDefinition }) {
+  const { t } = useTranslation();
+  const content = t(widget.contentLocalizationKey);
   return (
     <div data-slot="markdown-widget" className="prose prose-sm max-w-none">
       <pre className="whitespace-pre-wrap break-words font-sans text-sm text-foreground">
-        {widget.content}
+        {content}
       </pre>
     </div>
   );

--- a/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
@@ -1,0 +1,16 @@
+import type { TextWidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Built-in renderer for `TextWidgetDefinition`.
+ *
+ * Whitespace is preserved so multi-line text reads as authored. For richer
+ * formatting (lists, headings, links) hosts should register a Markdown
+ * renderer instead — Text is the lowest-fidelity widget, intentionally.
+ */
+export function TextWidget({ widget }: { readonly widget: TextWidgetDefinition }) {
+  return (
+    <p data-slot="text-widget" className="whitespace-pre-wrap break-words text-sm text-foreground">
+      {widget.content}
+    </p>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
@@ -1,16 +1,43 @@
-import type { TextWidgetDefinition } from '@granit/dashboards';
+import { useTranslation } from 'react-i18next';
+
+import type { TextWidgetDefinition, TextWidgetStyle } from '@granit/dashboards';
+
+const STYLE_CLASSES: Readonly<Record<TextWidgetStyle, string>> = {
+  body: 'text-sm text-foreground',
+  heading: 'text-2xl font-semibold tracking-tight text-foreground',
+  subheading: 'text-lg font-semibold text-foreground',
+  caption: 'text-xs text-muted-foreground',
+};
 
 /**
  * Built-in renderer for `TextWidgetDefinition`.
  *
- * Whitespace is preserved so multi-line text reads as authored. For richer
- * formatting (lists, headings, links) hosts should register a Markdown
- * renderer instead — Text is the lowest-fidelity widget, intentionally.
+ * Whitespace is preserved so multi-line text reads as authored. The visual
+ * style (body / heading / subheading / caption) is mapped to a Tailwind class
+ * set; consuming apps can override via the registry for a custom design system.
  */
 export function TextWidget({ widget }: { readonly widget: TextWidgetDefinition }) {
+  const { t } = useTranslation();
+  const content = t(widget.contentLocalizationKey);
+  const className = `whitespace-pre-wrap break-words ${STYLE_CLASSES[widget.style]}`;
+
+  if (widget.style === 'heading') {
+    return (
+      <h2 data-slot="text-widget" data-style="heading" className={className}>
+        {content}
+      </h2>
+    );
+  }
+  if (widget.style === 'subheading') {
+    return (
+      <h3 data-slot="text-widget" data-style="subheading" className={className}>
+        {content}
+      </h3>
+    );
+  }
   return (
-    <p data-slot="text-widget" className="whitespace-pre-wrap break-words text-sm text-foreground">
-      {widget.content}
+    <p data-slot="text-widget" data-style={widget.style} className={className}>
+      {content}
     </p>
   );
 }

--- a/packages/@granit/react-dashboards/src/hooks/use-effective-time-window.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-effective-time-window.ts
@@ -1,0 +1,22 @@
+import { DASHBOARD_TIME_WINDOW } from '@granit/dashboards';
+
+import { useDashboardContext } from '../components/dashboard-context.js';
+
+import type { DashboardTimeWindow } from '@granit/dashboards';
+
+/**
+ * Resolves the time window in effect for the calling widget. The cascade is:
+ *
+ * 1. Explicit override passed in by the caller (e.g. a widget with its own
+ *    `TimeWindowOverride` per proposals doc P1.3).
+ * 2. Active dashboard time window from {@link useDashboardContext}.
+ * 3. The framework default (`DASHBOARD_TIME_WINDOW.Last30Days`) so widgets
+ *    rendered standalone get a sensible value without ceremony.
+ *
+ * Always returns a defined `DashboardTimeWindow` — callers don't have to
+ * juggle `undefined`.
+ */
+export function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow {
+  const context = useDashboardContext();
+  return override ?? context?.timeWindow ?? DASHBOARD_TIME_WINDOW.Last30Days;
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -1,0 +1,23 @@
+// ---------------------------------------------------------------------------
+// @granit/react-dashboards — public API
+// ---------------------------------------------------------------------------
+
+// Layout + dispatcher
+export { Dashboard } from './components/dashboard.js';
+export type { DashboardProps } from './components/dashboard.js';
+export { WidgetRenderer } from './components/widget-renderer.js';
+export type { WidgetRendererProps } from './components/widget-renderer.js';
+export { WidgetCard } from './components/widget-card.js';
+export type { WidgetCardProps } from './components/widget-card.js';
+
+// Built-in widgets (exported for advanced composition / overriding)
+export { ImageWidget } from './components/widgets/image-widget.js';
+export { MarkdownWidget } from './components/widgets/markdown-widget.js';
+export { TextWidget } from './components/widgets/text-widget.js';
+
+// Registry
+export { defaultWidgetRegistry } from './registry/default-widget-registry.js';
+export { WidgetRegistryProvider, useWidgetRegistry } from './registry/widget-registry-context.js';
+export type { WidgetRegistryProviderProps } from './registry/widget-registry-context.js';
+export { composeRegistries } from './registry/widget-registry.js';
+export type { WidgetRegistry, WidgetRenderer } from './registry/widget-registry.js';

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -5,6 +5,11 @@
 // Layout + dispatcher
 export { Dashboard } from './components/dashboard.js';
 export type { DashboardProps } from './components/dashboard.js';
+export { DashboardContextProvider, useDashboardContext } from './components/dashboard-context.js';
+export type {
+  DashboardContextProviderProps,
+  DashboardContextValue,
+} from './components/dashboard-context.js';
 export { WidgetRenderer } from './components/widget-renderer.js';
 export type { WidgetRendererProps } from './components/widget-renderer.js';
 export { WidgetCard } from './components/widget-card.js';
@@ -20,4 +25,10 @@ export { defaultWidgetRegistry } from './registry/default-widget-registry.js';
 export { WidgetRegistryProvider, useWidgetRegistry } from './registry/widget-registry-context.js';
 export type { WidgetRegistryProviderProps } from './registry/widget-registry-context.js';
 export { composeRegistries } from './registry/widget-registry.js';
-export type { WidgetRegistry, WidgetRenderer } from './registry/widget-registry.js';
+// Renamed `WidgetRenderer` (type) → `WidgetRendererFn` to avoid collision with
+// the dispatcher component of the same name; consumers register components
+// matching this signature.
+export type {
+  WidgetRegistry,
+  WidgetRenderer as WidgetRendererFn,
+} from './registry/widget-registry.js';

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -5,11 +5,16 @@
 // Layout + dispatcher
 export { Dashboard } from './components/dashboard.js';
 export type { DashboardProps } from './components/dashboard.js';
-export { DashboardContextProvider, useDashboardContext } from './components/dashboard-context.js';
+export {
+  DashboardContextProvider,
+  useDashboardContext,
+  useDashboardTimeWindowState,
+} from './components/dashboard-context.js';
 export type {
   DashboardContextProviderProps,
   DashboardContextValue,
 } from './components/dashboard-context.js';
+export { useEffectiveTimeWindow } from './hooks/use-effective-time-window.js';
 export { WidgetRenderer } from './components/widget-renderer.js';
 export type { WidgetRendererProps } from './components/widget-renderer.js';
 export { WidgetCard } from './components/widget-card.js';

--- a/packages/@granit/react-dashboards/src/registry/default-widget-registry.ts
+++ b/packages/@granit/react-dashboards/src/registry/default-widget-registry.ts
@@ -1,0 +1,17 @@
+import { ImageWidget } from '../components/widgets/image-widget.js';
+import { MarkdownWidget } from '../components/widgets/markdown-widget.js';
+import { TextWidget } from '../components/widgets/text-widget.js';
+
+import type { WidgetRegistry, WidgetRenderer } from './widget-registry.js';
+
+/**
+ * Framework-default registry — covers every `FrameworkWidgetDefinition` type
+ * shipped by `@granit/dashboards`. Compose this with downstream registries
+ * (analytics, IoT, app-specific) via `composeRegistries` so apps never need
+ * to re-register the basics.
+ */
+export const defaultWidgetRegistry: WidgetRegistry = Object.freeze({
+  markdown: MarkdownWidget as WidgetRenderer,
+  image: ImageWidget as WidgetRenderer,
+  text: TextWidget as WidgetRenderer,
+});

--- a/packages/@granit/react-dashboards/src/registry/widget-registry-context.tsx
+++ b/packages/@granit/react-dashboards/src/registry/widget-registry-context.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import { composeRegistries, type WidgetRegistry } from './widget-registry.js';
+
+const WidgetRegistryContext = createContext<WidgetRegistry | null>(null);
+
+export interface WidgetRegistryProviderProps {
+  /** Registries are merged left-to-right; later entries win for the same type. */
+  readonly registries: readonly WidgetRegistry[];
+  readonly children: ReactNode;
+}
+
+/**
+ * Supplies the active {@link WidgetRegistry} to the dashboard renderer subtree.
+ *
+ * Place this near the app root, composing the registries you need — typically:
+ *   `[defaultWidgetRegistry, analyticsWidgetRegistry, appCustomRegistry]`.
+ *
+ * The provider memoises the composed registry so children only re-render when
+ * the actual set of renderers changes.
+ */
+export function WidgetRegistryProvider({ registries, children }: WidgetRegistryProviderProps) {
+  const registry = useMemo(() => composeRegistries(...registries), [registries]);
+  return (
+    <WidgetRegistryContext.Provider value={registry}>{children}</WidgetRegistryContext.Provider>
+  );
+}
+
+/**
+ * Reads the active {@link WidgetRegistry}. Throws when used outside a
+ * {@link WidgetRegistryProvider} — the dashboard renderer cannot dispatch
+ * widget types without a registry, so failing fast is preferable to rendering
+ * placeholders that silently lose data.
+ */
+export function useWidgetRegistry(): WidgetRegistry {
+  const registry = useContext(WidgetRegistryContext);
+  if (registry === null) {
+    throw new Error(
+      'useWidgetRegistry must be used inside a <WidgetRegistryProvider>. ' +
+        'Wrap your dashboard tree at the app root with the framework defaults plus any extension registries.'
+    );
+  }
+  return registry;
+}

--- a/packages/@granit/react-dashboards/src/registry/widget-registry.ts
+++ b/packages/@granit/react-dashboards/src/registry/widget-registry.ts
@@ -1,0 +1,39 @@
+import type { WidgetDefinition } from '@granit/dashboards';
+import type { ComponentType } from 'react';
+
+/**
+ * Renderer signature for a widget type. The component receives the typed
+ * widget definition and is responsible for rendering its body — the surrounding
+ * frame (title, padding, error boundary) is handled by `<WidgetCard>`.
+ */
+export type WidgetRenderer<T extends WidgetDefinition = WidgetDefinition> = ComponentType<{
+  readonly widget: T;
+}>;
+
+/**
+ * Mapping from widget `type` discriminator to a renderer component.
+ *
+ * The framework ships defaults for `markdown` / `image` / `text`. Downstream
+ * packages register their own (Analytics adds `kpi`, `chart`, `table`, `pivot`;
+ * IoT adds `gauge`, `camera-feed`, `alarm-light`; consuming apps add custom).
+ *
+ * A registry is just a frozen object — there's intentionally no class and no
+ * mutation API at runtime. New entries are composed at provider creation time.
+ */
+export type WidgetRegistry = Readonly<Record<string, WidgetRenderer>>;
+
+/**
+ * Composes multiple registries into one, with later entries overriding earlier
+ * ones for the same `type`. Use this to layer framework defaults + analytics
+ * widgets + app-specific overrides without mutating shared state.
+ *
+ * @example
+ *   const registry = composeRegistries(
+ *     defaultWidgetRegistry,
+ *     analyticsWidgetRegistry,
+ *     { 'company-logo': CompanyLogoWidget }
+ *   );
+ */
+export function composeRegistries(...registries: readonly WidgetRegistry[]): WidgetRegistry {
+  return Object.freeze(Object.assign({}, ...registries));
+}

--- a/packages/@granit/react-dashboards/tsconfig.json
+++ b/packages/@granit/react-dashboards/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-dashboards/tsconfig.json
+++ b/packages/@granit/react-dashboards/tsconfig.json
@@ -1,4 +1,5 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
 }

--- a/packages/@granit/react-dashboards/tsup.config.ts
+++ b/packages/@granit/react-dashboards/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,12 @@ importers:
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
+      echarts-for-react:
+        specifier: ^3.0.6
+        version: 3.0.6(echarts@6.0.0)(react@19.2.5)
       eslint:
         specifier: ^10.2.1
         version: 10.2.1(jiti@2.6.1)
@@ -298,6 +304,8 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/charts: {}
+
   packages/@granit/cookies: {}
 
   packages/@granit/cookies-klaro:
@@ -317,6 +325,8 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+
+  packages/@granit/dashboards: {}
 
   packages/@granit/data-exchange:
     dependencies:
@@ -941,6 +951,28 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/react-charts:
+    dependencies:
+      echarts:
+        specifier: ^6.0.0
+        version: 6.0.0
+      echarts-for-react:
+        specifier: ^3.0.6
+        version: 3.0.6(echarts@6.0.0)(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@granit/charts':
+        specifier: workspace:*
+        version: link:../charts
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-cookies:
     dependencies:
       '@granit/cookies':
@@ -984,6 +1016,25 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+
+  packages/@granit/react-dashboards:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+    devDependencies:
+      '@granit/dashboards':
+        specifier: workspace:*
+        version: link:../dashboards
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
 
   packages/@granit/react-data-exchange:
     dependencies:
@@ -4181,6 +4232,15 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  echarts-for-react@3.0.6:
+    resolution: {integrity: sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==}
+    peerDependencies:
+      echarts: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0
+      react: ^15.0.0 || >=16.0.0
+
+  echarts@6.0.0:
+    resolution: {integrity: sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==}
+
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
 
@@ -5428,6 +5488,9 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  size-sensor@1.0.3:
+    resolution: {integrity: sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==}
+
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
@@ -5593,6 +5656,9 @@ packages:
 
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -5936,6 +6002,9 @@ packages:
 
   zone.js@0.16.1:
     resolution: {integrity: sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==}
+
+  zrender@6.0.0:
+    resolution: {integrity: sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==}
 
 snapshots:
 
@@ -8083,6 +8152,18 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  echarts-for-react@3.0.6(echarts@6.0.0)(react@19.2.5):
+    dependencies:
+      echarts: 6.0.0
+      fast-deep-equal: 3.1.3
+      react: 19.2.5
+      size-sensor: 1.0.3
+
+  echarts@6.0.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 6.0.0
+
   electron-to-chromium@1.5.344: {}
 
   emoji-regex@10.6.0: {}
@@ -9510,6 +9591,8 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  size-sensor@1.0.3: {}
+
   slash@5.1.0: {}
 
   slice-ansi@7.1.2:
@@ -9656,6 +9739,8 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   tslib@1.14.1: {}
+
+  tslib@2.3.0: {}
 
   tslib@2.8.1: {}
 
@@ -9980,3 +10065,7 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zone.js@0.16.1: {}
+
+  zrender@6.0.0:
+    dependencies:
+      tslib: 2.3.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       lint-staged:
         specifier: ^16.4.0
         version: 16.4.0
+      lucide-react:
+        specifier: ^1.8.0
+        version: 1.8.0(react@19.2.5)
       markdownlint-cli2:
         specifier: ^0.22.1
         version: 0.22.1
@@ -187,6 +190,12 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+
+  packages/@granit/analytics:
+    devDependencies:
+      '@granit/dashboards':
+        specifier: workspace:*
+        version: link:../dashboards
 
   packages/@granit/api-client:
     dependencies:
@@ -641,6 +650,43 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+
+  packages/@granit/react-analytics:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.5
+        version: 5.100.5(react@19.2.5)
+      lucide-react:
+        specifier: ^1.0.0
+        version: 1.8.0(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+    devDependencies:
+      '@granit/analytics':
+        specifier: workspace:*
+        version: link:../analytics
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/dashboards':
+        specifier: workspace:*
+        version: link:../dashboards
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-dashboards':
+        specifier: workspace:*
+        version: link:../react-dashboards
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
 
   packages/@granit/react-api-client:
     dependencies:


### PR DESCRIPTION
## Summary

- Scaffolds **6 framework packages** for dashboard rendering — `@granit/dashboards` + `@granit/react-dashboards` + `@granit/charts` + `@granit/react-charts` + `@granit/analytics` + `@granit/react-analytics` — types, runtime hooks, widget registry, and Apache ECharts-backed chart primitives.
- Mirrors `Granit.Dashboards.Abstractions` + `Granit.Analytics` types exactly (Slug, Position, Size, RequiredPermission, localization keys, full DashboardCategory enum, IsSystem, Version).
- Ships [docs/dashboards-architecture-proposals.md](docs/dashboards-architecture-proposals.md) — consolidated proposals package transmitted to Claude .NET (P1.1-P3.3 + P2.6 react-grid-layout, after a deep audit of ThingsBoard's reference architecture).
- Companion showcase PR: [granit-fx/granit-showcase-admin-react#37](https://github.com/granit-fx/granit-showcase-admin-react/pull/37) renders a live demo via the new stack.

## Packages

| Package | Role |
| --- | --- |
| `@granit/dashboards` | Types — `DashboardDefinition`, `WidgetDefinition` discriminated union, `DashboardLayout`, `DashboardTimeWindow` (P1.3), `WidgetSize` presets |
| `@granit/react-dashboards` | `<Dashboard>` auto-flow grid renderer, `WidgetRegistry` provider + `composeRegistries`, framework widgets (Markdown / Image / Text), `<WidgetCard>` frame, `<WidgetRenderer>` dispatcher, `useEffectiveTimeWindow` hook |
| `@granit/charts` | Framework-agnostic chart primitives — `ChartSeries` types, `buildEChartsTheme()` (Tailwind tokens → registerable theme), `formatAxisTick()` Intl-driven formatters |
| `@granit/react-charts` | Apache ECharts wrapped with modular tree-shaken imports (~250-400 KB tree-shaken). `<Chart options>` escape hatch + typed `<LineChart>` / `<BarChart>` / `<PieChart>` / `<SparklineChart>` + `useEChartsTheme` (Tailwind dark-mode aware) |
| `@granit/analytics` | Types — `MetricResponse` envelope, `KpiWidgetDefinition`, `ChartWidgetDefinition`, `TableWidgetDefinition`, `PivotWidgetDefinition` |
| `@granit/react-analytics` | `useMetric` hook (TanStack Query, refreshHint-driven polling, no-retry-on-4xx via `HttpError`), `KpiTile` widget renderer, `KpiTileView` presentational, locale-aware formatters, default analytics registry |

## Architecture proposals (transmitted to Claude .NET)

The doc is the centerpiece — Claude .NET has the file and is acting on the urgent items.

| Priority | Item | Backend status |
| --- | --- | --- |
| **P1.1 (urgent)** | `[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]` discriminator | Must land before B2 #1453 merges |
| P1.2 | `Fit?` on `ImageWidgetDefinition` (Contain / Cover / Fill) | B1.5 follow-up |
| P1.3 | `DashboardTimeWindow` wrapping the existing `PeriodSpec` | B1.5 follow-up |
| P1.4 | Responsive layouts via per-breakpoint overrides | B1.5 follow-up |
| P1.5 | Declarative `WidgetAction` descriptors (no JS) | B3 #1384 |
| P2.1 | `DashboardView` (renamed from "State" for collision avoidance) + intra-dashboard navigation | B4 #1385 |
| P2.2 | `Datasource` abstraction + per-DataKey formatting | B5 |
| P2.3 | Entity aliases (4 resolver kinds, no RelationGraph for now) | B5 |
| P2.4 | SSE subscriptions — server-side `IMetricStreamProducer` abstraction, two endpoints (per-metric / per-dashboard multiplexed), snapshot+update events, tenant-pinned keying, bounded replay buffer | B6+ dedicated ticket |
| P2.5 | Dashboard-level filters with toolbar exposure | B4.5 |
| P2.6 | `WidgetInstance.Position` for editable persisted dashboards via `react-grid-layout` (lazy, ~33 KB gz only on edit mode) | B6+ dedicated ticket |

Anti-patterns explicitly rejected from ThingsBoard: inline JS in widget config, schemaless `[key: string]: any` blobs, dynamic-URL widget loading, WebSocket-for-everything.

## Test plan

- [ ] `pnpm lint` clean (run on full workspace)
- [ ] `pnpm exec vitest --run` — 2266 / 2266 passing (verified: 53 new tests in the 6 packages, 0 regression on the 2213 baseline)
- [ ] `markdownlint-cli2` clean on `docs/dashboards-architecture-proposals.md`
- [ ] `pnpm exec tsc --noEmit -p packages/@granit/{dashboards,react-dashboards,charts,react-charts,analytics,react-analytics}` — 0 errors per package

## Out of scope (deliberate)

- `ChartTile` / `TableTile` / `PivotTile` widget renderers — wait for query-engine integration (B5).
- `<DashboardEditor>` (react-grid-layout) — wait for `WidgetInstance.Position` on backend (B6+ dedicated ticket).
- Migration of the showcase inline `MetricCard` to `KpiTile` — see follow-up note in companion PR #37.
- Push transport for `realtime` widgets — `useMetric` polls today, switches to SSE when P2.4 endpoint ships.

## Companion branches

- Showcase consumer PR: [granit-fx/granit-showcase-admin-react#37](https://github.com/granit-fx/granit-showcase-admin-react/pull/37)
- granit-dotnet implementation PRs: TBD (Claude .NET is acting on P1.1 first)
