### PR TITLE
refactor(dashboards)!: align enum casings with backend wire format (PascalCase)

### DIFF
--- a/packages/@granit/analytics/src/__tests__/wire-format-enums.test.ts
+++ b/packages/@granit/analytics/src/__tests__/wire-format-enums.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RefreshHint, Trend, ValueKind } from '../metrics/metric-response.js';
+
+// Pinned wire-format fixtures for the @granit/analytics enum surface.
+
+describe('ValueKind — exhaustive enum surface (PascalCase, backend-ordered)', () => {
+  it('locks the six backend kinds in declaration order', () => {
+    const kinds: readonly ValueKind[] = [
+      'Count',
+      'Number',
+      'Currency',
+      'Percentage',
+      'Duration',
+      'Date',
+    ];
+    expect(kinds).toHaveLength(6);
+  });
+});
+
+describe('RefreshHint — exhaustive enum surface (PascalCase)', () => {
+  it('locks the three backend hints (Static / Dynamic / Realtime)', () => {
+    const hints: readonly RefreshHint[] = ['Static', 'Dynamic', 'Realtime'];
+    expect(hints).toHaveLength(3);
+  });
+});
+
+describe('Trend — backend ships as a plain string, NOT a JsonStringEnumConverter enum', () => {
+  it('keeps the documented lowercase values verbatim', () => {
+    const trends: readonly Trend[] = ['up', 'down', 'flat'];
+    expect(trends).toHaveLength(3);
+  });
+});

--- a/packages/@granit/analytics/src/metrics/metric-response.ts
+++ b/packages/@granit/analytics/src/metrics/metric-response.ts
@@ -6,11 +6,27 @@
  * directly without depending on a generated client.
  */
 
-export type ValueKind = 'count' | 'currency' | 'percentage' | 'duration' | 'date' | 'number';
+/**
+ * Mirrors `Granit.Analytics.MetricValueKind`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy, so enum names land verbatim. Order matches the backend enum
+ * declaration so a numeric drift surfaces in code review.
+ */
+export type ValueKind = 'Count' | 'Number' | 'Currency' | 'Percentage' | 'Duration' | 'Date';
 
+/**
+ * Direction of the previous-period delta. Backend ships this as a plain
+ * `string` (not an enum) on `MetricPreviousPayload.Trend`, with the
+ * documented values `"up"`, `"down"`, `"flat"` — lowercase, no
+ * `JsonStringEnumConverter` involvement. Stays lowercase here.
+ */
 export type Trend = 'up' | 'down' | 'flat';
 
-export type RefreshHint = 'static' | 'dynamic' | 'realtime';
+/**
+ * Mirrors `Granit.Analytics.RefreshHint`. PascalCase wire values — same
+ * convention as {@link ValueKind}.
+ */
+export type RefreshHint = 'Static' | 'Dynamic' | 'Realtime';
 
 /**
  * Calendar-aware period token. Backend (`Granit.Analytics.Metrics.PeriodSpec`)
@@ -55,7 +71,7 @@ export interface MetricPreviousPayload {
 export interface MetricSnapshotPayload {
   readonly value: number | null;
   readonly valueKind: ValueKind;
-  /** ISO 4217 currency code when `valueKind === 'currency'`. Null otherwise. */
+  /** ISO 4217 currency code when `valueKind === 'Currency'`. Null otherwise. */
   readonly currency: string | null;
   readonly isHigherBetter: boolean;
   readonly noData: boolean;

--- a/packages/@granit/dashboards/src/__tests__/wire-format-enums.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/wire-format-enums.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DashboardCategory } from '../types/dashboard-category.js';
+import type { TimeWindowKind } from '../types/dashboard-time-window.js';
+import type { TextWidgetStyle } from '../types/widget-definition.js';
+
+// Pinned wire-format fixtures for the framework's PascalCase enum surface.
+// All three enums ship via Granit's host JsonStringEnumConverter() with no
+// naming policy, so enum names land verbatim. Drift here = drift on the wire.
+
+describe('DashboardCategory — exhaustive enum surface (PascalCase, ordered)', () => {
+  it('locks the seven backend categories in declaration order', () => {
+    const categories: readonly DashboardCategory[] = [
+      'General',
+      'Finance',
+      'Operations',
+      'Security',
+      'Compliance',
+      'Platform',
+      'Iot',
+    ];
+    expect(categories).toHaveLength(7);
+  });
+});
+
+describe('TimeWindowKind — exhaustive enum surface (PascalCase)', () => {
+  it('locks the two backend kinds (History / Realtime)', () => {
+    const kinds: readonly TimeWindowKind[] = ['History', 'Realtime'];
+    expect(kinds).toHaveLength(2);
+  });
+});
+
+describe('TextWidgetStyle — exhaustive enum surface (PascalCase, ordered)', () => {
+  it('locks the four backend styles in declaration order', () => {
+    const styles: readonly TextWidgetStyle[] = ['Body', 'Heading', 'Subheading', 'Caption'];
+    expect(styles).toHaveLength(4);
+  });
+});

