### PR TITLE
feat(react-analytics): table snapshot renderer with per-column currency formatting (B5-B PR 2)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1423,6 +1423,11 @@
           "signature": "function KpiSnapshotTile("
         },
         {
+          "name": "TableSnapshotWidget",
+          "kind": "function",
+          "signature": "function TableSnapshotWidget("
+        },
+        {
           "name": "defaultAnalyticsWidgetRegistry",
           "kind": "const",
           "signature": "const defaultAnalyticsWidgetRegistry: WidgetRegistry"

--- a/packages/@granit/react-analytics/src/__tests__/table-snapshot-widget.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/table-snapshot-widget.test.tsx
@@ -1,0 +1,147 @@
+import { render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { TableSnapshotWidget } from '../components/table-snapshot-widget.js';
+
+import type { TableWidgetSnapshot } from '@granit/analytics';
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en-US',
+  fallbackLng: 'en-US',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    'en-US': {
+      translation: {
+        'Column:Invoice.Number': 'Invoice #',
+        'Column:Invoice.Amount': 'Amount',
+        'Column:Invoice.Status': 'Status',
+        'Widget:Table.ShowingNofM': 'Showing {{shown}} of {{total}}',
+        'Widget:Table.NoData': 'No data',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+}
+
+const ENVELOPE_BASE = {
+  id: '8c6b1e10-0000-0000-0000-000000000001',
+  status: 'Snapshot' as const,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic' as const,
+  reasonLocalizationKey: null,
+};
+
+function tableEnvelope(snapshot: TableWidgetSnapshot): DashboardRenderedWidget {
+  return { ...ENVELOPE_BASE, widgetType: 'Table', snapshot };
+}
+
+const SAMPLE_SNAPSHOT: TableWidgetSnapshot = {
+  columns: [
+    { name: 'invoiceNumber', labelLocalizationKey: 'Column:Invoice.Number' },
+    { name: 'amount', labelLocalizationKey: 'Column:Invoice.Amount', currencyCode: 'EUR' },
+    { name: 'status', labelLocalizationKey: 'Column:Invoice.Status' },
+  ],
+  rows: [
+    { invoiceNumber: 'INV-2026-0042', amount: 1240.5, status: 'Open' },
+    { invoiceNumber: 'INV-2026-0043', amount: 890, status: 'Paid' },
+  ],
+  totalRowCount: 27,
+};
+
+const normalizeSpaces = (s: string) => s.replace(/[\u0020\u00A0\u202F]+/g, ' ');
+
+describe('TableSnapshotWidget — rendering', () => {
+  it('renders one row per snapshot.rows entry with localized headers', () => {
+    const { container, getByText } = wrap(
+      <TableSnapshotWidget widget={tableEnvelope(SAMPLE_SNAPSHOT)} />
+    );
+    expect(getByText('Invoice #')).toBeInTheDocument();
+    expect(getByText('Amount')).toBeInTheDocument();
+    expect(getByText('Status')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-slot="table-snapshot-row"]')).toHaveLength(2);
+  });
+
+  it('shows the "Showing N of M" affordance from totalRowCount', () => {
+    const { getByText } = wrap(<TableSnapshotWidget widget={tableEnvelope(SAMPLE_SNAPSHOT)} />);
+    expect(getByText('Showing 2 of 27')).toBeInTheDocument();
+  });
+
+  it('formats numeric cells with the column-declared currency code (B3-8b)', () => {
+    const { container } = wrap(<TableSnapshotWidget widget={tableEnvelope(SAMPLE_SNAPSHOT)} />);
+    const amountCells = container.querySelectorAll('[data-column-name="amount"]');
+    // First match is the header <th>; subsequent ones are <td>.
+    const firstRowAmount = amountCells[1];
+    expect(normalizeSpaces(firstRowAmount?.textContent ?? '')).toBe('€1,240.50');
+  });
+
+  it('falls back to plain locale formatting when the column declares no currency', () => {
+    const snapshot: TableWidgetSnapshot = {
+      ...SAMPLE_SNAPSHOT,
+      columns: [{ name: 'count', labelLocalizationKey: null }],
+      rows: [{ count: 1234 }],
+      totalRowCount: 1,
+    };
+    const { container } = wrap(<TableSnapshotWidget widget={tableEnvelope(snapshot)} />);
+    const cells = container.querySelectorAll('[data-column-name="count"]');
+    expect(cells[1]?.textContent).toBe('1,234');
+  });
+
+  it('renders an empty-state row when no data', () => {
+    const snapshot: TableWidgetSnapshot = {
+      columns: [{ name: 'id', labelLocalizationKey: null }],
+      rows: [],
+      totalRowCount: 0,
+    };
+    const { container, getByText } = wrap(<TableSnapshotWidget widget={tableEnvelope(snapshot)} />);
+    expect(container.querySelector('[data-slot="table-snapshot-empty"]')).not.toBeNull();
+    expect(getByText('No data')).toBeInTheDocument();
+  });
+
+  it('renders the column name verbatim when labelLocalizationKey is null', () => {
+    const snapshot: TableWidgetSnapshot = {
+      columns: [{ name: 'rawColumnName', labelLocalizationKey: null }],
+      rows: [{ rawColumnName: 'value' }],
+      totalRowCount: 1,
+    };
+    const { getByText } = wrap(<TableSnapshotWidget widget={tableEnvelope(snapshot)} />);
+    expect(getByText('rawColumnName')).toBeInTheDocument();
+  });
+
+  it('renders an em dash for null and undefined cell values', () => {
+    const snapshot: TableWidgetSnapshot = {
+      columns: [
+        { name: 'absent', labelLocalizationKey: null },
+        { name: 'nulled', labelLocalizationKey: null },
+      ],
+      rows: [{ nulled: null }],
+      totalRowCount: 1,
+    };
+    const { container } = wrap(<TableSnapshotWidget widget={tableEnvelope(snapshot)} />);
+    const cells = container.querySelectorAll('[data-slot="table-snapshot-row"] td');
+    expect(cells[0]?.textContent).toBe('—');
+    expect(cells[1]?.textContent).toBe('—');
+  });
+
+  it('returns null on an Unavailable status', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Table',
+      status: 'Unavailable',
+      snapshot: null,
+      reasonLocalizationKey: 'Widget:Unavailable',
+    };
+    const { container } = render(<TableSnapshotWidget widget={widget} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/@granit/react-analytics/src/components/table-snapshot-widget.tsx
+++ b/packages/@granit/react-analytics/src/components/table-snapshot-widget.tsx
@@ -1,0 +1,107 @@
+import { isTableSnapshotEnvelope } from '@granit/analytics';
+import { useTranslation } from 'react-i18next';
+
+import type { TableWidgetColumn, TableWidgetSnapshot } from '@granit/analytics';
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Snapshot-driven renderer for the `'Table'` widget kind. Reads the rows
+ * inline from `widget.snapshot.rows` (no per-row fetching — the bundle
+ * carried them already), with localized headers via `useTranslation()`.
+ *
+ * Per-column currency formatting (B3-8b): when a column declares
+ * `currencyCode`, numeric cell values format via
+ * `Intl.NumberFormat({ style: 'currency', currency })` using the active
+ * locale. Mixing currencies across columns is supported by design (a
+ * table with `AmountEur` + `AmountUsd` shows both symbols side by side).
+ *
+ * The renderer stays narrow on purpose — sorting / pagination /
+ * client-side filtering belong to the host (apps that need them override
+ * the registry entry with a TanStack Table-based variant).
+ */
+export function TableSnapshotWidget({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  if (!isTableSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  return <TableBody snapshot={widget.snapshot} />;
+}
+
+function TableBody({ snapshot }: { readonly snapshot: TableWidgetSnapshot }) {
+  const { t, i18n } = useTranslation();
+  const { columns, rows, totalRowCount } = snapshot;
+
+  return (
+    <div data-slot="table-snapshot-widget" className="flex h-full flex-col gap-2">
+      <p className="text-xs text-muted-foreground" data-slot="table-snapshot-meta">
+        {t('Widget:Table.ShowingNofM', {
+          defaultValue: 'Showing {{shown}} of {{total}}',
+          shown: rows.length,
+          total: totalRowCount,
+        })}
+      </p>
+      <div className="flex-1 overflow-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b">
+              {columns.map((col) => (
+                <th
+                  key={col.name}
+                  data-column-name={col.name}
+                  className="py-1 pr-3 text-left font-medium"
+                >
+                  {col.labelLocalizationKey
+                    ? t(col.labelLocalizationKey, { defaultValue: col.name })
+                    : col.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columns.length}
+                  className="py-3 text-center text-xs text-muted-foreground"
+                  data-slot="table-snapshot-empty"
+                >
+                  {t('Widget:Table.NoData', { defaultValue: 'No data' })}
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, i) => (
+                <tr key={i} data-slot="table-snapshot-row" className="border-b last:border-0">
+                  {columns.map((col) => (
+                    <td
+                      key={col.name}
+                      data-column-name={col.name}
+                      className="py-1 pr-3 tabular-nums"
+                    >
+                      {formatCell(row[col.name], col, i18n.language)}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Per-column cell formatter. Honors `currencyCode` (B3-8b) for numeric
+ * values; otherwise falls back to locale-aware number formatting; falls
+ * through to `String()` for non-number primitives.
+ */
+function formatCell(value: unknown, column: TableWidgetColumn, locale: string): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'number') {
+    if (column.currencyCode) {
+      return new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency: column.currencyCode,
+      }).format(value);
+    }
+    return value.toLocaleString(locale);
+  }
+  return String(value);
+}

--- a/packages/@granit/react-analytics/src/index.ts
+++ b/packages/@granit/react-analytics/src/index.ts
@@ -12,8 +12,9 @@ export type { KpiTileProps } from './components/kpi-tile.js';
 export { KpiTileView } from './components/kpi-tile-view.js';
 export type { KpiTileViewProps } from './components/kpi-tile-view.js';
 
-// Snapshot renderer (B5 — bundle-driven, consumes the pre-rendered envelope)
+// Snapshot renderers (B5 — bundle-driven, consume the pre-rendered envelope)
 export { KpiSnapshotTile } from './components/kpi-snapshot-tile.js';
+export { TableSnapshotWidget } from './components/table-snapshot-widget.js';
 
 // Registries
 export { defaultAnalyticsWidgetRegistry } from './registry/default-analytics-widget-registry.js';

--- a/packages/@granit/react-analytics/src/registry/default-analytics-snapshot-widget-registry.ts
+++ b/packages/@granit/react-analytics/src/registry/default-analytics-snapshot-widget-registry.ts
@@ -1,4 +1,5 @@
 import { KpiSnapshotTile } from '../components/kpi-snapshot-tile.js';
+import { TableSnapshotWidget } from '../components/table-snapshot-widget.js';
 
 import type { SnapshotWidgetRegistry } from '@granit/react-dashboards';
 
@@ -21,4 +22,5 @@ import type { SnapshotWidgetRegistry } from '@granit/react-dashboards';
  */
 export const defaultAnalyticsSnapshotWidgetRegistry: SnapshotWidgetRegistry = Object.freeze({
   Kpi: KpiSnapshotTile,
+  Table: TableSnapshotWidget,
 });


### PR DESCRIPTION
## Summary

Second slice of **B5-B**: ships the snapshot renderer for the \`'Table'\` widget kind. \`<RenderedDashboard>\` now dispatches \`Table\` envelopes through a localized HTML renderer with per-column currency formatting (B3-8b).

PR sequence (validated): Chart [#266 ✓] → **Table [this PR]** → Pivot → Map → showcase wiring.

## What lands

### \`@granit/react-analytics\` — new export

\`\`\`ts
export { TableSnapshotWidget } from './components/table-snapshot-widget.js';
\`\`\`

Registered into \`defaultAnalyticsSnapshotWidgetRegistry\` (alongside the existing \`Kpi\` entry):

\`\`\`diff
 export const defaultAnalyticsSnapshotWidgetRegistry = Object.freeze({
   Kpi: KpiSnapshotTile,
+  Table: TableSnapshotWidget,
 });
\`\`\`

### \`<TableSnapshotWidget>\` behaviour

- Reads \`snapshot.columns\` for the header order, \`snapshot.rows\` for the body, \`snapshot.totalRowCount\` for the "Showing N of M" affordance.
- **Per-column currency formatting** (B3-8b): when \`column.currencyCode\` is set, numeric cell values format via \`Intl.NumberFormat({ style: 'currency', currency })\` with the active locale. Mixing currencies across columns works by design — a table with \`AmountEur\` + \`AmountUsd\` shows both symbols side by side.
- Localized headers via \`useTranslation()\` — falls back to \`column.name\` when \`labelLocalizationKey\` is null.
- Empty-state row + "No data" message when \`rows.length === 0\`.
- Em dash for null / undefined cell values.
- Returns \`null\` on \`Unavailable\` status (the \`<RenderedWidget>\` dispatcher handles the placeholder).

### Localization keys consumed

- \`Widget:Table.ShowingNofM\` (default \`'Showing {{shown}} of {{total}}'\`)
- \`Widget:Table.NoData\` (default \`'No data'\`)
- Per-column \`labelLocalizationKey\` (defaults to the column name)

Hosts override these via their i18n bundle.

## Why it stays narrow

No sorting / pagination / client-side filtering. The snapshot is pre-rendered server-side at the page size the widget configured; richer interactions belong to apps that override the registry entry with a TanStack Table-based variant. Keeps the framework default lightweight and pure-HTML — no extra dep.

## Tests (+8, total 2396 / 2396 ✓)

\`packages/@granit/react-analytics/src/__tests__/table-snapshot-widget.test.tsx\` exercises:
- Header localization (3 columns)
- Row count + total ("Showing 2 of 27")
- Per-column currency formatting (\`'EUR' → '€1,240.50'\`)
- Plain locale formatting (no currency declared)
- Empty-state row
- Verbatim column name when no localization key
- Em dash for null and undefined
- Unavailable short-circuit

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2396 / 2396** ✓ (+8)

## What's next

- **B5-B PR 3** — \`<PivotSnapshotWidget>\` (homegrown matrix from the showcase, productionised with currency-aware cells).
- **B5-B PR 4** — \`<MapSnapshotWidget>\` in a new \`@granit/react-map\` package: vanilla **Leaflet** wrapper (BSD-2, no react-leaflet — Hippocratic license rejected for compliance), OSM raster default tiles with attribution, optional \`leaflet.markercluster\`.
- **B5-B PR 5** — Showcase wiring: replace \`<DashboardBundlePanel>\` with \`<RenderedDashboard>\` + composed registries.