### PR TITLE
feat(dashboards): markdown / text / image snapshot envelopes (B3-3 mirror, ADR-039)

### DIFF
--- a/packages/@granit/dashboards/src/__tests__/content-snapshots.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/content-snapshots.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isImageSnapshotEnvelope,
+  isMarkdownSnapshotEnvelope,
+  isTextSnapshotEnvelope,
+} from '../rendering/index.js';
+
+import type {
+  ImageSnapshotEnvelope,
+  MarkdownSnapshotEnvelope,
+  TextSnapshotEnvelope,
+  WidgetSnapshotEnvelope,
+} from '../rendering/index.js';
+import type { ImageFit } from '../types/widget-definition.js';
+
+// Pinned wire-format fixtures mirroring B3-3 backend output:
+//   - Granit.Dashboards.Endpoints.Rendering.MarkdownWidgetInstanceRenderer
+//   - Granit.Dashboards.Endpoints.Rendering.TextWidgetInstanceRenderer
+//   - Granit.Dashboards.Endpoints.Rendering.ImageWidgetInstanceRenderer
+// Static-content renderers always emit RefreshHint.Static so the frontend
+// drops these widgets out of the refresh loop.
+
+const MARKDOWN_FIXTURE: MarkdownSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Markdown',
+  snapshot: {
+    contentLocalizationKey: 'Widget:Granit.Invoicing.FinanceOverview.Banner',
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  unavailableReasonLocalizationKey: null,
+};
+
+const TEXT_FIXTURE: TextSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Text',
+  snapshot: {
+    contentLocalizationKey: 'Widget:Granit.Invoicing.FinanceOverview.SectionHeading',
+    style: 'Heading',
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  unavailableReasonLocalizationKey: null,
+};
+
+const IMAGE_FIXTURE: ImageSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Image',
+  snapshot: {
+    source: 'blob:logo-banner',
+    altLocalizationKey: 'Widget:Granit.Showcase.Logo.Alt',
+    fit: 'Contain',
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  unavailableReasonLocalizationKey: null,
+};
+
+describe('MarkdownSnapshotEnvelope — wire format', () => {
+  it('accepts the snapshot variant with the static RefreshHint', () => {
+    expect(MARKDOWN_FIXTURE.widgetType).toBe('Markdown');
+    expect(MARKDOWN_FIXTURE.refreshHint).toBe('Static');
+    expect(MARKDOWN_FIXTURE.snapshot?.contentLocalizationKey).toContain('FinanceOverview');
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    expect(JSON.parse(JSON.stringify(MARKDOWN_FIXTURE))).toEqual(MARKDOWN_FIXTURE);
+  });
+});
+
+describe('TextSnapshotEnvelope — wire format', () => {
+  it('carries the PascalCase TextStyle on the wire', () => {
+    expect(TEXT_FIXTURE.snapshot?.style).toBe('Heading');
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    expect(JSON.parse(JSON.stringify(TEXT_FIXTURE))).toEqual(TEXT_FIXTURE);
+  });
+});
+
+describe('ImageSnapshotEnvelope — wire format', () => {
+  it('carries source, altLocalizationKey and PascalCase ImageFit', () => {
+    expect(IMAGE_FIXTURE.snapshot?.source).toBe('blob:logo-banner');
+    expect(IMAGE_FIXTURE.snapshot?.fit).toBe('Contain');
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    expect(JSON.parse(JSON.stringify(IMAGE_FIXTURE))).toEqual(IMAGE_FIXTURE);
+  });
+});
+
+describe('Type guards — heterogeneous bundle dispatch', () => {
+  const bundle: readonly WidgetSnapshotEnvelope[] = [MARKDOWN_FIXTURE, TEXT_FIXTURE, IMAGE_FIXTURE];
+
+  it('routes each envelope to exactly one type guard', () => {
+    const matches = bundle.map((env) => ({
+      markdown: isMarkdownSnapshotEnvelope(env),
+      text: isTextSnapshotEnvelope(env),
+      image: isImageSnapshotEnvelope(env),
+    }));
+
+    expect(matches[0]).toEqual({ markdown: true, text: false, image: false });
+    expect(matches[1]).toEqual({ markdown: false, text: true, image: false });
+    expect(matches[2]).toEqual({ markdown: false, text: false, image: true });
+  });
+});
+
+describe('ImageFit — exhaustive enum surface (PascalCase)', () => {
+  it('locks the three backend fits in declaration order', () => {
+    const fits: readonly ImageFit[] = ['Contain', 'Cover', 'Fill'];
+    expect(fits).toHaveLength(3);
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -22,6 +22,7 @@ export type {
   DashboardTimeWindow,
   DataKeyFormat,
   FrameworkWidgetDefinition,
+  ImageFit,
   ImageWidgetDefinition,
   MarkdownWidgetDefinition,
   MetricDatasource,
@@ -41,8 +42,20 @@ export type {
   WidgetSize,
 } from './types/index.js';
 
-// Rendering — wire contracts for the dashboard render pipeline (B3-1, ADR-039).
+// Rendering — wire contracts for the dashboard render pipeline plus per-kind
+// snapshots (B3-1 / B3-2 / B3-3, ADR-039).
+export {
+  isImageSnapshotEnvelope,
+  isMarkdownSnapshotEnvelope,
+  isTextSnapshotEnvelope,
+} from './rendering/index.js';
 export type {
+  ImageSnapshotEnvelope,
+  ImageWidgetSnapshot,
+  MarkdownSnapshotEnvelope,
+  MarkdownWidgetSnapshot,
+  TextSnapshotEnvelope,
+  TextWidgetSnapshot,
   WidgetSnapshotEnvelope,
   WidgetSnapshotEnvelopeOf,
   WidgetSnapshotStatus,

--- a/packages/@granit/dashboards/src/rendering/image-widget-snapshot.ts
+++ b/packages/@granit/dashboards/src/rendering/image-widget-snapshot.ts
@@ -1,0 +1,31 @@
+import type {
+  WidgetSnapshotEnvelope,
+  WidgetSnapshotEnvelopeOf,
+} from './widget-snapshot-envelope.js';
+import type { ImageFit } from '../types/widget-definition.js';
+
+/**
+ * Wire-shape snapshot for the `'Image'` widget kind — a static image tile
+ * (logo, illustration, banner). Mirrors
+ * `Granit.Dashboards.Endpoints.Rendering.ImageWidgetSnapshot` (B3-3,
+ * ADR-039). The frontend resolves blob references (`'blob:...'`) and the
+ * alt-text localization key against the active session and culture.
+ */
+export interface ImageWidgetSnapshot {
+  /** URL or blob reference (`'blob:logo-banner'`, `'https://cdn...'`). */
+  readonly source: string;
+  /** Localization key for the alt text (accessibility). */
+  readonly altLocalizationKey: string;
+  /** How the image fills its grid cell. */
+  readonly fit: ImageFit;
+}
+
+/** Narrowed {@link WidgetSnapshotEnvelope} for the `'Image'` widget kind. */
+export type ImageSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Image', ImageWidgetSnapshot>;
+
+/** Type guard refining a generic envelope to {@link ImageSnapshotEnvelope}. */
+export function isImageSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is ImageSnapshotEnvelope {
+  return envelope.widgetType === 'Image';
+}

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -1,8 +1,19 @@
 // ---------------------------------------------------------------------------
 // @granit/dashboards/rendering — wire contracts for the dashboard render
-// pipeline. Mirrors `Granit.Dashboards.Rendering` (B3-1, ADR-039).
+// pipeline. Mirrors `Granit.Dashboards.Rendering` + the per-kind snapshots
+// shipped by static-content renderers in `Granit.Dashboards.Endpoints.Rendering`
+// (B3-1 / B3-3, ADR-039).
 // ---------------------------------------------------------------------------
 
+export { isImageSnapshotEnvelope } from './image-widget-snapshot.js';
+export type { ImageSnapshotEnvelope, ImageWidgetSnapshot } from './image-widget-snapshot.js';
+export { isMarkdownSnapshotEnvelope } from './markdown-widget-snapshot.js';
+export type {
+  MarkdownSnapshotEnvelope,
+  MarkdownWidgetSnapshot,
+} from './markdown-widget-snapshot.js';
+export { isTextSnapshotEnvelope } from './text-widget-snapshot.js';
+export type { TextSnapshotEnvelope, TextWidgetSnapshot } from './text-widget-snapshot.js';
 export type {
   WidgetSnapshotEnvelope,
   WidgetSnapshotEnvelopeOf,

--- a/packages/@granit/dashboards/src/rendering/markdown-widget-snapshot.ts
+++ b/packages/@granit/dashboards/src/rendering/markdown-widget-snapshot.ts
@@ -1,0 +1,33 @@
+import type {
+  WidgetSnapshotEnvelope,
+  WidgetSnapshotEnvelopeOf,
+} from './widget-snapshot-envelope.js';
+
+/**
+ * Wire-shape snapshot for the `'Markdown'` widget kind. Carries the
+ * localization key the frontend resolves to a markdown body — the renderer
+ * itself never resolves the key (the active locale lives on the client and
+ * the localization bundle ships separately), so the snapshot stays static
+ * regardless of the requesting user's culture.
+ *
+ * Mirrors `Granit.Dashboards.Endpoints.Rendering.MarkdownWidgetSnapshot`
+ * (B3-3, ADR-039).
+ */
+export interface MarkdownWidgetSnapshot {
+  /** Localization key whose value is the markdown body. */
+  readonly contentLocalizationKey: string;
+}
+
+/**
+ * Narrowed {@link WidgetSnapshotEnvelope} for the `'Markdown'` widget kind.
+ * Use the {@link isMarkdownSnapshotEnvelope} type guard to refine a
+ * heterogeneous dashboard render response to Markdown envelopes only.
+ */
+export type MarkdownSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Markdown', MarkdownWidgetSnapshot>;
+
+/** Type guard refining a generic envelope to {@link MarkdownSnapshotEnvelope}. */
+export function isMarkdownSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is MarkdownSnapshotEnvelope {
+  return envelope.widgetType === 'Markdown';
+}

--- a/packages/@granit/dashboards/src/rendering/text-widget-snapshot.ts
+++ b/packages/@granit/dashboards/src/rendering/text-widget-snapshot.ts
@@ -1,0 +1,29 @@
+import type {
+  WidgetSnapshotEnvelope,
+  WidgetSnapshotEnvelopeOf,
+} from './widget-snapshot-envelope.js';
+import type { TextWidgetStyle } from '../types/widget-definition.js';
+
+/**
+ * Wire-shape snapshot for the `'Text'` widget kind — a plain-text tile
+ * (page heading, section subheading, caption) with no data binding. Mirrors
+ * `Granit.Dashboards.Endpoints.Rendering.TextWidgetSnapshot` (B3-3, ADR-039)
+ * one-to-one with `TextWidgetDefinition` — the frontend resolves the
+ * localization key against the active culture.
+ */
+export interface TextWidgetSnapshot {
+  /** Localization key for the text body. */
+  readonly contentLocalizationKey: string;
+  /** Visual style hint inherited from the declarative definition. */
+  readonly style: TextWidgetStyle;
+}
+
+/** Narrowed {@link WidgetSnapshotEnvelope} for the `'Text'` widget kind. */
+export type TextSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Text', TextWidgetSnapshot>;
+
+/** Type guard refining a generic envelope to {@link TextSnapshotEnvelope}. */
+export function isTextSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is TextSnapshotEnvelope {
+  return envelope.widgetType === 'Text';
+}

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -31,6 +31,7 @@ export type { DashboardLayout } from './dashboard-layout.js';
 export type { WidgetAction, WidgetActionKind, WidgetActionTrigger } from './widget-action.js';
 export type {
   FrameworkWidgetDefinition,
+  ImageFit,
   ImageWidgetDefinition,
   MarkdownWidgetDefinition,
   TextWidgetDefinition,

--- a/packages/@granit/dashboards/src/types/widget-definition.ts
+++ b/packages/@granit/dashboards/src/types/widget-definition.ts
@@ -62,6 +62,19 @@ export interface MarkdownWidgetDefinition extends WidgetDefinitionBase {
   readonly contentLocalizationKey: string;
 }
 
+/**
+ * How an {@link ImageWidgetDefinition} fills its grid cell. Mirrors
+ * `Granit.Dashboards.Widgets.ImageFit`. PascalCase wire values — backend's
+ * host registers a `JsonStringEnumConverter()` with no naming policy.
+ */
+export type ImageFit =
+  /** Preserve aspect ratio, letterbox to fit. Right for logos. */
+  | 'Contain'
+  /** Fill the cell, crop to maintain aspect. Right for banner photos. */
+  | 'Cover'
+  /** Stretch to fill (rarely correct — distorts the image). */
+  | 'Fill';
+
 /** Renders a static image — typically a logo or visual divider. */
 export interface ImageWidgetDefinition extends WidgetDefinitionBase {
   readonly type: 'image';
@@ -69,6 +82,11 @@ export interface ImageWidgetDefinition extends WidgetDefinitionBase {
   readonly source: string;
   /** Localization key for the alt text (accessibility). */
   readonly altLocalizationKey: string;
+  /**
+   * How the image fills its grid cell. Backend default is `'Contain'`
+   * (preserves aspect, letterboxes); fixtures that omit it are accepted.
+   */
+  readonly fit?: ImageFit;
 }
 
 /**

--- a/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
@@ -1,6 +1,13 @@
 import { useTranslation } from 'react-i18next';
 
-import type { ImageWidgetDefinition } from '@granit/dashboards';
+import type { ImageFit, ImageWidgetDefinition } from '@granit/dashboards';
+import type { CSSProperties } from 'react';
+
+const OBJECT_FIT_CLASS: Readonly<Record<ImageFit, NonNullable<CSSProperties['objectFit']>>> = {
+  Contain: 'contain',
+  Cover: 'cover',
+  Fill: 'fill',
+};
 
 /**
  * Built-in renderer for `ImageWidgetDefinition`.
@@ -12,18 +19,21 @@ import type { ImageWidgetDefinition } from '@granit/dashboards';
  *
  * The `source` field accepts either a plain URL or a `blob:<id>` reference
  * resolved by the host's blob storage adapter — apps that ship blob support
- * register a richer renderer overriding this default.
+ * register a richer renderer overriding this default. The `fit` field maps
+ * 1-to-1 to CSS `object-fit` (default `'Contain'` matches the backend default
+ * for logo-style imagery).
  */
 export function ImageWidget({ widget }: { readonly widget: ImageWidgetDefinition }) {
   const { t } = useTranslation();
   const alt = t(widget.altLocalizationKey);
+  const objectFit = OBJECT_FIT_CLASS[widget.fit ?? 'Contain'];
   return (
     <div data-slot="image-widget" className="flex h-full w-full items-center justify-center">
       <img
         src={widget.source}
         alt={alt}
         loading="lazy"
-        style={{ objectFit: 'contain' }}
+        style={{ objectFit }}
         className="h-full w-full"
       />
     </div>


### PR DESCRIPTION
## Summary

Frontend mirror for granit-dotnet [#1486](https://github.com/granit-fx/granit-dotnet/pull/1486) — static-content widget renderers (Markdown / Text / Image). Each kind ships a typed snapshot record + envelope alias + type guard so the future \`useDashboard\` hook dispatches a heterogeneous bundle without inspecting payload fields directly.

## \`@granit/dashboards\` — new exports

\`\`\`ts
// rendering/
export interface MarkdownWidgetSnapshot { contentLocalizationKey: string; }
export interface TextWidgetSnapshot     { contentLocalizationKey: string; style: TextWidgetStyle; }
export interface ImageWidgetSnapshot    { source: string; altLocalizationKey: string; fit: ImageFit; }

export type MarkdownSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Markdown', MarkdownWidgetSnapshot>;
export type TextSnapshotEnvelope     = WidgetSnapshotEnvelopeOf<'Text',     TextWidgetSnapshot>;
export type ImageSnapshotEnvelope    = WidgetSnapshotEnvelopeOf<'Image',    ImageWidgetSnapshot>;

export function isMarkdownSnapshotEnvelope(env): env is MarkdownSnapshotEnvelope;
export function isTextSnapshotEnvelope(env):     env is TextSnapshotEnvelope;
export function isImageSnapshotEnvelope(env):    env is ImageSnapshotEnvelope;

// types/widget-definition.ts
export type ImageFit = 'Contain' | 'Cover' | 'Fill';

export interface ImageWidgetDefinition extends WidgetDefinitionBase {
  // … existing source / altLocalizationKey fields
  readonly fit?: ImageFit;   // NEW — defaults to 'Contain' on backend
}
\`\`\`

PascalCase wire enums everywhere — backend's host registers \`JsonStringEnumConverter()\` with no naming policy.

## \`@granit/react-dashboards\` — \`ImageWidget\` honors \`fit\`

Maps \`widget.fit\` → CSS \`object-fit\` at render time:

| Wire value | CSS \`object-fit\` |
| --- | --- |
| \`'Contain'\` (default) | \`contain\` |
| \`'Cover'\` | \`cover\` |
| \`'Fill'\` | \`fill\` |

Fixtures that omit \`fit\` keep the prior behaviour (\`'Contain'\`).

## Static-content RefreshHint

All three renderers always emit \`refreshHint: 'Static'\` so the future \`useDashboard\` hook drops these widgets out of the refresh loop entirely.

## Wire-format contract tests

\`packages/@granit/dashboards/src/__tests__/content-snapshots.test.ts\`:
- 3 envelope round-trips (camelCase props + PascalCase enums)
- Heterogeneous bundle dispatch — guards route each envelope to exactly one type guard
- \`ImageFit\` exhaustive enum surface (3 values, declaration-ordered)

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2335/2335** ✓ (+8)

## What's next

- **B4-render** — \`POST /dashboards/{id}/render\` endpoint composes all renderers into a single bundle response. Frontend \`useDashboard\` hook lands then with the per-widget cache split (cf. ADR §6.2). The new type guards introduced here drive the per-widget renderer dispatch in that hook.