### PR TITLE
feat(dashboards): version-drift detection helper (ADR-038)

### DIFF
--- a/packages/@granit/dashboards/src/endpoints/__tests__/detect-version-drift.test.ts
+++ b/packages/@granit/dashboards/src/endpoints/__tests__/detect-version-drift.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectVersionDrift } from '../detect-version-drift.js';
+
+describe('detectVersionDrift', () => {
+  it('returns ad-hoc when the persisted instance has no source version', () => {
+    expect(detectVersionDrift(null, '1.0.0')).toBe('ad-hoc');
+    expect(detectVersionDrift(null, undefined)).toBe('ad-hoc');
+  });
+
+  it('returns unknown when the catalog does not expose the source definition', () => {
+    expect(detectVersionDrift('1.0.0', undefined)).toBe('unknown');
+  });
+
+  it('returns aligned when persisted matches catalog exactly', () => {
+    expect(detectVersionDrift('1.0.0', '1.0.0')).toBe('aligned');
+    expect(detectVersionDrift('2.5.3', '2.5.3')).toBe('aligned');
+  });
+
+  it('returns behind when persisted is older than catalog', () => {
+    expect(detectVersionDrift('1.0.0', '1.0.1')).toBe('behind');
+    expect(detectVersionDrift('1.0.0', '1.1.0')).toBe('behind');
+    expect(detectVersionDrift('1.9.9', '2.0.0')).toBe('behind');
+    expect(detectVersionDrift('0.5.0', '1.0.0')).toBe('behind');
+  });
+
+  it('returns ahead when persisted is newer than catalog', () => {
+    expect(detectVersionDrift('1.0.1', '1.0.0')).toBe('ahead');
+    expect(detectVersionDrift('1.1.0', '1.0.5')).toBe('ahead');
+    expect(detectVersionDrift('2.0.0', '1.9.9')).toBe('ahead');
+  });
+
+  it('compares semver components numerically (10 > 9, not lexically)', () => {
+    expect(detectVersionDrift('1.10.0', '1.9.0')).toBe('ahead');
+    expect(detectVersionDrift('1.0.10', '1.0.9')).toBe('ahead');
+  });
+
+  it('returns aligned for identical non-conventional version strings', () => {
+    // Pre-release tags / build metadata: equality short-circuits the
+    // semver parse so these still register as aligned.
+    expect(detectVersionDrift('1.0.0-alpha.3', '1.0.0-alpha.3')).toBe('aligned');
+    expect(detectVersionDrift('custom', 'custom')).toBe('aligned');
+  });
+
+  it('returns unknown for non-conventional differing version strings (cannot order safely)', () => {
+    expect(detectVersionDrift('1.0.0-alpha', '1.0.0-beta')).toBe('unknown');
+    expect(detectVersionDrift('custom-a', 'custom-b')).toBe('unknown');
+  });
+});

--- a/packages/@granit/dashboards/src/endpoints/detect-version-drift.ts
+++ b/packages/@granit/dashboards/src/endpoints/detect-version-drift.ts
@@ -1,0 +1,89 @@
+/**
+ * Outcome of comparing a persisted dashboard's
+ * `sourceDefinitionVersion` against the catalog entry's `version`.
+ * Mirrors the drift-detection contract in ADR-038.
+ *
+ * - `'aligned'`: persisted instance is on the same version as the
+ *   catalog. No re-sync needed.
+ * - `'behind'`: persisted instance carries an older semver than the
+ *   catalog. The author shipped a new revision since import; the
+ *   user can re-sync to pick up changes.
+ * - `'ahead'`: persisted instance is on a newer semver than the
+ *   catalog (catalog rolled back, dev environment runs an older
+ *   build, etc.). Surfaced for visibility but not an actionable
+ *   state — re-syncing would downgrade.
+ * - `'ad-hoc'`: persisted instance has no source definition (created
+ *   from scratch in the editor). Not driftable.
+ * - `'unknown'`: catalog doesn't expose the source definition (e.g.
+ *   the dashboard was imported from a definition that's no longer
+ *   registered in the host's module DI graph). Surfaced as a soft
+ *   warning — the user can archive or migrate manually.
+ */
+export type DashboardVersionDrift = 'aligned' | 'behind' | 'ahead' | 'ad-hoc' | 'unknown';
+
+/**
+ * Parses a `M.m.p` semver tuple into a 3-element array. Returns
+ * `null` for shapes the framework's version field doesn't promise to
+ * match (pre-release tags, build metadata, etc.) — callers fall back
+ * to string comparison when the parse fails.
+ */
+function parseSemver(version: string): [number, number, number] | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match) return null;
+  return [
+    Number.parseInt(match[1] ?? '0', 10),
+    Number.parseInt(match[2] ?? '0', 10),
+    Number.parseInt(match[3] ?? '0', 10),
+  ];
+}
+
+/**
+ * Compares two semver tuples. Returns `1` if `a > b`, `-1` if
+ * `a < b`, `0` if equal.
+ */
+function compareSemver(a: [number, number, number], b: [number, number, number]): number {
+  for (let i = 0; i < 3; i++) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    if (av !== bv) return av > bv ? 1 : -1;
+  }
+  return 0;
+}
+
+/**
+ * Detects whether a persisted dashboard has drifted from its source
+ * definition. Pure function, no React deps — used inline in
+ * `<DashboardListPage>` and any catalog-aware UI.
+ *
+ * Falls back to string equality when either version doesn't match
+ * the conventional `M.m.p` shape. Identical strings always return
+ * `'aligned'` regardless of shape so apps shipping pre-release
+ * versions (`1.0.0-alpha.3`) don't get false `'unknown'` results.
+ *
+ * @param persistedSourceVersion The persisted instance's
+ *   `sourceDefinitionVersion` — `null` when the dashboard was
+ *   composed ad-hoc in the editor.
+ * @param catalogVersion The catalog entry's `version` for the same
+ *   `sourceDefinitionName`. Pass `undefined` when the catalog
+ *   doesn't expose the source definition.
+ */
+export function detectVersionDrift(
+  persistedSourceVersion: string | null,
+  catalogVersion: string | undefined
+): DashboardVersionDrift {
+  if (persistedSourceVersion === null) return 'ad-hoc';
+  if (catalogVersion === undefined) return 'unknown';
+  if (persistedSourceVersion === catalogVersion) return 'aligned';
+
+  const persistedTuple = parseSemver(persistedSourceVersion);
+  const catalogTuple = parseSemver(catalogVersion);
+  if (persistedTuple === null || catalogTuple === null) {
+    // One side has a non-conventional version string. Already
+    // checked equality above; falling through means they differ
+    // somehow but we can't order them safely.
+    return 'unknown';
+  }
+  const cmp = compareSemver(persistedTuple, catalogTuple);
+  if (cmp === 0) return 'aligned';
+  return cmp < 0 ? 'behind' : 'ahead';
+}

