### PR TITLE
feat(dashboards): mirror backend Option B drift status on render envelope

### DIFF
--- a/packages/@granit/dashboards/src/__tests__/dashboard-render-response.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/dashboard-render-response.test.ts
@@ -80,6 +80,9 @@ const BUNDLE_FIXTURE: DashboardRenderResponse = {
     token: 'mtd',
   },
   activeViewName: null,
+  driftStatus: 'Aligned',
+  sourceDefinitionVersion: '1.0.0',
+  registeredVersion: '1.0.0',
   widgets: [KPI_WIDGET, MARKDOWN_WIDGET, UNAVAILABLE_WIDGET],
 };
 

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -104,6 +104,7 @@ export {
   isTextSnapshotEnvelope,
 } from './rendering/index.js';
 export type {
+  DashboardDriftStatus,
   DashboardRenderedWidget,
   DashboardRenderPeriod,
   DashboardRenderRequest,

--- a/packages/@granit/dashboards/src/rendering/dashboard-drift-status.ts
+++ b/packages/@granit/dashboards/src/rendering/dashboard-drift-status.ts
@@ -1,0 +1,39 @@
+/**
+ * Wire format for `Granit.Dashboards.Endpoints.Dtos.DashboardDriftStatus`
+ * (ADR-038 §3). Surfaced on {@link DashboardRenderResponse.driftStatus} —
+ * server-side comparison between the persisted dashboard's
+ * `sourceDefinitionVersion` and the currently-registered descriptor's
+ * `version`. PascalCase string literals match the backend's
+ * `JsonStringEnumConverter` output.
+ *
+ * Comparison is semver-aware: the backend parses `MAJOR.MINOR.PATCH`
+ * with optional pre-release / build suffix and orders numerically.
+ * Mismatched suffixes or unparseable strings collapse to `'Unknown'`.
+ *
+ * - `'NotApplicable'`: ad-hoc dashboard, no source definition. Hide
+ *   drift UI entirely.
+ * - `'Aligned'`: persisted version matches the registered descriptor.
+ *   No action.
+ * - `'Behind'`: persisted is older than the registered descriptor —
+ *   the source module shipped a new revision since import. Surface
+ *   "Click to resync".
+ * - `'Ahead'`: persisted is newer than the registered descriptor —
+ *   the host loaded an older module than at import. Resync would
+ *   downgrade; offer as an explicit force-resync.
+ * - `'Unknown'`: versions cannot be ordered (unparseable or mismatched
+ *   pre-release suffixes). Treat like `'Aligned'` for the main banner;
+ *   expose a tooltip with both raw versions for manual reconciliation.
+ * - `'SourceUnregistered'`: source definition is no longer registered
+ *   in the host. Resync impossible; surface a terminal warning.
+ *
+ * Distinct from {@link DashboardVersionDrift} — that 5-state union is
+ * computed client-side by `detectVersionDrift` from the list page's
+ * summary + catalog data when no render response is available.
+ */
+export type DashboardDriftStatus =
+  | 'NotApplicable'
+  | 'Aligned'
+  | 'Behind'
+  | 'Ahead'
+  | 'Unknown'
+  | 'SourceUnregistered';

--- a/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
+++ b/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
@@ -1,3 +1,4 @@
+import type { DashboardDriftStatus } from './dashboard-drift-status.js';
 import type { WidgetSnapshotStatus } from './widget-snapshot-status.js';
 import type { RefreshHint } from '../types/refresh-hint.js';
 import type { WidgetAction } from '../types/widget-action.js';
@@ -32,6 +33,26 @@ export interface DashboardRenderResponse {
    * `request.viewName → DashboardDefinition.DefaultView → first view`).
    */
   readonly activeViewName: string | null;
+  /**
+   * Drift status between the persisted dashboard's
+   * `sourceDefinitionVersion` and the currently-registered descriptor's
+   * version (ADR-038 §3, semver-aware on the backend). Lets the
+   * frontend surface a "Dashboard outdated, click to resync" affordance
+   * without an extra round-trip.
+   */
+  readonly driftStatus: DashboardDriftStatus;
+  /**
+   * Persisted version captured at import time. `null` when the dashboard
+   * was custom-built (no source definition).
+   */
+  readonly sourceDefinitionVersion: string | null;
+  /**
+   * Currently-registered descriptor version. `null` when the source
+   * definition is no longer registered (`driftStatus` =
+   * `'SourceUnregistered'`) or the dashboard has no source
+   * (`driftStatus` = `'NotApplicable'`).
+   */
+  readonly registeredVersion: string | null;
   /** One flat record per widget, in `WidgetInstance.Position` order. */
   readonly widgets: readonly DashboardRenderedWidget[];
 }

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -6,6 +6,7 @@
 // (B3-1 / B3-3 / B4-render, ADR-039).
 // ---------------------------------------------------------------------------
 
+export type { DashboardDriftStatus } from './dashboard-drift-status.js';
 export type { DashboardRenderRequest } from './dashboard-render-request.js';
 export type {
   DashboardRenderedWidget,


### PR DESCRIPTION
## Summary

granit-dotnet shipped semver-aware drift detection (ADR-038 §3 Option B): `DashboardDriftStatus` is now a 6-state enum (`NotApplicable / Aligned / Behind / Ahead / Unknown / SourceUnregistered`) and `DashboardRenderResponse` carries `DriftStatus`, `SourceDefinitionVersion`, `RegisteredVersion` on every render envelope. This PR mirrors those wire types front-side so consumers of `useDashboardRender` can read them via TypeScript instead of guessing from the JSON.

- New `DashboardDriftStatus` string-literal union under `@granit/dashboards/rendering`. PascalCase values match the backend's `JsonStringEnumConverter` output.
- `DashboardRenderResponse` extended with the 3 new fields, all readonly.
- Re-exported from the package barrel.
- Test fixture updated.

The list-page-side `detectVersionDrift` (5-state union) stays as is — it computes drift from the summary + catalog when no render response is available, intentionally with slightly different collapsing rules. The 6-state backend type and the 5-state client helper coexist by design.

A companion showcase PR threads the new fields through the MSW render fixture so the showcase doesn't TS-error against the new contract.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm exec vitest run packages/@granit/dashboards packages/@granit/react-dashboards` — 227 tests passing
