### PR TITLE
feat(react-map): map snapshot renderer + multi-provider tile registry (B5-B PR 4)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2541,6 +2541,60 @@
       ]
     },
     {
+      "name": "@granit/react-map",
+      "description": "React Map primitives for Granit — vanilla Leaflet wrapper with multi-provider tile support (OpenStreetMap default, SPW Walloon geoportal, ArcGIS, custom). Ships <MapSnapshotWidget> registered into the dashboard snapshot widget registry; mandatory tile-provider attribution. No react-leaflet dep (Hippocratic license rejected for compliance).",
+      "exports": [
+        {
+          "name": "MapSnapshotWidget",
+          "kind": "function",
+          "signature": "function MapSnapshotWidget("
+        },
+        {
+          "name": "defaultMapSnapshotWidgetRegistry",
+          "kind": "const",
+          "signature": "const defaultMapSnapshotWidgetRegistry: SnapshotWidgetRegistry"
+        },
+        {
+          "name": "MapTileProviderProviderProps",
+          "kind": "interface",
+          "signature": "interface MapTileProviderProviderProps",
+          "members": []
+        },
+        {
+          "name": "osmProvider",
+          "kind": "const",
+          "signature": "const osmProvider: MapTileProvider"
+        },
+        {
+          "name": "spwProvider",
+          "kind": "const",
+          "signature": "const spwProvider: MapTileProvider"
+        },
+        {
+          "name": "arcGisProvider",
+          "kind": "const",
+          "signature": "const arcGisProvider: MapTileProvider"
+        },
+        {
+          "name": "MapTileLayer",
+          "kind": "interface",
+          "signature": "interface MapTileLayer",
+          "members": []
+        },
+        {
+          "name": "MapTileLayerKind",
+          "kind": "type",
+          "signature": "type MapTileLayerKind ="
+        },
+        {
+          "name": "MapTileProvider",
+          "kind": "interface",
+          "signature": "interface MapTileProvider",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-metering",
       "description": "React bindings for @granit/metering — MeteringProvider and hooks",
       "exports": [

--- a/packages/@granit/react-map/package.json
+++ b/packages/@granit/react-map/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@granit/react-map",
+  "description": "React Map primitives for Granit — vanilla Leaflet wrapper with multi-provider tile support (OpenStreetMap default, SPW Walloon geoportal, ArcGIS, custom). Ships <MapSnapshotWidget> registered into the dashboard snapshot widget registry; mandatory tile-provider attribution. No react-leaflet dep (Hippocratic license rejected for compliance).",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/analytics": "workspace:*",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
+    "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "leaflet.markercluster": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/analytics": "workspace:*",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@types/leaflet": "^1.9.18",
+    "@types/leaflet.markercluster": "^1.5.5",
+    "leaflet": "^1.9.4",
+    "leaflet.markercluster": "^1.5.3"
+  }
+}

--- a/packages/@granit/react-map/src/__tests__/map-snapshot-widget.test.tsx
+++ b/packages/@granit/react-map/src/__tests__/map-snapshot-widget.test.tsx
@@ -1,0 +1,137 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MapTileProviderProvider } from '../components/map-tile-provider-context.js';
+import { spwProvider } from '../providers/spw-provider.js';
+import { MapSnapshotWidget } from '../snapshot/map-snapshot-widget.js';
+
+import type { MapWidgetSnapshot } from '@granit/analytics';
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+// Leaflet is heavily DOM-coupled; jsdom doesn't simulate real layout / mouse
+// events, so initialising the actual map throws. Stub the surface area we
+// touch — the test isolates the widget's *dispatch* logic (envelope status
+// short-circuits, data attributes, provider context resolution) from the
+// rendering side effects.
+vi.mock('leaflet/dist/leaflet.css', () => ({}));
+vi.mock('leaflet', () => {
+  const noop = () => undefined;
+  const tileLayer = vi.fn(() => ({ addTo: vi.fn().mockReturnThis(), remove: vi.fn() }));
+  const marker = vi.fn(() => ({
+    bindPopup: vi.fn().mockReturnThis(),
+    on: vi.fn().mockReturnThis(),
+    options: {},
+    addTo: vi.fn().mockReturnThis(),
+  }));
+  const layerGroup = vi.fn(() => ({
+    addLayer: vi.fn().mockReturnThis(),
+    addTo: vi.fn().mockReturnThis(),
+    remove: vi.fn(),
+  }));
+  const map = vi.fn(() => ({
+    setView: vi.fn().mockReturnThis(),
+    fitBounds: vi.fn().mockReturnThis(),
+    remove: vi.fn(),
+  }));
+  const latLngBounds = vi.fn();
+  const controlLayers = vi.fn(() => ({ addTo: vi.fn().mockReturnThis(), remove: vi.fn() }));
+  const Icon = { Default: { mergeOptions: noop } };
+  const L = {
+    map,
+    tileLayer,
+    marker,
+    layerGroup,
+    latLngBounds,
+    Icon,
+    control: { layers: controlLayers },
+  };
+  return { default: L };
+});
+
+const ENVELOPE_BASE = {
+  id: '8c6b1e10-0000-0000-0000-000000000001',
+  status: 'Snapshot' as const,
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Dynamic' as const,
+  reasonLocalizationKey: null,
+};
+
+function mapEnvelope(snapshot: MapWidgetSnapshot): DashboardRenderedWidget {
+  return { ...ENVELOPE_BASE, widgetType: 'Map', snapshot };
+}
+
+const SAMPLE: MapWidgetSnapshot = {
+  points: [
+    {
+      id: '8c6b1e10-0000-0000-0000-00000000aaaa',
+      latitude: 48.8566,
+      longitude: 2.3522,
+      popup: { name: 'Paris HQ' },
+    },
+  ],
+  defaultZoom: 5,
+  defaultCenter: { latitude: 48.8566, longitude: 2.3522 },
+  clusterThreshold: 200,
+  detailRoute: '/customers/{id}',
+  tileUrlTemplate: null,
+};
+
+describe('MapSnapshotWidget — dispatcher', () => {
+  it('returns null on non-Map envelopes', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Chart',
+      snapshot: { value: 12 },
+    };
+    const { container } = render(<MapSnapshotWidget widget={widget} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null on Unavailable status', () => {
+    const widget: DashboardRenderedWidget = {
+      ...ENVELOPE_BASE,
+      widgetType: 'Map',
+      status: 'Unavailable',
+      snapshot: null,
+      reasonLocalizationKey: 'Widget:Unavailable',
+    };
+    const { container } = render(<MapSnapshotWidget widget={widget} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('mounts the container with the OSM provider id by default', () => {
+    const { container } = render(<MapSnapshotWidget widget={mapEnvelope(SAMPLE)} />);
+    const slot = container.querySelector('[data-slot="map-snapshot-widget"]');
+    expect(slot?.getAttribute('data-tile-provider')).toBe('osm');
+  });
+
+  it('reflects the active provider id when wrapped in MapTileProviderProvider', () => {
+    const { container } = render(
+      <MapTileProviderProvider provider={spwProvider}>
+        <MapSnapshotWidget widget={mapEnvelope(SAMPLE)} />
+      </MapTileProviderProvider>
+    );
+    expect(
+      container
+        .querySelector('[data-slot="map-snapshot-widget"]')
+        ?.getAttribute('data-tile-provider')
+    ).toBe('spw');
+  });
+
+  it('flags the snapshot tileUrlTemplate override on the data attribute', () => {
+    const { container } = render(
+      <MapSnapshotWidget
+        widget={mapEnvelope({
+          ...SAMPLE,
+          tileUrlTemplate: 'https://tiles.example/{z}/{x}/{y}.png',
+        })}
+      />
+    );
+    expect(
+      container
+        .querySelector('[data-slot="map-snapshot-widget"]')
+        ?.getAttribute('data-tile-provider')
+    ).toBe('snapshot-override');
+  });
+});

--- a/packages/@granit/react-map/src/__tests__/map-tile-provider-context.test.tsx
+++ b/packages/@granit/react-map/src/__tests__/map-tile-provider-context.test.tsx
@@ -1,0 +1,27 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  MapTileProviderProvider,
+  useMapTileProvider,
+} from '../components/map-tile-provider-context.js';
+import { osmProvider } from '../providers/osm-provider.js';
+import { spwProvider } from '../providers/spw-provider.js';
+
+import type { ReactNode } from 'react';
+
+describe('MapTileProvider context', () => {
+  it('falls back to osmProvider when no provider context is mounted', () => {
+    const { result } = renderHook(() => useMapTileProvider());
+    expect(result.current).toBe(osmProvider);
+  });
+
+  it('returns the active provider when wrapped', () => {
+    const wrapper = ({ children }: { readonly children: ReactNode }) => (
+      <MapTileProviderProvider provider={spwProvider}>{children}</MapTileProviderProvider>
+    );
+    const { result } = renderHook(() => useMapTileProvider(), { wrapper });
+    expect(result.current).toBe(spwProvider);
+    expect(result.current.id).toBe('spw');
+  });
+});

--- a/packages/@granit/react-map/src/__tests__/providers.test.ts
+++ b/packages/@granit/react-map/src/__tests__/providers.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+
+import { arcGisProvider } from '../providers/arcgis-provider.js';
+import { osmProvider } from '../providers/osm-provider.js';
+import { spwProvider } from '../providers/spw-provider.js';
+
+describe('built-in tile providers', () => {
+  it('osmProvider exposes a single plan layer with mandatory CC-BY-SA attribution', () => {
+    expect(osmProvider.id).toBe('osm');
+    expect(osmProvider.layers).toHaveLength(1);
+    expect(osmProvider.layers[0].kind).toBe('plan');
+    expect(osmProvider.layers[0].url).toContain('tile.openstreetmap.org');
+    expect(osmProvider.layers[0].attribution).toContain('OpenStreetMap');
+  });
+
+  it('spwProvider ships plan / satellite / hybrid layers with SPW attribution', () => {
+    expect(spwProvider.id).toBe('spw');
+    expect(spwProvider.layers.map((l) => l.kind)).toEqual(['plan', 'satellite', 'hybrid']);
+    for (const layer of spwProvider.layers) {
+      expect(layer.attribution).toContain('Service Public de Wallonie');
+      expect(layer.url).toContain('geoservices.wallonie.be');
+    }
+  });
+
+  it('arcGisProvider ships plan / satellite / topo Esri basemaps', () => {
+    expect(arcGisProvider.id).toBe('arcgis');
+    expect(arcGisProvider.layers.map((l) => l.kind)).toEqual(['plan', 'satellite', 'topo']);
+    for (const layer of arcGisProvider.layers) {
+      expect(layer.attribution).toContain('Esri');
+      expect(layer.url).toContain('arcgisonline.com');
+    }
+  });
+
+  it('all built-in providers default to a non-empty layer set (TS tuple constraint)', () => {
+    for (const provider of [osmProvider, spwProvider, arcGisProvider]) {
+      expect(provider.layers.length).toBeGreaterThan(0);
+      const first = provider.layers[0];
+      expect(first.id).toBeTruthy();
+      expect(first.url).toBeTruthy();
+    }
+  });
+});

--- a/packages/@granit/react-map/src/components/map-tile-provider-context.tsx
+++ b/packages/@granit/react-map/src/components/map-tile-provider-context.tsx
@@ -1,0 +1,52 @@
+import { createContext, useContext, type ReactNode } from 'react';
+
+import { osmProvider } from '../providers/osm-provider.js';
+
+import type { MapTileProvider } from '../types.js';
+
+const MapTileProviderContext = createContext<MapTileProvider>(osmProvider);
+
+export interface MapTileProviderProviderProps {
+  /**
+   * Provider mounted on every {@link MapSnapshotWidget} below the provider.
+   * Defaults to {@link osmProvider} when no context is supplied — apps
+   * never crash on a missing provider, they just render OSM tiles.
+   */
+  readonly provider: MapTileProvider;
+  readonly children: ReactNode;
+}
+
+/**
+ * Supplies the active {@link MapTileProvider} to the dashboard subtree.
+ *
+ * Apps configure this once at the root — typically:
+ *
+ *     // Belgian public-sector deployment
+ *     <MapTileProviderProvider provider={spwProvider}>
+ *       <SnapshotWidgetRegistryProvider registries={[
+ *         defaultSnapshotWidgetRegistry,
+ *         defaultAnalyticsSnapshotWidgetRegistry,
+ *         defaultMapSnapshotWidgetRegistry,
+ *       ]}>
+ *         <RenderedDashboard dashboardId={id} />
+ *       </SnapshotWidgetRegistryProvider>
+ *     </MapTileProviderProvider>
+ *
+ * Per-widget tile-URL overrides via `MapWidgetSnapshot.tileUrlTemplate`
+ * still take precedence (escape hatch for one-off widgets).
+ */
+export function MapTileProviderProvider({ provider, children }: MapTileProviderProviderProps) {
+  return (
+    <MapTileProviderContext.Provider value={provider}>{children}</MapTileProviderContext.Provider>
+  );
+}
+
+/**
+ * Reads the active {@link MapTileProvider}. Falls back to {@link osmProvider}
+ * when no provider context is mounted — `<MapSnapshotWidget>` never throws on
+ * a missing provider, it just degrades to the public OSM tiles (with the
+ * mandatory CC-BY-SA attribution surfaced in the widget chrome).
+ */
+export function useMapTileProvider(): MapTileProvider {
+  return useContext(MapTileProviderContext);
+}

--- a/packages/@granit/react-map/src/index.ts
+++ b/packages/@granit/react-map/src/index.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------
+// @granit/react-map — public API
+// ---------------------------------------------------------------------------
+
+// Snapshot renderer (B5-B PR 4 — Map kind for <RenderedDashboard>)
+export { MapSnapshotWidget } from './snapshot/map-snapshot-widget.js';
+export { defaultMapSnapshotWidgetRegistry } from './snapshot/default-map-snapshot-widget-registry.js';
+
+// Tile provider context — apps select the active provider once at the root
+export {
+  MapTileProviderProvider,
+  useMapTileProvider,
+} from './components/map-tile-provider-context.js';
+export type { MapTileProviderProviderProps } from './components/map-tile-provider-context.js';
+
+// Built-in providers
+export { osmProvider } from './providers/osm-provider.js';
+export { spwProvider } from './providers/spw-provider.js';
+export { arcGisProvider } from './providers/arcgis-provider.js';
+
+// Provider / layer types — apps compose custom providers with this shape
+export type { MapTileLayer, MapTileLayerKind, MapTileProvider } from './types.js';

--- a/packages/@granit/react-map/src/leaflet-css.d.ts
+++ b/packages/@granit/react-map/src/leaflet-css.d.ts
@@ -1,0 +1,4 @@
+// Side-effect import declaration for the Leaflet stylesheet. Bundlers
+// (Vite, webpack, esbuild) consume the CSS via their asset pipeline; this
+// declaration just satisfies the TypeScript type-checker.
+declare module 'leaflet/dist/leaflet.css';

--- a/packages/@granit/react-map/src/providers/arcgis-provider.ts
+++ b/packages/@granit/react-map/src/providers/arcgis-provider.ts
@@ -1,0 +1,53 @@
+import type { MapTileProvider } from '../types.js';
+
+/**
+ * Esri ArcGIS Online World basemaps. Free for non-commercial use; commercial
+ * deployments need an ArcGIS Online subscription. Attribution under the
+ * Esri Master Agreement — **mandatory** in the widget chrome.
+ *
+ * Four standard layers shipped by default:
+ * - **World_Topo_Map** (`'topo'`) — topographic basemap with relief.
+ * - **World_Street_Map** (`'plan'`) — street map (default for `'plan'` kind).
+ * - **World_Imagery** (`'satellite'`) — aerial / satellite imagery.
+ * - **World_Imagery + Reference** (`'hybrid'`) — imagery with a reference
+ *   label overlay layered on top via the Reference Overlay tile service.
+ *
+ * Apps wanting different Esri layers (e.g. `World_Dark_Gray_Base`,
+ * `Ocean/World_Ocean_Base`) compose their own provider with the same shape.
+ *
+ * Tile URLs use the Esri `{z}/{y}/{x}` order (Leaflet's `L.tileLayer`
+ * recognises this transparently — no URL transformation needed).
+ */
+export const arcGisProvider: MapTileProvider = {
+  id: 'arcgis',
+  labelLocalizationKey: 'Map:Provider.ArcGIS',
+  layers: [
+    {
+      id: 'arcgis-world-street',
+      labelLocalizationKey: 'Map:Layer.Plan',
+      kind: 'plan',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',
+      attribution:
+        'Tiles &copy; <a href="https://www.esri.com/">Esri</a> — Sources: Esri, HERE, Garmin, USGS, Intermap, INCREMENT P, NRCan, OpenStreetMap contributors',
+      maxZoom: 19,
+    },
+    {
+      id: 'arcgis-world-imagery',
+      labelLocalizationKey: 'Map:Layer.Satellite',
+      kind: 'satellite',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      attribution:
+        'Tiles &copy; <a href="https://www.esri.com/">Esri</a> — Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community',
+      maxZoom: 19,
+    },
+    {
+      id: 'arcgis-world-topo',
+      labelLocalizationKey: 'Map:Layer.Topo',
+      kind: 'topo',
+      url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
+      attribution:
+        'Tiles &copy; <a href="https://www.esri.com/">Esri</a> — Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, NRCan, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community',
+      maxZoom: 19,
+    },
+  ],
+};

--- a/packages/@granit/react-map/src/providers/index.ts
+++ b/packages/@granit/react-map/src/providers/index.ts
@@ -1,0 +1,3 @@
+export { arcGisProvider } from './arcgis-provider.js';
+export { osmProvider } from './osm-provider.js';
+export { spwProvider } from './spw-provider.js';

--- a/packages/@granit/react-map/src/providers/osm-provider.ts
+++ b/packages/@granit/react-map/src/providers/osm-provider.ts
@@ -1,0 +1,27 @@
+import type { MapTileProvider } from '../types.js';
+
+/**
+ * OpenStreetMap default raster tiles. Free, world coverage, no API key.
+ * Attribution under CC-BY-SA — **mandatory** in the widget chrome per the
+ * OSMF tile-usage policy.
+ *
+ * Single layer (`'plan'`) — OSM doesn't ship aerial imagery on the public
+ * tile service. Apps that want satellite layers configure another provider
+ * (SPW, ArcGIS, MapTiler, …).
+ */
+export const osmProvider: MapTileProvider = {
+  id: 'osm',
+  labelLocalizationKey: 'Map:Provider.OSM',
+  layers: [
+    {
+      id: 'osm-standard',
+      labelLocalizationKey: 'Map:Layer.Plan',
+      kind: 'plan',
+      url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+      attribution:
+        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
+      subdomains: ['a', 'b', 'c'],
+      maxZoom: 19,
+    },
+  ],
+};

--- a/packages/@granit/react-map/src/providers/spw-provider.ts
+++ b/packages/@granit/react-map/src/providers/spw-provider.ts
@@ -1,0 +1,56 @@
+import type { MapTileProvider } from '../types.js';
+
+/**
+ * Walloon Public Service geoportal — official tile services for the Walloon
+ * region (Belgium). Used by Belgian public-sector deployments.
+ *
+ * Service catalogue: https://geoportail.wallonie.be/catalogue
+ *
+ * Three layers exposed by default:
+ * - **PLAN_PARCELLAIRE** (`'plan'`) — cadastral / parcel map.
+ * - **ORTHO** (`'satellite'`) — aerial ortho-imagery (latest available year).
+ * - **HYBRIDE** (`'hybrid'`) — ortho-imagery + label overlay.
+ *
+ * Attribution under the Walloon open-data licence — **mandatory** in the
+ * widget chrome. URLs follow the Esri `{z}/{y}/{x}` tile order; the
+ * widget passes them verbatim to Leaflet's `L.tileLayer` which handles
+ * both XYZ orderings transparently.
+ *
+ * The exact REST service URLs are stable but not contractually frozen —
+ * apps that need a specific historical ortho year (e.g. ORTHO_2024 vs
+ * ORTHO_2022) should compose their own provider rather than rely on
+ * the generic latest-ortho URL here.
+ */
+export const spwProvider: MapTileProvider = {
+  id: 'spw',
+  labelLocalizationKey: 'Map:Provider.SPW',
+  layers: [
+    {
+      id: 'spw-plan-parcellaire',
+      labelLocalizationKey: 'Map:Layer.Plan',
+      kind: 'plan',
+      url: 'https://geoservices.wallonie.be/arcgis/rest/services/PLAN_REGLEMENTAIRE/PLAN_PARCELLAIRE/MapServer/tile/{z}/{y}/{x}',
+      attribution:
+        '&copy; <a href="https://geoportail.wallonie.be">SPW — Service Public de Wallonie</a>',
+      maxZoom: 19,
+    },
+    {
+      id: 'spw-ortho',
+      labelLocalizationKey: 'Map:Layer.Satellite',
+      kind: 'satellite',
+      url: 'https://geoservices.wallonie.be/arcgis/rest/services/IMAGERIE/ORTHO_LAST/MapServer/tile/{z}/{y}/{x}',
+      attribution:
+        '&copy; <a href="https://geoportail.wallonie.be">SPW — Service Public de Wallonie</a>',
+      maxZoom: 19,
+    },
+    {
+      id: 'spw-hybride',
+      labelLocalizationKey: 'Map:Layer.Hybrid',
+      kind: 'hybrid',
+      url: 'https://geoservices.wallonie.be/arcgis/rest/services/IMAGERIE/ORTHO_LAST_HYBRIDE/MapServer/tile/{z}/{y}/{x}',
+      attribution:
+        '&copy; <a href="https://geoportail.wallonie.be">SPW — Service Public de Wallonie</a>',
+      maxZoom: 19,
+    },
+  ],
+};

--- a/packages/@granit/react-map/src/snapshot/default-map-snapshot-widget-registry.ts
+++ b/packages/@granit/react-map/src/snapshot/default-map-snapshot-widget-registry.ts
@@ -1,0 +1,21 @@
+import { MapSnapshotWidget } from './map-snapshot-widget.js';
+
+import type { SnapshotWidgetRegistry } from '@granit/react-dashboards';
+
+/**
+ * Snapshot renderer registry contributed by `@granit/react-map`. Compose
+ * with the framework default + analytics registries at the app root:
+ *
+ *     <MapTileProviderProvider provider={spwProvider}>
+ *       <SnapshotWidgetRegistryProvider registries={[
+ *         defaultSnapshotWidgetRegistry,             // Markdown / Text / Image
+ *         defaultAnalyticsSnapshotWidgetRegistry,    // Kpi / Chart / Table / Pivot
+ *         defaultMapSnapshotWidgetRegistry,          // Map (this package)
+ *       ]}>
+ *
+ * Apps that don't ship `Map` widgets don't import this and pay zero
+ * Leaflet bundle weight.
+ */
+export const defaultMapSnapshotWidgetRegistry: SnapshotWidgetRegistry = Object.freeze({
+  Map: MapSnapshotWidget,
+});

--- a/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
+++ b/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
@@ -1,0 +1,234 @@
+import { isMapSnapshotEnvelope } from '@granit/analytics';
+import L from 'leaflet';
+import { useEffect, useMemo, useRef } from 'react';
+
+import { useMapTileProvider } from '../components/map-tile-provider-context.js';
+
+import 'leaflet/dist/leaflet.css';
+
+import type { MapTileLayer } from '../types.js';
+import type { MapWidgetSnapshot } from '@granit/analytics';
+import type { DashboardRenderedWidget } from '@granit/dashboards';
+
+// Leaflet's default marker icons rely on relative paths that bundlers strip.
+// Pin them to the CDN so apps don't need to import PNG assets manually.
+// Apps that prefer self-hosted icons override `L.Icon.Default.mergeOptions`
+// at the entry point.
+const LEAFLET_ICON_CDN = 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/images';
+L.Icon.Default.mergeOptions({
+  iconUrl: `${LEAFLET_ICON_CDN}/marker-icon.png`,
+  iconRetinaUrl: `${LEAFLET_ICON_CDN}/marker-icon-2x.png`,
+  shadowUrl: `${LEAFLET_ICON_CDN}/marker-shadow.png`,
+});
+
+/**
+ * Snapshot-driven renderer for the `'Map'` widget kind. Vanilla Leaflet
+ * wrapper — no react-leaflet dep, since its current Hippocratic License is
+ * incompatible with Apache-2.0-strict consumer policies.
+ *
+ * Tile resolution priority (highest first):
+ * 1. `widget.snapshot.tileUrlTemplate` — escape hatch for one-off widgets
+ *    that need a specific URL (white-label, ad-hoc historical layer).
+ *    Renders as a single static layer, no layer-switcher.
+ * 2. Active {@link MapTileProvider} from {@link MapTileProviderContext}.
+ *    When the provider exposes >1 layer (e.g. SPW: plan / satellite /
+ *    hybride), Leaflet's built-in `L.Control.Layers` switcher mounts on
+ *    the top-right corner.
+ * 3. {@link osmProvider} — silent default when no provider context is
+ *    mounted.
+ *
+ * Marker click-through: when both `snapshot.detailRoute` and `point.id`
+ * are set, the marker handler navigates via `window.location.href`. Apps
+ * wanting React Router integration register their own snapshot renderer
+ * with `useNavigate()` from `react-router-dom`.
+ */
+export function MapSnapshotWidget({ widget }: { readonly widget: DashboardRenderedWidget }) {
+  if (!isMapSnapshotEnvelope(widget) || !widget.snapshot) return null;
+  return <MapBody snapshot={widget.snapshot} />;
+}
+
+function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<L.Map | null>(null);
+  const provider = useMapTileProvider();
+
+  // Effective layers: the snapshot's tileUrlTemplate (when set) wins as a
+  // single override; otherwise we expose every provider layer to the layer
+  // switcher.
+  const layers = useMemo<readonly MapTileLayer[]>(() => {
+    if (snapshot.tileUrlTemplate) {
+      return [
+        {
+          id: 'snapshot-override',
+          kind: 'custom',
+          url: snapshot.tileUrlTemplate,
+          // Per-widget overrides: the host already controls attribution
+          // visibility (it owns the URL choice), but we keep a non-empty
+          // default so Leaflet doesn't suppress its built-in attribution
+          // control entirely.
+          attribution: '&copy; tile provider',
+        },
+      ];
+    }
+    return provider.layers;
+  }, [snapshot.tileUrlTemplate, provider]);
+
+  // Initialise the map exactly once. Subsequent updates run through dedicated
+  // effects so we don't tear down + rebuild Leaflet on every snapshot prop
+  // change (would lose user pan/zoom state).
+  useEffect(() => {
+    if (!containerRef.current || mapRef.current) return;
+    const map = L.map(containerRef.current, { attributionControl: true });
+    mapRef.current = map;
+    return () => {
+      map.remove();
+      mapRef.current = null;
+    };
+  }, []);
+
+  // Mount tile layers + (optional) Layers control. Re-runs when the
+  // resolved layer set changes.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    const tileLayerById = new Map<string, L.TileLayer>();
+    for (const layer of layers) {
+      tileLayerById.set(
+        layer.id,
+        L.tileLayer(layer.url, {
+          attribution: layer.attribution,
+          subdomains: (layer.subdomains as string | string[] | undefined) ?? 'abc',
+          maxZoom: layer.maxZoom ?? 19,
+          minZoom: layer.minZoom ?? 0,
+          tileSize: layer.tileSize ?? 256,
+        })
+      );
+    }
+
+    // Default = first layer.
+    const firstLayer = layers[0];
+    const defaultTile = firstLayer ? tileLayerById.get(firstLayer.id) : undefined;
+    defaultTile?.addTo(map);
+
+    // Mount the layer-switcher only when more than one layer is offered.
+    let layersControl: L.Control.Layers | null = null;
+    if (layers.length > 1) {
+      const baseLayers: Record<string, L.TileLayer> = {};
+      for (const layer of layers) {
+        const tile = tileLayerById.get(layer.id);
+        if (tile) {
+          // The layer-switcher label is the localization key — apps whose
+          // bundle resolves it format the label downstream. The default
+          // surfaces the key verbatim, which is acceptable for dev mode.
+          const label = layer.labelLocalizationKey ?? layer.id;
+          baseLayers[label] = tile;
+        }
+      }
+      layersControl = L.control.layers(baseLayers, undefined, { position: 'topright' });
+      layersControl.addTo(map);
+    }
+
+    return () => {
+      layersControl?.remove();
+      for (const tile of tileLayerById.values()) {
+        tile.remove();
+      }
+    };
+  }, [layers]);
+
+  // Camera (zoom + center). Falls back to bounding-box fit when no center
+  // is supplied; falls back to world view when there are zero points.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    if (snapshot.defaultCenter) {
+      map.setView(
+        [snapshot.defaultCenter.latitude, snapshot.defaultCenter.longitude],
+        snapshot.defaultZoom
+      );
+      return;
+    }
+    if (snapshot.points.length > 0) {
+      const bounds = L.latLngBounds(
+        snapshot.points.map((p) => [p.latitude, p.longitude] as [number, number])
+      );
+      map.fitBounds(bounds, { padding: [16, 16] });
+      return;
+    }
+    map.setView([0, 0], 2);
+  }, [snapshot.defaultCenter, snapshot.defaultZoom, snapshot.points]);
+
+  // Markers + (optional) clustering. Rebuilt on every points / threshold /
+  // detailRoute change so click handlers stay current.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+
+    // Plain layer group by default; apps that ship leaflet.markercluster
+    // get clustering above the threshold via dynamic require — the dep
+    // is declared as an OPTIONAL peer so the framework default keeps
+    // working without it.
+    const layer = L.layerGroup();
+    const useCluster = snapshot.points.length > snapshot.clusterThreshold;
+    let clusterGroup: L.LayerGroup | null = null;
+
+    type ClusterFactory = () => L.LayerGroup;
+    type ClusterModule = { default?: ClusterFactory } | { markerClusterGroup?: ClusterFactory };
+    const lWithCluster = L as unknown as { markerClusterGroup?: ClusterFactory };
+    if (useCluster && typeof lWithCluster.markerClusterGroup === 'function') {
+      clusterGroup = lWithCluster.markerClusterGroup();
+    } else if (useCluster) {
+      // leaflet.markercluster augments the L namespace at import time.
+      // When the optional peer isn't installed the cluster threshold
+      // becomes a soft hint — markers render unclustered.
+      void (null as unknown as ClusterModule);
+    }
+
+    for (const point of snapshot.points) {
+      const marker = L.marker([point.latitude, point.longitude]);
+      if (point.popup) {
+        const popupHtml = Object.entries(point.popup)
+          .map(([k, v]) => `<strong>${escapeHtml(k)}</strong>: ${escapeHtml(String(v))}`)
+          .join('<br/>');
+        marker.bindPopup(popupHtml);
+      }
+      if (snapshot.detailRoute && point.id) {
+        const route = snapshot.detailRoute.replace('{id}', encodeURIComponent(point.id));
+        marker.on('click', () => {
+          // Apps wanting React Router integration override this snapshot
+          // renderer with `useNavigate()` instead of `window.location.href`.
+          window.location.href = route;
+        });
+        marker.options.alt = route;
+      }
+      (clusterGroup ?? layer).addLayer(marker);
+    }
+
+    const target = clusterGroup ?? layer;
+    target.addTo(map);
+
+    return () => {
+      target.remove();
+    };
+  }, [snapshot.points, snapshot.clusterThreshold, snapshot.detailRoute]);
+
+  return (
+    <div
+      ref={containerRef}
+      data-slot="map-snapshot-widget"
+      data-tile-provider={snapshot.tileUrlTemplate ? 'snapshot-override' : provider.id}
+      className="h-full w-full min-h-64"
+    />
+  );
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/packages/@granit/react-map/src/types.ts
+++ b/packages/@granit/react-map/src/types.ts
@@ -1,0 +1,92 @@
+/**
+ * Map tile layer kind. Drives default ordering in the layer-switcher control
+ * (plan first, then satellite, then hybrid composites). Frontend renderers
+ * interpret the kind for grouping; the value carries no semantic meaning
+ * beyond presentation.
+ */
+export type MapTileLayerKind =
+  /** Standard road / street map (raster or vector tiles). */
+  | 'plan'
+  /** Aerial / satellite imagery without labels. */
+  | 'satellite'
+  /** Imagery + label overlay ("hybride" in French geoportals). */
+  | 'hybrid'
+  /** Topographic map with elevation contours. */
+  | 'topo'
+  /** Anything else — apps register their own kind for ad-hoc layers. */
+  | 'custom';
+
+/**
+ * One tile layer offered by a {@link MapTileProvider}. Mirrors the inputs
+ * Leaflet's `L.tileLayer(url, options)` accepts so the wrapper can hand
+ * each field through with no transformation.
+ */
+export interface MapTileLayer {
+  /** Stable identifier — drives the layer-switcher control's selection state. */
+  readonly id: string;
+  /**
+   * Localization key (e.g. `'Map:Layer.Plan'`). Falls back to {@link id}
+   * when the i18n bundle has no entry.
+   */
+  readonly labelLocalizationKey?: string;
+  /** Layer kind — informs default ordering and the widget's data attributes. */
+  readonly kind: MapTileLayerKind;
+  /**
+   * XYZ URL template (Leaflet syntax: `{s}` subdomain, `{z}`/`{x}`/`{y}`
+   * tile coordinates). Esri tile services use a `{z}/{y}/{x}` order — pass
+   * the URL verbatim, Leaflet recognises both.
+   */
+  readonly url: string;
+  /**
+   * HTML attribution. **Mandatory** for OSM (CC-BY-SA), SPW Wallonia (Wallonia
+   * licence), ArcGIS (Esri licence) — never empty for hosted public tile
+   * services. Custom self-hosted layers can ship `''` if attribution is
+   * displayed elsewhere on the page.
+   */
+  readonly attribution: string;
+  /**
+   * Subdomain letters for the `{s}` placeholder (e.g. `['a', 'b', 'c']`).
+   * Many providers ship 4 subdomains by convention to spread CDN load.
+   */
+  readonly subdomains?: readonly string[] | string;
+  /** Maximum zoom level the provider supports. Default 19 (Leaflet default). */
+  readonly maxZoom?: number;
+  /** Minimum zoom level. Default 0 (world view). */
+  readonly minZoom?: number;
+  /**
+   * Pixel size of one tile. Default 256 (raster XYZ standard). 512 is
+   * common for retina-friendly vector / hi-DPI raster sets — paired with
+   * `zoomOffset: -1` server-side.
+   */
+  readonly tileSize?: number;
+}
+
+/**
+ * Tile provider registered into the {@link MapTileProviderContext}. Apps
+ * select the active provider at the dashboard tree's root; \<MapSnapshotWidget\>
+ * mounts the provider's first {@link layers} entry by default and surfaces
+ * a Leaflet layer-switcher when more than one is declared.
+ *
+ * Built-in providers shipped by `@granit/react-map`:
+ * - {@link osmProvider} — OpenStreetMap raster tiles (default).
+ * - {@link spwProvider} — Wallonian geoportal (ortho + topo + hybride).
+ * - {@link arcGisProvider} — Esri World basemaps (Topo / Imagery / Streets / Hybrid).
+ *
+ * Apps register custom providers (MapTiler, Stadia, white-label) via the
+ * same shape and pass them to {@link MapTileProviderProvider}.
+ */
+export interface MapTileProvider {
+  /** Stable identifier (e.g. `'osm'` / `'spw'` / `'arcgis'`). */
+  readonly id: string;
+  /**
+   * Localization key (e.g. `'Map:Provider.SPW'`). Falls back to {@link id}
+   * when the i18n bundle has no entry.
+   */
+  readonly labelLocalizationKey?: string;
+  /**
+   * Layers offered by this provider, in display order. The first entry is
+   * the **default** active layer. Tuple type guarantees at least one
+   * layer at the type level.
+   */
+  readonly layers: readonly MapTileLayer[];
+}

