### PR TITLE
fix(dashboards): drop the index-signature constraint from WidgetDefinition union

### DIFF
--- a/packages/@granit/dashboards/src/types/widget-definition.ts
+++ b/packages/@granit/dashboards/src/types/widget-definition.ts
@@ -119,11 +119,20 @@ export type FrameworkWidgetDefinition =
   | TextWidgetDefinition;
 
 /**
- * Open-ended widget definition — accepts any `type` string plus arbitrary
- * extra fields. This is what dashboard payloads are typed as on the wire
- * (a host can persist Analytics widgets, IoT widgets, etc., and the framework
- * treats them uniformly until a registered renderer is found for the `type`).
+ * Open-ended widget definition — accepts any `type` string plus the
+ * common base fields. Downstream packages (`@granit/analytics`,
+ * `@granit/iot`, …) ship their own `extends WidgetDefinitionBase`
+ * interfaces and feed them through this generic alias so the framework
+ * treats every widget uniformly until a registered renderer narrows on
+ * the `type` discriminator.
+ *
+ * The fallback alternative is `WidgetDefinitionBase` directly — not
+ * `WidgetDefinitionBase & Readonly<Record<string, unknown>>`. The
+ * intersection with an index signature was meant to encode "you may
+ * have extra fields", but typed interfaces don't structurally satisfy
+ * `Record<string, unknown>` (no implicit index signatures), so it
+ * rejected every concrete extension. The framework never reads extra
+ * fields by index — registered renderers narrow on `type` and access
+ * their own typed fields.
  */
-export type WidgetDefinition =
-  | FrameworkWidgetDefinition
-  | (WidgetDefinitionBase & Readonly<Record<string, unknown>>);
+export type WidgetDefinition = FrameworkWidgetDefinition | WidgetDefinitionBase;


### PR DESCRIPTION
## Summary

The fallback alternative on `WidgetDefinition` was `WidgetDefinitionBase & Readonly<Record<string, unknown>>`. The intersection was meant to encode "you may have extra fields beyond the base", but typed interfaces don't structurally satisfy `Record<string, unknown>` (TypeScript doesn't infer implicit index signatures). So the union rejected every concrete extension — showcase fixtures composing `KpiWidgetDefinition` / `MapWidgetDefinition` arrays errored with `Index signature for type 'string' is missing in type 'KpiWidgetDefinition'`.

Drops the intersection — the union becomes `FrameworkWidgetDefinition | WidgetDefinitionBase`. The framework never reads extra fields by index (registered renderers narrow on `type` and access their own typed fields), so the constraint was dead weight that broke downstream typings without buying anything.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm exec vitest run packages/@granit/dashboards packages/@granit/react-dashboards packages/@granit/react-dashboard-editor` — 277 tests passing
- [ ] Showcase: `tsc -b` no longer flags `KpiWidgetDefinition is not assignable to WidgetDefinition` on `sample-finance-dashboard.ts:80`.
