### PR TITLE
feat(react-dashboard-editor): widget palette + catalog primitives (B5-C PR 2)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2099,9 +2099,41 @@
           "members": []
         },
         {
+          "name": "WidgetPalette",
+          "kind": "function",
+          "signature": "function WidgetPalette("
+        },
+        {
+          "name": "WidgetPaletteProps",
+          "kind": "interface",
+          "signature": "interface WidgetPaletteProps",
+          "members": []
+        },
+        {
           "name": "reorderWidgets",
           "kind": "function",
           "signature": "function reorderWidgets( definition: DashboardDefinition, sourceSlug: string, targetSlug: string ): DashboardDefinition"
+        },
+        {
+          "name": "addWidget",
+          "kind": "function",
+          "signature": "function addWidget<TDefinition extends"
+        },
+        {
+          "name": "composeCatalogs",
+          "kind": "function",
+          "signature": "function composeCatalogs( ...catalogs: readonly (readonly WidgetCatalogEntry[])[] ): readonly WidgetCatalogEntry[]"
+        },
+        {
+          "name": "defaultWidgetCatalog",
+          "kind": "const",
+          "signature": "const defaultWidgetCatalog: readonly WidgetCatalogEntry[]"
+        },
+        {
+          "name": "WidgetCatalogEntry",
+          "kind": "interface",
+          "signature": "interface WidgetCatalogEntry",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-dashboard-editor/package.json
+++ b/packages/@granit/react-dashboard-editor/package.json
@@ -19,7 +19,8 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@granit/dashboards": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-dashboard-editor/src/__tests__/widget-catalog.test.ts
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/widget-catalog.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+
+import { addWidget, composeCatalogs, defaultWidgetCatalog } from '../lib/widget-catalog.js';
+
+import type { WidgetCatalogEntry } from '../lib/widget-catalog.js';
+import type { DashboardDefinition } from '@granit/dashboards';
+
+const baseDefinition: DashboardDefinition = {
+  name: 'Test',
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [],
+};
+
+describe('defaultWidgetCatalog', () => {
+  it('ships entries for the framework widget kinds (markdown / text / image)', () => {
+    const types = defaultWidgetCatalog.map((entry) => entry.type);
+    expect(types).toEqual(['markdown', 'text', 'image']);
+  });
+
+  it('factories produce widgets whose declared type matches the entry', () => {
+    for (const entry of defaultWidgetCatalog) {
+      const created = entry.createDefaultWidget('Tmp', 0);
+      expect(created.type).toBe(entry.type);
+      expect(created.slug).toBe('Tmp');
+      expect(created.position).toBe(0);
+    }
+  });
+});
+
+describe('composeCatalogs', () => {
+  const a: WidgetCatalogEntry = {
+    type: 'a',
+    labelLocalizationKey: 'a.label',
+    defaultSize: { width: 1, height: 1 },
+    createDefaultWidget: (slug, position) => ({
+      slug,
+      type: 'a',
+      position,
+      size: { width: 1, height: 1 },
+    }),
+  };
+  const b: WidgetCatalogEntry = {
+    type: 'b',
+    labelLocalizationKey: 'b.label',
+    defaultSize: { width: 2, height: 1 },
+    createDefaultWidget: (slug, position) => ({
+      slug,
+      type: 'b',
+      position,
+      size: { width: 2, height: 1 },
+    }),
+  };
+  const aOverride: WidgetCatalogEntry = { ...a, labelLocalizationKey: 'a.override' };
+
+  it('merges multiple catalogs', () => {
+    const merged = composeCatalogs([a], [b]);
+    expect(merged.map((e) => e.type)).toEqual(['a', 'b']);
+  });
+
+  it('lets later catalogs override earlier ones on type collision', () => {
+    const merged = composeCatalogs([a], [aOverride]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.labelLocalizationKey).toBe('a.override');
+  });
+
+  it('returns a frozen array', () => {
+    const merged = composeCatalogs([a]);
+    expect(Object.isFrozen(merged)).toBe(true);
+  });
+});
+
+describe('addWidget', () => {
+  const markdownEntry = defaultWidgetCatalog.find((e) => e.type === 'markdown');
+  const textEntry = defaultWidgetCatalog.find((e) => e.type === 'text');
+
+  it('appends a new widget at the next position', () => {
+    if (!markdownEntry) throw new Error('markdown entry missing');
+    const next = addWidget(baseDefinition, markdownEntry);
+    expect(next.widgets).toHaveLength(1);
+    expect(next.widgets[0]?.position).toBe(0);
+    expect(next.widgets[0]?.type).toBe('markdown');
+  });
+
+  it('mints a unique slug derived from the entry type, suffixed with the lowest free integer', () => {
+    if (!markdownEntry) throw new Error('markdown entry missing');
+    const once = addWidget(baseDefinition, markdownEntry);
+    const twice = addWidget(once, markdownEntry);
+    expect(once.widgets[0]?.slug).toBe('Markdown1');
+    expect(twice.widgets[1]?.slug).toBe('Markdown2');
+  });
+
+  it('skips slugs that already exist (gap-tolerant)', () => {
+    if (!markdownEntry) throw new Error('markdown entry missing');
+    const seeded: DashboardDefinition = {
+      ...baseDefinition,
+      widgets: [
+        {
+          slug: 'Markdown1',
+          type: 'markdown',
+          position: 0,
+          size: { width: 12, height: 1 },
+          contentLocalizationKey: 'Widget:Markdown1.Content',
+        },
+        {
+          slug: 'Markdown3',
+          type: 'markdown',
+          position: 1,
+          size: { width: 12, height: 1 },
+          contentLocalizationKey: 'Widget:Markdown3.Content',
+        },
+      ],
+    };
+    const next = addWidget(seeded, markdownEntry);
+    expect(next.widgets[2]?.slug).toBe('Markdown2');
+  });
+
+  it('forces the entry-declared default size onto the created widget', () => {
+    if (!textEntry) throw new Error('text entry missing');
+    const rogueEntry: WidgetCatalogEntry = {
+      ...textEntry,
+      defaultSize: { width: 4, height: 2 },
+      createDefaultWidget: (slug, position) => ({
+        slug,
+        type: 'text',
+        position,
+        // The factory accidentally returns a different size — addWidget
+        // must re-stamp it from the catalog entry to keep the two in sync.
+        size: { width: 99, height: 99 },
+        contentLocalizationKey: `Widget:${slug}.Content`,
+        style: 'Body',
+      }),
+    };
+    const next = addWidget(baseDefinition, rogueEntry);
+    expect(next.widgets[0]?.size).toEqual({ width: 4, height: 2 });
+  });
+
+  it('does not mutate the input definition', () => {
+    if (!markdownEntry) throw new Error('markdown entry missing');
+    const before = baseDefinition.widgets;
+    addWidget(baseDefinition, markdownEntry);
+    expect(baseDefinition.widgets).toBe(before);
+    expect(baseDefinition.widgets).toHaveLength(0);
+  });
+});

--- a/packages/@granit/react-dashboard-editor/src/__tests__/widget-palette.test.tsx
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/widget-palette.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WidgetPalette } from '../components/widget-palette.js';
+import { defaultWidgetCatalog } from '../lib/widget-catalog.js';
+
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        'Dashboard:Widget.Markdown.Label': 'Markdown',
+        'Dashboard:Widget.Text.Label': 'Text',
+        'Dashboard:Widget.Image.Label': 'Image',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+}
+
+describe('WidgetPalette', () => {
+  it('renders one button per catalog entry, labelled via i18n', () => {
+    const { container } = wrap(<WidgetPalette catalog={defaultWidgetCatalog} onAdd={vi.fn()} />);
+    const buttons = container.querySelectorAll('[data-slot="widget-palette-item"]');
+    expect(buttons).toHaveLength(3);
+    expect(buttons[0]?.textContent).toContain('Markdown');
+    expect(buttons[1]?.textContent).toContain('Text');
+    expect(buttons[2]?.textContent).toContain('Image');
+  });
+
+  it('tags each button with the widget type for downstream styling / e2e selectors', () => {
+    const { container } = wrap(<WidgetPalette catalog={defaultWidgetCatalog} onAdd={vi.fn()} />);
+    const types = Array.from(container.querySelectorAll('[data-slot="widget-palette-item"]')).map(
+      (b) => b.getAttribute('data-widget-type')
+    );
+    expect(types).toEqual(['markdown', 'text', 'image']);
+  });
+
+  it('invokes onAdd with the matching entry when a button is clicked', () => {
+    const onAdd = vi.fn();
+    const { container } = wrap(<WidgetPalette catalog={defaultWidgetCatalog} onAdd={onAdd} />);
+    const markdownButton = container.querySelector(
+      '[data-slot="widget-palette-item"][data-widget-type="markdown"]'
+    );
+    if (!(markdownButton instanceof HTMLElement)) {
+      throw new Error('markdown button not found');
+    }
+    fireEvent.click(markdownButton);
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd.mock.calls[0]?.[0]?.type).toBe('markdown');
+  });
+
+  it('renders an icon span only when iconKey is set on the entry', () => {
+    const { container } = wrap(
+      <WidgetPalette
+        catalog={[
+          {
+            type: 'plain',
+            labelLocalizationKey: 'Plain',
+            defaultSize: { width: 1, height: 1 },
+            createDefaultWidget: (slug, position) => ({
+              slug,
+              type: 'plain',
+              position,
+              size: { width: 1, height: 1 },
+            }),
+          },
+        ]}
+        onAdd={vi.fn()}
+      />
+    );
+    const icons = container.querySelectorAll('[data-slot="widget-palette-icon"]');
+    expect(icons).toHaveLength(0);
+  });
+
+  it('exposes a toolbar role with an aria-label for assistive tech', () => {
+    const { container } = wrap(<WidgetPalette catalog={defaultWidgetCatalog} onAdd={vi.fn()} />);
+    const toolbar = container.querySelector('[data-slot="widget-palette"]');
+    expect(toolbar?.getAttribute('role')).toBe('toolbar');
+    expect(toolbar?.getAttribute('aria-label')).toBe('Widget palette');
+  });
+});

