### PR TITLE
feat(entities,workspaces,entities-views): scaffold Phase 1 packages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -600,6 +600,16 @@
       ]
     },
     {
+      "name": "@granit/entities",
+      "description": "Framework-agnostic types and helpers for the Granit entity manifest — EntityDefinition discovery / metadata DTOs, form / detail / relation descriptors, visibility DSL evaluator (mirrors Granit.Entities.Abstractions + Granit.Entities.Endpoints.Dtos)",
+      "exports": []
+    },
+    {
+      "name": "@granit/entities-views",
+      "description": "Framework-agnostic types and helpers for Granit saved views — EntityView aggregate, visibility (Personal / Shared / Tenant), pin / default / personal-default flags, basedOn delta model (mirrors Granit.Entities.Views.Domain)",
+      "exports": []
+    },
+    {
       "name": "@granit/error-boundary",
       "description": "Structured error capture with React error boundary and global listeners",
       "exports": [
@@ -2684,6 +2694,16 @@
       ]
     },
     {
+      "name": "@granit/react-entities",
+      "description": "React renderer for @granit/entities — manifest hooks (useEntityDiscovery / useEntityMetadata) and the four generic renderers (EntityList, EntityKanban, EntityForm, EntityDetail) wired to the standard widget catalog",
+      "exports": []
+    },
+    {
+      "name": "@granit/react-entities-views",
+      "description": "React hooks + view tab strip for @granit/entities-views — CRUD / pin / star / share / set-default hooks plus the EntityViewTabStrip component (dirty badge, save-as-new, Notion-style 'Save for everyone' promotion)",
+      "exports": []
+    },
+    {
       "name": "@granit/react-error-boundary",
       "description": "React bindings for @granit/error-boundary — GranitErrorBoundary, GlobalErrorCapture, ErrorContextProvider",
       "exports": [
@@ -4099,6 +4119,11 @@
       ]
     },
     {
+      "name": "@granit/react-workspaces",
+      "description": "React renderer for @granit/workspaces — WorkspaceNav sidebar, /w/{workspace}/... routing, Notion-style SidePeek with ⌘+⇧+. expand, and the landing-route resolver hook",
+      "exports": []
+    },
+    {
       "name": "@granit/reference-data",
       "description": "Generic reference data types and API — mirrors Granit.ReferenceData .NET",
       "exports": []
@@ -4457,6 +4482,11 @@
           "signature": "type WorkflowHistoryPage = PagedResult<TransitionHistory>"
         }
       ]
+    },
+    {
+      "name": "@granit/workspaces",
+      "description": "Framework-agnostic types and helpers for the Granit workspace tree — WorkspaceDefinition / sections / items, landing route response, typed preset overlay (mirrors Granit.Workspaces.Abstractions + Granit.Workspaces.Endpoints.Dtos)",
+      "exports": []
     }
   ]
 }