--- a/packages/@granit/dashboards/src/types/dashboard-category.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-category.ts
@@ -3,21 +3,23 @@
  * Drives the catalogue ordering surfaced by the dashboard registry and the
  * section grouping in the admin import dialog.
  *
- * Mirrors `Granit.Dashboards.DashboardCategory` (numeric enum). Backend ships
- * via `JsonStringEnumConverter` so the wire is the lowercase form here.
+ * Mirrors `Granit.Dashboards.DashboardCategory`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy, so enum names land verbatim. Order matches the backend numeric
+ * declaration (`General = 0`, `Finance = 1`, …, `Iot = 6`).
  */
 export type DashboardCategory =
   /** Default — uncategorised. Use only when the others genuinely do not fit. */
-  | 'general'
+  | 'General'
   /** Invoicing, payments, subscriptions, customer balance, tax. */
-  | 'finance'
+  | 'Finance'
   /** AI usage, blob storage, background jobs, webhooks, observability. */
-  | 'operations'
+  | 'Operations'
   /** Identity, authorization, auditing. */
-  | 'security'
+  | 'Security'
   /** Privacy / GDPR (export requests, erasure, retention). */
-  | 'compliance'
+  | 'Compliance'
   /** Multi-tenancy, platform-level admin (tenant lifecycle, feature flags). */
-  | 'platform'
+  | 'Platform'
   /** IoT / real-time telemetry — sensors, alarms, video feeds. */
-  | 'iot';
+  | 'Iot';

