### PR TITLE
feat(react-analytics): pivot snapshot renderer with currency-aware cells (B5-B PR 3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1423,6 +1423,11 @@
           "signature": "function KpiSnapshotTile("
         },
         {
+          "name": "PivotSnapshotWidget",
+          "kind": "function",
+          "signature": "function PivotSnapshotWidget("
+        },
+        {
           "name": "TableSnapshotWidget",
           "kind": "function",
           "signature": "function TableSnapshotWidget("

--- a/packages/@granit/react-analytics/src/__tests__/pivot-snapshot-widget.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/pivot-snapshot-widget.test.tsx
@@ -1,0 +1,164 @@
+import { render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { PivotSnapshotWidget } from '../components/pivot-snapshot-widget.js';
+
+import type { PivotWidgetSnapshot } from '@granit/analytics';
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en-US',
+  fallbackLng: 'en-US',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    'en-US': {
+      translation: {
+        'Widget:Pivot.Rows': 'rows: {{fields}}',
+        'Widget:Pivot.Columns': 'columns: {{fields}}',
+        'Widget:Pivot.NoData': 'No data',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+}
+
+const ENVELOPE_BASE = {
+  id: '8c6b1e10-0000-0000-0000-000000000001',
+  status: 'Snapshot' as const,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic' as const,
+  reasonLocalizationKey: null,
+};
+
+function pivotEnvelope(snapshot: PivotWidgetSnapshot): DashboardRenderedWidget {
+  return { ...ENVELOPE_BASE, widgetType: 'Pivot', snapshot };
+}
+
+const SAMPLE_SNAPSHOT: PivotWidgetSnapshot = {
+  rowFields: ['Region'],
+  columnFields: ['Status'],
+  valueField: 'Total',
+  aggregation: 'Sum',
+  cells: [
+    { rowKeys: ['EU'], columnKeys: ['Open'], value: 9500 },
+    { rowKeys: ['EU'], columnKeys: ['Paid'], value: 12300 },
+    { rowKeys: ['NA'], columnKeys: ['Open'], value: 4200 },
+    { rowKeys: ['NA'], columnKeys: ['Paid'], value: null },
+  ],
+  currency: 'EUR',
+};
+
+const normalizeSpaces = (s: string) => s.replace(/[\u0020\u00A0\u202F]+/g, ' ');
+
+describe('PivotSnapshotWidget — matrix layout', () => {
+  it('pivots the flat cell list into a row-major matrix', () => {
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(SAMPLE_SNAPSHOT)} />);
+    const rows = container.querySelectorAll('[data-slot="pivot-snapshot-row"]');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.getAttribute('data-row-tuple')).toBe('EU');
+    expect(rows[1]?.getAttribute('data-row-tuple')).toBe('NA');
+
+    const headers = container.querySelectorAll('thead th[data-column-tuple]');
+    expect(headers).toHaveLength(2);
+    expect(headers[0]?.getAttribute('data-column-tuple')).toBe('Open');
+    expect(headers[1]?.getAttribute('data-column-tuple')).toBe('Paid');
+  });
+
+  it('formats every cell with the snapshot-level currency code (B3-8b)', () => {
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(SAMPLE_SNAPSHOT)} />);
+    const euRow = container.querySelector('[data-row-tuple="EU"]');
+    const cells = euRow?.querySelectorAll('td[data-column-tuple]') ?? [];
+    expect(normalizeSpaces(cells[0]?.textContent ?? '')).toBe('€9,500.00');
+    expect(normalizeSpaces(cells[1]?.textContent ?? '')).toBe('€12,300.00');
+  });
+
+  it('renders an em dash for null cell values (empty Avg/Min/Max groups)', () => {
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(SAMPLE_SNAPSHOT)} />);
+    const naRow = container.querySelector('[data-row-tuple="NA"]');
+    const cells = naRow?.querySelectorAll('td[data-column-tuple]') ?? [];
+    expect(cells[1]?.textContent).toBe('—');
+  });
+
+  it('falls back to plain locale formatting when no currency is declared', () => {
+    const snapshot: PivotWidgetSnapshot = {
+      ...SAMPLE_SNAPSHOT,
+      currency: null,
+      cells: [{ rowKeys: ['EU'], columnKeys: ['Open'], value: 1234 }],
+    };
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(snapshot)} />);
+    const cell = container.querySelector('[data-row-tuple="EU"] td[data-column-tuple]');
+    expect(cell?.textContent).toBe('1,234');
+  });
+
+  it('renders an empty-state row when the snapshot ships zero cells', () => {
+    const snapshot: PivotWidgetSnapshot = {
+      ...SAMPLE_SNAPSHOT,
+      cells: [],
+    };
+    const { container, getByText } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(snapshot)} />);
+    expect(container.querySelector('[data-slot="pivot-snapshot-empty"]')).not.toBeNull();
+    expect(getByText('No data')).toBeInTheDocument();
+  });
+
+  it('handles multi-key tuples on row and column dimensions', () => {
+    const snapshot: PivotWidgetSnapshot = {
+      rowFields: ['Region', 'Country'],
+      columnFields: ['Year', 'Quarter'],
+      valueField: null,
+      aggregation: 'Count',
+      cells: [
+        { rowKeys: ['EU', 'FR'], columnKeys: ['2026', 'Q1'], value: 12 },
+        { rowKeys: ['EU', 'BE'], columnKeys: ['2026', 'Q1'], value: 4 },
+      ],
+      currency: null,
+    };
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(snapshot)} />);
+    const rows = container.querySelectorAll('[data-slot="pivot-snapshot-row"]');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]?.getAttribute('data-row-tuple')).toBe('EU|FR');
+    expect(rows[1]?.getAttribute('data-row-tuple')).toBe('EU|BE');
+    const headers = container.querySelectorAll('thead th[data-column-tuple]');
+    expect(headers[0]?.getAttribute('data-column-tuple')).toBe('2026|Q1');
+  });
+
+  it('shows the aggregation label + currency in the meta line', () => {
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(SAMPLE_SNAPSHOT)} />);
+    const meta = container.querySelector('[data-slot="pivot-snapshot-meta"]');
+    expect(meta?.textContent).toContain('Sum(Total)');
+    expect(meta?.textContent).toContain('EUR');
+  });
+
+  it('drops the field segment when aggregation is Count (no valueField)', () => {
+    const snapshot: PivotWidgetSnapshot = {
+      ...SAMPLE_SNAPSHOT,
+      valueField: null,
+      aggregation: 'Count',
+    };
+    const { container } = wrap(<PivotSnapshotWidget widget={pivotEnvelope(snapshot)} />);
+    const meta = container.querySelector('[data-slot="pivot-snapshot-meta"]');
+    expect(meta?.textContent).toContain('Count');
+    expect(meta?.textContent).not.toContain('(Total)');
+  });
+
+  it('returns null on an Unavailable status', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Pivot',
+      status: 'Unavailable',
+      snapshot: null,
+      reasonLocalizationKey: 'Widget:Unavailable',
+    };
+    const { container } = render(<PivotSnapshotWidget widget={widget} />);
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/@granit/react-analytics/src/components/pivot-snapshot-widget.tsx
+++ b/packages/@granit/react-analytics/src/components/pivot-snapshot-widget.tsx
@@ -1,0 +1,134 @@
+import { isPivotSnapshotEnvelope } from '@granit/analytics';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import type { PivotWidgetSnapshot } from '@granit/analytics';
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+/**
+ * Snapshot-driven renderer for the `'Pivot'` widget kind. Pivots the flat
+ * `(rowKeys × columnKeys × value)` cell list emitted by the backend into a
+ * row-major matrix client-side — see `PivotWidgetSnapshot` (B3-6).
+ *
+ * Currency-aware (B3-8b): when `snapshot.currency` is set, every cell value
+ * formats via `Intl.NumberFormat({ style: 'currency', currency })` with the
+ * active locale. All cells share the same currency since they aggregate
+ * the same value field.
+ *
+ * The renderer stays narrow on purpose — drilling into a cell or
+ * repositioning row/column dimensions belongs to a richer admin variant
+ * apps can register on top of this default.
+ */
+export function PivotSnapshotWidget({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  if (!isPivotSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  return <PivotBody snapshot={widget.snapshot} />;
+}
+
+function PivotBody({ snapshot }: { readonly snapshot: PivotWidgetSnapshot }) {
+  const { t, i18n } = useTranslation();
+  const { rowFields, columnFields, valueField, aggregation, cells, currency } = snapshot;
+
+  // Pivot the flat cell list into a row-major matrix. Memoised so a parent
+  // re-render that doesn't change the snapshot identity skips the work.
+  const { rowTuples, columnTuples, cellByKey } = useMemo(() => {
+    const rowSeen = new Set<string>();
+    const colSeen = new Set<string>();
+    const rows: (readonly string[])[] = [];
+    const cols: (readonly string[])[] = [];
+    const byKey = new Map<string, number | null>();
+    for (const cell of cells) {
+      const rowKey = cell.rowKeys.join('');
+      const colKey = cell.columnKeys.join('');
+      if (!rowSeen.has(rowKey)) {
+        rowSeen.add(rowKey);
+        rows.push(cell.rowKeys);
+      }
+      if (!colSeen.has(colKey)) {
+        colSeen.add(colKey);
+        cols.push(cell.columnKeys);
+      }
+      byKey.set(`${rowKey}::${colKey}`, cell.value);
+    }
+    return { rowTuples: rows, columnTuples: cols, cellByKey: byKey };
+  }, [cells]);
+
+  const aggregationLabel = valueField ? `${aggregation}(${valueField})` : aggregation;
+
+  const formatValue = (value: number) =>
+    currency
+      ? new Intl.NumberFormat(i18n.language, {
+          style: 'currency',
+          currency,
+        }).format(value)
+      : value.toLocaleString(i18n.language);
+
+  return (
+    <div data-slot="pivot-snapshot-widget" className="flex h-full flex-col gap-2">
+      <p className="text-xs text-muted-foreground" data-slot="pivot-snapshot-meta">
+        {aggregationLabel}
+        {currency ? ` · ${currency}` : ''}
+        {' · '}
+        {t('Widget:Pivot.Rows', { defaultValue: 'rows: {{fields}}', fields: rowFields.join(', ') })}
+        {' · '}
+        {t('Widget:Pivot.Columns', {
+          defaultValue: 'columns: {{fields}}',
+          fields: columnFields.join(', ') || '—',
+        })}
+      </p>
+      <div className="flex-1 overflow-auto">
+        <table className="w-full text-xs">
+          <thead>
+            <tr className="border-b">
+              <th className="py-1 pr-3 text-left font-medium">{rowFields.join(' / ')}</th>
+              {columnTuples.map((tuple) => (
+                <th
+                  key={tuple.join('|')}
+                  data-column-tuple={tuple.join('|')}
+                  className="py-1 pr-3 text-right font-medium"
+                >
+                  {tuple.join(' / ') || '—'}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rowTuples.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={columnTuples.length + 1}
+                  className="py-3 text-center text-xs text-muted-foreground"
+                  data-slot="pivot-snapshot-empty"
+                >
+                  {t('Widget:Pivot.NoData', { defaultValue: 'No data' })}
+                </td>
+              </tr>
+            ) : (
+              rowTuples.map((rowTuple) => (
+                <tr
+                  key={rowTuple.join('|')}
+                  data-slot="pivot-snapshot-row"
+                  data-row-tuple={rowTuple.join('|')}
+                  className="border-b last:border-0"
+                >
+                  <td className="py-1 pr-3">{rowTuple.join(' / ')}</td>
+                  {columnTuples.map((colTuple) => {
+                    const value = cellByKey.get(`${rowTuple.join('')}::${colTuple.join('')}`);
+                    return (
+                      <td
+                        key={colTuple.join('|')}
+                        data-column-tuple={colTuple.join('|')}
+                        className="py-1 pr-3 text-right tabular-nums"
+                      >
+                        {value === undefined || value === null ? '—' : formatValue(value)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-analytics/src/index.ts
+++ b/packages/@granit/react-analytics/src/index.ts
@@ -14,6 +14,7 @@ export type { KpiTileViewProps } from './components/kpi-tile-view.js';
 
 // Snapshot renderers (B5 — bundle-driven, consume the pre-rendered envelope)
 export { KpiSnapshotTile } from './components/kpi-snapshot-tile.js';
+export { PivotSnapshotWidget } from './components/pivot-snapshot-widget.js';
 export { TableSnapshotWidget } from './components/table-snapshot-widget.js';
 
 // Registries

--- a/packages/@granit/react-analytics/src/registry/default-analytics-snapshot-widget-registry.ts
+++ b/packages/@granit/react-analytics/src/registry/default-analytics-snapshot-widget-registry.ts
@@ -1,4 +1,5 @@
 import { KpiSnapshotTile } from '../components/kpi-snapshot-tile.js';
+import { PivotSnapshotWidget } from '../components/pivot-snapshot-widget.js';
 import { TableSnapshotWidget } from '../components/table-snapshot-widget.js';
 
 import type { SnapshotWidgetRegistry } from '@granit/react-dashboards';
@@ -22,5 +23,6 @@ import type { SnapshotWidgetRegistry } from '@granit/react-dashboards';
  */
 export const defaultAnalyticsSnapshotWidgetRegistry: SnapshotWidgetRegistry = Object.freeze({
   Kpi: KpiSnapshotTile,
+  Pivot: PivotSnapshotWidget,
   Table: TableSnapshotWidget,
 });


### PR DESCRIPTION
## Summary

Third slice of **B5-B**: ships the snapshot renderer for the \`'Pivot'\` widget kind. \`<RenderedDashboard>\` now dispatches \`Pivot\` envelopes through a real matrix renderer with currency-aware cells (B3-8b).

PR sequence (validated): Chart [#266 ✓] → Table [#267 ✓] → **Pivot [this PR]** → Map → showcase wiring.

## What lands

### \`@granit/react-analytics\` — new export

\`\`\`ts
export { PivotSnapshotWidget } from './components/pivot-snapshot-widget.js';
\`\`\`

Registered into \`defaultAnalyticsSnapshotWidgetRegistry\` (alongside \`Kpi\` and \`Table\`):

\`\`\`diff
 export const defaultAnalyticsSnapshotWidgetRegistry = Object.freeze({
   Kpi: KpiSnapshotTile,
+  Pivot: PivotSnapshotWidget,
   Table: TableSnapshotWidget,
 });
\`\`\`

### \`<PivotSnapshotWidget>\` behaviour

- **Pivots the flat cell list client-side** into a row-major matrix. Builds the row / column tuple sets in stream-arrival order so the rendered axes match the underlying group-by traversal.
- **Currency-aware (B3-8b)**: when \`snapshot.currency\` is set, every cell value formats via \`Intl.NumberFormat({ style: 'currency', currency })\` with the active locale. All cells share the currency since they aggregate the same value field.
- **Multi-key tuples**: row and column dimensions can carry multiple fields (\`['Region', 'Country'] × ['Year', 'Quarter']\`) — tuple keys join with \`'|'\` for display, with \`U+001F\` (ASCII Unit Separator) internally for collision-safe lookup.
- **Em dash on null** for empty Avg/Min/Max groups, **empty-state row** when \`cells.length === 0\`.
- Meta line shows \`aggregation(valueField)\` + currency code + row/column field names.
- Returns \`null\` on \`Unavailable\` status (the \`<RenderedWidget>\` dispatcher handles the placeholder).

## Localization keys consumed

- \`Widget:Pivot.Rows\` (default \`'rows: {{fields}}'\`)
- \`Widget:Pivot.Columns\` (default \`'columns: {{fields}}'\`)
- \`Widget:Pivot.NoData\` (default \`'No data'\`)

## Why client-side pivoting

Backend ships a flat \`cells: PivotCell[]\` list to keep the wire shape stable across all widget kinds (every snapshot is just an array of cells / rows / buckets). The matrix is a presentation concern — pivoting client-side lets apps that swap the renderer (e.g. a richer interactive grid) freely reshape the layout without re-fetching.

## Tests (+9, total 2405 / 2405 ✓)

\`packages/@granit/react-analytics/src/__tests__/pivot-snapshot-widget.test.tsx\` exercises:
- Matrix layout (row + column tuples derived in stream order)
- Currency formatting (B3-8b — \`'EUR' → '€9,500.00'\`)
- Em dash for null cells
- Plain locale formatting when no currency
- Empty-state row
- Multi-key tuples on both axes
- Meta line content (aggregation label + currency + field names)
- Field segment dropped on \`Count\` (\`Sum(Total)\` → \`Count\`)
- Unavailable short-circuit

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2405 / 2405** ✓ (+9)

## What's next

- **B5-B PR 4** — \`<MapSnapshotWidget>\` in a new \`@granit/react-map\` package: vanilla **Leaflet** wrapper (BSD-2, no react-leaflet — Hippocratic license rejected for compliance), OSM raster default tiles with attribution, optional \`leaflet.markercluster\`.
- **B5-B PR 5** — Showcase wiring: replace \`<DashboardBundlePanel>\` with \`<RenderedDashboard>\` + composed registries.