--- a/packages/@granit/entities-views/README.md
+++ b/packages/@granit/entities-views/README.md
@@ -1,0 +1,32 @@
+# @granit/entities-views
+
+Framework-agnostic types and helpers for Granit saved views.
+
+## Why
+
+Saved views are how users carve a list down to "their slice": their open
+deals, their team's overdue invoices, the tenant-wide default kanban for
+support tickets. The .NET side promotes them to a first-class aggregate
+(`Granit.Entities.Views`) with a delta model — a view stacks on top of a
+base view and stores only what differs, so renaming a column on the base
+view doesn't fork every personal copy.
+
+This package owns the JavaScript-side contracts for that aggregate, plus
+the pure helpers that compose / diff / reset the delta. It deliberately
+sits in a separate package from `@granit/entities` so a renderer can
+consume the manifest without dragging the views CRUD surface in.
+
+## What's in here
+
+- `EntityView` + `EntityViewSummary` types
+- `EntityViewVisibility` (Personal / Shared / Tenant)
+- View flags: `isPinned`, `isDefault`, `isPersonalDefault`
+- `basedOn` delta (`baseViewName` + `state` patch)
+- View-state delta helpers: `composeViewState`, `diffViewState`, `resetViewState`
+
+The React hooks + tab strip live in [`@granit/react-entities-views`](../react-entities-views).
+
+## Status
+
+Scaffold only — implementation tracked under
+[granit-fx/granit-front#301](https://github.com/granit-fx/granit-front/issues/301).

--- a/packages/@granit/entities-views/package.json
+++ b/packages/@granit/entities-views/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/entities-views",
+  "description": "Framework-agnostic types and helpers for Granit saved views — EntityView aggregate, visibility (Personal / Shared / Tenant), pin / default / personal-default flags, basedOn delta model (mirrors Granit.Entities.Views.Domain)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/entities-views/src/index.ts
+++ b/packages/@granit/entities-views/src/index.ts
@@ -1,0 +1,9 @@
+// @granit/entities-views — public API
+//
+// Framework-agnostic contracts for Granit saved views (EntityView aggregate
+// from Granit.Entities.Views). Visibility (Personal / Shared / Tenant),
+// flags (isPinned / isDefault / isPersonalDefault), and the basedOn delta
+// model that lets a view stack onto a base view without copying its state.
+//
+// Implementation lands in subsequent stories of granit-fx/granit-front#301.
+export {};

--- a/packages/@granit/entities-views/tsconfig.json
+++ b/packages/@granit/entities-views/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/entities-views/tsup.config.ts
+++ b/packages/@granit/entities-views/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/entities/README.md
+++ b/packages/@granit/entities/README.md
@@ -1,0 +1,32 @@
+# @granit/entities
+
+Framework-agnostic types and helpers for the Granit entity manifest.
+
+## Why
+
+The .NET backbone (`Granit.Entities.Abstractions` + `Granit.Entities.Endpoints`)
+publishes a per-entity manifest at `GET /api/entities/{name}` describing forms,
+details, lists, relations, and side panels. Any front-end that wants to render
+those entities — React, mobile, or a future Vue app — needs a single source
+of truth for the wire shape.
+
+This package owns that source of truth, on the JavaScript side. It contains
+no React, no fetch logic, no UI: just the TypeScript contracts plus a couple
+of pure helpers (visibility-condition evaluator, type guards) that any
+consumer can use.
+
+## What's in here
+
+- TypeScript types mirroring the `.NET` DTOs
+  - `EntityDiscoveryResponse` and friends (`GET /api/entities`)
+  - `EntityManifestResponse` + sub-sections (`GET /api/entities/{name}`)
+  - Form / Detail / Field / Section / SidePanel / Relation descriptors
+- Visibility DSL types + `evaluateVisibility(condition, formValues)` helper
+- Runtime type guards used at the network boundary
+
+The React renderer lives in [`@granit/react-entities`](../react-entities).
+
+## Status
+
+Scaffold only — implementation tracked under
+[granit-fx/granit-front#298](https://github.com/granit-fx/granit-front/issues/298).

--- a/packages/@granit/entities/package.json
+++ b/packages/@granit/entities/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/entities",
+  "description": "Framework-agnostic types and helpers for the Granit entity manifest — EntityDefinition discovery / metadata DTOs, form / detail / relation descriptors, visibility DSL evaluator (mirrors Granit.Entities.Abstractions + Granit.Entities.Endpoints.Dtos)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/entities/src/index.ts
+++ b/packages/@granit/entities/src/index.ts
@@ -1,0 +1,9 @@
+// @granit/entities — public API
+//
+// Framework-agnostic contracts for the Granit entity manifest. Mirrors the
+// .NET DTOs from Granit.Entities.Abstractions + Granit.Entities.Endpoints.Dtos
+// so that any React (or non-React) consumer can read /api/entities and
+// /api/entities/{name} payloads with full type safety.
+//
+// Implementation lands in subsequent stories of granit-fx/granit-front#298.
+export {};

--- a/packages/@granit/entities/tsconfig.json
+++ b/packages/@granit/entities/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/entities/tsup.config.ts
+++ b/packages/@granit/entities/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-entities-views/README.md
+++ b/packages/@granit/react-entities-views/README.md
@@ -1,0 +1,32 @@
+# @granit/react-entities-views
+
+React hooks + view tab strip for Granit saved views.
+
+## Why
+
+The view tab strip is the daily driver of any list-heavy admin: pin three
+views you live in, accept the team's tenant default, save your in-progress
+filter as a new personal view, then "Save for everyone" once you're sure.
+This package bundles the hooks and the strip itself so apps don't reinvent
+the dirty-state UX every time.
+
+It also owns the clean-break replacement for the legacy `useSavedViews`
+hook from `@granit/react-query-engine`, which goes away in the same PR
+sequence (see [granit-fx/granit-front#301](https://github.com/granit-fx/granit-front/issues/301)).
+
+## What's in here
+
+- Hooks against `/api/entities/{name}/views`
+  - `useEntityViews(entityName)`, `useEntityView(entityName, id)`
+  - `useCreateEntityView`, `useUpdateEntityView`, `useDeleteEntityView`
+  - `usePinEntityView`, `useStarEntityView`, `useShareEntityView`,
+    `useSetDefaultEntityView`
+- `<EntityViewTabStrip />` — pinned + personal-default + recent, dirty
+  badge, save-as-new / update / reset, Notion-style "Save for everyone"
+  promotion (Personal → Shared / Tenant)
+- Integration helpers for `<EntityList />` (active-view binding)
+
+## Status
+
+Scaffold only — implementation tracked under
+[granit-fx/granit-front#301](https://github.com/granit-fx/granit-front/issues/301).

--- a/packages/@granit/react-entities-views/package.json
+++ b/packages/@granit/react-entities-views/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@granit/react-entities-views",
+  "description": "React hooks + view tab strip for @granit/entities-views — CRUD / pin / star / share / set-default hooks plus the EntityViewTabStrip component (dirty badge, save-as-new, Notion-style 'Save for everyone' promotion)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities-views": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities-views": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-entities-views/src/index.ts
+++ b/packages/@granit/react-entities-views/src/index.ts
@@ -1,0 +1,9 @@
+// @granit/react-entities-views — public API
+//
+// React hooks for the EntityView CRUD + flag endpoints, plus the view tab
+// strip with dirty badge and "Save for everyone" promotion.
+//
+// Implementation lands in subsequent stories of granit-fx/granit-front#301
+// — including the clean-break removal of the legacy useSavedViews hook
+// from @granit/react-query-engine.
+export {};

--- a/packages/@granit/react-entities-views/tsconfig.json
+++ b/packages/@granit/react-entities-views/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-entities-views/tsup.config.ts
+++ b/packages/@granit/react-entities-views/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-entities/README.md
+++ b/packages/@granit/react-entities/README.md
@@ -1,0 +1,37 @@
+# @granit/react-entities
+
+React hooks + generic renderers for the Granit entity manifest.
+
+## Why
+
+Most of an admin app is the same six screens repeated across thirty
+different aggregates: a list, a kanban, a form, a detail view, a relation
+drawer, a side peek. Hand-rolling those screens per entity is busywork that
+also makes cross-cutting changes (a new widget, a permission rule, a layout
+tweak) impossible to roll out at once.
+
+This package consumes the manifest produced by `Granit.Entities.Endpoints`
+(see [`@granit/entities`](../entities)) and gives you back four ready-to-use
+renderers. You declare the entity once, on the .NET side; you get the React
+UI for free.
+
+## What's in here
+
+- Hooks
+  - `useEntityDiscovery()` — calls `GET /api/entities`, ETag-aware
+  - `useEntityMetadata(name, { facets? })` — calls `GET /api/entities/{name}`
+- Generic renderers
+  - `<EntityList />` — bridges to `@granit/query-engine`
+  - `<EntityKanban />` — board grouped by enum
+  - `<EntityForm />` — sections / fields / widgets / `VisibleIf`
+  - `<EntityDetail />` — sections + side panels + smart-button slots
+- `<EntityRendererProvider>` — carries the widget catalog and i18n bridge
+- Standard widget catalog + `custom:` extension hook
+
+## Status
+
+Scaffold only. Implementation lands across:
+
+- [granit-fx/granit-front#298](https://github.com/granit-fx/granit-front/issues/298) — hooks
+- [granit-fx/granit-front#299](https://github.com/granit-fx/granit-front/issues/299) — renderers
+- [granit-fx/granit-front#302](https://github.com/granit-fx/granit-front/issues/302) — smart-button consumption

--- a/packages/@granit/react-entities/package.json
+++ b/packages/@granit/react-entities/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@granit/react-entities",
+  "description": "React renderer for @granit/entities — manifest hooks (useEntityDiscovery / useEntityMetadata) and the four generic renderers (EntityList, EntityKanban, EntityForm, EntityDetail) wired to the standard widget catalog",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -1,0 +1,6 @@
+// @granit/react-entities — public API
+//
+// React hooks + generic renderers driven by the manifest exposed by
+// @granit/entities. Implementation tracked under
+// granit-fx/granit-front#298 (hooks) and #299 (renderers).
+export {};

--- a/packages/@granit/react-entities/tsconfig.json
+++ b/packages/@granit/react-entities/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-entities/tsup.config.ts
+++ b/packages/@granit/react-entities/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-workspaces/README.md
+++ b/packages/@granit/react-workspaces/README.md
@@ -1,0 +1,31 @@
+# @granit/react-workspaces
+
+React shell components for the Granit workspace tree.
+
+## Why
+
+A workspace is more than a sidebar entry: it's the entry point a user lands
+on after login, the URL prefix that scopes their lists, and the context that
+decides which preset overlay applies to a shared entity. Wiring all that
+plumbing app-by-app produces drift; centralising it here means every
+consuming app inherits the same routing rules, the same side-peek shortcuts,
+and the same landing-redirect behaviour.
+
+This package is the React layer on top of [`@granit/workspaces`](../workspaces).
+
+## What's in here
+
+- Hooks: `useWorkspaces`, `useWorkspace`, `useLandingRoute`, `useSetLandingPin`
+- `<WorkspaceNav />` — recursive sidebar (≤ 4 levels), icons, breadcrumbs
+- Route helpers
+  - `/w/{workspace}/...` workspace-scoped lists
+  - `/entity/{id}` workspace-agnostic detail
+- `<SidePeek />` — Notion-style drawer (`?peek=…`, `Esc` to close,
+  `⌘+⇧+.` to expand to full page, stacked peeks)
+- `<LandingRedirect />` — calls `useLandingRoute()` on login, honours the
+  5-tier precedence and URL whitelist
+
+## Status
+
+Scaffold only — implementation tracked under
+[granit-fx/granit-front#300](https://github.com/granit-fx/granit-front/issues/300).

--- a/packages/@granit/react-workspaces/package.json
+++ b/packages/@granit/react-workspaces/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@granit/react-workspaces",
+  "description": "React renderer for @granit/workspaces — WorkspaceNav sidebar, /w/{workspace}/... routing, Notion-style SidePeek with ⌘+⇧+. expand, and the landing-route resolver hook",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/workspaces": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0",
+    "react-i18next": "^17.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/workspaces": "workspace:*"
+  }
+}

--- a/packages/@granit/react-workspaces/src/index.ts
+++ b/packages/@granit/react-workspaces/src/index.ts
@@ -1,0 +1,8 @@
+// @granit/react-workspaces — public API
+//
+// React shell for the workspace tree: WorkspaceNav sidebar, route helpers
+// (/w/{workspace}/... and /entity/{id}), the Notion-style SidePeek drawer,
+// and the LandingRedirect that consumes the .NET 5-tier resolver.
+//
+// Implementation lands in subsequent stories of granit-fx/granit-front#300.
+export {};

--- a/packages/@granit/react-workspaces/tsconfig.json
+++ b/packages/@granit/react-workspaces/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-workspaces/tsup.config.ts
+++ b/packages/@granit/react-workspaces/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/workspaces/README.md
+++ b/packages/@granit/workspaces/README.md
@@ -1,0 +1,33 @@
+# @granit/workspaces
+
+Framework-agnostic types and helpers for the Granit workspace tree.
+
+## Why
+
+Workspaces are the top-level navigation surface: a CRM workspace, an
+Accounting workspace, an Operations workspace. Each one groups entities,
+dashboards, sub-workspaces, and external links under a single sidebar. The
+.NET side (`Granit.Workspaces`) computes the user-filtered tree at
+`GET /api/workspaces` and resolves the landing route at
+`GET /api/me/landing-route`.
+
+This package owns the JavaScript-side contracts for both endpoints — plus
+the typed schema for the preset overlay that lets the same entity show up
+in two workspaces with different defaults (e.g. Party in CRM = full list,
+Party in Accounting = overdue-balance preset).
+
+## What's in here
+
+- `WorkspaceTreeResponse` + `WorkspaceResponse` / `WorkspaceSectionResponse`
+  / `WorkspaceItemResponse` types
+- `WorkspaceItemKind` discriminated union (Entity / Dashboard / Link /
+  SubWorkspace)
+- `LandingRouteResponse` + `LandingRouteSource`
+- Typed preset overlay schema + `composeWorkspacePresetOverlay(manifest, overlay)` helper
+
+The React renderer lives in [`@granit/react-workspaces`](../react-workspaces).
+
+## Status
+
+Scaffold only — implementation tracked under
+[granit-fx/granit-front#300](https://github.com/granit-fx/granit-front/issues/300).

--- a/packages/@granit/workspaces/package.json
+++ b/packages/@granit/workspaces/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/workspaces",
+  "description": "Framework-agnostic types and helpers for the Granit workspace tree — WorkspaceDefinition / sections / items, landing route response, typed preset overlay (mirrors Granit.Workspaces.Abstractions + Granit.Workspaces.Endpoints.Dtos)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/workspaces/src/index.ts
+++ b/packages/@granit/workspaces/src/index.ts
@@ -1,0 +1,8 @@
+// @granit/workspaces — public API
+//
+// Framework-agnostic contracts for the Granit workspace tree (sidebar
+// navigation) and the landing-route resolver. Mirrors the .NET DTOs from
+// Granit.Workspaces.Abstractions + Granit.Workspaces.Endpoints.Dtos.
+//
+// Implementation lands in subsequent stories of granit-fx/granit-front#300.
+export {};

--- a/packages/@granit/workspaces/tsconfig.json
+++ b/packages/@granit/workspaces/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/workspaces/tsup.config.ts
+++ b/packages/@granit/workspaces/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -372,6 +372,10 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/entities: {}
+
+  packages/@granit/entities-views: {}
+
   packages/@granit/error-boundary: {}
 
   packages/@granit/features:
@@ -1242,6 +1246,62 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-entities:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.5
+        version: 5.100.5(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/entities':
+        specifier: workspace:*
+        version: link:../entities
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-entities-views:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.5
+        version: 5.100.5(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/entities-views':
+        specifier: workspace:*
+        version: link:../entities-views
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -2157,6 +2217,37 @@ importers:
         specifier: workspace:*
         version: link:../types
 
+  packages/@granit/react-workspaces:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.5
+        version: 5.100.5(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+      react-i18next:
+        specifier: ^17.0.0
+        version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/entities':
+        specifier: workspace:*
+        version: link:../entities
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/workspaces':
+        specifier: workspace:*
+        version: link:../workspaces
+
   packages/@granit/reference-data:
     dependencies:
       '@granit/query-engine':
@@ -2326,6 +2417,8 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+
+  packages/@granit/workspaces: {}
 
 packages:
 


### PR DESCRIPTION
## Summary

- Scaffolds six packages mirroring the .NET Phase 1 backbone (granit-fx/granit-dotnet#1508): `@granit/entities`, `@granit/react-entities`, `@granit/workspaces`, `@granit/react-workspaces`, `@granit/entities-views`, `@granit/react-entities-views`
- Each package ships `package.json` (workspace peer deps wired), `tsconfig.json`, `tsup.config.ts`, an empty `src/index.ts`, and a README explaining the why + scope
- No runtime logic yet — implementation lands across granit-fx/granit-front#298, #299, #300, #301, #302 (sub-issues of Epic #242)

## Test plan

- [x] `pnpm install` clean (only the pre-existing `klaro`/`eslint` peer-dep warning surfaces)
- [x] `pnpm tsc` green
- [x] `pnpm lint` green (`--max-warnings 0`)
- [x] `npx markdownlint-cli2` green on the six READMEs
- [x] `.mcp-front-index.json` regenerated by the pre-commit hook

## Parent

Epic #242
