### PR TITLE
feat(analytics)!: data-bound snapshot envelopes (B3-4 / B3-5 / B3-6 mirror, ADR-039)

### DIFF
--- a/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
+++ b/packages/@granit/analytics/src/__tests__/data-snapshots.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isChartSnapshotEnvelope,
+  isPivotSnapshotEnvelope,
+  isTableSnapshotEnvelope,
+} from '../widgets/index.js';
+
+import type {
+  ChartSnapshotEnvelope,
+  ChartType,
+  PivotSnapshotEnvelope,
+  TableSnapshotEnvelope,
+} from '../widgets/index.js';
+import type { WidgetSnapshotEnvelope } from '@granit/dashboards';
+
+// Pinned wire-format fixtures mirroring B3-4 / B3-5 / B3-6 backend output:
+//   - Granit.Analytics.Endpoints.Rendering.TableWidgetInstanceRenderer
+//   - Granit.Analytics.Endpoints.Rendering.ChartWidgetInstanceRenderer
+//   - Granit.Analytics.Endpoints.Rendering.PivotWidgetInstanceRenderer
+// All emit camelCase property names + PascalCase enum values per ADR-039 §6.1.
+
+const TABLE_FIXTURE: TableSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Table',
+  snapshot: {
+    columns: [
+      { name: 'id', labelLocalizationKey: null },
+      { name: 'amount', labelLocalizationKey: 'Column:Invoice.Amount' },
+      { name: 'status', labelLocalizationKey: 'Column:Invoice.Status' },
+    ],
+    rows: [
+      { id: 'inv-001', amount: 1240.5, status: 'Open' },
+      { id: 'inv-002', amount: 890, status: 'Paid' },
+    ],
+    totalRowCount: 27,
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
+const CHART_FIXTURE: ChartSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Chart',
+  snapshot: {
+    chartType: 'HorizontalBar',
+    groupBy: 'IssuedAtMonth',
+    aggregation: 'Sum',
+    field: 'Total',
+    buckets: [
+      { label: '2026-02', value: 12500 },
+      { label: '2026-03', value: 18200 },
+      { label: '2026-04', value: null },
+    ],
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
+const PIVOT_FIXTURE: PivotSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Pivot',
+  snapshot: {
+    rowFields: ['Region'],
+    columnFields: ['Status'],
+    valueField: 'Total',
+    aggregation: 'Sum',
+    cells: [
+      { rowKeys: ['EU'], columnKeys: ['Open'], value: 9500 },
+      { rowKeys: ['EU'], columnKeys: ['Paid'], value: 12300 },
+      { rowKeys: ['NA'], columnKeys: ['Open'], value: null },
+    ],
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
+describe('TableSnapshotEnvelope — wire format', () => {
+  it('carries columns + rows + totalRowCount', () => {
+    expect(TABLE_FIXTURE.snapshot?.columns).toHaveLength(3);
+    expect(TABLE_FIXTURE.snapshot?.rows[0]?.['amount']).toBe(1240.5);
+    expect(TABLE_FIXTURE.snapshot?.totalRowCount).toBe(27);
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    expect(JSON.parse(JSON.stringify(TABLE_FIXTURE))).toEqual(TABLE_FIXTURE);
+  });
+});
+
+describe('ChartSnapshotEnvelope — wire format', () => {
+  it('echoes chartType / groupBy / aggregation / field plus buckets', () => {
+    expect(CHART_FIXTURE.snapshot?.chartType).toBe('HorizontalBar');
+    expect(CHART_FIXTURE.snapshot?.aggregation).toBe('Sum');
+    expect(CHART_FIXTURE.snapshot?.buckets).toHaveLength(3);
+  });
+
+  it('accepts null bucket values (Avg / Min / Max over empty groups)', () => {
+    expect(CHART_FIXTURE.snapshot?.buckets[2]?.value).toBeNull();
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    expect(JSON.parse(JSON.stringify(CHART_FIXTURE))).toEqual(CHART_FIXTURE);
+  });
+});
+
+describe('PivotSnapshotEnvelope — wire format', () => {
+  it('carries the flat (rowKeys × columnKeys × value) cell list', () => {
+    expect(PIVOT_FIXTURE.snapshot?.cells).toHaveLength(3);
+    expect(PIVOT_FIXTURE.snapshot?.cells[0]?.rowKeys).toEqual(['EU']);
+  });
+
+  it('accepts null cell values for empty groups', () => {
+    expect(PIVOT_FIXTURE.snapshot?.cells[2]?.value).toBeNull();
+  });
+
+  it('round-trips through JSON without mutation', () => {
+    expect(JSON.parse(JSON.stringify(PIVOT_FIXTURE))).toEqual(PIVOT_FIXTURE);
+  });
+});
+
+describe('Type guards — analytics envelope dispatch', () => {
+  const bundle: readonly WidgetSnapshotEnvelope[] = [TABLE_FIXTURE, CHART_FIXTURE, PIVOT_FIXTURE];
+
+  it('routes each envelope to exactly one type guard', () => {
+    const matches = bundle.map((env) => ({
+      table: isTableSnapshotEnvelope(env),
+      chart: isChartSnapshotEnvelope(env),
+      pivot: isPivotSnapshotEnvelope(env),
+    }));
+
+    expect(matches[0]).toEqual({ table: true, chart: false, pivot: false });
+    expect(matches[1]).toEqual({ table: false, chart: true, pivot: false });
+    expect(matches[2]).toEqual({ table: false, chart: false, pivot: true });
+  });
+});
+
+describe('ChartType — exhaustive enum surface (PascalCase, backend-ordered)', () => {
+  it('locks the six backend types in declaration order', () => {
+    const types: readonly ChartType[] = ['Bar', 'HorizontalBar', 'Line', 'Area', 'Pie', 'Donut'];
+    expect(types).toHaveLength(6);
+  });
+});

--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -17,16 +17,30 @@ export type {
   ValueKind,
 } from './metrics/index.js';
 
-// Widgets — catalog declarations consumed by @granit/dashboards
-export { isKpiSnapshotEnvelope } from './widgets/index.js';
+// Widgets — catalog declarations + snapshot envelopes consumed by @granit/dashboards
+export {
+  isChartSnapshotEnvelope,
+  isKpiSnapshotEnvelope,
+  isPivotSnapshotEnvelope,
+  isTableSnapshotEnvelope,
+} from './widgets/index.js';
 export type {
   AggregateFunction,
   AnalyticsWidgetDefinition,
+  ChartBucket,
+  ChartSnapshotEnvelope,
   ChartType,
   ChartWidgetDefinition,
+  ChartWidgetSnapshot,
   KpiSnapshot,
   KpiSnapshotEnvelope,
   KpiWidgetDefinition,
+  PivotCell,
+  PivotSnapshotEnvelope,
   PivotWidgetDefinition,
+  PivotWidgetSnapshot,
+  TableSnapshotEnvelope,
+  TableWidgetColumn,
   TableWidgetDefinition,
+  TableWidgetSnapshot,
 } from './widgets/index.js';

--- a/packages/@granit/analytics/src/widgets/chart-snapshot.ts
+++ b/packages/@granit/analytics/src/widgets/chart-snapshot.ts
@@ -1,0 +1,57 @@
+import type { AggregateFunction } from './aggregation.js';
+import type { ChartType } from './chart-widget.js';
+import type { WidgetSnapshotEnvelope, WidgetSnapshotEnvelopeOf } from '@granit/dashboards';
+
+/**
+ * One data point on the chart's category axis. Mirrors
+ * `Granit.Analytics.Endpoints.Rendering.ChartBucket`.
+ */
+export interface ChartBucket {
+  /**
+   * String-friendly group key (e.g. `'Open'`, `'Paid'`, `'2026-04'`). Null
+   * group keys surface as `'(null)'`.
+   */
+  readonly label: string;
+  /**
+   * Aggregate value for the bucket. `null` when the aggregation is
+   * `'Avg'` / `'Min'` / `'Max'` over a group with no usable values — the
+   * frontend renders "—" for that data point. `'Count'` and `'Sum'` always
+   * carry a non-null value (zero for empty groups).
+   */
+  readonly value: number | null;
+}
+
+/**
+ * Snapshot payload for the `'Chart'` widget kind. Mirrors
+ * `Granit.Analytics.Endpoints.Rendering.ChartWidgetSnapshot` (B3-5, ADR-039).
+ *
+ * Echoes the declarative configuration ({@link chartType}, {@link groupBy},
+ * {@link aggregation}, {@link field}) so the frontend renders without
+ * re-reading the widget config, and ships one {@link ChartBucket} per group
+ * as the data series.
+ */
+export interface ChartWidgetSnapshot {
+  /** Visual hint inherited from the declarative `ChartWidgetDefinition.chartType`. */
+  readonly chartType: ChartType;
+  /** Group-by field name echoed for the frontend's category-axis label. */
+  readonly groupBy: string;
+  /** Aggregation applied per bucket — drives the value-axis label. */
+  readonly aggregation: AggregateFunction;
+  /** Aggregated field; `null` for `'Count'`. */
+  readonly field: string | null;
+  /**
+   * Group-aggregate series. Order is preserved as the underlying group-by
+   * produces it.
+   */
+  readonly buckets: readonly ChartBucket[];
+}
+
+/** Narrowed {@link WidgetSnapshotEnvelope} for the `'Chart'` widget kind. */
+export type ChartSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Chart', ChartWidgetSnapshot>;
+
+/** Type guard refining a generic envelope to {@link ChartSnapshotEnvelope}. */
+export function isChartSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is ChartSnapshotEnvelope {
+  return envelope.widgetType === 'Chart';
+}

--- a/packages/@granit/analytics/src/widgets/chart-widget.ts
+++ b/packages/@granit/analytics/src/widgets/chart-widget.ts
@@ -2,10 +2,12 @@ import type { AggregateFunction } from './aggregation.js';
 import type { WidgetDefinitionBase } from '@granit/dashboards';
 
 /**
- * Visual hint for chart widgets, interpreted by the frontend renderer. Mirrors
- * `Granit.Analytics.Dashboards.Widgets.ChartType`.
+ * Visual hint for chart widgets, interpreted by the frontend renderer.
+ * Mirrors `Granit.Analytics.Dashboards.Widgets.ChartType`. PascalCase wire
+ * values — the framework's host registers a `JsonStringEnumConverter()`
+ * with no naming policy. Order matches the backend numeric declaration.
  */
-export type ChartType = 'bar' | 'horizontalBar' | 'line' | 'area' | 'pie' | 'donut';
+export type ChartType = 'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut';
 
 /**
  * Aggregated chart bound to a `QueryDefinition`. Mirrors
@@ -21,7 +23,7 @@ export interface ChartWidgetDefinition extends WidgetDefinitionBase {
   /** Field used as the chart's category axis (e.g. `IssuedAtMonth`). */
   readonly groupBy: string;
   readonly aggregation: AggregateFunction;
-  /** Field aggregated. Null when `aggregation === 'count'`. */
+  /** Field aggregated. Null when `aggregation === 'Count'`. */
   readonly field: string | null;
   readonly chartType: ChartType;
 }

--- a/packages/@granit/analytics/src/widgets/index.ts
+++ b/packages/@granit/analytics/src/widgets/index.ts
@@ -1,9 +1,19 @@
 export type { AggregateFunction } from './aggregation.js';
+export { isChartSnapshotEnvelope } from './chart-snapshot.js';
+export type { ChartBucket, ChartSnapshotEnvelope, ChartWidgetSnapshot } from './chart-snapshot.js';
 export type { ChartType, ChartWidgetDefinition } from './chart-widget.js';
 export { isKpiSnapshotEnvelope } from './kpi-snapshot.js';
 export type { KpiSnapshot, KpiSnapshotEnvelope } from './kpi-snapshot.js';
 export type { KpiWidgetDefinition } from './kpi-widget.js';
+export { isPivotSnapshotEnvelope } from './pivot-snapshot.js';
+export type { PivotCell, PivotSnapshotEnvelope, PivotWidgetSnapshot } from './pivot-snapshot.js';
 export type { PivotWidgetDefinition } from './pivot-widget.js';
+export { isTableSnapshotEnvelope } from './table-snapshot.js';
+export type {
+  TableSnapshotEnvelope,
+  TableWidgetColumn,
+  TableWidgetSnapshot,
+} from './table-snapshot.js';
 export type { TableWidgetDefinition } from './table-widget.js';
 
 import type { ChartWidgetDefinition } from './chart-widget.js';

--- a/packages/@granit/analytics/src/widgets/pivot-snapshot.ts
+++ b/packages/@granit/analytics/src/widgets/pivot-snapshot.ts
@@ -1,0 +1,67 @@
+import type { AggregateFunction } from './aggregation.js';
+import type { WidgetSnapshotEnvelope, WidgetSnapshotEnvelopeOf } from '@granit/dashboards';
+
+/**
+ * One cell of the pivot matrix. Mirrors
+ * `Granit.Analytics.Endpoints.Rendering.PivotCell`.
+ */
+export interface PivotCell {
+  /**
+   * Row-axis key tuple — same length and order as
+   * {@link PivotWidgetSnapshot.rowFields}. Null property values surface as
+   * `'(null)'`.
+   */
+  readonly rowKeys: readonly string[];
+  /**
+   * Column-axis key tuple — same length and order as
+   * {@link PivotWidgetSnapshot.columnFields}. Empty when no column fields
+   * were requested.
+   */
+  readonly columnKeys: readonly string[];
+  /**
+   * Aggregate value for the cell. `null` when the aggregation is
+   * `'Avg'` / `'Min'` / `'Max'` over a cell with no usable values — the
+   * frontend renders "—" for that data point. `'Count'` and `'Sum'` always
+   * carry a non-null value (zero for empty cells).
+   */
+  readonly value: number | null;
+}
+
+/**
+ * Snapshot payload for the `'Pivot'` widget kind. Mirrors
+ * `Granit.Analytics.Endpoints.Rendering.PivotWidgetSnapshot` (B3-6, ADR-039).
+ *
+ * Echoes the declarative configuration ({@link rowFields}, {@link columnFields},
+ * {@link valueField}, {@link aggregation}) so the frontend renders without
+ * re-reading the widget config, and ships one {@link PivotCell} per
+ * (row-tuple × column-tuple) bucket as a flat list — the renderer pivots
+ * into a matrix client-side.
+ */
+export interface PivotWidgetSnapshot {
+  /** Row-axis field names, in the order they were declared on the widget. */
+  readonly rowFields: readonly string[];
+  /**
+   * Column-axis field names, in declared order. Empty when the widget has
+   * only row dimensions.
+   */
+  readonly columnFields: readonly string[];
+  /** Aggregated field; `null` for `'Count'`. */
+  readonly valueField: string | null;
+  /** Aggregation applied per cell — drives the value-axis label client-side. */
+  readonly aggregation: AggregateFunction;
+  /**
+   * Per-cell results. Order is preserved as the underlying stream produces
+   * them; the frontend pivots into a row-major matrix.
+   */
+  readonly cells: readonly PivotCell[];
+}
+
+/** Narrowed {@link WidgetSnapshotEnvelope} for the `'Pivot'` widget kind. */
+export type PivotSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Pivot', PivotWidgetSnapshot>;
+
+/** Type guard refining a generic envelope to {@link PivotSnapshotEnvelope}. */
+export function isPivotSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is PivotSnapshotEnvelope {
+  return envelope.widgetType === 'Pivot';
+}

--- a/packages/@granit/analytics/src/widgets/pivot-widget.ts
+++ b/packages/@granit/analytics/src/widgets/pivot-widget.ts
@@ -13,7 +13,7 @@ export interface PivotWidgetDefinition extends WidgetDefinitionBase {
   readonly rowFields: readonly string[];
   /** Fields used as column dimensions (in order). */
   readonly columnFields: readonly string[];
-  /** Field aggregated in each cell. Null when `valueAggregation === 'count'`. */
+  /** Field aggregated in each cell. Null when `valueAggregation === 'Count'`. */
   readonly valueField: string | null;
   readonly valueAggregation: AggregateFunction;
 }

--- a/packages/@granit/analytics/src/widgets/table-snapshot.ts
+++ b/packages/@granit/analytics/src/widgets/table-snapshot.ts
@@ -1,0 +1,53 @@
+import type { WidgetSnapshotEnvelope, WidgetSnapshotEnvelopeOf } from '@granit/dashboards';
+
+/**
+ * One column header on the wire envelope. Mirrors
+ * `Granit.Analytics.Endpoints.Rendering.TableWidgetColumn`.
+ */
+export interface TableWidgetColumn {
+  /**
+   * Column property name (camelCase — matches the key in every row payload).
+   */
+  readonly name: string;
+  /**
+   * Localization key for the header. `null` when the source `QueryDefinition`
+   * declared no localized label — the frontend falls back to {@link name}.
+   */
+  readonly labelLocalizationKey: string | null;
+}
+
+/**
+ * Snapshot payload for the `'Table'` widget kind. Mirrors
+ * `Granit.Analytics.Endpoints.Rendering.TableWidgetSnapshot` (B3-4, ADR-039).
+ *
+ * The frontend's table renderer consumes the snapshot directly:
+ * {@link columns} drives the header order, {@link rows} carries the body,
+ * {@link totalRowCount} drives the "showing N of M" affordance.
+ */
+export interface TableWidgetSnapshot {
+  /**
+   * Column metadata in display order. Each entry's {@link TableWidgetColumn.name}
+   * matches a key in every row payload.
+   */
+  readonly columns: readonly TableWidgetColumn[];
+  /**
+   * Per-row JSON object with camelCase keys and typed JSON primitives.
+   * Length is at most the widget's configured page size.
+   */
+  readonly rows: ReadonlyArray<Readonly<Record<string, unknown>>>;
+  /**
+   * Total rows in the underlying source after filters apply. May exceed
+   * {@link rows} length when the page is full.
+   */
+  readonly totalRowCount: number;
+}
+
+/** Narrowed {@link WidgetSnapshotEnvelope} for the `'Table'` widget kind. */
+export type TableSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Table', TableWidgetSnapshot>;
+
+/** Type guard refining a generic envelope to {@link TableSnapshotEnvelope}. */
+export function isTableSnapshotEnvelope(
+  envelope: WidgetSnapshotEnvelope
+): envelope is TableSnapshotEnvelope {
+  return envelope.widgetType === 'Table';
+}


### PR DESCRIPTION
## Summary

Frontend mirror for the closing wave of B3 — the three data-bound widget renderers shipped recently on granit-dotnet:

| Backend PR | Slice | Backend record |
| --- | --- | --- |
| [#1491](https://github.com/granit-fx/granit-dotnet/pull/1491) | B3-4 Table | \`TableWidgetSnapshot\` + \`TableWidgetColumn\` |
| [#1492](https://github.com/granit-fx/granit-dotnet/pull/1492) + [#1493](https://github.com/granit-fx/granit-dotnet/pull/1493) + [#1494](https://github.com/granit-fx/granit-dotnet/pull/1494) | B3-5 / 5bis / 5ter Chart | \`ChartWidgetSnapshot\` + \`ChartBucket\` |
| [#1497](https://github.com/granit-fx/granit-dotnet/pull/1497) | B3-6 Pivot | \`PivotWidgetSnapshot\` + \`PivotCell\` |

With this PR every backend widget kind has a typed snapshot + envelope alias + type guard matching the bundle response.

## \`@granit/analytics\` — new exports

\`\`\`ts
// Table (B3-4)
export interface TableWidgetSnapshot { columns; rows; totalRowCount; }
export interface TableWidgetColumn   { name: string; labelLocalizationKey: string | null; }
export type      TableSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Table', TableWidgetSnapshot>;
export function  isTableSnapshotEnvelope(env): env is TableSnapshotEnvelope;

// Chart (B3-5)
export interface ChartWidgetSnapshot { chartType; groupBy; aggregation; field; buckets; }
export interface ChartBucket         { label: string; value: number | null; }
export type      ChartSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Chart', ChartWidgetSnapshot>;
export function  isChartSnapshotEnvelope(env): env is ChartSnapshotEnvelope;

// Pivot (B3-6)
export interface PivotWidgetSnapshot { rowFields; columnFields; valueField; aggregation; cells; }
export interface PivotCell           { rowKeys; columnKeys; value: number | null; }
export type      PivotSnapshotEnvelope = WidgetSnapshotEnvelopeOf<'Pivot', PivotWidgetSnapshot>;
export function  isPivotSnapshotEnvelope(env): env is PivotSnapshotEnvelope;
\`\`\`

## :warning: BREAKING — \`ChartType\` casing fix

\`ChartType\` migrates from camelCase (\`'bar' | 'horizontalBar' | …\`) to **PascalCase** (\`'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut'\`). Aligns with the framework's host \`JsonStringEnumConverter()\` (no naming policy) — the previous lowercase typing was a regression survived from before the casing-alignment PR (#234).

Doc updates fix the now-stale \`'count'\` lowercase references in \`ChartWidgetDefinition\` / \`PivotWidgetDefinition\` comments.

## What's NOT in this PR

- **B3-7** is backend-only (\`DashboardFilters\` composition in every runner). \`DashboardFilters\` already round-trips through \`useDashboardRender\`'s request shape — no frontend type change needed.
- **B3-2bis / B3-2ter** wire Sum/Avg/Min/Max in \`QueryAggregateRunner\`. \`KpiSnapshot\` is unchanged (= \`MetricSnapshotPayload\` regardless of which datasource kind produced it), so the existing \`isKpiSnapshotEnvelope\` guard already routes all three KPI flavours.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2362 / 2362** ✓ (+10)

Tests cover:
- Round-trip through JSON for each envelope (camelCase + PascalCase enums)
- Heterogeneous bundle dispatch (3 envelopes → 3 type guards exclusively)
- \`ChartType\` exhaustive enum surface (6 values, declaration-ordered)
- Null-value handling for empty Avg/Min/Max groups across Chart + Pivot

## What's next

- **Showcase**: extend the B4 bundle demo (\`<DashboardBundlePanel>\`) to dispatch Table / Chart / Pivot envelopes too — currently it only handles Markdown / Text / Image / KPI. Trivial: add three more \`isXxxSnapshotEnvelope\` branches.
- **Snapshot-aware renderer in \`@granit/react-dashboards\`**: now that all kinds are typed, a registry-style dispatcher (mirror of the existing definition-driven \`WidgetRegistry\`) becomes worth building. Drives a future \`<RenderedDashboard>\` component.