--- a/packages/@granit/dashboards/src/endpoints/index.ts
+++ b/packages/@granit/dashboards/src/endpoints/index.ts
@@ -25,3 +25,8 @@ export {
   widgetInstanceToDefinition,
 } from './widget-bridge.js';
 export type { DashboardWidgetDiff } from './widget-bridge.js';
+
+// Drift detection (ADR-038) — compares persisted instance's source
+// version against the catalog's current version.
+export { detectVersionDrift } from './detect-version-drift.js';
+export type { DashboardVersionDrift } from './detect-version-drift.js';

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -91,6 +91,11 @@ export {
 } from './endpoints/index.js';
 export type { DashboardWidgetDiff } from './endpoints/index.js';
 
+// Drift detection (ADR-038) — semver comparison between persisted
+// instances and their source-definition catalog entry.
+export { detectVersionDrift } from './endpoints/index.js';
+export type { DashboardVersionDrift } from './endpoints/index.js';
+
 // Rendering — wire contracts for the dashboard render pipeline plus per-kind
 // snapshots (B3-1 / B3-2 / B3-3, ADR-039).
 export {


### PR DESCRIPTION
## Summary

Per ADR-038, persisted dashboards capture the source definition's `version` at import time. Definitions evolve (modules ship new revisions); imported instances stay frozen unless explicitly re-synced. The catalog's `version` field is the current truth — comparing the two surfaces drift.

The wire surface already has both sides:
- Persisted instance: `DashboardSummaryResponse.sourceDefinitionVersion`
- Catalog entry: `DashboardCatalogEntryResponse.version`

This PR ships the **pure comparison helper** that consumers (list page, detail page, future re-sync flow) call inline. UI integration lands in a follow-up — keeping this PR scoped to the framework primitive.

## Surface

```ts
type DashboardVersionDrift =
  | 'aligned'   // versions match — no re-sync needed
  | 'behind'    // persisted older than catalog — actionable drift
  | 'ahead'     // persisted newer than catalog — surfaced for visibility
  | 'ad-hoc'    // persisted has no source — not driftable
  | 'unknown';  // catalog doesn't expose the source / non-semver strings differ

function detectVersionDrift(
  persistedSourceVersion: string | null,
  catalogVersion: string | undefined
): DashboardVersionDrift;
```

### Behaviour notes

- **Semver parsing**: conventional `M.m.p`. Numeric comparison so `1.10.0 > 1.9.0` (not lexical).
- **Identical non-conventional strings** (pre-release tags, build metadata): short-circuits to `'aligned'`.
- **Differing non-conventional strings**: returns `'unknown'` — ordering isn't defined safely.
- Pure data, no React deps. Used inline in `<DashboardListPage>` and any catalog-aware UI.

## Test plan

- [x] `pnpm exec vitest run packages/@granit/dashboards` — 11 files / 81 tests pass (8 new: every drift state, non-conventional strings, numeric ordering edge cases).
- [x] `pnpm lint` clean.
- [x] `pnpm tsc` clean across all 87 `@granit/*` packages.

## What's next

- `<DashboardListPage>` row-level drift indicator (small showcase PR — visual badge per row when drift !== 'aligned').
- Re-sync action button on `'behind'` rows — needs a backend `POST /dashboards/{id}/resync` endpoint that re-imports widgets from the current catalog source. Tracked in ADR-038.