### PR TITLE
feat(dashboards)!: datasource abstraction + KpiWidgetDefinition migration (P2.2)

### DIFF
--- a/packages/@granit/analytics/src/widgets/aggregation.ts
+++ b/packages/@granit/analytics/src/widgets/aggregation.ts
@@ -1,5 +1,8 @@
 /**
- * Aggregation operators. Mirrors `Granit.QueryEngine.Filtering.AggregateFunction`
- * — the same enum used for metric definitions on the backend.
+ * Aggregation operators. Re-exported from `@granit/dashboards` so analytics
+ * widgets can keep importing from `./aggregation.js`. The canonical source
+ * lives alongside `Datasource` (mirrors the backend's
+ * `Granit.Dashboards.Abstractions` → `Granit.QueryEngine.Abstractions`
+ * project reference).
  */
-export type AggregateFunction = 'count' | 'sum' | 'avg' | 'min' | 'max';
+export type { AggregateFunction } from '@granit/dashboards';

--- a/packages/@granit/analytics/src/widgets/kpi-widget.ts
+++ b/packages/@granit/analytics/src/widgets/kpi-widget.ts
@@ -1,15 +1,26 @@
-import type { WidgetDefinitionBase } from '@granit/dashboards';
+import type { Datasource, WidgetDefinitionBase } from '@granit/dashboards';
 
 /**
- * Single-value KPI tile bound to a `MetricDefinition`. Mirrors
- * `Granit.Analytics.Dashboards.Widgets.KpiWidgetDefinition`.
+ * Single-value KPI tile. Mirrors
+ * `Granit.Analytics.Dashboards.Widgets.KpiWidgetDefinition` (P2.2).
  *
- * The widget renders the metric's current value plus an optional comparison
- * delta with favorable / unfavorable color (driven by
- * `MetricSnapshotPayload.previous.isFavorable`).
+ * Renders the tile's value, an optional comparison delta and a
+ * favorable / unfavorable color cue. The cue is driven by
+ * `MetricDefinition.IsHigherBetter` when bound via {@link MetricDatasource};
+ * other datasource kinds render the value as-is.
+ *
+ * Datasource binding (P2.2) decouples the widget from how its data arrives:
+ *
+ * - {@link MetricDatasource} — analytics dashboards (the common case)
+ * - {@link QueryAggregateDatasource} — ad-hoc admin pages reusing the same widget
+ * - {@link TelemetryDatasource} — IoT gauges
  */
 export interface KpiWidgetDefinition extends WidgetDefinitionBase {
   readonly type: 'kpi';
-  /** The `MetricDefinition.Name` this KPI surfaces (e.g. `Granit.Invoicing.UnpaidInvoiceCountMetric`). */
-  readonly metricName: string;
+  /**
+   * Data binding for the KPI value. Use the `Datasource.metric(...)` /
+   * `Datasource.queryAggregate(...)` / `Datasource.telemetry(...)` factories
+   * for compact call sites.
+   */
+  readonly datasource: Datasource;
 }

