### PR TITLE
feat(react-query-engine): testing helper + /meta MSW handlers across modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
       "yaml": ">=2.8.3",
       "smol-toml": ">=1.6.1",
       "brace-expansion": ">=5.0.5",
-      "protobufjs": "^7.5.5"
+      "protobufjs": "^7.5.5",
+      "msw": "^2.13.6"
     }
   },
   "lint-staged": {

--- a/packages/@granit/react-ai/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { aiWorkspaceQueryMetadata, createAIHandlers } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/ai';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createAIHandlers /meta', () => {
+  it('responds with aiWorkspaceQueryMetadata at /workspaces/meta', async () => {
+    server.use(...createAIHandlers(BASE));
+    const response = await fetch(`${BASE}/workspaces/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(aiWorkspaceQueryMetadata);
+  });
+});

--- a/packages/@granit/react-ai/src/testing/handlers.ts
+++ b/packages/@granit/react-ai/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { BOOLEAN_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { groupBy as groupByField, paginate } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -12,6 +14,106 @@ import type {
 } from '@granit/ai';
 import type { PagedResult, QueryMetadata } from '@granit/query-engine';
 import type { Mutable } from '@granit/testing';
+
+/** Mock /meta payload for the AI workspaces resource. */
+export const aiWorkspaceQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'provider',
+      label: 'Provider',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'model',
+      label: 'Model',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'kind',
+      label: 'Kind',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'activated',
+      label: 'Activated',
+      type: 'Boolean',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'temperature',
+      label: 'Temperature',
+      type: 'Double',
+      order: 5,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'maxOutputTokens',
+      label: 'Max output tokens',
+      type: 'Int32',
+      order: 6,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'provider', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'model', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'kind', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'activated', type: 'Boolean', operators: BOOLEAN_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'provider' },
+    { name: 'model' },
+    { name: 'kind' },
+    { name: 'activated' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'activated', label: 'Activated', isDefault: true },
+    { name: 'deactivated', label: 'Deactivated', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'provider', type: 'String' },
+    { name: 'kind', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'name',
+};
 
 let usageCounter = mockUsageRecords.length;
 
@@ -187,6 +289,11 @@ export function createAIHandlers(baseUrl = '/api/v1/ai') {
   const usageRecords: Mutable<AIUsageRecord>[] = [...mockUsageRecords];
 
   return [
+    // --- Query metadata -------------------------------------------------------
+
+    // GET /workspaces/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/workspaces`, aiWorkspaceQueryMetadata),
+
     // --- Providers -------------------------------------------------------------
 
     // GET all providers

--- a/packages/@granit/react-ai/src/testing/index.ts
+++ b/packages/@granit/react-ai/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockProviderModels, mockProviders, mockUsageRecords, mockWorkspaces } from './data.js';
-export { createAIHandlers } from './handlers.js';
+export { aiWorkspaceQueryMetadata, createAIHandlers } from './handlers.js';

--- a/packages/@granit/react-ai/tsconfig.json
+++ b/packages/@granit/react-ai/tsconfig.json
@@ -4,7 +4,9 @@
     "paths": {
       "@granit/ai": ["../ai/src/index.ts"],
       "@granit/query-engine": ["../query-engine/src/index.ts"],
-      "@granit/types": ["../types/src/index.ts"]
+      "@granit/types": ["../types/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { auditEntryQueryMetadata, createAuditHandlers } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/auditing';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createAuditHandlers /meta', () => {
+  it('responds with auditEntryQueryMetadata at /audit-entries/meta', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(auditEntryQueryMetadata);
+  });
+});

--- a/packages/@granit/react-auditing/src/testing/handlers.ts
+++ b/packages/@granit/react-auditing/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  NUMBER_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { notFound, pagedResponse } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
@@ -6,6 +13,133 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockAuditEntries } from './data.js';
 
 import type { AuditEntry, AuditEntryDetail } from '@granit/auditing';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const AUDIT_CATEGORIES = ['DataMutation', 'ConfigurationChange', 'DataAccess', 'AccessDenied'];
+
+/** Mock /meta payload for the audit-entries resource. */
+export const auditEntryQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'timestamp',
+      label: 'Timestamp',
+      type: 'DateTime',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'userName',
+      label: 'User',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'category',
+      label: 'Category',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'ipAddress',
+      label: 'IP address',
+      type: 'String',
+      order: 4,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'tenantId',
+      label: 'Tenant',
+      type: 'Guid',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'correlationId',
+      label: 'Correlation ID',
+      type: 'String',
+      order: 6,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'entityChangeCount',
+      label: 'Changes',
+      type: 'Int32',
+      order: 7,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'timestamp', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'userName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'userId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'category', type: 'String', operators: ENUM_OPERATORS, enumValues: AUDIT_CATEGORIES },
+    { name: 'ipAddress', type: 'String', operators: STRING_OPERATORS },
+    { name: 'entityType', type: 'String', operators: STRING_OPERATORS },
+    { name: 'entityId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'tenantId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'correlationId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'entityChangeCount', type: 'Int32', operators: NUMBER_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'timestamp' },
+    { name: 'userName' },
+    { name: 'category' },
+    { name: 'entityChangeCount' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [
+    {
+      name: 'timestamp',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: [
+        'Today',
+        'ThisWeek',
+        'ThisMonth',
+        'LastMonth',
+        'ThisQuarter',
+        'ThisYear',
+        'Custom',
+      ],
+    },
+  ],
+  groupByFields: [
+    { name: 'category', type: 'String' },
+    { name: 'userName', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-timestamp',
+};
 
 /**
  * Create stateful MSW handlers for audit log endpoints.
@@ -15,6 +149,9 @@ import type { AuditEntry, AuditEntryDetail } from '@granit/auditing';
 export function createAuditHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const auditEntriesUrl = `${baseUrl}/audit-entries`;
   return [
+    // GET /audit-entries/meta — query metadata
+    createQueryMetaHandler(auditEntriesUrl, auditEntryQueryMetadata),
+
     // GET list — filtered, sorted newest-first, paginated
     http.get(auditEntriesUrl, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-auditing/src/testing/index.ts
+++ b/packages/@granit/react-auditing/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockAuditEntries } from './data.js';
-export { createAuditHandlers } from './handlers.js';
+export { auditEntryQueryMetadata, createAuditHandlers } from './handlers.js';

--- a/packages/@granit/react-auditing/tsconfig.json
+++ b/packages/@granit/react-auditing/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/auditing": ["../auditing/src/index.ts"]
+      "@granit/auditing": ["../auditing/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { apiKeyQueryMetadata, createApiKeyHandlers } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/authentication/api-keys';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createApiKeyHandlers /meta', () => {
+  it('responds with apiKeyQueryMetadata at base/meta', async () => {
+    server.use(...createApiKeyHandlers(BASE));
+    const response = await fetch(`${BASE}/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(apiKeyQueryMetadata);
+  });
+});

--- a/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { notFound, pagedResponse } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -11,6 +13,142 @@ import type {
   ApiKeyResponse,
   ApiKeyUpdateScopesRequest,
 } from '@granit/authentication-api-keys';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const API_KEY_TYPES = ['Secret', 'Publishable', 'Webhook', 'Ephemeral'];
+
+/** Mock /meta payload for the API keys resource. */
+export const apiKeyQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'type',
+      label: 'Type',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'environment',
+      label: 'Environment',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'prefix',
+      label: 'Prefix',
+      type: 'String',
+      order: 4,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastFourChars',
+      label: 'Last 4',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'expiresAt',
+      label: 'Expires at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastUsedAt',
+      label: 'Last used',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'revokedAt',
+      label: 'Revoked at',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 9,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'type', type: 'String', operators: ENUM_OPERATORS, enumValues: API_KEY_TYPES },
+    { name: 'environment', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'prefix', type: 'String', operators: STRING_OPERATORS },
+    { name: 'expiresAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'lastUsedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'revokedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'type' },
+    { name: 'environment' },
+    { name: 'expiresAt' },
+    { name: 'lastUsedAt' },
+    { name: 'revokedAt' },
+    { name: 'createdAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active', isDefault: true },
+    { name: 'revoked', label: 'Revoked', isDefault: false },
+    { name: 'expired', label: 'Expired', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'type', type: 'String' },
+    { name: 'environment', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
 
 type MutableApiKey = { -readonly [K in keyof ApiKeyResponse]: ApiKeyResponse[K] };
 
@@ -38,6 +176,9 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
   const apiKeys: MutableApiKey[] = mockApiKeys.map((k) => ({ ...k }));
 
   return [
+    // GET /api-keys/meta — query metadata
+    createQueryMetaHandler(baseUrl, apiKeyQueryMetadata),
+
     // GET list — paginated with filters
     http.get(baseUrl, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-authentication-api-keys/src/testing/index.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockApiKeys } from './data.js';
-export { createApiKeyHandlers } from './handlers.js';
+export { apiKeyQueryMetadata, createApiKeyHandlers } from './handlers.js';

--- a/packages/@granit/react-authentication-api-keys/tsconfig.json
+++ b/packages/@granit/react-authentication-api-keys/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/authentication-api-keys": ["../authentication-api-keys/src/index.ts"]
+      "@granit/authentication-api-keys": ["../authentication-api-keys/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/packages/@granit/react-background-jobs/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-background-jobs/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { backgroundJobQueryMetadata, createBackgroundJobHandlers } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/background-jobs';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createBackgroundJobHandlers /meta', () => {
+  it('responds with backgroundJobQueryMetadata at /jobs/meta', async () => {
+    server.use(...createBackgroundJobHandlers(BASE));
+    const response = await fetch(`${BASE}/jobs/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(backgroundJobQueryMetadata);
+  });
+});

--- a/packages/@granit/react-background-jobs/src/testing/handlers.ts
+++ b/packages/@granit/react-background-jobs/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  BOOLEAN_OPERATORS,
+  DATE_OPERATORS,
+  NUMBER_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { accepted, noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -7,6 +14,118 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockBackgroundJobs } from './data.js';
 
 import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { QueryMetadata } from '@granit/query-engine';
+
+/** Mock /meta payload for the background jobs resource. */
+export const backgroundJobQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'jobName',
+      label: 'Job name',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'cronExpression',
+      label: 'Schedule',
+      type: 'String',
+      order: 1,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'isEnabled',
+      label: 'Enabled',
+      type: 'Boolean',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastExecutedAt',
+      label: 'Last executed',
+      type: 'DateTime',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'nextExecutionAt',
+      label: 'Next execution',
+      type: 'DateTime',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'consecutiveFailures',
+      label: 'Failures',
+      type: 'Int32',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'deadLetterCount',
+      label: 'Dead-lettered',
+      type: 'Int32',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastError',
+      label: 'Last error',
+      type: 'String',
+      order: 7,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'jobName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'cronExpression', type: 'String', operators: STRING_OPERATORS },
+    { name: 'isEnabled', type: 'Boolean', operators: BOOLEAN_OPERATORS },
+    { name: 'lastExecutedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'nextExecutionAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'consecutiveFailures', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'deadLetterCount', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'lastError', type: 'String', operators: STRING_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'jobName' },
+    { name: 'isEnabled' },
+    { name: 'lastExecutedAt' },
+    { name: 'nextExecutionAt' },
+    { name: 'consecutiveFailures' },
+    { name: 'deadLetterCount' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'enabled', label: 'Enabled', isDefault: true },
+    { name: 'paused', label: 'Paused', isDefault: false },
+    { name: 'failing', label: 'Failing', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'jobName',
+};
 
 /**
  * Create stateful MSW handlers for background job endpoints.
@@ -19,6 +138,9 @@ export function createBackgroundJobHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const jobsUrl = `${baseUrl}/jobs`;
 
   return [
+    // GET /jobs/meta — query metadata
+    createQueryMetaHandler(jobsUrl, backgroundJobQueryMetadata),
+
     // GET list — sorted, paginated
     http.get(jobsUrl, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-background-jobs/src/testing/index.ts
+++ b/packages/@granit/react-background-jobs/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockBackgroundJobs } from './data.js';
-export { createBackgroundJobHandlers } from './handlers.js';
+export { backgroundJobQueryMetadata, createBackgroundJobHandlers } from './handlers.js';

--- a/packages/@granit/react-background-jobs/tsconfig.json
+++ b/packages/@granit/react-background-jobs/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/background-jobs": ["../background-jobs/src/index.ts"]
+      "@granit/background-jobs": ["../background-jobs/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { blobQueryMetadata, createBlobStorageHandlers } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/blob-storage';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createBlobStorageHandlers /meta', () => {
+  it('responds with blobQueryMetadata at /blobs/meta', async () => {
+    server.use(...createBlobStorageHandlers(BASE));
+    const response = await fetch(`${BASE}/blobs/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(blobQueryMetadata);
+  });
+});

--- a/packages/@granit/react-blob-storage/src/testing/handlers.ts
+++ b/packages/@granit/react-blob-storage/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import {
   applyStringFilter,
   groupBy as groupByField,
@@ -13,6 +14,103 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockBlobs, S } from './data.js';
 
 import type { BlobDescriptorResponse, BlobStatusValue } from '@granit/blob-storage';
+import type { QueryMetadata } from '@granit/query-engine';
+
+/** Mock /meta payload for the blobs resource. */
+export const blobQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'originalFileName',
+      label: 'File name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'containerName',
+      label: 'Container',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'declaredContentType',
+      label: 'Content type',
+      type: 'String',
+      order: 3,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'declaredSizeBytes',
+      label: 'Size',
+      type: 'Int64',
+      order: 4,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'Int32',
+      order: 5,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'originalFileName', type: 'String', operators: ['Eq', 'Contains', 'StartsWith'] },
+    { name: 'containerName', type: 'String', operators: ['Eq'] },
+    { name: 'declaredContentType', type: 'String', operators: ['Eq', 'Contains'] },
+  ],
+  sortableFields: [
+    { name: 'originalFileName' },
+    { name: 'containerName' },
+    { name: 'declaredSizeBytes' },
+    { name: 'createdAt' },
+    { name: 'status' },
+  ],
+  presetFilterGroups: [
+    {
+      name: 'status',
+      label: 'Status',
+      presets: [
+        { name: 'valid', label: 'Valid', isDefault: false },
+        { name: 'pending', label: 'Pending', isDefault: false },
+        { name: 'rejected', label: 'Rejected', isDefault: false },
+        { name: 'deleted', label: 'Deleted', isDefault: false },
+      ],
+    },
+  ],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'containerName', type: 'String' },
+    { name: 'status', type: 'Int32' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 50,
+    maxStreamSize: 1000,
+    supportsCursor: false,
+  },
+};
 
 const STATUS_LABELS: Record<BlobStatusValue, string> = {
   0: 'Pending',
@@ -30,102 +128,7 @@ const STATUS_LABELS: Record<BlobStatusValue, string> = {
  */
 export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
-    http.get(`${baseUrl}/blobs/meta`, () => {
-      return HttpResponse.json({
-        columns: [
-          {
-            name: 'originalFileName',
-            label: 'File name',
-            type: 'String',
-            order: 1,
-            isSortable: true,
-            isFilterable: true,
-            isVisible: true,
-          },
-          {
-            name: 'containerName',
-            label: 'Container',
-            type: 'String',
-            order: 2,
-            isSortable: true,
-            isFilterable: true,
-            isVisible: true,
-          },
-          {
-            name: 'declaredContentType',
-            label: 'Content type',
-            type: 'String',
-            order: 3,
-            isSortable: false,
-            isFilterable: true,
-            isVisible: true,
-          },
-          {
-            name: 'declaredSizeBytes',
-            label: 'Size',
-            type: 'Int64',
-            order: 4,
-            isSortable: true,
-            isFilterable: false,
-            isVisible: true,
-          },
-          {
-            name: 'status',
-            label: 'Status',
-            type: 'Int32',
-            order: 5,
-            isSortable: true,
-            isFilterable: false,
-            isVisible: true,
-          },
-          {
-            name: 'createdAt',
-            label: 'Created at',
-            type: 'DateTime',
-            order: 6,
-            isSortable: true,
-            isFilterable: false,
-            isVisible: true,
-          },
-        ],
-        filterableFields: [
-          { name: 'originalFileName', type: 'String', operators: ['Eq', 'Contains', 'StartsWith'] },
-          { name: 'containerName', type: 'String', operators: ['Eq'] },
-          { name: 'declaredContentType', type: 'String', operators: ['Eq', 'Contains'] },
-        ],
-        sortableFields: [
-          { name: 'originalFileName' },
-          { name: 'containerName' },
-          { name: 'declaredSizeBytes' },
-          { name: 'createdAt' },
-          { name: 'status' },
-        ],
-        presetFilterGroups: [
-          {
-            name: 'status',
-            label: 'Status',
-            presets: [
-              { name: 'valid', label: 'Valid', isDefault: false },
-              { name: 'pending', label: 'Pending', isDefault: false },
-              { name: 'rejected', label: 'Rejected', isDefault: false },
-              { name: 'deleted', label: 'Deleted', isDefault: false },
-            ],
-          },
-        ],
-        quickFilters: [],
-        dateFilters: [],
-        groupByFields: [
-          { name: 'containerName', type: 'String' },
-          { name: 'status', type: 'Int32' },
-        ],
-        pagination: {
-          defaultPageSize: 20,
-          maxPageSize: 50,
-          maxStreamSize: 1000,
-          supportsCursor: false,
-        },
-      });
-    }),
+    createQueryMetaHandler(`${baseUrl}/blobs`, blobQueryMetadata),
 
     http.get(`${baseUrl}/blobs`, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-blob-storage/src/testing/index.ts
+++ b/packages/@granit/react-blob-storage/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockBlobs, S } from './data.js';
-export { createBlobStorageHandlers } from './handlers.js';
+export { blobQueryMetadata, createBlobStorageHandlers } from './handlers.js';

--- a/packages/@granit/react-blob-storage/tsconfig.json
+++ b/packages/@granit/react-blob-storage/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "compilerOptions": {
+    "paths": {
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
+    }
+  }
 }

--- a/packages/@granit/react-customer-balance/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-customer-balance/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,23 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  balanceTransactionQueryMetadata,
+  createCustomerBalanceHandlers,
+} from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/customer-balance';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createCustomerBalanceHandlers /meta', () => {
+  it('responds with balanceTransactionQueryMetadata at /transactions/meta', async () => {
+    server.use(...createCustomerBalanceHandlers(BASE));
+    const response = await fetch(`${BASE}/transactions/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(balanceTransactionQueryMetadata);
+  });
+});

--- a/packages/@granit/react-customer-balance/src/testing/handlers.ts
+++ b/packages/@granit/react-customer-balance/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  NUMBER_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
@@ -6,6 +13,141 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { sampleBalance, sampleTransactions } from './data.js';
 
 import type { AdminCreditRequest } from '@granit/customer-balance';
+import type { QueryMetadata } from '@granit/query-engine';
+
+/** Mock /meta payload for the customer balance transactions resource. */
+export const balanceTransactionQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'createdAt',
+      label: 'Date',
+      type: 'DateTime',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'type',
+      label: 'Type',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'amount',
+      label: 'Amount',
+      type: 'Decimal',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'source',
+      label: 'Source',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'reason',
+      label: 'Reason',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'referenceType',
+      label: 'Reference type',
+      type: 'String',
+      order: 6,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'referenceId',
+      label: 'Reference ID',
+      type: 'String',
+      order: 7,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'expiresAt',
+      label: 'Expires at',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'type', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'amount', type: 'Decimal', operators: NUMBER_OPERATORS },
+    { name: 'source', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'reason', type: 'String', operators: STRING_OPERATORS },
+    { name: 'referenceType', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'expiresAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'createdAt' },
+    { name: 'type' },
+    { name: 'amount' },
+    { name: 'source' },
+    { name: 'expiresAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'credits', label: 'Credits', isDefault: false },
+    { name: 'debits', label: 'Debits', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'createdAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: [
+        'Today',
+        'ThisWeek',
+        'ThisMonth',
+        'LastMonth',
+        'ThisQuarter',
+        'ThisYear',
+        'Custom',
+      ],
+    },
+  ],
+  groupByFields: [
+    { name: 'type', type: 'String' },
+    { name: 'source', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
 
 /**
  * Create stateful MSW handlers for customer balance endpoints.
@@ -15,6 +157,9 @@ import type { AdminCreditRequest } from '@granit/customer-balance';
  */
 export function createCustomerBalanceHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
+    // GET /transactions/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/transactions`, balanceTransactionQueryMetadata),
+
     // GET current balance
     http.get(baseUrl, () => {
       return HttpResponse.json(sampleBalance);

--- a/packages/@granit/react-customer-balance/src/testing/index.ts
+++ b/packages/@granit/react-customer-balance/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { sampleBalance, sampleTransactions } from './data.js';
-export { createCustomerBalanceHandlers } from './handlers.js';
+export { balanceTransactionQueryMetadata, createCustomerBalanceHandlers } from './handlers.js';

--- a/packages/@granit/react-customer-balance/tsconfig.json
+++ b/packages/@granit/react-customer-balance/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/customer-balance": ["../customer-balance/src/index.ts"]
+      "@granit/customer-balance": ["../customer-balance/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-data-exchange/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-data-exchange/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,33 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createDataExchangeHandlers,
+  exportJobQueryMetadata,
+  importJobQueryMetadata,
+} from '../testing/index.js';
+
+const METADATA_BASE = 'http://api.test/api/v1/data-exchange/metadata';
+const IMPORT_BASE = 'http://api.test/api/v1/data-exchange/import';
+const EXPORT_JOBS_BASE = 'http://api.test/api/v1/data-exchange/export/jobs';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createDataExchangeHandlers /meta', () => {
+  it('responds with exportJobQueryMetadata at exportJobsBase/meta', async () => {
+    server.use(...createDataExchangeHandlers(METADATA_BASE, IMPORT_BASE, EXPORT_JOBS_BASE));
+    const response = await fetch(`${EXPORT_JOBS_BASE}/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(exportJobQueryMetadata);
+  });
+
+  it('responds with importJobQueryMetadata at importBase/jobs/meta', async () => {
+    server.use(...createDataExchangeHandlers(METADATA_BASE, IMPORT_BASE, EXPORT_JOBS_BASE));
+    const response = await fetch(`${IMPORT_BASE}/jobs/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(importJobQueryMetadata);
+  });
+});

--- a/packages/@granit/react-data-exchange/src/testing/handlers.ts
+++ b/packages/@granit/react-data-exchange/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  NUMBER_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { paginate } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
@@ -6,6 +13,258 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockExportHistory, mockImportHistory } from './data.js';
 
 import type { ExportJobResponse, ImportJobResponse } from '@granit/data-exchange';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const EXPORT_JOB_STATUSES = ['Queued', 'Exporting', 'Completed', 'Failed'];
+const IMPORT_JOB_STATUSES = [
+  'Created',
+  'Previewed',
+  'Mapped',
+  'Executing',
+  'Completed',
+  'PartiallyCompleted',
+  'Failed',
+  'Cancelled',
+];
+
+/** Mock /meta payload for the export jobs resource. */
+export const exportJobQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'definitionName',
+      label: 'Definition',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'format',
+      label: 'Format',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'rowCount',
+      label: 'Rows',
+      type: 'Int32',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'fileName',
+      label: 'File name',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'completedAt',
+      label: 'Completed at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'definitionName', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'format', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: EXPORT_JOB_STATUSES },
+    { name: 'rowCount', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'fileName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'completedAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'definitionName' },
+    { name: 'format' },
+    { name: 'status' },
+    { name: 'rowCount' },
+    { name: 'createdAt' },
+    { name: 'completedAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'completed', label: 'Completed', isDefault: false },
+    { name: 'failed', label: 'Failed', isDefault: false },
+    { name: 'inProgress', label: 'In progress', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'createdAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: ['Today', 'ThisWeek', 'ThisMonth', 'LastMonth', 'Custom'],
+    },
+  ],
+  groupByFields: [
+    { name: 'definitionName', type: 'String' },
+    { name: 'status', type: 'String' },
+    { name: 'format', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
+
+/** Mock /meta payload for the import jobs resource. */
+export const importJobQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'definitionName',
+      label: 'Definition',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'originalFileName',
+      label: 'File name',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'mimeType',
+      label: 'MIME type',
+      type: 'String',
+      order: 3,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'fileSizeBytes',
+      label: 'Size',
+      type: 'Int64',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'completedAt',
+      label: 'Completed at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'definitionName', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'originalFileName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'mimeType', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'fileSizeBytes', type: 'Int64', operators: NUMBER_OPERATORS },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: IMPORT_JOB_STATUSES },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'completedAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'definitionName' },
+    { name: 'originalFileName' },
+    { name: 'fileSizeBytes' },
+    { name: 'status' },
+    { name: 'createdAt' },
+    { name: 'completedAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'completed', label: 'Completed', isDefault: false },
+    { name: 'failed', label: 'Failed', isDefault: false },
+    { name: 'inProgress', label: 'In progress', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'createdAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: ['Today', 'ThisWeek', 'ThisMonth', 'LastMonth', 'Custom'],
+    },
+  ],
+  groupByFields: [
+    { name: 'definitionName', type: 'String' },
+    { name: 'status', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
 
 // ---------------------------------------------------------------------------
 // Static metadata
@@ -318,6 +577,12 @@ export function createDataExchangeHandlers(
   exportJobsBase = `${DEFAULT_BASE_PATH}/export/jobs`
 ) {
   return [
+    // Query metadata: export jobs
+    createQueryMetaHandler(exportJobsBase, exportJobQueryMetadata),
+
+    // Query metadata: import jobs
+    createQueryMetaHandler(`${importBase}/jobs`, importJobQueryMetadata),
+
     // Export: definitions
     http.get(`${metadataBase}/definitions`, () => {
       return HttpResponse.json(mockDefinitions);

--- a/packages/@granit/react-data-exchange/src/testing/index.ts
+++ b/packages/@granit/react-data-exchange/src/testing/index.ts
@@ -3,4 +3,8 @@
 // ---------------------------------------------------------------------------
 
 export { mockExportHistory, mockImportHistory } from './data.js';
-export { createDataExchangeHandlers } from './handlers.js';
+export {
+  createDataExchangeHandlers,
+  exportJobQueryMetadata,
+  importJobQueryMetadata,
+} from './handlers.js';

--- a/packages/@granit/react-data-exchange/tsconfig.json
+++ b/packages/@granit/react-data-exchange/tsconfig.json
@@ -4,7 +4,10 @@
     "paths": {
       "@granit/react-api-client": ["../react-api-client/src/index.ts"],
       "@granit/data-exchange": ["../data-exchange/src/index.ts"],
-      "@granit/utils": ["../utils/src/index.ts"]
+      "@granit/utils": ["../utils/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-identity/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-identity/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,21 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createIdentityHandlers, identityUserQueryMetadata } from '../testing/index.js';
+
+const PROVIDER_BASE = 'http://api.test/api/v1/identity/provider';
+const CACHE_BASE = 'http://api.test/api/v1/identity/users';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createIdentityHandlers /meta', () => {
+  it('responds with identityUserQueryMetadata at cacheBase/meta', async () => {
+    server.use(...createIdentityHandlers(PROVIDER_BASE, CACHE_BASE));
+    const response = await fetch(`${CACHE_BASE}/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(identityUserQueryMetadata);
+  });
+});

--- a/packages/@granit/react-identity/src/testing/handlers.ts
+++ b/packages/@granit/react-identity/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { BOOLEAN_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH, DEFAULT_PROVIDER_BASE_PATH } from '../constants.js';
@@ -5,6 +7,95 @@ import { DEFAULT_BASE_PATH, DEFAULT_PROVIDER_BASE_PATH } from '../constants.js';
 import { mockDevices, mockPasswordChangedAt, mockSessions, mockUsers } from './data.js';
 
 import type { IdentityProviderCapabilities, IdentityUser } from '@granit/identity';
+import type { QueryMetadata } from '@granit/query-engine';
+
+/** Mock /meta payload for the cached identity-users resource. */
+export const identityUserQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'userId',
+      label: 'User ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'username',
+      label: 'Username',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'email',
+      label: 'Email',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'firstName',
+      label: 'First name',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastName',
+      label: 'Last name',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'enabled',
+      label: 'Enabled',
+      type: 'Boolean',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'username', type: 'String', operators: STRING_OPERATORS },
+    { name: 'email', type: 'String', operators: STRING_OPERATORS },
+    { name: 'firstName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'lastName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'enabled', type: 'Boolean', operators: BOOLEAN_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'username' },
+    { name: 'email' },
+    { name: 'firstName' },
+    { name: 'lastName' },
+    { name: 'enabled' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'enabled', label: 'Enabled', isDefault: true },
+    { name: 'disabled', label: 'Disabled', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'username',
+};
 
 // ---------------------------------------------------------------------------
 // Mock role data
@@ -136,6 +227,9 @@ export function createIdentityHandlers(
 ) {
   return [
     // ── Cache endpoints (/identity/users) ───────────────────────────────────
+
+    // GET /identity/users/meta — query metadata
+    createQueryMetaHandler(cacheBase, identityUserQueryMetadata),
 
     http.get(`${cacheBase}/capabilities`, () => {
       return HttpResponse.json(capabilities);

--- a/packages/@granit/react-identity/src/testing/index.ts
+++ b/packages/@granit/react-identity/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockDevices, mockPasswordChangedAt, mockSessions, mockUsers } from './data.js';
-export { createIdentityHandlers } from './handlers.js';
+export { createIdentityHandlers, identityUserQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-identity/tsconfig.json
+++ b/packages/@granit/react-identity/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/identity": ["../identity/src/index.ts"]
+      "@granit/identity": ["../identity/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-invoicing/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-invoicing/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createInvoicingHandlers, invoiceQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/invoicing';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createInvoicingHandlers /meta', () => {
+  it('responds with invoiceQueryMetadata at /invoices/meta', async () => {
+    server.use(...createInvoicingHandlers(BASE));
+    const response = await fetch(`${BASE}/invoices/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(invoiceQueryMetadata);
+  });
+});

--- a/packages/@granit/react-invoicing/src/testing/handlers.ts
+++ b/packages/@granit/react-invoicing/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  NUMBER_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { notFound } from '@granit/testing/msw';
 import { toEntityId } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -7,6 +14,203 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { sampleInvoices } from './data.js';
 
 import type { InvoiceCreateRequest } from '@granit/invoicing';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const INVOICE_DOCUMENT_TYPES = ['Invoice', 'CreditNote'];
+const INVOICE_STATUSES = ['Draft', 'Open', 'Paid', 'Void', 'Uncollectible'];
+const COLLECTION_METHODS = ['ChargeAutomatically', 'SendInvoice'];
+const BILLING_REASONS = [
+  'Subscription',
+  'SubscriptionCreate',
+  'SubscriptionCycle',
+  'SubscriptionUpdate',
+  'Manual',
+  'Upcoming',
+];
+
+/** Mock /meta payload for the invoices resource. */
+export const invoiceQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'invoiceNumber',
+      label: 'Invoice number',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'documentType',
+      label: 'Document type',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'currency',
+      label: 'Currency',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'total',
+      label: 'Total',
+      type: 'Decimal',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'amountRemaining',
+      label: 'Remaining',
+      type: 'Decimal',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'collectionMethod',
+      label: 'Collection method',
+      type: 'String',
+      order: 7,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'billingReason',
+      label: 'Billing reason',
+      type: 'String',
+      order: 8,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'issuedAt',
+      label: 'Issued at',
+      type: 'DateTime',
+      order: 9,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'dueAt',
+      label: 'Due at',
+      type: 'DateTime',
+      order: 10,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'paidAt',
+      label: 'Paid at',
+      type: 'DateTime',
+      order: 11,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'invoiceNumber', type: 'String', operators: STRING_OPERATORS },
+    {
+      name: 'documentType',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: INVOICE_DOCUMENT_TYPES,
+    },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: INVOICE_STATUSES },
+    { name: 'currency', type: 'String', operators: ENUM_OPERATORS },
+    {
+      name: 'collectionMethod',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: COLLECTION_METHODS,
+    },
+    {
+      name: 'billingReason',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: BILLING_REASONS,
+    },
+    { name: 'total', type: 'Decimal', operators: NUMBER_OPERATORS },
+    { name: 'amountRemaining', type: 'Decimal', operators: NUMBER_OPERATORS },
+    { name: 'issuedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'dueAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'paidAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'invoiceNumber' },
+    { name: 'status' },
+    { name: 'total' },
+    { name: 'amountRemaining' },
+    { name: 'issuedAt' },
+    { name: 'dueAt' },
+    { name: 'paidAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'open', label: 'Open', isDefault: true },
+    { name: 'overdue', label: 'Overdue', isDefault: false },
+    { name: 'paid', label: 'Paid', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'issuedAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: [
+        'Today',
+        'ThisWeek',
+        'ThisMonth',
+        'LastMonth',
+        'ThisQuarter',
+        'ThisYear',
+        'Custom',
+      ],
+    },
+  ],
+  groupByFields: [
+    { name: 'status', type: 'String' },
+    { name: 'documentType', type: 'String' },
+    { name: 'currency', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-issuedAt',
+};
 
 /**
  * Create stateful MSW handlers for invoicing endpoints.
@@ -16,6 +220,9 @@ import type { InvoiceCreateRequest } from '@granit/invoicing';
  */
 export function createInvoicingHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
+    // GET /invoices/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/invoices`, invoiceQueryMetadata),
+
     // GET list all invoices
     http.get(`${baseUrl}/invoices`, () => {
       return HttpResponse.json(sampleInvoices);

--- a/packages/@granit/react-invoicing/src/testing/index.ts
+++ b/packages/@granit/react-invoicing/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { sampleInvoiceLineItems, sampleInvoices } from './data.js';
-export { createInvoicingHandlers } from './handlers.js';
+export { createInvoicingHandlers, invoiceQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-invoicing/tsconfig.json
+++ b/packages/@granit/react-invoicing/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/invoicing": ["../invoicing/src/index.ts"]
+      "@granit/invoicing": ["../invoicing/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-localization/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-localization/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createLocalizationHandlers, localizationOverrideQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/localization';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createLocalizationHandlers /meta', () => {
+  it('responds with localizationOverrideQueryMetadata at /overrides/meta', async () => {
+    server.use(...createLocalizationHandlers(BASE));
+    const response = await fetch(`${BASE}/overrides/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(localizationOverrideQueryMetadata);
+  });
+});

--- a/packages/@granit/react-localization/src/testing/handlers.ts
+++ b/packages/@granit/react-localization/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -7,6 +9,104 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { buildMockLocalization, mockLanguages, mockLocalizationOverrides } from './data.js';
 
 import type { LocalizationOverride } from '@granit/localization';
+import type { QueryMetadata } from '@granit/query-engine';
+
+/** Mock /meta payload for the localization overrides resource. */
+export const localizationOverrideQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'resourceName',
+      label: 'Resource',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'cultureName',
+      label: 'Culture',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'key',
+      label: 'Key',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'value',
+      label: 'Value',
+      type: 'String',
+      order: 4,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastModifiedAt',
+      label: 'Modified at',
+      type: 'DateTime',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastModifiedBy',
+      label: 'Modified by',
+      type: 'String',
+      order: 6,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'resourceName', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'cultureName', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'key', type: 'String', operators: STRING_OPERATORS },
+    { name: 'value', type: 'String', operators: STRING_OPERATORS },
+    { name: 'lastModifiedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'lastModifiedBy', type: 'String', operators: STRING_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'resourceName' },
+    { name: 'cultureName' },
+    { name: 'key' },
+    { name: 'lastModifiedAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'resourceName', type: 'String' },
+    { name: 'cultureName', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'key',
+};
 
 /**
  * Create stateful MSW handlers for localization endpoints (languages,
@@ -20,6 +120,9 @@ export function createLocalizationHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const overridesBase = `${baseUrl}/overrides`;
 
   return [
+    // GET /overrides/meta — query metadata
+    createQueryMetaHandler(overridesBase, localizationOverrideQueryMetadata),
+
     // GET /languages — list all languages
     http.get(`${baseUrl}/languages`, () => {
       return HttpResponse.json(languages);

--- a/packages/@granit/react-localization/src/testing/index.ts
+++ b/packages/@granit/react-localization/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { buildMockLocalization, mockLanguages, mockLocalizationOverrides } from './data.js';
-export { createLocalizationHandlers } from './handlers.js';
+export { createLocalizationHandlers, localizationOverrideQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-localization/tsconfig.json
+++ b/packages/@granit/react-localization/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "paths": {
       "@granit/localization": ["../localization/src/index.ts"],
-      "@granit/storage": ["../storage/src/index.ts"]
+      "@granit/storage": ["../storage/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/packages/@granit/react-metering/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-metering/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createMeteringHandlers, meterQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/metering';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createMeteringHandlers /meta', () => {
+  it('responds with meterQueryMetadata at /meters/meta', async () => {
+    server.use(...createMeteringHandlers(BASE));
+    const response = await fetch(`${BASE}/meters/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(meterQueryMetadata);
+  });
+});

--- a/packages/@granit/react-metering/src/testing/handlers.ts
+++ b/packages/@granit/react-metering/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  BOOLEAN_OPERATORS,
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound } from '@granit/testing/msw';
 import { toEntityId } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -7,6 +14,126 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { sampleMeters, sampleQuota, sampleUsage } from './data.js';
 
 import type { MeterDefinitionResponse } from '@granit/metering';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const AGGREGATION_TYPES = ['Sum', 'Count', 'Max', 'Last'];
+
+/** Mock /meta payload for the meters resource. */
+export const meterQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'unit',
+      label: 'Unit',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'aggregationType',
+      label: 'Aggregation',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'activated',
+      label: 'Active',
+      type: 'Boolean',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'tenantId',
+      label: 'Tenant',
+      type: 'Guid',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'modifiedAt',
+      label: 'Modified at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'unit', type: 'String', operators: STRING_OPERATORS },
+    {
+      name: 'aggregationType',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: AGGREGATION_TYPES,
+    },
+    { name: 'activated', type: 'Boolean', operators: BOOLEAN_OPERATORS },
+    { name: 'tenantId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'modifiedAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'unit' },
+    { name: 'aggregationType' },
+    { name: 'activated' },
+    { name: 'createdAt' },
+    { name: 'modifiedAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active', isDefault: true },
+    { name: 'inactive', label: 'Inactive', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'aggregationType', type: 'String' },
+    { name: 'unit', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
 
 /**
  * Create stateful MSW handlers for metering endpoints.
@@ -18,6 +145,9 @@ export function createMeteringHandlers(baseUrl = DEFAULT_BASE_PATH) {
   let meters = [...sampleMeters];
 
   return [
+    // GET /meters/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/meters`, meterQueryMetadata),
+
     // GET list active meters
     http.get(`${baseUrl}/meters`, () => {
       return HttpResponse.json(meters.filter((m) => m.activated));

--- a/packages/@granit/react-metering/src/testing/index.ts
+++ b/packages/@granit/react-metering/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { sampleMeters, sampleQuota, sampleUsage } from './data.js';
-export { createMeteringHandlers } from './handlers.js';
+export { createMeteringHandlers, meterQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-metering/tsconfig.json
+++ b/packages/@granit/react-metering/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/metering": ["../metering/src/index.ts"]
+      "@granit/metering": ["../metering/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-multi-tenancy/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createTenantHandlers, tenantQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/multi-tenancy';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createTenantHandlers /meta', () => {
+  it('responds with tenantQueryMetadata at /tenants/meta', async () => {
+    server.use(...createTenantHandlers(BASE));
+    const response = await fetch(`${BASE}/tenants/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(tenantQueryMetadata);
+  });
+});

--- a/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  STRING_OPERATORS,
+  ENUM_OPERATORS,
+  BOOLEAN_OPERATORS,
+  DATE_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
@@ -6,6 +13,104 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 import { mockTenants } from './data.js';
 
 import type { AdminTenant } from '@granit/multi-tenancy';
+import type { QueryMetadata } from '@granit/query-engine';
+
+/** Mock /meta payload for the tenant resource. */
+export const tenantQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'identifier',
+      label: 'Identifier',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'contactEmail',
+      label: 'Contact email',
+      type: 'String',
+      order: 3,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'isActive',
+      label: 'Active',
+      type: 'Boolean',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'jurisdiction',
+      label: 'Jurisdiction',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'identifier', type: 'String', operators: STRING_OPERATORS },
+    { name: 'contactEmail', type: 'String', operators: STRING_OPERATORS },
+    { name: 'isActive', type: 'Boolean', operators: BOOLEAN_OPERATORS },
+    { name: 'jurisdiction', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'identifier' },
+    { name: 'isActive' },
+    { name: 'createdAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active', isDefault: true },
+    { name: 'inactive', label: 'Inactive', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
 
 /**
  * Create stateful MSW handlers for tenant admin endpoints.
@@ -16,6 +121,9 @@ import type { AdminTenant } from '@granit/multi-tenancy';
  */
 export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
+    // GET /tenants/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/tenants`, tenantQueryMetadata),
+
     // GET /tenants — list all
     http.get(`${baseUrl}/tenants`, () => HttpResponse.json(mockTenants)),
 

--- a/packages/@granit/react-multi-tenancy/src/testing/index.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockTenants } from './data.js';
-export { createTenantHandlers } from './handlers.js';
+export { createTenantHandlers, tenantQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-multi-tenancy/tsconfig.json
+++ b/packages/@granit/react-multi-tenancy/tsconfig.json
@@ -4,7 +4,9 @@
     "paths": {
       "@granit/multi-tenancy": ["../multi-tenancy/src/index.ts"],
       "@granit/api-client": ["../api-client/src/index.ts"],
-      "@granit/testing/msw": ["../testing/src/msw.ts"]
+      "@granit/testing/msw": ["../testing/src/msw.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-notifications/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createNotificationsHandlers, notificationQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createNotificationsHandlers /meta', () => {
+  it('responds with notificationQueryMetadata at /notifications/meta', async () => {
+    server.use(...createNotificationsHandlers(BASE));
+    const response = await fetch(`${BASE}/notifications/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(notificationQueryMetadata);
+  });
+});

--- a/packages/@granit/react-notifications/src/testing/handlers.ts
+++ b/packages/@granit/react-notifications/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound } from '@granit/testing/msw';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -11,7 +13,144 @@ import type {
   UserNotification,
   UserNotificationPage,
 } from '@granit/notifications';
+import type { QueryMetadata } from '@granit/query-engine';
 import type { Mutable } from '@granit/testing';
+
+const NOTIFICATION_SEVERITIES = ['Info', 'Success', 'Warning', 'Error', 'Fatal'];
+const NOTIFICATION_STATES = ['Unread', 'Read'];
+
+/** Mock /meta payload for the user-notifications resource. */
+export const notificationQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'notificationTypeName',
+      label: 'Type',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'severity',
+      label: 'Severity',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'state',
+      label: 'State',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'relatedEntityType',
+      label: 'Related entity',
+      type: 'String',
+      order: 4,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'relatedEntityId',
+      label: 'Related id',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'recipientUserId',
+      label: 'Recipient',
+      type: 'Guid',
+      order: 6,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'readAt',
+      label: 'Read at',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'notificationTypeName', type: 'String', operators: STRING_OPERATORS },
+    {
+      name: 'severity',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: NOTIFICATION_SEVERITIES,
+    },
+    { name: 'state', type: 'String', operators: ENUM_OPERATORS, enumValues: NOTIFICATION_STATES },
+    { name: 'relatedEntityType', type: 'String', operators: STRING_OPERATORS },
+    { name: 'relatedEntityId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'recipientUserId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'readAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'notificationTypeName' },
+    { name: 'severity' },
+    { name: 'state' },
+    { name: 'createdAt' },
+    { name: 'readAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'unread', label: 'Unread', isDefault: true },
+    { name: 'read', label: 'Read', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'createdAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: ['Today', 'ThisWeek', 'ThisMonth', 'LastMonth', 'Custom'],
+    },
+  ],
+  groupByFields: [
+    { name: 'severity', type: 'String' },
+    { name: 'notificationTypeName', type: 'String' },
+    { name: 'state', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
 
 /**
  * Create stateful MSW handlers for notification endpoints.
@@ -25,6 +164,9 @@ export function createNotificationsHandlers(baseUrl = API_BASE_PATH) {
   let preferences: Mutable<NotificationPreference>[] = [...mockNotificationPreferences];
 
   return [
+    // GET /notifications/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/notifications`, notificationQueryMetadata),
+
     // SSE stream — open connection that sends a heartbeat comment
     http.get(`${baseUrl}/notifications/stream`, () => {
       const stream = new ReadableStream({

--- a/packages/@granit/react-notifications/src/testing/index.ts
+++ b/packages/@granit/react-notifications/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockNotificationPreferences, mockNotifications } from './data.js';
-export { createNotificationsHandlers } from './handlers.js';
+export { createNotificationsHandlers, notificationQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-notifications/tsconfig.json
+++ b/packages/@granit/react-notifications/tsconfig.json
@@ -5,7 +5,9 @@
       "@granit/notifications": ["../notifications/src/index.ts"],
       "@granit/query-engine": ["../query-engine/src/index.ts"],
       "@granit/react-query-engine": ["../react-query-engine/src/index.ts"],
-      "@granit/api-client/test-utils": ["../api-client/src/test-utils.ts"]
+      "@granit/api-client/test-utils": ["../api-client/src/test-utils.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-openiddict-admin/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,47 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  adminUserQueryMetadata,
+  createOpenIddictAdminHandlers,
+  oidcApplicationQueryMetadata,
+  oidcAuthorizationQueryMetadata,
+  oidcScopeQueryMetadata,
+} from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/admin';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createOpenIddictAdminHandlers /meta', () => {
+  it('responds with adminUserQueryMetadata at /users/meta', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/users/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(adminUserQueryMetadata);
+  });
+
+  it('responds with oidcApplicationQueryMetadata at /oidc/applications/meta', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/applications/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(oidcApplicationQueryMetadata);
+  });
+
+  it('responds with oidcScopeQueryMetadata at /oidc/scopes/meta', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/scopes/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(oidcScopeQueryMetadata);
+  });
+
+  it('responds with oidcAuthorizationQueryMetadata at /oidc/authorizations/meta', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/authorizations/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(oidcAuthorizationQueryMetadata);
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { BOOLEAN_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
@@ -11,6 +13,294 @@ import {
 } from './data.js';
 
 import type { AdminOidcApplication, AdminOidcScope } from '@granit/openiddict-admin';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const OIDC_APPLICATION_TYPES = ['public', 'confidential'];
+const OIDC_AUTHORIZATION_STATUSES = ['valid', 'revoked', 'inactive'];
+const OIDC_AUTHORIZATION_TYPES = ['permanent', 'ad-hoc'];
+
+/** Mock /meta payload for the admin users resource. */
+export const adminUserQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'userId',
+      label: 'User ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'username',
+      label: 'Username',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'email',
+      label: 'Email',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'firstName',
+      label: 'First name',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastName',
+      label: 'Last name',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'enabled',
+      label: 'Enabled',
+      type: 'Boolean',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'username', type: 'String', operators: STRING_OPERATORS },
+    { name: 'email', type: 'String', operators: STRING_OPERATORS },
+    { name: 'firstName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'lastName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'enabled', type: 'Boolean', operators: BOOLEAN_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'username' },
+    { name: 'email' },
+    { name: 'firstName' },
+    { name: 'lastName' },
+    { name: 'enabled' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'enabled', label: 'Enabled', isDefault: true },
+    { name: 'disabled', label: 'Disabled', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'username',
+};
+
+/** Mock /meta payload for the OIDC applications resource. */
+export const oidcApplicationQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'clientId',
+      label: 'Client ID',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'displayName',
+      label: 'Display name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'type',
+      label: 'Type',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'tenantId',
+      label: 'Tenant',
+      type: 'Guid',
+      order: 3,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'clientId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'displayName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'type', type: 'String', operators: ENUM_OPERATORS, enumValues: OIDC_APPLICATION_TYPES },
+    { name: 'tenantId', type: 'Guid', operators: ENUM_OPERATORS },
+  ],
+  sortableFields: [{ name: 'clientId' }, { name: 'displayName' }, { name: 'type' }],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [{ name: 'type', type: 'String' }],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'clientId',
+};
+
+/** Mock /meta payload for the OIDC scopes resource. */
+export const oidcScopeQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'displayName',
+      label: 'Display name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'description',
+      label: 'Description',
+      type: 'String',
+      order: 2,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'displayName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'description', type: 'String', operators: STRING_OPERATORS },
+  ],
+  sortableFields: [{ name: 'name' }, { name: 'displayName' }],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'name',
+};
+
+/** Mock /meta payload for the OIDC authorizations resource. */
+export const oidcAuthorizationQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'subject',
+      label: 'Subject',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'clientId',
+      label: 'Client ID',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'type',
+      label: 'Type',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'subject', type: 'String', operators: STRING_OPERATORS },
+    { name: 'clientId', type: 'String', operators: STRING_OPERATORS },
+    {
+      name: 'status',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: OIDC_AUTHORIZATION_STATUSES,
+    },
+    {
+      name: 'type',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: OIDC_AUTHORIZATION_TYPES,
+    },
+  ],
+  sortableFields: [{ name: 'subject' }, { name: 'clientId' }, { name: 'status' }, { name: 'type' }],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'valid', label: 'Valid', isDefault: true },
+    { name: 'revoked', label: 'Revoked', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'status', type: 'String' },
+    { name: 'type', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'subject',
+};
 
 /**
  * Create stateful MSW handlers for OpenIddict admin endpoints.
@@ -20,6 +310,13 @@ import type { AdminOidcApplication, AdminOidcScope } from '@granit/openiddict-ad
  */
 export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
+    // ── Query metadata ───────────────────────────────────────────────────────
+
+    createQueryMetaHandler(`${baseUrl}/users`, adminUserQueryMetadata),
+    createQueryMetaHandler(`${baseUrl}/oidc/applications`, oidcApplicationQueryMetadata),
+    createQueryMetaHandler(`${baseUrl}/oidc/scopes`, oidcScopeQueryMetadata),
+    createQueryMetaHandler(`${baseUrl}/oidc/authorizations`, oidcAuthorizationQueryMetadata),
+
     // ── Users ────────────────────────────────────────────────────────────────
 
     http.get(`${baseUrl}/users`, ({ request }) => {

--- a/packages/@granit/react-openiddict-admin/src/testing/index.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/index.ts
@@ -8,4 +8,10 @@ export {
   mockOidcAuthorizations,
   mockOidcScopes,
 } from './data.js';
-export { createOpenIddictAdminHandlers } from './handlers.js';
+export {
+  adminUserQueryMetadata,
+  createOpenIddictAdminHandlers,
+  oidcApplicationQueryMetadata,
+  oidcAuthorizationQueryMetadata,
+  oidcScopeQueryMetadata,
+} from './handlers.js';

--- a/packages/@granit/react-openiddict-admin/tsconfig.json
+++ b/packages/@granit/react-openiddict-admin/tsconfig.json
@@ -3,7 +3,9 @@
   "compilerOptions": {
     "paths": {
       "@granit/openiddict-admin": ["../openiddict-admin/src/index.ts"],
-      "@granit/testing/msw": ["../testing/src/msw.ts"]
+      "@granit/testing/msw": ["../testing/src/msw.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-parties/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-parties/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPartiesHandlers, partyQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/parties';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createPartiesHandlers /meta', () => {
+  it('responds with partyQueryMetadata at /meta', async () => {
+    server.use(...createPartiesHandlers(BASE));
+    const response = await fetch(`${BASE}/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(partyQueryMetadata);
+  });
+});

--- a/packages/@granit/react-parties/src/testing/handlers.ts
+++ b/packages/@granit/react-parties/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { toEntityId } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
@@ -27,8 +29,135 @@ import type {
   PartyTaxStatusRequest,
   PartyUpdateRequest,
 } from '@granit/parties';
+import type { QueryMetadata } from '@granit/query-engine';
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+
+const PARTY_KINDS = ['Individual', 'Company', 'Department'];
+const PARTY_STATUSES = ['Active', 'Suspended', 'Archived'];
+const PARTY_ROLES = ['None', 'Customer', 'Supplier', 'Employee', 'Lead'];
+
+/** Mock /meta payload for the parties resource. */
+export const partyQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'kind',
+      label: 'Kind',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'roles',
+      label: 'Roles',
+      type: 'String',
+      order: 3,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'defaultCurrency',
+      label: 'Currency',
+      type: 'String',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'primaryEmail',
+      label: 'Primary email',
+      type: 'String',
+      order: 6,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'primaryPhone',
+      label: 'Primary phone',
+      type: 'String',
+      order: 7,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'tenantId',
+      label: 'Tenant',
+      type: 'Guid',
+      order: 8,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'kind', type: 'String', operators: ENUM_OPERATORS, enumValues: PARTY_KINDS },
+    { name: 'roles', type: 'String', operators: ENUM_OPERATORS, enumValues: PARTY_ROLES },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: PARTY_STATUSES },
+    { name: 'defaultCurrency', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'primaryEmail', type: 'String', operators: STRING_OPERATORS },
+    { name: 'primaryPhone', type: 'String', operators: STRING_OPERATORS },
+    { name: 'tenantId', type: 'Guid', operators: ENUM_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'kind' },
+    { name: 'status' },
+    { name: 'defaultCurrency' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active', isDefault: true },
+    { name: 'suspended', label: 'Suspended', isDefault: false },
+    { name: 'archived', label: 'Archived', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'kind', type: 'String' },
+    { name: 'status', type: 'String' },
+    { name: 'defaultCurrency', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'name',
+};
 
 let createCounter = 1000;
 let subEntityCounter = 1000;
@@ -55,6 +184,9 @@ function notFound() {
  */
 export function createPartiesHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
+    // ── GET /meta — query metadata ───────────────────────────────────
+    createQueryMetaHandler(baseUrl, partyQueryMetadata),
+
     // ── GET list ─────────────────────────────────────────────────────
     http.get(baseUrl, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-parties/src/testing/index.ts
+++ b/packages/@granit/react-parties/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { sampleDuplicates, sampleParties, sampleParty, samplePartyId, toListItem } from './data.js';
-export { createPartiesHandlers } from './handlers.js';
+export { createPartiesHandlers, partyQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-parties/tsconfig.json
+++ b/packages/@granit/react-parties/tsconfig.json
@@ -3,7 +3,10 @@
   "compilerOptions": {
     "paths": {
       "@granit/parties": ["../parties/src/index.ts"],
-      "@granit/react-query-engine": ["../react-query-engine/src/index.ts"]
+      "@granit/react-query-engine": ["../react-query-engine/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-payments/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-payments/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createPaymentsHandlers, paymentTransactionQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/payments';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createPaymentsHandlers /meta', () => {
+  it('responds with paymentTransactionQueryMetadata at /transactions/meta', async () => {
+    server.use(...createPaymentsHandlers(BASE));
+    const response = await fetch(`${BASE}/transactions/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(paymentTransactionQueryMetadata);
+  });
+});

--- a/packages/@granit/react-payments/src/testing/handlers.ts
+++ b/packages/@granit/react-payments/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  NUMBER_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -18,7 +25,166 @@ import type {
   PaymentCheckoutRequest,
   PaymentRefundRequest,
 } from '@granit/payments';
+import type { QueryMetadata } from '@granit/query-engine';
 import type { CurrencyCode } from '@granit/types';
+
+const PAYMENT_STATUSES = [
+  'Pending',
+  'Processing',
+  'Succeeded',
+  'Failed',
+  'Canceled',
+  'RequiresAction',
+];
+
+/** Mock /meta payload for the payment transactions resource. */
+export const paymentTransactionQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'invoiceId',
+      label: 'Invoice',
+      type: 'Guid',
+      order: 1,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'amount',
+      label: 'Amount',
+      type: 'Decimal',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'currency',
+      label: 'Currency',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'providerName',
+      label: 'Provider',
+      type: 'String',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'providerTransactionId',
+      label: 'Provider txn',
+      type: 'String',
+      order: 6,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'succeededAt',
+      label: 'Succeeded at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'canceledAt',
+      label: 'Canceled at',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'tenantId',
+      label: 'Tenant',
+      type: 'Guid',
+      order: 9,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'invoiceId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'amount', type: 'Decimal', operators: NUMBER_OPERATORS },
+    { name: 'currency', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: PAYMENT_STATUSES },
+    { name: 'providerName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'providerTransactionId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'failureCode', type: 'String', operators: STRING_OPERATORS },
+    { name: 'succeededAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'canceledAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'tenantId', type: 'Guid', operators: ENUM_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'amount' },
+    { name: 'currency' },
+    { name: 'status' },
+    { name: 'providerName' },
+    { name: 'succeededAt' },
+    { name: 'canceledAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'succeeded', label: 'Succeeded', isDefault: false },
+    { name: 'failed', label: 'Failed', isDefault: false },
+    { name: 'pending', label: 'Pending', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'succeededAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: [
+        'Today',
+        'ThisWeek',
+        'ThisMonth',
+        'LastMonth',
+        'ThisQuarter',
+        'ThisYear',
+        'Custom',
+      ],
+    },
+  ],
+  groupByFields: [
+    { name: 'status', type: 'String' },
+    { name: 'providerName', type: 'String' },
+    { name: 'currency', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-succeededAt',
+};
 
 /**
  * Create stateful MSW handlers for payments endpoints.
@@ -28,6 +194,9 @@ import type { CurrencyCode } from '@granit/types';
  */
 export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
+    // GET /transactions/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/transactions`, paymentTransactionQueryMetadata),
+
     // GET all transactions
     http.get(`${baseUrl}/transactions`, () => {
       return HttpResponse.json(sampleTransactions);

--- a/packages/@granit/react-payments/src/testing/index.ts
+++ b/packages/@granit/react-payments/src/testing/index.ts
@@ -9,4 +9,4 @@ export {
   sampleRefunds,
   sampleTransactions,
 } from './data.js';
-export { createPaymentsHandlers } from './handlers.js';
+export { createPaymentsHandlers, paymentTransactionQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-payments/tsconfig.json
+++ b/packages/@granit/react-payments/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/payments": ["../payments/src/index.ts"]
+      "@granit/payments": ["../payments/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-privacy/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-privacy/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,39 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createPrivacyHandlers,
+  legalDocumentQueryMetadata,
+  privacyDeletionQueryMetadata,
+  privacyExportQueryMetadata,
+} from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/privacy';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createPrivacyHandlers /meta', () => {
+  it('responds with privacyExportQueryMetadata at /exports/meta', async () => {
+    server.use(...createPrivacyHandlers(BASE));
+    const response = await fetch(`${BASE}/exports/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(privacyExportQueryMetadata);
+  });
+
+  it('responds with privacyDeletionQueryMetadata at /deletions/meta', async () => {
+    server.use(...createPrivacyHandlers(BASE));
+    const response = await fetch(`${BASE}/deletions/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(privacyDeletionQueryMetadata);
+  });
+
+  it('responds with legalDocumentQueryMetadata at /legal-documents/meta', async () => {
+    server.use(...createPrivacyHandlers(BASE));
+    const response = await fetch(`${BASE}/legal-documents/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(legalDocumentQueryMetadata);
+  });
+});

--- a/packages/@granit/react-privacy/src/testing/handlers.ts
+++ b/packages/@granit/react-privacy/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
@@ -21,6 +23,292 @@ import type {
   PrivacyDeletionResponse,
   PrivacyExportStatusResponse,
 } from '@granit/privacy';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const EXPORT_STATES = ['Pending', 'Completed', 'PartiallyCompleted', 'TimedOut'];
+const DELETION_STATES = ['Deferred', 'Executed', 'Cancelled'];
+const LEGAL_LIFECYCLE_STATES = ['Draft', 'Published', 'Archived'];
+
+/** Mock /meta payload for the privacy exports resource. */
+export const privacyExportQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'requestId',
+      label: 'Request ID',
+      type: 'String',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'requestedAt',
+      label: 'Requested at',
+      type: 'DateTime',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'state',
+      label: 'State',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'completedAt',
+      label: 'Completed at',
+      type: 'DateTime',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'archiveBlobReferenceId',
+      label: 'Archive',
+      type: 'String',
+      order: 4,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'requestedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'state', type: 'String', operators: ENUM_OPERATORS, enumValues: EXPORT_STATES },
+    { name: 'completedAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [{ name: 'requestedAt' }, { name: 'state' }, { name: 'completedAt' }],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [
+    {
+      name: 'requestedAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: ['Today', 'ThisWeek', 'ThisMonth', 'LastMonth', 'ThisYear', 'Custom'],
+    },
+  ],
+  groupByFields: [{ name: 'state', type: 'String' }],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-requestedAt',
+};
+
+/** Mock /meta payload for the privacy deletions resource. */
+export const privacyDeletionQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'requestId',
+      label: 'Request ID',
+      type: 'String',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'reason',
+      label: 'Reason',
+      type: 'String',
+      order: 2,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'requestedAt',
+      label: 'Requested at',
+      type: 'DateTime',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'executedAt',
+      label: 'Executed at',
+      type: 'DateTime',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'scheduledDeletionAt',
+      label: 'Scheduled at',
+      type: 'DateTime',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'cancelledAt',
+      label: 'Cancelled at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: DELETION_STATES },
+    { name: 'reason', type: 'String', operators: STRING_OPERATORS },
+    { name: 'requestedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'executedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'scheduledDeletionAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'cancelledAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'status' },
+    { name: 'requestedAt' },
+    { name: 'executedAt' },
+    { name: 'scheduledDeletionAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [
+    {
+      name: 'requestedAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: ['Today', 'ThisWeek', 'ThisMonth', 'LastMonth', 'ThisYear', 'Custom'],
+    },
+  ],
+  groupByFields: [{ name: 'status', type: 'String' }],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-requestedAt',
+};
+
+/** Mock /meta payload for the legal-documents admin resource. */
+export const legalDocumentQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'String',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'documentId',
+      label: 'Document',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'displayName',
+      label: 'Display name',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'version',
+      label: 'Version',
+      type: 'Int32',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lifecycleStatus',
+      label: 'Status',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastModifiedAt',
+      label: 'Modified at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'documentId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'displayName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'version', type: 'Int32', operators: ENUM_OPERATORS },
+    {
+      name: 'lifecycleStatus',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: LEGAL_LIFECYCLE_STATES,
+    },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'lastModifiedAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'documentId' },
+    { name: 'displayName' },
+    { name: 'version' },
+    { name: 'lifecycleStatus' },
+    { name: 'createdAt' },
+    { name: 'lastModifiedAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'draft', label: 'Drafts', isDefault: false },
+    { name: 'published', label: 'Published', isDefault: true },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'lifecycleStatus', type: 'String' },
+    { name: 'documentId', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-lastModifiedAt',
+};
 
 type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 
@@ -48,6 +336,15 @@ export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const legalBase = `${baseUrl}/legal-documents`;
 
   return [
+    // GET /exports/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/exports`, privacyExportQueryMetadata),
+
+    // GET /deletions/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/deletions`, privacyDeletionQueryMetadata),
+
+    // GET /legal-documents/meta — query metadata
+    createQueryMetaHandler(legalBase, legalDocumentQueryMetadata),
+
     // POST /exports — request a new data export
     http.post(`${baseUrl}/exports`, () => {
       exportCounter++;

--- a/packages/@granit/react-privacy/src/testing/index.ts
+++ b/packages/@granit/react-privacy/src/testing/index.ts
@@ -10,4 +10,9 @@ export {
   mockLegalDocumentDetails,
   mockLegalDocuments,
 } from './data.js';
-export { createPrivacyHandlers } from './handlers.js';
+export {
+  createPrivacyHandlers,
+  legalDocumentQueryMetadata,
+  privacyDeletionQueryMetadata,
+  privacyExportQueryMetadata,
+} from './handlers.js';

--- a/packages/@granit/react-privacy/tsconfig.json
+++ b/packages/@granit/react-privacy/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/privacy": ["../privacy/src/index.ts"]
+      "@granit/privacy": ["../privacy/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/packages/@granit/react-query-engine/package.json
+++ b/packages/@granit/react-query-engine/package.json
@@ -4,7 +4,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"
@@ -19,10 +20,14 @@
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "axios": "*",
+    "msw": "^2.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    },
     "@tanstack/react-virtual": {
       "optional": true
     }
@@ -32,6 +37,10 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"

--- a/packages/@granit/react-query-engine/src/__tests__/testing.test.ts
+++ b/packages/@granit/react-query-engine/src/__tests__/testing.test.ts
@@ -1,0 +1,82 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { buildEmptyQueryMeta, createQueryMetaHandler } from '../testing/index.js';
+
+import type { QueryMetadata } from '@granit/query-engine';
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const BASE_URL = 'http://api.example.test/api/v1/widgets';
+
+describe('createQueryMetaHandler', () => {
+  it('responds to GET {basePath}/meta with the provided metadata', async () => {
+    const metadata: QueryMetadata = buildEmptyQueryMeta({
+      columns: [
+        {
+          name: 'id',
+          label: 'ID',
+          type: 'Guid',
+          order: 0,
+          isSortable: true,
+          isFilterable: true,
+          isVisible: true,
+        },
+      ],
+      sortableFields: [{ name: 'id' }],
+    });
+
+    server.use(createQueryMetaHandler(BASE_URL, metadata));
+
+    const response = await fetch(`${BASE_URL}/meta`);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(metadata);
+  });
+
+  it('does not match unrelated paths', async () => {
+    server.use(createQueryMetaHandler(BASE_URL, buildEmptyQueryMeta()));
+
+    const result = await fetch('http://api.example.test/api/v1/other/meta').catch((e: Error) => e);
+
+    expect(result).toBeInstanceOf(Error);
+  });
+});
+
+describe('buildEmptyQueryMeta', () => {
+  it('returns a structurally valid empty QueryMetadata', () => {
+    const meta = buildEmptyQueryMeta();
+
+    expect(meta.columns).toEqual([]);
+    expect(meta.filterableFields).toEqual([]);
+    expect(meta.sortableFields).toEqual([]);
+    expect(meta.presetFilterGroups).toEqual([]);
+    expect(meta.quickFilters).toEqual([]);
+    expect(meta.dateFilters).toEqual([]);
+    expect(meta.groupByFields).toEqual([]);
+    expect(meta.pagination.defaultPageSize).toBeGreaterThan(0);
+    expect(meta.pagination.maxPageSize).toBeGreaterThanOrEqual(meta.pagination.defaultPageSize);
+  });
+
+  it('merges overrides over the defaults', () => {
+    const meta = buildEmptyQueryMeta({
+      defaultSort: '-createdAt',
+      pagination: {
+        defaultPageSize: 50,
+        maxPageSize: 200,
+        maxStreamSize: 50_000,
+        supportsCursor: true,
+      },
+    });
+
+    expect(meta.defaultSort).toBe('-createdAt');
+    expect(meta.pagination.defaultPageSize).toBe(50);
+    expect(meta.pagination.supportsCursor).toBe(true);
+    // Other defaults remain in place.
+    expect(meta.filterableFields).toEqual([]);
+  });
+});

--- a/packages/@granit/react-query-engine/src/testing/index.ts
+++ b/packages/@granit/react-query-engine/src/testing/index.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// @granit/react-query-engine/testing — MSW handler factory for /meta endpoints
+// ---------------------------------------------------------------------------
+
+import { http, HttpResponse } from 'msw';
+
+import type { QueryMetadata } from '@granit/query-engine';
+import type { RequestHandler } from 'msw';
+
+/**
+ * Create an MSW handler that responds to `GET {basePath}/meta` with the
+ * provided {@link QueryMetadata}.
+ *
+ * Every queryable Granit resource exposes a `/meta` endpoint describing its
+ * columns, filterable/sortable fields, presets, quick filters and pagination
+ * defaults. `useSmartFilter` and `useQueryMeta` consume it directly — without
+ * a registered handler, list pages crash with
+ * `metadata.filterableFields is not iterable`.
+ *
+ * @param basePath - Resource base path, **without** the trailing `/meta`
+ *                   (e.g. `/api/v1/multi-tenancy/tenants`).
+ * @param metadata - The metadata payload to return.
+ */
+export function createQueryMetaHandler(basePath: string, metadata: QueryMetadata): RequestHandler {
+  return http.get(`${basePath}/meta`, () => HttpResponse.json(metadata));
+}
+
+/**
+ * Build a minimal {@link QueryMetadata} stub.
+ *
+ * Returns an empty-but-valid metadata object suitable for tests that need a
+ * `/meta` response shape but do not care about the contents.
+ *
+ * @param overrides - Partial metadata to merge over the empty defaults.
+ */
+export function buildEmptyQueryMeta(overrides?: Partial<QueryMetadata>): QueryMetadata {
+  return {
+    columns: [],
+    filterableFields: [],
+    sortableFields: [],
+    presetFilterGroups: [],
+    quickFilters: [],
+    dateFilters: [],
+    groupByFields: [],
+    pagination: {
+      defaultPageSize: 25,
+      maxPageSize: 100,
+      maxStreamSize: 10_000,
+      supportsCursor: false,
+    },
+    ...overrides,
+  };
+}

--- a/packages/@granit/react-query-engine/tsup.config.ts
+++ b/packages/@granit/react-query-engine/tsup.config.ts
@@ -1,3 +1,6 @@
 import { createTsupConfig } from '../../../tsup.preset';
 
-export default createTsupConfig();
+export default createTsupConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  external: [/^@granit\//, 'msw'],
+});

--- a/packages/@granit/react-scheduling/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-scheduling/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createSchedulingHandlers, scheduledActionQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/scheduling';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createSchedulingHandlers /meta', () => {
+  it('responds with scheduledActionQueryMetadata at /scheduled-actions/meta', async () => {
+    server.use(...createSchedulingHandlers(BASE));
+    const response = await fetch(`${BASE}/scheduled-actions/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(scheduledActionQueryMetadata);
+  });
+});

--- a/packages/@granit/react-scheduling/src/testing/handlers.ts
+++ b/packages/@granit/react-scheduling/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { DATE_OPERATORS, NUMBER_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { ScheduledActionStatus } from '@granit/scheduling';
 import {
   applyDateFilter,
@@ -15,8 +17,155 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 
 import { mockScheduledActions } from './data.js';
 
-import type { PagedResult } from '@granit/query-engine';
+import type { PagedResult, QueryMetadata } from '@granit/query-engine';
 import type { ScheduledActionResponse } from '@granit/scheduling';
+
+/** Mock /meta payload for the scheduled-actions resource. */
+export const scheduledActionQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'payloadType',
+      label: 'Payload type',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'Int32',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'executeAt',
+      label: 'Execute at',
+      type: 'DateTime',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'executedAt',
+      label: 'Executed at',
+      type: 'DateTime',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'correlationId',
+      label: 'Correlation ID',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'cancelledBy',
+      label: 'Cancelled by',
+      type: 'String',
+      order: 6,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'failureReason',
+      label: 'Failure reason',
+      type: 'String',
+      order: 7,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'payloadType', type: 'String', operators: STRING_OPERATORS },
+    { name: 'status', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'executeAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'executedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'correlationId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'cancelledBy', type: 'String', operators: STRING_OPERATORS },
+    { name: 'failureReason', type: 'String', operators: STRING_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'payloadType' },
+    { name: 'status' },
+    { name: 'executeAt' },
+    { name: 'executedAt' },
+    { name: 'createdAt' },
+  ],
+  presetFilterGroups: [
+    {
+      name: 'status',
+      label: 'Status',
+      presets: [
+        { name: 'pending', label: 'Pending', isDefault: true },
+        { name: 'processing', label: 'Processing', isDefault: false },
+        { name: 'executed', label: 'Executed', isDefault: false },
+        { name: 'cancelled', label: 'Cancelled', isDefault: false },
+        { name: 'failed', label: 'Failed', isDefault: false },
+      ],
+    },
+  ],
+  quickFilters: [
+    { name: 'pending', label: 'Pending', isDefault: true },
+    { name: 'failed', label: 'Failed', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'executeAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: [
+        'Today',
+        'ThisWeek',
+        'ThisMonth',
+        'LastMonth',
+        'ThisQuarter',
+        'ThisYear',
+        'Custom',
+      ],
+    },
+  ],
+  groupByFields: [
+    { name: 'status', type: 'Int32' },
+    { name: 'payloadType', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-executeAt',
+};
 
 const statusPresetMap: Record<string, ScheduledActionStatus> = {
   pending: ScheduledActionStatus.Pending,
@@ -36,6 +185,9 @@ export function createSchedulingHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const actionsUrl = `${baseUrl}/scheduled-actions`;
 
   return [
+    // GET /scheduled-actions/meta — query metadata
+    createQueryMetaHandler(actionsUrl, scheduledActionQueryMetadata),
+
     // GET list — supports @granit/query-engine serialized params
     http.get(actionsUrl, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-scheduling/src/testing/index.ts
+++ b/packages/@granit/react-scheduling/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockScheduledActions } from './data.js';
-export { createSchedulingHandlers } from './handlers.js';
+export { createSchedulingHandlers, scheduledActionQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-scheduling/tsconfig.json
+++ b/packages/@granit/react-scheduling/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/scheduling": ["../scheduling/src/index.ts"]
+      "@granit/scheduling": ["../scheduling/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/packages/@granit/react-subscriptions/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-subscriptions/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,31 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  createSubscriptionsHandlers,
+  planQueryMetadata,
+  subscriptionQueryMetadata,
+} from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/subscriptions';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createSubscriptionsHandlers /meta', () => {
+  it('responds with planQueryMetadata at /plans/meta', async () => {
+    server.use(...createSubscriptionsHandlers(BASE));
+    const response = await fetch(`${BASE}/plans/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(planQueryMetadata);
+  });
+
+  it('responds with subscriptionQueryMetadata at /subscriptions/meta', async () => {
+    server.use(...createSubscriptionsHandlers(BASE));
+    const response = await fetch(`${BASE}/subscriptions/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(subscriptionQueryMetadata);
+  });
+});

--- a/packages/@granit/react-subscriptions/src/testing/handlers.ts
+++ b/packages/@granit/react-subscriptions/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  NUMBER_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -6,6 +13,7 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 
 import { mockPlans, mockPriceHistory, mockSeats, mockSubscriptions } from './data.js';
 
+import type { QueryMetadata } from '@granit/query-engine';
 import type {
   PlanCreateRequest,
   PlanPriceResponse,
@@ -13,6 +21,295 @@ import type {
   SubscriptionResponse,
 } from '@granit/subscriptions';
 import type { CurrencyCode } from '@granit/types';
+
+const PRICING_MODELS = ['Flat', 'PerSeat', 'Tiered', 'UsageBased'];
+const BILLING_INTERVALS = ['Monthly', 'Quarterly', 'SemiAnnual', 'Annual'];
+const PLAN_LIFECYCLE_STATES = ['Draft', 'Published', 'Archived'];
+const SUBSCRIPTION_STATES = ['Active', 'Trial', 'PastDue', 'Canceled', 'Expired'];
+
+/** Mock /meta payload for the plans resource. */
+export const planQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'description',
+      label: 'Description',
+      type: 'String',
+      order: 2,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'pricingModel',
+      label: 'Pricing model',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'defaultInterval',
+      label: 'Interval',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'trialDays',
+      label: 'Trial days',
+      type: 'Int32',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'seatLimit',
+      label: 'Seat limit',
+      type: 'Int32',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'sortOrder',
+      label: 'Sort order',
+      type: 'Int32',
+      order: 7,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'lifecycleStatus',
+      label: 'Status',
+      type: 'String',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'description', type: 'String', operators: STRING_OPERATORS },
+    { name: 'pricingModel', type: 'String', operators: ENUM_OPERATORS, enumValues: PRICING_MODELS },
+    {
+      name: 'defaultInterval',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: BILLING_INTERVALS,
+    },
+    { name: 'trialDays', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'seatLimit', type: 'Int32', operators: NUMBER_OPERATORS },
+    {
+      name: 'lifecycleStatus',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: PLAN_LIFECYCLE_STATES,
+    },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'pricingModel' },
+    { name: 'defaultInterval' },
+    { name: 'trialDays' },
+    { name: 'seatLimit' },
+    { name: 'sortOrder' },
+    { name: 'lifecycleStatus' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'published', label: 'Published', isDefault: true },
+    { name: 'draft', label: 'Drafts', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'lifecycleStatus', type: 'String' },
+    { name: 'pricingModel', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'sortOrder',
+};
+
+/** Mock /meta payload for the subscriptions resource. */
+export const subscriptionQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'planId',
+      label: 'Plan',
+      type: 'Guid',
+      order: 1,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'currency',
+      label: 'Currency',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'currentPeriodStart',
+      label: 'Period start',
+      type: 'DateTime',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'currentPeriodEnd',
+      label: 'Period end',
+      type: 'DateTime',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'trialEndsAt',
+      label: 'Trial ends',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'cancelAtPeriodEnd',
+      label: 'Cancel at period end',
+      type: 'Boolean',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'cancelledAt',
+      label: 'Cancelled at',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'dunningAttempt',
+      label: 'Dunning attempt',
+      type: 'Int32',
+      order: 9,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'seatCount',
+      label: 'Seats',
+      type: 'Int32',
+      order: 10,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'planId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: SUBSCRIPTION_STATES },
+    { name: 'currency', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'currentPeriodStart', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'currentPeriodEnd', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'trialEndsAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'cancelAtPeriodEnd', type: 'Boolean', operators: ENUM_OPERATORS },
+    { name: 'cancelledAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'dunningAttempt', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'seatCount', type: 'Int32', operators: NUMBER_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'status' },
+    { name: 'currency' },
+    { name: 'currentPeriodStart' },
+    { name: 'currentPeriodEnd' },
+    { name: 'trialEndsAt' },
+    { name: 'cancelledAt' },
+    { name: 'seatCount' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active', isDefault: true },
+    { name: 'trial', label: 'Trial', isDefault: false },
+    { name: 'pastDue', label: 'Past due', isDefault: false },
+    { name: 'canceled', label: 'Canceled', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'currentPeriodEnd',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: ['ThisWeek', 'ThisMonth', 'LastMonth', 'ThisQuarter', 'ThisYear', 'Custom'],
+    },
+  ],
+  groupByFields: [
+    { name: 'status', type: 'String' },
+    { name: 'planId', type: 'Guid' },
+    { name: 'currency', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-currentPeriodStart',
+};
 
 /**
  * Create stateful MSW handlers for subscriptions endpoints.
@@ -23,6 +320,12 @@ import type { CurrencyCode } from '@granit/types';
  */
 export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
+    // GET /plans/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/plans`, planQueryMetadata),
+
+    // GET /subscriptions/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/subscriptions`, subscriptionQueryMetadata),
+
     // ---------------------------------------------------------------------------
     // Plans
     // ---------------------------------------------------------------------------

--- a/packages/@granit/react-subscriptions/src/testing/index.ts
+++ b/packages/@granit/react-subscriptions/src/testing/index.ts
@@ -3,4 +3,8 @@
 // ---------------------------------------------------------------------------
 
 export { mockPlans, mockPriceHistory, mockSeats, mockSubscriptions } from './data.js';
-export { createSubscriptionsHandlers } from './handlers.js';
+export {
+  createSubscriptionsHandlers,
+  planQueryMetadata,
+  subscriptionQueryMetadata,
+} from './handlers.js';

--- a/packages/@granit/react-subscriptions/tsconfig.json
+++ b/packages/@granit/react-subscriptions/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/subscriptions": ["../subscriptions/src/index.ts"]
+      "@granit/subscriptions": ["../subscriptions/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-templating/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-templating/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createTemplatesHandlers, templateQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/templating';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createTemplatesHandlers /meta', () => {
+  it('responds with templateQueryMetadata at /templates/meta', async () => {
+    server.use(...createTemplatesHandlers(BASE));
+    const response = await fetch(`${BASE}/templates/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(templateQueryMetadata);
+  });
+});

--- a/packages/@granit/react-templating/src/testing/handlers.ts
+++ b/packages/@granit/react-templating/src/testing/handlers.ts
@@ -1,3 +1,10 @@
+import {
+  DATE_OPERATORS,
+  ENUM_OPERATORS,
+  BOOLEAN_OPERATORS,
+  STRING_OPERATORS,
+} from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { TemplateLifecycleStatus } from '@granit/templating';
 import { noContent, notFound } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
@@ -12,7 +19,137 @@ import {
 } from './data.js';
 
 import type { MockTemplate } from './data.js';
+import type { QueryMetadata } from '@granit/query-engine';
 import type { SaveTemplateCategoryRequest, TemplateCategory } from '@granit/templating';
+
+/**
+ * Mock /meta payload for the templates resource.
+ * NOTE: `lifecycleStatus` is a numeric enum on the wire (Int32) — see TemplateLifecycleStatus.
+ */
+export const templateQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'culture',
+      label: 'Culture',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'category',
+      label: 'Category',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'layoutName',
+      label: 'Layout',
+      type: 'String',
+      order: 3,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'currentStatus',
+      label: 'Status',
+      type: 'Int32',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'mimeType',
+      label: 'MIME type',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'hasPublishedVersion',
+      label: 'Published',
+      type: 'Boolean',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastModifiedAt',
+      label: 'Modified at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastModifiedBy',
+      label: 'Modified by',
+      type: 'String',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: STRING_OPERATORS },
+    { name: 'culture', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'category', type: 'String', operators: STRING_OPERATORS },
+    { name: 'layoutName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'currentStatus', type: 'Int32', operators: ENUM_OPERATORS },
+    { name: 'mimeType', type: 'String', operators: ENUM_OPERATORS },
+    { name: 'hasPublishedVersion', type: 'Boolean', operators: BOOLEAN_OPERATORS },
+    { name: 'lastModifiedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'lastModifiedBy', type: 'String', operators: STRING_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'culture' },
+    { name: 'category' },
+    { name: 'currentStatus' },
+    { name: 'hasPublishedVersion' },
+    { name: 'lastModifiedAt' },
+    { name: 'lastModifiedBy' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'draft', label: 'Drafts', isDefault: false },
+    { name: 'published', label: 'Published', isDefault: true },
+    { name: 'archived', label: 'Archived', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'category', type: 'String' },
+    { name: 'currentStatus', type: 'Int32' },
+    { name: 'culture', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: 'name',
+};
 
 /**
  * Create stateful MSW handlers for templating endpoints.
@@ -28,6 +165,9 @@ export function createTemplatesHandlers(baseUrl = DEFAULT_BASE_PATH) {
   let nextCatIdx = categories.length + 1;
 
   return [
+    // GET /templates/meta — query metadata
+    createQueryMetaHandler(BASE, templateQueryMetadata),
+
     // ── Static routes MUST come before parameterized /:name routes ────────────
 
     // Layouts

--- a/packages/@granit/react-templating/src/testing/index.ts
+++ b/packages/@granit/react-templating/src/testing/index.ts
@@ -4,4 +4,4 @@
 
 export { mockTemplateCategories, mockTemplatesData } from './data.js';
 export type { MockTemplate } from './data.js';
-export { createTemplatesHandlers } from './handlers.js';
+export { createTemplatesHandlers, templateQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-templating/tsconfig.json
+++ b/packages/@granit/react-templating/tsconfig.json
@@ -4,7 +4,9 @@
     "paths": {
       "@granit/api-client/test-utils": ["../api-client/src/test-utils.ts"],
       "@granit/templating": ["../templating/src/index.ts"],
-      "@granit/testing/msw": ["../testing/src/msw.ts"]
+      "@granit/testing/msw": ["../testing/src/msw.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,20 @@
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createWebhooksHandlers, webhookSubscriptionQueryMetadata } from '../testing/index.js';
+
+const BASE = 'http://api.test/api/v1/webhooks';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('createWebhooksHandlers /meta', () => {
+  it('responds with webhookSubscriptionQueryMetadata at /subscriptions/meta', async () => {
+    server.use(...createWebhooksHandlers(BASE));
+    const response = await fetch(`${BASE}/subscriptions/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(webhookSubscriptionQueryMetadata);
+  });
+});

--- a/packages/@granit/react-webhooks/src/testing/handlers.ts
+++ b/packages/@granit/react-webhooks/src/testing/handlers.ts
@@ -1,3 +1,5 @@
+import { DATE_OPERATORS, NUMBER_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import {
   applyFilter,
   groupBy as groupByField,
@@ -19,7 +21,137 @@ import {
   mockWebhookSubscriptions,
 } from './data.js';
 
+import type { QueryMetadata } from '@granit/query-engine';
 import type { WebhookSubscriptionResponse } from '@granit/webhooks';
+
+/**
+ * Mock /meta payload for the webhook subscriptions resource.
+ * NOTE: `status` is a numeric enum on the wire (Int32) — see WebhookSubscriptionStatus.
+ */
+export const webhookSubscriptionQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'targetUrl',
+      label: 'Target URL',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'eventType',
+      label: 'Event type',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'Int32',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'consecutiveFailureCount',
+      label: 'Failures',
+      type: 'Int32',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastSuccessAt',
+      label: 'Last success',
+      type: 'DateTime',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'modifiedAt',
+      label: 'Modified at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'targetUrl', type: 'String', operators: STRING_OPERATORS },
+    { name: 'eventType', type: 'String', operators: STRING_OPERATORS },
+    { name: 'status', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'consecutiveFailureCount', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'lastSuccessAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'modifiedAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'targetUrl' },
+    { name: 'eventType' },
+    { name: 'status' },
+    { name: 'consecutiveFailureCount' },
+    { name: 'lastSuccessAt' },
+    { name: 'createdAt' },
+    { name: 'modifiedAt' },
+  ],
+  presetFilterGroups: [
+    {
+      name: 'status',
+      label: 'Status',
+      presets: [
+        { name: 'active', label: 'Active', isDefault: true },
+        { name: 'suspended', label: 'Suspended', isDefault: false },
+        { name: 'deactivated', label: 'Deactivated', isDefault: false },
+      ],
+    },
+  ],
+  quickFilters: [{ name: 'hasFailures', label: 'Has failures', isDefault: false }],
+  dateFilters: [
+    {
+      name: 'createdAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: ['Today', 'ThisWeek', 'ThisMonth', 'LastMonth', 'ThisYear', 'Custom'],
+    },
+  ],
+  groupByFields: [
+    { name: 'status', type: 'Int32' },
+    { name: 'eventType', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -77,6 +209,9 @@ export function createWebhooksHandlers(baseUrl = DEFAULT_WEBHOOKS_BASE_PATH) {
   const deliveryAttempts = [...mockWebhookDeliveryAttempts];
 
   return [
+    // GET /subscriptions/meta — query metadata
+    createQueryMetaHandler(`${baseUrl}/subscriptions`, webhookSubscriptionQueryMetadata),
+
     // -------------------------------------------------------------------------
     // Static routes MUST come before parameterized routes
     // -------------------------------------------------------------------------

--- a/packages/@granit/react-webhooks/src/testing/index.ts
+++ b/packages/@granit/react-webhooks/src/testing/index.ts
@@ -8,4 +8,4 @@ export {
   mockWebhookStats,
   mockWebhookSubscriptions,
 } from './data.js';
-export { createWebhooksHandlers } from './handlers.js';
+export { createWebhooksHandlers, webhookSubscriptionQueryMetadata } from './handlers.js';

--- a/packages/@granit/react-webhooks/tsconfig.json
+++ b/packages/@granit/react-webhooks/tsconfig.json
@@ -1,4 +1,11 @@
 {
   "extends": "../../../tsconfig.base.json",
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "compilerOptions": {
+    "paths": {
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   smol-toml: '>=1.6.1'
   brace-expansion: '>=5.0.5'
   protobufjs: ^7.5.5
+  msw: ^2.13.6
 
 importers:
 
@@ -595,8 +596,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -626,8 +627,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -716,8 +717,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -744,8 +745,8 @@ importers:
         specifier: workspace:*
         version: link:../authentication
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -766,8 +767,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -882,8 +883,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -913,8 +914,8 @@ importers:
         specifier: 1.15.2
         version: 1.15.2
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -938,8 +939,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -978,8 +979,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1041,8 +1042,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1100,8 +1101,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1150,8 +1151,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1187,8 +1188,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1215,8 +1216,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1246,8 +1247,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1289,8 +1290,8 @@ importers:
         specifier: ^25.0.0
         version: 25.8.14(typescript@5.9.3)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@5.9.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@5.9.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1317,8 +1318,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1348,8 +1349,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1376,8 +1377,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1445,8 +1446,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1476,8 +1477,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.4(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1513,8 +1514,8 @@ importers:
         specifier: ^1.0.0
         version: 1.8.0(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1544,8 +1545,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1583,6 +1584,9 @@ importers:
       axios:
         specifier: 1.15.2
         version: 1.15.2
+      msw:
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1637,8 +1641,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1668,8 +1672,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1708,8 +1712,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1739,8 +1743,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1767,8 +1771,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1826,8 +1830,8 @@ importers:
         specifier: workspace:*
         version: link:../timeline
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1912,8 +1916,8 @@ importers:
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1943,8 +1947,8 @@ importers:
         specifier: workspace:*
         version: link:../workflow
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -2049,11 +2053,11 @@ importers:
   packages/@granit/testing:
     dependencies:
       msw:
-        specifier: ^2.12.0
-        version: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
+        specifier: ^2.13.6
+        version: 2.13.6(@types/node@25.6.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.0.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -2842,35 +2846,13 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@inquirer/ansi@1.0.2':
-    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
-    engines: {node: '>=18'}
-
   '@inquirer/ansi@2.0.5':
     resolution: {integrity: sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
 
-  '@inquirer/confirm@5.1.21':
-    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
   '@inquirer/confirm@6.0.12':
     resolution: {integrity: sha512-h9FgGun3QwVYNj5TWIZZ+slii73bMoBFjPfVIGtnFuL4t8gBiNDV9PcSfIzkuxvgquJKt9nr1QzszpBzTbH8Og==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/core@10.3.2':
-    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
-    engines: {node: '>=18'}
     peerDependencies:
       '@types/node': '>=18'
     peerDependenciesMeta:
@@ -2886,22 +2868,9 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@1.0.15':
-    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
-    engines: {node: '>=18'}
-
   '@inquirer/figures@2.0.5':
     resolution: {integrity: sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0'}
-
-  '@inquirer/type@3.0.10':
-    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
 
   '@inquirer/type@4.0.5':
     resolution: {integrity: sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==}
@@ -2933,14 +2902,6 @@ packages:
 
   '@microsoft/signalr@10.0.0':
     resolution: {integrity: sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==}
-
-  '@mswjs/interceptors@0.41.3':
-    resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
-    engines: {node: '>=18'}
-
-  '@mswjs/interceptors@0.41.4':
-    resolution: {integrity: sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==}
-    engines: {node: '>=18'}
 
   '@mswjs/interceptors@0.41.6':
     resolution: {integrity: sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==}
@@ -3899,7 +3860,7 @@ packages:
   '@vitest/mocker@4.1.4':
     resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
-      msw: ^2.4.9
+      msw: ^2.13.6
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
@@ -3910,7 +3871,7 @@ packages:
   '@vitest/mocker@4.1.5':
     resolution: {integrity: sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==}
     peerDependencies:
-      msw: ^2.4.9
+      msw: ^2.13.6
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
@@ -4612,9 +4573,6 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
-  headers-polyfill@4.0.3:
-    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
-
   headers-polyfill@5.0.1:
     resolution: {integrity: sha512-1TJ6Fih/b8h5TIcv+1+Hw0PDQWJTKDKzFZzcKOiW1wJza3XoAQlkCuXLbymPYB8+ZQyw8mHvdw560e8zVFIWyA==}
 
@@ -5166,26 +5124,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msw@2.13.2:
-    resolution: {integrity: sha512-go2H1TIERKkC48pXiwec5l6sbNqYuvqOk3/vHGo1Zd+pq/H63oFawDQerH+WQdUw/flJFHDG7F+QdWMwhntA/A==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>= 4.8.x'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
-  msw@2.13.4:
-    resolution: {integrity: sha512-fPlKBeFe+8rpcyR3umUmmHuNwu6gc6T3STvkgEa9WDX/HEgal9wDeflpCUAIRtmvaLZM2igfI5y1bZ9G5J26KA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>= 4.8.x'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   msw@2.13.6:
     resolution: {integrity: sha512-GAJbQy8Ra/Ydjt0Hb2MGT2qhzd83J3+QZMHdH85uW7r/XkKc846+Ma2PLif5hGvTm5Yqa+wkcstpim0WeLZU9g==}
     engines: {node: '>=18'}
@@ -5195,10 +5133,6 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
-
-  mute-stream@2.0.0:
-    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
-    engines: {node: ^18.17.0 || >=20.5.0}
 
   mute-stream@3.0.0:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
@@ -5458,9 +5392,6 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
-
-  rettime@0.10.1:
-    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   rettime@0.11.8:
     resolution: {integrity: sha512-0fERGXktJTyJ+h8fBEiPxHPEFOu0h15JY7JtwrOVqR5K+vb99ho6IyOo7ekLS3h4sJCzIDy4VWKIbZUfe9njmg==}
@@ -5732,10 +5663,6 @@ packages:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
 
-  type-fest@5.5.0:
-    resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
-    engines: {node: '>=20'}
-
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
@@ -5987,10 +5914,6 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
-  wrap-ansi@6.2.0:
-    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
-    engines: {node: '>=8'}
-
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -6041,10 +5964,6 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-
-  yoctocolors-cjs@2.1.3:
-    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
-    engines: {node: '>=18'}
 
   zone.js@0.16.1:
     resolution: {integrity: sha512-dpvY17vxYIW3+bNrP0ClUlaiY0CiIRK3tnoLaGoQsQcY9/I/NpzIWQ7tQNhbV7LacQMpCII6wVzuL3tuWOyfuA==}
@@ -6851,34 +6770,12 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inquirer/ansi@1.0.2': {}
-
   '@inquirer/ansi@2.0.5': {}
-
-  '@inquirer/confirm@5.1.21(@types/node@25.6.0)':
-    dependencies:
-      '@inquirer/core': 10.3.2(@types/node@25.6.0)
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
-    optionalDependencies:
-      '@types/node': 25.6.0
 
   '@inquirer/confirm@6.0.12(@types/node@25.6.0)':
     dependencies:
       '@inquirer/core': 11.1.9(@types/node@25.6.0)
       '@inquirer/type': 4.0.5(@types/node@25.6.0)
-    optionalDependencies:
-      '@types/node': 25.6.0
-
-  '@inquirer/core@10.3.2(@types/node@25.6.0)':
-    dependencies:
-      '@inquirer/ansi': 1.0.2
-      '@inquirer/figures': 1.0.15
-      '@inquirer/type': 3.0.10(@types/node@25.6.0)
-      cli-width: 4.1.0
-      mute-stream: 2.0.0
-      signal-exit: 4.1.0
-      wrap-ansi: 6.2.0
-      yoctocolors-cjs: 2.1.3
     optionalDependencies:
       '@types/node': 25.6.0
 
@@ -6894,13 +6791,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/figures@1.0.15': {}
-
   '@inquirer/figures@2.0.5': {}
-
-  '@inquirer/type@3.0.10(@types/node@25.6.0)':
-    optionalDependencies:
-      '@types/node': 25.6.0
 
   '@inquirer/type@4.0.5(@types/node@25.6.0)':
     optionalDependencies:
@@ -6938,24 +6829,6 @@ snapshots:
       - bufferutil
       - encoding
       - utf-8-validate
-
-  '@mswjs/interceptors@0.41.3':
-    dependencies:
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/logger': 0.3.0
-      '@open-draft/until': 2.1.0
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      strict-event-emitter: 0.5.1
-
-  '@mswjs/interceptors@0.41.4':
-    dependencies:
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/logger': 0.3.0
-      '@open-draft/until': 2.1.0
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      strict-event-emitter: 0.5.1
 
   '@mswjs/interceptors@0.41.6':
     dependencies:
@@ -7825,15 +7698,6 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.13.2(@types/node@25.6.0)(typescript@6.0.3)
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
-
   '@vitest/mocker@4.1.4(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.1.4
@@ -8596,8 +8460,6 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  headers-polyfill@4.0.3: {}
-
   headers-polyfill@5.0.1:
     dependencies:
       '@types/set-cookie-parser': 2.4.10
@@ -9208,60 +9070,10 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.13.2(@types/node@25.6.0)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@25.6.0)
-      '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.13.2
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.10.1
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.5.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-
-  msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3):
-    dependencies:
-      '@inquirer/confirm': 5.1.21(@types/node@25.6.0)
-      '@mswjs/interceptors': 0.41.3
-      '@open-draft/deferred-promise': 2.2.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.13.2
-      headers-polyfill: 4.0.3
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.10.1
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.5.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - '@types/node'
-
-  msw@2.13.4(@types/node@25.6.0)(typescript@6.0.3):
+  msw@2.13.6(@types/node@25.6.0)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 6.0.12(@types/node@25.6.0)
-      '@mswjs/interceptors': 0.41.4
+      '@mswjs/interceptors': 0.41.6
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
@@ -9279,7 +9091,7 @@ snapshots:
       until-async: 3.0.2
       yargs: 17.7.2
     optionalDependencies:
-      typescript: 6.0.3
+      typescript: 5.9.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -9307,8 +9119,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
-
-  mute-stream@2.0.0: {}
 
   mute-stream@3.0.0: {}
 
@@ -9534,8 +9344,6 @@ snapshots:
     dependencies:
       onetime: 7.0.0
       signal-exit: 4.1.0
-
-  rettime@0.10.1: {}
 
   rettime@0.11.8: {}
 
@@ -9822,10 +9630,6 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  type-fest@5.5.0:
-    dependencies:
-      tagged-tag: 1.0.0
-
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
@@ -9919,36 +9723,6 @@ snapshots:
       jiti: 2.6.1
       sass: 1.97.3
       yaml: 2.8.3
-
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0)(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.13.2(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.6.0
-      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
-      jsdom: 29.1.0
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.0)(msw@2.13.6(@types/node@25.6.0)(typescript@6.0.3))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.8.3)):
     dependencies:
@@ -10064,12 +9838,6 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrap-ansi@6.2.0:
-    dependencies:
-      ansi-styles: 4.3.0
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -10107,8 +9875,6 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
-
-  yoctocolors-cjs@2.1.3: {}
 
   zone.js@0.16.1: {}
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2024",
-    "lib": ["ESNext", "DOM"],
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "moduleResolution": "bundler",
     "verbatimModuleSyntax": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -299,6 +299,10 @@ export default defineConfig({
         __dirname,
         'packages/@granit/react-privacy/src/index.ts'
       ),
+      '@granit/react-query-engine/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-query-engine/src/testing/index.ts'
+      ),
       '@granit/react-query-engine': path.resolve(
         __dirname,
         'packages/@granit/react-query-engine/src/index.ts'


### PR DESCRIPTION
## Summary

- Adds `@granit/react-query-engine/testing` subpath with `createQueryMetaHandler(basePath, metadata)` and `buildEmptyQueryMeta(overrides?)` so every queryable resource can register a `/meta` route in one line.
- Wires realistic per-entity `QueryMetadata` (columns, filterable, sortable, pagination, defaultSort) into the existing MSW factories of 21 `react-{module}/testing` packages — multi-tenancy, auditing, localization, identity, ai, authentication-api-keys, background-jobs, blob-storage, customer-balance, data-exchange, invoicing, metering, notifications, openiddict-admin, parties, payments, privacy, scheduling, subscriptions, templating, webhooks. Multi-resource modules (privacy, openiddict-admin, subscriptions, data-exchange) register one meta handler per resource. Skipped: `react-features` and `react-tax` (flat array endpoints, not consumed via `QueryProvider`).
- Each module gets a `__tests__/testing-handlers.test.ts` smoke test asserting `/meta` returns the exported metadata constant.

## Why

`useSmartFilter` / `useQueryMeta` (`@granit/react-query-engine`) call `GET {basePath}/meta` directly. Without a handler, MSW falls through to the dev-server SPA fallback, returns HTML, and the page crashes with `metadata.filterableFields is not iterable`. Reproduced on `granit-showcase-admin-react` (e.g. `/identity/localization/overrides`, `/multi-tenancy/tenants`).

## Infrastructure

- `tsconfig.base.json`: added `DOM.Iterable` so `URLSearchParams.entries()` types resolve under packages that pull older TS lib bundles.
- `package.json` `pnpm.overrides`: pinned `msw` to `^2.13.6` — multiple msw versions across packages caused `tsc` spread-arg type drift between `RequestHandler` declarations.
- 21 module `tsconfig.json` files patched with `paths` for `@granit/query-engine`, `@granit/react-query-engine/testing`, `@granit/testing/msw` (mirrors existing pattern, e.g. `@granit/testing/msw` already on multi-tenancy).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] `npx vitest run` — 302 files / 2298 tests passing (was 281 / 2270)
- [x] Helper unit tests (`createQueryMetaHandler`, `buildEmptyQueryMeta`)
- [x] Per-module smoke tests asserting `/meta` returns expected metadata
- [ ] Verify in `granit-showcase-admin-react`: navigating to a `QueryProvider`-backed list page no longer throws `metadata.filterableFields is not iterable`, smart-filter chips render with mocked fields.

## Out of scope

- Realistic row data (already covered by existing CRUD/list mocks).
- Backend changes (.NET already serves `/meta`).
- Adding `/meta` to non-queryable resources.