### PR TITLE
feat(react-dashboard-editor): per-widget config drawer + form registry (B5-C PR 3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2110,6 +2110,32 @@
           "members": []
         },
         {
+          "name": "WidgetConfigDrawer",
+          "kind": "function",
+          "signature": "function WidgetConfigDrawer("
+        },
+        {
+          "name": "WidgetConfigDrawerProps",
+          "kind": "interface",
+          "signature": "interface WidgetConfigDrawerProps",
+          "members": []
+        },
+        {
+          "name": "ImageConfigForm",
+          "kind": "function",
+          "signature": "function ImageConfigForm("
+        },
+        {
+          "name": "MarkdownConfigForm",
+          "kind": "function",
+          "signature": "function MarkdownConfigForm("
+        },
+        {
+          "name": "TextConfigForm",
+          "kind": "function",
+          "signature": "function TextConfigForm("
+        },
+        {
           "name": "reorderWidgets",
           "kind": "function",
           "signature": "function reorderWidgets( definition: DashboardDefinition, sourceSlug: string, targetSlug: string ): DashboardDefinition"
@@ -2134,6 +2160,26 @@
           "kind": "interface",
           "signature": "interface WidgetCatalogEntry",
           "members": []
+        },
+        {
+          "name": "removeWidget",
+          "kind": "function",
+          "signature": "function removeWidget(definition: DashboardDefinition, slug: string): DashboardDefinition"
+        },
+        {
+          "name": "updateWidget",
+          "kind": "function",
+          "signature": "function updateWidget( definition: DashboardDefinition, slug: string, next: WidgetDefinition ): DashboardDefinition"
+        },
+        {
+          "name": "defaultWidgetConfigFormRegistry",
+          "kind": "const",
+          "signature": "const defaultWidgetConfigFormRegistry: WidgetConfigFormRegistry"
+        },
+        {
+          "name": "composeWidgetConfigFormRegistries",
+          "kind": "function",
+          "signature": "function composeWidgetConfigFormRegistries( ...registries: readonly WidgetConfigFormRegistry[] ): WidgetConfigFormRegistry"
         }
       ]
     },

--- a/packages/@granit/react-dashboard-editor/src/__tests__/update-widget.test.ts
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/update-widget.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+
+import { removeWidget, updateWidget } from '../lib/update-widget.js';
+
+import type { DashboardDefinition, MarkdownWidgetDefinition } from '@granit/dashboards';
+
+const definition: DashboardDefinition = {
+  name: 'Test',
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [
+    {
+      slug: 'A',
+      type: 'markdown',
+      position: 0,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:A.Content',
+    },
+    {
+      slug: 'B',
+      type: 'markdown',
+      position: 1,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:B.Content',
+    },
+    {
+      slug: 'C',
+      type: 'markdown',
+      position: 2,
+      size: { width: 12, height: 1 },
+      contentLocalizationKey: 'Widget:C.Content',
+    },
+  ],
+};
+
+describe('updateWidget', () => {
+  it('replaces the widget matched by slug with the patched copy', () => {
+    const next = updateWidget(definition, 'B', {
+      slug: 'B',
+      type: 'markdown',
+      position: 1,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:B.NewContent',
+    } satisfies MarkdownWidgetDefinition);
+    const updated = next.widgets[1] as MarkdownWidgetDefinition;
+    expect(updated.contentLocalizationKey).toBe('Widget:B.NewContent');
+  });
+
+  it('preserves the existing slug + position even when the patch attempts to change them', () => {
+    const next = updateWidget(definition, 'B', {
+      slug: 'RENAMED',
+      type: 'markdown',
+      position: 99,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:B.NewContent',
+    } satisfies MarkdownWidgetDefinition);
+    const updated = next.widgets[1];
+    expect(updated?.slug).toBe('B');
+    expect(updated?.position).toBe(1);
+  });
+
+  it('returns the input unchanged when the slug is not found', () => {
+    const next = updateWidget(definition, 'MISSING', {
+      slug: 'MISSING',
+      type: 'markdown',
+      position: 0,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:Missing.Content',
+    } satisfies MarkdownWidgetDefinition);
+    expect(next).toBe(definition);
+  });
+
+  it('does not mutate the input definition', () => {
+    const before = definition.widgets;
+    updateWidget(definition, 'A', {
+      slug: 'A',
+      type: 'markdown',
+      position: 0,
+      size: { width: 6, height: 1 },
+      contentLocalizationKey: 'Widget:A.NewContent',
+    } satisfies MarkdownWidgetDefinition);
+    expect(definition.widgets).toBe(before);
+  });
+});
+
+describe('removeWidget', () => {
+  it('removes the widget matched by slug', () => {
+    const next = removeWidget(definition, 'B');
+    expect(next.widgets).toHaveLength(2);
+    expect(next.widgets.map((w) => w.slug)).toEqual(['A', 'C']);
+  });
+
+  it('re-ranks remaining widgets into a dense 0-based position sequence', () => {
+    const next = removeWidget(definition, 'A');
+    expect(next.widgets.map((w) => w.position)).toEqual([0, 1]);
+  });
+
+  it('returns the input unchanged when the slug is not found', () => {
+    const next = removeWidget(definition, 'MISSING');
+    expect(next).toBe(definition);
+  });
+
+  it('does not mutate the input definition', () => {
+    const before = definition.widgets;
+    removeWidget(definition, 'A');
+    expect(definition.widgets).toBe(before);
+  });
+});

