### PR TITLE
feat(react-analytics): editor catalog + config forms

### DIFF
--- a/packages/@granit/react-analytics/package.json
+++ b/packages/@granit/react-analytics/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./editor": "./src/editor/index.ts"
   },
   "files": [
     "dist"
@@ -18,17 +19,27 @@
     "@granit/api-client": "workspace:*",
     "@granit/dashboards": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "lucide-react": "^1.0.0",
     "react": "^19.0.0",
     "react-i18next": "^17.0.0"
   },
+  "peerDependenciesMeta": {
+    "@granit/react-dashboard-editor": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./editor": {
+        "types": "./dist/editor/index.d.ts",
+        "import": "./dist/editor/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"
@@ -38,6 +49,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/dashboards": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"

--- a/packages/@granit/react-analytics/src/__tests__/analytics-widget-catalog.test.ts
+++ b/packages/@granit/react-analytics/src/__tests__/analytics-widget-catalog.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { analyticsWidgetCatalog } from '../editor/analytics-widget-catalog.js';
+
+describe('analyticsWidgetCatalog', () => {
+  it('ships entries for the four analytics widget kinds (kpi / chart / table / pivot)', () => {
+    expect(analyticsWidgetCatalog.map((entry) => entry.type)).toEqual([
+      'kpi',
+      'chart',
+      'table',
+      'pivot',
+    ]);
+  });
+
+  it('factories produce widgets whose declared type matches the entry', () => {
+    for (const entry of analyticsWidgetCatalog) {
+      const created = entry.createDefaultWidget('Tmp', 0);
+      expect(created.type).toBe(entry.type);
+    }
+  });
+
+  it('chart and pivot factories default to `Sum` (the most common aggregation)', () => {
+    const chart = analyticsWidgetCatalog.find((e) => e.type === 'chart');
+    const pivot = analyticsWidgetCatalog.find((e) => e.type === 'pivot');
+    if (!chart || !pivot) throw new Error('catalog incomplete');
+    const chartWidget = chart.createDefaultWidget('C', 0) as { aggregation: string };
+    const pivotWidget = pivot.createDefaultWidget('P', 0) as { valueAggregation: string };
+    expect(chartWidget.aggregation).toBe('Sum');
+    expect(pivotWidget.valueAggregation).toBe('Sum');
+  });
+
+  it('kpi factory produces a metric datasource (the common case)', () => {
+    const kpi = analyticsWidgetCatalog.find((e) => e.type === 'kpi');
+    if (!kpi) throw new Error('kpi entry missing');
+    const widget = kpi.createDefaultWidget('K', 0) as { datasource: { kind: string } };
+    expect(widget.datasource.kind).toBe('metric');
+  });
+
+  it('chart / table / pivot factories produce empty `queryName` placeholders for the user to fill in', () => {
+    for (const type of ['chart', 'table', 'pivot'] as const) {
+      const entry = analyticsWidgetCatalog.find((e) => e.type === type);
+      if (!entry) throw new Error(`${type} entry missing`);
+      const widget = entry.createDefaultWidget('T', 0) as { queryName: string };
+      expect(widget.queryName).toBe('');
+    }
+  });
+});

--- a/packages/@granit/react-analytics/src/__tests__/kpi-config-form.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-config-form.test.tsx
@@ -1,0 +1,70 @@
+import { Datasource } from '@granit/dashboards';
+import { fireEvent, render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { KpiConfigForm } from '../editor/kpi-config-form.js';
+
+import type { KpiWidgetDefinition } from '@granit/analytics';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+}
+
+const baseKpi: KpiWidgetDefinition = {
+  slug: 'K',
+  type: 'kpi',
+  position: 0,
+  size: { width: 3, height: 1 },
+  datasource: Datasource.metric('Granit.Test.Metric'),
+};
+
+describe('KpiConfigForm', () => {
+  it('shows the metric-name input when bound to a metric datasource', () => {
+    const { container } = wrap(<KpiConfigForm widget={baseKpi} onChange={vi.fn()} />);
+    expect(container.querySelector('[data-slot="kpi-metric-name"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="kpi-query-name"]')).toBeNull();
+  });
+
+  it('emits an updated metric-name on change', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<KpiConfigForm widget={baseKpi} onChange={onChange} />);
+    const input = container.querySelector('[data-slot="kpi-metric-name"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: 'Granit.Test.NewMetric' } });
+    expect(onChange.mock.calls[0]?.[0]?.datasource).toEqual(
+      Datasource.metric('Granit.Test.NewMetric')
+    );
+  });
+
+  it('switches to query-aggregate when the kind selector changes', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<KpiConfigForm widget={baseKpi} onChange={onChange} />);
+    const select = container.querySelector('[data-slot="kpi-datasource-kind"]');
+    if (!(select instanceof HTMLSelectElement)) throw new Error('select not found');
+    fireEvent.change(select, { target: { value: 'query-aggregate' } });
+    expect(onChange.mock.calls[0]?.[0]?.datasource?.kind).toBe('query-aggregate');
+  });
+
+  it('shows query-name + aggregation inputs when bound to query-aggregate', () => {
+    const queryKpi: KpiWidgetDefinition = {
+      ...baseKpi,
+      datasource: Datasource.queryAggregate('Granit.Test.Query', 'Sum'),
+    };
+    const { container } = wrap(<KpiConfigForm widget={queryKpi} onChange={vi.fn()} />);
+    expect(container.querySelector('[data-slot="kpi-query-name"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="kpi-aggregation"]')).not.toBeNull();
+  });
+});