--- a/packages/@granit/dashboards/src/types/dashboard-time-window.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-time-window.ts
@@ -12,7 +12,7 @@
  */
 export interface DashboardTimeWindow {
   readonly period: DashboardPeriod;
-  /** Refresh semantics: `history` (frozen, refetch on range change) vs `realtime` (sliding window). */
+  /** Refresh semantics: `History` (frozen, refetch on range change) vs `Realtime` (sliding window). */
   readonly kind?: TimeWindowKind;
   /** Optional comparison window (e.g. `previous_period`). */
   readonly compareTo?: { readonly token: string };
@@ -23,7 +23,12 @@ export interface DashboardTimeWindow {
   readonly aggregationMs?: number;
 }
 
-export type TimeWindowKind = 'history' | 'realtime';
+/**
+ * Mirrors `Granit.Dashboards.TimeWindowKind`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy.
+ */
+export type TimeWindowKind = 'History' | 'Realtime';
 
 /**
  * Period selector — token-based (`last_30d`, `mtd`, `ytd`, `last_5m`, ...) or
@@ -36,13 +41,13 @@ export type DashboardPeriod =
 
 /** Convenience constants matching the conventional tokens. */
 export const DASHBOARD_TIME_WINDOW = Object.freeze({
-  Last24Hours: { period: { token: 'last_24h' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Last7Days: { period: { token: 'last_7d' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Last30Days: { period: { token: 'last_30d' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Mtd: { period: { token: 'mtd' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Ytd: { period: { token: 'ytd' }, kind: 'history' } satisfies DashboardTimeWindow,
+  Last24Hours: { period: { token: 'last_24h' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last7Days: { period: { token: 'last_7d' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last30Days: { period: { token: 'last_30d' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Mtd: { period: { token: 'mtd' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Ytd: { period: { token: 'ytd' }, kind: 'History' } satisfies DashboardTimeWindow,
   RealtimeLast5Minutes: {
     period: { token: 'last_5m' },
-    kind: 'realtime',
+    kind: 'Realtime',
   } satisfies DashboardTimeWindow,
 });

--- a/packages/@granit/dashboards/src/types/widget-definition.ts
+++ b/packages/@granit/dashboards/src/types/widget-definition.ts
@@ -71,8 +71,13 @@ export interface ImageWidgetDefinition extends WidgetDefinitionBase {
   readonly altLocalizationKey: string;
 }
 
-/** Visual style hint for `TextWidgetDefinition`. */
-export type TextWidgetStyle = 'body' | 'heading' | 'subheading' | 'caption';
+/**
+ * Visual style hint for `TextWidgetDefinition`. Mirrors
+ * `Granit.Dashboards.Widgets.TextStyle`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy.
+ */
+export type TextWidgetStyle = 'Body' | 'Heading' | 'Subheading' | 'Caption';
 
 /**
  * Plain text tile — short label or heading without markdown formatting.

--- a/packages/@granit/react-analytics/src/__tests__/format-metric-value.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/format-metric-value.test.ts
@@ -8,20 +8,20 @@ const normalize = (s: string) => s.replace(/[\u0020\u00A0\u202F]+/g, ' ');
 
 describe('formatMetricValue', () => {
   it('returns the fallback when the value is null', () => {
-    expect(formatMetricValue({ value: null, valueKind: 'count', locale: 'en-US' })).toBe('—');
+    expect(formatMetricValue({ value: null, valueKind: 'Count', locale: 'en-US' })).toBe('—');
   });
 
   it('returns a custom fallback when provided', () => {
     expect(
-      formatMetricValue({ value: null, valueKind: 'count', locale: 'en-US', fallback: 'N/A' })
+      formatMetricValue({ value: null, valueKind: 'Count', locale: 'en-US', fallback: 'N/A' })
     ).toBe('N/A');
   });
 
   it.each<{ kind: ValueKind; value: number; en: string; fr: string; currency?: string }>([
-    { kind: 'count', value: 1234, en: '1,234', fr: '1 234' },
-    { kind: 'currency', value: 12450.5, currency: 'EUR', en: '€12,450.50', fr: '12 450,50 €' },
-    { kind: 'percentage', value: 0.1507, en: '15.07%', fr: '15,07 %' },
-    { kind: 'number', value: 3.14159, en: '3.14', fr: '3,14' },
+    { kind: 'Count', value: 1234, en: '1,234', fr: '1 234' },
+    { kind: 'Currency', value: 12450.5, currency: 'EUR', en: '€12,450.50', fr: '12 450,50 €' },
+    { kind: 'Percentage', value: 0.1507, en: '15.07%', fr: '15,07 %' },
+    { kind: 'Number', value: 3.14159, en: '3.14', fr: '3,14' },
   ])('formats $kind=$value across en-US / fr-FR', ({ kind, value, en, fr, currency }) => {
     expect(
       normalize(formatMetricValue({ value, valueKind: kind, currency, locale: 'en-US' }))
@@ -32,11 +32,11 @@ describe('formatMetricValue', () => {
   });
 
   it('formats sub-minute durations as seconds', () => {
-    expect(formatMetricValue({ value: 42, valueKind: 'duration', locale: 'en-US' })).toBe('42s');
+    expect(formatMetricValue({ value: 42, valueKind: 'Duration', locale: 'en-US' })).toBe('42s');
   });
 
   it('formats minute-and-second durations', () => {
-    expect(formatMetricValue({ value: 125, valueKind: 'duration', locale: 'en-US' })).toBe('2m 5s');
+    expect(formatMetricValue({ value: 125, valueKind: 'Duration', locale: 'en-US' })).toBe('2m 5s');
   });
 });
 

--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
@@ -10,10 +10,10 @@ function makeResponse(overrides: Partial<MetricResponse['snapshot']> = {}): Metr
     name: 'Test.Metric',
     sequence: 1,
     emittedAt: '2026-04-28T12:00:00Z',
-    refreshHint: 'dynamic',
+    refreshHint: 'Dynamic',
     snapshot: {
       value: 12,
-      valueKind: 'count',
+      valueKind: 'Count',
       currency: null,
       isHigherBetter: true,
       noData: false,

--- a/packages/@granit/react-analytics/src/api/use-metric.ts
+++ b/packages/@granit/react-analytics/src/api/use-metric.ts
@@ -8,9 +8,9 @@ import type { MetricRequest, MetricResponse } from '@granit/analytics';
 const METRIC_PATH = '/analytics/metrics';
 
 const POLLING_INTERVAL_MS: Readonly<Record<MetricResponse['refreshHint'], number | false>> = {
-  static: false,
-  dynamic: false,
-  realtime: 5_000,
+  Static: false,
+  Dynamic: false,
+  Realtime: 5_000,
 };
 
 export interface UseMetricOptions {

--- a/packages/@granit/react-analytics/src/lib/format-metric-value.ts
+++ b/packages/@granit/react-analytics/src/lib/format-metric-value.ts
@@ -8,7 +8,7 @@ import type { ValueKind } from '@granit/analytics';
 export interface FormatMetricValueArgs {
   readonly value: number | null;
   readonly valueKind: ValueKind;
-  /** ISO 4217 currency code. Required when `valueKind === 'currency'`. */
+  /** ISO 4217 currency code. Required when `valueKind === 'Currency'`. */
   readonly currency?: string | null;
   /** BCP 47 tag. Defaults to runtime default (`undefined` → host default). */
   readonly locale?: string;
@@ -28,28 +28,28 @@ export function formatMetricValue({
   if (value === null || Number.isNaN(value)) return fallback;
 
   switch (valueKind) {
-    case 'count':
+    case 'Count':
       return new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(value);
 
-    case 'currency': {
+    case 'Currency': {
       if (!currency) return new Intl.NumberFormat(locale).format(value);
       return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value);
     }
 
-    case 'percentage':
+    case 'Percentage':
       return new Intl.NumberFormat(locale, {
         style: 'percent',
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       }).format(value);
 
-    case 'duration':
+    case 'Duration':
       return formatDuration(value, locale);
 
-    case 'date':
+    case 'Date':
       return new Intl.DateTimeFormat(locale).format(new Date(value));
 
-    case 'number':
+    case 'Number':
       return new Intl.NumberFormat(locale, {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
@@ -48,7 +48,7 @@ describe('Dashboard', () => {
   it('renders widgets in `position` order with their declared size', () => {
     const { container } = renderDashboard({
       name: 'Test',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 12, rowHeight: 80 },
@@ -59,7 +59,7 @@ describe('Dashboard', () => {
           position: 1,
           size: { width: 6, height: 1 },
           contentLocalizationKey: 'Widget:Test.Hello',
-          style: 'body',
+          style: 'Body',
         },
         {
           slug: 'Heading',
@@ -84,7 +84,7 @@ describe('Dashboard', () => {
   it('applies grid-template-columns from layout.columns', () => {
     const { container } = renderDashboard({
       name: 'Empty',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 8, rowHeight: 80 },
@@ -97,7 +97,7 @@ describe('Dashboard', () => {
   it('renders an unknown-widget placeholder when the type has no registered renderer', () => {
     renderDashboard({
       name: 'Test',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 12, rowHeight: 80 },
@@ -118,7 +118,7 @@ describe('Dashboard', () => {
   it('renders the TextWidget with style-aware HTML element', () => {
     const { container } = renderDashboard({
       name: 'Test',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 12, rowHeight: 80 },
@@ -129,7 +129,7 @@ describe('Dashboard', () => {
           position: 0,
           size: { width: 6, height: 1 },
           contentLocalizationKey: 'Widget:Test.Caption',
-          style: 'caption',
+          style: 'Caption',
         },
       ],
     });

--- a/packages/@granit/react-dashboards/src/__tests__/use-effective-time-window.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-effective-time-window.test.tsx
@@ -28,7 +28,7 @@ describe('useEffectiveTimeWindow', () => {
   it('prefers an explicit override over the dashboard timeWindow', () => {
     const override: DashboardTimeWindow = {
       period: { token: 'mtd' },
-      kind: 'history',
+      kind: 'History',
     };
     const wrapper = ({ children }: { children: ReactNode }) => (
       <DashboardContextProvider

--- a/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import type { TextWidgetDefinition, TextWidgetStyle } from '@granit/dashboards';
 
 const STYLE_CLASSES: Readonly<Record<TextWidgetStyle, string>> = {
-  body: 'text-sm text-foreground',
-  heading: 'text-2xl font-semibold tracking-tight text-foreground',
-  subheading: 'text-lg font-semibold text-foreground',
-  caption: 'text-xs text-muted-foreground',
+  Body: 'text-sm text-foreground',
+  Heading: 'text-2xl font-semibold tracking-tight text-foreground',
+  Subheading: 'text-lg font-semibold text-foreground',
+  Caption: 'text-xs text-muted-foreground',
 };
 
 /**
@@ -21,14 +21,14 @@ export function TextWidget({ widget }: { readonly widget: TextWidgetDefinition }
   const content = t(widget.contentLocalizationKey);
   const className = `whitespace-pre-wrap break-words ${STYLE_CLASSES[widget.style]}`;
 
-  if (widget.style === 'heading') {
+  if (widget.style === 'Heading') {
     return (
       <h2 data-slot="text-widget" data-style="heading" className={className}>
         {content}
       </h2>
     );
   }
-  if (widget.style === 'subheading') {
+  if (widget.style === 'Subheading') {
     return (
       <h3 data-slot="text-widget" data-style="subheading" className={className}>
         {content}
@@ -36,7 +36,7 @@ export function TextWidget({ widget }: { readonly widget: TextWidgetDefinition }
     );
   }
   return (
-    <p data-slot="text-widget" data-style={widget.style} className={className}>
+    <p data-slot="text-widget" data-style={widget.style.toLowerCase()} className={className}>
       {content}
     </p>
   );


### PR DESCRIPTION
## Summary

The framework's host registers \`System.Text.Json\`'s \`JsonStringEnumConverter()\` **without a naming policy**, so backend enums serialise as PascalCase verbatim. Five frontend types ship lowercase by mistake — fixed here.

## :warning: BREAKING

### \`@granit/analytics\`

| Type | Before | After |
| --- | --- | --- |
| \`ValueKind\` | \`'count' \| 'currency' \| 'percentage' \| 'duration' \| 'date' \| 'number'\` | \`'Count' \| 'Number' \| 'Currency' \| 'Percentage' \| 'Duration' \| 'Date'\` |
| \`RefreshHint\` | \`'static' \| 'dynamic' \| 'realtime'\` | \`'Static' \| 'Dynamic' \| 'Realtime'\` |
| \`Trend\` | \`'up' \| 'down' \| 'flat'\` | **unchanged** — backend ships \`MetricPreviousPayload.Trend\` as a plain \`string\`, not an enum |

### \`@granit/dashboards\`

| Type | Before | After |
| --- | --- | --- |
| \`DashboardCategory\` | \`'general' \| 'finance' \| ...\` | \`'General' \| 'Finance' \| 'Operations' \| 'Security' \| 'Compliance' \| 'Platform' \| 'Iot'\` |
| \`TimeWindowKind\` | \`'history' \| 'realtime'\` | \`'History' \| 'Realtime'\` |
| \`TextWidgetStyle\` | \`'body' \| 'heading' \| 'subheading' \| 'caption'\` | \`'Body' \| 'Heading' \| 'Subheading' \| 'Caption'\` |

\`DASHBOARD_TIME_WINDOW\` constants updated.

## Consumer updates

- \`format-metric-value\` switch cases (\`count\`/\`currency\`/… → \`Count\`/\`Currency\`/…)
- \`use-metric\` \`POLLING_INTERVAL_MS\` keys (\`static\`/\`dynamic\`/\`realtime\` → PascalCase)
- \`text-widget\` renderer style branches and \`STYLE_CLASSES\` record. The \`data-style\` HTML attribute now lower-cases the value at render time so CSS selectors stay stable independent of the wire-format casing.
- All affected tests in \`@granit/react-analytics\` and \`@granit/react-dashboards\`.

## Wire-format contract tests

New pinning tests in:
- \`@granit/analytics/src/__tests__/wire-format-enums.test.ts\` — \`ValueKind\`, \`RefreshHint\`, \`Trend\`
- \`@granit/dashboards/src/__tests__/wire-format-enums.test.ts\` — \`DashboardCategory\`, \`TimeWindowKind\`, \`TextWidgetStyle\`

Drift in the backend serialization fails CI here before it reaches the wire.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 2317/2317 ✓
- [ ] Showcase follow-up PR (this branch's sibling) updates the MSW mocks + sample dashboard category

## Stacked on

[#233 — \`feat(dashboards): widget action descriptors + timeWindowOverride\`](https://github.com/granit-fx/granit-front/pull/233). Rebase onto develop after that lands.