### PR TITLE
feat(react-charts): chart snapshot renderer + registry contribution (B5-B PR 1)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2028,6 +2028,16 @@
           "kind": "interface",
           "signature": "interface UseEChartsThemeOptions",
           "members": []
+        },
+        {
+          "name": "ChartSnapshotWidget",
+          "kind": "function",
+          "signature": "function ChartSnapshotWidget("
+        },
+        {
+          "name": "defaultChartSnapshotWidgetRegistry",
+          "kind": "const",
+          "signature": "const defaultChartSnapshotWidgetRegistry: SnapshotWidgetRegistry"
         }
       ]
     },

--- a/packages/@granit/react-charts/package.json
+++ b/packages/@granit/react-charts/package.json
@@ -14,10 +14,14 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/analytics": "workspace:*",
     "@granit/charts": "workspace:*",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
     "echarts": "^6.0.0",
     "echarts-for-react": "^3.0.6",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
   },
   "publishConfig": {
     "exports": {
@@ -29,7 +33,10 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
+    "@granit/analytics": "workspace:*",
     "@granit/charts": "workspace:*",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   }

--- a/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
@@ -1,0 +1,128 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChartSnapshotWidget } from '../snapshot/chart-snapshot-widget.js';
+
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+// jsdom doesn't implement Canvas; ECharts queries it on init. Stub the
+// echarts-for-react module the same way the typed-primitive tests do —
+// we only assert dispatch behaviour, not the rendered Canvas.
+vi.mock('echarts-for-react/lib/core', () => ({
+  default: ({ option }: { readonly option: unknown }) => (
+    <div data-testid="echarts-mock" data-option={JSON.stringify(option)} />
+  ),
+}));
+
+const ENVELOPE_BASE = {
+  id: '8c6b1e10-0000-0000-0000-000000000001',
+  status: 'Snapshot' as const,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic' as const,
+  reasonLocalizationKey: null,
+};
+
+function chartEnvelope(
+  chartType: 'Bar' | 'HorizontalBar' | 'Line' | 'Area' | 'Pie' | 'Donut',
+  overrides: Partial<{
+    field: string | null;
+    currency: string | null;
+    aggregation: string;
+  }> = {}
+): DashboardRenderedWidget {
+  return {
+    ...ENVELOPE_BASE,
+    widgetType: 'Chart',
+    snapshot: {
+      chartType,
+      groupBy: 'IssuedAtMonth',
+      aggregation: overrides.aggregation ?? 'Sum',
+      field: 'field' in overrides ? overrides.field! : 'Total',
+      buckets: [
+        { label: '2026-02', value: 12500 },
+        { label: '2026-03', value: 18200 },
+        { label: '2026-04', value: 21450 },
+      ],
+      currency: overrides.currency ?? null,
+    },
+  };
+}
+
+describe('ChartSnapshotWidget — dispatch by chartType', () => {
+  it('routes Bar to BarChart with vertical axes', () => {
+    const { container, getByTestId } = render(
+      <ChartSnapshotWidget widget={chartEnvelope('Bar')} />
+    );
+    const slot = container.querySelector('[data-slot="chart-snapshot-widget"]');
+    expect(slot?.getAttribute('data-chart-type')).toBe('Bar');
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('bar');
+    expect(opt.xAxis.type).toBe('category');
+    expect(opt.yAxis.type).toBe('value');
+  });
+
+  it('routes HorizontalBar to BarChart with swapped axes', () => {
+    const { getByTestId } = render(<ChartSnapshotWidget widget={chartEnvelope('HorizontalBar')} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.xAxis.type).toBe('value');
+    expect(opt.yAxis.type).toBe('category');
+  });
+
+  it('routes Line to LineChart', () => {
+    const { getByTestId } = render(<ChartSnapshotWidget widget={chartEnvelope('Line')} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('line');
+    expect(opt.series[0].areaStyle).toBeUndefined();
+  });
+
+  it('routes Area to LineChart with areaStyle filled', () => {
+    const { getByTestId } = render(<ChartSnapshotWidget widget={chartEnvelope('Area')} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('line');
+    expect(opt.series[0].areaStyle).toEqual({});
+  });
+
+  it('routes Pie to PieChart with full ring', () => {
+    const { getByTestId } = render(<ChartSnapshotWidget widget={chartEnvelope('Pie')} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('pie');
+    expect(opt.series[0].radius).toEqual(['0%', '70%']);
+  });
+
+  it('routes Donut to PieChart with hollow centre', () => {
+    const { getByTestId } = render(<ChartSnapshotWidget widget={chartEnvelope('Donut')} />);
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].type).toBe('pie');
+    expect(opt.series[0].radius).toEqual(['35%', '70%']);
+  });
+
+  it('appends the currency code to the value-axis label when set (B3-8b)', () => {
+    const { getByTestId } = render(
+      <ChartSnapshotWidget widget={chartEnvelope('Bar', { currency: 'EUR' })} />
+    );
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.yAxis.name).toBe('Sum(Total) (EUR)');
+  });
+
+  it('drops the field segment of the series name when aggregation is Count', () => {
+    const { getByTestId } = render(
+      <ChartSnapshotWidget widget={chartEnvelope('Bar', { field: null, aggregation: 'Count' })} />
+    );
+    const opt = JSON.parse(getByTestId('echarts-mock').dataset.option ?? '{}');
+    expect(opt.series[0].name).toBe('Count');
+    expect(opt.yAxis.name).toBe('Count');
+  });
+
+  it('returns null on an Unavailable status', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Chart',
+      status: 'Unavailable',
+      snapshot: null,
+      reasonLocalizationKey: 'Widget:Unavailable',
+    };
+    const { container } = render(<ChartSnapshotWidget widget={widget} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/@granit/react-charts/src/components/line-chart.tsx
+++ b/packages/@granit/react-charts/src/components/line-chart.tsx
@@ -11,6 +11,12 @@ export interface LineChartProps extends ChartDimensions {
   readonly yAxis?: ChartAxis;
   /** Smooth out the line interpolation. Defaults to `false` for fidelity. */
   readonly smooth?: boolean;
+  /**
+   * Fill the area under each series line. Defaults to `false`. Drives the
+   * frontend mapping for the `'Area'` chart type from the dashboard render
+   * pipeline.
+   */
+  readonly area?: boolean;
   /** Show the legend above the plot area. Defaults to `true` when >1 series. */
   readonly showLegend?: boolean;
   readonly className?: string;
@@ -31,6 +37,7 @@ export function LineChart({
   xAxis,
   yAxis,
   smooth = false,
+  area = false,
   showLegend,
   height,
   width,
@@ -68,11 +75,12 @@ export function LineChart({
         // ECharts' option types want mutable arrays; spread to drop readonly.
         data: s.data.map((p) => [...p]) as (number | string)[][],
         smooth,
+        areaStyle: area ? {} : undefined,
         itemStyle: s.color ? { color: s.color } : undefined,
         lineStyle: s.color ? { color: s.color } : undefined,
       })),
     };
-  }, [series, xAxis, yAxis, smooth, showLegend]);
+  }, [series, xAxis, yAxis, smooth, area, showLegend]);
 
   return (
     <Chart options={options} height={height ?? width ?? 320} className={className} theme={theme} />

--- a/packages/@granit/react-charts/src/index.ts
+++ b/packages/@granit/react-charts/src/index.ts
@@ -19,3 +19,7 @@ export type { SparklineChartProps } from './components/sparkline-chart.js';
 // Theming
 export { useEChartsTheme } from './hooks/use-echarts-theme.js';
 export type { UseEChartsThemeOptions } from './hooks/use-echarts-theme.js';
+
+// Snapshot rendering (B5-B — registry-driven Chart kind for <RenderedDashboard>)
+export { ChartSnapshotWidget } from './snapshot/chart-snapshot-widget.js';
+export { defaultChartSnapshotWidgetRegistry } from './snapshot/default-chart-snapshot-widget-registry.js';

--- a/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
+++ b/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
@@ -1,0 +1,81 @@
+import { isChartSnapshotEnvelope } from '@granit/analytics';
+
+import { BarChart } from '../components/bar-chart.js';
+import { LineChart } from '../components/line-chart.js';
+import { PieChart } from '../components/pie-chart.js';
+
+import type { ChartWidgetSnapshot } from '@granit/analytics';
+import type { ChartSeries } from '@granit/charts';
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Snapshot-driven renderer for the `'Chart'` widget kind. Mirrors the
+ * declarative `<Chart>` definition path: dispatches by `chartType` to the
+ * right typed primitive (`<BarChart>` / `<LineChart>` / `<PieChart>`) with
+ * the bucket series shaped accordingly.
+ *
+ * Currency-aware: when `snapshot.currency` is set (B3-8b), the y-axis label
+ * carries the ISO 4217 code so consumers can read it at a glance. Per-tick
+ * currency formatting is deferred until ECharts options gain a typed
+ * formatter slot in the chart primitives — for now the value-axis stays
+ * numeric and tooltips show the raw number.
+ */
+export function ChartSnapshotWidget({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  if (!isChartSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  return <ChartBody snapshot={widget.snapshot} />;
+}
+
+function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
+  const { chartType, groupBy, aggregation, field, buckets, currency } = snapshot;
+
+  const seriesName = field ? `${aggregation}(${field})` : aggregation;
+
+  if (chartType === 'Pie' || chartType === 'Donut') {
+    const pieData = buckets.map((b) => ({
+      id: b.label,
+      name: b.label,
+      value: b.value ?? 0,
+    }));
+    return (
+      <div data-slot="chart-snapshot-widget" data-chart-type={chartType}>
+        <PieChart data={pieData} innerRadiusRatio={chartType === 'Donut' ? 0.5 : 0} />
+      </div>
+    );
+  }
+
+  const series: readonly ChartSeries[] = [
+    {
+      id: 'series',
+      name: seriesName,
+      data: buckets.map((b) => [b.label, b.value ?? 0]),
+    },
+  ];
+
+  const valueAxisLabel = currency ? `${seriesName} (${currency})` : seriesName;
+
+  if (chartType === 'Line' || chartType === 'Area') {
+    return (
+      <div data-slot="chart-snapshot-widget" data-chart-type={chartType}>
+        <LineChart
+          series={series}
+          xAxis={{ label: groupBy }}
+          yAxis={{ label: valueAxisLabel }}
+          area={chartType === 'Area'}
+        />
+      </div>
+    );
+  }
+
+  // 'Bar' or 'HorizontalBar' — the union is exhaustive over ChartType.
+  const horizontal = chartType === 'HorizontalBar';
+  return (
+    <div data-slot="chart-snapshot-widget" data-chart-type={chartType}>
+      <BarChart
+        series={series}
+        xAxis={{ label: horizontal ? valueAxisLabel : groupBy }}
+        yAxis={{ label: horizontal ? groupBy : valueAxisLabel }}
+        horizontal={horizontal}
+      />
+    </div>
+  );
+}

--- a/packages/@granit/react-charts/src/snapshot/default-chart-snapshot-widget-registry.ts
+++ b/packages/@granit/react-charts/src/snapshot/default-chart-snapshot-widget-registry.ts
@@ -1,0 +1,21 @@
+import { ChartSnapshotWidget } from './chart-snapshot-widget.js';
+
+import type { SnapshotWidgetRegistry } from '@granit/react-dashboards';
+
+/**
+ * Snapshot renderer registry contributed by `@granit/react-charts`. Compose
+ * with the framework default + analytics registries at the app root:
+ *
+ *     <SnapshotWidgetRegistryProvider registries={[
+ *       defaultSnapshotWidgetRegistry,             // Markdown / Text / Image
+ *       defaultAnalyticsSnapshotWidgetRegistry,    // Kpi
+ *       defaultChartSnapshotWidgetRegistry,        // Chart
+ *       // app-specific overrides
+ *     ]}>
+ *
+ * Apps that don't ship `Chart` widgets don't import this and pay zero
+ * ECharts bundle weight.
+ */
+export const defaultChartSnapshotWidgetRegistry: SnapshotWidgetRegistry = Object.freeze({
+  Chart: ChartSnapshotWidget,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1027,10 +1027,22 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
     devDependencies:
+      '@granit/analytics':
+        specifier: workspace:*
+        version: link:../analytics
       '@granit/charts':
         specifier: workspace:*
         version: link:../charts
+      '@granit/dashboards':
+        specifier: workspace:*
+        version: link:../dashboards
+      '@granit/react-dashboards':
+        specifier: workspace:*
+        version: link:../react-dashboards
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Summary

First slice of **B5-B** (read-mode dashboard wiring): adds the snapshot renderer for the \`'Chart'\` widget kind. \`<RenderedDashboard>\` now dispatches \`Chart\` envelopes through a real ECharts renderer instead of falling through to the unknown-kind placeholder.

PR sequence (validated previously): **Chart → Table → Pivot → Map → showcase wiring**.

## What lands

### \`@granit/react-charts\` — new exports

\`\`\`ts
// Snapshot-driven renderer (consumes a DashboardRenderedWidget directly)
export { ChartSnapshotWidget } from './snapshot/chart-snapshot-widget.js';

// Registry contribution to compose at the app root
export { defaultChartSnapshotWidgetRegistry } from './snapshot/default-chart-snapshot-widget-registry.js';
\`\`\`

### \`<ChartSnapshotWidget>\`

Dispatches by \`snapshot.chartType\` to the existing typed primitives:

| chartType | Renderer | Notes |
| --- | --- | --- |
| \`Bar\` | \`<BarChart>\` | vertical, category x value |
| \`HorizontalBar\` | \`<BarChart horizontal>\` | swapped axes |
| \`Line\` | \`<LineChart>\` | |
| \`Area\` | \`<LineChart area>\` | new \`area\` prop on LineChart |
| \`Pie\` | \`<PieChart>\` | innerRadiusRatio: 0 |
| \`Donut\` | \`<PieChart>\` | innerRadiusRatio: 0.5 |

Currency-aware: when \`snapshot.currency\` is set (B3-8b), the value-axis label carries the ISO 4217 code (\`Sum(Total) (EUR)\`). Per-tick currency-symbol formatting on tooltips/axis labels is deferred until the chart primitives gain a typed formatter slot — straightforward follow-up.

Series name follows \`aggregation(field)\` for monetary aggregations and degenerates to just \`aggregation\` for \`Count\`.

### \`<LineChart area>\` prop

Added to support the \`'Area'\` chart type. Maps to ECharts \`areaStyle: {}\`. Default \`false\` preserves existing behaviour.

## Peer deps update

\`@granit/react-charts\` adds \`@granit/analytics\`, \`@granit/dashboards\`, \`@granit/react-dashboards\` (snapshot type guards + envelope contract) and \`react-i18next\` (held back for future i18n-aware tick formatters).

## Tests (+9, total 2388 / 2388 ✓)

\`packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx\` exercises:
- 6 chartType paths (Bar / HorizontalBar / Line / Area / Pie / Donut) — checks ECharts series \`type\` + radius / areaStyle
- Currency promotion of the y-axis label (B3-8b)
- Series name simplification when \`field\` is null (Count aggregation)
- Unavailable envelope short-circuit (returns null, no chart mounted)

ECharts is mocked (\`vi.mock('echarts-for-react/lib/core', ...)\`) — same pattern as the existing \`line-chart.test.tsx\`. Tests inspect the JSON-serialised options that would have been passed to ECharts, no Canvas required.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2388 / 2388** ✓ (+9)

## What's next

- **B5-B PR 2** — \`<TableSnapshotWidget>\` (TanStack Table or hand-rolled) in \`@granit/react-tables\` (or analytics). Per-column currency-aware formatting via \`Intl.NumberFormat\`.
- **B5-B PR 3** — \`<PivotSnapshotWidget>\` (homegrown matrix from the showcase, productionised).
- **B5-B PR 4** — \`<MapSnapshotWidget>\` in a new \`@granit/react-map\` package: vanilla **Leaflet** wrapper (BSD-2, no react-leaflet — Hippocratic license rejected for compliance), OSM raster default tiles with attribution, optional \`leaflet.markercluster\`.
- **B5-B PR 5** — Showcase wiring: replace \`<DashboardBundlePanel>\` with \`<RenderedDashboard>\` + composed registries.