### PR TITLE
feat(dashboards): runtime for entity aliases (P2.3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2325,6 +2325,22 @@
           "signature": "function mergeFilterValuesIntoRequest( request: DashboardRenderRequest, values: DashboardFilterValues | null | undefined ): DashboardRenderRequest"
         },
         {
+          "name": "AliasResolutionContext",
+          "kind": "interface",
+          "signature": "interface AliasResolutionContext",
+          "members": []
+        },
+        {
+          "name": "substituteAliases",
+          "kind": "function",
+          "signature": "function substituteAliases( value: string, aliases: DashboardAliasValues | null | undefined ): string"
+        },
+        {
+          "name": "substituteAliasesInRecord",
+          "kind": "function",
+          "signature": "function substituteAliasesInRecord( record: Readonly<Record<string, string>>, aliases: DashboardAliasValues | null | undefined ): Readonly<Record<string, string>>"
+        },
+        {
           "name": "useEffectiveTimeWindow",
           "kind": "function",
           "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"

--- a/packages/@granit/react-dashboards/src/__tests__/resolve-entity-alias.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/resolve-entity-alias.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveDashboardAliases,
+  resolveEntityAlias,
+  resolveEntityAliasResolver,
+} from '../lib/resolve-entity-alias.js';
+
+import type { EntityAlias } from '@granit/dashboards';
+
+const customerAlias: EntityAlias = {
+  name: 'currentCustomer',
+  entityType: 'Customer',
+  resolver: { kind: 'route-param', paramName: 'customerId' },
+};
+
+const tenantAlias: EntityAlias = {
+  name: 'currentTenant',
+  entityType: 'Tenant',
+  resolver: { kind: 'tenant-context' },
+};
+
+const staticAlias: EntityAlias = {
+  name: 'globalEntity',
+  entityType: 'Customer',
+  resolver: { kind: 'static', entityId: 'global-1' },
+};
+
+const viewAlias: EntityAlias = {
+  name: 'selectedDevice',
+  entityType: 'Device',
+  resolver: { kind: 'view-entity', paramName: 'entityId' },
+};
+
+const userSelectionAlias: EntityAlias = {
+  name: 'pickedCustomer',
+  entityType: 'Customer',
+  resolver: { kind: 'user-selection', lookupName: 'Customers' },
+};
+
+describe('resolveEntityAliasResolver', () => {
+  it('resolves static resolvers from the resolver itself (no context needed)', () => {
+    expect(resolveEntityAliasResolver({ kind: 'static', entityId: 'x-42' }, {})).toBe('x-42');
+  });
+
+  it('resolves tenant-context from currentTenantId', () => {
+    expect(resolveEntityAliasResolver({ kind: 'tenant-context' }, { currentTenantId: 't-7' })).toBe(
+      't-7'
+    );
+  });
+
+  it('returns null when tenant-context is requested but no tenant is in context', () => {
+    expect(resolveEntityAliasResolver({ kind: 'tenant-context' }, {})).toBeNull();
+  });
+
+  it('resolves route-param from routeParams', () => {
+    const value = resolveEntityAliasResolver(
+      { kind: 'route-param', paramName: 'customerId' },
+      { routeParams: { customerId: '42' } }
+    );
+    expect(value).toBe('42');
+  });
+
+  it('returns null when route-param is requested but the param is missing', () => {
+    expect(
+      resolveEntityAliasResolver({ kind: 'route-param', paramName: 'customerId' }, {})
+    ).toBeNull();
+    expect(
+      resolveEntityAliasResolver(
+        { kind: 'route-param', paramName: 'customerId' },
+        { routeParams: { otherParam: 'x' } }
+      )
+    ).toBeNull();
+  });
+
+  it('resolves view-entity from viewParams', () => {
+    expect(
+      resolveEntityAliasResolver(
+        { kind: 'view-entity', paramName: 'entityId' },
+        { viewParams: { entityId: 'd-99' } }
+      )
+    ).toBe('d-99');
+  });
+
+  it('resolves user-selection from userSelections keyed by alias name', () => {
+    expect(
+      resolveEntityAliasResolver(
+        { kind: 'user-selection', lookupName: 'Customers' },
+        { userSelections: { pickedCustomer: 'c-7' } },
+        'pickedCustomer'
+      )
+    ).toBe('c-7');
+  });
+
+  it('returns null when user-selection is requested without an alias name (no lookup possible)', () => {
+    expect(
+      resolveEntityAliasResolver(
+        { kind: 'user-selection', lookupName: 'Customers' },
+        { userSelections: { pickedCustomer: 'c-7' } }
+      )
+    ).toBeNull();
+  });
+});
+
+describe('resolveEntityAlias — convenience wrapper threading the alias name', () => {
+  it('resolves user-selection by alias name', () => {
+    expect(
+      resolveEntityAlias(userSelectionAlias, { userSelections: { pickedCustomer: 'c-7' } })
+    ).toBe('c-7');
+  });
+
+  it('resolves route-param against the alias resolver', () => {
+    expect(resolveEntityAlias(customerAlias, { routeParams: { customerId: '42' } })).toBe('42');
+  });
+});
+
+describe('resolveDashboardAliases', () => {
+  it('returns an empty map when aliases is null / undefined', () => {
+    expect(resolveDashboardAliases(null, {})).toEqual({});
+    expect(resolveDashboardAliases(undefined, {})).toEqual({});
+  });
+
+  it('resolves every alias in one pass against a shared context', () => {
+    const aliases = [customerAlias, tenantAlias, staticAlias];
+    const result = resolveDashboardAliases(aliases, {
+      routeParams: { customerId: '42' },
+      currentTenantId: 't-7',
+    });
+    expect(result).toEqual({
+      currentCustomer: '42',
+      currentTenant: 't-7',
+      globalEntity: 'global-1',
+    });
+  });
+
+  it('drops aliases that fail to resolve from the result map', () => {
+    const aliases = [customerAlias, tenantAlias];
+    const result = resolveDashboardAliases(aliases, {});
+    expect(result).toEqual({});
+  });
+
+  it("handles a mixed pass where some resolve and some don't", () => {
+    const aliases = [customerAlias, viewAlias, userSelectionAlias];
+    const result = resolveDashboardAliases(aliases, {
+      routeParams: { customerId: '42' },
+      // viewParams missing → viewAlias drops
+      userSelections: { pickedCustomer: 'c-7' },
+    });
+    expect(result).toEqual({
+      currentCustomer: '42',
+      pickedCustomer: 'c-7',
+    });
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/substitute-aliases.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/substitute-aliases.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import { substituteAliases, substituteAliasesInRecord } from '../lib/substitute-aliases.js';
+
+describe('substituteAliases', () => {
+  it('substitutes a single placeholder', () => {
+    expect(substituteAliases('${currentCustomer}', { currentCustomer: '42' })).toBe('42');
+  });
+
+  it('substitutes multiple placeholders in the same string', () => {
+    expect(
+      substituteAliases('customer/${currentCustomer}/device/${selectedDevice}', {
+        currentCustomer: '42',
+        selectedDevice: 'd-7',
+      })
+    ).toBe('customer/42/device/d-7');
+  });
+
+  it('leaves unknown placeholders verbatim (consumer / backend may resolve them)', () => {
+    expect(substituteAliases('${currentCustomer} / ${unresolved}', { currentCustomer: '42' })).toBe(
+      '42 / ${unresolved}'
+    );
+  });
+
+  it('returns the input verbatim when aliases is null / undefined', () => {
+    expect(substituteAliases('${currentCustomer}', null)).toBe('${currentCustomer}');
+    expect(substituteAliases('${currentCustomer}', undefined)).toBe('${currentCustomer}');
+  });
+
+  it('does not substitute malformed placeholders (missing brace, spaces, etc.)', () => {
+    expect(substituteAliases('${ currentCustomer }', { currentCustomer: '42' })).toBe(
+      '${ currentCustomer }'
+    );
+    expect(substituteAliases('$currentCustomer', { currentCustomer: '42' })).toBe(
+      '$currentCustomer'
+    );
+  });
+});
+
+describe('substituteAliasesInRecord', () => {
+  it('substitutes placeholders in every value', () => {
+    const out = substituteAliasesInRecord(
+      { Customer: '${currentCustomer}', Status: 'Open' },
+      { currentCustomer: '42' }
+    );
+    expect(out).toEqual({ Customer: '42', Status: 'Open' });
+  });
+
+  it('returns the input reference verbatim when no substitution is needed', () => {
+    const input = { Customer: '42', Status: 'Open' };
+    const out = substituteAliasesInRecord(input, { currentCustomer: 'whatever' });
+    expect(out).toBe(input);
+  });
+
+  it('returns the input verbatim when aliases is empty / null', () => {
+    const input = { Customer: '${currentCustomer}' };
+    expect(substituteAliasesInRecord(input, {})).toBe(input);
+    expect(substituteAliasesInRecord(input, null)).toBe(input);
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/dashboard-alias-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/dashboard-alias-context.tsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useMemo } from 'react';
+
+/**
+ * Resolved alias values surfaced to dashboard consumers — widget
+ * action handlers (navigation with the entity id), breadcrumbs,
+ * variable substitution in filter clauses (`${currentCustomer}`),
+ * and any custom widget that scopes its query by alias.
+ *
+ * Keyed by `EntityAlias.name`. Aliases that fail to resolve at
+ * provider construction (missing route param, no tenant, no user
+ * selection) are absent from the map — consumers check for presence
+ * rather than dealing with `null` values.
+ */
+export type DashboardAliasValues = Readonly<Record<string, string>>;
+
+const DashboardAliasContext = createContext<DashboardAliasValues | null>(null);
+
+export interface DashboardAliasProviderProps {
+  /**
+   * Resolved alias map. Apps build this from the dashboard's
+   * `definition.aliases` + their own resolution context (route
+   * params, current tenant, user selections) using
+   * {@link resolveDashboardAliases}, then feed the result here.
+   */
+  readonly values: DashboardAliasValues;
+  readonly children: React.ReactNode;
+}
+
+/**
+ * Provider for resolved alias values. Pairs with
+ * {@link useDashboardAliases} for read access. The provider is
+ * intentionally **uncontrolled-only**: alias resolution depends on
+ * external context (URL params, tenant, picker state) that the parent
+ * already owns, so there's no setter inside the provider.
+ *
+ * Apps wanting reactive resolution wrap their parent's resolution
+ * context in `useMemo`+`resolveDashboardAliases` and re-render this
+ * provider with fresh values on context changes.
+ */
+export function DashboardAliasProvider({ values, children }: DashboardAliasProviderProps) {
+  // Memoise the value object so descendants don't see a new reference
+  // every render (even when the parent passes the same map back).
+  const stable = useMemo(() => values, [values]);
+  return <DashboardAliasContext.Provider value={stable}>{children}</DashboardAliasContext.Provider>;
+}
+
+/**
+ * Reads the current alias values map. Returns `null` outside a
+ * provider — consumers (action handlers, variable substitution)
+ * gracefully degrade to the unscoped behaviour when no provider is
+ * mounted.
+ */
+export function useDashboardAliases(): DashboardAliasValues | null {
+  return useContext(DashboardAliasContext);
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -71,6 +71,23 @@ export type {
 export { DashboardFilterToolbar } from './components/dashboard-filter-toolbar.js';
 export type { DashboardFilterToolbarProps } from './components/dashboard-filter-toolbar.js';
 export { mergeFilterValuesIntoRequest } from './lib/merge-filter-values.js';
+
+// Entity alias runtime (P2.3) — resolution context, provider, helpers
+export {
+  DashboardAliasProvider,
+  useDashboardAliases,
+} from './components/dashboard-alias-context.js';
+export type {
+  DashboardAliasProviderProps,
+  DashboardAliasValues,
+} from './components/dashboard-alias-context.js';
+export {
+  resolveDashboardAliases,
+  resolveEntityAlias,
+  resolveEntityAliasResolver,
+} from './lib/resolve-entity-alias.js';
+export type { AliasResolutionContext } from './lib/resolve-entity-alias.js';
+export { substituteAliases, substituteAliasesInRecord } from './lib/substitute-aliases.js';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window.js';
 export {
   DASHBOARD_BREAKPOINT_MIN_WIDTH,

--- a/packages/@granit/react-dashboards/src/lib/resolve-entity-alias.ts
+++ b/packages/@granit/react-dashboards/src/lib/resolve-entity-alias.ts
@@ -1,0 +1,101 @@
+import {
+  isRouteParamResolver,
+  isStaticEntityResolver,
+  isTenantContextResolver,
+  isViewEntityResolver,
+  type EntityAlias,
+  type EntityAliasResolver,
+} from '@granit/dashboards';
+
+/**
+ * Resolution context fed to {@link resolveEntityAliasResolver}. Apps
+ * populate the fields their resolvers need:
+ *
+ * - `routeParams` — the URL parameter map (typically from React
+ *   Router's `useParams()` or equivalent). Read by `route-param`
+ *   resolvers.
+ * - `viewParams` — the active view's parameters (P2.1 view stack).
+ *   Read by `view-entity` resolvers.
+ * - `currentTenantId` — current authenticated tenant id. Read by
+ *   `tenant-context` resolvers.
+ * - `userSelections` — user-driven picker selections keyed by alias
+ *   name. Read by `user-selection` resolvers.
+ *
+ * Each field is optional — when the corresponding resolver kind isn't
+ * present in the alias list, the field is unused. When a resolver
+ * needs a field that's missing, the resolution returns `null` (no
+ * crash — the dashboard renders without scoping).
+ */
+export interface AliasResolutionContext {
+  readonly routeParams?: Readonly<Record<string, string | undefined>>;
+  readonly viewParams?: Readonly<Record<string, string | undefined>>;
+  readonly currentTenantId?: string | null;
+  readonly userSelections?: Readonly<Record<string, string | null>>;
+}
+
+/**
+ * Resolves a single {@link EntityAliasResolver} against a context.
+ * Returns the resolved entity id, or `null` when the resolver kind
+ * needs context fields the caller didn't provide.
+ *
+ * `user-selection` resolvers read from `userSelections[aliasName]`,
+ * which means callers need to pass the alias name through (the
+ * resolver itself doesn't carry one). Use {@link resolveEntityAlias}
+ * when the alias is available.
+ *
+ * Pure function, no React deps.
+ */
+export function resolveEntityAliasResolver(
+  resolver: EntityAliasResolver,
+  context: AliasResolutionContext,
+  aliasName?: string
+): string | null {
+  if (isStaticEntityResolver(resolver)) {
+    return resolver.entityId;
+  }
+  if (isTenantContextResolver(resolver)) {
+    return context.currentTenantId ?? null;
+  }
+  if (isRouteParamResolver(resolver)) {
+    return context.routeParams?.[resolver.paramName] ?? null;
+  }
+  if (isViewEntityResolver(resolver)) {
+    return context.viewParams?.[resolver.paramName] ?? null;
+  }
+  // user-selection — needs the alias name to look up the picker value.
+  if (aliasName === undefined) return null;
+  return context.userSelections?.[aliasName] ?? null;
+}
+
+/**
+ * Convenience wrapper resolving a complete {@link EntityAlias}
+ * (carries its own name).
+ */
+export function resolveEntityAlias(
+  alias: EntityAlias,
+  context: AliasResolutionContext
+): string | null {
+  return resolveEntityAliasResolver(alias.resolver, context, alias.name);
+}
+
+/**
+ * Resolves every alias in the dashboard against the same context,
+ * returning a `name → entityId` map. Aliases that resolve to `null`
+ * are dropped from the result — apps consuming the map check for
+ * presence rather than null values.
+ *
+ * Pure function. Use this from a route loader or context provider
+ * to seed `<DashboardAliasProvider initialValues>`.
+ */
+export function resolveDashboardAliases(
+  aliases: readonly EntityAlias[] | null | undefined,
+  context: AliasResolutionContext
+): Readonly<Record<string, string>> {
+  const out: Record<string, string> = {};
+  if (!aliases) return out;
+  for (const alias of aliases) {
+    const resolved = resolveEntityAlias(alias, context);
+    if (resolved !== null) out[alias.name] = resolved;
+  }
+  return out;
+}

--- a/packages/@granit/react-dashboards/src/lib/substitute-aliases.ts
+++ b/packages/@granit/react-dashboards/src/lib/substitute-aliases.ts
@@ -1,0 +1,58 @@
+import type { DashboardAliasValues } from '../components/dashboard-alias-context.js';
+
+/**
+ * Regex matching `${aliasName}` placeholders. The alias name must
+ * match the camel-case-with-dots convention the framework uses
+ * (`currentCustomer`, `selectedDevice`). Loose enough to also handle
+ * ad-hoc names; strict enough to refuse spaces / SQL-style injection.
+ */
+const PLACEHOLDER = /\$\{([A-Za-z][A-Za-z0-9_.]*)\}/g;
+
+/**
+ * Substitutes `${aliasName}` placeholders in a string with the
+ * resolved alias value. Used by the filter-values plumbing to expand
+ * clauses like `{ field: 'customer.id', op: 'Eq', value: '${currentCustomer}' }`
+ * into a concrete request before sending.
+ *
+ * Unknown placeholders (no matching key in `aliases`) are left
+ * verbatim — same behaviour as the backend's `IVariableSubstituter`,
+ * which lets per-widget substitution downstream catch them. This
+ * matches the principle that the frontend should be transparent: it
+ * doesn't reject inputs it doesn't understand, just forwards them.
+ *
+ * Pass `null` / `undefined` for `aliases` to leave every placeholder
+ * verbatim (useful for tests / callers without an alias provider).
+ *
+ * Pure function, no React deps.
+ */
+export function substituteAliases(
+  value: string,
+  aliases: DashboardAliasValues | null | undefined
+): string {
+  if (!aliases) return value;
+  return value.replace(PLACEHOLDER, (match, name: string) => {
+    const resolved = aliases[name];
+    return resolved !== undefined ? resolved : match;
+  });
+}
+
+/**
+ * Recursively substitutes `${aliasName}` placeholders in every
+ * string-valued entry of a `Record<string, string>` (the shape
+ * `DashboardRenderRequest.filters` uses). Non-string values are left
+ * untouched on the off-chance the caller passes a heterogeneous map.
+ */
+export function substituteAliasesInRecord(
+  record: Readonly<Record<string, string>>,
+  aliases: DashboardAliasValues | null | undefined
+): Readonly<Record<string, string>> {
+  if (!aliases || Object.keys(aliases).length === 0) return record;
+  let mutated = false;
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(record)) {
+    const next = substituteAliases(value, aliases);
+    if (next !== value) mutated = true;
+    out[key] = next;
+  }
+  return mutated ? out : record;
+}


### PR DESCRIPTION
## Summary

The \`EntityAlias\` types landed in #278 (\`EntityAlias\` + 5-variant \`EntityAliasResolver\` discriminator union: \`route-param\` / \`view-entity\` / \`tenant-context\` / \`user-selection\` / \`static\`) but no runtime was consuming them. This wires up the frontend-side primitives apps need for display, action handlers, and optional client-side pre-resolution.

Self-contained: no backend coordination needed. Aliases are resolved server-side at query-build time via \`IVariableSubstituter\` — the frontend role is display + action-handler scoping + optional pre-resolution.

## Surface

### Resolution helpers (pure)

| Helper | Purpose |
| --- | --- |
| \`AliasResolutionContext\` type | route params (URL), view params (P2.1 view stack), \`currentTenantId\`, user selection map. Each field optional |
| \`resolveEntityAliasResolver(resolver, context, aliasName?)\` | Resolves one resolver. Optional \`aliasName\` threads through for \`user-selection\` resolvers (which look up the picker value by alias name) |
| \`resolveEntityAlias(alias, context)\` | Wrapper threading the alias's own name |
| \`resolveDashboardAliases(aliases, context)\` | Resolves every alias in one pass; aliases that fail to resolve are dropped from the result map |

### Provider + hook

- \`<DashboardAliasProvider values={...}>\` — uncontrolled-only (alias resolution depends on external context the parent already owns). Apps memoise \`resolveDashboardAliases()\` and feed the result here.
- \`useDashboardAliases()\` — read access. Returns \`null\` outside the provider so consumers gracefully degrade.

### Variable substitution (pure)

- \`substituteAliases(value, aliases)\` — replaces \`\${aliasName}\` placeholders in a string. Unknown placeholders left verbatim (consumer or backend may resolve them later).
- \`substituteAliasesInRecord(record, aliases)\` — folds \`\${aliasName}\` replacements across every string value in a \`Record<string, string>\`. Returns the input reference verbatim when no substitution is needed.

## What's intentionally out of scope

- **Render-request integration**: \`DashboardRenderRequest\` doesn't carry aliases. The backend resolves them server-side from request context (route, tenant, headers). The frontend role is display + action-handler scoping only.
- **Built-in user-selection picker UI**: apps wire their own (lookup picker, command palette, etc.) and dispatch into the \`userSelections\` map. Framework contract is "manage the resolved values map", not "provide every input control".
- **React Router integration**: framework stays router-agnostic. Apps pass \`routeParams\` directly (e.g. from \`useParams()\`).

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-dashboards\` — 14 files / 117 tests pass (22 new: 5-resolver-kind resolution including missing-context fallback, mixed dashboard-wide pass, placeholder substitution including malformed inputs, reference-stability when no substitution needed).
- [x] \`pnpm lint\` clean.
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.