### PR TITLE
test(analytics): pin currency-aware QueryAggregate KPI wire path (B3-8)

### DIFF
--- a/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
+++ b/packages/@granit/analytics/src/__tests__/kpi-snapshot.test.ts
@@ -42,6 +42,27 @@ const KPI_UNAVAILABLE_FIXTURE: KpiSnapshotEnvelope = {
   unavailableReasonLocalizationKey: 'Widget:Unavailable.QueryAggregateNotImplemented',
 };
 
+// Currency-bearing variant emitted by the QueryAggregateDatasourceEvaluator
+// when the aggregated column carries `.Currency("EUR")` (B3-8). Locks the
+// promotion: valueKind goes from 'Number' to 'Currency' and `currency` carries
+// the ISO 4217 code that drives Intl.NumberFormat formatting downstream.
+const KPI_QUERY_AGGREGATE_CURRENCY_FIXTURE: KpiSnapshotEnvelope = {
+  status: 'Snapshot',
+  widgetType: 'Kpi',
+  snapshot: {
+    value: 18540.5,
+    valueKind: 'Currency',
+    currency: 'EUR',
+    isHigherBetter: true,
+    noData: false,
+    previous: null,
+  },
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic',
+  unavailableReasonLocalizationKey: null,
+};
+
 describe('KpiSnapshotEnvelope — wire format', () => {
   it('accepts the snapshot variant with a fully-populated MetricSnapshotPayload', () => {
     expect(KPI_SNAPSHOT_FIXTURE.widgetType).toBe('Kpi');
@@ -56,8 +77,20 @@ describe('KpiSnapshotEnvelope — wire format', () => {
     );
   });
 
+  it('accepts the currency variant emitted by the QueryAggregate path (B3-8)', () => {
+    // ValueKind promotes from 'Number' to 'Currency' when the aggregated column
+    // carries a declared currency code; `currency` then surfaces the ISO 4217
+    // value the column metadata declared.
+    expect(KPI_QUERY_AGGREGATE_CURRENCY_FIXTURE.snapshot?.valueKind).toBe('Currency');
+    expect(KPI_QUERY_AGGREGATE_CURRENCY_FIXTURE.snapshot?.currency).toBe('EUR');
+  });
+
   it('round-trips through JSON without mutation', () => {
-    for (const fixture of [KPI_SNAPSHOT_FIXTURE, KPI_UNAVAILABLE_FIXTURE]) {
+    for (const fixture of [
+      KPI_SNAPSHOT_FIXTURE,
+      KPI_UNAVAILABLE_FIXTURE,
+      KPI_QUERY_AGGREGATE_CURRENCY_FIXTURE,
+    ]) {
       expect(JSON.parse(JSON.stringify(fixture))).toEqual(fixture);
     }
   });


### PR DESCRIPTION
## Summary

Backend B3-8 (granit-dotnet [#1498](https://github.com/granit-fx/granit-dotnet/pull/1498)) surfaces a column's declared ISO 4217 currency code through \`MetricSnapshotPayload.Currency\` on the QueryAggregate KPI path:

- \`ValueKind\` promotes from \`'Number'\` to \`'Currency'\` when the aggregated column carries \`.Currency(\"EUR\")\`.
- The \`currency\` field carries the column-declared code instead of \`null\`.

**No frontend type change** — \`MetricSnapshotPayload.currency\` was already declared \`string | null\`, and \`formatMetricValue\` already routes \`valueKind === 'Currency'\` through \`Intl.NumberFormat({ style: 'currency', currency })\`. This PR is purely a wire-format contract pin.

## Change

\`@granit/analytics/src/__tests__/kpi-snapshot.test.ts\` adds a third KPI envelope fixture (\`KPI_QUERY_AGGREGATE_CURRENCY_FIXTURE\`) mirroring the new path:

\`\`\`ts
{
  valueKind: 'Currency',
  currency: 'EUR',
  value: 18540.5,
  isHigherBetter: true,
  noData: false,
  previous: null,
}
\`\`\`

A new test asserts the promotion + the currency field; the JSON round-trip loop now covers all three KPI variants (count, unavailable, currency).

## Why pin it

A backend regression that accidentally dropped \`currency\` on the QueryAggregate path (e.g. ValueKind stuck on \`Number\`, or the column descriptor lookup failing silently) would make Intl format the value as a plain decimal — silent UX degradation, no exception. Pinning the contract here surfaces the drift before it reaches the wire.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` (changed scope) — 19/19 ✓ (+1)