--- a/packages/@granit/react-dashboard-editor/src/components/widget-palette.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/widget-palette.tsx
@@ -1,0 +1,53 @@
+import { useTranslation } from 'react-i18next';
+
+import type { WidgetCatalogEntry } from '../lib/widget-catalog.js';
+
+/**
+ * Editor-side palette listing the widget kinds an app exposes. Each entry
+ * surfaces a click-to-add button: pressing it invokes `onAdd(entry)`,
+ * which the parent typically routes through {@link addWidget} to mutate
+ * the dashboard definition under edit.
+ *
+ * Drag-from-palette (drop a button into the grid to insert at a specific
+ * position) is deferred — keeps the v1 surface tight and avoids a second
+ * round of dnd-kit choreography. Apps wanting drag-to-add wrap their own
+ * `<DndContext>` around `<EditableDashboard>` + `<WidgetPalette>` and
+ * register palette items as additional sortable sources.
+ *
+ * Labels resolve through `useTranslation()` — when the localization key
+ * is missing from the bundle, i18next falls back to the key itself, so
+ * dev-mode without translations still surfaces a readable button.
+ */
+export interface WidgetPaletteProps {
+  readonly catalog: readonly WidgetCatalogEntry[];
+  readonly onAdd: (entry: WidgetCatalogEntry) => void;
+  readonly className?: string;
+}
+
+export function WidgetPalette({ catalog, onAdd, className }: WidgetPaletteProps) {
+  const { t } = useTranslation();
+  return (
+    <div
+      data-slot="widget-palette"
+      role="toolbar"
+      aria-label="Widget palette"
+      className={className}
+    >
+      {catalog.map((entry) => (
+        <button
+          key={entry.type}
+          type="button"
+          data-slot="widget-palette-item"
+          data-widget-type={entry.type}
+          onClick={() => onAdd(entry)}
+          className="inline-flex items-center gap-2 rounded-md border bg-card px-3 py-1.5 text-sm shadow-sm hover:bg-accent"
+        >
+          {entry.iconKey ? (
+            <span data-slot="widget-palette-icon" data-icon-key={entry.iconKey} aria-hidden />
+          ) : null}
+          <span data-slot="widget-palette-label">{t(entry.labelLocalizationKey)}</span>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/index.ts
+++ b/packages/@granit/react-dashboard-editor/src/index.ts
@@ -6,6 +6,10 @@ export { EditableDashboard } from './components/editable-dashboard.js';
 export type { EditableDashboardProps } from './components/editable-dashboard.js';
 export { SortableWidgetCell } from './components/sortable-widget-cell.js';
 export type { SortableWidgetCellProps } from './components/sortable-widget-cell.js';
+export { WidgetPalette } from './components/widget-palette.js';
+export type { WidgetPaletteProps } from './components/widget-palette.js';
 
-// Pure helpers — exported for tests + custom DnD wrappers
+// Pure helpers — exported for tests + custom palette / DnD wrappers
 export { reorderWidgets } from './lib/reorder-widgets.js';
+export { addWidget, composeCatalogs, defaultWidgetCatalog } from './lib/widget-catalog.js';
+export type { WidgetCatalogEntry } from './lib/widget-catalog.js';

--- a/packages/@granit/react-dashboard-editor/src/lib/widget-catalog.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/widget-catalog.ts
@@ -1,0 +1,175 @@
+import { WIDGET_SIZE } from '@granit/dashboards';
+
+import type { WidgetDefinition, WidgetSize } from '@granit/dashboards';
+
+/**
+ * Descriptor an editor uses to surface "add widget" buttons in a
+ * {@link WidgetPalette}. One entry per widget kind the host app exposes —
+ * downstream packages contribute their own (analytics ships entries for
+ * `kpi` / `chart` / `table` / `pivot` / `map`, etc.).
+ *
+ * Stays parallel to the read-mode `WidgetRegistry`: the registry maps
+ * `type` → renderer, the catalog maps `type` → "how to add a fresh one".
+ * Same composition pattern via {@link composeCatalogs}.
+ */
+export interface WidgetCatalogEntry {
+  /** Widget discriminator — must match a renderer registered for the same kind. */
+  readonly type: string;
+  /**
+   * Localization key resolving to the human-facing label shown on the
+   * palette button. Apps that ship a label without going through i18n can
+   * pass the literal label here — {@link WidgetPalette} renders it
+   * verbatim.
+   */
+  readonly labelLocalizationKey: string;
+  /**
+   * Optional icon descriptor — opaque to the editor. Apps render their
+   * own icon based on this key (e.g. lucide-react names, asset paths).
+   * `null` / missing = no icon, label-only button.
+   */
+  readonly iconKey?: string | null;
+  /** Grid size assigned to a freshly added widget. */
+  readonly defaultSize: WidgetSize;
+  /**
+   * Factory producing a fresh {@link WidgetDefinition} for this kind.
+   * Receives the slug + position {@link addWidget} computed for it; the
+   * factory fills in the kind-specific fields (content localization key,
+   * source URL, query name, etc.).
+   *
+   * Factories should NOT pre-generate `slug` / `position` themselves —
+   * those two fields are owned by {@link addWidget} so unique-slug
+   * generation stays centralized.
+   */
+  readonly createDefaultWidget: (slug: string, position: number) => WidgetDefinition;
+}
+
+/**
+ * Merges any number of catalog arrays. Later entries override earlier ones
+ * on `type` collision — same precedence rule as
+ * `composeRegistries(...registries)` for renderers, so an app importing
+ * `defaultWidgetCatalog` and adding a custom Markdown variant wins by
+ * passing its own catalog last.
+ *
+ * Returns a frozen array so consumers can safely pass the result through
+ * to React props without `useMemo` defensive copies.
+ */
+export function composeCatalogs(
+  ...catalogs: readonly (readonly WidgetCatalogEntry[])[]
+): readonly WidgetCatalogEntry[] {
+  const byType = new Map<string, WidgetCatalogEntry>();
+  for (const catalog of catalogs) {
+    for (const entry of catalog) {
+      byType.set(entry.type, entry);
+    }
+  }
+  return Object.freeze([...byType.values()]);
+}
+
+/**
+ * Slug-uniqueness helper. Backend constraint: a dashboard's widgets all
+ * carry distinct `slug`s (composes the localization key, primary key in
+ * the `WidgetInstance` table). The editor mints one by suffixing the
+ * lowest free integer to a PascalCase prefix derived from the catalog
+ * entry's `type`.
+ *
+ * Examples (existing slugs in parens):
+ * - `markdown` → `Markdown1` (none) / `Markdown2` (`Markdown1` exists)
+ * - `kpi` → `Kpi1`
+ */
+function nextUniqueSlug(type: string, existing: ReadonlySet<string>): string {
+  const prefix = type.charAt(0).toUpperCase() + type.slice(1);
+  for (let i = 1; ; i++) {
+    const candidate = `${prefix}${i}`;
+    if (!existing.has(candidate)) return candidate;
+  }
+}
+
+/**
+ * Pure helper: returns a new {@link import('@granit/dashboards').DashboardDefinition}
+ * with one additional widget produced by `entry.createDefaultWidget`. The
+ * new widget gets:
+ *
+ * - A slug minted via {@link nextUniqueSlug} so it doesn't clash with
+ *   existing ones.
+ * - `position` = `widgets.length` — appended to the end of the dense rank.
+ * - `size` = `entry.defaultSize` (the factory's `size` is overridden so
+ *   apps can't accidentally desync it from the catalog default).
+ *
+ * Stays decoupled from React so tests + custom palette wrappers can
+ * compose it without rendering.
+ */
+export function addWidget<TDefinition extends { readonly widgets: readonly WidgetDefinition[] }>(
+  definition: TDefinition,
+  entry: WidgetCatalogEntry
+): TDefinition {
+  const existingSlugs = new Set(definition.widgets.map((w) => w.slug));
+  const slug = nextUniqueSlug(entry.type, existingSlugs);
+  const position = definition.widgets.length;
+  const created = entry.createDefaultWidget(slug, position);
+  const widget: WidgetDefinition = {
+    ...created,
+    slug,
+    position,
+    size: entry.defaultSize,
+  };
+  return { ...definition, widgets: [...definition.widgets, widget] };
+}
+
+/**
+ * Catalog of every widget kind the framework itself ships (markdown / text
+ * / image). Downstream packages compose their own entries on top via
+ * {@link composeCatalogs}.
+ *
+ * Default sizes match the conventional pairings from {@link WIDGET_SIZE}:
+ * - markdown → `FULL_WIDTH_ROW` (banners)
+ * - text → `SMALL_KPI` proportions (3×1) — tighter than markdown
+ * - image → `MEDIA_TILE` (4×4 logo tile)
+ *
+ * The `*LocalizationKey` defaults follow the convention
+ * `Widget:{DashboardName}.{Slug}` — apps fill the actual content via i18n
+ * entries keyed off the freshly minted slug.
+ */
+export const defaultWidgetCatalog: readonly WidgetCatalogEntry[] = Object.freeze([
+  {
+    type: 'markdown',
+    labelLocalizationKey: 'Dashboard:Widget.Markdown.Label',
+    iconKey: 'markdown',
+    defaultSize: WIDGET_SIZE.FULL_WIDTH_ROW,
+    createDefaultWidget: (slug, position) => ({
+      slug,
+      type: 'markdown',
+      position,
+      size: WIDGET_SIZE.FULL_WIDTH_ROW,
+      contentLocalizationKey: `Widget:${slug}.Content`,
+    }),
+  },
+  {
+    type: 'text',
+    labelLocalizationKey: 'Dashboard:Widget.Text.Label',
+    iconKey: 'text',
+    defaultSize: { width: 3, height: 1 },
+    createDefaultWidget: (slug, position) => ({
+      slug,
+      type: 'text',
+      position,
+      size: { width: 3, height: 1 },
+      contentLocalizationKey: `Widget:${slug}.Content`,
+      style: 'Body',
+    }),
+  },
+  {
+    type: 'image',
+    labelLocalizationKey: 'Dashboard:Widget.Image.Label',
+    iconKey: 'image',
+    defaultSize: WIDGET_SIZE.MEDIA_TILE,
+    createDefaultWidget: (slug, position) => ({
+      slug,
+      type: 'image',
+      position,
+      size: WIDGET_SIZE.MEDIA_TILE,
+      source: '',
+      altLocalizationKey: `Widget:${slug}.Alt`,
+      fit: 'Contain',
+    }),
+  },
+]);


### PR DESCRIPTION
## Summary

Second slice of B5-C (dashboard composer). Adds the editor-side primitives that turn the read-mode `<Dashboard>` registry into an authoring surface — without committing to a specific UI shell.

- `WidgetCatalogEntry` — descriptor mapping a widget kind to its label key, default size, and a factory producing a fresh `WidgetDefinition`.
- `composeCatalogs(...catalogs)` — last-wins precedence on `type` collision, mirrors the read-mode `WidgetRegistry` composition pattern.
- `addWidget(definition, entry)` — pure helper appending a widget with auto-generated unique slug (`Markdown1`, `Markdown2`, gap-tolerant) + dense-ranked `position`. Entry-declared `defaultSize` wins over the factory output to prevent silent drift.
- `defaultWidgetCatalog` — entries for the framework-shipped kinds (markdown / text / image), with conventional sizes from `WIDGET_SIZE`.
- `<WidgetPalette catalog onAdd>` — toolbar of click-to-add buttons; labels resolved via `react-i18next`, ARIA `role=\"toolbar\"`, falls back to the localization key in dev mode.

Drag-from-palette (drop a button into the grid to insert at a target position) is intentionally deferred — keeps the v1 surface tight and avoids a second round of dnd-kit choreography. Apps wanting drag-to-add wrap their own `<DndContext>` around `<EditableDashboard>` + `<WidgetPalette>`.

## Scope notes

- `react-i18next` added to peer deps (matches the existing constraint on `@granit/react-dashboards`).
- Per-package catalog contributions (`analyticsWidgetCatalog`, `chartsWidgetCatalog`, `mapWidgetCatalog`) deferred to PR 4 (showcase wiring) so each ships next to its kind-specific config form (PR 3).
- The B7-3 mirror (PascalCase `MapTileLayerKind` + `defaultLayerKind`) is on its own PR (#271) and is independent of this slice.

## Test plan

- [x] `pnpm exec vitest run packages/@granit/react-dashboard-editor` — 4 files / 26 tests pass (16 new).
- [x] `pnpm exec vitest run` — repo-wide: 324 files / 2442 tests pass.
- [x] `pnpm lint` clean (no warnings, max-warnings 0).
- [x] `pnpm tsc` clean across all 87 `@granit/*` packages.
- [ ] Visual smoke once PR 4 wires the palette in showcase-admin-react.