### PR TITLE
fix(react-subscriptions): align price-history MSW handler with API path

### DIFF
--- a/packages/@granit/react-subscriptions/src/testing/handlers.ts
+++ b/packages/@granit/react-subscriptions/src/testing/handlers.ts
@@ -379,7 +379,7 @@ export function createSubscriptionsHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // Price versions
     // ---------------------------------------------------------------------------
 
-    http.get(`${baseUrl}/plans/:planId/prices`, ({ params }) => {
+    http.get(`${baseUrl}/plans/:planId/prices/history`, ({ params }) => {
       const prices = mockPriceHistory[params.planId as string] ?? [];
       return HttpResponse.json(prices);
     }),


### PR DESCRIPTION
## Summary

`@granit/react-subscriptions/testing` registered the price-history mock at `GET /plans/:planId/prices`, but the matching client call (`getPlanPriceHistory` in `@granit/subscriptions`) hits `GET /plans/:planId/prices/history`. Any consumer wiring this handler into MSW received a 404 on price-history fetches and had to override the path themselves. Aligning the mock with the real path makes the handler usable as-is.

The sibling `POST /plans/:planId/prices` (createPriceVersion) is untouched — that one already matches the client.

## Test plan

- [x] `pnpm exec vitest run packages/@granit/react-subscriptions` — 28 tests passing
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
