### PR TITLE
feat(react-dashboards): dashboard CRUD hooks (B5-C PR 4)

### DIFF
--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
@@ -1,0 +1,180 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  dashboardListQueryKey,
+  dashboardQueryKey,
+  useCreateDashboard,
+  useDashboard,
+  useDashboards,
+  useDeleteDashboard,
+  useUpdateDashboard,
+} from '../api/use-dashboard-crud.js';
+
+import type { DashboardDefinition } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const NAME = 'Granit.Showcase.Demo';
+
+const DEFINITION: DashboardDefinition = {
+  name: NAME,
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [
+    {
+      slug: 'Banner',
+      type: 'markdown',
+      position: 0,
+      size: { width: 12, height: 1 },
+      contentLocalizationKey: 'Widget:Granit.Showcase.Demo.Banner',
+    },
+  ],
+};
+
+const UPDATED: DashboardDefinition = { ...DEFINITION, version: '1.1.0' };
+
+let lastPostedBody: unknown = null;
+let lastPutBody: unknown = null;
+let lastDeleteName: string | null = null;
+
+const server = setupServer(
+  http.get('http://localhost/dashboards', () => HttpResponse.json([DEFINITION])),
+  http.get(`http://localhost/dashboards/${encodeURIComponent(NAME)}`, () =>
+    HttpResponse.json(DEFINITION)
+  ),
+  http.post('http://localhost/dashboards', async ({ request }) => {
+    lastPostedBody = await request.json();
+    return HttpResponse.json(DEFINITION);
+  }),
+  http.put(`http://localhost/dashboards/${encodeURIComponent(NAME)}`, async ({ request }) => {
+    lastPutBody = await request.json();
+    return HttpResponse.json(UPDATED);
+  }),
+  http.delete(`http://localhost/dashboards/${encodeURIComponent(NAME)}`, () => {
+    lastDeleteName = NAME;
+    return new HttpResponse(null, { status: 204 });
+  })
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(
+    http.get('http://localhost/dashboards', () => HttpResponse.json([DEFINITION])),
+    http.get(`http://localhost/dashboards/${encodeURIComponent(NAME)}`, () =>
+      HttpResponse.json(DEFINITION)
+    ),
+    http.post('http://localhost/dashboards', async ({ request }) => {
+      lastPostedBody = await request.json();
+      return HttpResponse.json(DEFINITION);
+    }),
+    http.put(`http://localhost/dashboards/${encodeURIComponent(NAME)}`, async ({ request }) => {
+      lastPutBody = await request.json();
+      return HttpResponse.json(UPDATED);
+    }),
+    http.delete(`http://localhost/dashboards/${encodeURIComponent(NAME)}`, () => {
+      lastDeleteName = NAME;
+      return new HttpResponse(null, { status: 204 });
+    })
+  );
+  lastPostedBody = null;
+  lastPutBody = null;
+  lastDeleteName = null;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('cache keys', () => {
+  it('list key is a single-element tuple so all CRUD invalidations target the same root', () => {
+    expect(dashboardListQueryKey()).toEqual(['dashboards']);
+  });
+
+  it('per-dashboard key namespaces under the list key for prefix-based invalidation', () => {
+    expect(dashboardQueryKey(NAME)).toEqual(['dashboards', NAME]);
+  });
+});
+
+describe('useDashboards', () => {
+  it('fetches the catalogue and exposes descriptors', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboards(), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.[0]?.name).toBe(NAME);
+  });
+
+  it('respects the enabled flag', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboards({ enabled: false }), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useDashboard', () => {
+  it('fetches a single dashboard by name', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboard(NAME), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.name).toBe(NAME);
+    expect(result.current.data?.widgets).toHaveLength(1);
+  });
+
+  it('stays idle when name is empty', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDashboard(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useCreateDashboard', () => {
+  it('POSTs the definition and refreshes the list cache', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(dashboardListQueryKey(), []);
+    const { result } = renderHook(() => useCreateDashboard(), { wrapper });
+    await result.current.mutateAsync(DEFINITION);
+    expect(lastPostedBody).toMatchObject({ name: NAME });
+    expect(queryClient.getQueryState(dashboardListQueryKey())?.isInvalidated).toBe(true);
+    // Single-dashboard cache is seeded with the server response.
+    expect(queryClient.getQueryData(dashboardQueryKey(NAME))).toMatchObject({ name: NAME });
+  });
+});
+
+describe('useUpdateDashboard', () => {
+  it('PUTs the definition and updates the per-dashboard cache', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useUpdateDashboard(), { wrapper });
+    await result.current.mutateAsync(DEFINITION);
+    expect(lastPutBody).toMatchObject({ name: NAME });
+    expect(queryClient.getQueryData<DashboardDefinition>(dashboardQueryKey(NAME))?.version).toBe(
+      '1.1.0'
+    );
+  });
+});
+
+describe('useDeleteDashboard', () => {
+  it('DELETEs by name and removes the per-dashboard cache entry', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(dashboardQueryKey(NAME), DEFINITION);
+    const { result } = renderHook(() => useDeleteDashboard(), { wrapper });
+    await result.current.mutateAsync(NAME);
+    expect(lastDeleteName).toBe(NAME);
+    expect(queryClient.getQueryData(dashboardQueryKey(NAME))).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-crud.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-crud.ts
@@ -1,0 +1,154 @@
+import { useGranitClient } from '@granit/react-api-client';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import type { DashboardDefinition, DashboardDefinitionDescriptor } from '@granit/dashboards';
+
+const DASHBOARD_PATH = '/dashboards';
+
+/**
+ * Cache keys for dashboard CRUD entries. Exported for tests + sibling hooks
+ * that need to invalidate / read the same query without going through the
+ * hook itself.
+ *
+ * - `['dashboards']` — list of descriptors.
+ * - `['dashboards', name]` — single full definition.
+ *
+ * The list query is the cheaper read (descriptors omit nothing today, but
+ * the split lets the backend evolve the descriptor shape without breaking
+ * the get-by-name contract).
+ */
+export const dashboardListQueryKey = () => ['dashboards'] as const;
+export const dashboardQueryKey = (name: string) => ['dashboards', name] as const;
+
+/**
+ * `GET /dashboards` — returns descriptors for every dashboard the caller is
+ * allowed to read. Mirrors `IDashboardDefinitionRegistry.list()` (B4-write).
+ *
+ * Long staleTime — the list is mostly admin-driven (manual create / edit /
+ * delete); we don't pay a refetch on every focus.
+ */
+export function useDashboards(
+  options: {
+    readonly enabled?: boolean;
+  } = {}
+): UseQueryResult<readonly DashboardDefinitionDescriptor[]> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: dashboardListQueryKey(),
+    queryFn: async ({ signal }) => {
+      const { data } = await api.get<readonly DashboardDefinitionDescriptor[]>(DASHBOARD_PATH, {
+        signal,
+      });
+      return data;
+    },
+    enabled: options.enabled ?? true,
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * `GET /dashboards/{name}` — returns the full definition for one dashboard.
+ * Mirrors `IDashboardDefinitionRegistry.get(name)` (B4-write).
+ *
+ * Used by the editor: the builder needs the widgets array to seed
+ * `<EditableDashboard>`, which the descriptor already carries — the split
+ * exists so the backend can evolve independently.
+ */
+export function useDashboard(
+  name: string,
+  options: { readonly enabled?: boolean } = {}
+): UseQueryResult<DashboardDefinition> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: dashboardQueryKey(name),
+    queryFn: async ({ signal }) => {
+      const { data } = await api.get<DashboardDefinition>(
+        `${DASHBOARD_PATH}/${encodeURIComponent(name)}`,
+        { signal }
+      );
+      return data;
+    },
+    enabled: (options.enabled ?? true) && name.length > 0,
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * `POST /dashboards` — creates a new dashboard. Body is the full
+ * {@link DashboardDefinition}. On success, invalidates the list query so
+ * the catalog refetches.
+ */
+export function useCreateDashboard(): UseMutationResult<
+  DashboardDefinition,
+  Error,
+  DashboardDefinition
+> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (definition: DashboardDefinition) => {
+      const { data } = await api.post<DashboardDefinition>(DASHBOARD_PATH, definition);
+      return data;
+    },
+    onSuccess: (created) => {
+      void queryClient.invalidateQueries({ queryKey: dashboardListQueryKey() });
+      queryClient.setQueryData(dashboardQueryKey(created.name), created);
+    },
+  });
+}
+
+/**
+ * `PUT /dashboards/{name}` — updates an existing dashboard. Body is the
+ * full {@link DashboardDefinition} (the editor commits the whole shape;
+ * widget-level diff endpoints are out of scope until B4 ships them).
+ *
+ * On success, refreshes the per-dashboard cache + invalidates the list so
+ * descriptor changes (renames, version bumps) propagate.
+ */
+export function useUpdateDashboard(): UseMutationResult<
+  DashboardDefinition,
+  Error,
+  DashboardDefinition
+> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (definition: DashboardDefinition) => {
+      const { data } = await api.put<DashboardDefinition>(
+        `${DASHBOARD_PATH}/${encodeURIComponent(definition.name)}`,
+        definition
+      );
+      return data;
+    },
+    onSuccess: (updated) => {
+      queryClient.setQueryData(dashboardQueryKey(updated.name), updated);
+      void queryClient.invalidateQueries({ queryKey: dashboardListQueryKey() });
+    },
+  });
+}
+
+/**
+ * `DELETE /dashboards/{name}` — removes a dashboard. Pass the dashboard
+ * name (the wire identifier, `Granit.{Module}.{Name}`).
+ *
+ * On success, drops the per-dashboard cache entry + invalidates the list.
+ */
+export function useDeleteDashboard(): UseMutationResult<void, Error, string> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (name: string) => {
+      await api.delete(`${DASHBOARD_PATH}/${encodeURIComponent(name)}`);
+    },
+    onSuccess: (_void, name) => {
+      queryClient.removeQueries({ queryKey: dashboardQueryKey(name) });
+      void queryClient.invalidateQueries({ queryKey: dashboardListQueryKey() });
+    },
+  });
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -13,6 +13,17 @@ export {
 export type { UseDashboardRenderOptions } from './api/use-dashboard-render.js';
 export { useDashboardWidget } from './api/use-dashboard-widget.js';
 
+// CRUD hooks (B4-write — list / get / create / update / delete)
+export {
+  dashboardListQueryKey,
+  dashboardQueryKey,
+  useCreateDashboard,
+  useDashboard,
+  useDashboards,
+  useDeleteDashboard,
+  useUpdateDashboard,
+} from './api/use-dashboard-crud.js';
+
 // Layout + dispatcher
 export { Dashboard } from './components/dashboard.js';
 export type { DashboardProps } from './components/dashboard.js';


### PR DESCRIPTION
## Summary

Read + write hooks for dashboard CRUD — the framework half of B4-write that the editor pipeline needs to load, save, and list dashboards. PR 5 wires them into showcase.

- `useDashboards()` — `GET /dashboards` (catalog descriptors)
- `useDashboard(name)` — `GET /dashboards/{name}` (full definition)
- `useCreateDashboard()` — `POST /dashboards`
- `useUpdateDashboard()` — `PUT /dashboards/{name}`
- `useDeleteDashboard()` — `DELETE /dashboards/{name}`

## Cache conventions

| Key | Holds |
| --- | --- |
| `['dashboards']` | Catalog descriptor list |
| `['dashboards', name]` | Single full definition |

Mutations invalidate the list and write through to the per-dashboard cache so the editor's `useDashboard(name)` reader sees the latest snapshot without a refetch round-trip. The per-dashboard key namespaces under the list key (prefix-based invalidation if the backend ever exposes optimistic patches).

## Notes

- Uses `useGranitClient()` from `@granit/react-api-client` so consuming apps inherit auth / CSRF / tenant interceptors automatically.
- `staleTime: 60_000` on reads — the catalog is admin-driven, no point refetching on every focus.
- `useUpdateDashboard` PUTs the full definition (the editor commits the whole shape). Widget-level diff endpoints are out of scope until the backend exposes them.
- 4xx still retries by default (TanStack default behaviour). Render hook already pins `shouldRetry` against 4xx — left CRUD on the default since editor errors are typically user-driven (validation, conflicts) rather than transient.

## Test plan

- [x] `pnpm exec vitest run packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx` — 9 new tests pass (msw-driven, covers all 5 hooks + cache invalidation + cache write-through).
- [x] `pnpm exec vitest run` — repo-wide: 327 files / 2468 tests pass.
- [x] `pnpm lint` clean (max-warnings 0).
- [x] `pnpm tsc` clean across all 87 \`@granit/*\` packages.
- [ ] Live integration validated by PR 5 (showcase wiring).