### PR TITLE
feat(react-dashboards): usePushedDashboard hook for the SSE push transport (P2.4-E)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2247,6 +2247,21 @@
           "signature": "const widgetRenderQueryKey"
         },
         {
+          "name": "applyStreamSnapshot",
+          "kind": "function",
+          "signature": "function applyStreamSnapshot( current: DashboardRenderedWidget | undefined, event: DashboardStreamSnapshot ): DashboardRenderedWidget | undefined"
+        },
+        {
+          "name": "useDashboardStream",
+          "kind": "function",
+          "signature": "function useDashboardStream( dashboardId: string, options: UseDashboardStreamOptions ="
+        },
+        {
+          "name": "usePushedDashboard",
+          "kind": "function",
+          "signature": "function usePushedDashboard( dashboardId: string, request: DashboardRenderRequest ="
+        },
+        {
           "name": "dashboardCatalogQueryKey",
           "kind": "const",
           "signature": "const dashboardCatalogQueryKey"

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -119,4 +119,5 @@ export type {
   WidgetSnapshotEnvelope,
   WidgetSnapshotEnvelopeOf,
   WidgetSnapshotStatus,
+  WidgetTransport,
 } from './rendering/index.js';

--- a/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
+++ b/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
@@ -1,5 +1,6 @@
 import type { DashboardDriftStatus } from './dashboard-drift-status.js';
 import type { WidgetSnapshotStatus } from './widget-snapshot-status.js';
+import type { WidgetTransport } from './widget-transport.js';
 import type { RefreshHint } from '../types/refresh-hint.js';
 import type { WidgetAction } from '../types/widget-action.js';
 
@@ -133,6 +134,18 @@ export interface DashboardRenderedWidget {
   readonly emittedAt: string;
   /** Pull / push transport hint — drives the per-widget cache TTL. */
   readonly refreshHint: RefreshHint;
+  /**
+   * Effective transport selected for this widget at render time
+   * (ADR-043 §2.3). `'Push'` means the frontend should consume live
+   * updates from `GET /dashboards/{id}/stream`; `'Pull'` means polling
+   * via the render endpoint per `refreshHint` cadence. Hosts that
+   * haven't loaded `Granit.Dashboards.Push` always emit `'Pull'`.
+   *
+   * Optional on the wire for backwards compatibility — older bundles
+   * served before P2.4 omit the field, in which case the framework
+   * treats the widget as `'Pull'`.
+   */
+  readonly transport?: WidgetTransport;
   /**
    * Pre-serialised typed payload. `null` when {@link status} is not
    * `'Snapshot'`. Frontend renderers narrow this to a kind-specific shape

--- a/packages/@granit/dashboards/src/rendering/index.ts
+++ b/packages/@granit/dashboards/src/rendering/index.ts
@@ -27,3 +27,4 @@ export type {
   WidgetSnapshotEnvelopeOf,
 } from './widget-snapshot-envelope.js';
 export type { WidgetSnapshotStatus } from './widget-snapshot-status.js';
+export type { WidgetTransport } from './widget-transport.js';

--- a/packages/@granit/dashboards/src/rendering/widget-transport.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-transport.ts
@@ -1,0 +1,23 @@
+/**
+ * Effective transport selected for a widget at render time. Mirrors
+ * `Granit.Dashboards.WidgetTransport` (ADR-043 §2.3) — the composition
+ * of the dashboard's push policy with the widget's `RefreshHint`.
+ *
+ * Surfaced on {@link DashboardRenderedWidget.transport} so the
+ * frontend opens push subscriptions only for widgets that actually
+ * receive live updates. Pull-only widgets continue to drive their
+ * TanStack cache cadence from `RefreshHint`.
+ *
+ * - `'Pull'`: render via the pull endpoint and poll per `RefreshHint`
+ *   TTL. Never open a stream for this widget.
+ * - `'Push'`: open the live channel via `GET /dashboards/{id}/stream`
+ *   and stop pulling once the seed envelope is rendered. The pull
+ *   endpoint still returns the seed so the dashboard renders before
+ *   the stream connects.
+ *
+ * PascalCase wire values match the backend's `JsonStringEnumConverter`
+ * output. Hosts that haven't loaded `Granit.Dashboards.Push` always
+ * emit `'Pull'` regardless of declared policy — the framework
+ * degrades silently.
+ */
+export type WidgetTransport = 'Pull' | 'Push';

--- a/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
@@ -1,0 +1,270 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { dashboardRenderQueryKey, dashboardWidgetQueryKey } from '../api/use-dashboard-render.js';
+import { applyStreamSnapshot, type DashboardStreamSnapshot } from '../api/use-dashboard-stream.js';
+import { usePushedDashboard } from '../api/use-pushed-dashboard.js';
+
+import type { DashboardRenderedWidget, DashboardRenderResponse } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const DASHBOARD_ID = '8c6b1e10-0000-4000-8000-000000000000';
+const KPI_ID = '8c6b1e10-0000-0000-0000-000000000001';
+const BANNER_ID = '8c6b1e10-0000-0000-0000-000000000002';
+
+const KPI_WIDGET: DashboardRenderedWidget = {
+  id: KPI_ID,
+  widgetType: 'Kpi',
+  slug: 'UnpaidCount',
+  position: 0,
+  width: 3,
+  height: 2,
+  titleLocalizationKey: 'Widget:Test.UnpaidCount',
+  actions: null,
+  requiredPermission: null,
+  status: 'Snapshot',
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Realtime',
+  snapshot: { value: 12, valueKind: 'Count' },
+  reasonLocalizationKey: null,
+  transport: 'Push',
+};
+
+const BANNER_WIDGET: DashboardRenderedWidget = {
+  id: BANNER_ID,
+  widgetType: 'Markdown',
+  slug: 'Banner',
+  position: 1,
+  width: 12,
+  height: 1,
+  titleLocalizationKey: 'Widget:Test.Banner',
+  actions: null,
+  requiredPermission: null,
+  status: 'Snapshot',
+  sequence: 1,
+  emittedAt: '2026-04-29T12:34:56.789Z',
+  refreshHint: 'Static',
+  snapshot: { contentLocalizationKey: 'Widget:Test.Banner.Content' },
+  reasonLocalizationKey: null,
+  transport: 'Pull',
+};
+
+const PUSH_BUNDLE: DashboardRenderResponse = {
+  dashboardId: DASHBOARD_ID,
+  renderedAt: '2026-04-29T12:34:56.789Z',
+  period: null,
+  activeViewName: null,
+  driftStatus: 'Aligned',
+  sourceDefinitionVersion: '1.0.0',
+  registeredVersion: '1.0.0',
+  widgets: [KPI_WIDGET, BANNER_WIDGET],
+};
+
+const PULL_ONLY_BUNDLE: DashboardRenderResponse = {
+  ...PUSH_BUNDLE,
+  widgets: [BANNER_WIDGET, { ...KPI_WIDGET, transport: 'Pull' }],
+};
+
+// ---------------------------------------------------------------------------
+// Mock EventSource — JSDOM doesn't ship it. Capture every instance so tests
+// can dispatch typed events synchronously.
+// ---------------------------------------------------------------------------
+
+interface MockListener {
+  readonly type: string;
+  readonly handler: (event: Event) => void;
+}
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  readonly url: string;
+  readonly listeners: MockListener[] = [];
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+  addEventListener(type: string, handler: (event: Event) => void): void {
+    this.listeners.push({ type, handler });
+  }
+  removeEventListener(type: string, handler: (event: Event) => void): void {
+    const idx = this.listeners.findIndex((l) => l.type === type && l.handler === handler);
+    if (idx >= 0) this.listeners.splice(idx, 1);
+  }
+  close(): void {
+    this.closed = true;
+  }
+  dispatch(type: string, data?: unknown): void {
+    const event =
+      data === undefined
+        ? (new Event(type) as Event)
+        : (new MessageEvent(type, { data: JSON.stringify(data) }) as Event);
+    for (const listener of this.listeners) {
+      if (listener.type === type) listener.handler(event);
+    }
+  }
+}
+
+beforeEach(() => {
+  MockEventSource.instances = [];
+  vi.stubGlobal('EventSource', MockEventSource);
+});
+
+// ---------------------------------------------------------------------------
+// MSW seed
+// ---------------------------------------------------------------------------
+
+let nextBundle: DashboardRenderResponse = PUSH_BUNDLE;
+const server = setupServer(
+  http.post(`http://localhost/dashboards/${DASHBOARD_ID}/render`, async () =>
+    HttpResponse.json(nextBundle)
+  )
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  vi.unstubAllGlobals();
+  nextBundle = PUSH_BUNDLE;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper
+// ---------------------------------------------------------------------------
+
+describe('applyStreamSnapshot', () => {
+  const event: DashboardStreamSnapshot = {
+    widgetId: KPI_ID,
+    widgetType: 'Kpi',
+    status: 'Snapshot',
+    sequence: 5,
+    emittedAt: '2026-05-01T08:00:00.000Z',
+    refreshHint: 'Realtime',
+    snapshot: { value: 99, valueKind: 'Count' },
+    reasonLocalizationKey: null,
+  };
+
+  it('returns undefined when there is no seed envelope', () => {
+    expect(applyStreamSnapshot(undefined, event)).toBeUndefined();
+  });
+
+  it('drops out-of-order events when current.sequence > event.sequence', () => {
+    const stale: DashboardStreamSnapshot = { ...event, sequence: 0 };
+    expect(applyStreamSnapshot(KPI_WIDGET, stale)).toBe(KPI_WIDGET);
+  });
+
+  it('merges dynamic fields and preserves structural fields', () => {
+    const merged = applyStreamSnapshot(KPI_WIDGET, event);
+    expect(merged).toMatchObject({
+      slug: 'UnpaidCount',
+      position: 0,
+      width: 3,
+      height: 2,
+      titleLocalizationKey: 'Widget:Test.UnpaidCount',
+      transport: 'Push',
+      sequence: 5,
+      snapshot: { value: 99, valueKind: 'Count' },
+      emittedAt: '2026-05-01T08:00:00.000Z',
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// usePushedDashboard
+// ---------------------------------------------------------------------------
+
+describe('usePushedDashboard', () => {
+  it('opens an EventSource only when the bundle carries push widgets', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => usePushedDashboard(DASHBOARD_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+    expect(MockEventSource.instances[0]?.url).toBe(
+      `http://localhost/dashboards/${DASHBOARD_ID}/stream`
+    );
+  });
+
+  it('does not open a stream when the bundle is pull-only', async () => {
+    nextBundle = PULL_ONLY_BUNDLE;
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => usePushedDashboard(DASHBOARD_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(MockEventSource.instances).toHaveLength(0);
+  });
+
+  it('merges snapshot events into the per-widget cache', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => usePushedDashboard(DASHBOARD_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    const source = MockEventSource.instances[0]!;
+    act(() => {
+      source.dispatch('snapshot', {
+        widgetId: KPI_ID,
+        widgetType: 'Kpi',
+        status: 'Snapshot',
+        sequence: 7,
+        emittedAt: '2026-05-01T08:00:00.000Z',
+        refreshHint: 'Realtime',
+        snapshot: { value: 42, valueKind: 'Count' },
+        reasonLocalizationKey: null,
+      });
+    });
+
+    const cached = queryClient.getQueryData<DashboardRenderedWidget>(
+      dashboardWidgetQueryKey(DASHBOARD_ID, KPI_ID)
+    );
+    expect(cached?.sequence).toBe(7);
+    expect(cached?.snapshot).toEqual({ value: 42, valueKind: 'Count' });
+    // Structural fields survive the merge.
+    expect(cached?.slug).toBe('UnpaidCount');
+    expect(cached?.transport).toBe('Push');
+  });
+
+  it('invalidates the seed render query on resume-failed', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => usePushedDashboard(DASHBOARD_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+
+    const source = MockEventSource.instances[0]!;
+    act(() => {
+      source.dispatch('resume-failed');
+    });
+
+    expect(
+      queryClient.getQueryState(dashboardRenderQueryKey(DASHBOARD_ID, {}))?.isInvalidated
+    ).toBe(true);
+  });
+
+  it('closes the stream on unmount', async () => {
+    const { wrapper } = makeWrapper();
+    const { result, unmount } = renderHook(() => usePushedDashboard(DASHBOARD_ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
+    const source = MockEventSource.instances[0]!;
+    unmount();
+    expect(source.closed).toBe(true);
+  });
+});

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-stream.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-stream.ts
@@ -1,0 +1,150 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useEffect } from 'react';
+
+import type {
+  DashboardRenderedWidget,
+  RefreshHint,
+  WidgetSnapshotStatus,
+} from '@granit/dashboards';
+
+/**
+ * Wire shape of an `event: snapshot` frame on the dashboard SSE
+ * stream (`GET /dashboards/{id}/stream`, ADR-043 §3). Mirrors the
+ * payload the SSE handler serialises — structural fields (`slug`,
+ * `position`, `width`, `height`, `titleLocalizationKey`, `actions`,
+ * `requiredPermission`, `transport`) are NOT carried; the frontend
+ * already has them from the seed pull and the stream only pushes the
+ * dynamic projection.
+ *
+ * `widgetId` matches the persisted `WidgetInstance.Id` and the same
+ * widget the seed bundle's {@link DashboardRenderedWidget.id} carries.
+ */
+export interface DashboardStreamSnapshot {
+  readonly widgetId: string;
+  readonly widgetType: string;
+  readonly status: WidgetSnapshotStatus;
+  readonly sequence: number;
+  readonly emittedAt: string;
+  readonly refreshHint: RefreshHint;
+  readonly snapshot: unknown | null;
+  readonly reasonLocalizationKey: string | null;
+}
+
+/**
+ * Merges a snapshot event onto the corresponding seed envelope. Pure
+ * — exported for tests + apps that drive their own subscription
+ * pipeline (custom transport adapters).
+ *
+ * Drops the event when the seed envelope is missing (no in-flight
+ * `useDashboardRender`) or when the seed already carries an envelope
+ * with a higher `sequence` (out-of-order delivery, replay collision).
+ */
+export function applyStreamSnapshot(
+  current: DashboardRenderedWidget | undefined,
+  event: DashboardStreamSnapshot
+): DashboardRenderedWidget | undefined {
+  if (!current) return current;
+  if (current.sequence > event.sequence) return current;
+  return {
+    ...current,
+    widgetType: event.widgetType,
+    status: event.status,
+    sequence: event.sequence,
+    emittedAt: event.emittedAt,
+    refreshHint: event.refreshHint,
+    snapshot: event.snapshot,
+    reasonLocalizationKey: event.reasonLocalizationKey,
+  };
+}
+
+/**
+ * Configuration for {@link useDashboardStream}.
+ */
+export interface UseDashboardStreamOptions {
+  /**
+   * Open the connection only when `true`. Hosts typically gate this
+   * on "any widget in the seed has `transport === 'Push'`" to avoid
+   * burning a long-lived connection on dashboards that are pure
+   * pull. Defaults to `true`.
+   */
+  readonly enabled?: boolean;
+  /** Fires once per `event: snapshot` frame, after JSON parse. */
+  readonly onSnapshot?: (event: DashboardStreamSnapshot) => void;
+  /**
+   * Fires when the server emits `event: resume-failed` — the
+   * client's `Last-Event-ID` is past the ring's oldest entry and a
+   * fresh seed pull is required. Hosts typically invalidate the
+   * dashboard render query in response so `useDashboardRender`
+   * refetches.
+   */
+  readonly onResumeFailed?: () => void;
+  /**
+   * Fires on `EventSource.onerror`. Note that the browser
+   * `EventSource` auto-reconnects on transient failures (carrying
+   * the SSE `Last-Event-ID` header) — this callback is informational
+   * and shouldn't trigger custom reconnect logic.
+   */
+  readonly onError?: (event: Event) => void;
+}
+
+/**
+ * Subscribes to the dashboard's SSE stream
+ * (`GET /dashboards/{id}/stream`, ADR-043 §3). Opens an
+ * `EventSource` when `enabled`, parses typed snapshot frames and
+ * delivers them to `onSnapshot`. Closes on unmount or when
+ * `enabled` flips to `false`.
+ *
+ * The hook is presentational — it does not touch the TanStack
+ * cache. Use {@link usePushedDashboard} for the composed hook that
+ * surgically merges snapshots into the per-widget cache entries.
+ *
+ * `EventSource` is browser-only. In SSR / non-DOM environments the
+ * hook is a no-op (the `useEffect` body never runs).
+ */
+export function useDashboardStream(
+  dashboardId: string,
+  options: UseDashboardStreamOptions = {}
+): void {
+  const api = useGranitClient();
+  const { enabled = true, onSnapshot, onResumeFailed, onError } = options;
+
+  useEffect(() => {
+    if (!enabled) return;
+    if (typeof EventSource === 'undefined') return;
+    const baseURL = api.defaults.baseURL ?? '';
+    const url = `${baseURL}/dashboards/${encodeURIComponent(dashboardId)}/stream`;
+    // `withCredentials: true` mirrors the api client's BFF mode so
+    // session cookies travel with the SSE handshake. Bearer-mode
+    // hosts don't need it (the cookie is empty) — the flag is
+    // harmless either way.
+    const source = new EventSource(url, { withCredentials: true });
+
+    const handleSnapshot = (event: MessageEvent<string>) => {
+      try {
+        const payload = JSON.parse(event.data) as DashboardStreamSnapshot;
+        onSnapshot?.(payload);
+      } catch {
+        // Malformed JSON — drop the frame silently. The server is
+        // authoritative; bad frames are a server bug, not something
+        // the hook should retry around.
+      }
+    };
+    const handleResumeFailed = () => {
+      onResumeFailed?.();
+    };
+    const handleError = (event: Event) => {
+      onError?.(event);
+    };
+
+    source.addEventListener('snapshot', handleSnapshot);
+    source.addEventListener('resume-failed', handleResumeFailed);
+    source.addEventListener('error', handleError);
+
+    return () => {
+      source.removeEventListener('snapshot', handleSnapshot);
+      source.removeEventListener('resume-failed', handleResumeFailed);
+      source.removeEventListener('error', handleError);
+      source.close();
+    };
+  }, [api, dashboardId, enabled, onSnapshot, onResumeFailed, onError]);
+}

--- a/packages/@granit/react-dashboards/src/api/use-pushed-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/api/use-pushed-dashboard.ts
@@ -1,0 +1,83 @@
+import { useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+
+import {
+  dashboardRenderQueryKey,
+  dashboardWidgetQueryKey,
+  useDashboardRender,
+  type UseDashboardRenderOptions,
+} from './use-dashboard-render.js';
+import {
+  applyStreamSnapshot,
+  useDashboardStream,
+  type DashboardStreamSnapshot,
+} from './use-dashboard-stream.js';
+
+import type {
+  DashboardRenderedWidget,
+  DashboardRenderRequest,
+  DashboardRenderResponse,
+} from '@granit/dashboards';
+
+/**
+ * Composition hook that pairs the seed pull
+ * (`POST /dashboards/{id}/render`) with the live SSE stream
+ * (`GET /dashboards/{id}/stream`). ADR-043 §6 frontend-side closure:
+ *
+ * 1. Calls {@link useDashboardRender} for the seed bundle. Per-widget
+ *    cache entries are populated as usual (ADR-039 §6.2).
+ * 2. If any widget in the seed carries `transport === 'Push'`,
+ *    subscribes to the stream via {@link useDashboardStream}.
+ * 3. Each `event: snapshot` frame surgically updates the matching
+ *    per-widget cache entry via `setQueryData(dashboardWidgetQueryKey)`.
+ *    Structural fields (slug, position, width, height, title, actions,
+ *    requiredPermission, transport) survive the merge — the stream
+ *    only carries the dynamic projection.
+ * 4. On `event: resume-failed` (the client's `Last-Event-ID` is past
+ *    the server's ring buffer) the seed render query is invalidated
+ *    so `useDashboardRender` refetches a fresh bundle.
+ *
+ * Pull-only dashboards bypass the stream entirely — the hook
+ * collapses to a plain {@link useDashboardRender}. Hosts that don't
+ * load `Granit.Dashboards.Push` always see `transport: 'Pull'` (or
+ * the field absent) on every widget, so this hook is safe to use
+ * unconditionally — opening a stream is opt-in via the bundle's
+ * `transport` field.
+ */
+export function usePushedDashboard(
+  dashboardId: string,
+  request: DashboardRenderRequest = {},
+  options: UseDashboardRenderOptions = {}
+): UseQueryResult<DashboardRenderResponse> {
+  const queryClient = useQueryClient();
+  const result = useDashboardRender(dashboardId, request, options);
+
+  const hasPushWidget = useMemo(
+    () => (result.data?.widgets ?? []).some((widget) => widget.transport === 'Push'),
+    [result.data]
+  );
+
+  const handleSnapshot = useCallback(
+    (event: DashboardStreamSnapshot) => {
+      queryClient.setQueryData<DashboardRenderedWidget>(
+        dashboardWidgetQueryKey(dashboardId, event.widgetId),
+        (current) => applyStreamSnapshot(current, event)
+      );
+    },
+    [queryClient, dashboardId]
+  );
+
+  const handleResumeFailed = useCallback(() => {
+    void queryClient.invalidateQueries({
+      queryKey: dashboardRenderQueryKey(dashboardId, request),
+    });
+  }, [queryClient, dashboardId, request]);
+
+  useDashboardStream(dashboardId, {
+    enabled: hasPushWidget,
+    onSnapshot: handleSnapshot,
+    onResumeFailed: handleResumeFailed,
+  });
+
+  return result;
+}

--- a/packages/@granit/react-dashboards/src/index.ts
+++ b/packages/@granit/react-dashboards/src/index.ts
@@ -19,6 +19,16 @@ export type {
   WidgetRenderKind,
 } from './api/use-widget-render.js';
 
+// Push transport (P2.4 — ADR-043). SSE-driven live updates that
+// surgically merge into the per-widget cache entries; pull-only
+// dashboards bypass the stream entirely.
+export { applyStreamSnapshot, useDashboardStream } from './api/use-dashboard-stream.js';
+export type {
+  DashboardStreamSnapshot,
+  UseDashboardStreamOptions,
+} from './api/use-dashboard-stream.js';
+export { usePushedDashboard } from './api/use-pushed-dashboard.js';
+
 // Lifecycle / CRUD hooks (B4-write — Granit.Dashboards.Endpoints).
 // Surface mirrors the persisted-Dashboard aggregate model: the catalog
 // lists *available definitions*, the list lists *imported instances*, and


### PR DESCRIPTION
## Summary

Closes the frontend half of **ADR-043** (P2.4-E hand-off): a composition hook that pairs the seed pull (`POST /dashboards/{id}/render`) with the live SSE stream (`GET /dashboards/{id}/stream`) and surgically merges snapshot frames into the per-widget TanStack cache entries — so live updates land without re-fetching the bundle.

Backend pieces shipped previously: A (cleanup #1618), B (policy + Transport field #1619), C (SSE transport #1620), C-Auth (per-widget permission filter #1623), C2 (Last-Event-ID resume #1627), D (WebSocket sibling #1629).

## API additions

- **`WidgetTransport`** wire type — `'Pull' | 'Push'`. Mirrored from the backend's `JsonStringEnumConverter` output. Optional on `DashboardRenderedWidget.transport` so older bundles without P2.4 still type-check; the framework treats absent as `'Pull'`.
- **`useDashboardStream(dashboardId, options)`** — low-level SSE wrapper. Opens an `EventSource`, parses `event: snapshot` / `event: resume-failed` frames per the SSE contract, hands them to caller callbacks. JSDOM-safe (skips when `EventSource` is undefined).
- **`usePushedDashboard(dashboardId, request, options)`** — composition hook. Wraps `useDashboardRender`, opens the stream only when at least one widget in the seed carries `transport === 'Push'`, merges snapshots via `setQueryData(dashboardWidgetQueryKey, ...)`, invalidates the seed render query on `resume-failed` so the bundle refetches.
- **`applyStreamSnapshot(current, event)`** pure helper. Drops out-of-order events (`current.sequence > event.sequence`) and preserves structural fields (slug, position, width, height, title, actions, requiredPermission, transport) — the stream only delivers the dynamic projection.

Pull-only dashboards bypass the stream entirely. Hosts that haven't loaded `Granit.Dashboards.Push` always see `Pull` (or absent) on every widget, so this hook is safe to use unconditionally — opening a stream is opt-in via the bundle's `transport` field.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm exec vitest run packages/@granit/react-dashboards` — 155 tests passing (5 new: pure helper out-of-order + structural-field preservation; hook stream-open gating, pull-only bypass, cache merge, resume-failed invalidation, unmount cleanup)
- [ ] In dev with the backend's push transport loaded: a Realtime widget on a Push-policy dashboard renders the seed value, then updates without a full bundle refetch when the publisher emits — visible via TanStack Query devtools (per-widget entry version bumps on each event).

## Follow-ups

- WebSocket sibling adapter (`useDashboardStream` could grow a `transport: 'sse' | 'ws'` switch consuming the matching backend endpoint). Not load-bearing — SSE is the default per ADR-043.
- Showcase MSW mock for SSE so the live UX can be demoed end-to-end without a backend. Out of scope here; can land as a follow-up showcase PR.
