### PR TITLE
feat(react-dashboards): rendered dashboard + snapshot widget registry (B5-A)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1418,9 +1418,19 @@
           "members": []
         },
         {
+          "name": "KpiSnapshotTile",
+          "kind": "function",
+          "signature": "function KpiSnapshotTile("
+        },
+        {
           "name": "defaultAnalyticsWidgetRegistry",
           "kind": "const",
           "signature": "const defaultAnalyticsWidgetRegistry: WidgetRegistry"
+        },
+        {
+          "name": "defaultAnalyticsSnapshotWidgetRegistry",
+          "kind": "const",
+          "signature": "const defaultAnalyticsSnapshotWidgetRegistry: SnapshotWidgetRegistry"
         },
         {
           "name": "formatDeltaRatio",
@@ -2135,6 +2145,59 @@
           "name": "composeRegistries",
           "kind": "function",
           "signature": "function composeRegistries(...registries: readonly WidgetRegistry[]): WidgetRegistry"
+        },
+        {
+          "name": "RenderedDashboard",
+          "kind": "function",
+          "signature": "function RenderedDashboard("
+        },
+        {
+          "name": "RenderedDashboardProps",
+          "kind": "interface",
+          "signature": "interface RenderedDashboardProps",
+          "members": []
+        },
+        {
+          "name": "RenderedWidget",
+          "kind": "function",
+          "signature": "function RenderedWidget("
+        },
+        {
+          "name": "RenderedWidgetProps",
+          "kind": "interface",
+          "signature": "interface RenderedWidgetProps",
+          "members": []
+        },
+        {
+          "name": "ImageSnapshotWidget",
+          "kind": "function",
+          "signature": "function ImageSnapshotWidget("
+        },
+        {
+          "name": "MarkdownSnapshotWidget",
+          "kind": "function",
+          "signature": "function MarkdownSnapshotWidget("
+        },
+        {
+          "name": "TextSnapshotWidget",
+          "kind": "function",
+          "signature": "function TextSnapshotWidget("
+        },
+        {
+          "name": "defaultSnapshotWidgetRegistry",
+          "kind": "const",
+          "signature": "const defaultSnapshotWidgetRegistry: SnapshotWidgetRegistry"
+        },
+        {
+          "name": "SnapshotWidgetRegistryProviderProps",
+          "kind": "interface",
+          "signature": "interface SnapshotWidgetRegistryProviderProps",
+          "members": []
+        },
+        {
+          "name": "composeSnapshotRegistries",
+          "kind": "function",
+          "signature": "function composeSnapshotRegistries( ...registries: readonly SnapshotWidgetRegistry[] ): SnapshotWidgetRegistry"
         }
       ]
     },

