### PR TITLE
feat(react-dashboard-editor): widget resize handles + drag handle polish

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2174,6 +2174,11 @@
           "signature": "function reorderWidgets( definition: DashboardDefinition, sourceSlug: string, targetSlug: string ): DashboardDefinition"
         },
         {
+          "name": "resizeWidget",
+          "kind": "function",
+          "signature": "function resizeWidget( definition: DashboardDefinition, slug: string, size: WidgetSize ): DashboardDefinition"
+        },
+        {
           "name": "addWidget",
           "kind": "function",
           "signature": "function addWidget<TDefinition extends"

--- a/packages/@granit/react-dashboard-editor/src/__tests__/resize-widget.test.ts
+++ b/packages/@granit/react-dashboard-editor/src/__tests__/resize-widget.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { resizeWidget } from '../lib/resize-widget.js';
+
+import type { DashboardDefinition } from '@granit/dashboards';
+
+const baseDefinition: DashboardDefinition = {
+  name: 'Test',
+  category: 'General',
+  isSystem: false,
+  version: '1.0.0',
+  layout: { columns: 12, rowHeight: 80 },
+  widgets: [
+    {
+      slug: 'A',
+      type: 'text',
+      position: 0,
+      size: { width: 4, height: 1 },
+      contentLocalizationKey: 'Widget:A',
+      style: 'Body',
+    },
+    {
+      slug: 'B',
+      type: 'text',
+      position: 1,
+      size: { width: 4, height: 1 },
+      contentLocalizationKey: 'Widget:B',
+      style: 'Body',
+    },
+  ],
+};
+
+describe('resizeWidget', () => {
+  it('updates the targeted widget size, leaves siblings untouched', () => {
+    const next = resizeWidget(baseDefinition, 'A', { width: 6, height: 2 });
+    expect(next.widgets[0]?.size).toEqual({ width: 6, height: 2 });
+    expect(next.widgets[1]?.size).toEqual({ width: 4, height: 1 });
+  });
+
+  it('returns the original definition when the slug is unknown (referential equality)', () => {
+    const next = resizeWidget(baseDefinition, 'Z', { width: 6, height: 2 });
+    expect(next).toBe(baseDefinition);
+  });
+
+  it('returns the original definition when the new size matches the current size', () => {
+    const next = resizeWidget(baseDefinition, 'A', { width: 4, height: 1 });
+    expect(next).toBe(baseDefinition);
+  });
+
+  it('clamps width to [1, layout.columns]', () => {
+    expect(resizeWidget(baseDefinition, 'A', { width: 0, height: 1 }).widgets[0]?.size.width).toBe(
+      1
+    );
+    expect(resizeWidget(baseDefinition, 'A', { width: 99, height: 1 }).widgets[0]?.size.width).toBe(
+      12
+    );
+  });
+
+  it('clamps height to [1, 12]', () => {
+    expect(resizeWidget(baseDefinition, 'A', { width: 4, height: 0 }).widgets[0]?.size.height).toBe(
+      1
+    );
+    expect(
+      resizeWidget(baseDefinition, 'A', { width: 4, height: 99 }).widgets[0]?.size.height
+    ).toBe(12);
+  });
+
+  it('preserves all non-size fields on the resized widget', () => {
+    const next = resizeWidget(baseDefinition, 'A', { width: 6, height: 2 });
+    const a = next.widgets[0];
+    expect(a).toMatchObject({
+      slug: 'A',
+      type: 'text',
+      position: 0,
+      contentLocalizationKey: 'Widget:A',
+      style: 'Body',
+    });
+  });
+});

--- a/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/editable-dashboard.tsx
@@ -18,29 +18,33 @@ import {
   useDashboardBreakpoint,
   WidgetRenderer,
 } from '@granit/react-dashboards';
-import { useMemo, type CSSProperties } from 'react';
+import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 
 import { reorderWidgets } from '../lib/reorder-widgets.js';
+import { resizeWidget } from '../lib/resize-widget.js';
 
 import { SortableWidgetCell } from './sortable-widget-cell.js';
 
-import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
+import type { DashboardDefinition, WidgetDefinition, WidgetSize } from '@granit/dashboards';
+
+const GRID_GAP_PX = 16;
 
 /**
  * Editor-mode dashboard. Mirrors the read-mode `<Dashboard>` from
  * `@granit/react-dashboards` (auto-flow CSS grid, widgets fill cells in
  * `position` order, each spans its declared `size.width × size.height`),
- * with two extras:
+ * with these editor extras:
  *
  * - **dnd-kit-driven reorder**: each cell is a sortable item keyed by its
  *   `slug`. A small drag handle on the top-left initiates the gesture; the
  *   widget body itself stays interactive (links, popovers, click actions).
+ * - **Drag-resize**: a bottom-right corner handle resizes the cell on
+ *   pointer drag, snapping to integer grid cells. Width clamped to
+ *   `[1, layout.columns]`, height to `[1, 12]`.
  * - **`onChange` callback**: emits a fresh `DashboardDefinition` whose
  *   widgets carry recomputed `position` ranks (0-based, contiguous) — ready
  *   to round-trip through the backend's widget-CRUD endpoints without a
  *   normalisation pass.
- *
- * v1 supports reorder only; resize and add/remove come in B5-C PRs 2 and 3.
  *
  * Apps drive saves via React Query mutations on the parent — the editor
  * stays presentational. The same widget registry the read-mode `<Dashboard>`
@@ -51,8 +55,8 @@ import type { DashboardDefinition, WidgetDefinition } from '@granit/dashboards';
 export interface EditableDashboardProps {
   readonly definition: DashboardDefinition;
   /**
-   * Fires after a successful drag-end. Consumers update local state +
-   * invalidate / persist via their own pipeline.
+   * Fires after a successful drag-end or drag-resize. Consumers update
+   * local state + invalidate / persist via their own pipeline.
    */
   readonly onChange: (next: DashboardDefinition) => void;
   readonly className?: string;
@@ -89,7 +93,7 @@ export function EditableDashboard({
     gridAutoFlow: 'dense',
     gridTemplateColumns: `repeat(${layout.columns}, minmax(0, 1fr))`,
     gridAutoRows: `${effectiveRowHeight}px`,
-    gap: '1rem',
+    gap: `${GRID_GAP_PX}px`,
   };
 
   const handleDragEnd = (event: DragEndEvent) => {
@@ -99,11 +103,39 @@ export function EditableDashboard({
     if (next !== definition) onChange(next);
   };
 
+  // Live container width drives the column-px metric for resize gestures.
+  // ResizeObserver fires on mount + whenever the parent reflows (sidebar
+  // toggle, viewport resize, etc.) so the resize gesture stays accurate.
+  const gridRef = useRef<HTMLDivElement | null>(null);
+  const [columnPx, setColumnPx] = useState(0);
+  useEffect(() => {
+    const element = gridRef.current;
+    // ResizeObserver is unavailable in JSDOM and old SSR runtimes —
+    // skip silently so the editor still renders (resize handle just
+    // won't move; reorder + everything else still works).
+    if (!element || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      const totalWidth = entry.contentRect.width;
+      const cellsTotalGap = (layout.columns - 1) * GRID_GAP_PX;
+      setColumnPx((totalWidth - cellsTotalGap) / layout.columns);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [layout.columns]);
+
+  const handleResize = (slug: string, size: WidgetSize) => {
+    const next = resizeWidget(definition, slug, size);
+    if (next !== definition) onChange(next);
+  };
+
   return (
     <DashboardContextProvider value={{ dashboardName: definition.name }}>
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
         <SortableContext items={sortableIds} strategy={rectSortingStrategy}>
           <div
+            ref={gridRef}
             data-slot="editable-dashboard"
             data-dashboard-name={definition.name}
             data-breakpoint={breakpoint}
@@ -111,7 +143,14 @@ export function EditableDashboard({
             style={gridStyle}
           >
             {orderedWidgets.map((widget) => (
-              <EditableCell key={widget.slug} widget={widget} />
+              <EditableCell
+                key={widget.slug}
+                widget={widget}
+                columnPx={columnPx}
+                rowPx={effectiveRowHeight}
+                maxColumns={layout.columns}
+                onResize={(size) => handleResize(widget.slug, size)}
+              />
             ))}
           </div>
         </SortableContext>
@@ -120,14 +159,34 @@ export function EditableDashboard({
   );
 }
 
-function EditableCell({ widget }: { readonly widget: WidgetDefinition }) {
+function EditableCell({
+  widget,
+  columnPx,
+  rowPx,
+  maxColumns,
+  onResize,
+}: {
+  readonly widget: WidgetDefinition;
+  readonly columnPx: number;
+  readonly rowPx: number;
+  readonly maxColumns: number;
+  readonly onResize: (size: WidgetSize) => void;
+}) {
   const cellStyle: CSSProperties = {
     gridColumn: `span ${widget.size.width}`,
     gridRow: `span ${widget.size.height}`,
   };
   return (
     <div data-slot="editable-dashboard-cell" data-widget-slug={widget.slug} style={cellStyle}>
-      <SortableWidgetCell id={widget.slug}>
+      <SortableWidgetCell
+        id={widget.slug}
+        size={widget.size}
+        columnPx={columnPx}
+        rowPx={rowPx}
+        gapPx={GRID_GAP_PX}
+        maxWidth={maxColumns}
+        onResize={onResize}
+      >
         <WidgetRenderer widget={widget} />
       </SortableWidgetCell>
     </div>

--- a/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
+++ b/packages/@granit/react-dashboard-editor/src/components/sortable-widget-cell.tsx
@@ -1,6 +1,8 @@
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { type ReactNode } from 'react';
+import { useCallback, useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from 'react';
+
+import type { WidgetSize } from '@granit/dashboards';
 
 /**
  * Wraps a widget cell in dnd-kit's {@link useSortable} hook so a
@@ -9,24 +11,113 @@ import { type ReactNode } from 'react';
  * of the cell) keeps interactive content inside the widget (links, popovers,
  * chart tooltips) free of pointer hijacking.
  *
+ * When `onResize` is wired, a bottom-right resize handle is rendered
+ * alongside the drag handle. The gesture snaps to integer cells using the
+ * grid metrics passed via `columnPx` / `rowPx` / `gapPx`. Live updates
+ * fire on every pointer move so the grid reflows under the cursor; on
+ * release no extra event is needed since the parent already holds the
+ * latest size.
+ *
  * The `id` prop is the widget's `slug` — stable across reorders, matches
  * the `WidgetDefinitionBase.slug` invariant.
  */
 export interface SortableWidgetCellProps {
   readonly id: string;
   readonly children: ReactNode;
+  /**
+   * Current widget size in grid cells. Required when `onResize` is set;
+   * ignored otherwise.
+   */
+  readonly size?: WidgetSize;
+  /**
+   * Called with the new size on every pointer move during a resize
+   * gesture. Snapped to integer cells. Wire into the same controlled-
+   * state pipeline as `onChange` on `<EditableDashboard>`.
+   */
+  readonly onResize?: (size: WidgetSize) => void;
+  /** Pixel width of one grid column. */
+  readonly columnPx?: number;
+  /** Pixel height of one grid row. */
+  readonly rowPx?: number;
+  /** Pixel gap between cells (CSS `gap`). */
+  readonly gapPx?: number;
+  /** Maximum width in cells — typically `definition.layout.columns`. */
+  readonly maxWidth?: number;
 }
 
-export function SortableWidgetCell({ id, children }: SortableWidgetCellProps) {
+const MAX_HEIGHT = 12;
+
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+export function SortableWidgetCell({
+  id,
+  children,
+  size,
+  onResize,
+  columnPx,
+  rowPx,
+  gapPx = 16,
+  maxWidth,
+}: SortableWidgetCellProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
   });
+
+  const startRef = useRef<{
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  } | null>(null);
+
+  const handleResizePointerDown = useCallback(
+    (event: ReactPointerEvent<HTMLButtonElement>) => {
+      if (!onResize || !size || !columnPx || !rowPx) return;
+      event.preventDefault();
+      event.stopPropagation();
+      startRef.current = {
+        x: event.clientX,
+        y: event.clientY,
+        width: size.width,
+        height: size.height,
+      };
+      const cap = event.currentTarget;
+      cap.setPointerCapture(event.pointerId);
+      const onMove = (ev: PointerEvent) => {
+        if (!startRef.current) return;
+        const dx = ev.clientX - startRef.current.x;
+        const dy = ev.clientY - startRef.current.y;
+        const stepX = columnPx + gapPx;
+        const stepY = rowPx + gapPx;
+        const nextWidth = clamp(startRef.current.width + Math.round(dx / stepX), 1, maxWidth ?? 12);
+        const nextHeight = clamp(startRef.current.height + Math.round(dy / stepY), 1, MAX_HEIGHT);
+        onResize({ width: nextWidth, height: nextHeight });
+      };
+      const onUp = (ev: PointerEvent) => {
+        startRef.current = null;
+        if (cap.hasPointerCapture(ev.pointerId)) cap.releasePointerCapture(ev.pointerId);
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+        window.removeEventListener('pointercancel', onUp);
+      };
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+      window.addEventListener('pointercancel', onUp);
+    },
+    [onResize, size, columnPx, rowPx, gapPx, maxWidth]
+  );
 
   const style = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.6 : undefined,
   };
+
+  const canResize = Boolean(onResize && size && columnPx && rowPx);
 
   return (
     <div
@@ -35,19 +126,75 @@ export function SortableWidgetCell({ id, children }: SortableWidgetCellProps) {
       data-slot="sortable-widget-cell"
       data-widget-slug={id}
       data-dragging={isDragging || undefined}
-      className="relative"
+      className="group/cell relative"
     >
       <button
         type="button"
         data-slot="sortable-widget-handle"
         aria-label={`Drag widget ${id}`}
-        className="absolute left-2 top-2 z-10 cursor-grab rounded-md border bg-card/80 px-1.5 py-0.5 text-xs text-muted-foreground shadow-sm hover:text-foreground active:cursor-grabbing"
+        className="absolute left-1 top-1 z-10 flex h-6 w-6 cursor-grab items-center justify-center rounded text-muted-foreground/40 opacity-0 transition-opacity hover:bg-accent hover:text-foreground focus-visible:opacity-100 group-hover/cell:opacity-100 active:cursor-grabbing"
         {...attributes}
         {...listeners}
       >
-        ⋮⋮
+        <GripVerticalIcon />
       </button>
       {children}
+      {canResize ? (
+        <button
+          type="button"
+          data-slot="sortable-widget-resize-handle"
+          aria-label={`Resize widget ${id}`}
+          onPointerDown={handleResizePointerDown}
+          className="absolute bottom-0 right-0 z-10 flex h-4 w-4 cursor-se-resize items-center justify-center rounded-tl-md text-muted-foreground/40 opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover/cell:opacity-100"
+        >
+          <ResizeCornerIcon />
+        </button>
+      ) : null}
     </div>
+  );
+}
+
+function GripVerticalIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="9" cy="5" r="1" />
+      <circle cx="9" cy="12" r="1" />
+      <circle cx="9" cy="19" r="1" />
+      <circle cx="15" cy="5" r="1" />
+      <circle cx="15" cy="12" r="1" />
+      <circle cx="15" cy="19" r="1" />
+    </svg>
+  );
+}
+
+function ResizeCornerIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="12"
+      height="12"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <line x1="20" y1="20" x2="20" y2="14" />
+      <line x1="20" y1="20" x2="14" y2="20" />
+      <line x1="20" y1="20" x2="9" y2="9" />
+    </svg>
   );
 }

--- a/packages/@granit/react-dashboard-editor/src/index.ts
+++ b/packages/@granit/react-dashboard-editor/src/index.ts
@@ -19,6 +19,7 @@ export { TextConfigForm } from './components/forms/text-config-form.js';
 
 // Pure helpers — exported for tests + custom palette / DnD wrappers
 export { reorderWidgets } from './lib/reorder-widgets.js';
+export { resizeWidget } from './lib/resize-widget.js';
 export { addWidget, composeCatalogs, defaultWidgetCatalog } from './lib/widget-catalog.js';
 export type { WidgetCatalogEntry } from './lib/widget-catalog.js';
 export { removeWidget, updateWidget } from './lib/update-widget.js';

--- a/packages/@granit/react-dashboard-editor/src/lib/resize-widget.ts
+++ b/packages/@granit/react-dashboard-editor/src/lib/resize-widget.ts
@@ -1,0 +1,49 @@
+import type { DashboardDefinition, WidgetSize } from '@granit/dashboards';
+
+/**
+ * Hard cap on widget height in grid rows. The framework grid is 12
+ * columns wide by convention; height has no protocol-level limit but
+ * 12 rows is plenty for any single tile (a full-screen 12×12 widget
+ * is ~960px at the default 80px row height) and the cap prevents
+ * runaway gestures from making a cell taller than the viewport.
+ */
+const MAX_HEIGHT_ROWS = 12;
+
+/**
+ * Clamps a value into `[min, max]` (inclusive).
+ */
+function clamp(value: number, min: number, max: number): number {
+  if (value < min) return min;
+  if (value > max) return max;
+  return value;
+}
+
+/**
+ * Returns a fresh `DashboardDefinition` with the widget identified by
+ * `slug` resized to `size`. Width is clamped to
+ * `[1, definition.layout.columns]`; height is clamped to
+ * `[1, MAX_HEIGHT_ROWS]`. Returns the original definition unchanged
+ * when the slug is unknown or the clamped size is identical to the
+ * widget's current size — lets callers diff cheaply with referential
+ * equality.
+ *
+ * Pure function — pairs with `reorderWidgets` and `addWidget` /
+ * `removeWidget` from the same `lib/` namespace.
+ */
+export function resizeWidget(
+  definition: DashboardDefinition,
+  slug: string,
+  size: WidgetSize
+): DashboardDefinition {
+  const targetWidth = clamp(size.width, 1, definition.layout.columns);
+  const targetHeight = clamp(size.height, 1, MAX_HEIGHT_ROWS);
+  let mutated = false;
+  const widgets = definition.widgets.map((widget) => {
+    if (widget.slug !== slug) return widget;
+    if (widget.size.width === targetWidth && widget.size.height === targetHeight) return widget;
+    mutated = true;
+    return { ...widget, size: { width: targetWidth, height: targetHeight } };
+  });
+  if (!mutated) return definition;
+  return { ...definition, widgets };
+}


### PR DESCRIPTION
## Summary

Two related editor improvements surfaced by showcase user feedback on the dashboard composer:

1. **Drag handle polish.** The placeholder text `⋮⋮` button bled into the widget body. Replaces with a `GripVertical` SVG inside a smaller, hover-reveal button — stays out of the way until the cell is hovered or focused, matches the visual weight of the rest of the toolbar.
2. **Drag-to-resize.** New bottom-right corner handle on every cell. The gesture snaps to integer grid cells using the live column width (measured via `ResizeObserver` on the grid container) and the configured row height. Width clamps to `[1, layout.columns]`, height to `[1, 12]`. Live updates fire on every pointer move so the grid reflows under the cursor — the parent's `onChange` handler is the same path the existing reorder gesture uses.

## API additions

- `resizeWidget(definition, slug, size)` pure helper alongside `reorderWidgets` / `addWidget` / etc. Returns the original definition by reference when the slug is unknown or the size is unchanged so callers can diff cheaply.
- `<SortableWidgetCell>` accepts five new optional props (`size`, `onResize`, `columnPx`, `rowPx`, `gapPx`, `maxWidth`). The resize handle only renders when all the metrics are wired — apps consuming the cell directly without the editor wrapper still work unchanged.

`ResizeObserver` is feature-detected so JSDOM-based tests still mount the editor (the resize handle just doesn't move without a width signal). All existing tests pass; new test file covers `resizeWidget`'s clamp + equality semantics.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm exec vitest run packages/@granit/react-dashboard-editor` — 49 tests passing (6 new for `resizeWidget`)
- [ ] In the showcase: hover a widget → grip + resize handles fade in; drag corner → cell snaps to new width/height; release → save button enables.