--- a/packages/@granit/dashboards/src/__tests__/datasource.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/datasource.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  Datasource,
+  isMetricDatasource,
+  isQueryAggregateDatasource,
+  isTelemetryDatasource,
+} from '../types/datasource.js';
+
+import type {
+  MetricDatasource,
+  QueryAggregateDatasource,
+  TelemetryDatasource,
+} from '../types/datasource.js';
+
+// Pinned wire-format fixtures. Each fixture is the literal JSON shape the
+// backend (`Granit.Dashboards.Abstractions.Tests/DatasourceTests`) round-trips
+// — kept verbatim so a casing or discriminator drift fails CI here before it
+// reaches the wire.
+const METRIC_FIXTURE = {
+  kind: 'metric',
+  metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
+} as const;
+
+const QUERY_AGGREGATE_FIXTURE = {
+  kind: 'query-aggregate',
+  queryName: 'Granit.Invoicing.InvoiceQuery',
+  aggregation: 'Sum',
+  field: 'Total',
+  keyFormats: null,
+} as const;
+
+const TELEMETRY_FIXTURE = {
+  kind: 'iot-telemetry',
+  entityAlias: 'currentDevice',
+  telemetryKey: 'temperature',
+  aggregation: 'Last',
+  keyFormats: null,
+} as const;
+
+describe('Datasource — wire format', () => {
+  it('accepts the metric kind verbatim', () => {
+    const ds: MetricDatasource = METRIC_FIXTURE;
+    expect(isMetricDatasource(ds)).toBe(true);
+    expect(ds.metricName).toBe('Granit.Invoicing.UnpaidInvoiceCountMetric');
+  });
+
+  it('accepts the query-aggregate kind verbatim', () => {
+    const ds: QueryAggregateDatasource = QUERY_AGGREGATE_FIXTURE;
+    expect(isQueryAggregateDatasource(ds)).toBe(true);
+    expect(ds.aggregation).toBe('Sum');
+  });
+
+  it('accepts the iot-telemetry kind verbatim', () => {
+    const ds: TelemetryDatasource = TELEMETRY_FIXTURE;
+    expect(isTelemetryDatasource(ds)).toBe(true);
+    expect(ds.aggregation).toBe('Last');
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    for (const fixture of [METRIC_FIXTURE, QUERY_AGGREGATE_FIXTURE, TELEMETRY_FIXTURE]) {
+      expect(JSON.parse(JSON.stringify(fixture))).toEqual(fixture);
+    }
+  });
+});
+
+describe('Datasource — factories', () => {
+  it('Datasource.metric mirrors the kebab discriminator', () => {
+    expect(Datasource.metric('M1')).toEqual({ kind: 'metric', metricName: 'M1' });
+  });
+
+  it('Datasource.queryAggregate defaults field and keyFormats to null', () => {
+    expect(Datasource.queryAggregate('Q1', 'Count')).toEqual({
+      kind: 'query-aggregate',
+      queryName: 'Q1',
+      aggregation: 'Count',
+      field: null,
+      keyFormats: null,
+    });
+  });
+
+  it('Datasource.telemetry defaults aggregation to Last (the most-recent reading)', () => {
+    expect(Datasource.telemetry('alias', 'temperature')).toEqual({
+      kind: 'iot-telemetry',
+      entityAlias: 'alias',
+      telemetryKey: 'temperature',
+      aggregation: 'Last',
+      keyFormats: null,
+    });
+  });
+
+  it('Datasource.telemetry passes through keyFormats and aggregation overrides', () => {
+    const ds = Datasource.telemetry('alias', 'rpm', 'Avg', [
+      { key: 'rpm', labelLocalizationKey: null, color: '#0a84ff', unit: null, decimals: 0 },
+    ]);
+    expect(ds.aggregation).toBe('Avg');
+    expect(ds.keyFormats).toHaveLength(1);
+    expect(ds.keyFormats?.[0]?.color).toBe('#0a84ff');
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -2,8 +2,17 @@
 // @granit/dashboards — public API (framework-agnostic)
 // ---------------------------------------------------------------------------
 
-export { DASHBOARD_TIME_WINDOW, DEFAULT_DASHBOARD_LAYOUT, WIDGET_SIZE } from './types/index.js';
+export {
+  DASHBOARD_TIME_WINDOW,
+  Datasource,
+  DEFAULT_DASHBOARD_LAYOUT,
+  isMetricDatasource,
+  isQueryAggregateDatasource,
+  isTelemetryDatasource,
+  WIDGET_SIZE,
+} from './types/index.js';
 export type {
+  AggregateFunction,
   DashboardCategory,
   DashboardDefinition,
   DashboardDefinitionDescriptor,
@@ -11,9 +20,14 @@ export type {
   DashboardLayout,
   DashboardPeriod,
   DashboardTimeWindow,
+  DataKeyFormat,
   FrameworkWidgetDefinition,
   ImageWidgetDefinition,
   MarkdownWidgetDefinition,
+  MetricDatasource,
+  QueryAggregateDatasource,
+  TelemetryAggregation,
+  TelemetryDatasource,
   TextWidgetDefinition,
   TextWidgetStyle,
   TimeWindowKind,

--- a/packages/@granit/dashboards/src/types/aggregate-function.ts
+++ b/packages/@granit/dashboards/src/types/aggregate-function.ts
@@ -1,0 +1,7 @@
+/**
+ * Aggregate functions available for grouped queries. Mirrors
+ * `Granit.QueryEngine.Filtering.AggregateFunction`. Wire format is the
+ * PascalCase enum name (Granit's HTTP JSON layer registers a
+ * `JsonStringEnumConverter` without a naming policy).
+ */
+export type AggregateFunction = 'Count' | 'Sum' | 'Avg' | 'Min' | 'Max';

--- a/packages/@granit/dashboards/src/types/data-key-format.ts
+++ b/packages/@granit/dashboards/src/types/data-key-format.ts
@@ -1,0 +1,35 @@
+/**
+ * Per-series presentation hints attached to a {@link Datasource} rather than
+ * to the consuming widget. Mirrors `Granit.Dashboards.DataKeyFormat` (P2.2).
+ *
+ * The same chart widget can be reused with different data shapes — a
+ * "Revenue by Region" chart and a "Revenue by Product" chart are the same
+ * `ChartWidgetDefinition` with different datasources — so colors and units
+ * belong to the data binding, not the visual.
+ */
+export interface DataKeyFormat {
+  /**
+   * Series identifier — matches the group-by value (chart) or the field name
+   * (multi-series KPI / pivot).
+   */
+  readonly key: string;
+  /**
+   * Localization key for the display label (legend, tooltip). `null` = the
+   * frontend falls back to {@link key}.
+   */
+  readonly labelLocalizationKey: string | null;
+  /**
+   * Hex color override. `null` = the active theme palette by series index.
+   */
+  readonly color: string | null;
+  /**
+   * Unit suffix (e.g. `"€"`, `"kWh"`, `"°C"`). When prefixed with `Unit:`,
+   * resolved via i18n. `null` = no unit suffix.
+   */
+  readonly unit: string | null;
+  /**
+   * Decimal places for numeric formatting. `null` = the widget's default
+   * (typically 0 for counts, 2 for currency).
+   */
+  readonly decimals: number | null;
+}

--- a/packages/@granit/dashboards/src/types/datasource.ts
+++ b/packages/@granit/dashboards/src/types/datasource.ts
@@ -1,0 +1,106 @@
+import type { AggregateFunction } from './aggregate-function.js';
+import type { DataKeyFormat } from './data-key-format.js';
+
+/**
+ * Aggregation kinds for live telemetry streams. Mirrors
+ * `Granit.Dashboards.TelemetryAggregation` (P2.2). PascalCase wire values —
+ * the backend registers a `JsonStringEnumConverter` without a naming policy.
+ */
+export type TelemetryAggregation = 'Last' | 'Avg' | 'Sum' | 'Min' | 'Max' | 'Count';
+
+/**
+ * Bound to a registered metric definition by name. The metric's own
+ * aggregation, base filter and period selector apply — no extra knobs.
+ * Mirrors `Granit.Dashboards.MetricDatasource`.
+ */
+export interface MetricDatasource {
+  readonly kind: 'metric';
+  /** Wire identifier of the metric (e.g. `Granit.Invoicing.UnpaidInvoiceCountMetric`). */
+  readonly metricName: string;
+}
+
+/**
+ * Bound to a registered query definition by name; applies an aggregation over
+ * a chosen field (`field === null` ⇒ {@link AggregateFunction} `'Count'`).
+ * Mirrors `Granit.Dashboards.QueryAggregateDatasource`.
+ */
+export interface QueryAggregateDatasource {
+  readonly kind: 'query-aggregate';
+  /** Wire identifier of the query (e.g. `Granit.Invoicing.InvoiceQuery`). */
+  readonly queryName: string;
+  readonly aggregation: AggregateFunction;
+  /** Field aggregated. `null` when {@link aggregation} is `'Count'`. */
+  readonly field: string | null;
+  /**
+   * Per-series presentation hints. When the consuming widget renders multiple
+   * series (e.g. a chart with a group-by), each entry's {@link DataKeyFormat.key}
+   * matches a series identifier. `null` = active theme palette.
+   */
+  readonly keyFormats: readonly DataKeyFormat[] | null;
+}
+
+/**
+ * Bound to live telemetry pushed from the runtime (IoT). Resolves the entity
+ * at render time via the dashboard's entity-alias bindings (P2.3). Mirrors
+ * `Granit.Dashboards.TelemetryDatasource`.
+ */
+export interface TelemetryDatasource {
+  readonly kind: 'iot-telemetry';
+  /** Entity alias name — resolves to a device id at render time. */
+  readonly entityAlias: string;
+  /** Telemetry key (e.g. `temperature`, `pressure`, `rpm`). */
+  readonly telemetryKey: string;
+  /** Aggregation applied over the dashboard's time window. Defaults to `'Last'`. */
+  readonly aggregation: TelemetryAggregation;
+  readonly keyFormats: readonly DataKeyFormat[] | null;
+}
+
+/**
+ * Abstract data binding for a widget — decouples a widget from how its data
+ * arrives. Mirrors `Granit.Dashboards.Datasource` (P2.2). Wire format uses the
+ * `kind` discriminator with kebab tags (`metric`, `query-aggregate`,
+ * `iot-telemetry`) — same approach as `WidgetDefinition.type` (P1.1) and
+ * `EntityAliasResolver.kind` (P2.3).
+ */
+export type Datasource = MetricDatasource | QueryAggregateDatasource | TelemetryDatasource;
+
+export function isMetricDatasource(ds: Datasource): ds is MetricDatasource {
+  return ds.kind === 'metric';
+}
+
+export function isQueryAggregateDatasource(ds: Datasource): ds is QueryAggregateDatasource {
+  return ds.kind === 'query-aggregate';
+}
+
+export function isTelemetryDatasource(ds: Datasource): ds is TelemetryDatasource {
+  return ds.kind === 'iot-telemetry';
+}
+
+/**
+ * Compact factories that mirror the backend's
+ * `Datasource.Metric(...)` / `Datasource.QueryAggregate(...)` / `Datasource.Telemetry(...)`
+ * convenience APIs. Use at definition call sites:
+ *
+ *     datasource: Datasource.metric('Granit.Invoicing.UnpaidInvoiceCountMetric'),
+ */
+export const Datasource = {
+  metric(metricName: string): MetricDatasource {
+    return { kind: 'metric', metricName };
+  },
+  queryAggregate(
+    queryName: string,
+    aggregation: AggregateFunction,
+    field: string | null = null,
+    keyFormats: readonly DataKeyFormat[] | null = null
+  ): QueryAggregateDatasource {
+    return { kind: 'query-aggregate', queryName, aggregation, field, keyFormats };
+  },
+  telemetry(
+    entityAlias: string,
+    telemetryKey: string,
+    aggregation: TelemetryAggregation = 'Last',
+    keyFormats: readonly DataKeyFormat[] | null = null
+  ): TelemetryDatasource {
+    return { kind: 'iot-telemetry', entityAlias, telemetryKey, aggregation, keyFormats };
+  },
+} as const;

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -1,5 +1,19 @@
+export type { AggregateFunction } from './aggregate-function.js';
+export type { DataKeyFormat } from './data-key-format.js';
 export type { DashboardCategory } from './dashboard-category.js';
 export { DASHBOARD_TIME_WINDOW } from './dashboard-time-window.js';
+export {
+  Datasource,
+  isMetricDatasource,
+  isQueryAggregateDatasource,
+  isTelemetryDatasource,
+} from './datasource.js';
+export type {
+  MetricDatasource,
+  QueryAggregateDatasource,
+  TelemetryAggregation,
+  TelemetryDatasource,
+} from './datasource.js';
 export type {
   DashboardPeriod,
   DashboardTimeWindow,

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -1,3 +1,4 @@
+import { isMetricDatasource } from '@granit/dashboards';
 import { useDashboardContext } from '@granit/react-dashboards';
 import { useTranslation } from 'react-i18next';
 
@@ -18,10 +19,14 @@ const DEFAULT_PERIOD: MetricRequest = {
  * for breadcrumb data, fetches the metric snapshot via {@link useMetric},
  * delegates rendering to {@link KpiTileView}.
  *
- * v1 uses a hardcoded `last_30d / previous_period` request shape — the
+ * v1 only handles {@link MetricDatasource}. Other datasource kinds
+ * ({@link QueryAggregateDatasource}, {@link TelemetryDatasource}) await the
+ * query-engine evaluator (B5) and the SSE telemetry transport (B7-2)
+ * respectively, and currently render an "unsupported" KpiTileView.
+ *
+ * v1 also uses a hardcoded `last_30d / previous_period` request shape — the
  * runtime `DashboardTimeWindow` (proposals doc P1.3) will replace this once
- * `Granit.Dashboards.DashboardTimeWindow` ships and is propagated via
- * dashboard context.
+ * the dashboard context propagates it.
  */
 export interface KpiTileProps {
   readonly widget: KpiWidgetDefinition;
@@ -30,14 +35,36 @@ export interface KpiTileProps {
 export function KpiTile({ widget }: KpiTileProps) {
   const { t, i18n } = useTranslation();
   const dashboardCtx = useDashboardContext();
+  const { datasource } = widget;
 
   const titleKey = dashboardCtx
     ? `Widget:${dashboardCtx.dashboardName}.${widget.slug}.Title`
     : `Widget:${widget.slug}.Title`;
   const translated = t(titleKey, { defaultValue: '' });
-  const title = translated || widget.metricName;
 
-  const query = useMetric(widget.metricName, DEFAULT_PERIOD);
+  const metricName = isMetricDatasource(datasource) ? datasource.metricName : '';
+  const title = translated || metricName || widget.slug;
+
+  const query = useMetric(metricName, DEFAULT_PERIOD, { enabled: metricName !== '' });
+
+  if (!isMetricDatasource(datasource)) {
+    const message = t('Analytics.UnsupportedDatasource', {
+      defaultValue: 'Datasource not supported yet ({{kind}})',
+      kind: datasource.kind,
+    });
+    return (
+      <div
+        data-slot="kpi-tile"
+        data-datasource-kind={datasource.kind}
+        className="flex h-full flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm"
+      >
+        <header data-slot="kpi-tile-header">
+          <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
+        </header>
+        <p className="text-xs text-muted-foreground">{message}</p>
+      </div>
+    );
+  }
 
   return (
     <KpiTileView


### PR DESCRIPTION
## Summary

Mirrors **P2.2** of the dashboards-architecture-proposals roadmap (backend PR [granit-dotnet#1464](https://github.com/granit-fx/granit-dotnet/pull/1464)). The same KPI tile can now be backed by a metric, a query aggregate or a live telemetry stream — same widget shape, different source.

### \`@granit/dashboards\`

- New **\`Datasource\`** discriminated union (\`kind\`: \`metric\` | \`query-aggregate\` | \`iot-telemetry\`) — wire format mirrors the backend's \`[JsonPolymorphic(TypeDiscriminatorPropertyName = \"kind\")]\` with kebab tags.
- **\`DataKeyFormat\`** for per-series presentation hints (key, labelLocalizationKey, color, unit, decimals) — colours and units belong to the data binding, not the visual.
- **\`TelemetryAggregation\`** (Last default / Avg / Sum / Min / Max / Count).
- **\`AggregateFunction\`** promoted from \`@granit/analytics\` to \`@granit/dashboards\` (mirrors backend's \`Granit.Dashboards.Abstractions\` → \`Granit.QueryEngine.Abstractions\` ProjectReference). **Casing fix** to PascalCase (\`'Count' | 'Sum' | 'Avg' | 'Min' | 'Max'\`) — backend serializes via \`JsonStringEnumConverter\` without a naming policy.
- Static factories \`Datasource.metric(...)\` / \`.queryAggregate(...)\` / \`.telemetry(...)\` for compact call sites — parity with the backend's static helpers.
- Type guards \`isMetricDatasource\` / \`isQueryAggregateDatasource\` / \`isTelemetryDatasource\`.

### \`@granit/analytics\` — :warning: BREAKING

\`\`\`diff
 export interface KpiWidgetDefinition extends WidgetDefinitionBase {
   readonly type: 'kpi';
-  readonly metricName: string;
+  readonly datasource: Datasource;
 }
\`\`\`

Use the factory:
\`\`\`ts
import { Datasource } from '@granit/dashboards';

const widget: KpiWidgetDefinition = {
  slug: 'UnpaidCount',
  type: 'kpi',
  position: 0,
  size: WIDGET_SIZE.SMALL_KPI,
  datasource: Datasource.metric('Granit.Invoicing.UnpaidInvoiceCountMetric'),
};
\`\`\`

### \`@granit/react-analytics\`

- \`KpiTile\` reads \`widget.datasource\`. **v1 only wires \`MetricDatasource\`** through \`useMetric\`; \`QueryAggregate\` / \`Telemetry\` kinds render an "unsupported" placeholder pending the query-engine evaluator (B5) and the SSE telemetry transport (B7-2).

### Wire-format contract tests

9 new tests in \`@granit/dashboards/src/__tests__/datasource.test.ts\` pin the kebab discriminators and PascalCase aggregation values verbatim — drift in the backend serialization fails CI here before it reaches the wire.

## Test plan

- [x] \`pnpm tsc\` (4 changed packages) — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` (changed-package scope) — 44/44 ✓
- [ ] Showcase migration validated end-to-end via [granit-fx/granit-showcase-admin-react PR for \`feature/dashboards-demo\`](https://github.com/granit-fx/granit-showcase-admin-react)

## Cross-repo coordination

| Repo | PR | Status |
| --- | --- | --- |
| granit-dotnet | [#1464](https://github.com/granit-fx/granit-dotnet/pull/1464) | Reference (backend) |
| granit-front | this PR | wires types + KpiTile |
| granit-showcase-admin-react | follow-up PR | demo migration |