--- a/packages/@granit/react-dashboard-editor/src/__tests__/widget-config-drawer.test.tsx
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/widget-config-drawer.test.tsx
@@ -1,0 +1,196 @@
+import { fireEvent, render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { WidgetConfigDrawer } from '../components/widget-config-drawer.js';
+import { defaultWidgetConfigFormRegistry } from '../lib/default-widget-config-form-registry.js';
+import { composeWidgetConfigFormRegistries } from '../lib/widget-config-form-registry.js';
+
+import type {
+  ImageWidgetDefinition,
+  MarkdownWidgetDefinition,
+  TextWidgetDefinition,
+  WidgetDefinition,
+} from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        'Dashboard:Widget.Markdown.ContentKey.Label': 'Markdown content key',
+        'Dashboard:Widget.Text.ContentKey.Label': 'Text content key',
+        'Dashboard:Widget.Text.Style.Label': 'Style',
+        'Dashboard:Widget.Image.Source.Label': 'Source',
+        'Dashboard:Widget.Image.AltKey.Label': 'Alt key',
+        'Dashboard:Widget.Image.Fit.Label': 'Fit',
+        'Dashboard:Widget.UnknownType': 'Unknown widget type: {{type}}',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+}
+
+const markdownWidget: MarkdownWidgetDefinition = {
+  slug: 'Markdown1',
+  type: 'markdown',
+  position: 0,
+  size: { width: 12, height: 1 },
+  contentLocalizationKey: 'Widget:Markdown1.Content',
+};
+
+const textWidget: TextWidgetDefinition = {
+  slug: 'Text1',
+  type: 'text',
+  position: 1,
+  size: { width: 3, height: 1 },
+  contentLocalizationKey: 'Widget:Text1.Content',
+  style: 'Body',
+};
+
+const imageWidget: ImageWidgetDefinition = {
+  slug: 'Image1',
+  type: 'image',
+  position: 2,
+  size: { width: 4, height: 4 },
+  source: 'https://example.com/logo.png',
+  altLocalizationKey: 'Widget:Image1.Alt',
+  fit: 'Contain',
+};
+
+describe('WidgetConfigDrawer', () => {
+  it('routes a markdown widget through the markdown form', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={markdownWidget}
+        onChange={onChange}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    expect(container.querySelector('[data-slot="markdown-config-form"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="text-config-form"]')).toBeNull();
+  });
+
+  it('emits onChange with the patched widget when the markdown content key changes', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={markdownWidget}
+        onChange={onChange}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    const input = container.querySelector('[data-slot="markdown-content-key"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: 'Widget:Markdown1.NewKey' } });
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0]?.[0]).toEqual({
+      ...markdownWidget,
+      contentLocalizationKey: 'Widget:Markdown1.NewKey',
+    });
+  });
+
+  it('routes a text widget through the text form and edits the style enum', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={textWidget}
+        onChange={onChange}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    const select = container.querySelector('[data-slot="text-style"]');
+    if (!(select instanceof HTMLSelectElement)) throw new Error('select not found');
+    fireEvent.change(select, { target: { value: 'Heading' } });
+    expect(onChange.mock.calls[0]?.[0]?.style).toBe('Heading');
+  });
+
+  it('routes an image widget through the image form and edits the source URL', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={imageWidget}
+        onChange={onChange}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    const input = container.querySelector('[data-slot="image-source"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: 'blob:logo-banner' } });
+    expect(onChange.mock.calls[0]?.[0]?.source).toBe('blob:logo-banner');
+  });
+
+  it('falls back to the unknown-type placeholder for kinds with no registered form', () => {
+    const unknown: WidgetDefinition = {
+      slug: 'X',
+      type: 'mystery',
+      position: 0,
+      size: { width: 1, height: 1 },
+    };
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={unknown}
+        onChange={vi.fn()}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    const fallback = container.querySelector('[data-slot="widget-config-drawer-fallback"]');
+    expect(fallback?.textContent).toBe('Unknown widget type: mystery');
+  });
+
+  it('surfaces the slug + type as data-attributes for downstream styling', () => {
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={markdownWidget}
+        onChange={vi.fn()}
+        registry={defaultWidgetConfigFormRegistry}
+      />
+    );
+    const root = container.querySelector('[data-slot="widget-config-drawer"]');
+    expect(root?.getAttribute('data-widget-slug')).toBe('Markdown1');
+    expect(root?.getAttribute('data-widget-type')).toBe('markdown');
+  });
+
+  it('renders the optional header slot next to the title', () => {
+    const { container } = wrap(
+      <WidgetConfigDrawer
+        widget={markdownWidget}
+        onChange={vi.fn()}
+        registry={defaultWidgetConfigFormRegistry}
+        header={<button type="button">Save</button>}
+      />
+    );
+    const header = container.querySelector('[data-slot="widget-config-drawer-header"]');
+    expect(header?.textContent).toContain('Save');
+  });
+});
+
+describe('composeWidgetConfigFormRegistries', () => {
+  it('lets later registries override earlier ones on type collision', () => {
+    const CustomMarkdown = () => <div data-slot="custom-markdown" />;
+    const composed = composeWidgetConfigFormRegistries(defaultWidgetConfigFormRegistry, {
+      markdown: CustomMarkdown,
+    });
+    const { container } = wrap(
+      <WidgetConfigDrawer widget={markdownWidget} onChange={vi.fn()} registry={composed} />
+    );
+    expect(container.querySelector('[data-slot="custom-markdown"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="markdown-config-form"]')).toBeNull();
+  });
+
+  it('returns a frozen registry', () => {
+    const composed = composeWidgetConfigFormRegistries(defaultWidgetConfigFormRegistry);
+    expect(Object.isFrozen(composed)).toBe(true);
+  });
+});