--- a/packages/@granit/react-analytics/src/components/kpi-snapshot-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-snapshot-tile.tsx
@@ -1,0 +1,42 @@
+import { isKpiSnapshotEnvelope } from '@granit/analytics';
+import { useTranslation } from 'react-i18next';
+
+import { KpiTileView } from './kpi-tile-view.js';
+
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Snapshot-driven renderer for the `'Kpi'` widget kind. Symmetric to the
+ * definition-side {@link KpiTile}: both delegate to the pure presentational
+ * {@link KpiTileView}, but the snapshot variant skips the `useMetric` fetch
+ * — the bundle response carried the snapshot directly.
+ *
+ * The wrapper synthesises the `MetricResponse` shape `KpiTileView` consumes
+ * by combining the envelope-level fields (sequence / emittedAt / refreshHint)
+ * with the snapshot payload (= `MetricSnapshotPayload`, B3-2 / B3-8). This
+ * keeps the visual identical between the two paths and avoids forking the
+ * pure-presentational layer.
+ */
+export function KpiSnapshotTile({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  const { i18n } = useTranslation();
+
+  if (!isKpiSnapshotEnvelope(widget) || !widget.snapshot) return null;
+
+  return (
+    <KpiTileView
+      data={{
+        // The bundle response doesn't carry the metric name (it's a render
+        // identity, not a wire field). The KpiTileView only uses `name` for
+        // an aria-label fallback — passing the widget id keeps a stable hook.
+        name: widget.id,
+        snapshot: widget.snapshot,
+        sequence: widget.sequence,
+        emittedAt: widget.emittedAt,
+        refreshHint: widget.refreshHint,
+      }}
+      isLoading={false}
+      error={null}
+      locale={i18n.language}
+    />
+  );
+}

--- a/packages/@granit/react-analytics/src/index.ts
+++ b/packages/@granit/react-analytics/src/index.ts
@@ -6,14 +6,18 @@
 export { normalizeMetricRequest, useMetric } from './api/use-metric.js';
 export type { UseMetricOptions } from './api/use-metric.js';
 
-// Widget renderers
+// Widget renderers — definition-driven (KpiTile fetches its own metric data)
 export { KpiTile } from './components/kpi-tile.js';
 export type { KpiTileProps } from './components/kpi-tile.js';
 export { KpiTileView } from './components/kpi-tile-view.js';
 export type { KpiTileViewProps } from './components/kpi-tile-view.js';
 
-// Registry
+// Snapshot renderer (B5 — bundle-driven, consumes the pre-rendered envelope)
+export { KpiSnapshotTile } from './components/kpi-snapshot-tile.js';
+
+// Registries
 export { defaultAnalyticsWidgetRegistry } from './registry/default-analytics-widget-registry.js';
+export { defaultAnalyticsSnapshotWidgetRegistry } from './registry/default-analytics-snapshot-widget-registry.js';
 
 // Formatters (re-exported for convenience — also available standalone)
 export { formatDeltaRatio, formatMetricValue } from './lib/format-metric-value.js';

--- a/packages/@granit/react-analytics/src/registry/default-analytics-snapshot-widget-registry.ts
+++ b/packages/@granit/react-analytics/src/registry/default-analytics-snapshot-widget-registry.ts
@@ -1,0 +1,24 @@
+import { KpiSnapshotTile } from '../components/kpi-snapshot-tile.js';
+
+import type { SnapshotWidgetRegistry } from '@granit/react-dashboards';
+
+/**
+ * Snapshot-driven analytics renderers, keyed by their PascalCase
+ * `widgetType` discriminator. Compose with the framework default snapshot
+ * registry at the app root so `<RenderedDashboard>` resolves analytics
+ * widgets without per-app re-registration:
+ *
+ *     <SnapshotWidgetRegistryProvider registries={[
+ *       defaultSnapshotWidgetRegistry,             // Markdown / Text / Image
+ *       defaultAnalyticsSnapshotWidgetRegistry,    // Kpi (+ Chart / Table / Pivot / Map as they ship)
+ *       appCustomSnapshotRegistry,
+ *     ]}>
+ *
+ * v1 ships `Kpi` only. `Chart` / `Table` / `Pivot` / `Map` renderers land as
+ * the per-kind UI components are productionised (compact previews exist in
+ * the showcase already; production-grade ECharts / Leaflet renderers come
+ * with B5-B and dedicated chart-library wiring).
+ */
+export const defaultAnalyticsSnapshotWidgetRegistry: SnapshotWidgetRegistry = Object.freeze({
+  Kpi: KpiSnapshotTile,
+});

--- a/packages/@granit/react-dashboards/src/__tests__/rendered-widget.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/rendered-widget.test.tsx
@@ -1,0 +1,126 @@
+import { render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { RenderedWidget } from '../components/rendered-widget.js';
+import { defaultSnapshotWidgetRegistry } from '../registry/default-snapshot-widget-registry.js';
+import { SnapshotWidgetRegistryProvider } from '../registry/snapshot-widget-registry-context.js';
+
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        'Widget:Test.Banner': 'Hello world',
+        'Widget:Test.Heading': 'Section heading',
+        'Widget:Test.Logo.Alt': 'Granit logo',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <SnapshotWidgetRegistryProvider registries={[defaultSnapshotWidgetRegistry]}>
+        {node}
+      </SnapshotWidgetRegistryProvider>
+    </I18nextProvider>
+  );
+}
+
+const ENVELOPE_BASE = {
+  id: '8c6b1e10-0000-0000-0000-000000000001',
+  status: 'Snapshot' as const,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static' as const,
+  reasonLocalizationKey: null,
+};
+
+describe('RenderedWidget — dispatcher', () => {
+  it('routes a Markdown envelope to the built-in MarkdownSnapshotWidget', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Markdown',
+      snapshot: { contentLocalizationKey: 'Widget:Test.Banner' },
+    };
+    const { container, getByText } = wrap(<RenderedWidget widget={widget} />);
+    expect(container.querySelector('[data-slot="markdown-snapshot-widget"]')).not.toBeNull();
+    expect(getByText('Hello world')).toBeInTheDocument();
+  });
+
+  it('routes a Text envelope to the built-in TextSnapshotWidget with style-aware tag', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Text',
+      snapshot: { contentLocalizationKey: 'Widget:Test.Heading', style: 'Heading' },
+    };
+    const { container } = wrap(<RenderedWidget widget={widget} />);
+    const text = container.querySelector('[data-slot="text-snapshot-widget"]');
+    expect(text?.tagName).toBe('H2');
+    expect(text?.getAttribute('data-style')).toBe('heading');
+  });
+
+  it('routes an Image envelope to the built-in ImageSnapshotWidget', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Image',
+      snapshot: {
+        source: 'https://cdn.example/logo.png',
+        altLocalizationKey: 'Widget:Test.Logo.Alt',
+        fit: 'Contain',
+      },
+    };
+    const { container } = wrap(<RenderedWidget widget={widget} />);
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('Granit logo');
+  });
+
+  it('renders an Unavailable slot when the envelope is gated', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Kpi',
+      status: 'Unavailable',
+      snapshot: null,
+      reasonLocalizationKey: 'Widget:Unavailable.MetricNotFound',
+    };
+    const { container, getByText } = wrap(<RenderedWidget widget={widget} />);
+    const slot = container.querySelector('[data-widget-status="unavailable"]');
+    expect(slot).not.toBeNull();
+    expect(getByText('Widget:Unavailable.MetricNotFound')).toBeInTheDocument();
+  });
+
+  it('renders an Error slot when the renderer threw server-side', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Chart',
+      status: 'Error',
+      snapshot: null,
+      reasonLocalizationKey: 'Widget:Error.UnknownWidgetType',
+    };
+    const { container, getByText } = wrap(<RenderedWidget widget={widget} />);
+    expect(container.querySelector('[data-widget-status="error"]')).not.toBeNull();
+    expect(getByText('Widget:Error.UnknownWidgetType')).toBeInTheDocument();
+  });
+
+  it('renders an unknown-kind placeholder when no renderer is registered', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Kpi',
+      snapshot: { value: 12 },
+    };
+    const { container, getByText } = wrap(<RenderedWidget widget={widget} />);
+    expect(container.querySelector('[data-widget-status="unknown-kind"]')).not.toBeNull();
+    expect(getByText(/Unknown widget kind: Kpi/)).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/rendered-dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/rendered-dashboard.tsx
@@ -1,0 +1,103 @@
+import { useDashboardRender, type UseDashboardRenderOptions } from '../api/use-dashboard-render.js';
+
+import { RenderedWidget } from './rendered-widget.js';
+
+import type { DashboardRenderRequest } from '@granit/dashboards';
+
+/**
+ * Read-mode dashboard component. Calls
+ * {@link useDashboardRender}(`dashboardId`) to fetch the bundle, then
+ * iterates `data.widgets` and dispatches each through {@link RenderedWidget}
+ * (which reads the active {@link SnapshotWidgetRegistry}).
+ *
+ * Until the bundle response carries layout metadata (sizes / positions —
+ * pending backend story B4-catalog), the widgets render as a flat
+ * responsive grid. Apps that need richer layout can drop down to the lower-
+ * level pieces (`useDashboardRender` + `<RenderedWidget>`) and own the grid
+ * themselves; this component is the reasonable default.
+ *
+ * Wrap the parent tree with:
+ *
+ *     <QueryClientProvider client={...}>
+ *       <GranitClientProvider client={...}>
+ *         <SnapshotWidgetRegistryProvider registries={[
+ *           defaultSnapshotWidgetRegistry,
+ *           defaultAnalyticsSnapshotWidgetRegistry,
+ *           // ...app registries
+ *         ]}>
+ *           <RenderedDashboard dashboardId={id} />
+ */
+export interface RenderedDashboardProps {
+  readonly dashboardId: string;
+  /** Forwarded to {@link useDashboardRender} — period bounds, locale, filters. */
+  readonly request?: DashboardRenderRequest;
+  readonly options?: UseDashboardRenderOptions;
+  /**
+   * Optional wrapper className applied to the grid root — host apps style
+   * the dashboard chrome (header, period selector) outside this component.
+   */
+  readonly className?: string;
+}
+
+export function RenderedDashboard({
+  dashboardId,
+  request,
+  options,
+  className,
+}: RenderedDashboardProps) {
+  const query = useDashboardRender(dashboardId, request, options);
+
+  if (query.isLoading) {
+    return <LoadingSkeleton className={className} />;
+  }
+  if (query.isError) {
+    return (
+      <div
+        data-slot="rendered-dashboard"
+        data-state="error"
+        className={joinClasses(
+          'rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive',
+          className
+        )}
+      >
+        Failed to load dashboard.
+      </div>
+    );
+  }
+  if (!query.data) return null;
+
+  return (
+    <div
+      data-slot="rendered-dashboard"
+      data-state="ready"
+      data-dashboard-id={dashboardId}
+      className={joinClasses('grid gap-3 md:grid-cols-2 xl:grid-cols-3', className)}
+    >
+      {query.data.widgets.map((widget) => (
+        <RenderedWidget key={widget.id} widget={widget} />
+      ))}
+    </div>
+  );
+}
+
+function LoadingSkeleton({ className }: { readonly className?: string }) {
+  return (
+    <div
+      data-slot="rendered-dashboard"
+      data-state="loading"
+      className={joinClasses('grid gap-3 md:grid-cols-2 xl:grid-cols-3', className)}
+    >
+      {Array.from({ length: 3 }, (_, i) => (
+        <div
+          key={i}
+          className="h-32 animate-pulse rounded-xl border bg-card p-4 shadow-sm"
+          aria-hidden
+        />
+      ))}
+    </div>
+  );
+}
+
+function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/packages/@granit/react-dashboards/src/components/rendered-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/rendered-widget.tsx
@@ -1,0 +1,112 @@
+import { useSnapshotWidgetRegistry } from '../registry/snapshot-widget-registry-context.js';
+
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Per-widget dispatcher for the bundle response. Switches on
+ * {@link DashboardRenderedWidget.widgetType} to pick the registered renderer,
+ * surfaces the framework's three runtime states inline, and falls back to a
+ * safe placeholder when no renderer is registered for the kind.
+ *
+ * Per ADR-039 §3 the dashboard renderer guarantees per-widget error
+ * isolation: the bundle response stays 200 even when a widget's renderer
+ * throws server-side, so the frontend always has *something* to dispatch on.
+ * This dispatcher honours the same contract — `'Unavailable'` and `'Error'`
+ * statuses render their localized reason key without invoking the typed
+ * renderer at all.
+ *
+ * Wrap the parent tree with {@link SnapshotWidgetRegistryProvider} composing
+ * `defaultSnapshotWidgetRegistry` plus any per-domain registries (analytics,
+ * IoT, app-specific) the host needs.
+ */
+export interface RenderedWidgetProps {
+  readonly widget: DashboardRenderedWidget;
+}
+
+export function RenderedWidget({ widget }: RenderedWidgetProps) {
+  const registry = useSnapshotWidgetRegistry();
+
+  if (widget.status === 'Unavailable') {
+    return (
+      <UnavailableSlot
+        reasonKey={widget.reasonLocalizationKey ?? 'Widget:Unavailable'}
+        widgetType={widget.widgetType}
+      />
+    );
+  }
+
+  if (widget.status === 'Error') {
+    return (
+      <ErrorSlot
+        reasonKey={widget.reasonLocalizationKey ?? 'Widget:Error'}
+        widgetType={widget.widgetType}
+      />
+    );
+  }
+
+  const Renderer = registry[widget.widgetType];
+  if (!Renderer) {
+    return <UnknownKindSlot widgetType={widget.widgetType} />;
+  }
+
+  return (
+    <div data-slot="rendered-widget" data-widget-type={widget.widgetType}>
+      <Renderer widget={widget} />
+    </div>
+  );
+}
+
+function UnavailableSlot({
+  reasonKey,
+  widgetType,
+}: {
+  readonly reasonKey: string;
+  readonly widgetType: string;
+}) {
+  return (
+    <div
+      data-slot="rendered-widget"
+      data-widget-type={widgetType}
+      data-widget-status="unavailable"
+      className="flex h-full items-center justify-center rounded-md border border-dashed bg-muted/40 p-3 text-xs text-muted-foreground"
+    >
+      {/* Reason key is the wire identifier; consumers translate via i18n. */}
+      <span data-slot="rendered-widget-reason">{reasonKey}</span>
+    </div>
+  );
+}
+
+function ErrorSlot({
+  reasonKey,
+  widgetType,
+}: {
+  readonly reasonKey: string;
+  readonly widgetType: string;
+}) {
+  return (
+    <div
+      data-slot="rendered-widget"
+      data-widget-type={widgetType}
+      data-widget-status="error"
+      className="flex h-full items-center justify-center rounded-md border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive"
+    >
+      <span data-slot="rendered-widget-reason">{reasonKey}</span>
+    </div>
+  );
+}
+
+function UnknownKindSlot({ widgetType }: { readonly widgetType: string }) {
+  // No registered renderer — typically means the host forgot to compose
+  // the relevant registry (analytics / IoT / app-specific). We log nothing
+  // here on purpose; the host wiring is the bug, not the bundle response.
+  return (
+    <div
+      data-slot="rendered-widget"
+      data-widget-type={widgetType}
+      data-widget-status="unknown-kind"
+      className="flex h-full items-center justify-center rounded-md border border-dashed border-amber-400/60 bg-amber-50/40 p-3 text-xs text-amber-700 dark:bg-amber-950/20 dark:text-amber-300"
+    >
+      <span>Unknown widget kind: {widgetType}</span>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widgets/image-snapshot-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/image-snapshot-widget.tsx
@@ -1,0 +1,38 @@
+import { isImageSnapshotEnvelope } from '@granit/dashboards';
+import { useTranslation } from 'react-i18next';
+
+import type { DashboardRenderedWidget, ImageFit } from '@granit/dashboards';
+import type { CSSProperties } from 'react';
+
+const OBJECT_FIT: Readonly<Record<ImageFit, NonNullable<CSSProperties['objectFit']>>> = {
+  Contain: 'contain',
+  Cover: 'cover',
+  Fill: 'fill',
+};
+
+/**
+ * Built-in snapshot renderer for the `'Image'` widget kind. Symmetric to the
+ * definition-side {@link ImageWidget}: native `<img>` (no router-aware loader
+ * dependency) with `loading="lazy"` and `object-fit` mapped from the
+ * snapshot's {@link ImageFit}.
+ */
+export function ImageSnapshotWidget({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  const { t } = useTranslation();
+  if (!isImageSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  const { source, altLocalizationKey, fit } = widget.snapshot;
+  const alt = t(altLocalizationKey, { defaultValue: altLocalizationKey });
+  return (
+    <div
+      data-slot="image-snapshot-widget"
+      className="flex h-full w-full items-center justify-center"
+    >
+      <img
+        src={source}
+        alt={alt}
+        loading="lazy"
+        style={{ objectFit: OBJECT_FIT[fit] }}
+        className="h-full w-full"
+      />
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widgets/markdown-snapshot-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/markdown-snapshot-widget.tsx
@@ -1,0 +1,27 @@
+import { isMarkdownSnapshotEnvelope } from '@granit/dashboards';
+import { useTranslation } from 'react-i18next';
+
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Built-in snapshot renderer for the `'Markdown'` widget kind. Resolves the
+ * snapshot's localization key via `useTranslation()` (same i18n surface as
+ * the definition-side {@link MarkdownWidget}) and renders the body inline.
+ *
+ * The renderer is intentionally trivial — Markdown formatting is a host
+ * concern. Apps that need real Markdown rendering swap this for a renderer
+ * piping `widget.snapshot.contentLocalizationKey` through their preferred
+ * library (`react-markdown`, MDX, …).
+ */
+export function MarkdownSnapshotWidget({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  const { t } = useTranslation();
+  if (!isMarkdownSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  const content = t(widget.snapshot.contentLocalizationKey, {
+    defaultValue: widget.snapshot.contentLocalizationKey,
+  });
+  return (
+    <div data-slot="markdown-snapshot-widget" className="whitespace-pre-wrap break-words text-sm">
+      {content}
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboards/src/components/widgets/text-snapshot-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/text-snapshot-widget.tsx
@@ -1,0 +1,44 @@
+import { isTextSnapshotEnvelope } from '@granit/dashboards';
+import { useTranslation } from 'react-i18next';
+
+import type { DashboardRenderedWidget, TextWidgetStyle } from '@granit/dashboards';
+
+const STYLE_CLASSES: Readonly<Record<TextWidgetStyle, string>> = {
+  Body: 'text-sm text-foreground',
+  Heading: 'text-2xl font-semibold tracking-tight text-foreground',
+  Subheading: 'text-lg font-semibold text-foreground',
+  Caption: 'text-xs text-muted-foreground',
+};
+
+/**
+ * Built-in snapshot renderer for the `'Text'` widget kind. Symmetric to the
+ * definition-side {@link TextWidget}: uses the same Tailwind class set and
+ * the same `<h2>` / `<h3>` / `<p>` HTML element switch.
+ */
+export function TextSnapshotWidget({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  const { t } = useTranslation();
+  if (!isTextSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  const { contentLocalizationKey, style } = widget.snapshot;
+  const content = t(contentLocalizationKey, { defaultValue: contentLocalizationKey });
+  const className = `whitespace-pre-wrap break-words ${STYLE_CLASSES[style]}`;
+
+  if (style === 'Heading') {
+    return (
+      <h2 data-slot="text-snapshot-widget" data-style="heading" className={className}>
+        {content}
+      </h2>
+    );
+  }
+  if (style === 'Subheading') {
+    return (
+      <h3 data-slot="text-snapshot-widget" data-style="subheading" className={className}>
+        {content}
+      </h3>
+    );
+  }
+  return (
+    <p data-slot="text-snapshot-widget" data-style={style.toLowerCase()} className={className}>
+      {content}
+    </p>
+  );
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -48,3 +48,30 @@ export type {
   WidgetRegistry,
   WidgetRenderer as WidgetRendererFn,
 } from './registry/widget-registry.js';
+
+// ---------------------------------------------------------------------------
+// Read-mode rendering (B5 — bundle-driven, snapshot-aware)
+// ---------------------------------------------------------------------------
+
+export { RenderedDashboard } from './components/rendered-dashboard.js';
+export type { RenderedDashboardProps } from './components/rendered-dashboard.js';
+export { RenderedWidget } from './components/rendered-widget.js';
+export type { RenderedWidgetProps } from './components/rendered-widget.js';
+
+// Built-in snapshot renderers (mirror of the definition-side widgets)
+export { ImageSnapshotWidget } from './components/widgets/image-snapshot-widget.js';
+export { MarkdownSnapshotWidget } from './components/widgets/markdown-snapshot-widget.js';
+export { TextSnapshotWidget } from './components/widgets/text-snapshot-widget.js';
+
+// Snapshot widget registry (PascalCase widgetType discriminator — B5)
+export { defaultSnapshotWidgetRegistry } from './registry/default-snapshot-widget-registry.js';
+export {
+  SnapshotWidgetRegistryProvider,
+  useSnapshotWidgetRegistry,
+} from './registry/snapshot-widget-registry-context.js';
+export type { SnapshotWidgetRegistryProviderProps } from './registry/snapshot-widget-registry-context.js';
+export { composeSnapshotRegistries } from './registry/snapshot-widget-registry.js';
+export type {
+  SnapshotWidgetRegistry,
+  SnapshotWidgetRenderer,
+} from './registry/snapshot-widget-registry.js';

--- a/packages/@granit/react-dashboards/src/registry/default-snapshot-widget-registry.ts
+++ b/packages/@granit/react-dashboards/src/registry/default-snapshot-widget-registry.ts
@@ -1,0 +1,22 @@
+import { ImageSnapshotWidget } from '../components/widgets/image-snapshot-widget.js';
+import { MarkdownSnapshotWidget } from '../components/widgets/markdown-snapshot-widget.js';
+import { TextSnapshotWidget } from '../components/widgets/text-snapshot-widget.js';
+
+import type { SnapshotWidgetRegistry } from './snapshot-widget-registry.js';
+
+/**
+ * Snapshot renderers shipped by `@granit/react-dashboards` for the framework's
+ * static-content widget kinds (`Markdown` / `Text` / `Image`). Symmetric to
+ * {@link defaultWidgetRegistry} on the definition side — both ship the same
+ * three kinds, but dispatch is keyed by the wire `widgetType` (PascalCase)
+ * here vs the declarative `type` (lowercase) there.
+ *
+ * Compose with downstream registries (e.g.
+ * `defaultAnalyticsSnapshotWidgetRegistry` from `@granit/react-analytics`)
+ * via {@link composeSnapshotRegistries}.
+ */
+export const defaultSnapshotWidgetRegistry: SnapshotWidgetRegistry = Object.freeze({
+  Markdown: MarkdownSnapshotWidget,
+  Text: TextSnapshotWidget,
+  Image: ImageSnapshotWidget,
+});

--- a/packages/@granit/react-dashboards/src/registry/snapshot-widget-registry-context.tsx
+++ b/packages/@granit/react-dashboards/src/registry/snapshot-widget-registry-context.tsx
@@ -1,0 +1,53 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import {
+  composeSnapshotRegistries,
+  type SnapshotWidgetRegistry,
+} from './snapshot-widget-registry.js';
+
+const SnapshotWidgetRegistryContext = createContext<SnapshotWidgetRegistry | null>(null);
+
+export interface SnapshotWidgetRegistryProviderProps {
+  /** Registries are merged left-to-right; later entries win for the same `widgetType`. */
+  readonly registries: readonly SnapshotWidgetRegistry[];
+  readonly children: ReactNode;
+}
+
+/**
+ * Supplies the active {@link SnapshotWidgetRegistry} to the
+ * {@link RenderedDashboard} subtree.
+ *
+ * Place this near the app root, composing the registries you need — typically:
+ *   `[defaultSnapshotWidgetRegistry, defaultAnalyticsSnapshotWidgetRegistry, appCustomRegistry]`.
+ *
+ * The provider memoises the composed registry so children only re-render when
+ * the actual set of renderers changes.
+ */
+export function SnapshotWidgetRegistryProvider({
+  registries,
+  children,
+}: SnapshotWidgetRegistryProviderProps) {
+  const registry = useMemo(() => composeSnapshotRegistries(...registries), [registries]);
+  return (
+    <SnapshotWidgetRegistryContext.Provider value={registry}>
+      {children}
+    </SnapshotWidgetRegistryContext.Provider>
+  );
+}
+
+/**
+ * Reads the active {@link SnapshotWidgetRegistry}. Throws when used outside a
+ * {@link SnapshotWidgetRegistryProvider} — the dashboard renderer cannot
+ * dispatch widget snapshots without a registry, so failing fast is
+ * preferable to silently rendering JSON pretty-prints.
+ */
+export function useSnapshotWidgetRegistry(): SnapshotWidgetRegistry {
+  const registry = useContext(SnapshotWidgetRegistryContext);
+  if (registry === null) {
+    throw new Error(
+      'useSnapshotWidgetRegistry must be used inside a <SnapshotWidgetRegistryProvider>. ' +
+        'Wrap your <RenderedDashboard> tree at the app root with the framework defaults plus any extension registries.'
+    );
+  }
+  return registry;
+}

--- a/packages/@granit/react-dashboards/src/registry/snapshot-widget-registry.ts
+++ b/packages/@granit/react-dashboards/src/registry/snapshot-widget-registry.ts
@@ -1,0 +1,51 @@
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+import type { ComponentType } from 'react';
+
+/**
+ * Renderer signature for a widget kind on the **rendered** side. The component
+ * receives a {@link DashboardRenderedWidget} (one slot from the bundle response
+ * `useDashboardRender` returns) and is responsible for narrowing the
+ * `widget.snapshot` payload via the per-kind type guard before consuming it.
+ *
+ * Symmetric to {@link WidgetRenderer} on the **definition** side: that one
+ * dispatches by lowercase `widget.type` (`'markdown'` / `'image'` / …) and
+ * receives a typed `WidgetDefinition`. This one dispatches by PascalCase
+ * `widget.widgetType` (`'Markdown'` / `'Kpi'` / …) and receives the
+ * snapshot envelope.
+ */
+export type SnapshotWidgetRenderer = ComponentType<{
+  readonly widget: DashboardRenderedWidget;
+}>;
+
+/**
+ * Mapping from `widget.widgetType` (PascalCase wire discriminator) to a
+ * renderer component.
+ *
+ * The framework ships defaults for the static-content kinds (`Markdown` /
+ * `Image` / `Text`). Downstream packages register their own (`@granit/react-
+ * analytics` adds `Kpi`, `Chart`, `Table`, `Pivot`, `Map`; consuming apps
+ * may add custom widget kinds for their domain).
+ *
+ * Composed via {@link composeSnapshotRegistries} at provider creation time —
+ * the registry value itself is intentionally frozen (no runtime mutation).
+ */
+export type SnapshotWidgetRegistry = Readonly<Record<string, SnapshotWidgetRenderer>>;
+
+/**
+ * Composes multiple snapshot registries into one, with later entries
+ * overriding earlier ones for the same `widgetType`. Layer framework defaults
+ * + analytics renderers + app-specific overrides without mutating shared
+ * state.
+ *
+ * @example
+ *   const registry = composeSnapshotRegistries(
+ *     defaultSnapshotWidgetRegistry,
+ *     defaultAnalyticsSnapshotWidgetRegistry,
+ *     { CompanyLogo: CompanyLogoSnapshotWidget }
+ *   );
+ */
+export function composeSnapshotRegistries(
+  ...registries: readonly SnapshotWidgetRegistry[]
+): SnapshotWidgetRegistry {
+  return Object.freeze(Object.assign({}, ...registries));
+}


### PR DESCRIPTION
## Summary

First slice of [B5 — Frontend dashboard composer + read-mode rendering](https://github.com/granit-fx/granit-dotnet/issues/1386). Closes the loop B4-render opened: \`<RenderedDashboard dashboardId={...}>\` consumes the bundle response and dispatches each widget through a registry-driven snapshot renderer.

The composer (drag-drop builder, per-widget config forms, list page) lands in **B5-B / B5-C** as separate PRs.

## Architecture

**Two parallel registries**, symmetric but distinct:

| | Definition-driven | Snapshot-driven |
| --- | --- | --- |
| Registry type | \`WidgetRegistry\` | \`SnapshotWidgetRegistry\` |
| Default | \`defaultWidgetRegistry\` | \`defaultSnapshotWidgetRegistry\` |
| Dispatcher key | \`widget.type\` (lowercase: \`'markdown'\` …) | \`widget.widgetType\` (PascalCase: \`'Markdown'\` …) |
| Component prop | \`{ widget: WidgetDefinition }\` | \`{ widget: DashboardRenderedWidget }\` |
| Top-level | \`<Dashboard definition={...}>\` (each widget fetches its own data) | \`<RenderedDashboard dashboardId={...}>\` (single bundle round-trip) |

The two paths coexist intentionally — definition-driven is fine for catalog previews and standalone tiles; snapshot-driven is the production-mode path B5 unlocks.

## New \`@granit/react-dashboards\` exports

\`\`\`ts
// Top-level read-mode component
export { RenderedDashboard } from './components/rendered-dashboard.js';
export { RenderedWidget }    from './components/rendered-widget.js';

// Built-in static-content snapshot renderers (Markdown / Text / Image)
export { ImageSnapshotWidget }    from './components/widgets/image-snapshot-widget.js';
export { MarkdownSnapshotWidget } from './components/widgets/markdown-snapshot-widget.js';
export { TextSnapshotWidget }     from './components/widgets/text-snapshot-widget.js';

// Registry surface
export { defaultSnapshotWidgetRegistry }                                  from './registry/default-snapshot-widget-registry.js';
export { SnapshotWidgetRegistryProvider, useSnapshotWidgetRegistry }      from './registry/snapshot-widget-registry-context.js';
export { composeSnapshotRegistries }                                      from './registry/snapshot-widget-registry.js';
export type { SnapshotWidgetRegistry, SnapshotWidgetRenderer }            from './registry/snapshot-widget-registry.js';
\`\`\`

## New \`@granit/react-analytics\` exports

\`\`\`ts
export { KpiSnapshotTile }                       from './components/kpi-snapshot-tile.js';
export { defaultAnalyticsSnapshotWidgetRegistry } from './registry/default-analytics-snapshot-widget-registry.js';
\`\`\`

\`KpiSnapshotTile\` reuses the existing pure-presentational \`KpiTileView\` — the visual stays identical between the definition-driven \`KpiTile\` (which fetches via \`useMetric\`) and the snapshot-driven path (which receives the snapshot directly from the bundle).

## App wiring

\`\`\`tsx
<QueryClientProvider client={queryClient}>
  <GranitClientProvider client={apiClient}>
    <SnapshotWidgetRegistryProvider registries={[
      defaultSnapshotWidgetRegistry,            // Markdown / Text / Image
      defaultAnalyticsSnapshotWidgetRegistry,   // Kpi (Chart / Table / Pivot / Map land in B5-B)
      // appCustomSnapshotRegistry,
    ]}>
      <RenderedDashboard dashboardId={id} />
    </SnapshotWidgetRegistryProvider>
  </GranitClientProvider>
</QueryClientProvider>
\`\`\`

## Runtime status handling

The dispatcher honours ADR-039 §3 per-widget guarantees:

- \`'Snapshot'\` → invoke the registered renderer with the typed envelope.
- \`'Unavailable'\` → render an inline placeholder showing the localization key (\`'Widget:Unavailable'\` default; renderer-specific keys like \`'Widget:Unavailable.MetricNotFound'\` flow through). No typed renderer invoked.
- \`'Error'\` → render a destructive-styled placeholder showing the reason key. The bundle stays 200; one bad widget cannot break the grid.
- **Unknown \`widgetType\`** → amber placeholder ("Unknown widget kind: X"). Indicates the host forgot to compose the relevant registry — fast, visible, host-side bug rather than runtime exception.

## Tests (+6, total 2379 / 2379 ✓)

\`packages/@granit/react-dashboards/src/__tests__/rendered-widget.test.tsx\` exercises the dispatcher across all five paths:

- Markdown / Text / Image envelopes route to their built-in renderers
- Unavailable / Error envelopes render their respective slots with the reason key
- Unknown kind renders the amber placeholder

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2379 / 2379** ✓

## What's next (B5-B / B5-C)

- **B5-B** — Showcase wiring: drop the ad-hoc \`<DashboardBundlePanel>\` in favour of \`<RenderedDashboard>\` + composed registries. Ship Chart / Table / Pivot / Map snapshot renderers in \`@granit/react-analytics\` (production-grade with real chart / map libraries) so all 8 kinds render end-to-end.
- **B5-C** — Composer: drag-drop builder page using \`react-grid-layout\`, widget palette sidebar, per-widget config forms. Wires against B4-write endpoints (already shipped on backend).