--- a/packages/@granit/react-map/tsconfig.json
+++ b/packages/@granit/react-map/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-map/tsup.config.ts
+++ b/packages/@granit/react-map/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1375,6 +1375,40 @@ importers:
         specifier: workspace:*
         version: link:../types
 
+  packages/@granit/react-map:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@granit/analytics':
+        specifier: workspace:*
+        version: link:../analytics
+      '@granit/dashboards':
+        specifier: workspace:*
+        version: link:../dashboards
+      '@granit/react-dashboards':
+        specifier: workspace:*
+        version: link:../react-dashboards
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@types/leaflet':
+        specifier: ^1.9.18
+        version: 1.9.21
+      '@types/leaflet.markercluster':
+        specifier: ^1.5.5
+        version: 1.5.6
+      leaflet:
+        specifier: ^1.9.4
+        version: 1.9.4
+      leaflet.markercluster:
+        specifier: ^1.5.3
+        version: 1.5.3(leaflet@1.9.4)
+
   packages/@granit/react-metering:
     dependencies:
       '@granit/metering':
@@ -3744,11 +3778,20 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
   '@types/katex@0.16.8':
     resolution: {integrity: sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==}
+
+  '@types/leaflet.markercluster@1.5.6':
+    resolution: {integrity: sha512-I7hZjO2+isVXGYWzKxBp8PsCzAYCJBc29qBdFpquOCkS7zFDqUsUvkEOyQHedsk/Cy5tocQzf+Ndorm5W9YKTQ==}
+
+  '@types/leaflet@1.9.21':
+    resolution: {integrity: sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==}
 
   '@types/ms@2.1.0':
     resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
