### PR TITLE
feat(dashboards): wire definition-side widgets to the action dispatcher

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2356,6 +2356,11 @@
           "signature": "function useEffectiveTimeWindow(override?: DashboardTimeWindow): DashboardTimeWindow"
         },
         {
+          "name": "useWidgetTriggerHandler",
+          "kind": "function",
+          "signature": "function useWidgetTriggerHandler( trigger: WidgetActionTrigger, actions: readonly WidgetAction[] | null | undefined ): ((data?: Readonly<Record<string, unknown>>) => void) | null"
+        },
+        {
           "name": "applyLayoutOverride",
           "kind": "function",
           "signature": "function applyLayoutOverride( base: DashboardLayout, override: DashboardLayoutOverride | undefined ): EffectiveDashboardLayout"

--- a/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
@@ -42,6 +42,13 @@ export interface KpiTileViewProps {
    * without trend visualization don't pull in the chart bundle.
    */
   readonly trendVisual?: ReactNode;
+  /**
+   * Click handler fired on body interaction. When set, the tile gains
+   * cursor / `role="button"` / keyboard activation affordances. Wired
+   * by the smart `<KpiTile>` from `widget.actions` (Click trigger);
+   * standalone consumers can wire their own.
+   */
+  readonly onClick?: () => void;
 }
 
 /**
@@ -68,9 +75,31 @@ export function KpiTileView({
   errorRetryLabel = 'Retry',
   className,
   trendVisual,
+  onClick,
 }: KpiTileViewProps) {
   return (
-    <div data-slot="kpi-tile" className={joinClasses('flex h-full flex-col gap-3', className)}>
+    <div
+      data-slot="kpi-tile"
+      data-interactive={onClick ? '' : undefined}
+      onClick={onClick}
+      onKeyDown={
+        onClick
+          ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      className={joinClasses(
+        'flex h-full flex-col gap-3',
+        onClick ? 'cursor-pointer' : undefined,
+        className
+      )}
+    >
       {title ? (
         <header data-slot="kpi-tile-header">
           <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -1,4 +1,5 @@
 import { isMetricDatasource } from '@granit/dashboards';
+import { useWidgetTriggerHandler } from '@granit/react-dashboards';
 import { useTranslation } from 'react-i18next';
 
 import { useMetric } from '../api/use-metric.js';
@@ -39,6 +40,12 @@ export function KpiTile({ widget }: KpiTileProps) {
 
   const query = useMetric(metricName, DEFAULT_PERIOD, { enabled: metricName !== '' });
 
+  // `Click` actions on the widget definition. Hook lives at the top
+  // of the component (before any conditional return) so the rules-of-
+  // hooks order is stable across the metric-vs-unsupported branches.
+  const onClick = useWidgetTriggerHandler('Click', widget.actions);
+  const handleClick = onClick ? () => onClick() : undefined;
+
   if (!isMetricDatasource(datasource)) {
     const message = t('Analytics.UnsupportedDatasource', {
       defaultValue: 'Datasource not supported yet ({{kind}})',
@@ -65,6 +72,7 @@ export function KpiTile({ widget }: KpiTileProps) {
       noDataLabel={t('Analytics.NoData', { defaultValue: 'No data for this period' })}
       errorTitle={t('Analytics.Error.Title', { defaultValue: 'Failed to load metric' })}
       errorRetryLabel={t('Analytics.Error.Retry', { defaultValue: 'Retry' })}
+      onClick={handleClick}
     />
   );
 }

--- a/packages/@granit/react-dashboards/src/__tests__/use-widget-trigger-handler.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-widget-trigger-handler.test.tsx
@@ -1,0 +1,161 @@
+import { fireEvent, render, renderHook } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { WidgetActionProvider } from '../components/widget-action-context.js';
+import { MarkdownWidget } from '../components/widgets/markdown-widget.js';
+import { useWidgetTriggerHandler } from '../hooks/use-widget-trigger-handler.js';
+import { defaultWidgetActionHandlers } from '../lib/default-widget-action-handlers.js';
+import {
+  composeWidgetActionHandlers,
+  type WidgetActionHandler,
+} from '../lib/widget-action-handler.js';
+
+import type { MarkdownWidgetDefinition, WidgetAction } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: { 'Widget:Test.Banner': 'Banner copy' } } },
+  interpolation: { escapeValue: false },
+});
+
+describe('useWidgetTriggerHandler', () => {
+  it('returns null when actions is null / undefined / empty', () => {
+    const { result: nullResult } = renderHook(() => useWidgetTriggerHandler('Click', null));
+    expect(nullResult.current).toBeNull();
+
+    const { result: undefResult } = renderHook(() => useWidgetTriggerHandler('Click', undefined));
+    expect(undefResult.current).toBeNull();
+
+    const { result: emptyResult } = renderHook(() => useWidgetTriggerHandler('Click', []));
+    expect(emptyResult.current).toBeNull();
+  });
+
+  it('returns null when no action matches the trigger', () => {
+    const actions: WidgetAction[] = [{ trigger: 'RowClick', kind: 'OpenDetail', target: 'detail' }];
+    const { result } = renderHook(() => useWidgetTriggerHandler('Click', actions));
+    expect(result.current).toBeNull();
+  });
+
+  it('returns a callable when at least one action matches the trigger', () => {
+    const actions: WidgetAction[] = [{ trigger: 'Click', kind: 'OpenDetail', target: 'detail' }];
+    const { result } = renderHook(() => useWidgetTriggerHandler('Click', actions));
+    expect(typeof result.current).toBe('function');
+  });
+
+  it('dispatches every matching action in declaration order', () => {
+    const captured: string[] = [];
+    const handler: WidgetActionHandler = (action) => {
+      captured.push(action.target);
+    };
+    const handlers = composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+      OpenDetail: handler,
+      ExportData: handler,
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <WidgetActionProvider handlers={handlers}>{children}</WidgetActionProvider>
+    );
+    const actions: WidgetAction[] = [
+      { trigger: 'Click', kind: 'OpenDetail', target: 'first' },
+      { trigger: 'RowClick', kind: 'OpenDetail', target: 'skipped' },
+      { trigger: 'Click', kind: 'ExportData', target: 'second' },
+    ];
+    const { result } = renderHook(() => useWidgetTriggerHandler('Click', actions), { wrapper });
+    result.current?.();
+    expect(captured).toEqual(['first', 'second']);
+  });
+
+  it("shares the dispatcher's placeholder substitution rules", () => {
+    const captured: WidgetAction[] = [];
+    const handlers = composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+      OpenDetail: (action) => {
+        captured.push(action);
+      },
+    });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <WidgetActionProvider handlers={handlers}>{children}</WidgetActionProvider>
+    );
+    const actions: WidgetAction[] = [
+      { trigger: 'Click', kind: 'OpenDetail', target: '/customers/${row.id}' },
+    ];
+    const { result } = renderHook(() => useWidgetTriggerHandler('Click', actions), { wrapper });
+    result.current?.({ id: '42' });
+    expect(captured[0]?.target).toBe('/customers/42');
+  });
+});
+
+describe('Definition-side widgets — Click integration', () => {
+  function withProviders(node: ReactNode, captured: { target?: string }) {
+    const handlers = composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+      OpenDetail: (action) => {
+        captured.target = action.target;
+      },
+    });
+    return render(
+      <I18nextProvider i18n={testI18n}>
+        <WidgetActionProvider handlers={handlers}>{node}</WidgetActionProvider>
+      </I18nextProvider>
+    );
+  }
+
+  it('MarkdownWidget without actions stays non-interactive (no role, no cursor)', () => {
+    const widget: MarkdownWidgetDefinition = {
+      slug: 'Banner',
+      type: 'markdown',
+      position: 0,
+      size: { width: 12, height: 1 },
+      contentLocalizationKey: 'Widget:Test.Banner',
+    };
+    const captured: { target?: string } = {};
+    const { container } = withProviders(<MarkdownWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="markdown-widget"]');
+    expect(root?.getAttribute('role')).toBeNull();
+    expect(root?.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('MarkdownWidget with a Click action gains role+tabindex and dispatches on click', () => {
+    const widget: MarkdownWidgetDefinition = {
+      slug: 'Banner',
+      type: 'markdown',
+      position: 0,
+      size: { width: 12, height: 1 },
+      contentLocalizationKey: 'Widget:Test.Banner',
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'banner-detail' }],
+    };
+    const captured: { target?: string } = {};
+    const { container } = withProviders(<MarkdownWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="markdown-widget"]');
+    expect(root?.getAttribute('role')).toBe('button');
+    expect(root?.getAttribute('tabindex')).toBe('0');
+    if (!(root instanceof HTMLElement)) throw new Error('root not found');
+    fireEvent.click(root);
+    expect(captured.target).toBe('banner-detail');
+  });
+
+  it('MarkdownWidget keyboard activation (Enter / Space) dispatches the same action', () => {
+    const widget: MarkdownWidgetDefinition = {
+      slug: 'Banner',
+      type: 'markdown',
+      position: 0,
+      size: { width: 12, height: 1 },
+      contentLocalizationKey: 'Widget:Test.Banner',
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'kb-detail' }],
+    };
+    const captured: { target?: string } = {};
+    const { container } = withProviders(<MarkdownWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="markdown-widget"]');
+    if (!(root instanceof HTMLElement)) throw new Error('root not found');
+    fireEvent.keyDown(root, { key: 'Enter' });
+    expect(captured.target).toBe('kb-detail');
+
+    captured.target = undefined;
+    fireEvent.keyDown(root, { key: ' ' });
+    expect(captured.target).toBe('kb-detail');
+  });
+});

--- a/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/image-widget.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
+import { useWidgetTriggerHandler } from '../../hooks/use-widget-trigger-handler.js';
+
 import type { ImageFit, ImageWidgetDefinition } from '@granit/dashboards';
 import type { CSSProperties } from 'react';
 
@@ -12,23 +14,49 @@ const OBJECT_FIT_CLASS: Readonly<Record<ImageFit, NonNullable<CSSProperties['obj
 /**
  * Built-in renderer for `ImageWidgetDefinition`.
  *
- * Uses native `<img>` rather than a framework-specific image component so the
- * widget remains usable in environments without a router-aware image loader
- * (Storybook, plain CRA, embed scenarios). `loading="lazy"` keeps off-screen
- * widgets cheap on long dashboards.
+ * Uses native `<img>` rather than a framework-specific image
+ * component so the widget remains usable in environments without a
+ * router-aware image loader (Storybook, plain CRA, embed scenarios).
+ * `loading="lazy"` keeps off-screen widgets cheap on long dashboards.
  *
- * The `source` field accepts either a plain URL or a `blob:<id>` reference
- * resolved by the host's blob storage adapter — apps that ship blob support
- * register a richer renderer overriding this default. The `fit` field maps
- * 1-to-1 to CSS `object-fit` (default `'Contain'` matches the backend default
- * for logo-style imagery).
+ * The `source` field accepts either a plain URL or a `blob:<id>`
+ * reference resolved by the host's blob storage adapter — apps that
+ * ship blob support register a richer renderer overriding this
+ * default. The `fit` field maps 1-to-1 to CSS `object-fit` (default
+ * `'Contain'` matches the backend default for logo-style imagery).
+ *
+ * `Click` actions on `widget.actions` fire on body click via
+ * {@link useWidgetTriggerHandler}. The wrapper element receives
+ * `role="button"` + keyboard activation only when at least one Click
+ * action is wired — non-actionable images stay keyboard-inert.
  */
 export function ImageWidget({ widget }: { readonly widget: ImageWidgetDefinition }) {
   const { t } = useTranslation();
   const alt = t(widget.altLocalizationKey);
   const objectFit = OBJECT_FIT_CLASS[widget.fit ?? 'Contain'];
+  const onClick = useWidgetTriggerHandler('Click', widget.actions);
+
   return (
-    <div data-slot="image-widget" className="flex h-full w-full items-center justify-center">
+    <div
+      data-slot="image-widget"
+      data-interactive={onClick ? '' : undefined}
+      onClick={onClick ? () => onClick() : undefined}
+      onKeyDown={
+        onClick
+          ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      className={`flex h-full w-full items-center justify-center${
+        onClick ? ' cursor-pointer' : ''
+      }`}
+    >
       <img
         src={widget.source}
         alt={alt}

--- a/packages/@granit/react-dashboards/src/components/widgets/markdown-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/markdown-widget.tsx
@@ -1,26 +1,48 @@
 import { useTranslation } from 'react-i18next';
 
+import { useWidgetTriggerHandler } from '../../hooks/use-widget-trigger-handler.js';
+
 import type { MarkdownWidgetDefinition } from '@granit/dashboards';
 
 /**
  * Built-in renderer for `MarkdownWidgetDefinition`.
  *
- * v1 ships a minimal pre-formatted fallback — the resolved Markdown renders
- * verbatim with whitespace preserved. To enable full Markdown rendering
- * (headings, lists, code blocks, links), apps register their own renderer in
- * the registry, typically backed by `react-markdown`. Keeping the fallback
- * dependency-free means `@granit/react-dashboards` doesn't drag react-markdown
- * into bundles that never use it.
+ * v1 ships a minimal pre-formatted fallback — the resolved Markdown
+ * renders verbatim with whitespace preserved. Full Markdown rendering
+ * (headings, lists, code blocks, links) is opt-in via a downstream
+ * renderer registered in the registry, typically backed by
+ * `react-markdown`. Keeping the fallback dependency-free means
+ * `@granit/react-dashboards` doesn't drag react-markdown into bundles
+ * that never use it.
  *
- * The widget's `contentLocalizationKey` is resolved directly via
- * `useTranslation()` — the backend ships the key fully composed
- * (`Widget:{DashboardName}.{Slug}`).
+ * `Click` actions declared on `widget.actions` fire on body click via
+ * {@link useWidgetTriggerHandler}. Cursor + role + keyboard
+ * affordances apply only when at least one Click action is wired —
+ * widgets without actions stay non-interactive.
  */
 export function MarkdownWidget({ widget }: { readonly widget: MarkdownWidgetDefinition }) {
   const { t } = useTranslation();
   const content = t(widget.contentLocalizationKey);
+  const onClick = useWidgetTriggerHandler('Click', widget.actions);
   return (
-    <div data-slot="markdown-widget" className="prose prose-sm max-w-none">
+    <div
+      data-slot="markdown-widget"
+      data-interactive={onClick ? '' : undefined}
+      onClick={onClick ? () => onClick() : undefined}
+      onKeyDown={
+        onClick
+          ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      className={`prose prose-sm max-w-none${onClick ? ' cursor-pointer' : ''}`}
+    >
       <pre className="whitespace-pre-wrap break-words font-sans text-sm text-foreground">
         {content}
       </pre>

--- a/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
+++ b/packages/@granit/react-dashboards/src/components/widgets/text-widget.tsx
@@ -1,5 +1,7 @@
 import { useTranslation } from 'react-i18next';
 
+import { useWidgetTriggerHandler } from '../../hooks/use-widget-trigger-handler.js';
+
 import type { TextWidgetDefinition, TextWidgetStyle } from '@granit/dashboards';
 
 const STYLE_CLASSES: Readonly<Record<TextWidgetStyle, string>> = {
@@ -12,31 +14,63 @@ const STYLE_CLASSES: Readonly<Record<TextWidgetStyle, string>> = {
 /**
  * Built-in renderer for `TextWidgetDefinition`.
  *
- * Whitespace is preserved so multi-line text reads as authored. The visual
- * style (body / heading / subheading / caption) is mapped to a Tailwind class
- * set; consuming apps can override via the registry for a custom design system.
+ * Whitespace is preserved so multi-line text reads as authored. The
+ * visual style (body / heading / subheading / caption) is mapped to
+ * a Tailwind class set; consuming apps can override via the registry
+ * for a custom design system.
+ *
+ * `Click` actions on `widget.actions` fire on body click via
+ * {@link useWidgetTriggerHandler}. The element receives `role="button"`
+ * and keyboard activation only when at least one Click action is
+ * wired.
  */
 export function TextWidget({ widget }: { readonly widget: TextWidgetDefinition }) {
   const { t } = useTranslation();
   const content = t(widget.contentLocalizationKey);
-  const className = `whitespace-pre-wrap break-words ${STYLE_CLASSES[widget.style]}`;
+  const onClick = useWidgetTriggerHandler('Click', widget.actions);
+
+  const baseClass = `whitespace-pre-wrap break-words ${STYLE_CLASSES[widget.style]}`;
+  const className = onClick ? `${baseClass} cursor-pointer` : baseClass;
+  const interactiveProps = onClick
+    ? {
+        onClick: () => onClick(),
+        onKeyDown: (event: React.KeyboardEvent) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault();
+            onClick();
+          }
+        },
+        role: 'button' as const,
+        tabIndex: 0,
+      }
+    : {};
 
   if (widget.style === 'Heading') {
     return (
-      <h2 data-slot="text-widget" data-style="heading" className={className}>
+      <h2 data-slot="text-widget" data-style="heading" className={className} {...interactiveProps}>
         {content}
       </h2>
     );
   }
   if (widget.style === 'Subheading') {
     return (
-      <h3 data-slot="text-widget" data-style="subheading" className={className}>
+      <h3
+        data-slot="text-widget"
+        data-style="subheading"
+        className={className}
+        {...interactiveProps}
+      >
         {content}
       </h3>
     );
   }
   return (
-    <p data-slot="text-widget" data-style={widget.style.toLowerCase()} className={className}>
+    <p
+      data-slot="text-widget"
+      data-style={widget.style.toLowerCase()}
+      className={className}
+      {...interactiveProps}
+    >
       {content}
     </p>
   );

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-trigger-handler.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-trigger-handler.ts
@@ -1,0 +1,56 @@
+import { useCallback } from 'react';
+
+import { useWidgetActionDispatcher } from '../components/widget-action-context.js';
+
+import type { WidgetAction, WidgetActionTrigger } from '@granit/dashboards';
+
+/**
+ * Returns an `onClick`-style callback that dispatches every
+ * {@link WidgetAction} matching the given {@link WidgetActionTrigger},
+ * or `null` when no action is wired (so consumers can attach the
+ * handler conditionally and skip the cursor / a11y affordances when
+ * there's nothing to fire).
+ *
+ * Dispatches happen through the surrounding {@link WidgetActionProvider}
+ * (or the framework defaults), so placeholder substitution
+ * (`${row.x}`, `${aliasName}`) and view-setter wiring
+ * happen automatically.
+ *
+ * Multiple actions on the same trigger fire in declaration order —
+ * matches the backend's `WidgetDefinitionBase.Actions` semantics
+ * (the action list is intentionally ordered, not a set).
+ *
+ * @example
+ *   function MarkdownWidget({ widget }) {
+ *     const onClick = useWidgetTriggerHandler('Click', widget.actions);
+ *     return (
+ *       <div
+ *         onClick={onClick ?? undefined}
+ *         className={onClick ? 'cursor-pointer' : ''}
+ *         role={onClick ? 'button' : undefined}
+ *       >
+ *         {body}
+ *       </div>
+ *     );
+ *   }
+ */
+export function useWidgetTriggerHandler(
+  trigger: WidgetActionTrigger,
+  actions: readonly WidgetAction[] | null | undefined
+): ((data?: Readonly<Record<string, unknown>>) => void) | null {
+  const dispatch = useWidgetActionDispatcher();
+
+  const handler = useCallback(
+    (data?: Readonly<Record<string, unknown>>) => {
+      if (!actions) return;
+      for (const action of actions) {
+        if (action.trigger === trigger) dispatch(action, data);
+      }
+    },
+    [dispatch, trigger, actions]
+  );
+
+  if (!actions || actions.length === 0) return null;
+  if (!actions.some((a) => a.trigger === trigger)) return null;
+  return handler;
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -112,6 +112,7 @@ export type {
   WidgetActionHandlerRegistry,
 } from './lib/widget-action-handler.js';
 export { useEffectiveTimeWindow } from './hooks/use-effective-time-window.js';
+export { useWidgetTriggerHandler } from './hooks/use-widget-trigger-handler.js';
 export {
   DASHBOARD_BREAKPOINT_MIN_WIDTH,
   resolveBreakpoint,


### PR DESCRIPTION
## Summary

Closes the per-renderer follow-up flagged in #285. Widget renderers on the definition path now fire their declared \`widget.actions\` on the right user gestures via a new \`useWidgetTriggerHandler\` hook.

The dispatcher itself (#285) was the plumbing — knows how to take an action declaration and route to the right handler. This PR connects renderers to fire it on click.

## Surface

### \`useWidgetTriggerHandler(trigger, actions)\` hook

Returns a callable that dispatches every action matching the trigger via the surrounding \`<WidgetActionProvider>\` (or framework defaults). Returns \`null\` when no action is wired so renderers attach \`cursor\` / \`role\` / keyboard affordances conditionally.

\`\`\`tsx
function MarkdownWidget({ widget }) {
  const onClick = useWidgetTriggerHandler('Click', widget.actions);
  return (
    <div
      onClick={onClick ? () => onClick() : undefined}
      role={onClick ? 'button' : undefined}
      tabIndex={onClick ? 0 : undefined}
      className={onClick ? 'cursor-pointer' : ''}
    >
      ...
    </div>
  );
}
\`\`\`

### Widget renderers wired

Definition-side framework widgets ship Click handlers:

| Widget | Trigger | Affordances when wired |
| --- | --- | --- |
| MarkdownWidget | Click | \`role="button"\`, \`tabIndex=0\`, Enter/Space activation, cursor-pointer |
| TextWidget | Click | same (preserves \`<h2>\` / \`<h3>\` / \`<p>\` semantic tags by style) |
| ImageWidget | Click | same on the wrapper div (img stays \`<img>\`) |
| KpiTile / KpiTileView | Click | new optional \`onClick\` prop on \`KpiTileView\` |

Widgets without actions stay inert — no spurious focus stops, no cursor change.

## What's intentionally out of scope

### Snapshot path (bundle render) — backend gap

The \`DashboardRenderedWidget\` envelope doesn't carry \`widget.actions\`. So \`KpiSnapshotTile\`, \`ChartSnapshotWidget\`, \`TableSnapshotWidget\`, \`PivotSnapshotWidget\`, \`MapSnapshotWidget\` can't dispatch actions — they don't see the declarations.

**Fix needed (backend)**: extend \`DashboardRenderedWidget\` (and its backend counterpart) with an \`actions: readonly WidgetAction[] | null\` field. Once that lands, snapshot widgets get the same wiring with one-line changes.

### Per-kind triggers beyond Click

- Table \`RowClick\` — needs a \`<TableSnapshotWidget>\` row click integration; the current renderer doesn't expose row click hooks.
- Chart \`SeriesClick\` / \`LegendClick\` — needs ECharts event integration on \`<ChartSnapshotWidget>\`.
- Map marker click — \`<MapSnapshotWidget>\` already has a hardcoded \`detailRoute\` flow; porting it to dispatch via \`useWidgetTriggerHandler\` is a follow-up alongside the snapshot envelope gap.

## Test plan

- [x] \`pnpm exec vitest run packages/@granit/react-dashboards\` — 17 files / 142 tests pass (8 new: hook null-cases, dispatch-in-order, placeholder substitution shared with the dispatcher, Markdown widget click + keyboard a11y, non-interactive baseline).
- [x] \`pnpm lint\` clean.
- [x] \`pnpm tsc\` clean across all 87 \`@granit/*\` packages.