--- a/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
+++ b/packages/@granit/react-analytics/src/editor/analytics-widget-catalog.ts
@@ -1,0 +1,96 @@
+import { Datasource } from '@granit/dashboards';
+
+import type {
+  ChartWidgetDefinition,
+  KpiWidgetDefinition,
+  PivotWidgetDefinition,
+  TableWidgetDefinition,
+} from '@granit/analytics';
+import type { WidgetCatalogEntry } from '@granit/react-dashboard-editor';
+
+/**
+ * Catalog entries for every analytics widget kind shipped by
+ * `@granit/analytics` (kpi / chart / table / pivot). Compose into the
+ * editor's palette via:
+ *
+ *     <WidgetPalette catalog={composeCatalogs(defaultWidgetCatalog, analyticsWidgetCatalog)} ... />
+ *
+ * Default sizes are intentionally slim — KPI sits at the framework's
+ * `SMALL_KPI` (3×1), the others default to a half-row 6×3 footprint
+ * which fits two side-by-side widgets per row on the conventional
+ * 12-column grid.
+ *
+ * Stub datasources / queries are placeholders: a freshly added analytics
+ * widget needs the user to wire its query / datasource via the matching
+ * config form (`AnalyticsWidgetConfigForms`). Until that happens, the
+ * widget renders empty — the framework treats unbound queries as
+ * "no data", not an error.
+ */
+export const analyticsWidgetCatalog: readonly WidgetCatalogEntry[] = Object.freeze([
+  {
+    type: 'kpi',
+    labelLocalizationKey: 'Dashboard:Widget.Kpi.Label',
+    iconKey: 'kpi',
+    defaultSize: { width: 3, height: 1 },
+    createDefaultWidget: (slug, position): KpiWidgetDefinition => ({
+      slug,
+      type: 'kpi',
+      position,
+      size: { width: 3, height: 1 },
+      // Empty metric name — the user binds it in the config form. The
+      // backend rejects empty metricName at construction, so a fresh
+      // widget can't be saved before being configured (acceptable v1
+      // behaviour: surfaces the contract).
+      datasource: Datasource.metric(''),
+    }),
+  },
+  {
+    type: 'chart',
+    labelLocalizationKey: 'Dashboard:Widget.Chart.Label',
+    iconKey: 'chart',
+    defaultSize: { width: 6, height: 3 },
+    createDefaultWidget: (slug, position): ChartWidgetDefinition => ({
+      slug,
+      type: 'chart',
+      position,
+      size: { width: 6, height: 3 },
+      queryName: '',
+      groupBy: '',
+      aggregation: 'Sum',
+      field: null,
+      chartType: 'Bar',
+    }),
+  },
+  {
+    type: 'table',
+    labelLocalizationKey: 'Dashboard:Widget.Table.Label',
+    iconKey: 'table',
+    defaultSize: { width: 6, height: 3 },
+    createDefaultWidget: (slug, position): TableWidgetDefinition => ({
+      slug,
+      type: 'table',
+      position,
+      size: { width: 6, height: 3 },
+      queryName: '',
+      visibleColumns: null,
+      pageSize: 10,
+    }),
+  },
+  {
+    type: 'pivot',
+    labelLocalizationKey: 'Dashboard:Widget.Pivot.Label',
+    iconKey: 'pivot',
+    defaultSize: { width: 6, height: 3 },
+    createDefaultWidget: (slug, position): PivotWidgetDefinition => ({
+      slug,
+      type: 'pivot',
+      position,
+      size: { width: 6, height: 3 },
+      queryName: '',
+      rowFields: [],
+      columnFields: [],
+      valueField: null,
+      valueAggregation: 'Sum',
+    }),
+  },
+]);

