### PR TITLE
fix(dashboards): widget-card overflow, chart auto-fill, leaflet icons, ECharts 6 deprecation

### DIFF
--- a/packages/@granit/react-charts/src/components/bar-chart.tsx
+++ b/packages/@granit/react-charts/src/components/bar-chart.tsx
@@ -55,7 +55,10 @@ export function BarChart({
         right: 16,
         top: wantLegend ? 32 : 8,
         bottom: 8,
-        containLabel: true,
+        // ECharts 6 deprecated `containLabel: true`; the equivalent is
+        // outerBoundsMode 'same' + outerBoundsContain 'axisLabel'.
+        outerBoundsMode: 'same',
+        outerBoundsContain: 'axisLabel',
       },
       xAxis: horizontal ? valueAxis : categoryAxis,
       yAxis: horizontal ? categoryAxis : valueAxis,

--- a/packages/@granit/react-charts/src/components/line-chart.tsx
+++ b/packages/@granit/react-charts/src/components/line-chart.tsx
@@ -54,7 +54,10 @@ export function LineChart({
         right: 16,
         top: wantLegend ? 32 : 8,
         bottom: 8,
-        containLabel: true,
+        // ECharts 6 deprecated `containLabel: true`; the equivalent is
+        // outerBoundsMode 'same' + outerBoundsContain 'axisLabel'.
+        outerBoundsMode: 'same',
+        outerBoundsContain: 'axisLabel',
       },
       xAxis: {
         type: xAxis?.type ?? 'category',

--- a/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
+++ b/packages/@granit/react-charts/src/snapshot/chart-snapshot-widget.tsx
@@ -30,6 +30,9 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
 
   const seriesName = field ? `${aggregation}(${field})` : aggregation;
 
+  // The widget cell is sized by the dashboard grid; charts must fill it
+  // rather than render at the typed primitives' default 320px (which
+  // overflows tight cells and leaves whitespace in tall ones).
   if (chartType === 'Pie' || chartType === 'Donut') {
     const pieData = buckets.map((b) => ({
       id: b.label,
@@ -37,8 +40,8 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
       value: b.value ?? 0,
     }));
     return (
-      <div data-slot="chart-snapshot-widget" data-chart-type={chartType}>
-        <PieChart data={pieData} innerRadiusRatio={chartType === 'Donut' ? 0.5 : 0} />
+      <div data-slot="chart-snapshot-widget" data-chart-type={chartType} className="h-full w-full">
+        <PieChart data={pieData} innerRadiusRatio={chartType === 'Donut' ? 0.5 : 0} height="100%" />
       </div>
     );
   }
@@ -55,12 +58,13 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
 
   if (chartType === 'Line' || chartType === 'Area') {
     return (
-      <div data-slot="chart-snapshot-widget" data-chart-type={chartType}>
+      <div data-slot="chart-snapshot-widget" data-chart-type={chartType} className="h-full w-full">
         <LineChart
           series={series}
           xAxis={{ label: groupBy }}
           yAxis={{ label: valueAxisLabel }}
           area={chartType === 'Area'}
+          height="100%"
         />
       </div>
     );
@@ -69,12 +73,13 @@ function ChartBody({ snapshot }: { readonly snapshot: ChartWidgetSnapshot }) {
   // 'Bar' or 'HorizontalBar' — the union is exhaustive over ChartType.
   const horizontal = chartType === 'HorizontalBar';
   return (
-    <div data-slot="chart-snapshot-widget" data-chart-type={chartType}>
+    <div data-slot="chart-snapshot-widget" data-chart-type={chartType} className="h-full w-full">
       <BarChart
         series={series}
         xAxis={{ label: horizontal ? valueAxisLabel : groupBy }}
         yAxis={{ label: horizontal ? groupBy : valueAxisLabel }}
         horizontal={horizontal}
+        height="100%"
       />
     </div>
   );

--- a/packages/@granit/react-dashboards/src/components/widget-card.tsx
+++ b/packages/@granit/react-dashboards/src/components/widget-card.tsx
@@ -26,7 +26,7 @@ export function WidgetCard({ title, children, className }: WidgetCardProps) {
           <h3 className="text-sm font-medium text-muted-foreground">{title}</h3>
         </header>
       ) : null}
-      <div data-slot="widget-card-body" className="flex-1 min-h-0">
+      <div data-slot="widget-card-body" className="flex-1 min-h-0 overflow-hidden">
         {children}
       </div>
     </div>

--- a/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
+++ b/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
@@ -14,11 +14,17 @@ import type { DashboardRenderedWidget } from '@granit/dashboards';
 // Pin them to the CDN so apps don't need to import PNG assets manually.
 // Apps that prefer self-hosted icons override `L.Icon.Default.mergeOptions`
 // at the entry point.
-const LEAFLET_ICON_CDN = 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/images';
+//
+// `imagePath` carries the full CDN base; the *Url options carry the bare
+// filenames. Leaflet's Icon.Default._getIconUrl concatenates them as
+// `imagePath + url`, so passing absolute CDN URLs in iconUrl alone
+// double-prefixes when Leaflet's auto-detected imagePath kicks in (Vite
+// resolves it to the local node_modules path under /@fs/...).
 L.Icon.Default.mergeOptions({
-  iconUrl: `${LEAFLET_ICON_CDN}/marker-icon.png`,
-  iconRetinaUrl: `${LEAFLET_ICON_CDN}/marker-icon-2x.png`,
-  shadowUrl: `${LEAFLET_ICON_CDN}/marker-shadow.png`,
+  imagePath: 'https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/images/',
+  iconUrl: 'marker-icon.png',
+  iconRetinaUrl: 'marker-icon-2x.png',
+  shadowUrl: 'marker-shadow.png',
 });
 
 /**


### PR DESCRIPTION
## Summary

Four small dashboard-tile rendering bugs surfacing together on the showcase render path:

1. **`<WidgetCard>` body bled outside its frame** — sized with `flex-1 min-h-0` but no overflow handling. Adds `overflow-hidden` so oversize content is masked at the card edge.

2. **Charts ignored their cell size** — `ChartSnapshotWidget` rendered at `BarChart`/`LineChart`/`PieChart`'s hardcoded 320px default, which both overflows tight cells and leaves whitespace in tall ones. Wraps each chart in `h-full w-full` and threads `height='100%'` through to the typed primitive so ECharts' resize observer picks up the cell's actual height.

3. **Leaflet marker icons 404'd** — Leaflet 1.9's `_getIconUrl` always concatenates `imagePath + options.iconUrl`. We were setting `iconUrl` to absolute CDN URLs, but Leaflet auto-detects `imagePath` from the served `leaflet.css` location (Vite resolves it to `/@fs/.../leaflet/dist/`), producing nonsense like `/@fs/.../leaflet/dist/images/https://cdn.jsdelivr.net/.../marker-icon-2x.png`. Fix: pass the CDN base via `imagePath` and only the bare filenames in the `*Url` options.

4. **ECharts 6 deprecation warning** — bar/line charts logged `Specified \`grid.containLabel\` but no \`use(LegacyGridContainLabel)\`; use \`grid.outerBounds\` instead.` Migrates to the ECharts 6 equivalent `{outerBoundsMode: 'same', outerBoundsContain: 'axisLabel'}`.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] `pnpm exec vitest run packages/@granit/react-dashboards packages/@granit/react-charts packages/@granit/react-map` — 199 tests passing
- [ ] Showcase: widget-card body content clips at the card edge
- [ ] Showcase: bar chart fills its cell at any rowHeight
- [ ] Showcase: map markers render (no 404 in DevTools)
- [ ] Showcase: console clean of ECharts containLabel deprecation warning
