### PR TITLE
feat(react-map): editor catalog + config form for the map widget

### DIFF
--- a/packages/@granit/react-map/package.json
+++ b/packages/@granit/react-map/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./editor": "./src/editor/index.ts"
   },
   "files": [
     "dist"
@@ -16,13 +17,21 @@
   "peerDependencies": {
     "@granit/analytics": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
-    "react": "^19.0.0"
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/react-dashboard-editor": {
+      "optional": true
+    },
     "leaflet.markercluster": {
+      "optional": true
+    },
+    "react-i18next": {
       "optional": true
     }
   },
@@ -31,6 +40,10 @@
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./editor": {
+        "types": "./dist/editor/index.d.ts",
+        "import": "./dist/editor/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"
@@ -38,6 +51,7 @@
   "devDependencies": {
     "@granit/analytics": "workspace:*",
     "@granit/dashboards": "workspace:*",
+    "@granit/react-dashboard-editor": "workspace:*",
     "@granit/react-dashboards": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",

--- a/packages/@granit/react-map/src/__tests__/map-config-form.test.tsx
+++ b/packages/@granit/react-map/src/__tests__/map-config-form.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MapConfigForm } from '../editor/map-config-form.js';
+
+import type { MapWidgetDefinition } from '@granit/analytics';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+}
+
+const baseMap: MapWidgetDefinition = {
+  slug: 'M',
+  type: 'map',
+  position: 0,
+  size: { width: 6, height: 4 },
+  queryName: 'Granit.Test.Customers',
+  pointSource: { kind: 'lat-lng', latitudeColumn: 'Latitude', longitudeColumn: 'Longitude' },
+  popupColumns: ['name'],
+  defaultZoom: 5,
+  defaultCenter: null,
+  clusterThreshold: 200,
+  detailRoute: null,
+  tileUrlTemplate: null,
+  defaultLayerKind: null,
+};
+
+describe('MapConfigForm', () => {
+  it('shows the lat / lng column inputs when bound to a lat-lng point source', () => {
+    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={vi.fn()} />);
+    expect(container.querySelector('[data-slot="map-latitude-column"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="map-longitude-column"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="map-geography-column"]')).toBeNull();
+  });
+
+  it('emits an updated query-name on change', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
+    const input = container.querySelector('[data-slot="map-query-name"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: 'Granit.Test.Branches' } });
+    expect(onChange.mock.calls[0]?.[0]?.queryName).toBe('Granit.Test.Branches');
+  });
+
+  it('switches to a geography column input when the point-source kind changes', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
+    const select = container.querySelector('[data-slot="map-point-source-kind"]');
+    if (!(select instanceof HTMLSelectElement)) throw new Error('select not found');
+    fireEvent.change(select, { target: { value: 'geography' } });
+    expect(onChange.mock.calls[0]?.[0]?.pointSource).toEqual({
+      kind: 'geography',
+      geographyColumn: '',
+    });
+  });
+
+  it('parses comma-separated popup columns into the array shape the backend expects', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
+    const input = container.querySelector('[data-slot="map-popup-columns"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: ' name , employees ' } });
+    expect(onChange.mock.calls[0]?.[0]?.popupColumns).toEqual(['name', 'employees']);
+  });
+
+  it('collapses the empty popup-columns input to null (backend convention)', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
+    const input = container.querySelector('[data-slot="map-popup-columns"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange.mock.calls[0]?.[0]?.popupColumns).toBeNull();
+  });
+
+  it('keeps defaultCenter null when only one of lat / lng is provided (avoids backend rejection)', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={onChange} />);
+    const lat = container.querySelector('[data-slot="map-default-center-latitude"]');
+    if (!(lat instanceof HTMLInputElement)) throw new Error('lat input not found');
+    fireEvent.change(lat, { target: { value: '50.85' } });
+    expect(onChange.mock.calls[0]?.[0]?.defaultCenter).toBeNull();
+  });
+
+  it('produces a complete defaultCenter once both lat + lng are filled in', () => {
+    const onChange = vi.fn();
+    const seeded: MapWidgetDefinition = {
+      ...baseMap,
+      defaultCenter: { latitude: 50.85, longitude: 0 },
+    };
+    const { container } = wrap(<MapConfigForm widget={seeded} onChange={onChange} />);
+    const lng = container.querySelector('[data-slot="map-default-center-longitude"]');
+    if (!(lng instanceof HTMLInputElement)) throw new Error('lng input not found');
+    fireEvent.change(lng, { target: { value: '4.35' } });
+    expect(onChange.mock.calls[0]?.[0]?.defaultCenter).toEqual({
+      latitude: 50.85,
+      longitude: 4.35,
+    });
+  });
+
+  it('exposes the layer-kind select with a "(provider default)" no-op option', () => {
+    const { container } = wrap(<MapConfigForm widget={baseMap} onChange={vi.fn()} />);
+    const select = container.querySelector('[data-slot="map-default-layer-kind"]');
+    expect(select).not.toBeNull();
+    if (!(select instanceof HTMLSelectElement)) throw new Error('select not found');
+    expect(select.value).toBe('');
+  });
+});

