### PR TITLE
feat(dashboards): widget instance ↔ definition bridge utility

### DIFF
--- a/packages/@granit/dashboards/src/endpoints/__tests__/widget-bridge.test.ts
+++ b/packages/@granit/dashboards/src/endpoints/__tests__/widget-bridge.test.ts
@@ -1,0 +1,368 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  dashboardDetailToDefinition,
+  diffDashboardWidgets,
+  extractSlugFromTitleKey,
+  widgetDefinitionToAddRequest,
+  widgetDefinitionToUpdateRequest,
+  widgetInstanceToDefinition,
+} from '../widget-bridge.js';
+
+import type {
+  MarkdownWidgetDefinition,
+  TextWidgetDefinition,
+  WidgetDefinition,
+  WidgetDefinitionBase,
+} from '../../types/index.js';
+import type { DashboardDetailResponse } from '../dashboard-detail-response.js';
+import type { WidgetInstanceResponse } from '../widget-instance-response.js';
+
+// Minimal stand-ins for the analytics widget shapes — replicated locally
+// to keep `@granit/dashboards` dep-free (the bridge works on the open
+// `WidgetDefinition` union; analytics-specific tests live in their own
+// package).
+interface KpiWidgetStub extends WidgetDefinitionBase {
+  readonly type: 'kpi';
+  readonly datasource:
+    | { readonly kind: 'metric'; readonly metricName: string }
+    | {
+        readonly kind: 'query-aggregate';
+        readonly queryName: string;
+        readonly aggregation: string;
+        readonly field: string | null;
+      };
+}
+
+interface MapWidgetStub extends WidgetDefinitionBase {
+  readonly type: 'map';
+  readonly queryName: string;
+  readonly pointSource: {
+    readonly kind: 'lat-lng';
+    readonly latitudeColumn: string;
+    readonly longitudeColumn: string;
+  };
+}
+
+const DASHBOARD_NAME = 'Granit.Showcase.Demo';
+const ID = '8c6b1e10-0000-4000-8000-000000000001';
+const WIDGET_ID = '8c6b1e10-0000-0000-0000-000000000010';
+
+describe('extractSlugFromTitleKey', () => {
+  it('strips the conventional `Widget:{DashboardName}.` prefix', () => {
+    expect(extractSlugFromTitleKey(`Widget:${DASHBOARD_NAME}.Banner`, DASHBOARD_NAME)).toBe(
+      'Banner'
+    );
+  });
+
+  it('falls back to the suffix after the last dot when the prefix does not match', () => {
+    expect(extractSlugFromTitleKey('Custom.Key.Banner', DASHBOARD_NAME)).toBe('Banner');
+  });
+
+  it('returns the verbatim string when no dot is present', () => {
+    expect(extractSlugFromTitleKey('Banner', DASHBOARD_NAME)).toBe('Banner');
+  });
+});
+
+describe('widgetInstanceToDefinition', () => {
+  it('round-trips a markdown widget through the bridge', () => {
+    const instance: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Markdown',
+      position: 0,
+      width: 12,
+      height: 1,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Banner`,
+      metricName: null,
+      queryName: null,
+      configJson: JSON.stringify({ contentLocalizationKey: 'Widget:Demo.Banner.Content' }),
+      requiredPermission: null,
+    };
+    const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as MarkdownWidgetDefinition;
+    expect(widget.slug).toBe('Banner');
+    expect(widget.type).toBe('markdown');
+    expect(widget.position).toBe(0);
+    expect(widget.size).toEqual({ width: 12, height: 1 });
+    expect(widget.contentLocalizationKey).toBe('Widget:Demo.Banner.Content');
+  });
+
+  it('preserves requiredPermission when set', () => {
+    const instance: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Text',
+      position: 0,
+      width: 3,
+      height: 1,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Note`,
+      metricName: null,
+      queryName: null,
+      configJson: JSON.stringify({ contentLocalizationKey: 'Widget:Demo.Note', style: 'Body' }),
+      requiredPermission: 'Granit.Demo.SeeNote',
+    };
+    const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as TextWidgetDefinition;
+    expect(widget.requiredPermission).toBe('Granit.Demo.SeeNote');
+  });
+
+  it('survives malformed configJson by returning a minimal widget shape', () => {
+    const instance: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Markdown',
+      position: 1,
+      width: 6,
+      height: 1,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Broken`,
+      metricName: null,
+      queryName: null,
+      configJson: '{this is not valid json',
+      requiredPermission: null,
+    };
+    const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME);
+    expect(widget.slug).toBe('Broken');
+    expect(widget.type).toBe('markdown');
+    expect(widget.position).toBe(1);
+  });
+});
+
+describe('dashboardDetailToDefinition', () => {
+  it('lifts the full detail response into the editor-shaped DashboardDefinition', () => {
+    const detail: DashboardDetailResponse = {
+      id: ID,
+      name: DASHBOARD_NAME,
+      category: 'General',
+      status: 'Draft',
+      isSystem: false,
+      sourceDefinitionName: DASHBOARD_NAME,
+      sourceDefinitionVersion: '1.2.3',
+      layoutColumns: 12,
+      layoutRowHeight: 80,
+      widgets: [
+        {
+          id: WIDGET_ID,
+          widgetType: 'Markdown',
+          position: 0,
+          width: 12,
+          height: 1,
+          titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Banner`,
+          metricName: null,
+          queryName: null,
+          configJson: JSON.stringify({ contentLocalizationKey: 'Widget:Demo.Banner' }),
+          requiredPermission: null,
+        },
+      ],
+    };
+    const definition = dashboardDetailToDefinition(detail);
+    expect(definition.name).toBe(DASHBOARD_NAME);
+    expect(definition.version).toBe('1.2.3');
+    expect(definition.layout).toEqual({ columns: 12, rowHeight: 80 });
+    expect(definition.widgets).toHaveLength(1);
+    expect(definition.widgets[0]?.slug).toBe('Banner');
+  });
+
+  it('falls back to "1.0.0" when sourceDefinitionVersion is null (ad-hoc dashboard)', () => {
+    const detail: DashboardDetailResponse = {
+      id: ID,
+      name: DASHBOARD_NAME,
+      category: 'General',
+      status: 'Draft',
+      isSystem: false,
+      sourceDefinitionName: null,
+      sourceDefinitionVersion: null,
+      layoutColumns: 12,
+      layoutRowHeight: 80,
+      widgets: [],
+    };
+    expect(dashboardDetailToDefinition(detail).version).toBe('1.0.0');
+  });
+});
+
+describe('widgetDefinitionToAddRequest', () => {
+  it('serializes a markdown widget into the AddWidgetRequest shape', () => {
+    const widget: MarkdownWidgetDefinition = {
+      slug: 'Banner',
+      type: 'markdown',
+      position: 0,
+      size: { width: 12, height: 1 },
+      contentLocalizationKey: 'Widget:Demo.Banner.Content',
+    };
+    const request = widgetDefinitionToAddRequest(widget, DASHBOARD_NAME);
+    expect(request.widgetType).toBe('Markdown');
+    expect(request.titleLocalizationKey).toBe(`Widget:${DASHBOARD_NAME}.Banner`);
+    expect(request.metricName).toBeNull();
+    expect(request.queryName).toBeNull();
+    expect(JSON.parse(request.configJson)).toEqual({
+      contentLocalizationKey: 'Widget:Demo.Banner.Content',
+    });
+  });
+
+  it('denormalizes metricName for a KPI bound to a Metric datasource', () => {
+    const widget: KpiWidgetStub = {
+      slug: 'UnpaidCount',
+      type: 'kpi',
+      position: 0,
+      size: { width: 3, height: 1 },
+      datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+    };
+    const request = widgetDefinitionToAddRequest(widget, DASHBOARD_NAME);
+    expect(request.metricName).toBe('Granit.Invoicing.UnpaidInvoiceCountMetric');
+    expect(request.queryName).toBeNull();
+  });
+
+  it('denormalizes queryName for a KPI bound to a QueryAggregate datasource', () => {
+    const widget: KpiWidgetStub = {
+      slug: 'TotalRevenue',
+      type: 'kpi',
+      position: 0,
+      size: { width: 3, height: 1 },
+      datasource: {
+        kind: 'query-aggregate',
+        queryName: 'Granit.Invoicing.RevenueQuery',
+        aggregation: 'Sum',
+        field: 'Total',
+      },
+    };
+    const request = widgetDefinitionToAddRequest(widget, DASHBOARD_NAME);
+    expect(request.metricName).toBeNull();
+    expect(request.queryName).toBe('Granit.Invoicing.RevenueQuery');
+  });
+
+  it('denormalizes queryName for non-KPI data widgets (chart / table / pivot / map)', () => {
+    const widget: MapWidgetStub = {
+      slug: 'Branches',
+      type: 'map',
+      position: 0,
+      size: { width: 6, height: 4 },
+      queryName: 'Granit.Test.Branches',
+      pointSource: { kind: 'lat-lng', latitudeColumn: 'Lat', longitudeColumn: 'Lng' },
+    };
+    const request = widgetDefinitionToAddRequest(widget, DASHBOARD_NAME);
+    expect(request.queryName).toBe('Granit.Test.Branches');
+    expect(request.metricName).toBeNull();
+  });
+});
+
+describe('widgetDefinitionToUpdateRequest', () => {
+  it('emits the 5 editable fields the backend accepts on PUT', () => {
+    const widget: MarkdownWidgetDefinition = {
+      slug: 'Banner',
+      type: 'markdown',
+      position: 1,
+      size: { width: 6, height: 2 },
+      contentLocalizationKey: 'Widget:Demo.Banner.Content',
+    };
+    const request = widgetDefinitionToUpdateRequest(widget, DASHBOARD_NAME);
+    expect(request).toEqual({
+      position: 1,
+      width: 6,
+      height: 2,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.Banner`,
+      configJson: JSON.stringify({ contentLocalizationKey: 'Widget:Demo.Banner.Content' }),
+    });
+  });
+});
+
+describe('round-trip: instance → definition → addRequest → instance-shaped fields', () => {
+  it('preserves every widget field across the bridge', () => {
+    const original: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Kpi',
+      position: 2,
+      width: 3,
+      height: 1,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.UnpaidCount`,
+      metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
+      queryName: null,
+      configJson: JSON.stringify({
+        datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+      }),
+      requiredPermission: null,
+    };
+    const definition = widgetInstanceToDefinition(original, DASHBOARD_NAME);
+    const addRequest = widgetDefinitionToAddRequest(definition, DASHBOARD_NAME);
+    expect(addRequest.widgetType).toBe(original.widgetType);
+    expect(addRequest.position).toBe(original.position);
+    expect(addRequest.width).toBe(original.width);
+    expect(addRequest.height).toBe(original.height);
+    expect(addRequest.titleLocalizationKey).toBe(original.titleLocalizationKey);
+    expect(addRequest.metricName).toBe(original.metricName);
+    expect(addRequest.queryName).toBe(original.queryName);
+    expect(JSON.parse(addRequest.configJson)).toEqual(JSON.parse(original.configJson));
+  });
+});
+
+describe('diffDashboardWidgets', () => {
+  function makeServerInstance(slug: string, position: number): WidgetInstanceResponse {
+    return {
+      id: `id-${slug}`,
+      widgetType: 'Markdown',
+      position,
+      width: 12,
+      height: 1,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.${slug}`,
+      metricName: null,
+      queryName: null,
+      configJson: JSON.stringify({ contentLocalizationKey: `Widget:${DASHBOARD_NAME}.${slug}` }),
+      requiredPermission: null,
+    };
+  }
+
+  function makeLocalWidget(slug: string, position: number): WidgetDefinition {
+    return {
+      slug,
+      type: 'markdown',
+      position,
+      size: { width: 12, height: 1 },
+      contentLocalizationKey: `Widget:${DASHBOARD_NAME}.${slug}`,
+    } satisfies MarkdownWidgetDefinition;
+  }
+
+  it('classifies new local slugs as `added`', () => {
+    const diff = diffDashboardWidgets([], [makeLocalWidget('Banner', 0)], DASHBOARD_NAME);
+    expect(diff.added).toHaveLength(1);
+    expect(diff.added[0]?.slug).toBe('Banner');
+    expect(diff.updated).toHaveLength(0);
+    expect(diff.removed).toHaveLength(0);
+  });
+
+  it('classifies missing slugs as `removed` and carries the server widget id', () => {
+    const diff = diffDashboardWidgets([makeServerInstance('Banner', 0)], [], DASHBOARD_NAME);
+    expect(diff.removed).toEqual([{ slug: 'Banner', widgetId: 'id-Banner' }]);
+  });
+
+  it('classifies position changes as `updated`', () => {
+    const diff = diffDashboardWidgets(
+      [makeServerInstance('Banner', 0)],
+      [makeLocalWidget('Banner', 1)],
+      DASHBOARD_NAME
+    );
+    expect(diff.updated).toHaveLength(1);
+    expect(diff.updated[0]?.widgetId).toBe('id-Banner');
+    expect(diff.updated[0]?.request.position).toBe(1);
+  });
+
+  it('emits zero ops when local + server match exactly (no-op idempotency)', () => {
+    const diff = diffDashboardWidgets(
+      [makeServerInstance('Banner', 0)],
+      [makeLocalWidget('Banner', 0)],
+      DASHBOARD_NAME
+    );
+    expect(diff.added).toHaveLength(0);
+    expect(diff.updated).toHaveLength(0);
+    expect(diff.removed).toHaveLength(0);
+  });
+
+  it('handles a mixed diff (add + update + remove in one pass)', () => {
+    const server: WidgetInstanceResponse[] = [
+      makeServerInstance('Banner', 0),
+      makeServerInstance('Note', 1),
+    ];
+    const local: WidgetDefinition[] = [
+      makeLocalWidget('Banner', 0), // unchanged
+      makeLocalWidget('Kpi', 1), // new
+      // 'Note' removed
+    ];
+    const diff = diffDashboardWidgets(server, local, DASHBOARD_NAME);
+    expect(diff.added.map((a) => a.slug)).toEqual(['Kpi']);
+    expect(diff.removed.map((r) => r.slug)).toEqual(['Note']);
+    expect(diff.updated).toHaveLength(0);
+  });
+});

--- a/packages/@granit/dashboards/src/endpoints/index.ts
+++ b/packages/@granit/dashboards/src/endpoints/index.ts
@@ -13,3 +13,15 @@ export type { DashboardSummaryResponse } from './dashboard-summary-response.js';
 export type { PagedResponse } from './paged-response.js';
 export type { WidgetInstanceResponse } from './widget-instance-response.js';
 export type { AddWidgetRequest, UpdateWidgetRequest } from './widget-requests.js';
+
+// Bridge: persistence ↔ definition
+export {
+  STRUCTURAL_WIDGET_FIELDS,
+  dashboardDetailToDefinition,
+  diffDashboardWidgets,
+  extractSlugFromTitleKey,
+  widgetDefinitionToAddRequest,
+  widgetDefinitionToUpdateRequest,
+  widgetInstanceToDefinition,
+} from './widget-bridge.js';
+export type { DashboardWidgetDiff } from './widget-bridge.js';

--- a/packages/@granit/dashboards/src/endpoints/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/endpoints/widget-bridge.ts
@@ -1,0 +1,331 @@
+// ---------------------------------------------------------------------------
+// Bridge: persisted-instance shape ↔ declarative-definition shape
+// ---------------------------------------------------------------------------
+//
+// The framework ships two views of a widget that share fields but diverge
+// on shape:
+//
+// - `WidgetInstanceResponse` (persistence) — id-keyed, structural fields
+//   first-class (id / widgetType / position / width / height /
+//   titleLocalizationKey + denormalized metricName / queryName), kind-
+//   specific fields packed into a `configJson` string.
+//
+// - `WidgetDefinition` (declaration / editor) — slug-keyed, kind-specific
+//   fields surfaced as typed top-level properties (e.g.
+//   `MarkdownWidgetDefinition.contentLocalizationKey`,
+//   `KpiWidgetDefinition.datasource`).
+//
+// The editor primitives (`<EditableDashboard>`, `<WidgetConfigDrawer>`,
+// `addWidget` / `updateWidget` helpers) all consume `WidgetDefinition`.
+// The CRUD endpoints expect `AddWidgetRequest` / `UpdateWidgetRequest`
+// shaped against the persistence view. This module is the round-trip
+// bridge between the two — pure data transformation, no React deps.
+
+import type { DashboardDetailResponse } from './dashboard-detail-response.js';
+import type { AddWidgetRequest, UpdateWidgetRequest, WidgetInstanceResponse } from './index.js';
+import type {
+  DashboardDefinition,
+  WidgetDefinition,
+  WidgetDefinitionBase,
+} from '../types/index.js';
+
+/**
+ * The five structural fields that live outside `configJson` because the
+ * backend either denormalizes them for indexing or lifts them onto
+ * persistence-level columns. Everything else inside a {@link WidgetDefinition}
+ * is round-tripped through `configJson`.
+ *
+ * Exported as a constant so consumers building custom serializers stay
+ * in sync with the bridge's contract.
+ */
+export const STRUCTURAL_WIDGET_FIELDS = Object.freeze([
+  'slug',
+  'type',
+  'position',
+  'size',
+  'requiredPermission',
+] as const);
+
+/**
+ * Backend convention: `Widget:{DashboardName}.{Slug}`. Used in both
+ * directions — read extracts slug from this shape, write composes it.
+ */
+function composeTitleLocalizationKey(dashboardName: string, slug: string): string {
+  return `Widget:${dashboardName}.${slug}`;
+}
+
+/**
+ * Extracts the slug from a {@link WidgetInstanceResponse.titleLocalizationKey}.
+ * Handles the `Widget:{DashboardName}.{Slug}` convention; falls back to
+ * the suffix after the last `.` for ad-hoc keys that don't match (which
+ * the backend permits but the framework discourages).
+ */
+export function extractSlugFromTitleKey(
+  titleLocalizationKey: string,
+  dashboardName: string
+): string {
+  const prefix = `Widget:${dashboardName}.`;
+  if (titleLocalizationKey.startsWith(prefix)) {
+    return titleLocalizationKey.slice(prefix.length);
+  }
+  const lastDot = titleLocalizationKey.lastIndexOf('.');
+  return lastDot === -1 ? titleLocalizationKey : titleLocalizationKey.slice(lastDot + 1);
+}
+
+/**
+ * Pulls the denormalized `metricName` / `queryName` off a {@link WidgetDefinition}
+ * for the persistence-level columns. Reads from the kind-specific fields:
+ *
+ * - KPI: `datasource.metricName` (when `kind === 'metric'`) or
+ *   `datasource.queryName` (when `kind === 'query-aggregate'`)
+ * - Chart / Table / Pivot / Map: top-level `queryName`
+ * - Markdown / Image / Text: both `null`
+ *
+ * The backend keeps this index even though the same data lives inside
+ * `configJson` — letting it filter / sort dashboards by their bound
+ * metric / query without parsing every config blob.
+ */
+function denormalizeReferences(widget: WidgetDefinitionBase): {
+  metricName: string | null;
+  queryName: string | null;
+} {
+  const w = widget as unknown as Readonly<Record<string, unknown>>;
+  if (widget.type === 'kpi') {
+    const datasource = w['datasource'] as
+      | { kind?: string; metricName?: string; queryName?: string }
+      | undefined;
+    if (datasource?.kind === 'metric') {
+      return { metricName: datasource.metricName ?? null, queryName: null };
+    }
+    if (datasource?.kind === 'query-aggregate') {
+      return { metricName: null, queryName: datasource.queryName ?? null };
+    }
+    return { metricName: null, queryName: null };
+  }
+  // Chart / Table / Pivot / Map all expose `queryName` at the top level.
+  const queryName = typeof w['queryName'] === 'string' ? (w['queryName'] as string) : null;
+  return { metricName: null, queryName };
+}
+
+/**
+ * Strips the structural fields from a widget definition and serializes
+ * the remainder to JSON. Round-trip-safe: `configJsonToWidgetFields`
+ * undoes this exactly when paired with the same structural fields.
+ */
+function widgetFieldsToConfigJson(widget: WidgetDefinitionBase): string {
+  const config: Record<string, unknown> = {};
+  const w = widget as unknown as Readonly<Record<string, unknown>>;
+  for (const key of Object.keys(w)) {
+    if ((STRUCTURAL_WIDGET_FIELDS as readonly string[]).includes(key)) continue;
+    config[key] = w[key];
+  }
+  return JSON.stringify(config);
+}
+
+/**
+ * Inverse of {@link widgetFieldsToConfigJson}. Parses the JSON blob and
+ * re-merges with the structural fields the persistence view kept
+ * separate. Returns `null` if the JSON is malformed — callers fall back
+ * to a placeholder rather than crashing the editor.
+ */
+function configJsonToWidgetFields(configJson: string): Readonly<Record<string, unknown>> | null {
+  try {
+    const parsed = JSON.parse(configJson) as unknown;
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return parsed as Readonly<Record<string, unknown>>;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Read direction: persistence → editor
+// ---------------------------------------------------------------------------
+
+/**
+ * Lifts a single {@link WidgetInstanceResponse} into a {@link WidgetDefinition}
+ * suitable for the editor primitives. `dashboardName` is taken from the
+ * parent {@link DashboardDetailResponse.name} and used to extract the slug
+ * from `titleLocalizationKey`.
+ *
+ * Robust to malformed `configJson`: returns a minimal widget shape
+ * (slug + type + position + size) when the JSON can't be parsed.
+ */
+export function widgetInstanceToDefinition(
+  instance: WidgetInstanceResponse,
+  dashboardName: string
+): WidgetDefinition {
+  const slug = extractSlugFromTitleKey(instance.titleLocalizationKey, dashboardName);
+  const fields = configJsonToWidgetFields(instance.configJson) ?? {};
+  const widget: WidgetDefinitionBase & Readonly<Record<string, unknown>> = {
+    ...fields,
+    slug,
+    // PascalCase widgetType → lowercase definition `type` discriminator.
+    type: instance.widgetType.charAt(0).toLowerCase() + instance.widgetType.slice(1),
+    position: instance.position,
+    size: { width: instance.width, height: instance.height },
+    ...(instance.requiredPermission !== null
+      ? { requiredPermission: instance.requiredPermission }
+      : {}),
+  };
+  return widget as WidgetDefinition;
+}
+
+/**
+ * Lifts a full {@link DashboardDetailResponse} into a {@link DashboardDefinition}
+ * the editor primitives can consume.
+ *
+ * `category`, `version` and `isSystem` are copied straight through.
+ * Layout reconstructs `columns` / `rowHeight` from the flattened
+ * `layoutColumns` / `layoutRowHeight` fields the persistence view
+ * exposes — responsive overrides (`widgetSizes`, `breakpoints`, etc.)
+ * are not yet round-tripped because the persistence view only carries
+ * the base values.
+ */
+export function dashboardDetailToDefinition(detail: DashboardDetailResponse): DashboardDefinition {
+  return {
+    name: detail.name,
+    category: detail.category,
+    isSystem: detail.isSystem,
+    version: detail.sourceDefinitionVersion ?? '1.0.0',
+    layout: { columns: detail.layoutColumns, rowHeight: detail.layoutRowHeight },
+    widgets: detail.widgets.map((w) => widgetInstanceToDefinition(w, detail.name)),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Write direction: editor → persistence
+// ---------------------------------------------------------------------------
+
+/**
+ * Serializes a {@link WidgetDefinition} into the {@link AddWidgetRequest}
+ * shape expected by `POST /dashboards/{id}/widgets`. The dashboard's
+ * name is required so the helper can compose the canonical
+ * `titleLocalizationKey`.
+ *
+ * `widgetType` is the PascalCase form of the definition's lowercase
+ * `type` discriminator. `metricName` / `queryName` are pulled off the
+ * kind-specific fields per {@link denormalizeReferences}.
+ */
+export function widgetDefinitionToAddRequest(
+  widget: WidgetDefinitionBase,
+  dashboardName: string
+): AddWidgetRequest {
+  const { metricName, queryName } = denormalizeReferences(widget);
+  return {
+    widgetType: widget.type.charAt(0).toUpperCase() + widget.type.slice(1),
+    position: widget.position,
+    width: widget.size.width,
+    height: widget.size.height,
+    titleLocalizationKey: composeTitleLocalizationKey(dashboardName, widget.slug),
+    configJson: widgetFieldsToConfigJson(widget),
+    metricName,
+    queryName,
+    requiredPermission: widget.requiredPermission ?? null,
+  };
+}
+
+/**
+ * Serializes a {@link WidgetDefinition} into the {@link UpdateWidgetRequest}
+ * shape expected by `PUT /dashboards/{id}/widgets/{widgetId}`.
+ *
+ * `widgetType` / `metricName` / `queryName` / `requiredPermission` are
+ * intentionally absent — the backend treats kind-switching and
+ * metric/query rebinding as delete + add, not edit.
+ */
+export function widgetDefinitionToUpdateRequest(
+  widget: WidgetDefinitionBase,
+  dashboardName: string
+): UpdateWidgetRequest {
+  return {
+    position: widget.position,
+    width: widget.size.width,
+    height: widget.size.height,
+    titleLocalizationKey: composeTitleLocalizationKey(dashboardName, widget.slug),
+    configJson: widgetFieldsToConfigJson(widget),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diff: editor state → ordered CRUD operations
+// ---------------------------------------------------------------------------
+
+/**
+ * Operations a {@link diffDashboardWidgets} run produces. Apply in the
+ * order: removed → added → updated. Removing first frees position
+ * slots; adding next mints fresh ids; updating last persists the
+ * surviving widgets' final state.
+ *
+ * Slug is the editor's stable identity — server widgets are matched
+ * back to their slug via {@link extractSlugFromTitleKey}.
+ */
+export interface DashboardWidgetDiff {
+  /** Widgets present locally but not on the server — emit as `useAddWidget` calls. */
+  readonly added: readonly { readonly slug: string; readonly request: AddWidgetRequest }[];
+  /** Widgets present on both sides whose persistence shape differs — emit as `useUpdateWidget` calls. */
+  readonly updated: readonly {
+    readonly slug: string;
+    readonly widgetId: string;
+    readonly request: UpdateWidgetRequest;
+  }[];
+  /** Widgets present on the server but missing locally — emit as `useRemoveWidget` calls. */
+  readonly removed: readonly { readonly slug: string; readonly widgetId: string }[];
+}
+
+/**
+ * Diffs the local (editor) and server (persistence) widget pools and
+ * produces the ordered set of CRUD operations needed to sync the server
+ * with the local state.
+ *
+ * Matching is by slug. A widget is considered "updated" when any of its
+ * `position` / `width` / `height` / `titleLocalizationKey` /
+ * `configJson` projections differ from the server snapshot — same five
+ * fields the backend's `UpdateWidgetRequest` carries.
+ *
+ * No-ops are filtered out — a widget whose local + server state match
+ * exactly produces zero operations.
+ */
+export function diffDashboardWidgets(
+  serverWidgets: readonly WidgetInstanceResponse[],
+  localWidgets: readonly WidgetDefinitionBase[],
+  dashboardName: string
+): DashboardWidgetDiff {
+  const serverBySlug = new Map<string, WidgetInstanceResponse>();
+  for (const instance of serverWidgets) {
+    serverBySlug.set(
+      extractSlugFromTitleKey(instance.titleLocalizationKey, dashboardName),
+      instance
+    );
+  }
+  const localSlugs = new Set(localWidgets.map((w) => w.slug));
+
+  const added: { slug: string; request: AddWidgetRequest }[] = [];
+  const updated: { slug: string; widgetId: string; request: UpdateWidgetRequest }[] = [];
+
+  for (const local of localWidgets) {
+    const server = serverBySlug.get(local.slug);
+    if (!server) {
+      added.push({ slug: local.slug, request: widgetDefinitionToAddRequest(local, dashboardName) });
+      continue;
+    }
+    const request = widgetDefinitionToUpdateRequest(local, dashboardName);
+    if (
+      request.position !== server.position ||
+      request.width !== server.width ||
+      request.height !== server.height ||
+      request.titleLocalizationKey !== server.titleLocalizationKey ||
+      request.configJson !== server.configJson
+    ) {
+      updated.push({ slug: local.slug, widgetId: server.id, request });
+    }
+  }
+
+  const removed: { slug: string; widgetId: string }[] = [];
+  for (const [slug, server] of serverBySlug) {
+    if (!localSlugs.has(slug)) {
+      removed.push({ slug, widgetId: server.id });
+    }
+  }
+
+  return { added, updated, removed };
+}

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -77,6 +77,20 @@ export type {
   WidgetInstanceResponse,
 } from './endpoints/index.js';
 
+// Bridge between persistence (`WidgetInstanceResponse`) and declarative
+// (`WidgetDefinition`) views — used by editor surfaces saving back through
+// the per-widget CRUD endpoints.
+export {
+  STRUCTURAL_WIDGET_FIELDS,
+  dashboardDetailToDefinition,
+  diffDashboardWidgets,
+  extractSlugFromTitleKey,
+  widgetDefinitionToAddRequest,
+  widgetDefinitionToUpdateRequest,
+  widgetInstanceToDefinition,
+} from './endpoints/index.js';
+export type { DashboardWidgetDiff } from './endpoints/index.js';
+
 // Rendering — wire contracts for the dashboard render pipeline plus per-kind
 // snapshots (B3-1 / B3-2 / B3-3, ADR-039).
 export {


### PR DESCRIPTION
## Summary

Pure data transformation lifting between the two views the framework ships of a widget:

| View | Used by | Shape |
| --- | --- | --- |
| \`WidgetInstanceResponse\` (persistence) | \`/dashboards/:id/widgets\` endpoints | id-keyed, structural fields first-class, kind-specific fields packed into a \`configJson\` string |
| \`WidgetDefinition\` (declaration / editor) | \`<EditableDashboard>\`, \`<WidgetConfigDrawer>\`, \`addWidget\` / \`updateWidget\` / \`removeWidget\` | slug-keyed, kind-specific fields surfaced as typed top-level properties |

This is the missing piece flagged in showcase #60 — the rich palette/drawer composer was dropped because there was no way to round-trip a \`DashboardDetailResponse\` through the editor primitives back into per-widget CRUD calls. Now there is.

Pure data transformation, no React deps. Lives in \`@granit/dashboards\` since both shapes already do.

## Surface

### Read direction

- \`extractSlugFromTitleKey(titleKey, dashboardName)\` — strips the \`Widget:{DashboardName}.{Slug}\` prefix; falls back to the suffix-after-last-dot for ad-hoc keys.
- \`widgetInstanceToDefinition(instance, dashboardName)\` — lifts one instance. Robust to malformed \`configJson\` (returns a minimal widget shape instead of crashing).
- \`dashboardDetailToDefinition(detail)\` — full \`DashboardDetailResponse\` → \`DashboardDefinition\`. Reconstructs layout from the flattened \`layoutColumns\`/\`layoutRowHeight\`; falls back to \`"1.0.0"\` for ad-hoc dashboards with null \`sourceDefinitionVersion\`.

### Write direction

- \`widgetDefinitionToAddRequest(widget, dashboardName)\` — denormalizes \`metricName\`/\`queryName\` per kind (KPI Metric vs QueryAggregate; chart/table/pivot/map → top-level \`queryName\`); serializes the remaining fields to \`configJson\`.
- \`widgetDefinitionToUpdateRequest(widget, dashboardName)\` — emits the 5 editable fields the backend accepts on PUT.

### Diff helper

- \`diffDashboardWidgets(server, local, dashboardName)\` — produces an ordered \`DashboardWidgetDiff\` (\`added\` / \`updated\` / \`removed\`) suitable for dispatching as a sequence of \`useAddWidget\` / \`useUpdateWidget\` / \`useRemoveWidget\` calls. Matches by slug; emits zero ops for unchanged widgets (no-op idempotency).

### Constants

- \`STRUCTURAL_WIDGET_FIELDS\` — frozen tuple of the 5 fields that live outside \`configJson\` (\`slug\` / \`type\` / \`position\` / \`size\` / \`requiredPermission\`). Exported so consumers building custom serializers stay in sync.

## Type-system tweak

Relaxed the bridge function signatures from \`WidgetDefinition\` to \`WidgetDefinitionBase\`. Same fix as \`WidgetCatalogEntry.createDefaultWidget\` and \`WidgetConfigFormProps\` — the closed \`Record<string, unknown>\` half of the framework union doesn't admit downstream concrete types like \`KpiWidgetDefinition\` without an unsafe cast.

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/dashboards\` — 10 files / 73 tests pass (19 new: slug extraction, instance lift in nominal + malformed-JSON cases, full detail lift, kind-specific reference denormalization for kpi/chart/table/pivot/map, full round-trip preserving every field, diff classification including no-op idempotency and mixed add/update/remove pass).
- [x] \`pnpm exec vitest run packages/@granit/dashboards packages/@granit/react-dashboards packages/@granit/react-dashboard-editor\` — 22 files / 161 tests pass.
- [x] \`pnpm lint\` clean (max-warnings 0).
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.

## What's next

After this lands, the showcase rich composer can come back: a follow-up showcase PR will replace the current metadata-only edit page with the full \`<EditableDashboard>\` + \`<WidgetPalette>\` + \`<WidgetConfigDrawer>\` composition, using \`dashboardDetailToDefinition\` for load and \`diffDashboardWidgets\` on save to dispatch the right add/update/remove sequence.