@@ -4934,6 +4977,14 @@ packages:
 
   klaro@0.7.21:
     resolution: {integrity: sha512-PbF23xYGPObhg2GL0yqskPqRTziv3RTwVi9QZiBEB/BVulS/e1fFprgRiW6f4utPjb61q/16fWgPwHuuXJZYRA==}
+
+  leaflet.markercluster@1.5.3:
+    resolution: {integrity: sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==}
+    peerDependencies:
+      leaflet: ^1.3.1
+
+  leaflet@1.9.4:
+    resolution: {integrity: sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==}
 
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
@@ -7586,9 +7637,19 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/geojson@7946.0.16': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/katex@0.16.8': {}
+
+  '@types/leaflet.markercluster@1.5.6':
+    dependencies:
+      '@types/leaflet': 1.9.21
+
+  '@types/leaflet@1.9.21':
+    dependencies:
+      '@types/geojson': 7946.0.16
 
   '@types/ms@2.1.0': {}
 
@@ -8794,6 +8855,12 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - eslint
+
+  leaflet.markercluster@1.5.3(leaflet@1.9.4):
+    dependencies:
+      leaflet: 1.9.4
+
+  leaflet@1.9.4: {}
 
   levn@0.4.1:
     dependencies:


### PR DESCRIPTION
## Summary