--- a/packages/@granit/react-map/src/__tests__/map-widget-catalog.test.ts
+++ b/packages/@granit/react-map/src/__tests__/map-widget-catalog.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { mapWidgetCatalog } from '../editor/map-widget-catalog.js';
+
+describe('mapWidgetCatalog', () => {
+  it('ships a single entry for the `map` kind', () => {
+    expect(mapWidgetCatalog.map((entry) => entry.type)).toEqual(['map']);
+  });
+
+  it('factory returns a widget bound to a lat-lng point source by default', () => {
+    const entry = mapWidgetCatalog[0];
+    if (!entry) throw new Error('catalog empty');
+    const widget = entry.createDefaultWidget('M', 0) as {
+      type: string;
+      pointSource: { kind: string };
+      clusterThreshold: number;
+    };
+    expect(widget.type).toBe('map');
+    expect(widget.pointSource.kind).toBe('lat-lng');
+    expect(widget.clusterThreshold).toBe(200);
+  });
+
+  it('factory leaves queryName / lat / lng columns empty for the user to fill in', () => {
+    const entry = mapWidgetCatalog[0];
+    if (!entry) throw new Error('catalog empty');
+    const widget = entry.createDefaultWidget('M', 0) as {
+      queryName: string;
+      pointSource: { latitudeColumn: string; longitudeColumn: string };
+    };
+    expect(widget.queryName).toBe('');
+    expect(widget.pointSource.latitudeColumn).toBe('');
+    expect(widget.pointSource.longitudeColumn).toBe('');
+  });
+
+  it('default size matches the framework MEDIA_TILE proportions on a 12-column grid', () => {
+    const entry = mapWidgetCatalog[0];
+    if (!entry) throw new Error('catalog empty');
+    expect(entry.defaultSize).toEqual({ width: 6, height: 4 });
+  });
+});

--- a/packages/@granit/react-map/src/editor/index.ts
+++ b/packages/@granit/react-map/src/editor/index.ts
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------------
+// @granit/react-map/editor — catalog + config form for the dashboard
+// composer (B5-C). Imported only by editor-enabled apps; tree-shaken away
+// for read-only consumers.
+// ---------------------------------------------------------------------------
+
+import { MapConfigForm } from './map-config-form.js';
+
+import type { WidgetConfigForm, WidgetConfigFormRegistry } from '@granit/react-dashboard-editor';
+
+export { mapWidgetCatalog } from './map-widget-catalog.js';
+export { MapConfigForm } from './map-config-form.js';
+
+/**
+ * Pre-composed config-form registry — the map kind in a single registry
+ * shaped to drop straight into
+ * `composeWidgetConfigFormRegistries(default, analytics, mapWidgetConfigFormRegistry)`.
+ *
+ * Cast routes through `unknown` because TypeScript can't relate the
+ * narrow `MapWidgetDefinition` to the open `WidgetDefinition` union the
+ * registry's value type uses — same pattern as the analytics registry.
+ */
+export const mapWidgetConfigFormRegistry: WidgetConfigFormRegistry = Object.freeze({
+  map: MapConfigForm as unknown as WidgetConfigForm,
+});

