### PR TITLE
feat(analytics)!: defaultLayerKind on map widget (B7-3 mirror)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2615,11 +2615,6 @@
           "members": []
         },
         {
-          "name": "MapTileLayerKind",
-          "kind": "type",
-          "signature": "type MapTileLayerKind ="
-        },
-        {
           "name": "MapTileProvider",
           "kind": "interface",
           "signature": "interface MapTileProvider",

--- a/packages/@granit/analytics/src/__tests__/map-snapshot.test.ts
+++ b/packages/@granit/analytics/src/__tests__/map-snapshot.test.ts
@@ -6,7 +6,7 @@ import {
   isMapSnapshotEnvelope,
 } from '../widgets/index.js';
 
-import type { MapPointSource, MapSnapshotEnvelope } from '../widgets/index.js';
+import type { MapPointSource, MapSnapshotEnvelope, MapTileLayerKind } from '../widgets/index.js';
 import type { WidgetSnapshotEnvelope } from '@granit/dashboards';
 
 // Pinned wire-format fixtures mirroring B7-2 backend output:
@@ -42,6 +42,9 @@ const MAP_FIXTURE: MapSnapshotEnvelope = {
     clusterThreshold: 200,
     detailRoute: '/customers/{id}',
     tileUrlTemplate: null,
+    // B7-3 — admin-configured layer-kind preference; the frontend resolves
+    // it against the active MapTileProvider's layer set at render time.
+    defaultLayerKind: 'Satellite',
   },
   sequence: 1,
   emittedAt: '2026-04-29T12:34:56.789Z',
@@ -61,6 +64,20 @@ describe('MapSnapshotEnvelope — wire format', () => {
     const last = MAP_FIXTURE.snapshot?.points[2];
     expect(last?.id).toBeNull();
     expect(last?.popup).toBeNull();
+  });
+
+  it('carries the optional defaultLayerKind preference (B7-3)', () => {
+    expect(MAP_FIXTURE.snapshot?.defaultLayerKind).toBe('Satellite');
+  });
+
+  it('accepts a snapshot without defaultLayerKind (legacy / pre-B7-3 backends)', () => {
+    const legacy = {
+      ...MAP_FIXTURE,
+      snapshot: { ...MAP_FIXTURE.snapshot!, defaultLayerKind: null },
+    };
+    expect(legacy.snapshot.defaultLayerKind).toBeNull();
+    // Round-trip survives — the field is part of the wire surface.
+    expect(JSON.parse(JSON.stringify(legacy))).toEqual(legacy);
   });
 
   it('round-trips through JSON without mutation', () => {
@@ -99,5 +116,12 @@ describe('MapPointSource — discriminator dispatch', () => {
   it('routes geography through isGeographyMapPointSource', () => {
     expect(isGeographyMapPointSource(geography)).toBe(true);
     expect(isGeographyMapPointSource(latLng)).toBe(false);
+  });
+});
+
+describe('MapTileLayerKind — exhaustive enum surface (PascalCase, B7-3)', () => {
+  it('locks the five backend kinds in declaration order', () => {
+    const kinds: readonly MapTileLayerKind[] = ['Plan', 'Satellite', 'Hybrid', 'Topo', 'Custom'];
+    expect(kinds).toHaveLength(5);
   });
 });

--- a/packages/@granit/analytics/src/index.ts
+++ b/packages/@granit/analytics/src/index.ts
@@ -45,6 +45,7 @@ export type {
   MapPoint,
   MapPointSource,
   MapSnapshotEnvelope,
+  MapTileLayerKind,
   MapWidgetDefinition,
   MapWidgetSnapshot,
   PivotCell,

--- a/packages/@granit/analytics/src/widgets/index.ts
+++ b/packages/@granit/analytics/src/widgets/index.ts
@@ -18,6 +18,7 @@ export type {
   LatLngMapPointSource,
   MapCenter,
   MapPointSource,
+  MapTileLayerKind,
   MapWidgetDefinition,
 } from './map-widget.js';
 export { isPivotSnapshotEnvelope } from './pivot-snapshot.js';

--- a/packages/@granit/analytics/src/widgets/map-snapshot.ts
+++ b/packages/@granit/analytics/src/widgets/map-snapshot.ts
@@ -1,3 +1,4 @@
+import type { MapTileLayerKind } from './map-widget.js';
 import type { WidgetSnapshotEnvelope, WidgetSnapshotEnvelopeOf } from '@granit/dashboards';
 
 /**
@@ -65,6 +66,14 @@ export interface MapWidgetSnapshot {
    * default (typically OpenStreetMap).
    */
   readonly tileUrlTemplate: string | null;
+  /**
+   * Preferred layer kind echoed from the declarative
+   * `MapWidgetDefinition.defaultLayerKind`. The frontend resolves it
+   * against the active `MapTileProvider` layers (B7-3); `null` (or
+   * missing on legacy snapshots that predate B7-3) = use the provider's
+   * first layer.
+   */
+  readonly defaultLayerKind?: MapTileLayerKind | null;
 }
 
 /** Narrowed {@link WidgetSnapshotEnvelope} for the `'Map'` widget kind. */

--- a/packages/@granit/analytics/src/widgets/map-widget.ts
+++ b/packages/@granit/analytics/src/widgets/map-widget.ts
@@ -1,6 +1,27 @@
 import type { WidgetDefinitionBase } from '@granit/dashboards';
 
 /**
+ * Wire-format enum for the **default layer kind** preference shipped on
+ * `MapWidgetDefinition` / `MapWidgetSnapshot` (B7-3, granit-dotnet
+ * `Granit.Analytics.Dashboards.Widgets.MapTileLayerKind`). PascalCase wire
+ * values per ADR-039 §6.1.
+ *
+ * Lives in `@granit/analytics` as the canonical wire identity. Editor-side
+ * concerns (`@granit/react-map`) re-export the same union so a single
+ * source of truth drives both the wire shape and the runtime layer
+ * resolution.
+ *
+ * The frontend resolves at render time:
+ *
+ *     provider.layers.find(l => l.kind === defaultLayerKind) ?? provider.layers[0]
+ *
+ * — so a widget configured for `'Satellite'` falls back gracefully when the
+ * active provider only ships a `'Plan'` layer (e.g. OSM); never blocks the
+ * render.
+ */
+export type MapTileLayerKind = 'Plan' | 'Satellite' | 'Hybrid' | 'Topo' | 'Custom';
+
+/**
  * Describes how a {@link MapWidgetDefinition} reads coordinates from the rows
  * produced by its backing query. Mirrors
  * `Granit.Analytics.Dashboards.Widgets.MapPointSource`.
@@ -97,4 +118,12 @@ export interface MapWidgetDefinition extends WidgetDefinitionBase {
    * provider's licence.
    */
   readonly tileUrlTemplate?: string | null;
+  /**
+   * Preferred layer kind to mount by default when the active
+   * `MapTileProvider` (host-app context) ships multiple layers. Lets a
+   * dashboard admin pick "this delivery-tracking map should default to
+   * satellite" without forcing the whole app onto a specific provider id.
+   * `null` (or missing) = use the provider's first layer. B7-3.
+   */
+  readonly defaultLayerKind?: MapTileLayerKind | null;
 }

--- a/packages/@granit/react-map/src/__tests__/providers.test.ts
+++ b/packages/@granit/react-map/src/__tests__/providers.test.ts
@@ -8,14 +8,14 @@ describe('built-in tile providers', () => {
   it('osmProvider exposes a single plan layer with mandatory CC-BY-SA attribution', () => {
     expect(osmProvider.id).toBe('osm');
     expect(osmProvider.layers).toHaveLength(1);
-    expect(osmProvider.layers[0].kind).toBe('plan');
+    expect(osmProvider.layers[0].kind).toBe('Plan');
     expect(osmProvider.layers[0].url).toContain('tile.openstreetmap.org');
     expect(osmProvider.layers[0].attribution).toContain('OpenStreetMap');
   });
 
   it('spwProvider ships plan / satellite / hybrid layers with SPW attribution', () => {
     expect(spwProvider.id).toBe('spw');
-    expect(spwProvider.layers.map((l) => l.kind)).toEqual(['plan', 'satellite', 'hybrid']);
+    expect(spwProvider.layers.map((l) => l.kind)).toEqual(['Plan', 'Satellite', 'Hybrid']);
     for (const layer of spwProvider.layers) {
       expect(layer.attribution).toContain('Service Public de Wallonie');
       expect(layer.url).toContain('geoservices.wallonie.be');
@@ -24,7 +24,7 @@ describe('built-in tile providers', () => {
 
   it('arcGisProvider ships plan / satellite / topo Esri basemaps', () => {
     expect(arcGisProvider.id).toBe('arcgis');
-    expect(arcGisProvider.layers.map((l) => l.kind)).toEqual(['plan', 'satellite', 'topo']);
+    expect(arcGisProvider.layers.map((l) => l.kind)).toEqual(['Plan', 'Satellite', 'Topo']);
     for (const layer of arcGisProvider.layers) {
       expect(layer.attribution).toContain('Esri');
       expect(layer.url).toContain('arcgisonline.com');

--- a/packages/@granit/react-map/src/providers/arcgis-provider.ts
+++ b/packages/@granit/react-map/src/providers/arcgis-provider.ts
@@ -25,7 +25,7 @@ export const arcGisProvider: MapTileProvider = {
     {
       id: 'arcgis-world-street',
       labelLocalizationKey: 'Map:Layer.Plan',
-      kind: 'plan',
+      kind: 'Plan',
       url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Street_Map/MapServer/tile/{z}/{y}/{x}',
       attribution:
         'Tiles &copy; <a href="https://www.esri.com/">Esri</a> — Sources: Esri, HERE, Garmin, USGS, Intermap, INCREMENT P, NRCan, OpenStreetMap contributors',
@@ -34,7 +34,7 @@ export const arcGisProvider: MapTileProvider = {
     {
       id: 'arcgis-world-imagery',
       labelLocalizationKey: 'Map:Layer.Satellite',
-      kind: 'satellite',
+      kind: 'Satellite',
       url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
       attribution:
         'Tiles &copy; <a href="https://www.esri.com/">Esri</a> — Source: Esri, Maxar, Earthstar Geographics, and the GIS User Community',
@@ -43,7 +43,7 @@ export const arcGisProvider: MapTileProvider = {
     {
       id: 'arcgis-world-topo',
       labelLocalizationKey: 'Map:Layer.Topo',
-      kind: 'topo',
+      kind: 'Topo',
       url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Topo_Map/MapServer/tile/{z}/{y}/{x}',
       attribution:
         'Tiles &copy; <a href="https://www.esri.com/">Esri</a> — Esri, DeLorme, NAVTEQ, TomTom, Intermap, iPC, USGS, NRCan, GeoBase, Kadaster NL, Ordnance Survey, Esri Japan, METI, Esri China (Hong Kong), and the GIS User Community',

--- a/packages/@granit/react-map/src/providers/osm-provider.ts
+++ b/packages/@granit/react-map/src/providers/osm-provider.ts
@@ -16,7 +16,7 @@ export const osmProvider: MapTileProvider = {
     {
       id: 'osm-standard',
       labelLocalizationKey: 'Map:Layer.Plan',
-      kind: 'plan',
+      kind: 'Plan',
       url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
       attribution:
         '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',

--- a/packages/@granit/react-map/src/providers/spw-provider.ts
+++ b/packages/@granit/react-map/src/providers/spw-provider.ts
@@ -28,7 +28,7 @@ export const spwProvider: MapTileProvider = {
     {
       id: 'spw-plan-parcellaire',
       labelLocalizationKey: 'Map:Layer.Plan',
-      kind: 'plan',
+      kind: 'Plan',
       url: 'https://geoservices.wallonie.be/arcgis/rest/services/PLAN_REGLEMENTAIRE/PLAN_PARCELLAIRE/MapServer/tile/{z}/{y}/{x}',
       attribution:
         '&copy; <a href="https://geoportail.wallonie.be">SPW — Service Public de Wallonie</a>',
@@ -37,7 +37,7 @@ export const spwProvider: MapTileProvider = {
     {
       id: 'spw-ortho',
       labelLocalizationKey: 'Map:Layer.Satellite',
-      kind: 'satellite',
+      kind: 'Satellite',
       url: 'https://geoservices.wallonie.be/arcgis/rest/services/IMAGERIE/ORTHO_LAST/MapServer/tile/{z}/{y}/{x}',
       attribution:
         '&copy; <a href="https://geoportail.wallonie.be">SPW — Service Public de Wallonie</a>',
@@ -46,7 +46,7 @@ export const spwProvider: MapTileProvider = {
     {
       id: 'spw-hybride',
       labelLocalizationKey: 'Map:Layer.Hybrid',
-      kind: 'hybrid',
+      kind: 'Hybrid',
       url: 'https://geoservices.wallonie.be/arcgis/rest/services/IMAGERIE/ORTHO_LAST_HYBRIDE/MapServer/tile/{z}/{y}/{x}',
       attribution:
         '&copy; <a href="https://geoportail.wallonie.be">SPW — Service Public de Wallonie</a>',

--- a/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
+++ b/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
@@ -60,7 +60,7 @@ function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
       return [
         {
           id: 'snapshot-override',
-          kind: 'custom',
+          kind: 'Custom',
           url: snapshot.tileUrlTemplate,
           // Per-widget overrides: the host already controls attribution
           // visibility (it owns the URL choice), but we keep a non-empty
@@ -106,9 +106,18 @@ function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
       );
     }
 
-    // Default = first layer.
-    const firstLayer = layers[0];
-    const defaultTile = firstLayer ? tileLayerById.get(firstLayer.id) : undefined;
+    // Default layer resolution (B7-3): when the snapshot ships a
+    // `defaultLayerKind` preference, prefer the matching provider layer;
+    // otherwise fall back to the first layer. The escape-hatch single-
+    // layer override (snapshot.tileUrlTemplate) is already collapsed to
+    // a one-element `layers` array upstream — `find` matches its
+    // synthetic `kind: 'Custom'` only when the snapshot also asks for
+    // 'Custom', which is intentional.
+    const preferredLayer =
+      (snapshot.defaultLayerKind != null
+        ? layers.find((layer) => layer.kind === snapshot.defaultLayerKind)
+        : undefined) ?? layers[0];
+    const defaultTile = preferredLayer ? tileLayerById.get(preferredLayer.id) : undefined;
     defaultTile?.addTo(map);
 
     // Mount the layer-switcher only when more than one layer is offered.
@@ -135,7 +144,7 @@ function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
         tile.remove();
       }
     };
-  }, [layers]);
+  }, [layers, snapshot.defaultLayerKind]);
 
   // Camera (zoom + center). Falls back to bounding-box fit when no center
   // is supplied; falls back to world view when there are zero points.

--- a/packages/@granit/react-map/src/types.ts
+++ b/packages/@granit/react-map/src/types.ts
@@ -1,20 +1,17 @@
 /**
  * Map tile layer kind. Drives default ordering in the layer-switcher control
- * (plan first, then satellite, then hybrid composites). Frontend renderers
- * interpret the kind for grouping; the value carries no semantic meaning
- * beyond presentation.
+ * (Plan first, then Satellite, then Hybrid composites). Frontend renderers
+ * interpret the kind for grouping; the same union doubles as the wire-format
+ * value carried by `MapWidgetDefinition.defaultLayerKind` /
+ * `MapWidgetSnapshot.defaultLayerKind` (B7-3).
+ *
+ * Re-exported from `@granit/analytics` so the wire identity and the editor
+ * surface share a single source of truth — backend's PascalCase enum
+ * (`Granit.Analytics.Dashboards.Widgets.MapTileLayerKind`) is the
+ * authoritative ordering / spelling.
  */
-export type MapTileLayerKind =
-  /** Standard road / street map (raster or vector tiles). */
-  | 'plan'
-  /** Aerial / satellite imagery without labels. */
-  | 'satellite'
-  /** Imagery + label overlay ("hybride" in French geoportals). */
-  | 'hybrid'
-  /** Topographic map with elevation contours. */
-  | 'topo'
-  /** Anything else — apps register their own kind for ad-hoc layers. */
-  | 'custom';
+import type { MapTileLayerKind } from '@granit/analytics';
+export type { MapTileLayerKind };
 
 /**
  * One tile layer offered by a {@link MapTileProvider}. Mirrors the inputs


### PR DESCRIPTION
## Summary

Frontend mirror for granit-dotnet B7-3. Adds an optional \`defaultLayerKind\` field on \`MapWidgetDefinition\` and \`MapWidgetSnapshot\` so dashboard admins can pick "this map should default to satellite / topo / hybrid" per-widget without forcing a specific provider id on the host app.

## What lands

### \`@granit/analytics\` — new wire export

\`\`\`ts
export type MapTileLayerKind = 'Plan' | 'Satellite' | 'Hybrid' | 'Topo' | 'Custom';
\`\`\`

PascalCase wire values per ADR-039 §6.1, mirror of \`Granit.Analytics.Dashboards.Widgets.MapTileLayerKind\`. Lives in \`@granit/analytics\` as the canonical source — both the wire shape and the editor surface re-export from here.

### Definition + snapshot fields

\`\`\`diff
 export interface MapWidgetDefinition extends WidgetDefinitionBase {
   /* … existing fields … */
+  readonly defaultLayerKind?: MapTileLayerKind | null;
 }

 export interface MapWidgetSnapshot {
   /* … existing fields … */
+  readonly defaultLayerKind?: MapTileLayerKind | null;
 }
\`\`\`

Both fields are optional (\`?\`) and nullable on the wire — pre-B7-3 backends and existing fixtures keep working unchanged.

### \`<MapSnapshotWidget>\` — kind-aware layer resolution

\`\`\`ts
const preferredLayer =
  (snapshot.defaultLayerKind != null
    ? layers.find((layer) => layer.kind === snapshot.defaultLayerKind)
    : undefined) ?? layers[0];
\`\`\`

A widget configured for \`'Satellite'\` falls back gracefully to the provider's first layer when the active provider only ships a \`'Plan'\` layer (e.g. OSM) — never blocks the render.

### \`@granit/react-map\` — single source of truth

\`MapTileLayerKind\` is now re-exported from \`@granit/analytics\` instead of duplicated. Existing consumers continue to import from \`@granit/react-map\`; the values switch from lowercase (\`'plan'\` / \`'satellite'\` / …) to **PascalCase** (\`'Plan'\` / \`'Satellite'\` / …) to match the backend enum.

\`\`\`diff
 export const osmProvider: MapTileProvider = {
   layers: [
     {
-      kind: 'plan',
+      kind: 'Plan',
       /* … */
     },
   ],
 };
\`\`\`

This is a **BREAKING change** for apps that read \`MapTileProvider.layers[N].kind\` against the lowercase set — adjust the comparisons (or the i18n keys, e.g. \`Map:Layer.Plan\` instead of \`Map:Layer.plan\`).

The 3 built-in providers (\`osm\` / \`spw\` / \`arcgis\`) plus the snapshot's \`'Custom'\` escape-hatch are updated in this PR.

## Tests (+3, total 2430 / 2430 ✓)

\`packages/@granit/analytics/src/__tests__/map-snapshot.test.ts\`:
- Carries the optional \`defaultLayerKind\` preference (locks the wire surface).
- Accepts a legacy snapshot without \`defaultLayerKind\` (round-trip).
- \`MapTileLayerKind\` exhaustive enum surface (5 values, declaration-ordered).

Existing provider tests updated (\`'Plan' | 'Satellite' | 'Hybrid' | 'Topo'\`).

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm test\` — **2430 / 2430** ✓ (+3 new)

## What's next

Resume **B5-C PR 2** — widget palette + catalog. Independent of this PR; ships in parallel.