### PR TITLE
feat(react-dashboards): useResyncDashboard hook (ADR-038 §3 closure)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2294,6 +2294,11 @@
           "members": []
         },
         {
+          "name": "useResyncDashboard",
+          "kind": "function",
+          "signature": "function useResyncDashboard(): UseMutationResult<DashboardResyncResponse, Error, string>"
+        },
+        {
           "name": "useAddWidget",
           "kind": "function",
           "signature": "function useAddWidget(): UseMutationResult< WidgetInstanceResponse, Error, AddWidgetVariables >"

--- a/packages/@granit/dashboards/src/endpoints/dashboard-resync-response.ts
+++ b/packages/@granit/dashboards/src/endpoints/dashboard-resync-response.ts
@@ -1,0 +1,47 @@
+import type { DashboardStatus } from './dashboard-status.js';
+
+/**
+ * Wire shape for `POST /dashboards/{id}/resync` (ADR-038 §3). Mirrors
+ * `Granit.Dashboards.Endpoints.Dtos.DashboardResyncResponse`.
+ *
+ * Echoes the dashboard's identifying fields alongside a change-summary so
+ * admins can audit what the resync actually moved without re-reading the
+ * aggregate. The user-renamable {@link name} and lifecycle {@link status}
+ * are intentionally preserved by the backend — a published dashboard stays
+ * published, a renamed one keeps its tenant rename.
+ */
+export interface DashboardResyncResponse {
+  /** Persisted dashboard identifier (unchanged). */
+  readonly id: string;
+  /** Dashboard name — preserved across the resync. */
+  readonly name: string;
+  /** Dashboard status — preserved across the resync. */
+  readonly status: DashboardStatus;
+  /** Wire identifier of the source definition (unchanged). */
+  readonly sourceDefinitionName: string;
+  /**
+   * Source-definition version recorded on the dashboard before this
+   * resync ran. `null` when the dashboard had never carried a version
+   * (legacy data shipped before the version field was introduced).
+   */
+  readonly previousSourceDefinitionVersion: string | null;
+  /**
+   * Source-definition version captured by the resync — pulled from the
+   * currently-registered descriptor. Always non-null since resync
+   * requires the source to be registered.
+   */
+  readonly sourceDefinitionVersion: string;
+  /**
+   * Count of widgets the descriptor introduced (matched by
+   * `Widget:{Name}.{slug}`).
+   */
+  readonly widgetsAdded: number;
+  /** Count of widgets the descriptor no longer declares. */
+  readonly widgetsRemoved: number;
+  /**
+   * Count of widgets whose persisted overrides were preserved on the
+   * new instances via slug match. Slugs the descriptor renamed silently
+   * lose their overrides.
+   */
+  readonly overridesCarriedOver: number;
+}

--- a/packages/@granit/dashboards/src/endpoints/index.ts
+++ b/packages/@granit/dashboards/src/endpoints/index.ts
@@ -8,6 +8,7 @@ export type { DashboardCatalogEntryResponse } from './dashboard-catalog-entry-re
 export type { DashboardDetailResponse } from './dashboard-detail-response.js';
 export type { DashboardImportResponse } from './dashboard-import-response.js';
 export type { DashboardMetadataUpdateRequest } from './dashboard-metadata-update-request.js';
+export type { DashboardResyncResponse } from './dashboard-resync-response.js';
 export type { DashboardStatus } from './dashboard-status.js';
 export type { DashboardSummaryResponse } from './dashboard-summary-response.js';
 export type { PagedResponse } from './paged-response.js';

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -70,6 +70,7 @@ export type {
   DashboardDetailResponse,
   DashboardImportResponse,
   DashboardMetadataUpdateRequest,
+  DashboardResyncResponse,
   DashboardStatus,
   DashboardSummaryResponse,
   PagedResponse,

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
@@ -15,6 +15,7 @@ import {
   useRestoreDashboard,
 } from '../api/use-dashboard-state-transitions.js';
 import { useImportDashboard } from '../api/use-import-dashboard.js';
+import { useResyncDashboard } from '../api/use-resync-dashboard.js';
 import { useUpdateDashboardMetadata } from '../api/use-update-dashboard-metadata.js';
 import { useAddWidget, useRemoveWidget, useUpdateWidget } from '../api/use-widget-crud.js';
 
@@ -122,6 +123,19 @@ function freshHandlers() {
     http.post(
       `http://localhost/dashboards/${encodeURIComponent(ID)}/restore`,
       () => new HttpResponse(null, { status: 204 })
+    ),
+    http.post(`http://localhost/dashboards/${encodeURIComponent(ID)}/resync`, () =>
+      HttpResponse.json({
+        id: ID,
+        name: 'Invoicing overview',
+        status: 'Draft',
+        sourceDefinitionName: DEFINITION_NAME,
+        previousSourceDefinitionVersion: '1.0.0',
+        sourceDefinitionVersion: '1.1.0',
+        widgetsAdded: 1,
+        widgetsRemoved: 0,
+        overridesCarriedOver: 3,
+      })
     ),
     http.post(
       `http://localhost/dashboards/${encodeURIComponent(ID)}/widgets`,
@@ -267,6 +281,23 @@ describe('useArchiveDashboard / useRestoreDashboard / usePublishDashboard', () =
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useRestoreDashboard(), { wrapper });
     await expect(result.current.mutateAsync(ID)).resolves.toBeUndefined();
+  });
+});
+
+describe('useResyncDashboard', () => {
+  it('POSTs to /resync, returns the change summary, and invalidates list + detail + render', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(dashboardDetailQueryKey(ID), DETAIL);
+    const { result } = renderHook(() => useResyncDashboard(), { wrapper });
+    const summary = await result.current.mutateAsync(ID);
+    expect(summary).toMatchObject({
+      previousSourceDefinitionVersion: '1.0.0',
+      sourceDefinitionVersion: '1.1.0',
+      widgetsAdded: 1,
+      widgetsRemoved: 0,
+      overridesCarriedOver: 3,
+    });
+    expect(queryClient.getQueryState(dashboardDetailQueryKey(ID))?.isInvalidated).toBe(true);
   });
 });
 