--- a/packages/@granit/react-map/src/editor/map-config-form.tsx
+++ b/packages/@granit/react-map/src/editor/map-config-form.tsx
@@ -1,0 +1,294 @@
+import { isGeographyMapPointSource, isLatLngMapPointSource } from '@granit/analytics';
+import { useTranslation } from 'react-i18next';
+
+import type { MapTileLayerKind, MapWidgetDefinition } from '@granit/analytics';
+import type { WidgetConfigFormProps } from '@granit/react-dashboard-editor';
+
+const LAYER_KINDS: readonly MapTileLayerKind[] = ['Plan', 'Satellite', 'Hybrid', 'Topo', 'Custom'];
+
+/**
+ * Built-in config form for {@link MapWidgetDefinition}. Edits the query
+ * binding, point-source flavour (lat/lng pair vs PostGIS geography
+ * column), comma-separated popup columns, default camera (zoom +
+ * optional center), cluster threshold, optional detail-route + tile
+ * provider override.
+ *
+ * Center coordinates accept either both lat + lng or neither (the
+ * server-side validator rejects half-bound centers). Empty inputs
+ * collapse the center to `null` so the snapshot renderer falls back to
+ * fitting the bounding box of the rendered points.
+ */
+export function MapConfigForm({ widget, onChange }: WidgetConfigFormProps<MapWidgetDefinition>) {
+  const { t } = useTranslation();
+  const { pointSource } = widget;
+
+  const handlePointSourceKindChange = (kind: 'lat-lng' | 'geography') => {
+    if (kind === 'lat-lng') {
+      onChange({
+        ...widget,
+        pointSource: { kind: 'lat-lng', latitudeColumn: '', longitudeColumn: '' },
+      });
+    } else {
+      onChange({ ...widget, pointSource: { kind: 'geography', geographyColumn: '' } });
+    }
+  };
+
+  const popupColumnsValue = widget.popupColumns?.join(', ') ?? '';
+  const center = widget.defaultCenter;
+
+  return (
+    <div data-slot="map-config-form" className="space-y-3">
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.QueryName.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="map-query-name"
+          value={widget.queryName}
+          onChange={(event) => onChange({ ...widget, queryName: event.target.value })}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.PointSourceKind.Label')}
+        </span>
+        <select
+          data-slot="map-point-source-kind"
+          value={pointSource.kind}
+          onChange={(event) =>
+            handlePointSourceKindChange(event.target.value as 'lat-lng' | 'geography')
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          <option value="lat-lng">Lat / lng pair</option>
+          <option value="geography">PostGIS geography column</option>
+        </select>
+      </label>
+
+      {isLatLngMapPointSource(pointSource) && (
+        <>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Map.LatitudeColumn.Label')}
+            </span>
+            <input
+              type="text"
+              data-slot="map-latitude-column"
+              value={pointSource.latitudeColumn}
+              onChange={(event) =>
+                onChange({
+                  ...widget,
+                  pointSource: { ...pointSource, latitudeColumn: event.target.value },
+                })
+              }
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="mb-1 block text-muted-foreground">
+              {t('Dashboard:Widget.Map.LongitudeColumn.Label')}
+            </span>
+            <input
+              type="text"
+              data-slot="map-longitude-column"
+              value={pointSource.longitudeColumn}
+              onChange={(event) =>
+                onChange({
+                  ...widget,
+                  pointSource: { ...pointSource, longitudeColumn: event.target.value },
+                })
+              }
+              className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+            />
+          </label>
+        </>
+      )}
+
+      {isGeographyMapPointSource(pointSource) && (
+        <label className="block text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            {t('Dashboard:Widget.Map.GeographyColumn.Label')}
+          </span>
+          <input
+            type="text"
+            data-slot="map-geography-column"
+            value={pointSource.geographyColumn}
+            onChange={(event) =>
+              onChange({
+                ...widget,
+                pointSource: { ...pointSource, geographyColumn: event.target.value },
+              })
+            }
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          />
+        </label>
+      )}
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.PopupColumns.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="map-popup-columns"
+          value={popupColumnsValue}
+          placeholder="leave empty for no popup body"
+          onChange={(event) => {
+            const raw = event.target.value.trim();
+            const next =
+              raw === ''
+                ? null
+                : raw
+                    .split(',')
+                    .map((s) => s.trim())
+                    .filter((s) => s.length > 0);
+            onChange({ ...widget, popupColumns: next });
+          }}
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.DefaultZoom.Label')}
+        </span>
+        <input
+          type="number"
+          data-slot="map-default-zoom"
+          min={0}
+          max={18}
+          value={widget.defaultZoom ?? 5}
+          onChange={(event) =>
+            onChange({ ...widget, defaultZoom: Number.parseInt(event.target.value, 10) || 0 })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+
+      <div className="grid grid-cols-2 gap-2">
+        <label className="block text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            {t('Dashboard:Widget.Map.DefaultCenter.Latitude.Label')}
+          </span>
+          <input
+            type="number"
+            data-slot="map-default-center-latitude"
+            value={center?.latitude ?? ''}
+            onChange={(event) => {
+              const lat = event.target.value === '' ? null : Number.parseFloat(event.target.value);
+              const lng = center?.longitude ?? null;
+              onChange({
+                ...widget,
+                defaultCenter:
+                  lat !== null && lng !== null ? { latitude: lat, longitude: lng } : null,
+              });
+            }}
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          />
+        </label>
+        <label className="block text-sm">
+          <span className="mb-1 block text-muted-foreground">
+            {t('Dashboard:Widget.Map.DefaultCenter.Longitude.Label')}
+          </span>
+          <input
+            type="number"
+            data-slot="map-default-center-longitude"
+            value={center?.longitude ?? ''}
+            onChange={(event) => {
+              const lng = event.target.value === '' ? null : Number.parseFloat(event.target.value);
+              const lat = center?.latitude ?? null;
+              onChange({
+                ...widget,
+                defaultCenter:
+                  lat !== null && lng !== null ? { latitude: lat, longitude: lng } : null,
+              });
+            }}
+            className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+          />
+        </label>
+      </div>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.ClusterThreshold.Label')}
+        </span>
+        <input
+          type="number"
+          data-slot="map-cluster-threshold"
+          min={1}
+          value={widget.clusterThreshold ?? 200}
+          onChange={(event) =>
+            onChange({ ...widget, clusterThreshold: Number.parseInt(event.target.value, 10) || 1 })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.DetailRoute.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="map-detail-route"
+          value={widget.detailRoute ?? ''}
+          placeholder="/customers/{id}"
+          onChange={(event) =>
+            onChange({
+              ...widget,
+              detailRoute: event.target.value === '' ? null : event.target.value,
+            })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.DefaultLayerKind.Label')}
+        </span>
+        <select
+          data-slot="map-default-layer-kind"
+          value={widget.defaultLayerKind ?? ''}
+          onChange={(event) =>
+            onChange({
+              ...widget,
+              defaultLayerKind:
+                event.target.value === '' ? null : (event.target.value as MapTileLayerKind),
+            })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        >
+          <option value="">(provider default)</option>
+          {LAYER_KINDS.map((kind) => (
+            <option key={kind} value={kind}>
+              {kind}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      <label className="block text-sm">
+        <span className="mb-1 block text-muted-foreground">
+          {t('Dashboard:Widget.Map.TileUrlTemplate.Label')}
+        </span>
+        <input
+          type="text"
+          data-slot="map-tile-url-template"
+          value={widget.tileUrlTemplate ?? ''}
+          placeholder="leave empty to use the active provider"
+          onChange={(event) =>
+            onChange({
+              ...widget,
+              tileUrlTemplate: event.target.value === '' ? null : event.target.value,
+            })
+          }
+          className="w-full rounded-md border bg-background px-3 py-1.5 text-sm"
+        />
+      </label>
+    </div>
+  );
+}

--- a/packages/@granit/react-map/src/editor/map-widget-catalog.ts
+++ b/packages/@granit/react-map/src/editor/map-widget-catalog.ts
@@ -1,0 +1,45 @@
+import type { MapWidgetDefinition } from '@granit/analytics';
+import type { WidgetCatalogEntry } from '@granit/react-dashboard-editor';
+
+/**
+ * Catalog entry for the `'map'` widget kind. Compose into the editor's
+ * palette via:
+ *
+ *     <WidgetPalette
+ *       catalog={composeCatalogs(defaultWidgetCatalog, mapWidgetCatalog)}
+ *       ... />
+ *
+ * Default size matches the `MEDIA_TILE` proportions on a 12-column grid
+ * (4×4) — large enough to show a meaningful map with markers without
+ * dominating the dashboard. Apps that want a wider map override
+ * `defaultSize` by composing their own catalog entry with the same type.
+ *
+ * The factory produces a minimal-but-valid widget bound to a
+ * `lat-lng` point source with empty column names — the user fills the
+ * column names + `queryName` via {@link MapConfigForm}. Until configured,
+ * the map renders empty (no rows from an unbound query); the framework
+ * treats unbound queries as "no data", not an error.
+ */
+export const mapWidgetCatalog: readonly WidgetCatalogEntry[] = Object.freeze([
+  {
+    type: 'map',
+    labelLocalizationKey: 'Dashboard:Widget.Map.Label',
+    iconKey: 'map',
+    defaultSize: { width: 6, height: 4 },
+    createDefaultWidget: (slug, position): MapWidgetDefinition => ({
+      slug,
+      type: 'map',
+      position,
+      size: { width: 6, height: 4 },
+      queryName: '',
+      pointSource: { kind: 'lat-lng', latitudeColumn: '', longitudeColumn: '' },
+      popupColumns: null,
+      defaultZoom: 5,
+      defaultCenter: null,
+      clusterThreshold: 200,
+      detailRoute: null,
+      tileUrlTemplate: null,
+      defaultLayerKind: null,
+    }),
+  },
+]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1414,6 +1414,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
     devDependencies:
       '@granit/analytics':
         specifier: workspace:*
@@ -1421,6 +1424,9 @@ importers:
       '@granit/dashboards':
         specifier: workspace:*
         version: link:../dashboards
+      '@granit/react-dashboard-editor':
+        specifier: workspace:*
+        version: link:../react-dashboard-editor
       '@granit/react-dashboards':
         specifier: workspace:*
         version: link:../react-dashboards


### PR DESCRIPTION
## Summary

Adds the editor-side primitives for the `'map'` widget kind. With this in place plus PR #275 (analytics catalog), the dashboard composer covers every widget kind shipped by the framework.

Exposed under the optional subpath `@granit/react-map/editor` so apps that only render dashboards (no editor) don't pull dnd-kit transitively.

### Catalog
- `mapWidgetCatalog` — palette entry for the `map` kind. Default size 6×4 (matches the framework's `MEDIA_TILE` proportions on a 12-column grid). Factory produces a minimal-but-valid widget bound to a lat-lng point source with empty column names + `queryName` for the user to fill in.

### Config form
`MapConfigForm` covers the full surface:
- `queryName` + point-source kind discriminator (lat/lng pair vs PostGIS geography column) with the right field set per kind
- comma-separated popup columns (collapses to `null` when empty so the backend's "no popup body" convention is preserved)
- default zoom + optional default center (lat + lng both required — half-bound centers stay `null` so the server validator doesn't reject the save)
- cluster threshold (rows-above-which clustering activates)
- optional detail-route template (`/customers/{id}` style)
- default layer kind override (Plan / Satellite / Hybrid / Topo / Custom from B7-3) with a "(provider default)" no-op option
- optional tile URL template override

### Pre-composed registry
- `mapWidgetConfigFormRegistry` — drop straight into `composeWidgetConfigFormRegistries(default, analytics, mapWidgetConfigFormRegistry)`.

## Notes

- `react-i18next` added as an optional peer dep (the form uses `useTranslation`; only loaded when `/editor` is imported).
- `@granit/react-dashboard-editor` added as an optional peer dep (same reasoning).
- Showcase wiring (composing all three catalogs in the edit page) lands in the next PR.

## Test plan

- [x] `pnpm exec vitest run packages/@granit/react-map` — 5 files / 23 tests pass (12 new).
- [x] `pnpm exec vitest run` — repo-wide: 331 files / 2492 tests pass.
- [x] `pnpm lint` clean (max-warnings 0).
- [x] `pnpm tsc` clean across all 87 \`@granit/*\` packages.