### PR TITLE
feat(dashboards): multi-view rendering runtime (P2.1)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2277,6 +2277,38 @@
           "members": []
         },
         {
+          "name": "DashboardViewProvider",
+          "kind": "function",
+          "signature": "function DashboardViewProvider("
+        },
+        {
+          "name": "useDashboardView",
+          "kind": "function",
+          "signature": "function useDashboardView(): DashboardViewContextValue | null"
+        },
+        {
+          "name": "DashboardViewSwitcher",
+          "kind": "function",
+          "signature": "function DashboardViewSwitcher("
+        },
+        {
+          "name": "DashboardViewSwitcherProps",
+          "kind": "interface",
+          "signature": "interface DashboardViewSwitcherProps",
+          "members": []
+        },
+        {
+          "name": "resolveActiveView",
+          "kind": "function",
+          "signature": "function resolveActiveView( definition: DashboardDefinition, currentViewName: string | null = null ): ActiveDashboardView"
+        },
+        {
+          "name": "ActiveDashboardView",
+          "kind": "interface",
+          "signature": "interface ActiveDashboardView",
+          "members": []
+        },
+        {
           "name": "useEffectiveTimeWindow",
           "kind": "function",
           "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard-view.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard-view.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DashboardViewSwitcher } from '../components/dashboard-view-switcher.js';
+import { Dashboard } from '../components/dashboard.js';
+import { defaultWidgetRegistry } from '../registry/default-widget-registry.js';
+import { WidgetRegistryProvider } from '../registry/widget-registry-context.js';
+
+import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        'Dashboard:Granit.Test.MultiView.View.list': 'List',
+        'Dashboard:Granit.Test.MultiView.View.detail': 'Detail',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <WidgetRegistryProvider registries={[defaultWidgetRegistry]}>{node}</WidgetRegistryProvider>
+    </I18nextProvider>
+  );
+}
+
+const widget = (slug: string, position: number): WidgetDefinition =>
+  ({
+    slug,
+    type: 'markdown',
+    position,
+    size: { width: 12, height: 1 },
+    contentLocalizationKey: `Widget:${slug}.Content`,
+  }) as WidgetDefinition;
+
+const multiView: DashboardDefinition = {
+  name: 'Granit.Test.MultiView',
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [widget('top-banner', 0)],
+  views: [
+    { name: 'list', widgets: [widget('list-banner', 0)] },
+    { name: 'detail', widgets: [widget('detail-kpi', 0)] },
+  ],
+  defaultView: 'list',
+};
+
+describe('<Dashboard /> — multi-view rendering', () => {
+  it('renders the default view widgets when uncontrolled', () => {
+    const { container } = wrap(<Dashboard definition={multiView} />);
+    const cells = container.querySelectorAll('[data-slot="dashboard-cell"]');
+    expect(cells).toHaveLength(1);
+    expect(cells[0]?.getAttribute('data-widget-slug')).toBe('list-banner');
+  });
+
+  it('honours the controlled `currentView` prop', () => {
+    const { container } = wrap(<Dashboard definition={multiView} currentView="detail" />);
+    const cells = container.querySelectorAll('[data-slot="dashboard-cell"]');
+    expect(cells[0]?.getAttribute('data-widget-slug')).toBe('detail-kpi');
+  });
+
+  it('exposes the active view name as a data-attribute on the grid root', () => {
+    const { container } = wrap(<Dashboard definition={multiView} currentView="detail" />);
+    const root = container.querySelector('[data-slot="dashboard"]');
+    expect(root?.getAttribute('data-current-view')).toBe('detail');
+  });
+
+  it('falls back to the top-level pool when views are absent (single-view)', () => {
+    const single: DashboardDefinition = { ...multiView, views: undefined, defaultView: undefined };
+    const { container } = wrap(<Dashboard definition={single} />);
+    const cells = container.querySelectorAll('[data-slot="dashboard-cell"]');
+    expect(cells[0]?.getAttribute('data-widget-slug')).toBe('top-banner');
+  });
+});
+
+describe('<DashboardViewSwitcher />', () => {
+  it('renders nothing when views is null / empty', () => {
+    const empty1 = wrap(<DashboardViewSwitcher views={null} onChange={vi.fn()} />);
+    expect(empty1.container.querySelector('[data-slot="dashboard-view-switcher"]')).toBeNull();
+
+    const empty2 = wrap(<DashboardViewSwitcher views={[]} onChange={vi.fn()} />);
+    expect(empty2.container.querySelector('[data-slot="dashboard-view-switcher"]')).toBeNull();
+  });
+
+  it('renders nothing when no setter is available (no onChange + no surrounding provider)', () => {
+    const { container } = wrap(<DashboardViewSwitcher views={multiView.views} />);
+    expect(container.querySelector('[data-slot="dashboard-view-switcher"]')).toBeNull();
+  });
+
+  it('renders one tab per view in controlled mode', () => {
+    const { container } = wrap(
+      <DashboardViewSwitcher views={multiView.views} currentView="list" onChange={vi.fn()} />
+    );
+    const tabs = container.querySelectorAll('[data-slot="dashboard-view-switcher-tab"]');
+    expect(tabs).toHaveLength(2);
+    expect(tabs[0]?.getAttribute('data-view-name')).toBe('list');
+    expect(tabs[1]?.getAttribute('data-view-name')).toBe('detail');
+  });
+
+  it('marks the active tab via data-active + aria-selected', () => {
+    const { container } = wrap(
+      <DashboardViewSwitcher views={multiView.views} currentView="detail" onChange={vi.fn()} />
+    );
+    const tabs = Array.from(
+      container.querySelectorAll('[data-slot="dashboard-view-switcher-tab"]')
+    );
+    const detailTab = tabs.find((t) => t.getAttribute('data-view-name') === 'detail');
+    const listTab = tabs.find((t) => t.getAttribute('data-view-name') === 'list');
+    expect(detailTab?.getAttribute('aria-selected')).toBe('true');
+    expect(listTab?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('dispatches onChange with the clicked view name', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <DashboardViewSwitcher views={multiView.views} currentView="list" onChange={onChange} />
+    );
+    const detailTab = container.querySelector(
+      '[data-slot="dashboard-view-switcher-tab"][data-view-name="detail"]'
+    );
+    if (!(detailTab instanceof HTMLElement)) throw new Error('detail tab not found');
+    fireEvent.click(detailTab);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('detail');
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/resolve-active-view.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/resolve-active-view.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveActiveView } from '../lib/resolve-active-view.js';
+
+import type { DashboardDefinition, DashboardView, WidgetDefinition } from '@granit/dashboards';
+
+const widget = (slug: string, position: number): WidgetDefinition =>
+  ({
+    slug,
+    type: 'markdown',
+    position,
+    size: { width: 12, height: 1 },
+    contentLocalizationKey: `Widget:${slug}.Content`,
+  }) as WidgetDefinition;
+
+const baseDefinition: DashboardDefinition = {
+  name: 'Granit.Test.Dashboard',
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [widget('Top', 0)],
+};
+
+const listView: DashboardView = {
+  name: 'list',
+  widgets: [widget('TableWidget', 0)],
+};
+
+const detailView: DashboardView = {
+  name: 'detail',
+  widgets: [widget('DetailKpi', 0)],
+  layout: { columns: 6, rowHeight: 100 },
+};
+
+describe('resolveActiveView — single-view dashboards', () => {
+  it('returns the top-level pool with activeViewName: null when views is null', () => {
+    const result = resolveActiveView(baseDefinition);
+    expect(result.activeViewName).toBeNull();
+    expect(result.widgets).toBe(baseDefinition.widgets);
+    expect(result.layout).toBe(baseDefinition.layout);
+  });
+
+  it('returns the top-level pool when views is an empty array', () => {
+    const result = resolveActiveView({ ...baseDefinition, views: [] });
+    expect(result.activeViewName).toBeNull();
+    expect(result.widgets).toBe(baseDefinition.widgets);
+  });
+});
+
+describe('resolveActiveView — multi-view dashboards', () => {
+  const multiView: DashboardDefinition = {
+    ...baseDefinition,
+    views: [listView, detailView],
+    defaultView: 'detail',
+  };
+
+  it('honours the explicit currentViewName when set', () => {
+    const result = resolveActiveView(multiView, 'list');
+    expect(result.activeViewName).toBe('list');
+    expect(result.widgets).toBe(listView.widgets);
+  });
+
+  it('falls back to defaultView when currentViewName is null', () => {
+    const result = resolveActiveView(multiView, null);
+    expect(result.activeViewName).toBe('detail');
+    expect(result.widgets).toBe(detailView.widgets);
+  });
+
+  it('falls back to the first view when defaultView is null too', () => {
+    const result = resolveActiveView({ ...multiView, defaultView: null }, null);
+    expect(result.activeViewName).toBe('list');
+    expect(result.widgets).toBe(listView.widgets);
+  });
+
+  it('replaces the layout with the view override when set', () => {
+    const result = resolveActiveView(multiView, 'detail');
+    expect(result.layout).toBe(detailView.layout);
+    expect(result.layout.columns).toBe(6);
+  });
+
+  it('falls back to the dashboard layout when the view has no layout override', () => {
+    const result = resolveActiveView(multiView, 'list');
+    expect(result.layout).toBe(multiView.layout);
+  });
+
+  it('returns the top-level pool when the requested view is not found', () => {
+    const result = resolveActiveView(multiView, 'nonexistent');
+    expect(result.activeViewName).toBeNull();
+    expect(result.widgets).toBe(baseDefinition.widgets);
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/dashboard-view-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-view-context.tsx
@@ -1,0 +1,48 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Active-view state surfaced to consumers — widget renderers,
+ * action-trigger handlers (`WidgetActionKind.OpenDashboardView`),
+ * breadcrumb components, view switchers.
+ *
+ * `currentView` is `null` for single-view dashboards. `setCurrentView`
+ * always exists so action handlers can call it unconditionally; on
+ * single-view dashboards it's a no-op upstream.
+ */
+export interface DashboardViewContextValue {
+  /** Active view name, or `null` for single-view dashboards. */
+  readonly currentView: string | null;
+  /** Switch to a named view. No-op on single-view dashboards. */
+  readonly setCurrentView: (name: string) => void;
+}
+
+const DashboardViewContext = createContext<DashboardViewContextValue | null>(null);
+
+export interface DashboardViewProviderProps {
+  readonly value: DashboardViewContextValue;
+  readonly children: React.ReactNode;
+}
+
+/**
+ * Provider for the active dashboard view. `<Dashboard>` /
+ * `<EditableDashboard>` mount this internally; downstream hooks
+ * (`useDashboardView`) read it.
+ *
+ * Apps wanting URL-bound views (`/dashboards/{name}/view/{viewName}`)
+ * lift the controlled state up and feed both `value` here and
+ * `<Dashboard currentView ...>` from the same source.
+ */
+export function DashboardViewProvider({ value, children }: DashboardViewProviderProps) {
+  return <DashboardViewContext.Provider value={value}>{children}</DashboardViewContext.Provider>;
+}
+
+/**
+ * Reads the active view state. Returns `null` when called outside a
+ * `<Dashboard>` / `<EditableDashboard>` (single-widget standalone
+ * usage) — callers that need a guarantee can throw, but most consumers
+ * (action handlers, breadcrumbs) gracefully degrade when there's no
+ * dashboard surrounding them.
+ */
+export function useDashboardView(): DashboardViewContextValue | null {
+  return useContext(DashboardViewContext);
+}

--- a/packages/@granit/react-dashboards/src/components/dashboard-view-switcher.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-view-switcher.tsx
@@ -1,0 +1,100 @@
+import { useTranslation } from 'react-i18next';
+
+import { useDashboardContext } from './dashboard-context.js';
+import { useDashboardView } from './dashboard-view-context.js';
+
+import type { DashboardView } from '@granit/dashboards';
+
+/**
+ * Tabs-style view switcher. Renders one button per
+ * {@link DashboardView}, highlights the active one, and switches the
+ * dashboard's view via either:
+ *
+ * - the controlled `currentView` + `onChange` props (typical when the
+ *   parent owns the view state — URL binding, breadcrumb sync), OR
+ * - the surrounding {@link DashboardViewProvider} when the props are
+ *   omitted (works inside `<Dashboard>` automatically).
+ *
+ * Labels resolve through `useTranslation()` against
+ * `view.displayNameLocalizationKey ?? Dashboard:{name}.View.{viewName}`
+ * — the convention the backend ships when the field is null. When no
+ * translation is found, the view's `name` is used verbatim.
+ *
+ * Renders nothing for single-view dashboards (`views` empty / null).
+ */
+export interface DashboardViewSwitcherProps {
+  readonly views: readonly DashboardView[] | null | undefined;
+  /**
+   * Controlled active view name. When omitted, the switcher reads the
+   * view from the surrounding {@link DashboardViewProvider}.
+   */
+  readonly currentView?: string | null;
+  /**
+   * Notification when a tab is clicked. When omitted, the switcher
+   * dispatches via the surrounding {@link DashboardViewProvider}.
+   */
+  readonly onChange?: (name: string) => void;
+  readonly className?: string;
+}
+
+export function DashboardViewSwitcher({
+  views,
+  currentView,
+  onChange,
+  className,
+}: DashboardViewSwitcherProps) {
+  const { t } = useTranslation();
+  const dashboardCtx = useDashboardContext();
+  const viewCtx = useDashboardView();
+
+  const activeView = currentView !== undefined ? currentView : (viewCtx?.currentView ?? null);
+  const setView = onChange ?? viewCtx?.setCurrentView;
+
+  if (!views || views.length === 0 || !setView) return null;
+
+  return (
+    <div
+      data-slot="dashboard-view-switcher"
+      role="tablist"
+      aria-label="Dashboard views"
+      className={joinClasses(
+        'inline-flex items-center gap-1 rounded-md border bg-card p-1',
+        className
+      )}
+    >
+      {views.map((view) => {
+        const isActive = view.name === activeView;
+        const labelKey =
+          view.displayNameLocalizationKey ??
+          (dashboardCtx
+            ? `Dashboard:${dashboardCtx.dashboardName}.View.${view.name}`
+            : `Dashboard:View.${view.name}`);
+        const label = t(labelKey, { defaultValue: view.name });
+        return (
+          <button
+            key={view.name}
+            type="button"
+            role="tab"
+            data-slot="dashboard-view-switcher-tab"
+            data-view-name={view.name}
+            data-active={isActive || undefined}
+            aria-selected={isActive}
+            onClick={() => setView(view.name)}
+            className={joinClasses(
+              'rounded-sm px-2.5 py-1 text-sm transition-colors',
+              isActive
+                ? 'bg-foreground text-background'
+                : 'text-muted-foreground hover:bg-accent hover:text-foreground'
+            )}
+          >
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/packages/@granit/react-dashboards/src/components/dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard.tsx
@@ -1,9 +1,11 @@
-import { useMemo, type CSSProperties } from 'react';
+import { useCallback, useMemo, useState, type CSSProperties } from 'react';
 
 import { useDashboardBreakpoint } from '../hooks/use-dashboard-breakpoint.js';
+import { resolveActiveView } from '../lib/resolve-active-view.js';
 import { resolveEffectiveLayout } from '../lib/resolve-effective-layout.js';
 
 import { DashboardContextProvider } from './dashboard-context.js';
+import { DashboardViewProvider } from './dashboard-view-context.js';
 import { WidgetRenderer } from './widget-renderer.js';
 
 import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
@@ -13,37 +15,86 @@ export interface DashboardProps {
   readonly className?: string;
   /**
    * Override the row height (in pixels). Falls back to the active
-   * breakpoint's resolved row height (or `definition.layout.rowHeight`
-   * when the dashboard ships no breakpoint overrides).
+   * breakpoint's resolved row height (or the active view's layout
+   * row height when the dashboard ships views).
    */
   readonly rowHeight?: number;
+  /**
+   * Active view name (controlled). Falls back to
+   * `definition.defaultView`, then the first view, then null
+   * (single-view dashboards). Required when the parent owns the view
+   * state (URL-bound, breadcrumb-bound, etc.).
+   */
+  readonly currentView?: string;
+  /**
+   * Notification when an action handler or view switcher requests a
+   * different view. When omitted, `<Dashboard>` falls back to internal
+   * state — fine for self-contained demos.
+   */
+  readonly onViewChange?: (name: string) => void;
 }
 
 /**
  * Renders a {@link DashboardDefinition} as a CSS auto-flow grid.
  *
- * Resolves the active {@link DashboardBreakpoint} via
- * {@link useDashboardBreakpoint} and merges
- * `definition.layout.breakpoints[active]` over the base via
- * {@link resolveEffectiveLayout}. Per-breakpoint overrides apply:
+ * Pipeline:
  *
- * - **columns / rowHeight** — replace the base for the active viewport.
- * - **widgetSizes** — replace per-widget `size` for the active layout.
- * - **widgetOrder** — replace the rendered order; un-listed widgets
- *   keep their declared `position`.
- * - **hiddenWidgets** — slugs are dropped from the layout but stay in
- *   the widget pool (state survives a viewport flip back).
+ * 1. **Active view** — {@link resolveActiveView} picks the view's
+ *    widgets + layout from `definition.views[currentView]` (with the
+ *    standard fallback chain: prop → `defaultView` → first view →
+ *    top-level pool).
+ * 2. **Active breakpoint** — {@link useDashboardBreakpoint} resolves
+ *    the viewport class.
+ * 3. **Effective layout** — {@link resolveEffectiveLayout} merges the
+ *    active breakpoint's overrides over the view's layout (per-widget
+ *    sizes, ordering, hidden slugs).
  *
  * Wraps children in a {@link DashboardContextProvider} so widget
  * renderers (and future TimeWindow / alias hooks) have a stable handle
- * on the active dashboard.
+ * on the active dashboard, plus a {@link DashboardViewProvider} so
+ * action handlers and view switchers can read / write the active view.
  */
-export function Dashboard({ definition, className, rowHeight }: DashboardProps) {
+export function Dashboard({
+  definition,
+  className,
+  rowHeight,
+  currentView,
+  onViewChange,
+}: DashboardProps) {
+  // Internal view state for uncontrolled usage. Initial value follows
+  // the same fallback chain `resolveActiveView` uses, so the very first
+  // render picks the right view without an extra reconciliation.
+  const [internalView, setInternalView] = useState<string | null>(
+    currentView ?? definition.defaultView ?? definition.views?.[0]?.name ?? null
+  );
+  const activeViewName = currentView ?? internalView;
+
+  const setView = useCallback(
+    (name: string) => {
+      if (currentView === undefined) setInternalView(name);
+      onViewChange?.(name);
+    },
+    [currentView, onViewChange]
+  );
+
   const breakpoint = useDashboardBreakpoint();
 
+  const {
+    layout: viewLayout,
+    widgets: viewWidgets,
+    resolvedView,
+  } = useMemo(() => {
+    const active = resolveActiveView(definition, activeViewName);
+    return {
+      layout: active.layout,
+      widgets: active.widgets,
+      resolvedView: active.activeViewName,
+    };
+  }, [definition, activeViewName]);
+
   const { layout, widgets } = useMemo(
-    () => resolveEffectiveLayout(definition.layout, definition.widgets, breakpoint),
-    [definition.layout, definition.widgets, breakpoint]
+    () => resolveEffectiveLayout(viewLayout, viewWidgets, breakpoint),
+    [viewLayout, viewWidgets, breakpoint]
   );
 
   const effectiveRowHeight = rowHeight ?? layout.rowHeight;
@@ -58,19 +109,22 @@ export function Dashboard({ definition, className, rowHeight }: DashboardProps) 
 
   return (
     <DashboardContextProvider value={{ dashboardName: definition.name }}>
-      <div
-        data-slot="dashboard"
-        data-dashboard-name={definition.name}
-        data-breakpoint={breakpoint}
-        className={className}
-        style={gridStyle}
-      >
-        {widgets.map((widget) => (
-          <DashboardCell key={widget.slug} widget={widget}>
-            <WidgetRenderer widget={widget} />
-          </DashboardCell>
-        ))}
-      </div>
+      <DashboardViewProvider value={{ currentView: resolvedView, setCurrentView: setView }}>
+        <div
+          data-slot="dashboard"
+          data-dashboard-name={definition.name}
+          data-breakpoint={breakpoint}
+          data-current-view={resolvedView ?? undefined}
+          className={className}
+          style={gridStyle}
+        >
+          {widgets.map((widget) => (
+            <DashboardCell key={widget.slug} widget={widget}>
+              <WidgetRenderer widget={widget} />
+            </DashboardCell>
+          ))}
+        </div>
+      </DashboardViewProvider>
     </DashboardContextProvider>
   );
 }

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -50,6 +50,15 @@ export type {
   DashboardContextProviderProps,
   DashboardContextValue,
 } from './components/dashboard-context.js';
+export { DashboardViewProvider, useDashboardView } from './components/dashboard-view-context.js';
+export type {
+  DashboardViewContextValue,
+  DashboardViewProviderProps,
+} from './components/dashboard-view-context.js';
+export { DashboardViewSwitcher } from './components/dashboard-view-switcher.js';
+export type { DashboardViewSwitcherProps } from './components/dashboard-view-switcher.js';
+export { resolveActiveView } from './lib/resolve-active-view.js';
+export type { ActiveDashboardView } from './lib/resolve-active-view.js';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window.js';
 export {
   DASHBOARD_BREAKPOINT_MIN_WIDTH,

--- a/packages/@granit/react-dashboards/src/lib/resolve-active-view.ts
+++ b/packages/@granit/react-dashboards/src/lib/resolve-active-view.ts
@@ -1,0 +1,62 @@
+import type { DashboardDefinition, DashboardLayout, WidgetDefinition } from '@granit/dashboards';
+
+/**
+ * Result of {@link resolveActiveView} — the widget pool + layout the
+ * dashboard should render given a (possibly null) active view name.
+ *
+ * `activeViewName` is `null` for single-view dashboards (no `views`
+ * entries) and for the rare case where the requested view isn't found
+ * (the resolver falls back to the top-level pool to keep the dashboard
+ * renderable rather than blank).
+ */
+export interface ActiveDashboardView {
+  /** The widgets to render — view-scoped or top-level fallback. */
+  readonly widgets: readonly WidgetDefinition[];
+  /** Layout to apply — view's `layout` override falls back to the dashboard's. */
+  readonly layout: DashboardLayout;
+  /** Active view's name, or `null` for single-view dashboards. */
+  readonly activeViewName: string | null;
+}
+
+/**
+ * Picks the active {@link DashboardView} given a (possibly null)
+ * requested view name, applying the framework's fallback chain:
+ *
+ * 1. `currentViewName` — explicit selection (controlled state, URL
+ *    binding, action handler).
+ * 2. {@link DashboardDefinition.defaultView} — author-declared entry
+ *    view.
+ * 3. The first view in {@link DashboardDefinition.views}.
+ *
+ * For single-view dashboards (`views` empty / null), returns the
+ * top-level `widgets` + `layout` and `activeViewName: null`. For
+ * multi-view dashboards where the requested view isn't found, returns
+ * the same fallback so the dashboard stays renderable rather than
+ * going blank.
+ *
+ * The view's optional `layout` override **replaces** the dashboard's
+ * `layout` when set (does NOT merge — `DashboardLayoutOverride` is for
+ * breakpoint composition, not view composition). This matches the
+ * backend's `DashboardView.Layout: DashboardLayout?` semantics.
+ *
+ * Pure function, no React deps.
+ */
+export function resolveActiveView(
+  definition: DashboardDefinition,
+  currentViewName: string | null = null
+): ActiveDashboardView {
+  const views = definition.views;
+  if (!views || views.length === 0) {
+    return { widgets: definition.widgets, layout: definition.layout, activeViewName: null };
+  }
+  const requested = currentViewName ?? definition.defaultView ?? views[0]?.name ?? null;
+  const view = requested ? views.find((v) => v.name === requested) : undefined;
+  if (!view) {
+    return { widgets: definition.widgets, layout: definition.layout, activeViewName: null };
+  }
+  return {
+    widgets: view.widgets,
+    layout: view.layout ?? definition.layout,
+    activeViewName: view.name,
+  };
+}


### PR DESCRIPTION
## Summary

The \`DashboardView\` types landed in #278 (\`DashboardDefinition.views\`, \`DashboardDefinition.defaultView\`, \`DashboardView\` record) but neither \`<Dashboard>\` nor \`<RenderedDashboard>\` were dispatching on the active view — the fields were declarative-only. This wires up the runtime side.

Self-contained: no backend coordination needed, just consumes types already in place.

## Surface

### Pure helper

\`resolveActiveView(definition, currentViewName?)\` — returns the active view's widgets + layout, with the framework's fallback chain:

1. \`currentViewName\` (explicit selection)
2. \`definition.defaultView\` (author-declared entry view)
3. First view in \`definition.views\`
4. Top-level pool (single-view dashboards or unknown view name)

\`view.layout\` **replaces** \`definition.layout\` when set (matches backend semantics — view-level layout is a full override, not a partial merge; per-breakpoint composition happens after via \`resolveEffectiveLayout\`).

### Context + hook

\`<DashboardViewProvider>\` + \`useDashboardView()\` — shares the active view + setter across the dashboard tree so action handlers (\`WidgetActionKind.OpenDashboardView\`), breadcrumbs, and view switchers can read/write without lifting state to every callsite.

### \`<Dashboard>\` integration

- Accepts optional \`currentView\` + \`onViewChange\` props (controlled)
- Falls back to internal state seeded from \`defaultView\` (uncontrolled)
- Composes \`resolveActiveView\` → \`resolveEffectiveLayout\` so per-breakpoint overrides still apply on top of the view's layout
- Mounts \`<DashboardViewProvider>\` so descendants reach the active view
- \`data-current-view\` on the grid root

### \`<DashboardViewSwitcher>\` tabs UI

- Accepts controlled props (\`currentView\` + \`onChange\`) for parent-owned state (URL binding, breadcrumb sync) OR reads the surrounding \`<DashboardViewProvider>\` when omitted
- Renders nothing for single-view dashboards (\`views\` null/empty) so apps drop it anywhere without conditionals
- Labels resolve via \`Dashboard:{name}.View.{viewName}\` convention, override-able via \`view.displayNameLocalizationKey\`
- ARIA \`role="tablist"\`/\`"tab"\`, \`aria-selected\`, \`data-view-name\` selectors

## What's intentionally out of scope

- \`<EditableDashboard>\` multi-view editing — the editor still works on \`definition.widgets\` (top-level pool). Multi-view authoring is a richer feature (per-view widget pools + reordering across views) and lands in a follow-up.
- \`<RenderedDashboard>\` (bundle path) view dispatching — the bundle response doesn't carry view metadata yet, that's a backend gap (\`DashboardRenderResponse\` doesn't include \`activeView\`).
- \`WidgetActionKind.OpenDashboardView\` action wiring — the trigger lands in a follow-up alongside the rest of the action dispatcher.
- URL sync via React Router — apps wire this themselves with the controlled-state pattern.

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-dashboards\` — 10 files / 78 tests pass (18 new: resolveActiveView fallback chain across 6 cases, controlled / uncontrolled \`<Dashboard>\`, single-view rendering paths, tab interactions).
- [x] \`pnpm lint\` clean.
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.