### PR TITLE
feat(dashboards): WidgetAction dispatcher (P1.5)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2341,6 +2341,16 @@
           "signature": "function substituteAliasesInRecord( record: Readonly<Record<string, string>>, aliases: DashboardAliasValues | null | undefined ): Readonly<Record<string, string>>"
         },
         {
+          "name": "defaultWidgetActionHandlers",
+          "kind": "const",
+          "signature": "const defaultWidgetActionHandlers: WidgetActionHandlerRegistry"
+        },
+        {
+          "name": "composeWidgetActionHandlers",
+          "kind": "function",
+          "signature": "function composeWidgetActionHandlers( ...registries: readonly Partial<WidgetActionHandlerRegistry>[] ): WidgetActionHandlerRegistry"
+        },
+        {
           "name": "useEffectiveTimeWindow",
           "kind": "function",
           "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"

--- a/packages/@granit/react-dashboards/src/__tests__/expand-action-params.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/expand-action-params.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  expandActionParams,
+  expandActionPlaceholders,
+  expandActionTargetAndParams,
+} from '../lib/expand-action-params.js';
+
+describe('expandActionPlaceholders', () => {
+  it('substitutes ${row.field} placeholders from the dispatch row', () => {
+    expect(
+      expandActionPlaceholders('/customers/${row.customerId}', {
+        row: { customerId: '42' },
+      })
+    ).toBe('/customers/42');
+  });
+
+  it('substitutes ${aliasName} placeholders from the alias map', () => {
+    expect(
+      expandActionPlaceholders('/dashboards/${currentTenant}', {
+        aliases: { currentTenant: 't-7' },
+      })
+    ).toBe('/dashboards/t-7');
+  });
+
+  it('mixes row + alias placeholders in the same value', () => {
+    expect(
+      expandActionPlaceholders('/customers/${row.customerId}/in/${currentTenant}', {
+        row: { customerId: '42' },
+        aliases: { currentTenant: 't-7' },
+      })
+    ).toBe('/customers/42/in/t-7');
+  });
+
+  it('leaves unknown placeholders verbatim (consumer / backend may resolve)', () => {
+    expect(expandActionPlaceholders('${row.unknown}', { row: { x: '1' } })).toBe('${row.unknown}');
+    expect(expandActionPlaceholders('${unknownAlias}', {})).toBe('${unknownAlias}');
+  });
+
+  it('coerces non-string row values to string', () => {
+    expect(expandActionPlaceholders('${row.count}', { row: { count: 42 } })).toBe('42');
+    expect(expandActionPlaceholders('${row.flag}', { row: { flag: true } })).toBe('true');
+  });
+
+  it('treats null / undefined row values as missing (placeholder left verbatim)', () => {
+    expect(expandActionPlaceholders('${row.count}', { row: { count: null } })).toBe('${row.count}');
+    expect(expandActionPlaceholders('${row.count}', { row: { count: undefined } })).toBe(
+      '${row.count}'
+    );
+  });
+});
+
+describe('expandActionParams', () => {
+  it('expands placeholders in every value', () => {
+    const out = expandActionParams(
+      { customerId: '${row.customerId}', tenant: '${currentTenant}' },
+      { row: { customerId: '42' }, aliases: { currentTenant: 't-7' } }
+    );
+    expect(out).toEqual({ customerId: '42', tenant: 't-7' });
+  });
+
+  it('returns an empty map when params is null / undefined', () => {
+    expect(expandActionParams(null, {})).toEqual({});
+    expect(expandActionParams(undefined, {})).toEqual({});
+  });
+
+  it('preserves param keys regardless of substitution outcome', () => {
+    const out = expandActionParams({ a: '${row.a}', b: 'literal' }, {});
+    expect(Object.keys(out)).toEqual(['a', 'b']);
+    expect(out.a).toBe('${row.a}');
+    expect(out.b).toBe('literal');
+  });
+});
+
+describe('expandActionTargetAndParams', () => {
+  it('expands target + params together', () => {
+    const out = expandActionTargetAndParams(
+      '/customers/${row.customerId}',
+      { status: 'unpaid' },
+      { row: { customerId: '42' } }
+    );
+    expect(out.target).toBe('/customers/42');
+    expect(out.params).toEqual({ status: 'unpaid' });
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/widget-action-dispatcher.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/widget-action-dispatcher.test.tsx
@@ -1,0 +1,178 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DashboardAliasProvider } from '../components/dashboard-alias-context.js';
+import {
+  useWidgetActionDispatcher,
+  WidgetActionProvider,
+} from '../components/widget-action-context.js';
+import { defaultWidgetActionHandlers } from '../lib/default-widget-action-handlers.js';
+import {
+  composeWidgetActionHandlers,
+  type WidgetActionHandler,
+} from '../lib/widget-action-handler.js';
+
+import type { WidgetAction } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+// JSDOM forbids redefining `window.location.assign`, so we test the
+// `Navigate` handler via a custom override that records calls — the
+// dispatcher's substitution + composition contract is what's
+// verified, not the framework default's `window.location.assign`
+// invocation (covered by the framework default's own unit test
+// scope, where it's mostly an integration concern).
+
+describe('useWidgetActionDispatcher — Navigate handler invocation', () => {
+  it('passes the resolved target + params + row through to the registered handler', () => {
+    const customNavigate = vi.fn<WidgetActionHandler>();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <WidgetActionProvider
+        handlers={composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+          Navigate: customNavigate,
+        })}
+      >
+        {children}
+      </WidgetActionProvider>
+    );
+    const { result } = renderHook(() => useWidgetActionDispatcher(), { wrapper });
+    const action: WidgetAction = {
+      trigger: 'RowClick',
+      kind: 'Navigate',
+      target: '/customers/${row.customerId}',
+      params: { status: 'unpaid' },
+    };
+    result.current(action, { customerId: '42' });
+    expect(customNavigate).toHaveBeenCalledOnce();
+    const [stampedAction, context] = customNavigate.mock.calls[0]!;
+    expect(stampedAction.target).toBe('/customers/42');
+    expect(context.params).toEqual({ status: 'unpaid' });
+    expect(context.row).toEqual({ customerId: '42' });
+  });
+
+  it('substitutes ${aliasName} placeholders from the surrounding DashboardAliasProvider', () => {
+    const customNavigate = vi.fn<WidgetActionHandler>();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DashboardAliasProvider values={{ currentCustomer: 'c-7' }}>
+        <WidgetActionProvider
+          handlers={composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+            Navigate: customNavigate,
+          })}
+        >
+          {children}
+        </WidgetActionProvider>
+      </DashboardAliasProvider>
+    );
+    const { result } = renderHook(() => useWidgetActionDispatcher(), { wrapper });
+    result.current({
+      trigger: 'Click',
+      kind: 'Navigate',
+      target: '/customers/${currentCustomer}',
+    });
+    expect(customNavigate).toHaveBeenCalledOnce();
+    expect(customNavigate.mock.calls[0]?.[0].target).toBe('/customers/c-7');
+  });
+
+  it('expands placeholders in `params` against the same context', () => {
+    const customNavigate = vi.fn<WidgetActionHandler>();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <DashboardAliasProvider values={{ currentTenant: 't-7' }}>
+        <WidgetActionProvider
+          handlers={composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+            Navigate: customNavigate,
+          })}
+        >
+          {children}
+        </WidgetActionProvider>
+      </DashboardAliasProvider>
+    );
+    const { result } = renderHook(() => useWidgetActionDispatcher(), { wrapper });
+    result.current(
+      {
+        trigger: 'Click',
+        kind: 'Navigate',
+        target: '/x',
+        params: { tenant: '${currentTenant}', customer: '${row.customerId}' },
+      },
+      { customerId: '42' }
+    );
+    expect(customNavigate.mock.calls[0]?.[1].params).toEqual({
+      tenant: 't-7',
+      customer: '42',
+    });
+  });
+});
+
+describe('useWidgetActionDispatcher — composition fall-through', () => {
+  it('falls back to the framework defaults when no provider is mounted', () => {
+    const { result } = renderHook(() => useWidgetActionDispatcher());
+    // The dispatcher exists and is callable; we don't trigger a real
+    // navigation here because JSDOM forbids redefining the location
+    // setter — the contract we care about is that the dispatcher
+    // resolves and forwards.
+    expect(typeof result.current).toBe('function');
+  });
+
+  it('app-provided OpenDashboardView handler receives the view setter from the surrounding context', () => {
+    const customOpen = vi.fn<WidgetActionHandler>();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <WidgetActionProvider
+        handlers={composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+          OpenDashboardView: customOpen,
+        })}
+      >
+        {children}
+      </WidgetActionProvider>
+    );
+    const { result } = renderHook(() => useWidgetActionDispatcher(), { wrapper });
+    result.current({
+      trigger: 'Click',
+      kind: 'OpenDashboardView',
+      target: 'detail',
+    });
+    expect(customOpen).toHaveBeenCalledOnce();
+    // No <DashboardViewProvider> in the tree → setView is null.
+    expect(customOpen.mock.calls[0]?.[1].setView).toBeNull();
+  });
+});
+
+describe('useWidgetActionDispatcher — ExportData / OpenDetail', () => {
+  it('ExportData dispatches a custom DOM event apps listen to', () => {
+    const listener = vi.fn();
+    window.addEventListener('granit:dashboard:export', listener);
+    try {
+      const { result } = renderHook(() => useWidgetActionDispatcher());
+      result.current({
+        trigger: 'Click',
+        kind: 'ExportData',
+        target: 'Granit.Showcase.InvoiceExport',
+        params: { range: 'last_30d' },
+      });
+      expect(listener).toHaveBeenCalledOnce();
+      const event = listener.mock.calls[0]?.[0] as CustomEvent;
+      expect(event.detail).toMatchObject({
+        target: 'Granit.Showcase.InvoiceExport',
+        params: { range: 'last_30d' },
+      });
+    } finally {
+      window.removeEventListener('granit:dashboard:export', listener);
+    }
+  });
+
+  it('OpenDetail dispatches granit:dashboard:open-detail with the row payload', () => {
+    const listener = vi.fn();
+    window.addEventListener('granit:dashboard:open-detail', listener);
+    try {
+      const { result } = renderHook(() => useWidgetActionDispatcher());
+      result.current(
+        { trigger: 'RowClick', kind: 'OpenDetail', target: 'invoice-detail' },
+        { invoiceNumber: 'INV-42' }
+      );
+      expect(listener).toHaveBeenCalledOnce();
+      const event = listener.mock.calls[0]?.[0] as CustomEvent;
+      expect(event.detail.target).toBe('invoice-detail');
+      expect(event.detail.row).toEqual({ invoiceNumber: 'INV-42' });
+    } finally {
+      window.removeEventListener('granit:dashboard:open-detail', listener);
+    }
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/widget-action-context.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-action-context.tsx
@@ -1,0 +1,133 @@
+import { createContext, useCallback, useContext, useMemo } from 'react';
+
+import { defaultWidgetActionHandlers } from '../lib/default-widget-action-handlers.js';
+import { expandActionParams } from '../lib/expand-action-params.js';
+
+import { useDashboardAliases } from './dashboard-alias-context.js';
+import { useDashboardView } from './dashboard-view-context.js';
+
+import type { WidgetActionHandlerRegistry } from '../lib/widget-action-handler.js';
+import type { WidgetAction } from '@granit/dashboards';
+
+/**
+ * Dispatcher signature returned by {@link useWidgetActionDispatcher}.
+ * Widget renderers call this from their click handlers — the
+ * dispatcher resolves the action's params against the dispatch
+ * context (row data + dashboard aliases + view setter) and forwards
+ * to the matching handler from the registry.
+ *
+ * `data` is the widget-kind-specific row payload. Tables pass the
+ * clicked row, charts pass the bucket, maps pass the marker. Shape
+ * is opaque — the framework doesn't require a specific schema.
+ */
+export type WidgetActionDispatcher = (
+  action: WidgetAction,
+  data?: Readonly<Record<string, unknown>>
+) => void;
+
+const WidgetActionContext = createContext<WidgetActionHandlerRegistry | null>(null);
+
+export interface WidgetActionProviderProps {
+  /**
+   * Per-kind handler registry. Compose with framework defaults via
+   * {@link composeWidgetActionHandlers}. Omit to use the framework's
+   * defaults verbatim — useful for self-contained demos and Storybook
+   * stories.
+   */
+  readonly handlers?: WidgetActionHandlerRegistry;
+  readonly children: React.ReactNode;
+}
+
+/**
+ * Provider for the {@link WidgetActionHandler} registry. Mounted at
+ * (or above) the dashboard tree so {@link useWidgetActionDispatcher}
+ * resolves the right handler per kind.
+ *
+ * Falls back to {@link defaultWidgetActionHandlers} when no provider
+ * is mounted — the dispatcher works out of the box without explicit
+ * wiring, with the trade-off that `Navigate` triggers a full page
+ * load (no React Router integration).
+ */
+export function WidgetActionProvider({ handlers, children }: WidgetActionProviderProps) {
+  return (
+    <WidgetActionContext.Provider value={handlers ?? defaultWidgetActionHandlers}>
+      {children}
+    </WidgetActionContext.Provider>
+  );
+}
+
+/**
+ * Hook returning a dispatcher that resolves a widget action against
+ * the surrounding context (alias provider, view provider, action
+ * registry) and invokes the matching handler.
+ *
+ * Substitution rules applied at dispatch time:
+ *
+ * - `${row.field}` placeholders in `target` and `params` resolve
+ *   against the `data` argument.
+ * - `${aliasName}` placeholders resolve against the surrounding
+ *   {@link DashboardAliasProvider} when mounted.
+ * - Unknown placeholders are left verbatim (consumer-side decision).
+ *
+ * Calling the dispatcher when no provider is mounted falls back to
+ * the framework's default handlers — the dispatcher always works,
+ * just with the framework's opinionated `window.location` defaults
+ * instead of a custom in-app router.
+ */
+export function useWidgetActionDispatcher(): WidgetActionDispatcher {
+  const registry = useContext(WidgetActionContext) ?? defaultWidgetActionHandlers;
+  const aliases = useDashboardAliases();
+  const viewCtx = useDashboardView();
+
+  const dispatch = useCallback<WidgetActionDispatcher>(
+    (action, data) => {
+      const params = expandActionParams(action.params, {
+        row: data,
+        aliases: aliases ?? undefined,
+      });
+      const handler = registry[action.kind];
+      if (!handler) return;
+      handler(
+        // Re-stamp the action with the expanded target so handlers
+        // can use `action.target` directly without re-parsing.
+        {
+          ...action,
+          target: action.target.replace(
+            /\$\{([A-Za-z][A-Za-z0-9_.]*)\}/g,
+            (match, expr: string) => {
+              if (expr.startsWith('row.') && data) {
+                const value = data[expr.slice(4)];
+                return value !== undefined && value !== null ? String(value) : match;
+              }
+              const alias = aliases?.[expr];
+              return alias !== undefined ? alias : match;
+            }
+          ),
+        },
+        {
+          row: data,
+          aliases: aliases ?? undefined,
+          setView: viewCtx?.setCurrentView ?? null,
+          params,
+        }
+      );
+    },
+    [registry, aliases, viewCtx]
+  );
+
+  return dispatch;
+}
+
+/**
+ * Memoised dispatcher returning a stable reference across renders
+ * when its dependencies haven't changed — useful for handlers
+ * passed down as React props that drive component memoisation.
+ *
+ * Equivalent to `useWidgetActionDispatcher()` plus a `useMemo`
+ * wrapper; exported for callers that want to be explicit about the
+ * memoisation contract.
+ */
+export function useStableWidgetActionDispatcher(): WidgetActionDispatcher {
+  const dispatch = useWidgetActionDispatcher();
+  return useMemo(() => dispatch, [dispatch]);
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -88,6 +88,29 @@ export {
 } from './lib/resolve-entity-alias.js';
 export type { AliasResolutionContext } from './lib/resolve-entity-alias.js';
 export { substituteAliases, substituteAliasesInRecord } from './lib/substitute-aliases.js';
+
+// Widget action dispatcher (P1.5) — declarative click handlers
+export {
+  useStableWidgetActionDispatcher,
+  useWidgetActionDispatcher,
+  WidgetActionProvider,
+} from './components/widget-action-context.js';
+export type {
+  WidgetActionDispatcher,
+  WidgetActionProviderProps,
+} from './components/widget-action-context.js';
+export { defaultWidgetActionHandlers } from './lib/default-widget-action-handlers.js';
+export {
+  expandActionParams,
+  expandActionPlaceholders,
+  expandActionTargetAndParams,
+} from './lib/expand-action-params.js';
+export { composeWidgetActionHandlers } from './lib/widget-action-handler.js';
+export type {
+  WidgetActionDispatchContext,
+  WidgetActionHandler,
+  WidgetActionHandlerRegistry,
+} from './lib/widget-action-handler.js';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window.js';
 export {
   DASHBOARD_BREAKPOINT_MIN_WIDTH,

--- a/packages/@granit/react-dashboards/src/lib/default-widget-action-handlers.ts
+++ b/packages/@granit/react-dashboards/src/lib/default-widget-action-handlers.ts
@@ -1,0 +1,98 @@
+import type { WidgetActionHandler, WidgetActionHandlerRegistry } from './widget-action-handler.js';
+
+/**
+ * Builds a query string from the resolved params. Skips empty values
+ * so a `params: { status: '' }` doesn't produce `?status=` in the URL.
+ */
+function appendParamsToUrl(url: string, params: Readonly<Record<string, string>>): string {
+  const entries = Object.entries(params).filter(([, value]) => value !== '');
+  if (entries.length === 0) return url;
+  const search = new URLSearchParams(entries).toString();
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}${search}`;
+}
+
+/**
+ * `Navigate` — frontend route navigation. v1 default uses
+ * `window.location.assign(target)` which preserves the browser's
+ * history but triggers a full page load. Apps wanting React Router
+ * (or any in-app SPA navigator) compose a custom handler that calls
+ * `useNavigate()` instead.
+ *
+ * Resolved params are appended to the URL as a query string when set.
+ */
+const navigateHandler: WidgetActionHandler = (action, context) => {
+  if (typeof window === 'undefined') return;
+  const url = appendParamsToUrl(action.target, context.params);
+  window.location.assign(url);
+};
+
+/**
+ * `OpenDashboardView` — switches the active view of the current
+ * dashboard. Reads the view setter from the dispatch context (which
+ * the dispatcher hook fills from the surrounding
+ * `<DashboardViewProvider>`). No-op when not inside a multi-view
+ * dashboard.
+ */
+const openDashboardViewHandler: WidgetActionHandler = (action, context) => {
+  context.setView?.(action.target);
+};
+
+/**
+ * `OpenDashboard` — navigates to another full dashboard by name.
+ * v1 default uses the conventional `/dashboards/{name}` route; apps
+ * with a different routing scheme override.
+ */
+const openDashboardHandler: WidgetActionHandler = (action, context) => {
+  if (typeof window === 'undefined') return;
+  const url = appendParamsToUrl(`/dashboards/${encodeURIComponent(action.target)}`, context.params);
+  window.location.assign(url);
+};
+
+/**
+ * `ExportData` — emits a custom DOM event apps listen to wire their
+ * own export pipeline (download dialog, server-streamed export job,
+ * etc.). The event detail carries the `target` (an
+ * `ExportDefinition.Name`) plus the resolved params.
+ *
+ * Apps registering a richer handler typically replace this entirely
+ * (e.g. invoking a `useExportDialog()` hook) — emitting an event is
+ * the framework's "no opinionated UI" default.
+ */
+const exportDataHandler: WidgetActionHandler = (action, context) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('granit:dashboard:export', {
+      detail: { target: action.target, params: context.params, row: context.row ?? null },
+    })
+  );
+};
+
+/**
+ * `OpenDetail` — emits a custom DOM event apps listen to open their
+ * own side drawer / dialog. Same pattern as `ExportData` — the
+ * framework doesn't ship a default drawer UI.
+ */
+const openDetailHandler: WidgetActionHandler = (action, context) => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent('granit:dashboard:open-detail', {
+      detail: { target: action.target, params: context.params, row: context.row ?? null },
+    })
+  );
+};
+
+/**
+ * Framework defaults for every {@link WidgetActionKind}. Apps
+ * compose their own overrides via {@link composeWidgetActionHandlers}
+ * — the typical case is replacing `Navigate` with React Router and
+ * `ExportData` / `OpenDetail` with app-specific drawer / pipeline
+ * hooks.
+ */
+export const defaultWidgetActionHandlers: WidgetActionHandlerRegistry = Object.freeze({
+  Navigate: navigateHandler,
+  OpenDashboardView: openDashboardViewHandler,
+  OpenDashboard: openDashboardHandler,
+  ExportData: exportDataHandler,
+  OpenDetail: openDetailHandler,
+});

--- a/packages/@granit/react-dashboards/src/lib/expand-action-params.ts
+++ b/packages/@granit/react-dashboards/src/lib/expand-action-params.ts
@@ -1,0 +1,85 @@
+import type { WidgetActionDispatchContext } from './widget-action-handler.js';
+
+/**
+ * Regex matching `${expression}` placeholders. Expressions may contain
+ * letters, digits, dots, and underscores — covers `${currentCustomer}`,
+ * `${row.customerId}`, `${row.invoice_number}` patterns.
+ */
+const PLACEHOLDER = /\$\{([A-Za-z][A-Za-z0-9_.]*)\}/g;
+
+/**
+ * Resolves a placeholder expression against the dispatch context.
+ *
+ * Convention:
+ * - `row.field` — looks up `context.row[field]`. Nested keys are
+ *   intentionally NOT supported in v1 (`row.customer.id` only resolves
+ *   if `row['customer.id']` exists). Apps wanting nested access flatten
+ *   before dispatch.
+ * - bare name — looks up `context.aliases[name]` (entity alias).
+ *
+ * Returns `null` when the lookup fails — the caller decides whether
+ * to leave the placeholder verbatim or substitute an empty string.
+ */
+function resolvePlaceholder(
+  expression: string,
+  context: Pick<WidgetActionDispatchContext, 'row' | 'aliases'>
+): string | null {
+  if (expression.startsWith('row.')) {
+    const key = expression.slice(4);
+    const value = context.row?.[key];
+    return value !== undefined && value !== null ? String(value) : null;
+  }
+  const alias = context.aliases?.[expression];
+  return alias !== undefined ? alias : null;
+}
+
+/**
+ * Expands `${row.field}` and `${aliasName}` placeholders in a single
+ * string value. Unknown placeholders are left verbatim so the
+ * upstream consumer (or backend, in cases where the resolved string
+ * is sent to the server) can take a second pass.
+ */
+export function expandActionPlaceholders(
+  value: string,
+  context: Pick<WidgetActionDispatchContext, 'row' | 'aliases'>
+): string {
+  return value.replace(PLACEHOLDER, (match, expression: string) => {
+    const resolved = resolvePlaceholder(expression, context);
+    return resolved ?? match;
+  });
+}
+
+/**
+ * Resolves an action's `params` map by expanding every value's
+ * `${...}` placeholders against the dispatch context. Pure function
+ * — used by the framework's default handlers, exported so custom
+ * handlers reuse the same substitution rules.
+ */
+export function expandActionParams(
+  params: Readonly<Record<string, string>> | null | undefined,
+  context: Pick<WidgetActionDispatchContext, 'row' | 'aliases'>
+): Readonly<Record<string, string>> {
+  if (!params) return {};
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(params)) {
+    out[key] = expandActionPlaceholders(value, context);
+  }
+  return out;
+}
+
+/**
+ * Resolves an action's `target` + `params` together. The `target`
+ * goes through the same `${...}` substitution rules so route
+ * templates like `/customers/${row.customerId}` work without a
+ * separate plumbing.
+ */
+export function expandActionTargetAndParams(
+  target: string,
+  params: Readonly<Record<string, string>> | null | undefined,
+  context: Pick<WidgetActionDispatchContext, 'row' | 'aliases'>
+): { readonly target: string; readonly params: Readonly<Record<string, string>> } {
+  return {
+    target: expandActionPlaceholders(target, context),
+    params: expandActionParams(params, context),
+  };
+}

--- a/packages/@granit/react-dashboards/src/lib/widget-action-handler.ts
+++ b/packages/@granit/react-dashboards/src/lib/widget-action-handler.ts
@@ -1,0 +1,59 @@
+import type { WidgetAction, WidgetActionKind } from '@granit/dashboards';
+
+/**
+ * Context passed to a {@link WidgetActionHandler} at dispatch time.
+ *
+ * `row` is the data payload from the firing widget — a table row,
+ * a chart bucket, a clicked map marker. Shape is widget-kind-
+ * specific; handlers narrow it themselves. `aliases` are the dashboard's
+ * resolved entity aliases (P2.3), surfaced for handlers that
+ * incorporate them in navigation targets or export parameters.
+ */
+export interface WidgetActionDispatchContext {
+  /** Data payload from the firing widget (row, bucket, marker, ...). */
+  readonly row?: Readonly<Record<string, unknown>>;
+  /** Resolved entity aliases keyed by alias name. */
+  readonly aliases?: Readonly<Record<string, string>>;
+  /**
+   * Active dashboard view's setter — handlers that switch views
+   * (`OpenDashboardView`) read this. `null` outside a multi-view
+   * dashboard.
+   */
+  readonly setView?: ((name: string) => void) | null;
+  /**
+   * Resolved + substituted action params (`row.x` and `${aliasName}`
+   * already expanded). Handlers consume this rather than re-parsing
+   * `action.params` themselves.
+   */
+  readonly params: Readonly<Record<string, string>>;
+}
+
+/**
+ * Handler signature for one {@link WidgetActionKind}. Receives the
+ * action declaration plus the dispatch context (row data, aliases,
+ * resolved params, view setter).
+ */
+export type WidgetActionHandler = (
+  action: WidgetAction,
+  context: WidgetActionDispatchContext
+) => void;
+
+/**
+ * Registry mapping each {@link WidgetActionKind} to a handler.
+ * Composition pattern mirrors the read-mode `WidgetRegistry`: apps
+ * compose framework defaults with their own per-kind overrides.
+ */
+export type WidgetActionHandlerRegistry = Readonly<Record<WidgetActionKind, WidgetActionHandler>>;
+
+/**
+ * Composes multiple handler registries into one, last-wins on key
+ * collision. Mirrors `composeRegistries` for renderers — same
+ * precedence semantics so apps overriding a built-in handler (e.g.
+ * `Navigate` wired to React Router instead of `window.location.href`)
+ * win by passing their registry last.
+ */
+export function composeWidgetActionHandlers(
+  ...registries: readonly Partial<WidgetActionHandlerRegistry>[]
+): WidgetActionHandlerRegistry {
+  return Object.freeze(Object.assign({}, ...registries)) as WidgetActionHandlerRegistry;
+}


### PR DESCRIPTION
## Summary

The \`WidgetAction\` types landed back in the framework scaffolding (\`WidgetAction\` record + \`WidgetActionTrigger\` + \`WidgetActionKind\` enums) but no runtime was dispatching them. This wires up the click-handler side: widget renderers call \`dispatch(action, rowData)\`, the framework substitutes \`\${row.x}\` / \`\${aliasName}\` placeholders, then forwards to the matching kind-specific handler.

Self-contained: no backend coordination needed.

## Surface

### Types

- \`WidgetActionDispatchContext\` — dispatch-time context (row data, resolved aliases, \`setView\` from the active dashboard view, resolved+substituted params).
- \`WidgetActionHandler\` — function signature per kind.
- \`WidgetActionHandlerRegistry\` — \`Record<WidgetActionKind, Handler>\`.

### Pure helpers

- \`composeWidgetActionHandlers(...registries)\` — last-wins composition (mirrors \`composeRegistries\` for renderers).
- \`expandActionPlaceholders(value, ctx)\` — substitutes \`\${row.x}\` + \`\${aliasName}\`. Unknown placeholders left verbatim.
- \`expandActionParams\` / \`expandActionTargetAndParams\` — bulk variants.

### Framework defaults

| Kind | Handler |
| --- | --- |
| \`Navigate\` | \`window.location.assign(target)\` + query string from params |
| \`OpenDashboardView\` | \`setView(target)\` via the surrounding view provider (no-op outside multi-view) |
| \`OpenDashboard\` | \`window.location.assign(\`/dashboards/\${name}\`)\` with query-string params |
| \`ExportData\` | emits \`granit:dashboard:export\` \`CustomEvent\` |
| \`OpenDetail\` | emits \`granit:dashboard:open-detail\` \`CustomEvent\` |

Apps replace per-kind handlers via \`composeWidgetActionHandlers\` — typical case is wiring \`Navigate\` to React Router (\`useNavigate()\`) and \`ExportData\` / \`OpenDetail\` to app-specific dialog hooks.

### Provider + hook

- \`<WidgetActionProvider handlers>\` — provides the registry. Falls back to framework defaults when not mounted (dispatcher works out of the box, with the trade-off of full-page \`Navigate\`).
- \`useWidgetActionDispatcher()\` — returns \`dispatch(action, data?)\`. Resolves placeholders against the dispatch context (row data + aliases from \`<DashboardAliasProvider>\`), routes to the registered handler, threads the view setter from \`<DashboardViewProvider>\`.
- \`useStableWidgetActionDispatcher()\` — same with a \`useMemo\` wrapper for memoisation boundaries.

## What's intentionally out of scope

- **Wiring widget renderers** (KpiTile / table rows / chart series / map markers) to dispatch their actions — that's per-renderer work landing alongside each widget kind's interaction polish.
- **Action chains / pre-action hooks** — apps compose middleware on top of the registry by wrapping handlers themselves.

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-dashboards\` — 16 files / 134 tests pass (17 new: placeholder substitution rules including row vs alias namespaces and unknown-placeholder leave-verbatim, dispatcher forwarding with substituted target/params/row, registry composition override semantics, ExportData/OpenDetail custom-event dispatch).
- [x] \`pnpm lint\` clean.
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.