### PR TITLE
fix(dashboards): drop double card chrome on widgets, frame the bundle path

### DIFF
--- a/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
@@ -46,8 +46,15 @@ export interface KpiTileViewProps {
 
 /**
  * Pure presentational KPI tile. Decoupled from data fetching so Storybook
- * stories drive it directly with fixtures (no QueryClient required) and the
- * smart wrapper {@link KpiTile} handles loading / error / success transitions.
+ * stories drive it directly with fixtures (no QueryClient required) and
+ * the smart wrapper {@link KpiTile} handles loading / error / success
+ * transitions.
+ *
+ * Renders **body only** (value + delta + optional trend visual). Card
+ * chrome (border, shadow, padding) and title rendering are owned by the
+ * surrounding `<WidgetCard>` — the framework's universal frame the
+ * dispatcher (`<WidgetRenderer>` / `<RenderedWidget>`) wraps every widget
+ * in. Standalone usages outside a dashboard wrap manually.
  */
 export function KpiTileView({
   title,
@@ -63,13 +70,7 @@ export function KpiTileView({
   trendVisual,
 }: KpiTileViewProps) {
   return (
-    <div
-      data-slot="kpi-tile"
-      className={joinClasses(
-        'flex h-full flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm',
-        className
-      )}
-    >
+    <div data-slot="kpi-tile" className={joinClasses('flex h-full flex-col gap-3', className)}>
       {title ? (
         <header data-slot="kpi-tile-header">
           <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -1,5 +1,4 @@
 import { isMetricDatasource } from '@granit/dashboards';
-import { useDashboardContext } from '@granit/react-dashboards';
 import { useTranslation } from 'react-i18next';
 
 import { useMetric } from '../api/use-metric.js';
@@ -34,16 +33,9 @@ export interface KpiTileProps {
 
 export function KpiTile({ widget }: KpiTileProps) {
   const { t, i18n } = useTranslation();
-  const dashboardCtx = useDashboardContext();
   const { datasource } = widget;
 
-  const titleKey = dashboardCtx
-    ? `Widget:${dashboardCtx.dashboardName}.${widget.slug}.Title`
-    : `Widget:${widget.slug}.Title`;
-  const translated = t(titleKey, { defaultValue: '' });
-
   const metricName = isMetricDatasource(datasource) ? datasource.metricName : '';
-  const title = translated || metricName || widget.slug;
 
   const query = useMetric(metricName, DEFAULT_PERIOD, { enabled: metricName !== '' });
 
@@ -56,19 +48,15 @@ export function KpiTile({ widget }: KpiTileProps) {
       <div
         data-slot="kpi-tile"
         data-datasource-kind={datasource.kind}
-        className="flex h-full flex-col gap-3 rounded-xl border bg-card p-4 shadow-sm"
+        className="flex h-full items-center text-xs text-muted-foreground"
       >
-        <header data-slot="kpi-tile-header">
-          <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
-        </header>
-        <p className="text-xs text-muted-foreground">{message}</p>
+        {message}
       </div>
     );
   }
 
   return (
     <KpiTileView
-      title={title}
       data={query.data}
       isLoading={query.isLoading}
       error={query.error}

--- a/packages/@granit/react-dashboards/src/components/rendered-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/rendered-widget.tsx
@@ -1,5 +1,7 @@
 import { useSnapshotWidgetRegistry } from '../registry/snapshot-widget-registry-context.js';
 
+import { WidgetCard } from './widget-card.js';
+
 import type { DashboardRenderedWidget } from '@granit/dashboards';
 
 /**
@@ -21,9 +23,21 @@ import type { DashboardRenderedWidget } from '@granit/dashboards';
  */
 export interface RenderedWidgetProps {
   readonly widget: DashboardRenderedWidget;
+  /**
+   * When `true` (default), the widget body is wrapped in a {@link WidgetCard}
+   * for chrome consistency with the definition path's `<WidgetRenderer>`.
+   * Set to `false` when the snapshot renderer ships its own chrome
+   * (e.g. an Image widget that bleeds to the cell edges).
+   *
+   * `title` is intentionally not resolved here — the bundle envelope
+   * does not yet carry a title localization key (backend gap). Apps
+   * needing titles in the bundle path render their own frame layer
+   * keyed off the parent definition.
+   */
+  readonly framed?: boolean;
 }
 
-export function RenderedWidget({ widget }: RenderedWidgetProps) {
+export function RenderedWidget({ widget, framed = true }: RenderedWidgetProps) {
   const registry = useSnapshotWidgetRegistry();
 
   if (widget.status === 'Unavailable') {
@@ -49,11 +63,13 @@ export function RenderedWidget({ widget }: RenderedWidgetProps) {
     return <UnknownKindSlot widgetType={widget.widgetType} />;
   }
 
-  return (
+  const body = (
     <div data-slot="rendered-widget" data-widget-type={widget.widgetType}>
       <Renderer widget={widget} />
     </div>
   );
+
+  return framed ? <WidgetCard>{body}</WidgetCard> : body;
 }
 
 function UnavailableSlot({


### PR DESCRIPTION
## Summary

Two visual bugs the wire-surface alignment audit didn't surface (it only covered types / endpoints / enums) — both visible on \`/dashboards\` after the alignment work landed.

### Bug 1 — Double card chrome on the definition path

\`KpiTileView\` shipped its own card chrome (\`rounded-xl border bg-card p-4 shadow-sm\`) AND a title \`<header>\`. \`<WidgetCard>\` already wraps every widget renderer with the same chrome, also rendering the title from \`Widget:{dashboardName}.{slug}.Title\`. Result: two stacked cards, two stacked titles for the same i18n key — the duplicate "Unpaid invoices" / "Unpaid amount" labels visibly overlapping the values in the screenshot.

**Fix**: \`<WidgetCard>\` becomes the sole chrome owner. \`KpiTileView\` renders a bare body. The fallback path in \`KpiTile\` (unsupported datasource) loses its chrome too. Standalone usages outside a dashboard wrap in \`<WidgetCard>\` manually.

### Bug 2 — No chrome on the bundle path

\`<RenderedWidget>\` rendered the snapshot widget body directly without a frame, so KPI / Markdown / etc. widgets in the bundle path appeared nude while the definition path had cards. Asymmetric.

**Fix**: \`<RenderedWidget>\` wraps in \`<WidgetCard>\` by default with a \`framed\` opt-out for snapshot renderers that ship their own chrome.

### Side cleanup

\`KpiTile\` no longer reads the dashboard context — title resolution now fully belongs to \`<WidgetCard>\` upstream. Removed the unused \`useDashboardContext\` import.

## Known follow-up gap (NOT in this PR)

The bundle envelope (\`DashboardRenderedWidget\`) carries no \`titleLocalizationKey\` and no per-widget structural metadata (\`size\`, \`position\`). So:

- The bundle path shows widgets with chrome but **no title** (definition path resolves it from \`Widget:{name}.{slug}.Title\` via the dashboard context + the \`slug\` on \`WidgetDefinition\` — the bundle has neither).
- The bundle path falls back to a hardcoded \`md:grid-cols-2 xl:grid-cols-3\` responsive grid because it can't reconstruct \`definition.layout\` × per-widget \`size\` from snapshot envelopes alone.

Both gaps need backend movement on \`DashboardRenderResponse\`:
- Add \`titleLocalizationKey\` to each rendered widget envelope.
- Add structural metadata (\`width\`, \`height\`, \`position\`, \`slug\`) so the bundle becomes self-sufficient for layout reconstruction.

Until that lands, apps wanting a consistent-with-definition layout in read mode use \`<Dashboard definition={...}>\` (definition path) rather than \`<RenderedDashboard>\` (bundle path).

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-analytics packages/@granit/react-dashboards\` — 13 files / 94 tests pass.
- [x] \`pnpm lint\` clean.
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.
- [ ] Visual smoke: navigate \`/dashboards\` after this lands + the showcase paired PR. Definition path should show single cards with single titles. Bundle path should show all 7 widgets each in a card.