--- a/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/chart-config-form.tsx
@@ -1,0 +1,102 @@
+import { useTranslation } from 'react-i18next';
+
+import type { ChartType, ChartWidgetDefinition } from '@granit/analytics';
+import type { AggregateFunction } from '@granit/dashboards';
+import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
+
+const CHART_TYPES: readonly ChartType[] = ['Bar', 'HorizontalBar', 'Line', 'Area', 'Pie', 'Donut'];
+const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
+
+/**
+ * Built-in config form for {@link ChartWidgetDefinition}. Edits the
+ * essential fields needed to bind a query: queryName, groupBy, the
+ * aggregation function, the optional aggregated field, and the chart
+ * type. Visual styling (palette, theme) is inherited from the active
+ * `<EChartsThemeProvider>` and stays out of scope for the form.
+ */
+export function ChartConfigForm({
+  widget,
+  onChange,
+}: WidgetConfigFormProps<ChartWidgetDefinition>) {
+  const { t } = useTranslation();
+  return (
+    <div data-slot="chart-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Chart.QueryName.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="chart-query-name"
+          value={widget.queryName}
+          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Chart.GroupBy.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="chart-group-by"
+          value={widget.groupBy}
+          onChange={(event) => onChange({ ...widget, groupBy: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Chart.Aggregation.Label')}
+        </span>
+        <select
+          data-slot="chart-aggregation"
+          value={widget.aggregation}
+          onChange={(event) =>
+            onChange({ ...widget, aggregation: event.target.value as AggregateFunction })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          {AGGREGATIONS.map((agg) => (
+            <option key={agg} value={agg}>
+              {agg}
+            </option>
+          ))}
+        </select>
+      </label>
+      {/* Field is required for everything except Count. The label hints at it. */}
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Chart.Field.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="chart-field"
+          value={widget.field ?? ''}
+          onChange={(event) =>
+            onChange({ ...widget, field: event.target.value === '' ? null : event.target.value })
+          }
+          disabled={widget.aggregation === 'Count'}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-50"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Chart.ChartType.Label')}
+        </span>
+        <select
+          data-slot="chart-type"
+          value={widget.chartType}
+          onChange={(event) => onChange({ ...widget, chartType: event.target.value as ChartType })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          {CHART_TYPES.map((type) => (
+            <option key={type} value={type}>
+              {type}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/packages/@granit/react-analytics/src/editor/index.ts
+++ b/packages/@granit/react-analytics/src/editor/index.ts
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------
+// @granit/react-analytics/editor — catalog + config forms for the dashboard
+// composer (B5-C). Imported only by editor-enabled apps; tree-shaken away
+// for read-only consumers.
+// ---------------------------------------------------------------------------
+
+import { ChartConfigForm } from './chart-config-form.js';
+import { KpiConfigForm } from './kpi-config-form.js';
+import { PivotConfigForm } from './pivot-config-form.js';
+import { TableConfigForm } from './table-config-form.js';
+
+import type { WidgetConfigForm, WidgetConfigFormRegistry } from '@granit/react-dashboard-editor';
+
+export { analyticsWidgetCatalog } from './analytics-widget-catalog.js';
+export { ChartConfigForm } from './chart-config-form.js';
+export { KpiConfigForm } from './kpi-config-form.js';
+export { PivotConfigForm } from './pivot-config-form.js';
+export { TableConfigForm } from './table-config-form.js';
+
+/**
+ * Pre-composed config-form registry — the four analytics kinds in a
+ * single registry shaped to drop straight into
+ * `composeWidgetConfigFormRegistries(default, analyticsWidgetConfigFormRegistry)`.
+ *
+ * Casts route through `unknown` because TypeScript can't relate each
+ * form's narrow widget type (`KpiWidgetDefinition`, etc.) to the open
+ * `WidgetDefinition` union the registry's value type uses — same pattern
+ * as `defaultAnalyticsWidgetRegistry` for the read-mode renderers.
+ */
+export const analyticsWidgetConfigFormRegistry: WidgetConfigFormRegistry = Object.freeze({
+  kpi: KpiConfigForm as unknown as WidgetConfigForm,
+  chart: ChartConfigForm as unknown as WidgetConfigForm,
+  table: TableConfigForm as unknown as WidgetConfigForm,
+  pivot: PivotConfigForm as unknown as WidgetConfigForm,
+});

--- a/packages/@granit/react-analytics/src/editor/kpi-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/kpi-config-form.tsx
@@ -1,0 +1,117 @@
+import { Datasource, isMetricDatasource, isQueryAggregateDatasource } from '@granit/dashboards';
+import { useTranslation } from 'react-i18next';
+
+import type { KpiWidgetDefinition } from '@granit/analytics';
+import type { AggregateFunction } from '@granit/dashboards';
+import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
+
+/**
+ * Built-in config form for {@link KpiWidgetDefinition}. v1 covers the two
+ * common datasource flavours — Metric (the typical case) and
+ * QueryAggregate (ad-hoc admin pages reusing the widget).
+ *
+ * Telemetry datasources are out of scope for the form: those carry an
+ * `entityAlias` that only makes sense in an IoT context. Apps wanting to
+ * edit telemetry-bound KPIs ship a custom form via
+ * `composeWidgetConfigFormRegistries`.
+ */
+export function KpiConfigForm({ widget, onChange }: WidgetConfigFormProps<KpiWidgetDefinition>) {
+  const { t } = useTranslation();
+  const { datasource } = widget;
+
+  const handleKindChange = (kind: 'metric' | 'query-aggregate') => {
+    if (kind === 'metric') {
+      onChange({ ...widget, datasource: Datasource.metric('') });
+    } else {
+      onChange({ ...widget, datasource: Datasource.queryAggregate('', 'Sum') });
+    }
+  };
+
+  return (
+    <div data-slot="kpi-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Kpi.DatasourceKind.Label')}
+        </span>
+        <select
+          data-slot="kpi-datasource-kind"
+          value={datasource.kind === 'iot-telemetry' ? 'metric' : datasource.kind}
+          onChange={(event) => handleKindChange(event.target.value as 'metric' | 'query-aggregate')}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          <option value="metric">Metric</option>
+          <option value="query-aggregate">Query aggregate</option>
+        </select>
+      </label>
+
+      {isMetricDatasource(datasource) && (
+        <label className="block text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            {t('Dashboard:Widget.Kpi.MetricName.Label')}
+          </span>
+          <input
+            type="text"
+            data-slot="kpi-metric-name"
+            value={datasource.metricName}
+            onChange={(event) =>
+              onChange({ ...widget, datasource: Datasource.metric(event.target.value) })
+            }
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          />
+        </label>
+      )}
+
+      {isQueryAggregateDatasource(datasource) && (
+        <>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Kpi.QueryName.Label')}
+            </span>
+            <input
+              type="text"
+              data-slot="kpi-query-name"
+              value={datasource.queryName}
+              onChange={(event) =>
+                onChange({
+                  ...widget,
+                  datasource: Datasource.queryAggregate(
+                    event.target.value,
+                    datasource.aggregation,
+                    datasource.field
+                  ),
+                })
+              }
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Kpi.Aggregation.Label')}
+            </span>
+            <select
+              data-slot="kpi-aggregation"
+              value={datasource.aggregation}
+              onChange={(event) =>
+                onChange({
+                  ...widget,
+                  datasource: Datasource.queryAggregate(
+                    datasource.queryName,
+                    event.target.value as AggregateFunction,
+                    datasource.field
+                  ),
+                })
+              }
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            >
+              <option value="Sum">Sum</option>
+              <option value="Avg">Avg</option>
+              <option value="Min">Min</option>
+              <option value="Max">Max</option>
+              <option value="Count">Count</option>
+            </select>
+          </label>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-analytics/src/editor/pivot-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/pivot-config-form.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next';
+
+import type { PivotWidgetDefinition } from '@granit/analytics';
+import type { AggregateFunction } from '@granit/dashboards';
+import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
+
+const AGGREGATIONS: readonly AggregateFunction[] = ['Count', 'Sum', 'Avg', 'Min', 'Max'];
+
+const splitFields = (raw: string) =>
+  raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+/**
+ * Built-in config form for {@link PivotWidgetDefinition}. Edits the
+ * query binding, the row + column dimension lists (comma-separated), the
+ * aggregated value field, and the aggregation function. v1 keeps fields
+ * as plain text — column-pickers / drag-and-drop dimension reorder ship
+ * via custom forms registered downstream.
+ */
+export function PivotConfigForm({
+  widget,
+  onChange,
+}: WidgetConfigFormProps<PivotWidgetDefinition>) {
+  const { t } = useTranslation();
+  return (
+    <div data-slot="pivot-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Pivot.QueryName.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="pivot-query-name"
+          value={widget.queryName}
+          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Pivot.RowFields.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="pivot-row-fields"
+          value={widget.rowFields.join(', ')}
+          onChange={(event) => onChange({ ...widget, rowFields: splitFields(event.target.value) })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Pivot.ColumnFields.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="pivot-column-fields"
+          value={widget.columnFields.join(', ')}
+          onChange={(event) =>
+            onChange({ ...widget, columnFields: splitFields(event.target.value) })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Pivot.ValueField.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="pivot-value-field"
+          value={widget.valueField ?? ''}
+          onChange={(event) =>
+            onChange({
+              ...widget,
+              valueField: event.target.value === '' ? null : event.target.value,
+            })
+          }
+          disabled={widget.valueAggregation === 'Count'}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm disabled:opacity-50"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Pivot.ValueAggregation.Label')}
+        </span>
+        <select
+          data-slot="pivot-value-aggregation"
+          value={widget.valueAggregation}
+          onChange={(event) =>
+            onChange({ ...widget, valueAggregation: event.target.value as AggregateFunction })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          {AGGREGATIONS.map((agg) => (
+            <option key={agg} value={agg}>
+              {agg}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
+  );
+}

--- a/packages/@granit/react-analytics/src/editor/table-config-form.tsx
+++ b/packages/@granit/react-analytics/src/editor/table-config-form.tsx
@@ -1,0 +1,73 @@
+import { useTranslation } from 'react-i18next';
+
+import type { TableWidgetDefinition } from '@granit/analytics';
+import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
+
+/**
+ * Built-in config form for {@link TableWidgetDefinition}. Edits the
+ * query binding + page size. Column visibility (`visibleColumns`) is
+ * left as comma-separated input — apps wanting a column-picker dialog
+ * register their own form via `composeWidgetConfigFormRegistries`.
+ */
+export function TableConfigForm({
+  widget,
+  onChange,
+}: WidgetConfigFormProps<TableWidgetDefinition>) {
+  const { t } = useTranslation();
+  const visibleColumnsValue = widget.visibleColumns?.join(', ') ?? '';
+
+  return (
+    <div data-slot="table-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Table.QueryName.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="table-query-name"
+          value={widget.queryName}
+          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Table.VisibleColumns.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="table-visible-columns"
+          value={visibleColumnsValue}
+          placeholder="leave empty for all columns"
+          onChange={(event) => {
+            const raw = event.target.value.trim();
+            const next =
+              raw === ''
+                ? null
+                : raw
+                    .split(',')
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+            onChange({ ...widget, visibleColumns: next });
+          }}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Table.PageSize.Label')}
+        </span>
+        <input
+          type="number"
+          data-slot="table-page-size"
+          min={1}
+          value={widget.pageSize}
+          onChange={(event) =>
+            onChange({ ...widget, pageSize: Number.parseInt(event.target.value, 10) || 1 })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+    </div>
+  );
+}

--- a/packages/@granit/react-dashboard-editor/src/lib/widget-catalog.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/widget-catalog.ts
@@ -1,6 +1,6 @@
 import { WIDGET_SIZE } from '@granit/dashboards';
 
-import type { WidgetDefinition, WidgetSize } from '@granit/dashboards';
+import type { WidgetDefinition, WidgetDefinitionBase, WidgetSize } from '@granit/dashboards';
 
 /**
  * Descriptor an editor uses to surface "add widget" buttons in a
@@ -31,16 +31,23 @@ export interface WidgetCatalogEntry {
   /** Grid size assigned to a freshly added widget. */
   readonly defaultSize: WidgetSize;
   /**
-   * Factory producing a fresh {@link WidgetDefinition} for this kind.
-   * Receives the slug + position {@link addWidget} computed for it; the
-   * factory fills in the kind-specific fields (content localization key,
-   * source URL, query name, etc.).
+   * Factory producing a fresh widget for this kind. Receives the slug +
+   * position {@link addWidget} computed for it; the factory fills in the
+   * kind-specific fields (content localization key, source URL, query
+   * name, etc.).
+   *
+   * Return type is the open `WidgetDefinitionBase` rather than the closed
+   * {@link WidgetDefinition} union so downstream packages can return
+   * their concrete definitions (`KpiWidgetDefinition`,
+   * `ChartWidgetDefinition`, etc.) without an unchecked cast — those
+   * extend the base but don't satisfy the open
+   * `Readonly<Record<string, unknown>>` half of the framework union.
    *
    * Factories should NOT pre-generate `slug` / `position` themselves —
    * those two fields are owned by {@link addWidget} so unique-slug
    * generation stays centralized.
    */
-  readonly createDefaultWidget: (slug: string, position: number) => WidgetDefinition;
+  readonly createDefaultWidget: (slug: string, position: number) => WidgetDefinitionBase;
 }
 
 /**
@@ -106,12 +113,18 @@ export function addWidget<TDefinition extends { readonly widgets: readonly Widge
   const slug = nextUniqueSlug(entry.type, existingSlugs);
   const position = definition.widgets.length;
   const created = entry.createDefaultWidget(slug, position);
-  const widget: WidgetDefinition = {
+  // Cast to the open `WidgetDefinition` union after stamping the
+  // editor-owned fields (slug / position / size). Downstream factories
+  // return concrete `WidgetDefinitionBase` extensions which don't satisfy
+  // the union's open `Record<string, unknown>` half, but are still valid
+  // wire shapes — the runtime contract is enforced by the renderer
+  // registry, not the type.
+  const widget = {
     ...created,
     slug,
     position,
     size: entry.defaultSize,
-  };
+  } as WidgetDefinition;
   return { ...definition, widgets: [...definition.widgets, widget] };
 }
 

--- a/packages/@granit/react-dashboard-editor/src/lib/widget-config-form-registry.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/widget-config-form-registry.ts
@@ -1,4 +1,4 @@
-import type { WidgetDefinition } from '@granit/dashboards';
+import type { WidgetDefinition, WidgetDefinitionBase } from '@granit/dashboards';
 import type { ComponentType } from 'react';
 
 /**
@@ -12,8 +12,15 @@ import type { ComponentType } from 'react';
  * (composes the localization key + drives DnD identity); position is
  * owned by `reorderWidgets`; size is owned by the (future) resize gesture
  * + the catalog's `defaultSize`.
+ *
+ * `T` is constrained to `WidgetDefinitionBase` (not `WidgetDefinition`) so
+ * downstream packages can type their forms against their own concrete
+ * definitions (`KpiWidgetDefinition`, `ChartWidgetDefinition`, etc.) —
+ * those extend the base but don't satisfy the open
+ * `Readonly<Record<string, unknown>>` half of the `WidgetDefinition`
+ * union.
  */
-export interface WidgetConfigFormProps<T extends WidgetDefinition = WidgetDefinition> {
+export interface WidgetConfigFormProps<T extends WidgetDefinitionBase = WidgetDefinition> {
   readonly widget: T;
   readonly onChange: (next: T) => void;
 }
@@ -24,7 +31,7 @@ export interface WidgetConfigFormProps<T extends WidgetDefinition = WidgetDefini
  * callers can wire their own validation / submission pipeline (typically
  * a controlled form mirroring the parent dashboard state).
  */
-export type WidgetConfigForm<T extends WidgetDefinition = WidgetDefinition> = ComponentType<
+export type WidgetConfigForm<T extends WidgetDefinitionBase = WidgetDefinition> = ComponentType<
   WidgetConfigFormProps<T>
 >;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -682,6 +682,9 @@ importers:
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
+      '@granit/react-dashboard-editor':
+        specifier: workspace:*
+        version: link:../react-dashboard-editor
       '@granit/react-dashboards':
         specifier: workspace:*
         version: link:../react-dashboards
@@ -1105,6 +1108,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
     devDependencies:
       '@dnd-kit/core':
         specifier: ^6.3.0


### PR DESCRIPTION
## Summary

Adds the editor-side primitives for the four analytics widget kinds. With this in place, the dashboard composer can add and configure KPI / Chart / Table / Pivot widgets — not just the framework primitives (Markdown / Text / Image).

Exposed under the optional subpath \`@granit/react-analytics/editor\` so apps that only render dashboards (no editor) don't pull dnd-kit transitively.

### Catalog
- \`analyticsWidgetCatalog\` — palette entries for kpi / chart / table / pivot. Conventional default sizes (3×1 KPI, 6×3 for the rest). Factories produce minimal-but-valid widgets with empty \`queryName\` / \`metricName\` placeholders the user fills in via the matching form.

### Config forms
- \`KpiConfigForm\` — datasource discriminator (Metric / QueryAggregate), with the right field set per kind. Telemetry intentionally omitted (IoT-only — that ships in the IoT package's own form once it lands).
- \`ChartConfigForm\` — queryName, groupBy, aggregation, optional field, chart type. Field input disabled when \`aggregation === 'Count'\`.
- \`TableConfigForm\` — queryName, comma-separated visible columns, page size.
- \`PivotConfigForm\` — queryName, comma-separated row/column dimensions, value field, value aggregation. Same Count-disables-field rule as Chart.

### Pre-composed registry
- \`analyticsWidgetConfigFormRegistry\` — drop straight into \`composeWidgetConfigFormRegistries(default, analyticsWidgetConfigFormRegistry)\`.

## Type-system tweak

Relaxed two constraints in \`@granit/react-dashboard-editor\` from the closed \`WidgetDefinition\` union to the open \`WidgetDefinitionBase\`:
- \`WidgetConfigFormProps<T>\`
- \`WidgetCatalogEntry.createDefaultWidget\` return type

The closed union's \`Readonly<Record<string, unknown>>\` half doesn't admit downstream concrete types like \`KpiWidgetDefinition\` without an unsafe cast. Relaxing the constraint preserves exhaustiveness on the read side (\`WidgetRegistry\` etc. still typed against the union) while letting downstream packages stay strongly-typed on the edit side.

## Notes

- Map widget catalog + config form coming in the next PR (\`@granit/react-map\`).
- Showcase wiring (composing all catalogs in the edit page) lands after both per-package PRs merge.

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-analytics\` — 7 files / 49 tests pass (10 new).
- [x] \`pnpm exec vitest run\` — repo-wide: 329 files / 2480 tests pass.
- [x] \`pnpm lint\` clean (max-warnings 0).
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.