### PR TITLE
fix(dashboards): replay merged-but-floating stacked PRs (#234, #235, #236) onto develop

### DIFF
--- a/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
+++ b/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+
+import { isKpiSnapshotEnvelope } from '../widgets/kpi-snapshot.js';
+
+import type { KpiSnapshotEnvelope } from '../widgets/kpi-snapshot.js';
+import type { WidgetSnapshotEnvelope } from '@granit/dashboards';
+
+// Pinned wire-format fixture mirroring what `KpiWidgetInstanceRenderer`
+// (B3-2, ADR-039 §7.bis) emits for a successful metric-backed Kpi:
+// envelope-level fields (camelCase, PascalCase enums) wrapping a
+// MetricSnapshotPayload (also camelCase, PascalCase ValueKind).
+
+const KPI_SNAPSHOT_FIXTURE: KpiSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Kpi',
+  snapshot: {
+    value: 12,
+    valueKind: 'Count',
+    currency: null,
+    isHigherBetter: false,
+    noData: false,
+    previous: {
+      value: 14,
+      deltaRatio: -0.1428,
+      trend: 'down',
+      isFavorable: true,
+    },
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
+const KPI_UNAVAILABLE_FIXTURE: KpiSnapshotEnvelope = {
+  status: 'Unavailable',
+  widgetType: 'Kpi',
+  snapshot: null,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  unavailableReasonLocalizationKey: 'Widget:Unavailable.QueryAggregateNotImplemented',
+};
+
+describe('KpiSnapshotEnvelope — wire format', () => {
+  it('accepts the snapshot variant with a fully-populated MetricSnapshotPayload', () => {
+    expect(KPI_SNAPSHOT_FIXTURE.widgetType).toBe('Kpi');
+    expect(KPI_SNAPSHOT_FIXTURE.snapshot?.valueKind).toBe('Count');
+    expect(KPI_SNAPSHOT_FIXTURE.snapshot?.previous?.trend).toBe('down');
+  });
+
+  it('accepts the unavailable variant emitted by stub datasource evaluators', () => {
+    expect(KPI_UNAVAILABLE_FIXTURE.snapshot).toBeNull();
+    expect(KPI_UNAVAILABLE_FIXTURE.unavailableReasonLocalizationKey).toBe(
+      'Widget:Unavailable.QueryAggregateNotImplemented'
+    );
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    for (const fixture of [KPI_SNAPSHOT_FIXTURE, KPI_UNAVAILABLE_FIXTURE]) {
+      expect(JSON.parse(JSON.stringify(fixture))).toEqual(fixture);
+    }
+  });
+});
+
+describe('isKpiSnapshotEnvelope — type guard', () => {
+  it('narrows when widgetType is the Kpi discriminator', () => {
+    const generic: WidgetSnapshotEnvelope = KPI_SNAPSHOT_FIXTURE;
+    expect(isKpiSnapshotEnvelope(generic)).toBe(true);
+    if (isKpiSnapshotEnvelope(generic)) {
+      expect(generic.snapshot?.valueKind).toBe('Count');
+    }
+  });
+
+  it('rejects envelopes carrying a different widgetType', () => {
+    const chartEnvelope: WidgetSnapshotEnvelope = {
+      ...KPI_SNAPSHOT_FIXTURE,
+      widgetType: 'Chart',
+      snapshot: null,
+    };
+    expect(isKpiSnapshotEnvelope(chartEnvelope)).toBe(false);
+  });
+});

--- a/packages/@granit/analytics/src/__tests__/wire-format-enums.test.ts
+++ b/packages/@granit/analytics/src/__tests__/wire-format-enums.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RefreshHint, Trend, ValueKind } from '../metrics/metric-response.js';
+
+// Pinned wire-format fixtures for the @granit/analytics enum surface.
+
+describe('ValueKind — exhaustive enum surface (PascalCase, backend-ordered)', () => {
+  it('locks the six backend kinds in declaration order', () => {
+    const kinds: readonly ValueKind[] = [
+      'Count',
+      'Number',
+      'Currency',
+      'Percentage',
+      'Duration',
+      'Date',
+    ];
+    expect(kinds).toHaveLength(6);
+  });
+});
+
+describe('RefreshHint — exhaustive enum surface (PascalCase)', () => {
+  it('locks the three backend hints (Static / Dynamic / Realtime)', () => {
+    const hints: readonly RefreshHint[] = ['Static', 'Dynamic', 'Realtime'];
+    expect(hints).toHaveLength(3);
+  });
+});
+
+describe('Trend — backend ships as a plain string, NOT a JsonStringEnumConverter enum', () => {
+  it('keeps the documented lowercase values verbatim', () => {
+    const trends: readonly Trend[] = ['up', 'down', 'flat'];
+    expect(trends).toHaveLength(3);
+  });
+});

--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -18,11 +18,14 @@ export type {
 } from './metrics/index.js';
 
 // Widgets — catalog declarations consumed by @granit/dashboards
+export { isKpiSnapshotEnvelope } from './widgets/index.js';
 export type {
   AggregateFunction,
   AnalyticsWidgetDefinition,
   ChartType,
   ChartWidgetDefinition,
+  KpiSnapshot,
+  KpiSnapshotEnvelope,
   KpiWidgetDefinition,
   PivotWidgetDefinition,
   TableWidgetDefinition,

--- a/packages/@granit/analytics/src/metrics/metric-response.ts
+++ b/packages/@granit/analytics/src/metrics/metric-response.ts
@@ -22,11 +22,13 @@ export type ValueKind = 'Count' | 'Number' | 'Currency' | 'Percentage' | 'Durati
  */
 export type Trend = 'up' | 'down' | 'flat';
 
-/**
- * Mirrors `Granit.Analytics.RefreshHint`. PascalCase wire values — same
- * convention as {@link ValueKind}.
- */
-export type RefreshHint = 'Static' | 'Dynamic' | 'Realtime';
+// `RefreshHint` is shared between metric responses (this module) and the
+// dashboard widget envelope (`@granit/dashboards/rendering`). It lives in
+// `@granit/dashboards` to mirror the backend's `Granit.Analytics.Abstractions`
+// promotion (ADR-039) and keep the dependency arrow analytics → dashboards
+// clean. Re-exported here for source-level back-compat.
+import type { RefreshHint } from '@granit/dashboards';
+export type { RefreshHint };
 
 /**
  * Calendar-aware period token. Backend (`Granit.Analytics.Metrics.PeriodSpec`)

--- a/packages/@granit/analytics/src/metrics/metric-response.ts
+++ b/packages/@granit/analytics/src/metrics/metric-response.ts
@@ -6,11 +6,27 @@
  * directly without depending on a generated client.
  */
 
-export type ValueKind = 'count' | 'currency' | 'percentage' | 'duration' | 'date' | 'number';
+/**
+ * Mirrors `Granit.Analytics.MetricValueKind`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy, so enum names land verbatim. Order matches the backend enum
+ * declaration so a numeric drift surfaces in code review.
+ */
+export type ValueKind = 'Count' | 'Number' | 'Currency' | 'Percentage' | 'Duration' | 'Date';
 
+/**
+ * Direction of the previous-period delta. Backend ships this as a plain
+ * `string` (not an enum) on `MetricPreviousPayload.Trend`, with the
+ * documented values `"up"`, `"down"`, `"flat"` — lowercase, no
+ * `JsonStringEnumConverter` involvement. Stays lowercase here.
+ */
 export type Trend = 'up' | 'down' | 'flat';
 
-export type RefreshHint = 'static' | 'dynamic' | 'realtime';
+/**
+ * Mirrors `Granit.Analytics.RefreshHint`. PascalCase wire values — same
+ * convention as {@link ValueKind}.
+ */
+export type RefreshHint = 'Static' | 'Dynamic' | 'Realtime';
 
 /**
  * Calendar-aware period token. Backend (`Granit.Analytics.Metrics.PeriodSpec`)
@@ -55,7 +71,7 @@ export interface MetricPreviousPayload {
 export interface MetricSnapshotPayload {
   readonly value: number | null;
   readonly valueKind: ValueKind;
-  /** ISO 4217 currency code when `valueKind === 'currency'`. Null otherwise. */
+  /** ISO 4217 currency code when `valueKind === 'Currency'`. Null otherwise. */
   readonly currency: string | null;
   readonly isHigherBetter: boolean;
   readonly noData: boolean;

--- a/packages/@granit/analytics/src/widgets/index.ts
+++ b/packages/@granit/analytics/src/widgets/index.ts
@@ -1,5 +1,7 @@
 export type { AggregateFunction } from './aggregation.js';
 export type { ChartType, ChartWidgetDefinition } from './chart-widget.js';
+export { isKpiSnapshotEnvelope } from './kpi-snapshot.js';
+export type { KpiSnapshot, KpiSnapshotEnvelope } from './kpi-snapshot.js';
 export type { KpiWidgetDefinition } from './kpi-widget.js';
 export type { PivotWidgetDefinition } from './pivot-widget.js';
 export type { TableWidgetDefinition } from './table-widget.js';

--- a/packages/@granit/analytics/src/widgets/kpi-snapshot.ts
+++ b/packages/@granit/analytics/src/widgets/kpi-snapshot.ts
@@ -1,0 +1,34 @@
+import type { MetricSnapshotPayload } from '../metrics/metric-response.js';
+import type { WidgetSnapshotEnvelope, WidgetSnapshotEnvelopeOf } from '@granit/dashboards';
+
+/**
+ * Snapshot payload returned by the KPI widget renderer. Mirrors the backend
+ * `KpiWidgetInstanceRenderer` output (B3-2, ADR-039 §7.bis): the renderer
+ * dispatches on the persisted `Datasource.kind` and reuses
+ * `MetricSnapshotPayload` as the wire shape regardless of which datasource
+ * (metric / query-aggregate / telemetry) produced the value.
+ *
+ * Effectively a structural alias for {@link MetricSnapshotPayload} — kept
+ * named so consumers reading `widget.snapshot` see the KPI semantics rather
+ * than the inline-metric envelope.
+ */
+export type KpiSnapshot = MetricSnapshotPayload;
+
+/**
+ * Narrowed {@link WidgetSnapshotEnvelope} for the `'Kpi'` widget kind. Use
+ * the {@link isKpiSnapshotEnvelope} type guard to refine a heterogeneous
+ * dashboard render response to KPI envelopes only.
+ */
+export type KpiSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Kpi', KpiSnapshot>;
+
+/**
+ * Type guard refining a generic {@link WidgetSnapshotEnvelope} to the
+ * KPI-specific {@link KpiSnapshotEnvelope}. Drives renderer dispatch in the
+ * frontend `useDashboard` hook (and in any consumer that walks the bundle
+ * response widget by widget).
+ */
+export function isKpiSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is KpiSnapshotEnvelope {
+  return envelope.widgetType === 'Kpi';
+}

--- a/packages/@granit/dashboards/src/__tests__/widget-snapshot-envelope.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/widget-snapshot-envelope.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WidgetSnapshotEnvelope, WidgetSnapshotStatus } from '../rendering/index.js';
+
+// Pinned wire-format fixtures for the B3-1 envelope (ADR-039 §6).
+// Mirrors what `Granit.Dashboards.Rendering.WidgetSnapshotEnvelope`
+// serialises through the framework's host JsonSerializerOptions
+// (camelCase property names, PascalCase enum values).
+
+const SNAPSHOT_FIXTURE: WidgetSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Kpi',
+  snapshot: {
+    /* Snapshot is `unknown`: typed shape (KpiSnapshot, ChartSnapshot, …)
+       lands as B3-2..B3-6 ship. */
+    value: 12,
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
+const UNAVAILABLE_FIXTURE: WidgetSnapshotEnvelope = {
+  status: 'Unavailable',
+  widgetType: 'Chart',
+  snapshot: null,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: 'Widget:Unavailable',
+};
+
+const ERROR_FIXTURE: WidgetSnapshotEnvelope = {
+  status: 'Error',
+  widgetType: 'Pivot',
+  snapshot: null,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  unavailableReasonLocalizationKey: null,
+};
+
+describe('WidgetSnapshotEnvelope — wire format', () => {
+  it('accepts the Snapshot variant verbatim', () => {
+    expect(SNAPSHOT_FIXTURE.status).toBe('Snapshot');
+    expect(SNAPSHOT_FIXTURE.widgetType).toBe('Kpi');
+    expect(SNAPSHOT_FIXTURE.snapshot).not.toBeNull();
+    expect(SNAPSHOT_FIXTURE.unavailableReasonLocalizationKey).toBeNull();
+  });
+
+  it('accepts the Unavailable variant — snapshot null, reason key set', () => {
+    expect(UNAVAILABLE_FIXTURE.status).toBe('Unavailable');
+    expect(UNAVAILABLE_FIXTURE.snapshot).toBeNull();
+    expect(UNAVAILABLE_FIXTURE.unavailableReasonLocalizationKey).toBe('Widget:Unavailable');
+  });
+
+  it('accepts the Error variant — snapshot null, reason key null (server-side log only)', () => {
+    expect(ERROR_FIXTURE.status).toBe('Error');
+    expect(ERROR_FIXTURE.snapshot).toBeNull();
+    expect(ERROR_FIXTURE.unavailableReasonLocalizationKey).toBeNull();
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    for (const fixture of [SNAPSHOT_FIXTURE, UNAVAILABLE_FIXTURE, ERROR_FIXTURE]) {
+      expect(JSON.parse(JSON.stringify(fixture))).toEqual(fixture);
+    }
+  });
+});
+
+describe('WidgetSnapshotStatus — exhaustive enum surface (PascalCase)', () => {
+  it('locks the three runtime outcomes (Snapshot / Unavailable / Error)', () => {
+    const statuses: readonly WidgetSnapshotStatus[] = ['Snapshot', 'Unavailable', 'Error'];
+    expect(statuses).toHaveLength(3);
+  });
+});

--- a/packages/@granit/dashboards/src/__tests__/wire-format-enums.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/wire-format-enums.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import type { DashboardCategory } from '../types/dashboard-category.js';
+import type { TimeWindowKind } from '../types/dashboard-time-window.js';
+import type { TextWidgetStyle } from '../types/widget-definition.js';
+
+// Pinned wire-format fixtures for the framework's PascalCase enum surface.
+// All three enums ship via Granit's host JsonStringEnumConverter() with no
+// naming policy, so enum names land verbatim. Drift here = drift on the wire.
+
+describe('DashboardCategory — exhaustive enum surface (PascalCase, ordered)', () => {
+  it('locks the seven backend categories in declaration order', () => {
+    const categories: readonly DashboardCategory[] = [
+      'General',
+      'Finance',
+      'Operations',
+      'Security',
+      'Compliance',
+      'Platform',
+      'Iot',
+    ];
+    expect(categories).toHaveLength(7);
+  });
+});
+
+describe('TimeWindowKind — exhaustive enum surface (PascalCase)', () => {
+  it('locks the two backend kinds (History / Realtime)', () => {
+    const kinds: readonly TimeWindowKind[] = ['History', 'Realtime'];
+    expect(kinds).toHaveLength(2);
+  });
+});
+
+describe('TextWidgetStyle — exhaustive enum surface (PascalCase, ordered)', () => {
+  it('locks the four backend styles in declaration order', () => {
+    const styles: readonly TextWidgetStyle[] = ['Body', 'Heading', 'Subheading', 'Caption'];
+    expect(styles).toHaveLength(4);
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -42,4 +42,8 @@ export type {
 } from './types/index.js';
 
 // Rendering — wire contracts for the dashboard render pipeline (B3-1, ADR-039).
-export type { WidgetSnapshotEnvelope, WidgetSnapshotStatus } from './rendering/index.js';
+export type {
+  WidgetSnapshotEnvelope,
+  WidgetSnapshotEnvelopeOf,
+  WidgetSnapshotStatus,
+} from './rendering/index.js';

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -26,6 +26,8 @@ export type {
   MarkdownWidgetDefinition,
   MetricDatasource,
   QueryAggregateDatasource,
+  RefreshHint,
+  ResolvedPeriod,
   TelemetryAggregation,
   TelemetryDatasource,
   TextWidgetDefinition,
@@ -38,3 +40,6 @@ export type {
   WidgetDefinitionBase,
   WidgetSize,
 } from './types/index.js';
+
+// Rendering — wire contracts for the dashboard render pipeline (B3-1, ADR-039).
+export type { WidgetSnapshotEnvelope, WidgetSnapshotStatus } from './rendering/index.js';

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -1,0 +1,7 @@
+// ---------------------------------------------------------------------------
+// @granit/dashboards/rendering — wire contracts for the dashboard render
+// pipeline. Mirrors `Granit.Dashboards.Rendering` (B3-1, ADR-039).
+// ---------------------------------------------------------------------------
+
+export type { WidgetSnapshotEnvelope } from './widget-snapshot-envelope.js';
+export type { WidgetSnapshotStatus } from './widget-snapshot-status.js';

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -3,5 +3,8 @@
 // pipeline. Mirrors `Granit.Dashboards.Rendering` (B3-1, ADR-039).
 // ---------------------------------------------------------------------------
 
-export type { WidgetSnapshotEnvelope } from './widget-snapshot-envelope.js';
+export type {
+  WidgetSnapshotEnvelope,
+  WidgetSnapshotEnvelopeOf,
+} from './widget-snapshot-envelope.js';
 export type { WidgetSnapshotStatus } from './widget-snapshot-status.js';

--- a/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
@@ -50,3 +50,24 @@ export interface WidgetSnapshotEnvelope {
    */
   readonly unavailableReasonLocalizationKey: string | null;
 }
+
+/**
+ * Narrowed flavour of {@link WidgetSnapshotEnvelope} for a specific widget
+ * kind. Per-kind packages (e.g. `@granit/analytics`) compose their own typed
+ * envelope by binding `TKind` to the discriminator value (`'Kpi'`, `'Chart'`,
+ * …) and `TSnapshot` to the kind's payload shape:
+ *
+ *     export type KpiSnapshotEnvelope =
+ *       WidgetSnapshotEnvelopeOf<'Kpi', MetricSnapshotPayload>;
+ *
+ * Pair with a runtime type guard (`widgetType === 'Kpi'`) to narrow a
+ * generic envelope obtained from the dashboard render endpoint to the
+ * kind-specific shape.
+ */
+export type WidgetSnapshotEnvelopeOf<TKind extends string, TSnapshot> = Omit<
+  WidgetSnapshotEnvelope,
+  'widgetType' | 'snapshot'
+> & {
+  readonly widgetType: TKind;
+  readonly snapshot: TSnapshot | null;
+};

--- a/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
@@ -1,0 +1,52 @@
+import type { WidgetSnapshotStatus } from './widget-snapshot-status.js';
+import type { RefreshHint } from '../types/refresh-hint.js';
+
+/**
+ * Non-generic envelope returned by every widget renderer (one per
+ * `WidgetInstance`). Bundles the runtime {@link status}, the declarative
+ * {@link widgetType}, and a pre-serialised {@link snapshot} so the dashboard
+ * render endpoint can compose heterogeneous widgets into one response without
+ * leaking per-kind generics.
+ *
+ * Mirrors `Granit.Dashboards.Rendering.WidgetSnapshotEnvelope`. See
+ * ADR-039 §2 for the design rationale and §2.1 for why the snapshot is
+ * pre-serialised JSON (not a typed `object?`) at the boundary.
+ *
+ * On the wire, {@link snapshot} is the concrete typed payload for the
+ * widget's kind — `KpiSnapshot` for `Kpi`, `ChartSnapshot` for `Chart`, etc.
+ * Frontend consumers cast to the kind-specific type after dispatching on
+ * {@link widgetType} via the widget registry; until B3-2/3/4/5/6 land per-kind
+ * snapshots, the type stays `unknown`.
+ */
+export interface WidgetSnapshotEnvelope {
+  /** Runtime outcome (snapshot / unavailable / error). */
+  readonly status: WidgetSnapshotStatus;
+  /**
+   * Declarative kind discriminator — mirrors `WidgetDefinition.type`'s
+   * `[JsonDerivedType]` tag (`'Kpi'`, `'Chart'`, `'Markdown'`, ...).
+   * Carried even on `Unavailable` / `Error` so the frontend keeps a typed
+   * slot for the absent widget.
+   */
+  readonly widgetType: string;
+  /**
+   * Pre-serialised typed payload. `null` when {@link status} is not
+   * `'Snapshot'`. Frontend renderers narrow this to a kind-specific shape
+   * (e.g. `KpiSnapshot`) by inspecting {@link widgetType} via the widget
+   * registry.
+   */
+  readonly snapshot: unknown | null;
+  /**
+   * Always `1` in pull mode; future push transport increments per
+   * (widget instance, tenant). Locked v1 per EPIC #1366 invariant #2.
+   */
+  readonly sequence: number;
+  /** Server-side timestamp of the computation (ISO 8601 UTC). */
+  readonly emittedAt: string;
+  /** Pull / push transport hint inherited from the underlying definition. */
+  readonly refreshHint: RefreshHint;
+  /**
+   * Localization key for the user-facing reason (e.g. `'Widget:Unavailable'`)
+   * when {@link status} is `'Unavailable'`; `null` otherwise.
+   */
+  readonly unavailableReasonLocalizationKey: string | null;
+}

--- a/packages/@granit/dashboards/src/rendering/widget-snapshot-status.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-snapshot-status.ts
@@ -1,0 +1,21 @@
+/**
+ * Runtime outcome of a single widget render — the "what happened" axis of
+ * the per-widget envelope. Decoupled from `WidgetSnapshotEnvelope.widgetType`
+ * (the declarative kind) so a frontend `useDashboard` hook can branch on
+ * "render the snapshot" vs "render an unavailable / error placeholder"
+ * without inspecting the snapshot payload itself.
+ *
+ * Mirrors `Granit.Dashboards.Rendering.WidgetSnapshotStatus`. PascalCase
+ * wire values — backend's host registers a `JsonStringEnumConverter()`
+ * with no naming policy.
+ *
+ * See ADR-039 §2 for why the original draft's single `kind` field was split
+ * into `status` (this) + `widgetType` on the envelope.
+ */
+export type WidgetSnapshotStatus =
+  /** The renderer produced a typed snapshot — `WidgetSnapshotEnvelope.snapshot` is non-null. */
+  | 'Snapshot'
+  /** The current user lacks the widget's required permission. The dashboard render endpoint short-circuits before invoking the underlying metric / query. */
+  | 'Unavailable'
+  /** The renderer threw an unexpected exception. Logged server-side; the bundle response stays 200 so a single bad widget does not break the whole dashboard. */
+  | 'Error';

--- a/packages/@granit/dashboards/src/types/dashboard-category.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-category.ts
@@ -3,21 +3,23 @@
  * Drives the catalogue ordering surfaced by the dashboard registry and the
  * section grouping in the admin import dialog.
  *
- * Mirrors `Granit.Dashboards.DashboardCategory` (numeric enum). Backend ships
- * via `JsonStringEnumConverter` so the wire is the lowercase form here.
+ * Mirrors `Granit.Dashboards.DashboardCategory`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy, so enum names land verbatim. Order matches the backend numeric
+ * declaration (`General = 0`, `Finance = 1`, …, `Iot = 6`).
  */
 export type DashboardCategory =
   /** Default — uncategorised. Use only when the others genuinely do not fit. */
-  | 'general'
+  | 'General'
   /** Invoicing, payments, subscriptions, customer balance, tax. */
-  | 'finance'
+  | 'Finance'
   /** AI usage, blob storage, background jobs, webhooks, observability. */
-  | 'operations'
+  | 'Operations'
   /** Identity, authorization, auditing. */
-  | 'security'
+  | 'Security'
   /** Privacy / GDPR (export requests, erasure, retention). */
-  | 'compliance'
+  | 'Compliance'
   /** Multi-tenancy, platform-level admin (tenant lifecycle, feature flags). */
-  | 'platform'
+  | 'Platform'
   /** IoT / real-time telemetry — sensors, alarms, video feeds. */
-  | 'iot';
+  | 'Iot';

--- a/packages/@granit/dashboards/src/types/dashboard-time-window.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-time-window.ts
@@ -12,7 +12,7 @@
  */
 export interface DashboardTimeWindow {
   readonly period: DashboardPeriod;
-  /** Refresh semantics: `history` (frozen, refetch on range change) vs `realtime` (sliding window). */
+  /** Refresh semantics: `History` (frozen, refetch on range change) vs `Realtime` (sliding window). */
   readonly kind?: TimeWindowKind;
   /** Optional comparison window (e.g. `previous_period`). */
   readonly compareTo?: { readonly token: string };
@@ -23,7 +23,12 @@ export interface DashboardTimeWindow {
   readonly aggregationMs?: number;
 }
 
-export type TimeWindowKind = 'history' | 'realtime';
+/**
+ * Mirrors `Granit.Dashboards.TimeWindowKind`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy.
+ */
+export type TimeWindowKind = 'History' | 'Realtime';
 
 /**
  * Period selector — token-based (`last_30d`, `mtd`, `ytd`, `last_5m`, ...) or
@@ -36,13 +41,13 @@ export type DashboardPeriod =
 
 /** Convenience constants matching the conventional tokens. */
 export const DASHBOARD_TIME_WINDOW = Object.freeze({
-  Last24Hours: { period: { token: 'last_24h' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Last7Days: { period: { token: 'last_7d' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Last30Days: { period: { token: 'last_30d' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Mtd: { period: { token: 'mtd' }, kind: 'history' } satisfies DashboardTimeWindow,
-  Ytd: { period: { token: 'ytd' }, kind: 'history' } satisfies DashboardTimeWindow,
+  Last24Hours: { period: { token: 'last_24h' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last7Days: { period: { token: 'last_7d' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Last30Days: { period: { token: 'last_30d' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Mtd: { period: { token: 'mtd' }, kind: 'History' } satisfies DashboardTimeWindow,
+  Ytd: { period: { token: 'ytd' }, kind: 'History' } satisfies DashboardTimeWindow,
   RealtimeLast5Minutes: {
     period: { token: 'last_5m' },
-    kind: 'realtime',
+    kind: 'Realtime',
   } satisfies DashboardTimeWindow,
 });

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -1,4 +1,6 @@
 export type { AggregateFunction } from './aggregate-function.js';
+export type { RefreshHint } from './refresh-hint.js';
+export type { ResolvedPeriod } from './resolved-period.js';
 export type { DataKeyFormat } from './data-key-format.js';
 export type { DashboardCategory } from './dashboard-category.js';
 export { DASHBOARD_TIME_WINDOW } from './dashboard-time-window.js';

--- a/packages/@granit/dashboards/src/types/refresh-hint.ts
+++ b/packages/@granit/dashboards/src/types/refresh-hint.ts
@@ -1,0 +1,21 @@
+/**
+ * Pull / push transport hint shipped on every widget envelope. Drives how
+ * `useDashboard` (and its single-widget cousin `useMetric`) cadence their
+ * background refetch:
+ *
+ * - `Static`  — the snapshot is computed offline; never refetch.
+ * - `Dynamic` — refetch on demand, no polling. The default for KPI / chart
+ *   tiles bound to dashboard time windows.
+ * - `Realtime` — short polling (~5s) until the future SSE / WS push
+ *   transport (P2.4) replaces it.
+ *
+ * Lives in `@granit/dashboards` rather than `@granit/analytics` so the
+ * widget-renderer envelope can carry it without forcing the dashboards
+ * package to depend on analytics — mirrors backend's
+ * `Granit.Analytics.Metrics.RefreshHint` promotion to
+ * `Granit.Analytics.Abstractions` per ADR-039.
+ *
+ * PascalCase wire values — backend's host registers a
+ * `JsonStringEnumConverter()` with no naming policy.
+ */
+export type RefreshHint = 'Static' | 'Dynamic' | 'Realtime';

--- a/packages/@granit/dashboards/src/types/resolved-period.ts
+++ b/packages/@granit/dashboards/src/types/resolved-period.ts
@@ -1,0 +1,17 @@
+/**
+ * Absolute, half-open `[from, to)` time window — the resolved form of a
+ * `PeriodSpec` after named-token expansion against the backend's `IClock`.
+ * Mirrors `Granit.Analytics.ResolvedPeriod`. ISO 8601 UTC strings on the
+ * wire.
+ *
+ * Lives in `@granit/dashboards` (alongside the rendering envelope) rather
+ * than `@granit/analytics` so the dashboards rendering boundary can carry
+ * it without dragging in the analytics surface — mirrors the backend's
+ * `Granit.Analytics.Abstractions` placement per ADR-039.
+ */
+export interface ResolvedPeriod {
+  /** Inclusive lower bound (UTC). */
+  readonly from: string;
+  /** Exclusive upper bound (UTC). */
+  readonly to: string;
+}

--- a/packages/@granit/dashboards/src/types/widget-definition.ts
+++ b/packages/@granit/dashboards/src/types/widget-definition.ts
@@ -71,8 +71,13 @@ export interface ImageWidgetDefinition extends WidgetDefinitionBase {
   readonly altLocalizationKey: string;
 }
 
-/** Visual style hint for `TextWidgetDefinition`. */
-export type TextWidgetStyle = 'body' | 'heading' | 'subheading' | 'caption';
+/**
+ * Visual style hint for `TextWidgetDefinition`. Mirrors
+ * `Granit.Dashboards.Widgets.TextStyle`. PascalCase wire values — the
+ * framework's host registers a `JsonStringEnumConverter()` with no naming
+ * policy.
+ */
+export type TextWidgetStyle = 'Body' | 'Heading' | 'Subheading' | 'Caption';
 
 /**
  * Plain text tile — short label or heading without markdown formatting.

--- a/packages/@granit/react-analytics/src/__tests__/format-metric-value.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/format-metric-value.test.ts
@@ -8,20 +8,20 @@ const normalize = (s: string) => s.replace(/[\u0020\u00A0\u202F]+/g, ' ');
 
 describe('formatMetricValue', () => {
   it('returns the fallback when the value is null', () => {
-    expect(formatMetricValue({ value: null, valueKind: 'count', locale: 'en-US' })).toBe('—');
+    expect(formatMetricValue({ value: null, valueKind: 'Count', locale: 'en-US' })).toBe('—');
   });
 
   it('returns a custom fallback when provided', () => {
     expect(
-      formatMetricValue({ value: null, valueKind: 'count', locale: 'en-US', fallback: 'N/A' })
+      formatMetricValue({ value: null, valueKind: 'Count', locale: 'en-US', fallback: 'N/A' })
     ).toBe('N/A');
   });
 
   it.each<{ kind: ValueKind; value: number; en: string; fr: string; currency?: string }>([
-    { kind: 'count', value: 1234, en: '1,234', fr: '1 234' },
-    { kind: 'currency', value: 12450.5, currency: 'EUR', en: '€12,450.50', fr: '12 450,50 €' },
-    { kind: 'percentage', value: 0.1507, en: '15.07%', fr: '15,07 %' },
-    { kind: 'number', value: 3.14159, en: '3.14', fr: '3,14' },
+    { kind: 'Count', value: 1234, en: '1,234', fr: '1 234' },
+    { kind: 'Currency', value: 12450.5, currency: 'EUR', en: '€12,450.50', fr: '12 450,50 €' },
+    { kind: 'Percentage', value: 0.1507, en: '15.07%', fr: '15,07 %' },
+    { kind: 'Number', value: 3.14159, en: '3.14', fr: '3,14' },
   ])('formats $kind=$value across en-US / fr-FR', ({ kind, value, en, fr, currency }) => {
     expect(
       normalize(formatMetricValue({ value, valueKind: kind, currency, locale: 'en-US' }))
@@ -32,11 +32,11 @@ describe('formatMetricValue', () => {
   });
 
   it('formats sub-minute durations as seconds', () => {
-    expect(formatMetricValue({ value: 42, valueKind: 'duration', locale: 'en-US' })).toBe('42s');
+    expect(formatMetricValue({ value: 42, valueKind: 'Duration', locale: 'en-US' })).toBe('42s');
   });
 
   it('formats minute-and-second durations', () => {
-    expect(formatMetricValue({ value: 125, valueKind: 'duration', locale: 'en-US' })).toBe('2m 5s');
+    expect(formatMetricValue({ value: 125, valueKind: 'Duration', locale: 'en-US' })).toBe('2m 5s');
   });
 });
 

--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
@@ -10,10 +10,10 @@ function makeResponse(overrides: Partial<MetricResponse['snapshot']> = {}): Metr
     name: 'Test.Metric',
     sequence: 1,
     emittedAt: '2026-04-28T12:00:00Z',
-    refreshHint: 'dynamic',
+    refreshHint: 'Dynamic',
     snapshot: {
       value: 12,
-      valueKind: 'count',
+      valueKind: 'Count',
       currency: null,
       isHigherBetter: true,
       noData: false,

--- a/packages/@granit/react-analytics/src/api/use-metric.ts
+++ b/packages/@granit/react-analytics/src/api/use-metric.ts
@@ -8,9 +8,9 @@ import type { MetricRequest, MetricResponse } from '@granit/analytics';
 const METRIC_PATH = '/analytics/metrics';
 
 const POLLING_INTERVAL_MS: Readonly<Record<MetricResponse['refreshHint'], number | false>> = {
-  static: false,
-  dynamic: false,
-  realtime: 5_000,
+  Static: false,
+  Dynamic: false,
+  Realtime: 5_000,
 };
 
 export interface UseMetricOptions {

--- a/packages/@granit/react-analytics/src/lib/format-metric-value.ts
+++ b/packages/@granit/react-analytics/src/lib/format-metric-value.ts
@@ -8,7 +8,7 @@ import type { ValueKind } from '@granit/analytics';
 export interface FormatMetricValueArgs {
   readonly value: number | null;
   readonly valueKind: ValueKind;
-  /** ISO 4217 currency code. Required when `valueKind === 'currency'`. */
+  /** ISO 4217 currency code. Required when `valueKind === 'Currency'`. */
   readonly currency?: string | null;
   /** BCP 47 tag. Defaults to runtime default (`undefined` → host default). */
   readonly locale?: string;
@@ -28,28 +28,28 @@ export function formatMetricValue({
   if (value === null || Number.isNaN(value)) return fallback;
 
   switch (valueKind) {
-    case 'count':
+    case 'Count':
       return new Intl.NumberFormat(locale, { maximumFractionDigits: 0 }).format(value);
 
-    case 'currency': {
+    case 'Currency': {
       if (!currency) return new Intl.NumberFormat(locale).format(value);
       return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(value);
     }
 
-    case 'percentage':
+    case 'Percentage':
       return new Intl.NumberFormat(locale, {
         style: 'percent',
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
       }).format(value);
 
-    case 'duration':
+    case 'Duration':
       return formatDuration(value, locale);
 
-    case 'date':
+    case 'Date':
       return new Intl.DateTimeFormat(locale).format(new Date(value));
 
-    case 'number':
+    case 'Number':
       return new Intl.NumberFormat(locale, {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard.test.tsx
@@ -48,7 +48,7 @@ describe('Dashboard', () => {
   it('renders widgets in `position` order with their declared size', () => {
     const { container } = renderDashboard({
       name: 'Test',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 12, rowHeight: 80 },
@@ -59,7 +59,7 @@ describe('Dashboard', () => {
           position: 1,
           size: { width: 6, height: 1 },
           contentLocalizationKey: 'Widget:Test.Hello',
-          style: 'body',
+          style: 'Body',
         },
         {
           slug: 'Heading',
@@ -84,7 +84,7 @@ describe('Dashboard', () => {
   it('applies grid-template-columns from layout.columns', () => {
     const { container } = renderDashboard({
       name: 'Empty',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 8, rowHeight: 80 },
@@ -97,7 +97,7 @@ describe('Dashboard', () => {
   it('renders an unknown-widget placeholder when the type has no registered renderer', () => {
     renderDashboard({
       name: 'Test',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 12, rowHeight: 80 },
@@ -118,7 +118,7 @@ describe('Dashboard', () => {
   it('renders the TextWidget with style-aware HTML element', () => {
     const { container } = renderDashboard({
       name: 'Test',
-      category: 'general',
+      category: 'General',
       isSystem: false,
       version: '1.0.0',
       layout: { columns: 12, rowHeight: 80 },
@@ -129,7 +129,7 @@ describe('Dashboard', () => {
           position: 0,
           size: { width: 6, height: 1 },
           contentLocalizationKey: 'Widget:Test.Caption',
-          style: 'caption',
+          style: 'Caption',
         },
       ],
     });

--- a/packages/@granit/react-dashboards/src/__tests__/use-effective-time-window.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-effective-time-window.test.tsx
@@ -28,7 +28,7 @@ describe('useEffectiveTimeWindow', () => {
   it('prefers an explicit override over the dashboard timeWindow', () => {
     const override: DashboardTimeWindow = {
       period: { token: 'mtd' },
-      kind: 'history',
+      kind: 'History',
     };
     const wrapper = ({ children }: { children: ReactNode }) => (
       <DashboardContextProvider

--- a/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
@@ -3,10 +3,10 @@ import { useTranslation } from 'react-i18next';
 import type { TextWidgetDefinition, TextWidgetStyle } from '@granit/dashboards';
 
 const STYLE_CLASSES: Readonly<Record<TextWidgetStyle, string>> = {
-  body: 'text-sm text-foreground',
-  heading: 'text-2xl font-semibold tracking-tight text-foreground',
-  subheading: 'text-lg font-semibold text-foreground',
-  caption: 'text-xs text-muted-foreground',
+  Body: 'text-sm text-foreground',
+  Heading: 'text-2xl font-semibold tracking-tight text-foreground',
+  Subheading: 'text-lg font-semibold text-foreground',
+  Caption: 'text-xs text-muted-foreground',
 };
 
 /**
@@ -21,14 +21,14 @@ export function TextWidget({ widget }: { readonly widget: TextWidgetDefinition }
   const content = t(widget.contentLocalizationKey);
   const className = `whitespace-pre-wrap break-words ${STYLE_CLASSES[widget.style]}`;
 
-  if (widget.style === 'heading') {
+  if (widget.style === 'Heading') {
     return (
       <h2 data-slot="text-widget" data-style="heading" className={className}>
         {content}
       </h2>
     );
   }
-  if (widget.style === 'subheading') {
+  if (widget.style === 'Subheading') {
     return (
       <h3 data-slot="text-widget" data-style="subheading" className={className}>
         {content}
@@ -36,7 +36,7 @@ export function TextWidget({ widget }: { readonly widget: TextWidgetDefinition }
     );
   }
   return (
-    <p data-slot="text-widget" data-style={widget.style} className={className}>
+    <p data-slot="text-widget" data-style={widget.style.toLowerCase()} className={className}>
       {content}
     </p>
   );


### PR DESCRIPTION
## Context

PRs #234, #235, #236 show as **MERGED** in GitHub but their changes never reached \`develop\`. They were merged into their **stack base branches** (each PR's \`base\` was the previous PR's branch, not \`develop\`):

| PR | Stack base | Merge commit | On develop? |
| --- | --- | --- | --- |
| #234 (PascalCase casing) | \`feature/dashboards-p15-widget-actions\` | \`b87d502\` | :x: |
| #235 (B3-1 render contracts) | \`feature/dashboards-enums-pascalcase\` | \`d231eb5\` | :x: |
| #236 (B3-2 KPI snapshot) | \`feature/dashboards-b31-render-contracts\` | \`ef8ab03\` | :x: |

Once #233 was squash-merged to \`develop\`, the stacked bases lost their reason to also land on \`develop\` — the stack-merge-into-stack pattern only updated the intermediate branches, never \`develop\`. Classic stacked-PR pitfall.

## Resolution

Branched from \`origin/develop\`, cherry-picked the three squash commits in order (\`b87d502\` → \`d231eb5\` → \`ef8ab03\`), no conflicts.

## Net delta

25 files / +508 / -56 — exactly the union of the three originally-reviewed PRs, byte-for-byte:

- **Casing PascalCase**: \`ValueKind\`, \`RefreshHint\`, \`DashboardCategory\`, \`TimeWindowKind\`, \`TextWidgetStyle\` (and all consumers / tests / showcase mocks). \`Trend\` stays lowercase (backend ships it as a plain \`string\`).
- **B3-1 render contracts**: \`WidgetSnapshotStatus\`, \`WidgetSnapshotEnvelope\`, \`ResolvedPeriod\`. \`RefreshHint\` promoted from \`@granit/analytics\` to \`@granit/dashboards\` per ADR-039 mirror.
- **B3-2 KPI snapshot**: \`WidgetSnapshotEnvelopeOf<TKind, TSnapshot>\` generic helper, \`KpiSnapshot\` / \`KpiSnapshotEnvelope\` / \`isKpiSnapshotEnvelope\`.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — 2327/2327 ✓

## Showcase follow-up

Showcase PRs #40 and #41 are still **OPEN** (their bases \`feature/dashboards-demo\` and \`feature/dashboards-p15-widget-actions\` show MERGED for the upstream PRs but not for the showcase ones themselves). I'll re-target them to \`develop\` after this lands.