### PR TITLE
feat(analytics): kpi snapshot envelope + type guard (B3-2 mirror, ADR-039)

### DIFF
--- a/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
+++ b/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { isKpiSnapshotEnvelope } from '../widgets/kpi-snapshot.js';
+
+import type { KpiSnapshotEnvelope } from '../widgets/kpi-snapshot.js';
+import type { WidgetSnapshotEnvelope } from '@granit/dashboards';
+
+// Pinned wire-format fixture mirroring what `KpiWidgetInstanceRenderer`
+// (B3-2, ADR-039 §7.bis) emits for a successful metric-backed Kpi:
+// envelope-level fields (camelCase, PascalCase enums) wrapping a
+// MetricSnapshotPayload (also camelCase, PascalCase ValueKind).
+
+const KPI_SNAPSHOT_FIXTURE: KpiSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Kpi',
+  snapshot: {
+    value: 12,
+    valueKind: 'Count',
+    currency: null,
+    isHigherBetter: false,
+    noData: false,
+    previous: {
+      value: 14,
+      deltaRatio: -0.1428,
+      trend: 'down',
+      isFavorable: true,
+    },
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
+const KPI_UNAVAILABLE_FIXTURE: KpiSnapshotEnvelope = {
+  status: 'Unavailable',
+  widgetType: 'Kpi',
+  snapshot: null,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  unavailableReasonLocalizationKey: 'Widget:Unavailable.QueryAggregateNotImplemented',
+};
+
+describe('KpiSnapshotEnvelope — wire format', () => {
+  it('accepts the snapshot variant with a fully-populated MetricSnapshotPayload', () => {
+    expect(KPI_SNAPSHOT_FIXTURE.widgetType).toBe('Kpi');
+    expect(KPI_SNAPSHOT_FIXTURE.snapshot?.valueKind).toBe('Count');
+    expect(KPI_SNAPSHOT_FIXTURE.snapshot?.previous?.trend).toBe('down');
+  });
+
+  it('accepts the unavailable variant emitted by stub datasource evaluators', () => {
+    expect(KPI_UNAVAILABLE_FIXTURE.snapshot).toBeNull();
+    expect(KPI_UNAVAILABLE_FIXTURE.unavailableReasonLocalizationKey).toBe(
+      'Widget:Unavailable.QueryAggregateNotImplemented'
+    );
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    for (const fixture of [KPI_SNAPSHOT_FIXTURE, KPI_UNAVAILABLE_FIXTURE]) {
+      expect(JSON.parse(JSON.stringify(fixture))).toEqual(fixture);
+    }
+  });
+});
+
+describe('isKpiSnapshotEnvelope — type guard', () => {
+  it('narrows when widgetType is the Kpi discriminator', () => {
+    const generic: WidgetSnapshotEnvelope = KPI_SNAPSHOT_FIXTURE;
+    expect(isKpiSnapshotEnvelope(generic)).toBe(true);
+    if (isKpiSnapshotEnvelope(generic)) {
+      expect(generic.snapshot?.valueKind).toBe('Count');
+    }
+  });
+
+  it('rejects envelopes carrying a different widgetType', () => {
+    const chartEnvelope: WidgetSnapshotEnvelope = {
+      ...KPI_SNAPSHOT_FIXTURE,
+      widgetType: 'Chart',
+      snapshot: null,
+    };
+    expect(isKpiSnapshotEnvelope(chartEnvelope)).toBe(false);
+  });
+});

--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -18,11 +18,14 @@ export type {
 } from './metrics/index.js';
 
 // Widgets — catalog declarations consumed by @granit/dashboards
+export { isKpiSnapshotEnvelope } from './widgets/index.js';
 export type {
   AggregateFunction,
   AnalyticsWidgetDefinition,
   ChartType,
   ChartWidgetDefinition,
+  KpiSnapshot,
+  KpiSnapshotEnvelope,
   KpiWidgetDefinition,
   PivotWidgetDefinition,
   TableWidgetDefinition,

--- a/packages/@granit/analytics/src/widgets/index.ts
+++ b/packages/@granit/analytics/src/widgets/index.ts
@@ -1,5 +1,7 @@
 export type { AggregateFunction } from './aggregation.js';
 export type { ChartType, ChartWidgetDefinition } from './chart-widget.js';
+export { isKpiSnapshotEnvelope } from './kpi-snapshot.js';
+export type { KpiSnapshot, KpiSnapshotEnvelope } from './kpi-snapshot.js';
 export type { KpiWidgetDefinition } from './kpi-widget.js';
 export type { PivotWidgetDefinition } from './pivot-widget.js';
 export type { TableWidgetDefinition } from './table-widget.js';

--- a/packages/@granit/analytics/src/widgets/kpi-snapshot.ts
+++ b/packages/@granit/analytics/src/widgets/kpi-snapshot.ts
@@ -1,0 +1,34 @@
+import type { MetricSnapshotPayload } from '../metrics/metric-response.js';
+import type { WidgetSnapshotEnvelope, WidgetSnapshotEnvelopeOf } from '@granit/dashboards';
+
+/**
+ * Snapshot payload returned by the KPI widget renderer. Mirrors the backend
+ * `KpiWidgetInstanceRenderer` output (B3-2, ADR-039 §7.bis): the renderer
+ * dispatches on the persisted `Datasource.kind` and reuses
+ * `MetricSnapshotPayload` as the wire shape regardless of which datasource
+ * (metric / query-aggregate / telemetry) produced the value.
+ *
+ * Effectively a structural alias for {@link MetricSnapshotPayload} — kept
+ * named so consumers reading `widget.snapshot` see the KPI semantics rather
+ * than the inline-metric envelope.
+ */
+export type KpiSnapshot = MetricSnapshotPayload;
+
+/**
+ * Narrowed {@link WidgetSnapshotEnvelope} for the `'Kpi'` widget kind. Use
+ * the {@link isKpiSnapshotEnvelope} type guard to refine a heterogeneous
+ * dashboard render response to KPI envelopes only.
+ */
+export type KpiSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Kpi', KpiSnapshot>;
+
+/**
+ * Type guard refining a generic {@link WidgetSnapshotEnvelope} to the
+ * KPI-specific {@link KpiSnapshotEnvelope}. Drives renderer dispatch in the
+ * frontend `useDashboard` hook (and in any consumer that walks the bundle
+ * response widget by widget).
+ */
+export function isKpiSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is KpiSnapshotEnvelope {
+  return envelope.widgetType === 'Kpi';
+}

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -42,4 +42,8 @@ export type {
 } from './types/index.js';
 
 // Rendering — wire contracts for the dashboard render pipeline (B3-1, ADR-039).
-export type { WidgetSnapshotEnvelope, WidgetSnapshotStatus } from './rendering/index.js';
+export type {
+  WidgetSnapshotEnvelope,
+  WidgetSnapshotEnvelopeOf,
+  WidgetSnapshotStatus,
+} from './rendering/index.js';

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -3,5 +3,8 @@
 // pipeline. Mirrors `Granit.Dashboards.Rendering` (B3-1, ADR-039).
 // ---------------------------------------------------------------------------
 
-export type { WidgetSnapshotEnvelope } from './widget-snapshot-envelope.js';
+export type {
+  WidgetSnapshotEnvelope,
+  WidgetSnapshotEnvelopeOf,
+} from './widget-snapshot-envelope.js';
 export type { WidgetSnapshotStatus } from './widget-snapshot-status.js';

--- a/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
@@ -50,3 +50,24 @@ export interface WidgetSnapshotEnvelope {
    */
   readonly unavailableReasonLocalizationKey: string | null;
 }
+
+/**
+ * Narrowed flavour of {@link WidgetSnapshotEnvelope} for a specific widget
+ * kind. Per-kind packages (e.g. `@granit/analytics`) compose their own typed
+ * envelope by binding `TKind` to the discriminator value (`'Kpi'`, `'Chart'`,
+ * …) and `TSnapshot` to the kind's payload shape:
+ *
+ *     export type KpiSnapshotEnvelope =
+ *       WidgetSnapshotEnvelopeOf<'Kpi', MetricSnapshotPayload>;
+ *
+ * Pair with a runtime type guard (`widgetType === 'Kpi'`) to narrow a
+ * generic envelope obtained from the dashboard render endpoint to the
+ * kind-specific shape.
+ */
+export type WidgetSnapshotEnvelopeOf<TKind extends string, TSnapshot> = Omit<
+  WidgetSnapshotEnvelope,
+  'widgetType' | 'snapshot'
+> & {
+  readonly widgetType: TKind;
+  readonly snapshot: TSnapshot | null;
+};


### PR DESCRIPTION
## Summary

Frontend mirror for granit-dotnet \`feat(analytics): KPI widget renderer + datasource dispatch (B3-2, ADR-039)\` ([commit](https://github.com/granit-fx/granit-dotnet/commit/c887725f6)).

The backend renderer reuses \`MetricSnapshotPayload\` as the snapshot wire shape regardless of which datasource (metric / query-aggregate / telemetry) produced it. So the frontend only needs a **typed view** of the bundled envelope — no new payload type.

## \`@granit/dashboards\` — new generic helper

\`\`\`ts
export type WidgetSnapshotEnvelopeOf<TKind extends string, TSnapshot> =
  Omit<WidgetSnapshotEnvelope, 'widgetType' | 'snapshot'> & {
    readonly widgetType: TKind;
    readonly snapshot: TSnapshot | null;
  };
\`\`\`

Per-kind packages compose their typed envelope by binding \`TKind\` and \`TSnapshot\`, then pair with a runtime type guard for renderer dispatch in the future \`useDashboard\` hook.

## \`@granit/analytics\` — KPI envelope

\`\`\`ts
export type KpiSnapshot = MetricSnapshotPayload;
export type KpiSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Kpi', KpiSnapshot>;

export function isKpiSnapshotEnvelope(
  envelope: WidgetSnapshotEnvelope,
): envelope is KpiSnapshotEnvelope;
\`\`\`

\`KpiSnapshot\` is a structural alias for \`MetricSnapshotPayload\`. Kept named so consumers reading \`widget.snapshot\` see the KPI semantics, not the inline-metric envelope.

## Wire-format contract tests

\`packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts\` pins the snapshot **and** unavailable variants verbatim, plus a JSON round-trip and the type-guard narrowing behaviour. Drift in the backend serialization fails CI here before it reaches the wire.

## Stacked on

[#235 — \`feat(dashboards): widget render contracts mirror (B3-1, ADR-039)\`](https://github.com/granit-fx/granit-front/pull/235). Rebase onto develop after that lands.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 2327/2327 ✓

## What's next

- **B3-3** (Markdown / Text / Image renderers backend-side) — pure projection of \`WidgetInstance.ConfigJson\`, no I/O. Frontend mirror is similarly trivial: \`MarkdownSnapshot\` / \`TextSnapshot\` / \`ImageSnapshot\` aliases over the existing \`*WidgetDefinition\` content fields.
- **B4-render** — once \`POST /dashboards/{id}/render\` ships, add \`useDashboard\` hook with the bundle → per-widget cache split (cf. ADR §6.2). The \`isKpiSnapshotEnvelope\` guard introduced here drives the dispatch.