--- a/packages/@granit/react-dashboard-editor/src/components/forms/image-config-form.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/forms/image-config-form.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next';
+
+import type { WidgetConfigFormProps } from '../../lib/widget-config-form-registry.js';
+import type { ImageFit, ImageWidgetDefinition } from '@granit/dashboards';
+
+const IMAGE_FITS: readonly ImageFit[] = ['Contain', 'Cover', 'Fill'];
+
+/**
+ * Built-in config form for `ImageWidgetDefinition`. Edits the source URL
+ * (or blob reference), the alt-text localization key, and the
+ * cell-fitting strategy (PascalCase wire values).
+ */
+export function ImageConfigForm({
+  widget,
+  onChange,
+}: WidgetConfigFormProps<ImageWidgetDefinition>) {
+  const { t } = useTranslation();
+  return (
+    <div data-slot="image-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Image.Source.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="image-source"
+          value={widget.source}
+          onChange={(event) => onChange({ ...widget, source: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Image.AltKey.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="image-alt-key"
+          value={widget.altLocalizationKey}
+          onChange={(event) => onChange({ ...widget, altLocalizationKey: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Image.Fit.Label')}
+        </span>
+        <select
+          data-slot="image-fit"
+          value={widget.fit ?? 'Contain'}
+          onChange={(event) => onChange({ ...widget, fit: event.target.value as ImageFit })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          {IMAGE_FITS.map((fit) => (
+            <option key={fit} value={fit}>
+              {fit}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/components/forms/markdown-config-form.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/forms/markdown-config-form.tsx
@@ -1,0 +1,35 @@
+import { useTranslation } from 'react-i18next';
+
+import type { WidgetConfigFormProps } from '../../lib/widget-config-form-registry.js';
+import type { MarkdownWidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Built-in config form for `MarkdownWidgetDefinition`. Edits the
+ * `contentLocalizationKey` only — the actual Markdown body lives in the
+ * app's i18n bundle (B5-A architecture: keys persist, content is a
+ * tenant-overridable translation). Apps wanting an inline content editor
+ * (writing Markdown directly into the dashboard JSON) register their own
+ * form via `composeWidgetConfigFormRegistries`.
+ */
+export function MarkdownConfigForm({
+  widget,
+  onChange,
+}: WidgetConfigFormProps<MarkdownWidgetDefinition>) {
+  const { t } = useTranslation();
+  return (
+    <div data-slot="markdown-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Markdown.ContentKey.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="markdown-content-key"
+          value={widget.contentLocalizationKey}
+          onChange={(event) => onChange({ ...widget, contentLocalizationKey: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/components/forms/text-config-form.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/forms/text-config-form.tsx
@@ -1,0 +1,50 @@
+import { useTranslation } from 'react-i18next';
+
+import type { WidgetConfigFormProps } from '../../lib/widget-config-form-registry.js';
+import type { TextWidgetDefinition, TextWidgetStyle } from '@granit/dashboards';
+
+const TEXT_STYLES: readonly TextWidgetStyle[] = ['Body', 'Heading', 'Subheading', 'Caption'];
+
+/**
+ * Built-in config form for `TextWidgetDefinition`. Edits the
+ * `contentLocalizationKey` + the `style` enum (Body / Heading / Subheading
+ * / Caption — PascalCase wire values per ADR-039 §6.1).
+ */
+export function TextConfigForm({ widget, onChange }: WidgetConfigFormProps<TextWidgetDefinition>) {
+  const { t } = useTranslation();
+  return (
+    <div data-slot="text-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Text.ContentKey.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="text-content-key"
+          value={widget.contentLocalizationKey}
+          onChange={(event) => onChange({ ...widget, contentLocalizationKey: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Text.Style.Label')}
+        </span>
+        <select
+          data-slot="text-style"
+          value={widget.style}
+          onChange={(event) =>
+            onChange({ ...widget, style: event.target.value as TextWidgetStyle })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          {TEXT_STYLES.map((style) => (
+            <option key={style} value={style}>
+              {style}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/components/widget-config-drawer.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/widget-config-drawer.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next';
+
+import type { WidgetConfigFormRegistry } from '../lib/widget-config-form-registry.js';
+import type { WidgetDefinition } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+/**
+ * Drawer surface that picks the right config form for a widget's `type`
+ * and renders it. The drawer is presentational — apps own its open / close
+ * state, animation, and side-panel chrome (Sheet, Drawer, Dialog, etc.).
+ *
+ * The `widget` prop drives which form renders; the `onChange` prop is
+ * forwarded to the matched form so each emit goes back through the same
+ * controlled-state pipeline. The drawer title surfaces the widget slug —
+ * stable across reorders, matches what the read-mode renderer keys off.
+ *
+ * Unknown widget kinds (no entry in the registry) surface a localized
+ * fallback message — same behaviour as the read-mode "Unknown widget
+ * type" placeholder, so authoring + rendering stay symmetric.
+ */
+export interface WidgetConfigDrawerProps {
+  readonly widget: WidgetDefinition;
+  readonly onChange: (next: WidgetDefinition) => void;
+  readonly registry: WidgetConfigFormRegistry;
+  readonly className?: string;
+  /**
+   * Optional header slot — apps render their own close button / save
+   * button here. The drawer renders nothing of its own beyond the title +
+   * the form.
+   */
+  readonly header?: ReactNode;
+}
+
+export function WidgetConfigDrawer({
+  widget,
+  onChange,
+  registry,
+  className,
+  header,
+}: WidgetConfigDrawerProps) {
+  const { t } = useTranslation();
+  const Form = registry[widget.type];
+
+  return (
+    <div
+      data-slot="widget-config-drawer"
+      data-widget-slug={widget.slug}
+      data-widget-type={widget.type}
+      className={className}
+    >
+      <div data-slot="widget-config-drawer-header" className="flex items-center justify-between">
+        <h2 className="text-base font-semibold">{widget.slug}</h2>
+        {header}
+      </div>
+      {Form ? (
+        <Form widget={widget} onChange={onChange} />
+      ) : (
+        <p data-slot="widget-config-drawer-fallback" className="text-sm text-muted-foreground">
+          {t('Dashboard:Widget.UnknownType', { type: widget.type })}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/index.ts
+++ b/packages/@granit/react-dashboard-editor/src/index.ts
@@ -8,8 +8,24 @@ export { SortableWidgetCell } from './components/sortable-widget-cell.js';
 export type { SortableWidgetCellProps } from './components/sortable-widget-cell.js';
 export { WidgetPalette } from './components/widget-palette.js';
 export type { WidgetPaletteProps } from './components/widget-palette.js';
+export { WidgetConfigDrawer } from './components/widget-config-drawer.js';
+export type { WidgetConfigDrawerProps } from './components/widget-config-drawer.js';
+
+// Built-in config forms — re-exported so apps can compose against the
+// concrete components (e.g. wrapping MarkdownConfigForm in a Sheet).
+export { ImageConfigForm } from './components/forms/image-config-form.js';
+export { MarkdownConfigForm } from './components/forms/markdown-config-form.js';
+export { TextConfigForm } from './components/forms/text-config-form.js';
 
 // Pure helpers — exported for tests + custom palette / DnD wrappers
 export { reorderWidgets } from './lib/reorder-widgets.js';
 export { addWidget, composeCatalogs, defaultWidgetCatalog } from './lib/widget-catalog.js';
 export type { WidgetCatalogEntry } from './lib/widget-catalog.js';
+export { removeWidget, updateWidget } from './lib/update-widget.js';
+export { defaultWidgetConfigFormRegistry } from './lib/default-widget-config-form-registry.js';
+export { composeWidgetConfigFormRegistries } from './lib/widget-config-form-registry.js';
+export type {
+  WidgetConfigForm,
+  WidgetConfigFormProps,
+  WidgetConfigFormRegistry,
+} from './lib/widget-config-form-registry.js';

--- a/packages/@granit/react-dashboard-editor/src/lib/default-widget-config-form-registry.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/default-widget-config-form-registry.ts
@@ -1,0 +1,18 @@
+import { ImageConfigForm } from '../components/forms/image-config-form.js';
+import { MarkdownConfigForm } from '../components/forms/markdown-config-form.js';
+import { TextConfigForm } from '../components/forms/text-config-form.js';
+
+import type { WidgetConfigForm, WidgetConfigFormRegistry } from './widget-config-form-registry.js';
+
+/**
+ * Framework-default config-form registry — covers every
+ * `FrameworkWidgetDefinition` kind shipped by `@granit/dashboards`. Compose
+ * with downstream registries (analytics, IoT, app-specific) via
+ * `composeWidgetConfigFormRegistries` so apps never need to re-register
+ * the basics.
+ */
+export const defaultWidgetConfigFormRegistry: WidgetConfigFormRegistry = Object.freeze({
+  markdown: MarkdownConfigForm as WidgetConfigForm,
+  text: TextConfigForm as WidgetConfigForm,
+  image: ImageConfigForm as WidgetConfigForm,
+});

--- a/packages/@granit/react-dashboard-editor/src/lib/update-widget.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/update-widget.ts
@@ -1,0 +1,44 @@
+import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Pure helper: returns a new {@link DashboardDefinition} with the widget
+ * matching `slug` replaced by `next`. The replacement preserves the
+ * existing `slug` + `position` (callers can't accidentally rename or
+ * reorder a widget through the config drawer — those are owned by
+ * {@link reorderWidgets} / {@link addWidget}).
+ *
+ * Slug not found → returns the input definition unchanged. This keeps the
+ * editor pipeline idempotent under late-arriving onChange callbacks (e.g.
+ * a debounced form submission firing after the widget was deleted).
+ */
+export function updateWidget(
+  definition: DashboardDefinition,
+  slug: string,
+  next: WidgetDefinition
+): DashboardDefinition {
+  const index = definition.widgets.findIndex((w) => w.slug === slug);
+  if (index === -1) return definition;
+  const current = definition.widgets[index];
+  if (!current) return definition;
+  const merged: WidgetDefinition = { ...next, slug: current.slug, position: current.position };
+  const widgets = [...definition.widgets];
+  widgets[index] = merged;
+  return { ...definition, widgets };
+}
+
+/**
+ * Pure helper: returns a new {@link DashboardDefinition} with the widget
+ * matching `slug` removed and remaining widgets re-ranked into a dense
+ * 0-based `position` sequence — same invariant the backend enforces on
+ * `WidgetInstance.Position`.
+ *
+ * Slug not found → returns the input definition unchanged.
+ */
+export function removeWidget(definition: DashboardDefinition, slug: string): DashboardDefinition {
+  const remaining = definition.widgets.filter((w) => w.slug !== slug);
+  if (remaining.length === definition.widgets.length) return definition;
+  const repositioned = [...remaining]
+    .sort((a, b) => a.position - b.position)
+    .map((widget, index) => ({ ...widget, position: index }));
+  return { ...definition, widgets: repositioned };
+}

--- a/packages/@granit/react-dashboard-editor/src/lib/widget-config-form-registry.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/widget-config-form-registry.ts
@@ -1,0 +1,50 @@
+import type { WidgetDefinition } from '@granit/dashboards';
+import type { ComponentType } from 'react';
+
+/**
+ * Props every kind-specific config form receives. Mirrors the read-mode
+ * `WidgetRenderer` shape on the registry side: the form takes the typed
+ * widget definition + an `onChange` callback emitting a fresh widget
+ * whose extra fields the form has mutated.
+ *
+ * `slug` / `position` / `size` are deliberately NOT editable through this
+ * surface — the drawer owns kind-specific fields only. Slug is immutable
+ * (composes the localization key + drives DnD identity); position is
+ * owned by `reorderWidgets`; size is owned by the (future) resize gesture
+ * + the catalog's `defaultSize`.
+ */
+export interface WidgetConfigFormProps<T extends WidgetDefinition = WidgetDefinition> {
+  readonly widget: T;
+  readonly onChange: (next: T) => void;
+}
+
+/**
+ * React component rendering a kind-specific config form. The component is
+ * fully presentational — no internal mutable state, no debouncing — so
+ * callers can wire their own validation / submission pipeline (typically
+ * a controlled form mirroring the parent dashboard state).
+ */
+export type WidgetConfigForm<T extends WidgetDefinition = WidgetDefinition> = ComponentType<
+  WidgetConfigFormProps<T>
+>;
+
+/**
+ * Mapping from widget `type` discriminator to a config-form component.
+ * Same composition pattern as `WidgetRegistry` on the read-mode side —
+ * downstream packages contribute their own (analytics adds `kpi` /
+ * `chart` / `table` / `pivot` / `map`, IoT adds its sensor variants, etc.).
+ */
+export type WidgetConfigFormRegistry = Readonly<Record<string, WidgetConfigForm>>;
+
+/**
+ * Composes multiple config-form registries into one, with later entries
+ * overriding earlier ones on `type` collision. Mirrors `composeRegistries`
+ * for renderers — same precedence semantics so apps that override a
+ * built-in form (e.g. a custom Markdown editor with a live preview) win
+ * by passing their registry last.
+ */
+export function composeWidgetConfigFormRegistries(
+  ...registries: readonly WidgetConfigFormRegistry[]
+): WidgetConfigFormRegistry {
+  return Object.freeze(Object.assign({}, ...registries));
+}


### PR DESCRIPTION
## Summary

Third slice of B5-C (dashboard composer). Adds the editor surface for editing kind-specific widget fields, plus the pure helpers needed to commit those edits back into a `DashboardDefinition`.

- `WidgetConfigForm<T>` + `WidgetConfigFormRegistry` — same composition pattern as the read-mode `WidgetRegistry`. `composeWidgetConfigFormRegistries(...registries)` applies last-wins precedence on `type` collisions.
- `defaultWidgetConfigFormRegistry` — built-in forms for the framework kinds:
  - `MarkdownConfigForm` (content key)
  - `TextConfigForm` (content key + `style` enum)
  - `ImageConfigForm` (source URL + alt key + `fit` enum)
- `<WidgetConfigDrawer widget onChange registry header />` — picks the matching form by `widget.type`. Unknown kinds surface a localized fallback (mirrors the read-mode \"Unknown widget type\" placeholder so authoring + rendering stay symmetric). Apps own the surrounding chrome (Sheet / Drawer / Dialog).
- `updateWidget(definition, slug, next)` — pure helper preserving `slug` + `position` so the drawer can't accidentally rename or reorder a widget. Missing slug returns the input unchanged for late-arriving onChange callbacks.
- `removeWidget(definition, slug)` — pure helper that re-ranks remaining widgets into a dense 0-based position sequence.

Forms stay presentational (no internal state, no debouncing) so apps wire their own validation / submission pipeline. Per-package config forms (analytics / charts / map) ship in PR 4 alongside their catalog contributions.

## Scope notes

- Enum wire values (`TextWidgetStyle`, `ImageFit`) are PascalCase per ADR-039 §6.1.
- The drawer is intentionally chrome-less — apps style and animate their own panel; the only opinion is the title (slug) + an optional `header` slot for Save/Close buttons.
- Built-in forms are exported individually so apps that want only the styling-of-it (without going through the registry) can compose them directly.

## Test plan

- [x] `pnpm exec vitest run packages/@granit/react-dashboard-editor` — 6 files / 43 tests pass (17 new).
- [x] `pnpm exec vitest run` — repo-wide: 326 files / 2459 tests pass.
- [x] `pnpm lint` clean (max-warnings 0).
- [x] `pnpm tsc` clean across all 87 \`@granit/*\` packages.
- [ ] Visual smoke once PR 4 wires the drawer in showcase-admin-react.