--- a/packages/@granit/react-dashboards/src/api/use-resync-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/api/use-resync-dashboard.ts
@@ -1,0 +1,50 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { dashboardDetailQueryKey } from './use-dashboard-detail.js';
+
+import type { DashboardResyncResponse } from '@granit/dashboards';
+
+const DASHBOARDS_PATH = '/dashboards';
+
+/**
+ * `POST /dashboards/{id}/resync` — replays the registered
+ * `DashboardDefinition` behind a persisted dashboard's
+ * `sourceDefinitionName`. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardResyncEndpoints.ResyncAsync`
+ * (ADR-038 §3).
+ *
+ * Resolves the drift surface: the render endpoint surfaces a
+ * `'Behind'` / `'Ahead'` `driftStatus`, this mutation is the action the
+ * "click to resync" affordance dispatches.
+ *
+ * The backend preserves the user-renamable `name` and lifecycle
+ * `status` and best-effort carries persisted overrides via
+ * `Widget:{Name}.{slug}` match. Returns a change-summary so callers can
+ * surface "X widgets added, Y removed, Z overrides preserved" toasts.
+ *
+ * Backend rejects 409 on ad-hoc dashboards (no source definition) and
+ * when the source definition is no longer registered in the host.
+ *
+ * Invalidates the dashboard list (drift status flips to `'Aligned'`),
+ * the per-id detail (widgets and version refresh), and the per-id
+ * render bundle so subsequent reads hit fresh data.
+ */
+export function useResyncDashboard(): UseMutationResult<DashboardResyncResponse, Error, string> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const response = await api.post<DashboardResyncResponse>(
+        `${DASHBOARDS_PATH}/${encodeURIComponent(id)}/resync`
+      );
+      return response.data;
+    },
+    onSuccess: (_response, id) => {
+      void queryClient.invalidateQueries({ queryKey: ['dashboards', 'list'] });
+      void queryClient.invalidateQueries({ queryKey: ['dashboards', 'catalog'] });
+      void queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(id) });
+      void queryClient.invalidateQueries({ queryKey: ['dashboard', id, 'render'] });
+    },
+  });
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -37,6 +37,7 @@ export {
   usePublishDashboard,
   useRestoreDashboard,
 } from './api/use-dashboard-state-transitions.js';
+export { useResyncDashboard } from './api/use-resync-dashboard.js';
 export { useAddWidget, useRemoveWidget, useUpdateWidget } from './api/use-widget-crud.js';
 export type {
   AddWidgetVariables,


### PR DESCRIPTION
## Summary

granit-dotnet shipped `POST /dashboards/{id}/resync` (ADR-038 §3 closure to drift detection). This wires the matching front-side mutation hook + wire DTO so the "click to resync" affordance the drift indicator hints at can dispatch.

- New `DashboardResyncResponse` mirroring the backend record: `id`, `name`, `status`, `sourceDefinitionName`, `previousSourceDefinitionVersion`, `sourceDefinitionVersion`, plus the change counts (`widgetsAdded`, `widgetsRemoved`, `overridesCarriedOver`) so admins can audit what the resync moved without re-reading the aggregate.
- New `useResyncDashboard` mutation hook returning the summary. Invalidates the list (drift state flips), the catalog, the per-id detail (widgets + version refresh), and the per-id render bundle so subsequent reads hit fresh data.
- Tests cover the happy path + invalidation.

Backend rejects 409 on ad-hoc dashboards and unregistered sources. Showcase UI gating + 409 toast handling lands separately as the consuming PR.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm exec vitest run packages/@granit/react-dashboards` — 147 tests passing
