### PR TITLE
feat(dashboards): widget render contracts mirror (B3-1, ADR-039)

### DIFF
--- a/packages/@granit/analytics/src/metrics/metric-response.ts
+++ b/packages/@granit/analytics/src/metrics/metric-response.ts
@@ -22,11 +22,13 @@ export type ValueKind = 'Count' | 'Number' | 'Currency' | 'Percentage' | 'Durati
  */
 export type Trend = 'up' | 'down' | 'flat';
 
-/**
- * Mirrors `Granit.Analytics.RefreshHint`. PascalCase wire values — same
- * convention as {@link ValueKind}.
- */
-export type RefreshHint = 'Static' | 'Dynamic' | 'Realtime';
+// `RefreshHint` is shared between metric responses (this module) and the
+// dashboard widget envelope (`@granit/dashboards/rendering`). It lives in
+// `@granit/dashboards` to mirror the backend's `Granit.Analytics.Abstractions`
+// promotion (ADR-039) and keep the dependency arrow analytics → dashboards
+// clean. Re-exported here for source-level back-compat.
+import type { RefreshHint } from '@granit/dashboards';
+export type { RefreshHint };
 
 /**
  * Calendar-aware period token. Backend (`Granit.Analytics.Metrics.PeriodSpec`)

--- a/packages/@granit/dashboards/src/__tests__/widget-snapshot-envelope.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/widget-snapshot-envelope.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WidgetSnapshotEnvelope, WidgetSnapshotStatus } from '../rendering/index.js';
+
+// Pinned wire-format fixtures for the B3-1 envelope (ADR-039 §6).
+// Mirrors what `Granit.Dashboards.Rendering.WidgetSnapshotEnvelope`
+// serialises through the framework's host JsonSerializerOptions
+// (camelCase property names, PascalCase enum values).
+
+const SNAPSHOT_FIXTURE: WidgetSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Kpi',
+  snapshot: {
+    /* Snapshot is `unknown`: typed shape (KpiSnapshot, ChartSnapshot, …)
+       lands as B3-2..B3-6 ship. */
+    value: 12,
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
+const UNAVAILABLE_FIXTURE: WidgetSnapshotEnvelope = {
+  status: 'Unavailable',
+  widgetType: 'Chart',
+  snapshot: null,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: 'Widget:Unavailable',
+};
+
+const ERROR_FIXTURE: WidgetSnapshotEnvelope = {
+  status: 'Error',
+  widgetType: 'Pivot',
+  snapshot: null,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  unavailableReasonLocalizationKey: null,
+};
+
+describe('WidgetSnapshotEnvelope — wire format', () => {
+  it('accepts the Snapshot variant verbatim', () => {
+    expect(SNAPSHOT_FIXTURE.status).toBe('Snapshot');
+    expect(SNAPSHOT_FIXTURE.widgetType).toBe('Kpi');
+    expect(SNAPSHOT_FIXTURE.snapshot).not.toBeNull();
+    expect(SNAPSHOT_FIXTURE.unavailableReasonLocalizationKey).toBeNull();
+  });
+
+  it('accepts the Unavailable variant — snapshot null, reason key set', () => {
+    expect(UNAVAILABLE_FIXTURE.status).toBe('Unavailable');
+    expect(UNAVAILABLE_FIXTURE.snapshot).toBeNull();
+    expect(UNAVAILABLE_FIXTURE.unavailableReasonLocalizationKey).toBe('Widget:Unavailable');
+  });
+
+  it('accepts the Error variant — snapshot null, reason key null (server-side log only)', () => {
+    expect(ERROR_FIXTURE.status).toBe('Error');
+    expect(ERROR_FIXTURE.snapshot).toBeNull();
+    expect(ERROR_FIXTURE.unavailableReasonLocalizationKey).toBeNull();
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    for (const fixture of [SNAPSHOT_FIXTURE, UNAVAILABLE_FIXTURE, ERROR_FIXTURE]) {
+      expect(JSON.parse(JSON.stringify(fixture))).toEqual(fixture);
+    }
+  });
+});
+
+describe('WidgetSnapshotStatus — exhaustive enum surface (PascalCase)', () => {
+  it('locks the three runtime outcomes (Snapshot / Unavailable / Error)', () => {
+    const statuses: readonly WidgetSnapshotStatus[] = ['Snapshot', 'Unavailable', 'Error'];
+    expect(statuses).toHaveLength(3);
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -26,6 +26,8 @@ export type {
   MarkdownWidgetDefinition,
   MetricDatasource,
   QueryAggregateDatasource,
+  RefreshHint,
+  ResolvedPeriod,
   TelemetryAggregation,
   TelemetryDatasource,
   TextWidgetDefinition,
@@ -38,3 +40,6 @@ export type {
   WidgetDefinitionBase,
   WidgetSize,
 } from './types/index.js';
+
+// Rendering — wire contracts for the dashboard render pipeline (B3-1, ADR-039).
+export type { WidgetSnapshotEnvelope, WidgetSnapshotStatus } from './rendering/index.js';

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -1,0 +1,7 @@
+// ---------------------------------------------------------------------------
+// @granit/dashboards/rendering — wire contracts for the dashboard render
+// pipeline. Mirrors `Granit.Dashboards.Rendering` (B3-1, ADR-039).
+// ---------------------------------------------------------------------------
+
+export type { WidgetSnapshotEnvelope } from './widget-snapshot-envelope.js';
+export type { WidgetSnapshotStatus } from './widget-snapshot-status.js';

--- a/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
@@ -1,0 +1,52 @@
+import type { WidgetSnapshotStatus } from './widget-snapshot-status.js';
+import type { RefreshHint } from '../types/refresh-hint.js';
+
+/**
+ * Non-generic envelope returned by every widget renderer (one per
+ * `WidgetInstance`). Bundles the runtime {@link status}, the declarative
+ * {@link widgetType}, and a pre-serialised {@link snapshot} so the dashboard
+ * render endpoint can compose heterogeneous widgets into one response without
+ * leaking per-kind generics.
+ *
+ * Mirrors `Granit.Dashboards.Rendering.WidgetSnapshotEnvelope`. See
+ * ADR-039 §2 for the design rationale and §2.1 for why the snapshot is
+ * pre-serialised JSON (not a typed `object?`) at the boundary.
+ *
+ * On the wire, {@link snapshot} is the concrete typed payload for the
+ * widget's kind — `KpiSnapshot` for `Kpi`, `ChartSnapshot` for `Chart`, etc.
+ * Frontend consumers cast to the kind-specific type after dispatching on
+ * {@link widgetType} via the widget registry; until B3-2/3/4/5/6 land per-kind
+ * snapshots, the type stays `unknown`.
+ */
+export interface WidgetSnapshotEnvelope {
+  /** Runtime outcome (snapshot / unavailable / error). */
+  readonly status: WidgetSnapshotStatus;
+  /**
+   * Declarative kind discriminator — mirrors `WidgetDefinition.type`'s
+   * `[JsonDerivedType]` tag (`'Kpi'`, `'Chart'`, `'Markdown'`, ...).
+   * Carried even on `Unavailable` / `Error` so the frontend keeps a typed
+   * slot for the absent widget.
+   */
+  readonly widgetType: string;
+  /**
+   * Pre-serialised typed payload. `null` when {@link status} is not
+   * `'Snapshot'`. Frontend renderers narrow this to a kind-specific shape
+   * (e.g. `KpiSnapshot`) by inspecting {@link widgetType} via the widget
+   * registry.
+   */
+  readonly snapshot: unknown | null;
+  /**
+   * Always `1` in pull mode; future push transport increments per
+   * (widget instance, tenant). Locked v1 per EPIC #1366 invariant #2.
+   */
+  readonly sequence: number;
+  /** Server-side timestamp of the computation (ISO 8601 UTC). */
+  readonly emittedAt: string;
+  /** Pull / push transport hint inherited from the underlying definition. */
+  readonly refreshHint: RefreshHint;
+  /**
+   * Localization key for the user-facing reason (e.g. `'Widget:Unavailable'`)
+   * when {@link status} is `'Unavailable'`; `null` otherwise.
+   */
+  readonly unavailableReasonLocalizationKey: string | null;
+}

--- a/packages/@granit/dashboards/src/rendering/widget-snapshot-status.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-snapshot-status.ts
@@ -1,0 +1,21 @@
+/**
+ * Runtime outcome of a single widget render — the "what happened" axis of
+ * the per-widget envelope. Decoupled from `WidgetSnapshotEnvelope.widgetType`
+ * (the declarative kind) so a frontend `useDashboard` hook can branch on
+ * "render the snapshot" vs "render an unavailable / error placeholder"
+ * without inspecting the snapshot payload itself.
+ *
+ * Mirrors `Granit.Dashboards.Rendering.WidgetSnapshotStatus`. PascalCase
+ * wire values — backend's host registers a `JsonStringEnumConverter()`
+ * with no naming policy.
+ *
+ * See ADR-039 §2 for why the original draft's single `kind` field was split
+ * into `status` (this) + `widgetType` on the envelope.
+ */
+export type WidgetSnapshotStatus =
+  /** The renderer produced a typed snapshot — `WidgetSnapshotEnvelope.snapshot` is non-null. */
+  | 'Snapshot'
+  /** The current user lacks the widget's required permission. The dashboard render endpoint short-circuits before invoking the underlying metric / query. */
+  | 'Unavailable'
+  /** The renderer threw an unexpected exception. Logged server-side; the bundle response stays 200 so a single bad widget does not break the whole dashboard. */
+  | 'Error';

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -1,4 +1,6 @@
 export type { AggregateFunction } from './aggregate-function.js';
+export type { RefreshHint } from './refresh-hint.js';
+export type { ResolvedPeriod } from './resolved-period.js';
 export type { DataKeyFormat } from './data-key-format.js';
 export type { DashboardCategory } from './dashboard-category.js';
 export { DASHBOARD_TIME_WINDOW } from './dashboard-time-window.js';

--- a/packages/@granit/dashboards/src/types/refresh-hint.ts
+++ b/packages/@granit/dashboards/src/types/refresh-hint.ts
@@ -1,0 +1,21 @@
+/**
+ * Pull / push transport hint shipped on every widget envelope. Drives how
+ * `useDashboard` (and its single-widget cousin `useMetric`) cadence their
+ * background refetch:
+ *
+ * - `Static`  — the snapshot is computed offline; never refetch.
+ * - `Dynamic` — refetch on demand, no polling. The default for KPI / chart
+ *   tiles bound to dashboard time windows.
+ * - `Realtime` — short polling (~5s) until the future SSE / WS push
+ *   transport (P2.4) replaces it.
+ *
+ * Lives in `@granit/dashboards` rather than `@granit/analytics` so the
+ * widget-renderer envelope can carry it without forcing the dashboards
+ * package to depend on analytics — mirrors backend's
+ * `Granit.Analytics.Metrics.RefreshHint` promotion to
+ * `Granit.Analytics.Abstractions` per ADR-039.
+ *
+ * PascalCase wire values — backend's host registers a
+ * `JsonStringEnumConverter()` with no naming policy.
+ */
+export type RefreshHint = 'Static' | 'Dynamic' | 'Realtime';

--- a/packages/@granit/dashboards/src/types/resolved-period.ts
+++ b/packages/@granit/dashboards/src/types/resolved-period.ts
@@ -1,0 +1,17 @@
+/**
+ * Absolute, half-open `[from, to)` time window — the resolved form of a
+ * `PeriodSpec` after named-token expansion against the backend's `IClock`.
+ * Mirrors `Granit.Analytics.ResolvedPeriod`. ISO 8601 UTC strings on the
+ * wire.
+ *
+ * Lives in `@granit/dashboards` (alongside the rendering envelope) rather
+ * than `@granit/analytics` so the dashboards rendering boundary can carry
+ * it without dragging in the analytics surface — mirrors the backend's
+ * `Granit.Analytics.Abstractions` placement per ADR-039.
+ */
+export interface ResolvedPeriod {
+  /** Inclusive lower bound (UTC). */
+  readonly from: string;
+  /** Exclusive upper bound (UTC). */
+  readonly to: string;
+}


### PR DESCRIPTION
## Summary

Frontend mirror for granit-dotnet [#1483](https://github.com/granit-fx/granit-dotnet/pull/1483) — pure wire types for the dashboard render pipeline. **No renderer dispatch, no \`useDashboard\` hook yet** (B3-2..B3-6 ship those).

## New \`@granit/dashboards\` exports

\`\`\`ts
export type WidgetSnapshotStatus = 'Snapshot' | 'Unavailable' | 'Error';

export interface WidgetSnapshotEnvelope {
  readonly status: WidgetSnapshotStatus;
  readonly widgetType: string;             // 'Kpi' | 'Chart' | 'Markdown' | …
  readonly snapshot: unknown | null;       // typed shape lands B3-2..B3-6
  readonly sequence: number;
  readonly emittedAt: string;              // ISO 8601 UTC
  readonly refreshHint: RefreshHint;
  readonly unavailableReasonLocalizationKey: string | null;
}

export interface ResolvedPeriod {
  readonly from: string;                   // [from, to) — half-open, UTC
  readonly to: string;
}
\`\`\`

The \`status\` ↔ \`widgetType\` split solves the original ADR draft's collision (a single \`kind\` field that conflated runtime outcome with declarative kind). Drift would have surfaced on \`Unavailable\` / \`Error\` envelopes where there is no snapshot to inspect.

## :recycle: \`RefreshHint\` promoted to \`@granit/dashboards\`

The type lives in \`@granit/dashboards/types/refresh-hint.ts\` so the rendering envelope can carry it without forcing the dashboards package to depend on analytics — **mirrors backend's \`Granit.Analytics.Abstractions\` promotion per ADR-039** (\`RefreshHint\` was moved out of \`Granit.Analytics\` into \`Granit.Analytics.Abstractions\` for the same reason).

\`@granit/analytics\` re-exports \`RefreshHint\` from \`@granit/dashboards\` for source-level back-compat. The dependency arrow stays \`analytics → dashboards\`.

## Wire-format contract tests

New file \`packages/@granit/dashboards/src/__tests__/widget-snapshot-envelope.test.ts\` pins the three envelope variants (Snapshot / Unavailable / Error) verbatim plus a JSON round-trip. Drift in the backend serialization fails CI here before it reaches the wire.

## Stacked on

[#234 — \`refactor(dashboards)!: align enum casings with backend wire format (PascalCase)\`](https://github.com/granit-fx/granit-front/pull/234). Rebase onto develop after that lands.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 2322/2322 ✓

## What's next (B3-2..)

- \`KpiWidgetInstanceRenderer\` + \`MetricDatasourceEvaluator\` + \`QueryAggregateDatasourceEvaluator\` (granit-dotnet B3-2). Frontend follow-up will type the Kpi snapshot.
- Per-kind snapshot types (\`KpiSnapshot\`, \`ChartSnapshot\`, …) on the \`@granit/analytics\` side, narrowing \`WidgetSnapshotEnvelope.snapshot\` from \`unknown\` to a typed union via the widget registry.