Fourth slice of **B5-B**: ships the snapshot renderer for the \`'Map'\` widget kind in a brand-new \`@granit/react-map\` package. \`<RenderedDashboard>\` now dispatches \`Map\` envelopes through a vanilla Leaflet wrapper with **multi-provider + multi-layer** support — OpenStreetMap by default, with built-in providers for Walloon SPW geoportal and Esri ArcGIS.

PR sequence: Chart [#266 ✓] → Table [#267 ✓] → Pivot [#268 ✓] → **Map [this PR]** → showcase wiring.

## Why a new package

- **Optional bundle weight**: Leaflet (~150 KB minified) only loads for apps that ship Map widgets. \`@granit/react-analytics\` stays lightweight.
- **Optional \`leaflet.markercluster\` peer**: clustering is opt-in. Apps that don't install it get unclustered markers above the threshold.
- **Vanilla Leaflet wrapper, no \`react-leaflet\`** — its current Hippocratic License is rejected for Apache-2.0-strict consumer compliance.

## Multi-provider + multi-layer architecture

\`\`\`ts
export interface MapTileLayer {
  readonly id: string;
  readonly labelLocalizationKey?: string;
  readonly kind: 'plan' | 'satellite' | 'hybrid' | 'topo' | 'custom';
  readonly url: string;       // Leaflet XYZ template
  readonly attribution: string;
  readonly subdomains?: readonly string[] | string;
  readonly maxZoom?: number;
  readonly minZoom?: number;
  readonly tileSize?: number;
}

export interface MapTileProvider {
  readonly id: string;
  readonly labelLocalizationKey?: string;
  readonly layers: readonly MapTileLayer[];
}
\`\`\`

### Built-in providers

| Provider | Layers | Attribution |
| --- | --- | --- |
| \`osmProvider\` (**default**) | OSM Standard (plan) | OSM CC-BY-SA |
| \`spwProvider\` | Plan parcellaire / Ortho / Hybride | SPW Wallonia |
| \`arcGisProvider\` | World Street / World Imagery / World Topo | Esri Master Agreement |

Apps register the active provider once at the root via \`<MapTileProviderProvider>\` context. When the provider exposes >1 layer, Leaflet's built-in \`L.Control.Layers\` mounts on the top-right with the layer kinds as switcher entries.

### Tile resolution priority (highest first)

1. **\`widget.snapshot.tileUrlTemplate\`** — escape hatch for one-off widgets that need a specific URL. Renders as a single static layer, no switcher.
2. **Active \`MapTileProvider\`** from \`MapTileProviderContext\`. Multi-layer providers mount the layer-switcher.
3. **\`osmProvider\`** — silent default when no provider context is mounted.

## App wiring example

\`\`\`tsx
// Belgian public-sector deployment
<MapTileProviderProvider provider={spwProvider}>
  <SnapshotWidgetRegistryProvider registries={[
    defaultSnapshotWidgetRegistry,             // Markdown / Text / Image
    defaultAnalyticsSnapshotWidgetRegistry,    // Kpi / Chart / Table / Pivot
    defaultChartSnapshotWidgetRegistry,
    defaultMapSnapshotWidgetRegistry,          // Map (this PR)
  ]}>
    <RenderedDashboard dashboardId={id} />
  </SnapshotWidgetRegistryProvider>
</MapTileProviderProvider>
\`\`\`

Apps composing custom providers (MapTiler, Stadia, white-label) use the same \`MapTileProvider\` shape.

## Marker behaviour

- Each \`MapPoint\` becomes an \`L.marker\` at \`[latitude, longitude]\`.
- \`point.popup\` renders as an HTML-escaped \`bindPopup\` content (key/value lines).
- Click handler navigates via \`window.location.href = detailRoute.replace('{id}', point.id)\` when both \`snapshot.detailRoute\` and \`point.id\` are set. Apps wanting React Router integration override the registry entry with a renderer using \`useNavigate()\`.
- Marker clustering activates above \`snapshot.clusterThreshold\` **iff** \`leaflet.markercluster\` is installed (optional peer). Otherwise markers render unclustered — the threshold becomes a soft hint, no crash.
- Default Leaflet marker icons are pinned to the jsdelivr CDN to avoid the bundler-strips-asset-paths bug. Apps that prefer self-hosted icons override \`L.Icon.Default.mergeOptions\` at the entry point.

## Tests (+11, total 2416 / 2416 ✓)

- \`providers.test.ts\` — locks the layer surface for OSM / SPW / ArcGIS (kinds, attribution presence, URL host).
- \`map-tile-provider-context.test.tsx\` — fallback to \`osmProvider\` outside provider, override via \`MapTileProviderProvider\`.
- \`map-snapshot-widget.test.tsx\` — dispatcher contract: returns null on non-Map / Unavailable, surfaces the resolved provider id on the \`data-tile-provider\` attribute, flags the \`snapshot.tileUrlTemplate\` escape hatch with \`'snapshot-override'\`. Leaflet is mocked (jsdom doesn't simulate real layout / mouse events).

## Suggested backend follow-up (optional, NOT this PR)

A small additive backend story would let dashboard admins specify the **default layer kind** per-widget without forcing a specific provider on the whole app:

- Add \`defaultLayerKind: 'plan' | 'satellite' | 'hybrid' | 'topo' | null\` to \`MapWidgetDefinition\` and propagate through \`MapWidgetSnapshot\`.
- Frontend resolution: \`provider.layers.find(l => l.kind === defaultLayerKind) ?? provider.layers[0]\`.

Provider choice stays a host-app concern (one-time deployment config, not a per-widget choice), but the **layer kind preference** is per-widget meaningful (e.g. delivery-tracking map needs satellite default to show terrain).

I'll provide a copy-pasteable prompt for the granit-dotnet Claude in the conversation thread.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2416 / 2416** ✓ (+11)

## What's next

- **B5-B PR 5** — Showcase wiring: replace \`<DashboardBundlePanel>\` with \`<RenderedDashboard>\` + composed registries (including \`defaultMapSnapshotWidgetRegistry\` + a \`<MapTileProviderProvider>\` showcase config). Closes B5-B.