### PR TITLE
feat(react-dashboard-editor): editable dashboard + reorder via dnd-kit (B5-C PR 1)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2073,6 +2073,39 @@
       "exports": []
     },
     {
+      "name": "@granit/react-dashboard-editor",
+      "description": "React dashboard editor primitives for Granit — drag-and-drop reorderable widget grid built on dnd-kit. Pairs with the read-mode <RenderedDashboard> from @granit/react-dashboards. Frontend half of EPIC #1366 story B5-C (dashboard composer).",
+      "exports": [
+        {
+          "name": "EditableDashboard",
+          "kind": "function",
+          "signature": "function EditableDashboard("
+        },
+        {
+          "name": "EditableDashboardProps",
+          "kind": "interface",
+          "signature": "interface EditableDashboardProps",
+          "members": []
+        },
+        {
+          "name": "SortableWidgetCell",
+          "kind": "function",
+          "signature": "function SortableWidgetCell("
+        },
+        {
+          "name": "SortableWidgetCellProps",
+          "kind": "interface",
+          "signature": "interface SortableWidgetCellProps",
+          "members": []
+        },
+        {
+          "name": "reorderWidgets",
+          "kind": "function",
+          "signature": "function reorderWidgets( definition: DashboardDefinition, sourceSlug: string, targetSlug: string ): DashboardDefinition"
+        }
+      ]
+    },
+    {
       "name": "@granit/react-dashboards",
       "description": "React renderer for @granit/dashboards — Dashboard layout component, WidgetRegistry provider, and built-in renderers for Markdown / Image / Text widgets",
       "exports": [

--- a/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/chart-snapshot-widget.test.tsx
@@ -8,7 +8,7 @@ import type { DashboardRenderedWidget } from '@granit/dashboards';
 // jsdom doesn't implement Canvas; ECharts queries it on init. Stub the
 // echarts-for-react module the same way the typed-primitive tests do —
 // we only assert dispatch behaviour, not the rendered Canvas.
-vi.mock('echarts-for-react/lib/core', () => ({
+vi.mock('echarts-for-react/esm/core', () => ({
   default: ({ option }: { readonly option: unknown }) => (
     <div data-testid="echarts-mock" data-option={JSON.stringify(option)} />
   ),

--- a/packages/@granit/react-charts/src/__tests__/line-chart.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/line-chart.test.tsx
@@ -9,7 +9,7 @@ import { SparklineChart } from '../components/sparkline-chart.js';
 import type { ChartSeries } from '@granit/charts';
 
 // jsdom doesn't implement Canvas; ECharts queries it on init. Stub the call.
-vi.mock('echarts-for-react/lib/core', () => ({
+vi.mock('echarts-for-react/esm/core', () => ({
   default: ({ option }: { readonly option: unknown }) => (
     <div data-testid="echarts-mock" data-option={JSON.stringify(option)} />
   ),

--- a/packages/@granit/react-charts/src/components/chart.tsx
+++ b/packages/@granit/react-charts/src/components/chart.tsx
@@ -1,4 +1,11 @@
-import EChartsReactCore from 'echarts-for-react/lib/core';
+// Use the package's ESM entry — the CJS `lib/core` path leaks the
+// `{ default: ... }` shim into Vite's import graph (the `default`
+// property holds the class, not the import binding itself), which
+// surfaces at runtime as
+//   "Element type is invalid... got: object. Check the render method of `Chart`."
+// when the bundler can't unwrap the CJS interop. The ESM path ships a
+// real `export default EChartsReactCore` that Vite consumes verbatim.
+import EChartsReactCore from 'echarts-for-react/esm/core';
 
 import { echarts } from '../echarts-instance.js';
 

--- a/packages/@granit/react-dashboard-editor/package.json
+++ b/packages/@granit/react-dashboard-editor/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@granit/react-dashboard-editor",
+  "description": "React dashboard editor primitives for Granit — drag-and-drop reorderable widget grid built on dnd-kit. Pairs with the read-mode <RenderedDashboard> from @granit/react-dashboards. Frontend half of EPIC #1366 story B5-C (dashboard composer).",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@dnd-kit/core": "^6.3.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@dnd-kit/core": "^6.3.0",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
+    "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboards": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-dashboard-editor/src/__tests__/editable-dashboard.test.tsx
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/editable-dashboard.test.tsx
@@ -1,0 +1,87 @@
+import { defaultWidgetRegistry, WidgetRegistryProvider } from '@granit/react-dashboards';
+import { render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EditableDashboard } from '../components/editable-dashboard.js';
+
+import type { DashboardDefinition } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: { translation: { 'Widget:Test.A': 'A', 'Widget:Test.B': 'B' } },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>{node}</WidgetRegistryProvider>
+    </I18nextProvider>
+  );
+}
+
+const definition: DashboardDefinition = {
+  name: 'Test',
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [
+    {
+      slug: 'A',
+      type: 'text',
+      position: 0,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:Test.A',
+      style: 'Body',
+    },
+    {
+      slug: 'B',
+      type: 'text',
+      position: 1,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:Test.B',
+      style: 'Body',
+    },
+  ],
+};
+
+describe('EditableDashboard — initial render', () => {
+  it('renders one editable cell per widget in position order', () => {
+    const { container } = wrap(<EditableDashboard definition={definition} onChange={vi.fn()} />);
+    const cells = container.querySelectorAll('[data-slot="editable-dashboard-cell"]');
+    expect(cells).toHaveLength(2);
+    expect(cells[0]?.getAttribute('data-widget-slug')).toBe('A');
+    expect(cells[1]?.getAttribute('data-widget-slug')).toBe('B');
+  });
+
+  it('mounts a sortable handle button on every cell with an aria-label', () => {
+    const { container } = wrap(<EditableDashboard definition={definition} onChange={vi.fn()} />);
+    const handles = container.querySelectorAll('[data-slot="sortable-widget-handle"]');
+    expect(handles).toHaveLength(2);
+    expect(handles[0]?.getAttribute('aria-label')).toBe('Drag widget A');
+  });
+
+  it('respects layout.columns on the grid template', () => {
+    const { container } = wrap(<EditableDashboard definition={definition} onChange={vi.fn()} />);
+    const root = container.querySelector('[data-slot="editable-dashboard"]');
+    expect(root).toHaveStyle({ gridTemplateColumns: 'repeat(12, minmax(0, 1fr))' });
+  });
+
+  it('honors the rowHeight prop override', () => {
+    const { container } = wrap(
+      <EditableDashboard definition={definition} onChange={vi.fn()} rowHeight={120} />
+    );
+    const root = container.querySelector('[data-slot="editable-dashboard"]');
+    expect(root).toHaveStyle({ gridAutoRows: '120px' });
+  });
+});

--- a/packages/@granit/react-dashboard-editor/src/__tests__/reorder-widgets.test.ts
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/reorder-widgets.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { reorderWidgets } from '../lib/reorder-widgets.js';
+
+import type { DashboardDefinition } from '@granit/dashboards';
+
+const baseDefinition: DashboardDefinition = {
+  name: 'Test',
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [
+    {
+      slug: 'A',
+      type: 'text',
+      position: 0,
+      size: { width: 4, height: 1 },
+      contentLocalizationKey: 'Widget:A',
+      style: 'Body',
+    },
+    {
+      slug: 'B',
+      type: 'text',
+      position: 1,
+      size: { width: 4, height: 1 },
+      contentLocalizationKey: 'Widget:B',
+      style: 'Body',
+    },
+    {
+      slug: 'C',
+      type: 'text',
+      position: 2,
+      size: { width: 4, height: 1 },
+      contentLocalizationKey: 'Widget:C',
+      style: 'Body',
+    },
+  ],
+};
+
+describe('reorderWidgets', () => {
+  it('moves the source widget to the target position and re-ranks', () => {
+    const next = reorderWidgets(baseDefinition, 'A', 'C');
+    expect(next.widgets.map((w) => w.slug)).toEqual(['B', 'C', 'A']);
+    expect(next.widgets.map((w) => w.position)).toEqual([0, 1, 2]);
+  });
+
+  it('returns the input unchanged when source equals target', () => {
+    const next = reorderWidgets(baseDefinition, 'B', 'B');
+    expect(next).toBe(baseDefinition);
+  });
+
+  it('returns the input unchanged when source is unknown', () => {
+    const next = reorderWidgets(baseDefinition, 'Z', 'A');
+    expect(next).toBe(baseDefinition);
+  });
+
+  it('returns the input unchanged when target is unknown', () => {
+    const next = reorderWidgets(baseDefinition, 'A', 'Z');
+    expect(next).toBe(baseDefinition);
+  });
+
+  it('preserves the dashboard metadata (name, category, layout)', () => {
+    const next = reorderWidgets(baseDefinition, 'A', 'B');
+    expect(next.name).toBe(baseDefinition.name);
+    expect(next.category).toBe(baseDefinition.category);
+    expect(next.layout).toEqual(baseDefinition.layout);
+  });
+
+  it('preserves widget content (only position changes)', () => {
+    const next = reorderWidgets(baseDefinition, 'A', 'C');
+    const moved = next.widgets.find((w) => w.slug === 'A');
+    expect(moved).toMatchObject({
+      slug: 'A',
+      type: 'text',
+      size: { width: 4, height: 1 },
+      contentLocalizationKey: 'Widget:A',
+    });
+  });
+
+  it('produces dense-ranked positions (0-based, contiguous) regardless of input gaps', () => {
+    const sparse: DashboardDefinition = {
+      ...baseDefinition,
+      widgets: baseDefinition.widgets.map((w, i) => ({ ...w, position: i * 10 })),
+    };
+    const next = reorderWidgets(sparse, 'A', 'C');
+    expect(next.widgets.map((w) => w.position)).toEqual([0, 1, 2]);
+  });
+});

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -1,0 +1,127 @@
+import {
+  closestCenter,
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  rectSortingStrategy,
+  SortableContext,
+  sortableKeyboardCoordinates,
+} from '@dnd-kit/sortable';
+import { DashboardContextProvider, WidgetRenderer } from '@granit/react-dashboards';
+import { useMemo, type CSSProperties } from 'react';
+
+import { reorderWidgets } from '../lib/reorder-widgets.js';
+
+import { SortableWidgetCell } from './sortable-widget-cell.js';
+
+import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Editor-mode dashboard. Mirrors the read-mode `<Dashboard>` from
+ * `@granit/react-dashboards` (auto-flow CSS grid, widgets fill cells in
+ * `position` order, each spans its declared `size.width × size.height`),
+ * with two extras:
+ *
+ * - **dnd-kit-driven reorder**: each cell is a sortable item keyed by its
+ *   `slug`. A small drag handle on the top-left initiates the gesture; the
+ *   widget body itself stays interactive (links, popovers, click actions).
+ * - **`onChange` callback**: emits a fresh `DashboardDefinition` whose
+ *   widgets carry recomputed `position` ranks (0-based, contiguous) — ready
+ *   to round-trip through the backend's widget-CRUD endpoints without a
+ *   normalisation pass.
+ *
+ * v1 supports reorder only; resize and add/remove come in B5-C PRs 2 and 3.
+ *
+ * Apps drive saves via React Query mutations on the parent — the editor
+ * stays presentational. The same widget registry the read-mode `<Dashboard>`
+ * consumes drives the renderers here, so a kind that doesn't ship a
+ * renderer surfaces the framework's "Unknown widget type" placeholder
+ * (no special editor-side fallback).
+ */
+export interface EditableDashboardProps {
+  readonly definition: DashboardDefinition;
+  /**
+   * Fires after a successful drag-end. Consumers update local state +
+   * invalidate / persist via their own pipeline.
+   */
+  readonly onChange: (next: DashboardDefinition) => void;
+  readonly className?: string;
+  /** Override the row height (in pixels). Falls back to `definition.layout.rowHeight`. */
+  readonly rowHeight?: number;
+}
+
+export function EditableDashboard({
+  definition,
+  onChange,
+  className,
+  rowHeight,
+}: EditableDashboardProps) {
+  const orderedWidgets = useMemo(
+    () => [...definition.widgets].sort((a, b) => a.position - b.position),
+    [definition.widgets]
+  );
+  const sortableIds = useMemo(() => orderedWidgets.map((w) => w.slug), [orderedWidgets]);
+
+  // PointerSensor with a small activation distance so click-on-handle
+  // doesn't accidentally start a drag every time the user grabs the cell.
+  // KeyboardSensor wires arrow-key reorder for keyboard-only operators.
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const effectiveRowHeight = rowHeight ?? definition.layout.rowHeight;
+
+  const gridStyle: CSSProperties = {
+    display: 'grid',
+    gridAutoFlow: 'dense',
+    gridTemplateColumns: `repeat(${definition.layout.columns}, minmax(0, 1fr))`,
+    gridAutoRows: `${effectiveRowHeight}px`,
+    gap: '1rem',
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const next = reorderWidgets(definition, String(active.id), String(over.id));
+    if (next !== definition) onChange(next);
+  };
+
+  return (
+    <DashboardContextProvider value={{ dashboardName: definition.name }}>
+      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+        <SortableContext items={sortableIds} strategy={rectSortingStrategy}>
+          <div
+            data-slot="editable-dashboard"
+            data-dashboard-name={definition.name}
+            className={className}
+            style={gridStyle}
+          >
+            {orderedWidgets.map((widget) => (
+              <EditableCell key={widget.slug} widget={widget} />
+            ))}
+          </div>
+        </SortableContext>
+      </DndContext>
+    </DashboardContextProvider>
+  );
+}
+
+function EditableCell({ widget }: { readonly widget: WidgetDefinition }) {
+  const cellStyle: CSSProperties = {
+    gridColumn: `span ${widget.size.width}`,
+    gridRow: `span ${widget.size.height}`,
+  };
+  return (
+    <div data-slot="editable-dashboard-cell" data-widget-slug={widget.slug} style={cellStyle}>
+      <SortableWidgetCell id={widget.slug}>
+        <WidgetRenderer widget={widget} />
+      </SortableWidgetCell>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
@@ -1,0 +1,53 @@
+import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import { type ReactNode } from 'react';
+
+/**
+ * Wraps a widget cell in dnd-kit's {@link useSortable} hook so a
+ * {@link DndContext} → {@link SortableContext} parent can drive reordering
+ * by `slug`. The dedicated drag-handle markup (a small grip on the top-left
+ * of the cell) keeps interactive content inside the widget (links, popovers,
+ * chart tooltips) free of pointer hijacking.
+ *
+ * The `id` prop is the widget's `slug` — stable across reorders, matches
+ * the `WidgetDefinitionBase.slug` invariant.
+ */
+export interface SortableWidgetCellProps {
+  readonly id: string;
+  readonly children: ReactNode;
+}
+
+export function SortableWidgetCell({ id, children }: SortableWidgetCellProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.6 : undefined,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      data-slot="sortable-widget-cell"
+      data-widget-slug={id}
+      data-dragging={isDragging || undefined}
+      className="relative"
+    >
+      <button
+        type="button"
+        data-slot="sortable-widget-handle"
+        aria-label={`Drag widget ${id}`}
+        className="absolute left-2 top-2 z-10 cursor-grab rounded-md border bg-card/80 px-1.5 py-0.5 text-xs text-muted-foreground shadow-sm hover:text-foreground active:cursor-grabbing"
+        {...attributes}
+        {...listeners}
+      >
+        ⋮⋮
+      </button>
+      {children}
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/index.ts
+++ b/packages/@granit/react-dashboard-editor/src/index.ts
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------------------
+// @granit/react-dashboard-editor — public API
+// ---------------------------------------------------------------------------
+
+export { EditableDashboard } from './components/editable-dashboard.js';
+export type { EditableDashboardProps } from './components/editable-dashboard.js';
+export { SortableWidgetCell } from './components/sortable-widget-cell.js';
+export type { SortableWidgetCellProps } from './components/sortable-widget-cell.js';
+
+// Pure helpers — exported for tests + custom DnD wrappers
+export { reorderWidgets } from './lib/reorder-widgets.js';

--- a/packages/@granit/react-dashboard-editor/src/lib/reorder-widgets.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/reorder-widgets.ts
@@ -1,0 +1,44 @@
+import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Pure helper used by {@link EditableDashboard} after a sortable drag-end:
+ * given a source slug and a target slug, returns a new
+ * {@link DashboardDefinition} whose widgets are repositioned so the source
+ * widget sits where the target was, with subsequent widgets shifted by one.
+ *
+ * The returned widgets carry a freshly dense-ranked `position` field
+ * (0-based, contiguous) — matches the backend invariant on
+ * `WidgetInstance.Position` so a save round-trip survives without a
+ * re-normalisation pass.
+ *
+ * Edge cases:
+ * - Source slug not found → returns the input definition unchanged.
+ * - Target slug not found → returns the input definition unchanged.
+ * - Source === target → returns the input definition unchanged.
+ *
+ * Exported standalone so tests + custom editor wrappers (e.g. apps shipping
+ * their own DnD layer) can compose the same reorder logic.
+ */
+export function reorderWidgets(
+  definition: DashboardDefinition,
+  sourceSlug: string,
+  targetSlug: string
+): DashboardDefinition {
+  if (sourceSlug === targetSlug) return definition;
+
+  const widgets = [...definition.widgets].sort((a, b) => a.position - b.position);
+  const fromIndex = widgets.findIndex((w) => w.slug === sourceSlug);
+  const toIndex = widgets.findIndex((w) => w.slug === targetSlug);
+  if (fromIndex === -1 || toIndex === -1) return definition;
+
+  const [moved] = widgets.splice(fromIndex, 1);
+  if (!moved) return definition;
+  widgets.splice(toIndex, 0, moved);
+
+  const repositioned: WidgetDefinition[] = widgets.map((widget, index) => ({
+    ...widget,
+    position: index,
+  }));
+
+  return { ...definition, widgets: repositioned };
+}

--- a/packages/@granit/react-dashboard-editor/tsconfig.json
+++ b/packages/@granit/react-dashboard-editor/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-dashboard-editor/tsup.config.ts
+++ b/packages/@granit/react-dashboard-editor/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1100,6 +1100,34 @@ importers:
         specifier: workspace:*
         version: link:../types
 
+  packages/@granit/react-dashboard-editor:
+    dependencies:
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.0
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.5)
+      '@granit/dashboards':
+        specifier: workspace:*
+        version: link:../dashboards
+      '@granit/react-dashboards':
+        specifier: workspace:*
+        version: link:../react-dashboards
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-dashboards:
     dependencies:
       '@tanstack/react-query':
@@ -2541,6 +2569,28 @@ packages:
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -6458,6 +6508,31 @@ snapshots:
   '@csstools/css-tokenizer@4.0.0': {}
 
   '@date-fns/tz@1.4.1': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
## Summary

First slice of **B5-C** (dashboard composer). Adds a new \`@granit/react-dashboard-editor\` package shipping \`<EditableDashboard>\` — the editor-mode counterpart to the existing read-mode \`<Dashboard>\` from \`@granit/react-dashboards\`.

PR sequence (planned):
- **PR 1 [this] — \`<EditableDashboard>\` reorder via drag-and-drop**
- PR 2 — Widget palette sidebar (drag new widgets onto the grid)
- PR 3 — Per-widget config drawer (per-kind config forms)
- PR 4 — Showcase wiring: \`/admin/dashboards\` list page + \`/admin/dashboards/{id}/edit\` builder page (B4-write CRUD)

## Architecture

### New package \`@granit/react-dashboard-editor\`

Mirrors the optional-dep pattern of \`@granit/react-charts\` (ECharts) and \`@granit/react-map\` (Leaflet) — apps that don't ship the editor don't pay the dnd-kit bundle weight.

Peer deps:
- \`@dnd-kit/core ^6.3.0\` (MIT, React 19-compatible drag primitives)
- \`@dnd-kit/sortable ^10.0.0\` (sortable strategies)
- \`@dnd-kit/utilities ^3.2.2\` (CSS transform helper)
- \`@granit/dashboards\` + \`@granit/react-dashboards\` (workspace types + registry)

### \`<EditableDashboard>\`

\`\`\`tsx
export function DashboardEditorPage({ id }) {
  const [definition, setDefinition] = useState(initialDefinition);
  return (
    <EditableDashboard
      definition={definition}
      onChange={(next) => {
        setDefinition(next);
        // Apps invalidate / persist via their own React Query mutation pipeline.
      }}
    />
  );
}
\`\`\`

- Mirrors the \`<Dashboard>\` auto-flow CSS grid layout (widgets fill cells in \`position\` order with declared \`size.width × size.height\` spans).
- Each cell wraps in \`<SortableWidgetCell>\` — a drag handle on the top-left initiates the gesture; the widget body itself stays interactive so links / popovers / chart tooltips don't pointer-hijack.
- \`onChange\` fires after a successful drag-end with a fresh \`DashboardDefinition\`. The widgets carry **dense-ranked \`position\`** values (0-based, contiguous) ready to round-trip through the backend's widget-CRUD endpoints without normalisation.

### \`reorderWidgets(definition, sourceSlug, targetSlug)\` — pure helper

Exported standalone so tests + custom editor wrappers (apps shipping their own DnD layer) can compose the same logic. Edge cases pinned by tests:
- \`source === target\` → returns input unchanged (referential).
- Unknown source / target slug → returns input unchanged.
- Sparse positions (\`[0, 10, 20]\`) → emits dense ranks (\`[0, 1, 2]\`).

## Hotfix bundled in this PR

\`packages/@granit/react-charts/src/components/chart.tsx\`:

\`\`\`diff
- import EChartsReactCore from 'echarts-for-react/lib/core';
+ import EChartsReactCore from 'echarts-for-react/esm/core';
\`\`\`

The CJS path leaked the \`{ default: ... }\` interop wrapper through Vite's import graph (the \`default\` property held the class, not the import binding itself). At runtime this surfaced as:

\`> Element type is invalid... got: object. Check the render method of \`Chart\`.\`

The ESM path ships a real \`export default EChartsReactCore\` Vite consumes verbatim. Test mocks updated to match.

## Tests (+11, total 2427 / 2427 ✓)

- \`reorder-widgets.test.ts\` — 7 tests on the pure helper (move semantics, dense ranking, edge cases, metadata preservation).
- \`editable-dashboard.test.tsx\` — 4 tests on the rendered surface (cell-per-widget order, drag-handle aria-label, grid columns, rowHeight override).

dnd-kit's pointer-driven drag is hard to drive in jsdom; the \`onDragEnd\` integration test will land alongside PR 4 (showcase wiring) where playwright covers it end-to-end.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2427 / 2427** ✓ (+11 new, +5 pre-existing chart tests fixed by the ESM hotfix)