### PR TITLE
feat(react-modules): wire query-engine peer deps for createQueryMetaHandler

### DIFF
--- a/packages/@granit/react-ai/package.json
+++ b/packages/@granit/react-ai/package.json
@@ -17,12 +17,20 @@
   "peerDependencies": {
     "@granit/ai": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-auditing/package.json
+++ b/packages/@granit/react-auditing/package.json
@@ -26,11 +26,18 @@
     "@granit/auditing": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-authentication-api-keys/package.json
+++ b/packages/@granit/react-authentication-api-keys/package.json
@@ -23,11 +23,19 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/authentication-api-keys": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-background-jobs/package.json
+++ b/packages/@granit/react-background-jobs/package.json
@@ -19,11 +19,18 @@
     "@granit/background-jobs": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-blob-storage/package.json
+++ b/packages/@granit/react-blob-storage/package.json
@@ -17,11 +17,19 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/blob-storage": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-customer-balance/package.json
+++ b/packages/@granit/react-customer-balance/package.json
@@ -17,13 +17,21 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/customer-balance": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-customer-balance/src/testing/handlers.ts
+++ b/packages/@granit/react-customer-balance/src/testing/handlers.ts
@@ -161,7 +161,7 @@ export function createCustomerBalanceHandlers(baseUrl = DEFAULT_BASE_PATH) {
     createQueryMetaHandler(`${baseUrl}/transactions`, balanceTransactionQueryMetadata),
 
     // GET current balance
-    http.get(baseUrl, () => {
+    http.get(`${baseUrl}/balance`, () => {
       return HttpResponse.json(sampleBalance);
     }),
 

--- a/packages/@granit/react-data-exchange/package.json
+++ b/packages/@granit/react-data-exchange/package.json
@@ -19,6 +19,7 @@
     "@granit/data-exchange": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
@@ -26,6 +27,12 @@
     "react-dom": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-identity/package.json
+++ b/packages/@granit/react-identity/package.json
@@ -17,12 +17,20 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/identity": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-invoicing/package.json
+++ b/packages/@granit/react-invoicing/package.json
@@ -17,13 +17,21 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/invoicing": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-localization/package.json
+++ b/packages/@granit/react-localization/package.json
@@ -17,6 +17,8 @@
     "@date-fns/tz": "^1.0.0",
     "@granit/api-client": "workspace:*",
     "@granit/localization": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/storage": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "date-fns": "^4.0.0",
@@ -26,6 +28,12 @@
     "react-i18next": "^16.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-metering/package.json
+++ b/packages/@granit/react-metering/package.json
@@ -17,13 +17,21 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/metering": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-multi-tenancy/package.json
+++ b/packages/@granit/react-multi-tenancy/package.json
@@ -17,12 +17,20 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/multi-tenancy": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-openiddict-admin/package.json
+++ b/packages/@granit/react-openiddict-admin/package.json
@@ -17,12 +17,20 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/openiddict-admin": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-parties/package.json
+++ b/packages/@granit/react-parties/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/parties": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
@@ -26,6 +27,12 @@
     "react-i18next": "^16.0.0 || ^17.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-payments/package.json
+++ b/packages/@granit/react-payments/package.json
@@ -17,7 +17,9 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/payments": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "lucide-react": "^1.0.0",
@@ -25,6 +27,12 @@
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-privacy/package.json
+++ b/packages/@granit/react-privacy/package.json
@@ -17,12 +17,20 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/privacy": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-scheduling/package.json
+++ b/packages/@granit/react-scheduling/package.json
@@ -18,12 +18,19 @@
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/scheduling": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-subscriptions/package.json
+++ b/packages/@granit/react-subscriptions/package.json
@@ -18,6 +18,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/subscriptions": "workspace:*",
     "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
@@ -25,6 +26,12 @@
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-templating/package.json
+++ b/packages/@granit/react-templating/package.json
@@ -25,13 +25,21 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/templating": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-webhooks/package.json
+++ b/packages/@granit/react-webhooks/package.json
@@ -16,12 +16,20 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/webhooks": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,6 +623,9 @@ importers:
       '@granit/ai':
         specifier: workspace:*
         version: link:../ai
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -713,6 +716,9 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -763,6 +769,12 @@ importers:
       '@granit/authentication-api-keys':
         specifier: workspace:*
         version: link:../authentication-api-keys
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -935,6 +947,9 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -975,6 +990,9 @@ importers:
       '@granit/blob-storage':
         specifier: workspace:*
         version: link:../blob-storage
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1038,6 +1056,12 @@ importers:
       '@granit/customer-balance':
         specifier: workspace:*
         version: link:../customer-balance
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1094,6 +1118,9 @@ importers:
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
@@ -1212,6 +1239,12 @@ importers:
       '@granit/identity':
         specifier: workspace:*
         version: link:../identity
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1243,6 +1276,12 @@ importers:
       '@granit/invoicing':
         specifier: workspace:*
         version: link:../invoicing
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1277,6 +1316,12 @@ importers:
       '@granit/localization':
         specifier: workspace:*
         version: link:../localization
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@granit/storage':
         specifier: workspace:*
         version: link:../storage
@@ -1314,6 +1359,12 @@ importers:
       '@granit/metering':
         specifier: workspace:*
         version: link:../metering
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1345,6 +1396,12 @@ importers:
       '@granit/multi-tenancy':
         specifier: workspace:*
         version: link:../multi-tenancy
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1442,6 +1499,12 @@ importers:
       '@granit/openiddict-admin':
         specifier: workspace:*
         version: link:../openiddict-admin
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1470,6 +1533,9 @@ importers:
       '@granit/parties':
         specifier: workspace:*
         version: link:../parties
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/react-query-engine':
         specifier: workspace:*
         version: link:../react-query-engine
@@ -1507,6 +1573,12 @@ importers:
       '@granit/payments':
         specifier: workspace:*
         version: link:../payments
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1541,6 +1613,12 @@ importers:
       '@granit/privacy':
         specifier: workspace:*
         version: link:../privacy
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1634,6 +1712,9 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@granit/scheduling':
         specifier: workspace:*
         version: link:../scheduling
@@ -1705,6 +1786,9 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@granit/subscriptions':
         specifier: workspace:*
         version: link:../subscriptions
@@ -1767,6 +1851,9 @@ importers:
 
   packages/@granit/react-templating:
     dependencies:
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.5
         version: 5.100.5(react@19.2.5)
@@ -1909,6 +1996,12 @@ importers:
 
   packages/@granit/react-webhooks:
     dependencies:
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@granit/webhooks':
         specifier: workspace:*
         version: link:../webhooks


### PR DESCRIPTION
## Summary

Follow-up to PR #229 (`feat(react-query-engine): testing helper + /meta MSW handlers across modules`).

- Declare `@granit/query-engine` and `@granit/react-query-engine` as **optional peer dependencies** on every `@granit/react-*` module that ships an MSW testing bundle. The shared `createQueryMetaHandler` consumed by those bundles depends on them at runtime, so the dependency graph now matches reality and pnpm stops hoisting the wrong copy.
- Fix the customer-balance handler URL regression — the bare `GET /api/v1/customer-balance` route was matching the module URL and swallowing the new `/transactions` and `/meta` routes. Pinned to `/balance`.
- Refresh `pnpm-lock.yaml` for the propagated peer-dep graph.

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm test` — 44/44 in changed-package scope
- [ ] Spot-check: `/transactions` and `/meta` MSW routes resolve correctly on customer-balance list page after this lands