### PR TITLE
feat(dashboards): consume DashboardLayout.breakpoints at render time

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2282,6 +2282,22 @@
           "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"
         },
         {
+          "name": "applyLayoutOverride",
+          "kind": "function",
+          "signature": "function applyLayoutOverride( base: DashboardLayout, override: DashboardLayoutOverride | undefined ): EffectiveDashboardLayout"
+        },
+        {
+          "name": "resolveEffectiveLayout",
+          "kind": "function",
+          "signature": "function resolveEffectiveLayout( base: DashboardLayout, widgets: readonly WidgetDefinition[], breakpoint: DashboardBreakpoint ):"
+        },
+        {
+          "name": "EffectiveDashboardLayout",
+          "kind": "interface",
+          "signature": "interface EffectiveDashboardLayout",
+          "members": []
+        },
+        {
           "name": "WidgetRenderer",
           "kind": "function",
           "signature": "function WidgetRenderer("

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -12,7 +12,12 @@ import {
   SortableContext,
   sortableKeyboardCoordinates,
 } from '@dnd-kit/sortable';
-import { DashboardContextProvider, WidgetRenderer } from '@granit/react-dashboards';
+import {
+  DashboardContextProvider,
+  resolveEffectiveLayout,
+  useDashboardBreakpoint,
+  WidgetRenderer,
+} from '@granit/react-dashboards';
 import { useMemo, type CSSProperties } from 'react';
 
 import { reorderWidgets } from '../lib/reorder-widgets.js';
@@ -61,9 +66,11 @@ export function EditableDashboard({
   className,
   rowHeight,
 }: EditableDashboardProps) {
-  const orderedWidgets = useMemo(
-    () => [...definition.widgets].sort((a, b) => a.position - b.position),
-    [definition.widgets]
+  const breakpoint = useDashboardBreakpoint();
+
+  const { layout, widgets: orderedWidgets } = useMemo(
+    () => resolveEffectiveLayout(definition.layout, definition.widgets, breakpoint),
+    [definition.layout, definition.widgets, breakpoint]
   );
   const sortableIds = useMemo(() => orderedWidgets.map((w) => w.slug), [orderedWidgets]);
 
@@ -75,12 +82,12 @@ export function EditableDashboard({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
-  const effectiveRowHeight = rowHeight ?? definition.layout.rowHeight;
+  const effectiveRowHeight = rowHeight ?? layout.rowHeight;
 
   const gridStyle: CSSProperties = {
     display: 'grid',
     gridAutoFlow: 'dense',
-    gridTemplateColumns: `repeat(${definition.layout.columns}, minmax(0, 1fr))`,
+    gridTemplateColumns: `repeat(${layout.columns}, minmax(0, 1fr))`,
     gridAutoRows: `${effectiveRowHeight}px`,
     gap: '1rem',
   };
@@ -99,6 +106,7 @@ export function EditableDashboard({
           <div
             data-slot="editable-dashboard"
             data-dashboard-name={definition.name}
+            data-breakpoint={breakpoint}
             className={className}
             style={gridStyle}
           >

--- a/packages/@granit/react-dashboards/src/__tests__/resolve-effective-layout.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/resolve-effective-layout.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { applyLayoutOverride, resolveEffectiveLayout } from '../lib/resolve-effective-layout.js';
+
+import type { DashboardLayout, WidgetDefinition } from '@granit/dashboards';
+
+const baseLayout: DashboardLayout = {
+  columns: 12,
+  rowHeight: 80,
+  widgetSizes: { Banner: { width: 12, height: 1 } },
+  widgetOrder: ['Banner', 'Kpi'],
+  breakpoints: {
+    Sm: { columns: 6, hiddenWidgets: ['Pivot'] },
+    Md: { rowHeight: 100, widgetSizes: { Banner: { width: 6, height: 1 } } },
+  },
+};
+
+const widget = (slug: string, position: number, width = 3, height = 1): WidgetDefinition =>
+  ({
+    slug,
+    type: 'markdown',
+    position,
+    size: { width, height },
+    contentLocalizationKey: `Widget:${slug}.Content`,
+  }) as WidgetDefinition;
+
+describe('applyLayoutOverride', () => {
+  it('returns the base layout verbatim when no override is provided', () => {
+    const effective = applyLayoutOverride(baseLayout, undefined);
+    expect(effective.columns).toBe(12);
+    expect(effective.rowHeight).toBe(80);
+    expect(effective.widgetSizes).toEqual({ Banner: { width: 12, height: 1 } });
+    expect(effective.widgetOrder).toEqual(['Banner', 'Kpi']);
+    expect(effective.hiddenWidgets.size).toBe(0);
+  });
+
+  it('replaces scalar fields when set on the override', () => {
+    const effective = applyLayoutOverride(baseLayout, { columns: 6, rowHeight: 100 });
+    expect(effective.columns).toBe(6);
+    expect(effective.rowHeight).toBe(100);
+  });
+
+  it('shallow-merges widgetSizes (override slugs replace, others fall through)', () => {
+    const effective = applyLayoutOverride(baseLayout, {
+      widgetSizes: { Kpi: { width: 6, height: 2 } },
+    });
+    expect(effective.widgetSizes).toEqual({
+      Banner: { width: 12, height: 1 },
+      Kpi: { width: 6, height: 2 },
+    });
+  });
+
+  it('overrides widgetOrder verbatim when set', () => {
+    const effective = applyLayoutOverride(baseLayout, { widgetOrder: ['Kpi', 'Banner'] });
+    expect(effective.widgetOrder).toEqual(['Kpi', 'Banner']);
+  });
+
+  it('exposes hiddenWidgets as a Set for O(1) lookups', () => {
+    const effective = applyLayoutOverride(baseLayout, { hiddenWidgets: ['Pivot', 'Kpi'] });
+    expect(effective.hiddenWidgets.has('Pivot')).toBe(true);
+    expect(effective.hiddenWidgets.has('Banner')).toBe(false);
+  });
+});
+
+describe('resolveEffectiveLayout', () => {
+  const widgets: readonly WidgetDefinition[] = [
+    widget('Banner', 0, 12, 1),
+    widget('Kpi', 1, 3, 1),
+    widget('Pivot', 2, 6, 2),
+  ];
+
+  it('returns the original widgets reference when no breakpoint override touches them', () => {
+    const { layout, widgets: result } = resolveEffectiveLayout(baseLayout, widgets, 'Lg');
+    // No 'Lg' override → base widgetSizes (Banner) match the declared
+    // sizes → no per-widget mutation. The order list reorders, so
+    // the array reference is allowed to differ but content matches.
+    expect(layout.columns).toBe(12);
+    expect(layout.rowHeight).toBe(80);
+    expect(result.map((w) => w.slug)).toEqual(['Banner', 'Kpi', 'Pivot']);
+  });
+
+  it('applies the active-breakpoint override on top of the base', () => {
+    const { layout } = resolveEffectiveLayout(baseLayout, widgets, 'Sm');
+    expect(layout.columns).toBe(6);
+    expect(layout.hiddenWidgets.has('Pivot')).toBe(true);
+  });
+
+  it('drops hiddenWidgets from the rendered list (widget pool stays intact)', () => {
+    const { widgets: result } = resolveEffectiveLayout(baseLayout, widgets, 'Sm');
+    expect(result.map((w) => w.slug)).toEqual(['Banner', 'Kpi']);
+    expect(result).toHaveLength(2);
+  });
+
+  it('replaces widget size when the override carries widgetSizes', () => {
+    const { widgets: result } = resolveEffectiveLayout(baseLayout, widgets, 'Md');
+    const banner = result.find((w) => w.slug === 'Banner');
+    expect(banner?.size).toEqual({ width: 6, height: 1 });
+  });
+
+  it('honours widgetOrder before declared position', () => {
+    const layout: DashboardLayout = {
+      columns: 12,
+      rowHeight: 80,
+      widgetOrder: ['Kpi', 'Banner', 'Pivot'],
+    };
+    const { widgets: result } = resolveEffectiveLayout(layout, widgets, 'Lg');
+    expect(result.map((w) => w.slug)).toEqual(['Kpi', 'Banner', 'Pivot']);
+  });
+
+  it('appends widgets not listed in widgetOrder in declared position order', () => {
+    const layout: DashboardLayout = {
+      columns: 12,
+      rowHeight: 80,
+      widgetOrder: ['Kpi'],
+    };
+    const { widgets: result } = resolveEffectiveLayout(layout, widgets, 'Lg');
+    expect(result.map((w) => w.slug)).toEqual(['Kpi', 'Banner', 'Pivot']);
+  });
+
+  it('emits the same widget references when no widget needs a size override', () => {
+    const layout: DashboardLayout = { columns: 12, rowHeight: 80 };
+    const { widgets: result } = resolveEffectiveLayout(layout, widgets, 'Lg');
+    // No size overrides → mapping should not allocate replacement widget
+    // objects. We can't assert reference equality on the array (sort
+    // creates a new array) but per-widget references should match.
+    for (const w of widgets) {
+      const found = result.find((r) => r.slug === w.slug);
+      expect(found).toBe(w);
+    }
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-breakpoint.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-breakpoint.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DASHBOARD_BREAKPOINT_MIN_WIDTH,
+  resolveBreakpoint,
+} from '../hooks/use-dashboard-breakpoint.js';
+
+describe('DASHBOARD_BREAKPOINT_MIN_WIDTH', () => {
+  it('matches the conventional Tailwind / Bootstrap thresholds', () => {
+    expect(DASHBOARD_BREAKPOINT_MIN_WIDTH).toEqual({
+      Xs: 0,
+      Sm: 640,
+      Md: 768,
+      Lg: 1024,
+      Xl: 1280,
+    });
+  });
+});
+
+describe('resolveBreakpoint', () => {
+  it('returns Xs for any width below the Sm threshold', () => {
+    expect(resolveBreakpoint(0)).toBe('Xs');
+    expect(resolveBreakpoint(320)).toBe('Xs');
+    expect(resolveBreakpoint(639)).toBe('Xs');
+  });
+
+  it('matches each threshold exactly', () => {
+    expect(resolveBreakpoint(640)).toBe('Sm');
+    expect(resolveBreakpoint(768)).toBe('Md');
+    expect(resolveBreakpoint(1024)).toBe('Lg');
+    expect(resolveBreakpoint(1280)).toBe('Xl');
+  });
+
+  it('returns the strongest matching breakpoint for in-between widths', () => {
+    expect(resolveBreakpoint(700)).toBe('Sm');
+    expect(resolveBreakpoint(900)).toBe('Md');
+    expect(resolveBreakpoint(1200)).toBe('Lg');
+    expect(resolveBreakpoint(1920)).toBe('Xl');
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard.tsx
@@ -1,5 +1,8 @@
 import { useMemo, type CSSProperties } from 'react';
 
+import { useDashboardBreakpoint } from '../hooks/use-dashboard-breakpoint.js';
+import { resolveEffectiveLayout } from '../lib/resolve-effective-layout.js';
+
 import { DashboardContextProvider } from './dashboard-context.js';
 import { WidgetRenderer } from './widget-renderer.js';
 
@@ -9,10 +12,9 @@ export interface DashboardProps {
   readonly definition: DashboardDefinition;
   readonly className?: string;
   /**
-   * Override the row height (in pixels). Falls back to
-   * `definition.layout.rowHeight`. The grid columns scale to available width;
-   * only row height is fixed so widget heights remain stable across viewport
-   * changes.
+   * Override the row height (in pixels). Falls back to the active
+   * breakpoint's resolved row height (or `definition.layout.rowHeight`
+   * when the dashboard ships no breakpoint overrides).
    */
   readonly rowHeight?: number;
 }
@@ -20,24 +22,36 @@ export interface DashboardProps {
 /**
  * Renders a {@link DashboardDefinition} as a CSS auto-flow grid.
  *
- * v1 implementation — widgets fill the grid in `position` order, each taking
- * its declared `size.width × size.height`. The browser handles placement via
- * `grid-auto-flow: dense`. v2 will swap this for `react-grid-layout` to
- * enable drag/resize/persist; the public API (just pass a `definition`)
- * remains stable across that swap.
+ * Resolves the active {@link DashboardBreakpoint} via
+ * {@link useDashboardBreakpoint} and merges
+ * `definition.layout.breakpoints[active]` over the base via
+ * {@link resolveEffectiveLayout}. Per-breakpoint overrides apply:
  *
- * Wraps children in a {@link DashboardContextProvider} so widget renderers
- * (and future TimeWindow / alias hooks) have a stable handle on the active
- * dashboard.
+ * - **columns / rowHeight** — replace the base for the active viewport.
+ * - **widgetSizes** — replace per-widget `size` for the active layout.
+ * - **widgetOrder** — replace the rendered order; un-listed widgets
+ *   keep their declared `position`.
+ * - **hiddenWidgets** — slugs are dropped from the layout but stay in
+ *   the widget pool (state survives a viewport flip back).
+ *
+ * Wraps children in a {@link DashboardContextProvider} so widget
+ * renderers (and future TimeWindow / alias hooks) have a stable handle
+ * on the active dashboard.
  */
 export function Dashboard({ definition, className, rowHeight }: DashboardProps) {
-  const orderedWidgets = useMemo(() => sortByPosition(definition.widgets), [definition.widgets]);
-  const effectiveRowHeight = rowHeight ?? definition.layout.rowHeight;
+  const breakpoint = useDashboardBreakpoint();
+
+  const { layout, widgets } = useMemo(
+    () => resolveEffectiveLayout(definition.layout, definition.widgets, breakpoint),
+    [definition.layout, definition.widgets, breakpoint]
+  );
+
+  const effectiveRowHeight = rowHeight ?? layout.rowHeight;
 
   const gridStyle: CSSProperties = {
     display: 'grid',
     gridAutoFlow: 'dense',
-    gridTemplateColumns: `repeat(${definition.layout.columns}, minmax(0, 1fr))`,
+    gridTemplateColumns: `repeat(${layout.columns}, minmax(0, 1fr))`,
     gridAutoRows: `${effectiveRowHeight}px`,
     gap: '1rem',
   };
@@ -47,10 +61,11 @@ export function Dashboard({ definition, className, rowHeight }: DashboardProps) 
       <div
         data-slot="dashboard"
         data-dashboard-name={definition.name}
+        data-breakpoint={breakpoint}
         className={className}
         style={gridStyle}
       >
-        {orderedWidgets.map((widget) => (
+        {widgets.map((widget) => (
           <DashboardCell key={widget.slug} widget={widget}>
             <WidgetRenderer widget={widget} />
           </DashboardCell>
@@ -76,10 +91,4 @@ function DashboardCell({
       {children}
     </div>
   );
-}
-
-function sortByPosition(widgets: readonly WidgetDefinition[]): readonly WidgetDefinition[] {
-  // Stable sort on `position` so authors can declare widgets in any order in
-  // their definition and the renderer respects the explicit `Position`.
-  return [...widgets].sort((a, b) => a.position - b.position);
 }

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-breakpoint.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-breakpoint.ts
@@ -1,0 +1,79 @@
+import { useEffect, useState } from 'react';
+
+import type { DashboardBreakpoint } from '@granit/dashboards';
+
+/**
+ * Tailwind / Bootstrap-style breakpoint thresholds (min-width in px). Mirrors
+ * the same values the framework's UI library uses, so a `Sm`-flagged
+ * dashboard layout matches the same viewport range as a `sm:` Tailwind
+ * utility.
+ *
+ * Exported so apps that need programmatic access to the thresholds (e.g.
+ * Storybook viewport addon) stay in sync without re-declaring constants.
+ */
+export const DASHBOARD_BREAKPOINT_MIN_WIDTH: Readonly<Record<DashboardBreakpoint, number>> =
+  Object.freeze({
+    Xs: 0,
+    Sm: 640,
+    Md: 768,
+    Lg: 1024,
+    Xl: 1280,
+  });
+
+const ORDERED: readonly DashboardBreakpoint[] = ['Xl', 'Lg', 'Md', 'Sm', 'Xs'];
+
+/**
+ * Picks the strongest {@link DashboardBreakpoint} matching a viewport
+ * width. `'Xs'` is the floor (matches every width).
+ *
+ * Exported so tests can drive the resolution without rendering, and apps
+ * implementing custom breakpoint detection (SSR-aware, container-query
+ * based) reuse the same mapping.
+ */
+export function resolveBreakpoint(viewportWidth: number): DashboardBreakpoint {
+  for (const bp of ORDERED) {
+    if (viewportWidth >= DASHBOARD_BREAKPOINT_MIN_WIDTH[bp]) return bp;
+  }
+  return 'Xs';
+}
+
+/**
+ * SSR-safe accessor for the current window width. Returns `null` during
+ * server rendering so the hook can fall back to `'Xs'` (mobile-first
+ * default) until the client hydrates.
+ */
+function readViewportWidth(): number | null {
+  if (typeof window === 'undefined') return null;
+  return window.innerWidth;
+}
+
+/**
+ * Hook returning the active {@link DashboardBreakpoint}. Used by
+ * `<Dashboard>` / `<EditableDashboard>` to merge
+ * `DashboardLayout.breakpoints[active]` over the base layout.
+ *
+ * SSR-safe: emits `'Xs'` until the client mounts; the `resize` listener
+ * registers in `useEffect` so server bundles never touch `window`.
+ *
+ * @example
+ *   const breakpoint = useDashboardBreakpoint();
+ *   const override = definition.layout.breakpoints?.[breakpoint];
+ */
+export function useDashboardBreakpoint(): DashboardBreakpoint {
+  const [breakpoint, setBreakpoint] = useState<DashboardBreakpoint>(() => {
+    const width = readViewportWidth();
+    return width === null ? 'Xs' : resolveBreakpoint(width);
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+    const handleResize = () => setBreakpoint(resolveBreakpoint(window.innerWidth));
+    window.addEventListener('resize', handleResize);
+    // Run once after mount to flip from the SSR-safe `'Xs'` to the actual
+    // viewport without waiting for the first resize.
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return breakpoint;
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -51,6 +51,13 @@ export type {
   DashboardContextValue,
 } from './components/dashboard-context.js';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window.js';
+export {
+  DASHBOARD_BREAKPOINT_MIN_WIDTH,
+  resolveBreakpoint,
+  useDashboardBreakpoint,
+} from './hooks/use-dashboard-breakpoint.js';
+export { applyLayoutOverride, resolveEffectiveLayout } from './lib/resolve-effective-layout.js';
+export type { EffectiveDashboardLayout } from './lib/resolve-effective-layout.js';
 export { WidgetRenderer } from './components/widget-renderer.js';
 export type { WidgetRendererProps } from './components/widget-renderer.js';
 export { WidgetCard } from './components/widget-card.js';

--- a/packages/@granit/react-dashboards/src/lib/resolve-effective-layout.ts
+++ b/packages/@granit/react-dashboards/src/lib/resolve-effective-layout.ts
@@ -1,0 +1,138 @@
+import type {
+  DashboardBreakpoint,
+  DashboardLayout,
+  DashboardLayoutOverride,
+  WidgetDefinition,
+  WidgetSize,
+} from '@granit/dashboards';
+
+/**
+ * Applies a {@link DashboardLayoutOverride} on top of a base
+ * {@link DashboardLayout}, returning the effective layout for the active
+ * viewport. Pure function, no React deps — exported for tests + custom
+ * dashboard wrappers.
+ *
+ * Override semantics (per
+ * `Granit.Dashboards.DashboardLayoutOverride` on the backend):
+ *
+ * - Scalar fields (`columns`, `rowHeight`) — replace the base when set.
+ * - `widgetSizes` — shallow merge. Per-widget sizes in the override
+ *   replace the base for that slug; un-overridden slugs fall through.
+ * - `widgetOrder` — replace the base when set.
+ * - `hiddenWidgets` — kept on the result so the renderer can drop
+ *   matching slugs from the grid without touching the widget pool
+ *   (state survives a viewport flip back).
+ *
+ * Falsy / `undefined` override fields fall through to the base.
+ */
+export function applyLayoutOverride(
+  base: DashboardLayout,
+  override: DashboardLayoutOverride | undefined
+): EffectiveDashboardLayout {
+  if (!override) {
+    return {
+      columns: base.columns,
+      rowHeight: base.rowHeight,
+      widgetSizes: base.widgetSizes ?? {},
+      widgetOrder: base.widgetOrder ?? null,
+      hiddenWidgets: new Set<string>(),
+    };
+  }
+  return {
+    columns: override.columns ?? base.columns,
+    rowHeight: override.rowHeight ?? base.rowHeight,
+    widgetSizes: { ...(base.widgetSizes ?? {}), ...(override.widgetSizes ?? {}) },
+    widgetOrder: override.widgetOrder ?? base.widgetOrder ?? null,
+    hiddenWidgets: new Set(override.hiddenWidgets ?? []),
+  };
+}
+
+/**
+ * Resolves the effective layout + widget list for the active
+ * breakpoint. Composes {@link applyLayoutOverride} with the widget-pool
+ * filtering / reordering rules:
+ *
+ * - `hiddenWidgets` — slugs in the set are dropped from the rendered
+ *   list (the widget pool stays intact).
+ * - `widgetOrder` — when set, widgets render in that slug order;
+ *   widgets not listed are appended in declared `position` order.
+ * - `widgetSizes` — per-widget size overrides replace the widget's
+ *   declared `size` for the active layout.
+ *
+ * Returns the original widgets array reference when no overrides apply,
+ * so React's `key` semantics + memoization stay stable.
+ */
+export function resolveEffectiveLayout(
+  base: DashboardLayout,
+  widgets: readonly WidgetDefinition[],
+  breakpoint: DashboardBreakpoint
+): { readonly layout: EffectiveDashboardLayout; readonly widgets: readonly WidgetDefinition[] } {
+  const override = base.breakpoints?.[breakpoint];
+  const layout = applyLayoutOverride(base, override);
+  const sized = applyWidgetSizes(widgets, layout.widgetSizes);
+  const ordered = applyWidgetOrder(sized, layout.widgetOrder);
+  const visible =
+    layout.hiddenWidgets.size > 0
+      ? ordered.filter((w) => !layout.hiddenWidgets.has(w.slug))
+      : ordered;
+  return { layout, widgets: visible };
+}
+
+/**
+ * Effective layout — the resolved combination of base + active-breakpoint
+ * override. Differs from {@link DashboardLayout} in two ways:
+ *
+ * - `widgetSizes` is a non-optional record (empty = no overrides)
+ * - `hiddenWidgets` is a Set instead of a list (efficient `.has` lookups)
+ * - `breakpoints` is intentionally absent — the effective layout is
+ *   already breakpoint-resolved
+ */
+export interface EffectiveDashboardLayout {
+  readonly columns: number;
+  readonly rowHeight: number;
+  readonly widgetSizes: Readonly<Record<string, WidgetSize>>;
+  readonly widgetOrder: readonly string[] | null;
+  readonly hiddenWidgets: ReadonlySet<string>;
+}
+
+function applyWidgetSizes(
+  widgets: readonly WidgetDefinition[],
+  sizes: Readonly<Record<string, WidgetSize>>
+): readonly WidgetDefinition[] {
+  // Avoid allocating a new array when no widget has an override at this
+  // breakpoint — preserves React reference equality + memo identity.
+  if (Object.keys(sizes).length === 0) return widgets;
+  let mutated = false;
+  const next = widgets.map((widget) => {
+    const override = sizes[widget.slug];
+    if (!override) return widget;
+    if (override.width === widget.size.width && override.height === widget.size.height) {
+      return widget;
+    }
+    mutated = true;
+    return { ...widget, size: override };
+  });
+  return mutated ? next : widgets;
+}
+
+function applyWidgetOrder(
+  widgets: readonly WidgetDefinition[],
+  order: readonly string[] | null
+): readonly WidgetDefinition[] {
+  if (!order || order.length === 0) {
+    return [...widgets].sort((a, b) => a.position - b.position);
+  }
+  const bySlug = new Map(widgets.map((w) => [w.slug, w] as const));
+  const ordered: WidgetDefinition[] = [];
+  for (const slug of order) {
+    const widget = bySlug.get(slug);
+    if (widget) {
+      ordered.push(widget);
+      bySlug.delete(slug);
+    }
+  }
+  // Trailing widgets (declared but not in the explicit order) keep their
+  // declared `position` order.
+  const trailing = [...bySlug.values()].sort((a, b) => a.position - b.position);
+  return [...ordered, ...trailing];
+}


### PR DESCRIPTION
## Summary

The responsive-layout types landed in #278 (\`DashboardBreakpoint\` enum + \`DashboardLayoutOverride\` record) but neither \`<Dashboard>\` nor \`<EditableDashboard>\` were consuming them — \`breakpoints\` was purely declarative. This wires up the runtime side.

Self-contained: no breaking changes, no backend movement needed — just consumes types already in place.

## What ships

### \`useDashboardBreakpoint()\`

Resolves the active \`DashboardBreakpoint\` from \`window.innerWidth\` against Tailwind / Bootstrap-style thresholds:

| Breakpoint | Min width |
| --- | --- |
| Xs | 0 (floor) |
| Sm | 640 |
| Md | 768 |
| Lg | 1024 |
| Xl | 1280 |

SSR-safe: emits \`'Xs'\` until the client mounts, then a \`useEffect\`-registered resize listener flips to the actual viewport. Listener cleaned up on unmount.

### \`resolveEffectiveLayout()\` (pure helper)

Merges \`layout.breakpoints[active]\` over the base:

| Field | Override semantics |
| --- | --- |
| \`columns\`, \`rowHeight\` | Replace the base when set |
| \`widgetSizes\` | Shallow merge — slugs in the override replace the base, others fall through |
| \`widgetOrder\` | Replace verbatim; widgets not listed are appended in declared \`position\` order |
| \`hiddenWidgets\` | Dropped from the rendered list, kept in the pool so state survives a viewport flip back |

Returns the original widget references when no override touches them — preserves React reference equality + memo identity. Pure function, no React deps, exported for tests + custom dashboard wrappers.

### Wired into \`<Dashboard>\` + \`<EditableDashboard>\`

Both components now resolve the active breakpoint, merge overrides, and apply the resulting layout to the CSS grid. \`data-breakpoint\` attribute on the grid root for downstream styling and e2e selectors.

### Helpers exported from \`@granit/react-dashboards\`

- \`useDashboardBreakpoint\`
- \`resolveBreakpoint\` (pure resolution from a width)
- \`DASHBOARD_BREAKPOINT_MIN_WIDTH\` (frozen threshold map)
- \`applyLayoutOverride\` (single-shot merge)
- \`resolveEffectiveLayout\` (full resolve + widget filtering / sizing / ordering)
- \`EffectiveDashboardLayout\` type

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-dashboards packages/@granit/react-dashboard-editor\` — 14 files / 104 tests pass (23 new: breakpoint resolution at every threshold including boundaries, layout override application across all 5 fields, no-op detection preserving widget references).
- [x] \`pnpm lint\` clean.
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.
- [ ] Visual smoke: a dashboard authored with breakpoint overrides should reflow on viewport resize (e.g. \`Md: { columns: 6 }\` halves the column count).