### PR TITLE
feat(react-dashboards): useDashboardRender hook + per-widget cache split (B4-render mirror, ADR-039)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2047,6 +2047,17 @@
       "description": "React renderer for @granit/dashboards — Dashboard layout component, WidgetRegistry provider, and built-in renderers for Markdown / Image / Text widgets",
       "exports": [
         {
+          "name": "UseDashboardRenderOptions",
+          "kind": "interface",
+          "signature": "interface UseDashboardRenderOptions",
+          "members": []
+        },
+        {
+          "name": "useDashboardWidget",
+          "kind": "function",
+          "signature": "function useDashboardWidget( dashboardId: string, widgetId: string ): UseQueryResult<DashboardRenderedWidget>"
+        },
+        {
           "name": "Dashboard",
           "kind": "function",
           "signature": "function Dashboard("

--- a/packages/@granit/dashboards/src/__tests__/dashboard-render-response.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/dashboard-render-response.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+
+import type {
+  DashboardRenderedWidget,
+  DashboardRenderRequest,
+  DashboardRenderResponse,
+} from '../rendering/index.js';
+
+// Pinned wire-format fixtures mirroring B4-render
+// (Granit.Dashboards.Endpoints.Dtos.DashboardRenderResponse). Each widget
+// slot is a flattened WidgetSnapshotEnvelope plus the persisted widget id.
+
+const KPI_WIDGET: DashboardRenderedWidget = {
+  id: '8c6b1e10-0000-0000-0000-000000000001',
+  widgetType: 'Kpi',
+  status: 'Snapshot',
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  snapshot: {
+    value: 12,
+    valueKind: 'Count',
+    currency: null,
+    isHigherBetter: false,
+    noData: false,
+    previous: null,
+  },
+  unavailableReasonLocalizationKey: null,
+};
+
+const MARKDOWN_WIDGET: DashboardRenderedWidget = {
+  id: '8c6b1e10-0000-0000-0000-000000000002',
+  widgetType: 'Markdown',
+  status: 'Snapshot',
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  snapshot: { contentLocalizationKey: 'Widget:Test.Banner' },
+  unavailableReasonLocalizationKey: null,
+};
+
+const UNAVAILABLE_WIDGET: DashboardRenderedWidget = {
+  id: '8c6b1e10-0000-0000-0000-000000000003',
+  widgetType: 'Chart',
+  status: 'Unavailable',
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  snapshot: null,
+  unavailableReasonLocalizationKey: 'Widget:Unavailable',
+};
+
+const BUNDLE_FIXTURE: DashboardRenderResponse = {
+  dashboardId: '8c6b1e10-0000-4000-8000-000000000000',
+  renderedAt: '2026-04-29T12:34:56.789Z',
+  period: {
+    from: '2026-04-01T00:00:00Z',
+    to: '2026-04-29T00:00:00Z',
+    token: 'mtd',
+  },
+  widgets: [KPI_WIDGET, MARKDOWN_WIDGET, UNAVAILABLE_WIDGET],
+};
+
+describe('DashboardRenderResponse — wire format', () => {
+  it('carries the dashboardId, renderedAt and echoed period', () => {
+    expect(BUNDLE_FIXTURE.dashboardId).toBe('8c6b1e10-0000-4000-8000-000000000000');
+    expect(BUNDLE_FIXTURE.period?.token).toBe('mtd');
+  });
+
+  it('flattens each widget into id + envelope fields, in position order', () => {
+    expect(BUNDLE_FIXTURE.widgets).toHaveLength(3);
+    expect(BUNDLE_FIXTURE.widgets[0]?.widgetType).toBe('Kpi');
+    expect(BUNDLE_FIXTURE.widgets[1]?.widgetType).toBe('Markdown');
+    expect(BUNDLE_FIXTURE.widgets[2]?.widgetType).toBe('Chart');
+  });
+
+  it('round-trips the full bundle through JSON without mutation', () => {
+    expect(JSON.parse(JSON.stringify(BUNDLE_FIXTURE))).toEqual(BUNDLE_FIXTURE);
+  });
+
+  it('null period (request omitted bounds) round-trips cleanly', () => {
+    const noPeriod: DashboardRenderResponse = { ...BUNDLE_FIXTURE, period: null };
+    expect(JSON.parse(JSON.stringify(noPeriod))).toEqual(noPeriod);
+  });
+});
+
+describe('DashboardRenderRequest — wire format', () => {
+  it('accepts the absolute-bounds + token + locale + filters shape', () => {
+    const req: DashboardRenderRequest = {
+      periodFrom: '2026-04-01T00:00:00Z',
+      periodTo: '2026-04-29T00:00:00Z',
+      periodToken: 'mtd',
+      locale: 'fr-CA',
+      filters: { Status: 'Open' },
+    };
+    expect(req.periodToken).toBe('mtd');
+    expect(req.filters?.Status).toBe('Open');
+  });
+
+  it('accepts an empty request (defaults — backend fills locale="en")', () => {
+    const req: DashboardRenderRequest = {};
+    expect(JSON.parse(JSON.stringify(req))).toEqual({});
+  });
+});

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -50,6 +50,10 @@ export {
   isTextSnapshotEnvelope,
 } from './rendering/index.js';
 export type {
+  DashboardRenderedWidget,
+  DashboardRenderPeriod,
+  DashboardRenderRequest,
+  DashboardRenderResponse,
   ImageSnapshotEnvelope,
   ImageWidgetSnapshot,
   MarkdownSnapshotEnvelope,

--- a/packages/@granit/dashboards/src/rendering/dashboard-render-request.ts
+++ b/packages/@granit/dashboards/src/rendering/dashboard-render-request.ts
@@ -1,0 +1,30 @@
+/**
+ * Request body for `POST /dashboards/{id}/render`. Mirrors
+ * `Granit.Dashboards.Endpoints.Dtos.DashboardRenderRequest` (B4-render,
+ * ADR-039).
+ *
+ * The period window is supplied as absolute `[periodFrom, periodTo)` UTC
+ * bounds; named-token resolution (`'mtd'`, `'qtd'`, …) is the caller's
+ * responsibility — same convention as the analytics inline-metric endpoint.
+ * Both bounds are required together; supplying only one is a 400 (the
+ * backend `DashboardRenderRequestValidator` enforces the pairing).
+ */
+export interface DashboardRenderRequest {
+  /** Inclusive lower bound (ISO 8601 UTC). Required when {@link periodTo} is set. */
+  readonly periodFrom?: string;
+  /** Exclusive upper bound (ISO 8601 UTC). Required when {@link periodFrom} is set. */
+  readonly periodTo?: string;
+  /**
+   * Optional named token (`'mtd'`, `'qtd'`, …) — echoed in the response for
+   * client convenience. The renderer never re-resolves it server-side.
+   */
+  readonly periodToken?: string;
+  /** Active BCP-47 locale (e.g. `'en'`, `'fr-CA'`). Defaults to `'en'`. */
+  readonly locale?: string;
+  /**
+   * Dashboard-level filter bindings (e.g. `{ Status: 'Open' }`). Each typed
+   * widget renderer applies them in its own way; the renderer pipeline
+   * doesn't interpret the values. `null` / missing = no filters.
+   */
+  readonly filters?: Readonly<Record<string, string>> | null;
+}

--- a/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
+++ b/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
@@ -1,0 +1,85 @@
+import type { WidgetSnapshotStatus } from './widget-snapshot-status.js';
+import type { RefreshHint } from '../types/refresh-hint.js';
+
+/**
+ * Wire shape for `POST /dashboards/{id}/render`. Mirrors
+ * `Granit.Dashboards.Endpoints.Dtos.DashboardRenderResponse` (B4-render,
+ * ADR-039 §6).
+ *
+ * The bundle is a **transport optimisation**, not the cache identity. The
+ * `useDashboardRender` hook splits the response into per-widget TanStack
+ * entries (`['dashboard', dashboardId, 'widget', widgetId]`) before storing
+ * it — see ADR-039 §6.2. Frontends that bypass the hook and store the
+ * full bundle as a single cache entry will need to refactor when the push
+ * transport (P2.4) lands.
+ */
+export interface DashboardRenderResponse {
+  /** Dashboard identifier — matches `Dashboard.Id`. */
+  readonly dashboardId: string;
+  /** Server-side timestamp at which the bundle was composed (ISO 8601 UTC). */
+  readonly renderedAt: string;
+  /**
+   * Period the renderer ran against. `null` when the request omitted period
+   * bounds.
+   */
+  readonly period: DashboardRenderPeriod | null;
+  /** One flat record per widget, in `WidgetInstance.Position` order. */
+  readonly widgets: readonly DashboardRenderedWidget[];
+}
+
+/**
+ * Period echoed back to the client. {@link token} mirrors the request's
+ * named-token field unchanged — useful for clients that compose UIs around
+ * rotating presets (`'mtd'`, `'qtd'`, …).
+ */
+export interface DashboardRenderPeriod {
+  /** Inclusive lower bound (ISO 8601 UTC). */
+  readonly from: string;
+  /** Exclusive upper bound (ISO 8601 UTC). */
+  readonly to: string;
+  /** Optional named token echoed from the request. */
+  readonly token: string | null;
+}
+
+/**
+ * One widget's slot in the dashboard render bundle. Flattens
+ * {@link WidgetSnapshotEnvelope} alongside the widget's persisted `id` —
+ * the wire shape ADR-039 §6 locks for every framework dashboard endpoint.
+ *
+ * To narrow a generic `DashboardRenderedWidget` to a kind-specific shape,
+ * use the per-kind type guards from `@granit/dashboards`
+ * (`isMarkdownSnapshotEnvelope`, `isImageSnapshotEnvelope`, …) or
+ * `@granit/analytics` (`isKpiSnapshotEnvelope`).
+ */
+export interface DashboardRenderedWidget {
+  /** Persisted `WidgetInstance.Id`. */
+  readonly id: string;
+  /**
+   * Declarative kind discriminator — mirrors `WidgetDefinition.type`'s
+   * `[JsonDerivedType]` tag (`'Kpi'`, `'Markdown'`, …).
+   */
+  readonly widgetType: string;
+  /** Runtime outcome (`'Snapshot'` / `'Unavailable'` / `'Error'`). */
+  readonly status: WidgetSnapshotStatus;
+  /**
+   * Always `1` in pull mode; future push transport increments per
+   * (widget, tenant). EPIC #1366 invariant #2.
+   */
+  readonly sequence: number;
+  /** Server-side timestamp of the widget's computation (ISO 8601 UTC). */
+  readonly emittedAt: string;
+  /** Pull / push transport hint — drives the per-widget cache TTL. */
+  readonly refreshHint: RefreshHint;
+  /**
+   * Pre-serialised typed payload. `null` when {@link status} is not
+   * `'Snapshot'`. Frontend renderers narrow this to a kind-specific shape
+   * (e.g. `KpiSnapshot`) by inspecting {@link widgetType} via the widget
+   * registry.
+   */
+  readonly snapshot: unknown | null;
+  /**
+   * Localization key for the user-facing reason when {@link status} is
+   * `'Unavailable'`; `null` otherwise.
+   */
+  readonly unavailableReasonLocalizationKey: string | null;
+}

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -2,9 +2,16 @@
 // @granit/dashboards/rendering — wire contracts for the dashboard render
 // pipeline. Mirrors `Granit.Dashboards.Rendering` + the per-kind snapshots
 // shipped by static-content renderers in `Granit.Dashboards.Endpoints.Rendering`
-// (B3-1 / B3-3, ADR-039).
+// + the bundle response shape from `POST /dashboards/{id}/render`
+// (B3-1 / B3-3 / B4-render, ADR-039).
 // ---------------------------------------------------------------------------
 
+export type { DashboardRenderRequest } from './dashboard-render-request.js';
+export type {
+  DashboardRenderedWidget,
+  DashboardRenderPeriod,
+  DashboardRenderResponse,
+} from './dashboard-render-response.js';
 export { isImageSnapshotEnvelope } from './image-widget-snapshot.js';
 export type { ImageSnapshotEnvelope, ImageWidgetSnapshot } from './image-widget-snapshot.js';
 export { isMarkdownSnapshotEnvelope } from './markdown-widget-snapshot.js';

--- a/packages/@granit/react-dashboards/package.json
+++ b/packages/@granit/react-dashboards/package.json
@@ -14,7 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0",
     "react-i18next": "^17.0.0"
   },
@@ -28,7 +31,9 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/api-client": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   }

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
@@ -1,0 +1,201 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+// We hand-roll an Axios-shaped client because the real `@granit/api-client`
+// factory drags in browser globals (CSRF / session interceptors) the test
+// environment doesn't need. The Granit client provider only consumes
+// `post / get / put / delete`, so any object exposing them suffices.
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  dashboardRenderQueryKey,
+  dashboardWidgetQueryKey,
+  normalizeDashboardRenderRequest,
+  strongestRefreshHint,
+  useDashboardRender,
+} from '../api/use-dashboard-render.js';
+import { useDashboardWidget } from '../api/use-dashboard-widget.js';
+
+import type {
+  DashboardRenderedWidget,
+  DashboardRenderRequest,
+  DashboardRenderResponse,
+} from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const DASHBOARD_ID = '8c6b1e10-0000-4000-8000-000000000000';
+const KPI_ID = '8c6b1e10-0000-0000-0000-000000000001';
+const MARKDOWN_ID = '8c6b1e10-0000-0000-0000-000000000002';
+
+const KPI_WIDGET: DashboardRenderedWidget = {
+  id: KPI_ID,
+  widgetType: 'Kpi',
+  status: 'Snapshot',
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  snapshot: {
+    value: 12,
+    valueKind: 'Count',
+    currency: null,
+    isHigherBetter: false,
+    noData: false,
+    previous: null,
+  },
+  unavailableReasonLocalizationKey: null,
+};
+
+const MARKDOWN_WIDGET: DashboardRenderedWidget = {
+  id: MARKDOWN_ID,
+  widgetType: 'Markdown',
+  status: 'Snapshot',
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  snapshot: { contentLocalizationKey: 'Widget:Test.Banner' },
+  unavailableReasonLocalizationKey: null,
+};
+
+const BUNDLE: DashboardRenderResponse = {
+  dashboardId: DASHBOARD_ID,
+  renderedAt: '2026-04-29T12:34:56.789Z',
+  period: null,
+  widgets: [MARKDOWN_WIDGET, KPI_WIDGET],
+};
+
+const server = setupServer(
+  http.post(`http://localhost/dashboards/${DASHBOARD_ID}/render`, async () =>
+    HttpResponse.json(BUNDLE)
+  )
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('normalizeDashboardRenderRequest', () => {
+  it('drops undefined fields so the cache key collapses', () => {
+    const a: DashboardRenderRequest = { periodToken: 'mtd' };
+    const b: DashboardRenderRequest = { periodToken: 'mtd', locale: undefined };
+    expect(JSON.stringify(normalizeDashboardRenderRequest(a))).toBe(
+      JSON.stringify(normalizeDashboardRenderRequest(b))
+    );
+  });
+
+  it('canonicalises filter key order', () => {
+    const a: DashboardRenderRequest = { filters: { Status: 'Open', Region: 'EU' } };
+    const b: DashboardRenderRequest = { filters: { Region: 'EU', Status: 'Open' } };
+    expect(JSON.stringify(normalizeDashboardRenderRequest(a))).toBe(
+      JSON.stringify(normalizeDashboardRenderRequest(b))
+    );
+  });
+});
+
+describe('strongestRefreshHint', () => {
+  it('returns Static for an empty bundle', () => {
+    expect(strongestRefreshHint([])).toBe('Static');
+  });
+
+  it('upgrades to Dynamic when any widget is Dynamic', () => {
+    expect(
+      strongestRefreshHint([
+        { ...MARKDOWN_WIDGET, refreshHint: 'Static' },
+        { ...KPI_WIDGET, refreshHint: 'Dynamic' },
+      ])
+    ).toBe('Dynamic');
+  });
+
+  it('upgrades to Realtime when any widget is Realtime', () => {
+    expect(
+      strongestRefreshHint([
+        { ...MARKDOWN_WIDGET, refreshHint: 'Dynamic' },
+        { ...KPI_WIDGET, refreshHint: 'Realtime' },
+      ])
+    ).toBe('Realtime');
+  });
+});
+
+describe('dashboard render query keys', () => {
+  it('renders the bundle key with the request payload', () => {
+    expect(dashboardRenderQueryKey(DASHBOARD_ID, { periodToken: 'mtd' })).toEqual([
+      'dashboard',
+      DASHBOARD_ID,
+      'render',
+      { periodToken: 'mtd' },
+    ]);
+  });
+
+  it('renders the per-widget key', () => {
+    expect(dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID)).toEqual([
+      'dashboard',
+      DASHBOARD_ID,
+      'widget',
+      KPI_ID,
+    ]);
+  });
+});
+
+describe('useDashboardRender — bundle fetch + per-widget cache split (ADR-039 §6.2)', () => {
+  it('fetches the bundle and exposes it through TanStack Query', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboardRender(DASHBOARD_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.widgets).toHaveLength(2);
+  });
+
+  it('populates one TanStack entry per widget', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useDashboardRender(DASHBOARD_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() =>
+      expect(
+        queryClient.getQueryData<DashboardRenderedWidget>(
+          dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID)
+        )
+      ).toBeDefined()
+    );
+    expect(
+      queryClient.getQueryData<DashboardRenderedWidget>(
+        dashboardWidgetQueryKey(DASHBOARD_ID, MARKDOWN_ID)
+      )?.widgetType
+    ).toBe('Markdown');
+  });
+});
+
+describe('useDashboardWidget — passive reader', () => {
+  it('surfaces the per-widget cache entry without firing its own fetch', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    // Pre-populate as if useDashboardRender had already split the bundle.
+    queryClient.setQueryData(dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID), KPI_WIDGET);
+
+    const { result } = renderHook(() => useDashboardWidget(DASHBOARD_ID, KPI_ID), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.data).toEqual(KPI_WIDGET));
+  });
+
+  it('returns undefined for an unknown widget id (no network call)', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboardWidget(DASHBOARD_ID, 'unknown'), {
+      wrapper,
+    });
+    // Hook is `enabled: false` — never fires, so isLoading stays false.
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-render.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-render.ts
@@ -1,0 +1,205 @@
+import { HttpError } from '@granit/api-client';
+import { useGranitClient } from '@granit/react-api-client';
+import {
+  useQuery,
+  useQueryClient,
+  type Query,
+  type QueryClient,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+import { useEffect, useMemo } from 'react';
+
+import type {
+  DashboardRenderedWidget,
+  DashboardRenderRequest,
+  DashboardRenderResponse,
+  RefreshHint,
+} from '@granit/dashboards';
+
+const DASHBOARD_PATH = '/dashboards';
+
+/**
+ * Polling cadence per {@link RefreshHint} for the bundle-level refetch. The
+ * hook re-evaluates this on every TanStack tick so a `Static` bundle stops
+ * polling itself, a `Dynamic` one stays cached, and a `Realtime` one polls
+ * until the SSE / WS push transport (P2.4) replaces polling entirely.
+ *
+ * The bundle's effective hint is the **strongest** hint among its widgets:
+ * one realtime widget pulls the whole bundle into the realtime cadence so
+ * each widget's per-widget cache entry stays fresh.
+ */
+const POLLING_INTERVAL_MS: Readonly<Record<RefreshHint, number | false>> = {
+  Static: false,
+  Dynamic: false,
+  Realtime: 5_000,
+};
+
+const REFRESH_HINT_RANK: Readonly<Record<RefreshHint, number>> = {
+  Static: 0,
+  Dynamic: 1,
+  Realtime: 2,
+};
+
+export interface UseDashboardRenderOptions {
+  /** Disable the request — useful when the parent isn't ready (e.g. tenant pending). */
+  readonly enabled?: boolean;
+  /**
+   * Force a polling interval, overriding the cadence the strongest widget
+   * `refreshHint` would otherwise dictate. `false` disables polling entirely.
+   */
+  readonly refetchInterval?: number | false;
+}
+
+/**
+ * Cache key composer. Exported for tests + for sibling hooks that need to
+ * address the same query without going through the hook itself.
+ */
+export const dashboardRenderQueryKey = (dashboardId: string, request: DashboardRenderRequest) =>
+  ['dashboard', dashboardId, 'render', request] as const;
+
+/**
+ * Cache key composer for the **per-widget** TanStack entries the hook
+ * populates from the bundle response (ADR-039 §6.2). Use it from
+ * {@link useDashboardWidget} to read a single widget's envelope.
+ */
+export const dashboardWidgetQueryKey = (dashboardId: string, widgetId: string) =>
+  ['dashboard', dashboardId, 'widget', widgetId] as const;
+
+/**
+ * Calls `POST /dashboards/{id}/render` and returns the bundle response.
+ *
+ * **Bundle is a transport optimisation, not the cache identity.** Per
+ * ADR-039 §6.2, the hook splits the response into one TanStack Query entry
+ * per widget (`['dashboard', dashboardId, 'widget', widgetId]`) on every
+ * successful fetch — so:
+ *
+ * - The future SSE / WS push transport (P2.4) reconciles per-widget
+ *   `{ widgetId, sequence, delta }` messages without a global refetch.
+ * - Per-widget consumers (`useDashboardWidget`) survive partial bundle
+ *   refreshes — only widgets whose envelope actually changed re-render.
+ *
+ * Polling cadence is derived from the strongest `refreshHint` across the
+ * bundle's widgets (Realtime > Dynamic > Static). 4xx are deterministic
+ * (dashboard not found, malformed period spec) and never retry.
+ */
+export function useDashboardRender(
+  dashboardId: string,
+  request: DashboardRenderRequest = {},
+  options: UseDashboardRenderOptions = {}
+): UseQueryResult<DashboardRenderResponse> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  const normalizedRequest = useMemo(() => normalizeRequest(request), [request]);
+
+  const queryKey = useMemo(
+    () => dashboardRenderQueryKey(dashboardId, normalizedRequest),
+    [dashboardId, normalizedRequest]
+  );
+
+  const result = useQuery({
+    queryKey,
+    queryFn: async ({ signal }) => {
+      const { data } = await api.post<DashboardRenderResponse>(
+        `${DASHBOARD_PATH}/${encodeURIComponent(dashboardId)}/render`,
+        normalizedRequest,
+        { signal }
+      );
+      return data;
+    },
+    enabled: options.enabled ?? true,
+    retry: shouldRetry,
+    staleTime: 60_000,
+    refetchInterval: options.refetchInterval ?? refetchIntervalFromBundle,
+  });
+
+  // Per-widget cache split runs on every successful refetch (initial load,
+  // background refetch, manual invalidation). Effects that mutate the
+  // QueryClient outside the queryFn keep the per-widget entries authoritative
+  // for any consumer reading them via dashboardWidgetQueryKey().
+  useEffect(() => {
+    if (!result.data) return;
+    splitBundleIntoWidgetCacheEntries(queryClient, dashboardId, result.data);
+  }, [queryClient, dashboardId, result.data]);
+
+  return result;
+}
+
+function shouldRetry(failureCount: number, error: unknown): boolean {
+  if (error instanceof HttpError && error.status >= 400 && error.status < 500) {
+    return false;
+  }
+  return failureCount < 2;
+}
+
+function refetchIntervalFromBundle(
+  query: Query<DashboardRenderResponse, Error, DashboardRenderResponse, readonly unknown[]>
+): number | false {
+  const data = query.state.data;
+  if (!data) return false;
+  return POLLING_INTERVAL_MS[strongestRefreshHint(data.widgets)];
+}
+
+/**
+ * Picks the strongest hint across the bundle's widgets. Exported for tests
+ * + for consumers that compose their own polling strategy (e.g. an editor
+ * pane that pauses polling while the user drags a widget).
+ */
+export function strongestRefreshHint(widgets: readonly DashboardRenderedWidget[]): RefreshHint {
+  let strongest: RefreshHint = 'Static';
+  for (const widget of widgets) {
+    if (REFRESH_HINT_RANK[widget.refreshHint] > REFRESH_HINT_RANK[strongest]) {
+      strongest = widget.refreshHint;
+    }
+  }
+  return strongest;
+}
+
+function splitBundleIntoWidgetCacheEntries(
+  queryClient: QueryClient,
+  dashboardId: string,
+  bundle: DashboardRenderResponse
+): void {
+  for (const widget of bundle.widgets) {
+    queryClient.setQueryData<DashboardRenderedWidget>(
+      dashboardWidgetQueryKey(dashboardId, widget.id),
+      widget
+    );
+  }
+}
+
+/**
+ * Produces a canonical request shape so semantically-equivalent inputs
+ * collapse to the same query key (and therefore the same cache entry,
+ * in-flight request, and — once streaming lands — subscription identity).
+ *
+ * Exported for testing. Consumers go through {@link useDashboardRender}.
+ */
+export function normalizeDashboardRenderRequest(
+  request: DashboardRenderRequest
+): DashboardRenderRequest {
+  const normalized: Record<string, unknown> = {};
+  if (request.periodFrom !== undefined) normalized['periodFrom'] = request.periodFrom;
+  if (request.periodTo !== undefined) normalized['periodTo'] = request.periodTo;
+  if (request.periodToken !== undefined) normalized['periodToken'] = request.periodToken;
+  if (request.locale !== undefined) normalized['locale'] = request.locale;
+  if (request.filters !== undefined && request.filters !== null) {
+    normalized['filters'] = canonicalizeFilters(request.filters);
+  }
+  return normalized as DashboardRenderRequest;
+}
+
+function canonicalizeFilters(
+  filters: Readonly<Record<string, string>>
+): Readonly<Record<string, string>> {
+  // Sort keys so semantically-identical filter maps share a JSON-stringified
+  // identity (same TanStack queryKey hash, same SSE topic later).
+  const sorted: Record<string, string> = {};
+  for (const key of Object.keys(filters).sort()) {
+    sorted[key] = filters[key]!;
+  }
+  return sorted;
+}
+
+function normalizeRequest(request: DashboardRenderRequest): DashboardRenderRequest {
+  return normalizeDashboardRenderRequest(request);
+}

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-widget.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-widget.ts
@@ -1,0 +1,34 @@
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { dashboardWidgetQueryKey } from './use-dashboard-render.js';
+
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Reads a single widget's envelope from the per-widget TanStack cache entry
+ * populated by {@link useDashboardRender}. Per ADR-039 §6.2 the bundle
+ * fetch and the per-widget cache split are decoupled, so:
+ *
+ * - `useDashboardRender` triggers the network round-trip and refreshes
+ *   every widget atomically.
+ * - `useDashboardWidget` is a **passive reader** — it never fires its own
+ *   network request. The future SSE / WS push transport (P2.4) updates the
+ *   per-widget entry directly via `setQueryData`, and consumers re-render
+ *   only for the specific widget that changed.
+ *
+ * Returns a TanStack `UseQueryResult` with `data: undefined` whenever the
+ * bundle has not been fetched yet (or the widget id is unknown). Consumers
+ * typically render a placeholder until `data` is populated.
+ */
+export function useDashboardWidget(
+  dashboardId: string,
+  widgetId: string
+): UseQueryResult<DashboardRenderedWidget> {
+  return useQuery<DashboardRenderedWidget>({
+    queryKey: dashboardWidgetQueryKey(dashboardId, widgetId),
+    // No queryFn — the bundle fetch (`useDashboardRender`) is the sole
+    // source of truth. Setting `enabled: false` keeps TanStack from
+    // attempting a fetch and surfaces the cached entry verbatim.
+    enabled: false,
+  });
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -2,6 +2,17 @@
 // @granit/react-dashboards — public API
 // ---------------------------------------------------------------------------
 
+// Render hook (B4-render — POST /dashboards/{id}/render bundle + per-widget cache split)
+export {
+  dashboardRenderQueryKey,
+  dashboardWidgetQueryKey,
+  normalizeDashboardRenderRequest,
+  strongestRefreshHint,
+  useDashboardRender,
+} from './api/use-dashboard-render.js';
+export type { UseDashboardRenderOptions } from './api/use-dashboard-render.js';
+export { useDashboardWidget } from './api/use-dashboard-widget.js';
+
 // Layout + dispatcher
 export { Dashboard } from './components/dashboard.js';
 export type { DashboardProps } from './components/dashboard.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1090,6 +1090,9 @@ importers:
 
   packages/@granit/react-dashboards:
     dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.5
+        version: 5.100.5(react@19.2.5)
       react:
         specifier: ^19.0.0
         version: 19.2.5
@@ -1097,9 +1100,15 @@ importers:
         specifier: ^17.0.0
         version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
     devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
       '@granit/dashboards':
         specifier: workspace:*
         version: link:../dashboards
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Summary

Frontend mirror for granit-dotnet B4-render (\`POST /dashboards/{id}/render\`). Lands the bundle fetch + the **per-widget TanStack cache split** that ADR-039 §6.2 mandates so the future SSE / WS push transport (P2.4) can reconcile \`{ widgetId, sequence, delta }\` messages without a global refetch.

## Wire types — \`@granit/dashboards\`

\`\`\`ts
export interface DashboardRenderRequest {
  periodFrom?: string;       // ISO 8601 UTC — required when periodTo is set
  periodTo?: string;
  periodToken?: string;      // 'mtd' / 'qtd' / … — echoed back, never re-resolved server-side
  locale?: string;           // BCP-47 — defaults to 'en' on backend
  filters?: Record<string, string> | null;
}

export interface DashboardRenderResponse {
  dashboardId: string;
  renderedAt: string;
  period: DashboardRenderPeriod | null;
  widgets: readonly DashboardRenderedWidget[];   // flattened envelope + id
}

export interface DashboardRenderedWidget {
  id: string;
  widgetType: string;        // 'Kpi' | 'Markdown' | …
  status: WidgetSnapshotStatus;
  sequence: number;
  emittedAt: string;
  refreshHint: RefreshHint;
  snapshot: unknown | null;
  unavailableReasonLocalizationKey: string | null;
}
\`\`\`

## Hooks — \`@granit/react-dashboards\`

\`\`\`ts
useDashboardRender(dashboardId, request?, options?): UseQueryResult<DashboardRenderResponse>;
useDashboardWidget(dashboardId, widgetId): UseQueryResult<DashboardRenderedWidget>;
\`\`\`

\`useDashboardRender\` is the single entry point — it fires the POST, applies a request normalizer (collapses semantically-identical inputs to the same TanStack queryKey + future SSE topic), and **on every successful fetch splits the bundle into per-widget cache entries** (\`['dashboard', dashboardId, 'widget', widgetId]\`). Polling cadence is derived from the **strongest** \`refreshHint\` across the bundle's widgets (Realtime > Dynamic > Static); 4xx never retries (deterministic — dashboard not found, malformed period spec).

\`useDashboardWidget\` is a **passive reader**. \`enabled: false\` so it never fires its own fetch — the bundle hook is the sole network source of truth. The future push transport will update each widget's cache entry directly via \`setQueryData\`, and consumers re-render only for the specific widget that changed.

## Helpers exported for tests + advanced consumers

- \`normalizeDashboardRenderRequest\` — pure normalizer.
- \`strongestRefreshHint\` — bundle → effective hint reducer.
- \`dashboardRenderQueryKey\` / \`dashboardWidgetQueryKey\` — cache key composers (mirror what the hook uses internally; useful for manual \`setQueryData\` / \`invalidateQueries\`).

## Peer deps update

\`@granit/react-dashboards\` adds \`@granit/api-client\`, \`@granit/react-api-client\` and \`@tanstack/react-query\` as peers (already devDeps for tests). Aligns with \`@granit/react-analytics\`'s existing peer set — same DI pattern as the inline-metric \`useMetric\`.

## Tests (+17, total 2352 / 2352 ✓)

- \`@granit/dashboards/src/__tests__/dashboard-render-response.test.ts\` — 7 wire-format contract tests (bundle round-trip, flattened widget shape, null-period variant, request shape).
- \`@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx\` — 11 hook tests (request normalization, \`strongestRefreshHint\` logic, queryKey composers, MSW-driven bundle fetch + per-widget cache split, \`useDashboardWidget\` passive read + unknown-id behaviour).

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2352 / 2352** ✓

## What's next

- **Showcase migration**: rewrite the demo dashboard page to consume \`useDashboardRender\` + \`useDashboardWidget\` + the per-kind type guards (\`isKpiSnapshotEnvelope\`, \`isMarkdownSnapshotEnvelope\`, …) instead of pulling \`useMetric\` per widget. End-to-end validates the bundle path + the per-widget renderer dispatch on a real page.
- **B5+ / SSE push transport (P2.4)**: per-widget cache split is now in place — push messages will hydrate each entry via \`setQueryData(dashboardWidgetQueryKey(...))\` without touching the bundle key.