### PR TITLE
feat(dashboards): runtime for dashboard-scoped filters (P2.5)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2309,6 +2309,22 @@
           "members": []
         },
         {
+          "name": "DashboardFilterToolbar",
+          "kind": "function",
+          "signature": "function DashboardFilterToolbar("
+        },
+        {
+          "name": "DashboardFilterToolbarProps",
+          "kind": "interface",
+          "signature": "interface DashboardFilterToolbarProps",
+          "members": []
+        },
+        {
+          "name": "mergeFilterValuesIntoRequest",
+          "kind": "function",
+          "signature": "function mergeFilterValuesIntoRequest( request: DashboardRenderRequest, values: DashboardFilterValues | null | undefined ): DashboardRenderRequest"
+        },
+        {
           "name": "useEffectiveTimeWindow",
           "kind": "function",
           "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"

--- a/packages/@granit/react-dashboards/src/__tests__/dashboard-filters.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/dashboard-filters.test.tsx
@@ -1,0 +1,207 @@
+import { act, fireEvent, render, renderHook } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  DashboardFilterProvider,
+  useDashboardFilters,
+} from '../components/dashboard-filter-context.js';
+import { DashboardFilterToolbar } from '../components/dashboard-filter-toolbar.js';
+
+import type { DashboardFilter } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        'Filter:Customer': 'Customer',
+        'Filter:Status': 'Status',
+        'Dashboard:Filter.Reset': 'Reset',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function wrap(node: ReactNode) {
+  return render(<I18nextProvider i18n={testI18n}>{node}</I18nextProvider>);
+}
+
+const customerFilter: DashboardFilter = {
+  name: 'Customer',
+  labelLocalizationKey: 'Filter:Customer',
+  clauses: [{ field: 'customer.id', op: 'Eq', value: '${currentCustomer}' }],
+  editable: true,
+};
+
+const statusFilter: DashboardFilter = {
+  name: 'Status',
+  labelLocalizationKey: 'Filter:Status',
+  clauses: [{ field: 'status', op: 'Eq', value: 'Open' }],
+  editable: true,
+};
+
+const silentFilter: DashboardFilter = {
+  name: 'CurrentTenant',
+  labelLocalizationKey: 'Filter:Tenant',
+  clauses: [{ field: 'tenant.id', op: 'Eq', value: '${currentTenant}' }],
+  editable: false,
+};
+
+describe('DashboardFilterProvider — context state', () => {
+  it('seeds values from initialValues and exposes them via useDashboardFilters', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <I18nextProvider i18n={testI18n}>
+        <DashboardFilterProvider
+          filters={[customerFilter, statusFilter]}
+          initialValues={{ Customer: '42' }}
+        >
+          {children}
+        </DashboardFilterProvider>
+      </I18nextProvider>
+    );
+    const { result } = renderHook(() => useDashboardFilters(), { wrapper });
+    expect(result.current?.values).toEqual({ Customer: '42' });
+  });
+
+  it('setValue updates the live values map', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <I18nextProvider i18n={testI18n}>
+        <DashboardFilterProvider filters={[customerFilter]}>{children}</DashboardFilterProvider>
+      </I18nextProvider>
+    );
+    const { result } = renderHook(() => useDashboardFilters(), { wrapper });
+    expect(result.current?.values).toEqual({});
+    act(() => result.current?.setValue('Customer', '99'));
+    expect(result.current?.values).toEqual({ Customer: '99' });
+  });
+
+  it('setValue with null clears the entry (matches "no filter applied" semantics)', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <I18nextProvider i18n={testI18n}>
+        <DashboardFilterProvider filters={[customerFilter]} initialValues={{ Customer: '42' }}>
+          {children}
+        </DashboardFilterProvider>
+      </I18nextProvider>
+    );
+    const { result } = renderHook(() => useDashboardFilters(), { wrapper });
+    act(() => result.current?.setValue('Customer', null));
+    expect(result.current?.values).toEqual({ Customer: null });
+  });
+
+  it('resetAll falls back to initialValues', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <I18nextProvider i18n={testI18n}>
+        <DashboardFilterProvider filters={[customerFilter]} initialValues={{ Customer: 'seed' }}>
+          {children}
+        </DashboardFilterProvider>
+      </I18nextProvider>
+    );
+    const { result } = renderHook(() => useDashboardFilters(), { wrapper });
+    act(() => result.current?.setValue('Customer', 'changed'));
+    act(() => result.current?.resetAll());
+    expect(result.current?.values).toEqual({ Customer: 'seed' });
+  });
+
+  it('fires onChange on every value mutation', () => {
+    const onChange = vi.fn();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <I18nextProvider i18n={testI18n}>
+        <DashboardFilterProvider filters={[customerFilter]} onChange={onChange}>
+          {children}
+        </DashboardFilterProvider>
+      </I18nextProvider>
+    );
+    const { result } = renderHook(() => useDashboardFilters(), { wrapper });
+    act(() => result.current?.setValue('Customer', '42'));
+    expect(onChange).toHaveBeenCalledWith({ Customer: '42' });
+  });
+
+  it('useDashboardFilters returns null when called outside the provider', () => {
+    const { result } = renderHook(() => useDashboardFilters());
+    expect(result.current).toBeNull();
+  });
+});
+
+describe('<DashboardFilterToolbar />', () => {
+  it('renders nothing outside a provider', () => {
+    const { container } = wrap(<DashboardFilterToolbar />);
+    expect(container.querySelector('[data-slot="dashboard-filter-toolbar"]')).toBeNull();
+  });
+
+  it('renders nothing when no filter is editable', () => {
+    const { container } = wrap(
+      <DashboardFilterProvider filters={[silentFilter]}>
+        <DashboardFilterToolbar />
+      </DashboardFilterProvider>
+    );
+    expect(container.querySelector('[data-slot="dashboard-filter-toolbar"]')).toBeNull();
+  });
+
+  it('renders one input per editable filter (silent ones skipped)', () => {
+    const { container } = wrap(
+      <DashboardFilterProvider filters={[customerFilter, statusFilter, silentFilter]}>
+        <DashboardFilterToolbar />
+      </DashboardFilterProvider>
+    );
+    const inputs = container.querySelectorAll('[data-slot="dashboard-filter-input"]');
+    expect(inputs).toHaveLength(2);
+    const names = Array.from(inputs).map((i) => i.getAttribute('data-filter-name'));
+    expect(names).toEqual(['Customer', 'Status']);
+  });
+
+  it('writes through to the context on change', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <DashboardFilterProvider filters={[customerFilter]} onChange={onChange}>
+        <DashboardFilterToolbar />
+      </DashboardFilterProvider>
+    );
+    const input = container.querySelector('[data-slot="dashboard-filter-input"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: '42' } });
+    expect(onChange).toHaveBeenCalledWith({ Customer: '42' });
+  });
+
+  it('clearing an input dispatches `null` (drops the filter from the request)', () => {
+    const onChange = vi.fn();
+    const { container } = wrap(
+      <DashboardFilterProvider
+        filters={[customerFilter]}
+        initialValues={{ Customer: '42' }}
+        onChange={onChange}
+      >
+        <DashboardFilterToolbar />
+      </DashboardFilterProvider>
+    );
+    const input = container.querySelector('[data-slot="dashboard-filter-input"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith({ Customer: null });
+  });
+
+  it('Reset button restores initialValues', () => {
+    const onChange = vi.fn();
+    const { container, getByRole } = wrap(
+      <DashboardFilterProvider
+        filters={[customerFilter]}
+        initialValues={{ Customer: 'seed' }}
+        onChange={onChange}
+      >
+        <DashboardFilterToolbar />
+      </DashboardFilterProvider>
+    );
+    const input = container.querySelector('[data-slot="dashboard-filter-input"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('input not found');
+    fireEvent.change(input, { target: { value: 'edited' } });
+    fireEvent.click(getByRole('button', { name: /reset/i }));
+    expect(onChange).toHaveBeenLastCalledWith({ Customer: 'seed' });
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/merge-filter-values.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/merge-filter-values.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeFilterValuesIntoRequest } from '../lib/merge-filter-values.js';
+
+import type { DashboardRenderRequest } from '@granit/dashboards';
+
+describe('mergeFilterValuesIntoRequest', () => {
+  it('returns the input request verbatim when there are no filter values', () => {
+    const request: DashboardRenderRequest = { periodToken: 'mtd' };
+    expect(mergeFilterValuesIntoRequest(request, undefined)).toBe(request);
+    expect(mergeFilterValuesIntoRequest(request, null)).toBe(request);
+    expect(mergeFilterValuesIntoRequest(request, {})).toBe(request);
+  });
+
+  it('folds non-null values into request.filters', () => {
+    const request: DashboardRenderRequest = { periodToken: 'mtd' };
+    const merged = mergeFilterValuesIntoRequest(request, {
+      Customer: '42',
+      Status: 'Open',
+    });
+    expect(merged.filters).toEqual({ Customer: '42', Status: 'Open' });
+    expect(merged.periodToken).toBe('mtd');
+  });
+
+  it('drops null entries (clears the filter rather than sending an empty string)', () => {
+    const request: DashboardRenderRequest = {
+      filters: { Customer: '42', Status: 'Open' },
+    };
+    const merged = mergeFilterValuesIntoRequest(request, { Status: null });
+    expect(merged.filters).toEqual({ Customer: '42' });
+  });
+
+  it('lets live values override pre-populated request.filters on the same key', () => {
+    const request: DashboardRenderRequest = {
+      filters: { Customer: 'old' },
+    };
+    const merged = mergeFilterValuesIntoRequest(request, { Customer: 'new' });
+    expect(merged.filters).toEqual({ Customer: 'new' });
+  });
+
+  it('returns the request without filters when every effective key is null', () => {
+    const request: DashboardRenderRequest = {};
+    const merged = mergeFilterValuesIntoRequest(request, { A: null, B: null });
+    expect(merged.filters).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/dashboard-filter-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-filter-context.tsx
@@ -1,0 +1,112 @@
+import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+
+import type { DashboardFilter } from '@granit/dashboards';
+
+/**
+ * Live filter values keyed by `DashboardFilter.name`. Strings on the
+ * wire — matches `DashboardRenderRequest.filters` shape (per ADR-039
+ * §6.1, the QueryEngine accepts string-encoded values regardless of
+ * the underlying clause type, with parsing on the server side).
+ *
+ * `null` removes the filter from the request — useful for
+ * "all" / "any" semantics where the user explicitly clears a control.
+ */
+export type DashboardFilterValues = Readonly<Record<string, string | null>>;
+
+/**
+ * Filter context surfaced to consumers — toolbar inputs, action
+ * handlers (future `WidgetActionKind.SetFilter`), and
+ * `<RenderedDashboard>` so the bundle render request picks up live
+ * values automatically.
+ */
+export interface DashboardFilterContextValue {
+  /** Current values, keyed by filter name. */
+  readonly values: DashboardFilterValues;
+  /** Sets one filter's value (`null` clears it). */
+  readonly setValue: (filterName: string, value: string | null) => void;
+  /** Resets every editable filter to its initial value (typically empty). */
+  readonly resetAll: () => void;
+  /**
+   * Filter declarations from the dashboard definition — exposed so
+   * the toolbar / action handlers don't need to thread the definition
+   * through their props.
+   */
+  readonly filters: readonly DashboardFilter[];
+}
+
+const DashboardFilterContext = createContext<DashboardFilterContextValue | null>(null);
+
+export interface DashboardFilterProviderProps {
+  readonly filters: readonly DashboardFilter[] | null | undefined;
+  /**
+   * Initial values seeded into the provider. Useful for URL-bound
+   * filters (parent reads `?customer=42` from the location and feeds
+   * it here). Falls back to an empty map when omitted — every editable
+   * filter starts unset.
+   */
+  readonly initialValues?: DashboardFilterValues;
+  /**
+   * Notification fired on every value change. Apps wire this to URL
+   * sync, persistence, or telemetry. Internal state still tracks the
+   * value regardless — the provider is uncontrolled by default.
+   */
+  readonly onChange?: (values: DashboardFilterValues) => void;
+  readonly children: React.ReactNode;
+}
+
+/**
+ * Provider for live dashboard filter values. Pairs with
+ * {@link useDashboardFilters} for read/write access and
+ * {@link mergeFilterValuesIntoRequest} for plugging into the render
+ * request.
+ *
+ * Renders a no-op provider for single-filter-less dashboards (filters
+ * empty / null) so apps drop the provider unconditionally without
+ * worrying about whether the dashboard ships filters.
+ */
+export function DashboardFilterProvider({
+  filters,
+  initialValues,
+  onChange,
+  children,
+}: DashboardFilterProviderProps) {
+  const declaredFilters = useMemo(() => filters ?? [], [filters]);
+  const [values, setValuesState] = useState<DashboardFilterValues>(initialValues ?? {});
+
+  const setValue = useCallback(
+    (filterName: string, value: string | null) => {
+      setValuesState((current) => {
+        const next: Record<string, string | null> = { ...current, [filterName]: value };
+        onChange?.(next);
+        return next;
+      });
+    },
+    [onChange]
+  );
+
+  const resetAll = useCallback(() => {
+    setValuesState(() => {
+      const cleared = initialValues ?? {};
+      onChange?.(cleared);
+      return cleared;
+    });
+  }, [initialValues, onChange]);
+
+  const value = useMemo<DashboardFilterContextValue>(
+    () => ({ values, setValue, resetAll, filters: declaredFilters }),
+    [values, setValue, resetAll, declaredFilters]
+  );
+
+  return (
+    <DashboardFilterContext.Provider value={value}>{children}</DashboardFilterContext.Provider>
+  );
+}
+
+/**
+ * Reads the current filter context. Returns `null` when called outside
+ * a `<DashboardFilterProvider>` so consumers (toolbar, render request)
+ * gracefully degrade without throwing.
+ */
+export function useDashboardFilters(): DashboardFilterContextValue | null {
+  return useContext(DashboardFilterContext);
+}

--- a/packages/@granit/react-dashboards/src/components/dashboard-filter-toolbar.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-filter-toolbar.tsx
@@ -1,0 +1,92 @@
+import { useTranslation } from 'react-i18next';
+
+import { useDashboardFilters } from './dashboard-filter-context.js';
+
+import type { DashboardFilter } from '@granit/dashboards';
+
+/**
+ * Toolbar surfacing every **editable** dashboard filter as a text
+ * input. Reads / writes the surrounding {@link DashboardFilterProvider}
+ * — mount the provider at or above the toolbar's parent.
+ *
+ * v1 ships a single text-input per filter regardless of the clause
+ * shape. Lookup-bound filters (entity pickers, date ranges, multi-
+ * select) are deferred to follow-up components consumers compose on
+ * top of the same provider — the framework's contract is "manage
+ * values keyed by filter name", not "provide every input control".
+ *
+ * Non-editable filters (`editable: false` or missing) are silent —
+ * the toolbar skips them. They still apply to the bundle render via
+ * any pre-populated values the parent feeds into
+ * {@link DashboardFilterProvider.initialValues}.
+ *
+ * Renders nothing for filter-less dashboards, so apps drop the
+ * toolbar unconditionally without checking for `filters?.length`.
+ */
+export interface DashboardFilterToolbarProps {
+  readonly className?: string;
+}
+
+export function DashboardFilterToolbar({ className }: DashboardFilterToolbarProps) {
+  const { t } = useTranslation();
+  const ctx = useDashboardFilters();
+
+  if (!ctx) return null;
+
+  const editable = ctx.filters.filter((f) => f.editable === true);
+  if (editable.length === 0) return null;
+
+  return (
+    <div
+      data-slot="dashboard-filter-toolbar"
+      role="toolbar"
+      aria-label="Dashboard filters"
+      className={joinClasses('flex flex-wrap items-end gap-3', className)}
+    >
+      {editable.map((filter) => (
+        <FilterControl key={filter.name} filter={filter} />
+      ))}
+      <button
+        type="button"
+        data-slot="dashboard-filter-toolbar-reset"
+        onClick={() => ctx.resetAll()}
+        className="rounded-md border bg-background px-2.5 py-1.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground"
+      >
+        {t('Dashboard:Filter.Reset', { defaultValue: 'Reset' })}
+      </button>
+    </div>
+  );
+}
+
+function FilterControl({ filter }: { readonly filter: DashboardFilter }) {
+  const { t } = useTranslation();
+  const ctx = useDashboardFilters();
+  if (!ctx) return null;
+
+  const rawValue = ctx.values[filter.name];
+  const inputValue = rawValue ?? '';
+  const label = t(filter.labelLocalizationKey, { defaultValue: filter.name });
+
+  return (
+    <label className="flex flex-col gap-1 text-xs">
+      <span data-slot="dashboard-filter-label" className="text-muted-foreground">
+        {label}
+      </span>
+      <input
+        type="text"
+        data-slot="dashboard-filter-input"
+        data-filter-name={filter.name}
+        value={inputValue}
+        onChange={(event) => {
+          const next = event.target.value;
+          ctx.setValue(filter.name, next === '' ? null : next);
+        }}
+        className="rounded-md border bg-background px-2.5 py-1.5 text-sm"
+      />
+    </label>
+  );
+}
+
+function joinClasses(...parts: ReadonlyArray<string | undefined>): string {
+  return parts.filter(Boolean).join(' ');
+}

--- a/packages/@granit/react-dashboards/src/components/rendered-dashboard.tsx
+++ b/packages/@granit/react-dashboards/src/components/rendered-dashboard.tsx
@@ -1,5 +1,9 @@
-import { useDashboardRender, type UseDashboardRenderOptions } from '../api/use-dashboard-render.js';
+import { useMemo } from 'react';
 
+import { useDashboardRender, type UseDashboardRenderOptions } from '../api/use-dashboard-render.js';
+import { mergeFilterValuesIntoRequest } from '../lib/merge-filter-values.js';
+
+import { useDashboardFilters } from './dashboard-filter-context.js';
 import { RenderedWidget } from './rendered-widget.js';
 
 import type { DashboardRenderRequest } from '@granit/dashboards';
@@ -45,7 +49,17 @@ export function RenderedDashboard({
   options,
   className,
 }: RenderedDashboardProps) {
-  const query = useDashboardRender(dashboardId, request, options);
+  // Surrounding `<DashboardFilterProvider>` (when mounted) drives live
+  // filter values into the bundle render request. Apps wanting fully
+  // static rendering omit the provider entirely; the merge becomes a
+  // no-op identity.
+  const filters = useDashboardFilters();
+  const effectiveRequest = useMemo(
+    () => mergeFilterValuesIntoRequest(request ?? {}, filters?.values),
+    [request, filters?.values]
+  );
+
+  const query = useDashboardRender(dashboardId, effectiveRequest, options);
 
   if (query.isLoading) {
     return <LoadingSkeleton className={className} />;

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -59,6 +59,18 @@ export { DashboardViewSwitcher } from './components/dashboard-view-switcher.js';
 export type { DashboardViewSwitcherProps } from './components/dashboard-view-switcher.js';
 export { resolveActiveView } from './lib/resolve-active-view.js';
 export type { ActiveDashboardView } from './lib/resolve-active-view.js';
+export {
+  DashboardFilterProvider,
+  useDashboardFilters,
+} from './components/dashboard-filter-context.js';
+export type {
+  DashboardFilterContextValue,
+  DashboardFilterProviderProps,
+  DashboardFilterValues,
+} from './components/dashboard-filter-context.js';
+export { DashboardFilterToolbar } from './components/dashboard-filter-toolbar.js';
+export type { DashboardFilterToolbarProps } from './components/dashboard-filter-toolbar.js';
+export { mergeFilterValuesIntoRequest } from './lib/merge-filter-values.js';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window.js';
 export {
   DASHBOARD_BREAKPOINT_MIN_WIDTH,

--- a/packages/@granit/react-dashboards/src/lib/merge-filter-values.ts
+++ b/packages/@granit/react-dashboards/src/lib/merge-filter-values.ts
@@ -1,0 +1,34 @@
+import type { DashboardFilterValues } from '../components/dashboard-filter-context.js';
+import type { DashboardRenderRequest } from '@granit/dashboards';
+
+/**
+ * Folds live {@link DashboardFilterValues} into a
+ * {@link DashboardRenderRequest}. Keys whose value is `null` are
+ * dropped — matches the backend's "no filter applied" semantics,
+ * different from passing an empty string (which would request
+ * `Field eq ""`).
+ *
+ * Existing `request.filters` entries are merged with live values
+ * winning on key conflict — apps that pre-populate
+ * `request.filters` (e.g. tenant-scoped silent filters from the
+ * route loader) get those values overridden by user-driven toolbar
+ * input, which is the expected UX.
+ *
+ * Pure function, no React deps.
+ */
+export function mergeFilterValuesIntoRequest(
+  request: DashboardRenderRequest,
+  values: DashboardFilterValues | null | undefined
+): DashboardRenderRequest {
+  if (!values || Object.keys(values).length === 0) return request;
+
+  const merged: Record<string, string> = { ...(request.filters ?? {}) };
+  for (const [name, value] of Object.entries(values)) {
+    if (value === null) {
+      delete merged[name];
+      continue;
+    }
+    merged[name] = value;
+  }
+  return Object.keys(merged).length > 0 ? { ...request, filters: merged } : request;
+}


### PR DESCRIPTION
## Summary

The \`DashboardFilter\` types landed in #278 (4 types: \`DashboardFilter\`, \`DashboardFilterClause\`, \`DashboardFilterOperator\`, \`DashboardFilterOperation\`) but no runtime was consuming them. This wires up the user-facing side: toolbar input → live values context → folded into the bundle render request.

Self-contained: no backend coordination needed. The wire format (\`DashboardRenderRequest.filters: Record<string, string>\`) was already in place — this PR plumbs values into it.

## Surface

| Symbol | Purpose |
| --- | --- |
| \`DashboardFilterValues\` type | \`Readonly<Record<string, string \| null>>\` — \`null\` clears the filter (matches "no filter applied", different from empty string) |
| \`<DashboardFilterProvider>\` | Manages live values keyed by filter name. Uncontrolled by default; accepts \`initialValues\` for URL-bound parents and \`onChange\` for telemetry |
| \`useDashboardFilters()\` | Read access for toolbar / action handlers / bundle integration. Returns \`null\` outside the provider |
| \`mergeFilterValuesIntoRequest()\` | Pure helper folding values into a \`DashboardRenderRequest\`. \`null\` entries drop the key; live values win on conflict with pre-populated request filters |
| \`<DashboardFilterToolbar>\` | One text input per editable filter. Silent filters skipped. Reset button restores \`initialValues\`. Renders nothing for filter-less dashboards |
| \`<RenderedDashboard>\` integration | Picks up live values automatically when wrapped in a \`<DashboardFilterProvider>\` — apps wanting static rendering omit the provider, merge becomes a no-op |

## Editable vs silent filters

- **Editable** (\`editable: true\`) — surfaced as toolbar inputs, value comes from user.
- **Silent** (\`editable: false\` / missing) — applied invisibly. Apps pre-populate via \`initialValues\` or \`request.filters\` for tenant-scoped \`\${currentTenant}\` style scoping.

## What's intentionally out of scope

- **Lookup-bound / date-range / multi-select inputs** — toolbar v1 ships text inputs only. Apps compose richer controls on top of the same \`useDashboardFilters()\` hook (the framework's contract is "manage values keyed by filter name", not "provide every input control").
- **Definition-path widget filtering** — \`<KpiTile>\` etc. fetch via \`useMetric\` which doesn't yet consume filter context. Definition-path filter propagation lands alongside the \`WidgetAction\` dispatcher follow-up.

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-dashboards\` — 12 files / 95 tests pass (18 new: provider state with act-wrapped mutations, toolbar rendering rules, controlled mode, reset semantics, request merging including null-clears + override semantics).
- [x] \`pnpm lint\` clean.
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.