### PR TITLE
feat(entities): manifest TS types mirroring .NET DTOs

### DIFF
--- a/packages/@granit/entities/src/index.ts
+++ b/packages/@granit/entities/src/index.ts
@@ -1,9 +1,45 @@
-// @granit/entities — public API
+// ---------------------------------------------------------------------------
+// @granit/entities — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
 //
-// Framework-agnostic contracts for the Granit entity manifest. Mirrors the
-// .NET DTOs from Granit.Entities.Abstractions + Granit.Entities.Endpoints.Dtos
-// so that any React (or non-React) consumer can read /api/entities and
-// /api/entities/{name} payloads with full type safety.
+// Mirrors the .NET DTOs from Granit.Entities.Abstractions +
+// Granit.Entities.Endpoints.Dtos so any consumer (React renderer, mobile
+// app, future Vue port) can read the `/api/entities` and
+// `/api/entities/{name}` payloads with full type safety.
 //
-// Implementation lands in subsequent stories of granit-fx/granit-front#298.
-export {};
+// Wire conventions: camelCase property names (System.Text.Json default),
+// PascalCase string-literal enums (Granit registers a
+// `JsonStringEnumConverter` without naming policy), `IReadOnlyList<T>` →
+// `readonly T[]`, `IReadOnlyDictionary<string, T>` →
+// `Readonly<Record<string, T>>`.
+
+export { ALL_ENTITY_FACETS, MANIFEST_SCHEMA_VERSION } from './types/index.js';
+export type {
+  EntityCollectionReference,
+  EntityCollectionsSection,
+  EntityDetailManifest,
+  EntityDetailSectionManifest,
+  EntityDetailSidePanelManifest,
+  EntityDiscoveryItem,
+  EntityDiscoveryLinks,
+  EntityDiscoveryResponse,
+  EntityFacet,
+  EntityFormFieldManifest,
+  EntityFormManifest,
+  EntityFormSectionManifest,
+  EntityIdentitySection,
+  EntityManifestResponse,
+  EntityModuleGroup,
+  EntityPermissionsSection,
+  EntityRelationAggregateManifest,
+  EntityRelationManifest,
+  FieldOp,
+  RelationAggregateKind,
+  RelationAggregateValue,
+  RelationAggregatesRequest,
+  RelationAggregatesResponse,
+  RelationCardinality,
+  RelationDisplay,
+  SidePanelKind,
+  VisibilityCondition,
+} from './types/index.js';

--- a/packages/@granit/entities/src/types/collections.ts
+++ b/packages/@granit/entities/src/types/collections.ts
@@ -1,0 +1,34 @@
+/**
+ * Reference to one external declarative primitive (Query / Export / Metric /
+ * Dashboard) surfaced by the entity. The full metadata for each primitive
+ * stays served by its dedicated endpoint — the manifest only carries the
+ * key + URL the renderer uses to address it.
+ *
+ * Mirrors `Granit.Entities.Endpoints.Dtos.EntityCollectionReference`.
+ */
+export interface EntityCollectionReference {
+  /** Wire identifier (e.g. `"Granit.Invoicing.InvoiceQuery"`). */
+  readonly name: string;
+  /** Short CLR type name of the underlying definition — debugging aid. */
+  readonly clrTypeName: string;
+}
+
+/**
+ * Collections facet — the queries / exports / metrics / dashboards the
+ * entity surfaces, plus the resolved default `EntityView` per the
+ * 5-tier precedence (ADR-049).
+ *
+ * Mirrors `Granit.Entities.Endpoints.Dtos.EntityCollectionsSection`.
+ */
+export interface EntityCollectionsSection {
+  /** Query reference (list / kanban), or `null` when no list collection. */
+  readonly query: EntityCollectionReference | null;
+  /** Export reference (CSV / XLSX), or `null`. */
+  readonly export: EntityCollectionReference | null;
+  /** Metric KPIs surfaced on the detail header. */
+  readonly metrics: readonly EntityCollectionReference[];
+  /** Dashboards embedded on the detail header. */
+  readonly dashboards: readonly EntityCollectionReference[];
+  /** Resolved default `EntityView` id, or `null` when none applies. */
+  readonly defaultViewId: string | null;
+}

--- a/packages/@granit/entities/src/types/detail.ts
+++ b/packages/@granit/entities/src/types/detail.ts
@@ -1,0 +1,48 @@
+/**
+ * Closed enum of standard side panels a detail view may surface. Each value
+ * maps to an existing Granit module; the renderer no-ops gracefully when
+ * the target module isn't loaded in the host. Mirrors
+ * `Granit.Entities.Details.SidePanelKind` (ADR-046).
+ */
+export type SidePanelKind = 'Audit' | 'Timeline' | 'Comments' | 'Documents' | 'Activities';
+
+/**
+ * One detail-view section. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityDetailSectionManifest`.
+ *
+ * `inheritsFromFormVariant` and `fields` are mutually exclusive — when set,
+ * the section reuses a form variant's structure in read mode.
+ */
+export interface EntityDetailSectionManifest {
+  /** Stable section key. */
+  readonly key: string;
+  /** i18n key for the section header. */
+  readonly labelKey: string | null;
+  /** Display order (lower first). */
+  readonly order: number;
+  /** Form variant whose structure this section inherits in read mode. */
+  readonly inheritsFromFormVariant: string | null;
+  /** Free-form list of property names — used when not inheriting. */
+  readonly fields: readonly string[] | null;
+}
+
+/**
+ * One side panel in the detail's right rail. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityDetailSidePanelManifest`.
+ */
+export interface EntityDetailSidePanelManifest {
+  readonly kind: SidePanelKind;
+  /** Display order within the rail. */
+  readonly order: number;
+}
+
+/**
+ * One detail-view variant. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityDetailManifest`.
+ */
+export interface EntityDetailManifest {
+  /** Variant name, unique per entity. */
+  readonly name: string;
+  readonly sections: readonly EntityDetailSectionManifest[];
+  readonly sidePanels: readonly EntityDetailSidePanelManifest[];
+}

--- a/packages/@granit/entities/src/types/discovery.ts
+++ b/packages/@granit/entities/src/types/discovery.ts
@@ -1,0 +1,49 @@
+/**
+ * Hypermedia links attached to a discovery entry. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityDiscoveryLinks`.
+ */
+export interface EntityDiscoveryLinks {
+  /** Absolute path to the per-entity manifest (always present). */
+  readonly manifest: string;
+  /** Absolute path to the list query endpoint, or `null` when no query is registered. */
+  readonly list: string | null;
+}
+
+/**
+ * One entity entry in the discovery tree. Entities the caller cannot read
+ * are omitted entirely (defense in depth, ADR-040 §6) — not just hidden via
+ * a flag. Mirrors `Granit.Entities.Endpoints.Dtos.EntityDiscoveryItemResponse`.
+ */
+export interface EntityDiscoveryItem {
+  /** Wire identifier (e.g. `"Granit.Parties.Party"`). */
+  readonly name: string;
+  /** i18n key for the display name (singular). */
+  readonly displayKey: string | null;
+  /** Icon name from the standard catalog. */
+  readonly icon: string | null;
+  /** Permission-group prefix (e.g. `"Parties.Parties"`). */
+  readonly permissionGroup: string | null;
+  readonly links: EntityDiscoveryLinks;
+}
+
+/**
+ * One module group in the discovery tree. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityModuleGroupResponse`.
+ */
+export interface EntityModuleGroup {
+  /** Module name (PascalCase, derived from the entity's namespace prefix). */
+  readonly module: string;
+  /** Entities the caller can read, registered under this module. */
+  readonly items: readonly EntityDiscoveryItem[];
+}
+
+/**
+ * Top-level payload returned by `GET /api/entities`. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityDiscoveryResponse`.
+ */
+export interface EntityDiscoveryResponse {
+  /** Manifest schema version (semver-major) — bumps on breaking shape changes. */
+  readonly schemaVersion: number;
+  /** Module groups, alphabetical by `module`. */
+  readonly modules: readonly EntityModuleGroup[];
+}

--- a/packages/@granit/entities/src/types/form.ts
+++ b/packages/@granit/entities/src/types/form.ts
@@ -1,0 +1,59 @@
+import type { VisibilityCondition } from './visibility.js';
+
+/**
+ * One form field. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityFormFieldManifest`.
+ */
+export interface EntityFormFieldManifest {
+  /** PascalCase property name on the entity. */
+  readonly propertyName: string;
+  /** Short CLR type name — drives the renderer when `widget` doesn't override it. */
+  readonly clrTypeName: string;
+  /**
+   * Widget identifier — either from the standard catalog or the `custom:`
+   * namespace (ADR-041).
+   */
+  readonly widget: string;
+  /** Opaque widget-specific configuration. */
+  readonly config: Readonly<Record<string, unknown>> | null;
+  /** i18n key for the field label. */
+  readonly labelKey: string | null;
+  /** i18n key for the help text under the field. */
+  readonly helpKey: string | null;
+  /** Display order within the section (lower first). */
+  readonly order: number;
+  /** Read-only in the form context. */
+  readonly readOnly: boolean;
+  /** Closed-DSL conditional-visibility rule (ADR-040). */
+  readonly visibleIf: VisibilityCondition | null;
+}
+
+/**
+ * One form section. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityFormSectionManifest`.
+ */
+export interface EntityFormSectionManifest {
+  /** Stable section key (e.g. `"identity"`). */
+  readonly key: string;
+  /** i18n key for the section header. */
+  readonly labelKey: string | null;
+  /** Display order (lower first). */
+  readonly order: number;
+  /** Whether the section starts collapsed. */
+  readonly collapsedByDefault: boolean;
+  /** Fields the user is allowed to see — already permission-filtered server-side. */
+  readonly fields: readonly EntityFormFieldManifest[];
+}
+
+/**
+ * One form variant exposed in the manifest. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityFormManifest`.
+ */
+export interface EntityFormManifest {
+  /** Variant name, unique per entity (e.g. `"default"`, `"quick"`, `"wizard"`). */
+  readonly name: string;
+  /** When `true`, tenant admins may reorder / regroup / hide fields (Tier B Layer 1). */
+  readonly customizable: boolean;
+  /** Sections in declaration order. */
+  readonly sections: readonly EntityFormSectionManifest[];
+}

--- a/packages/@granit/entities/src/types/identity.ts
+++ b/packages/@granit/entities/src/types/identity.ts
@@ -1,0 +1,18 @@
+/**
+ * Identity facet of the per-entity manifest. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityIdentitySection`.
+ */
+export interface EntityIdentitySection {
+  /** Wire identifier (e.g. `"Granit.Parties.Party"`). */
+  readonly name: string;
+  /** Full CLR type name — debugging aid, not security-sensitive. */
+  readonly entityClrType: string;
+  /** i18n key for the singular display name. */
+  readonly displayKey: string | null;
+  /** Icon name from the standard catalog. */
+  readonly icon: string | null;
+  /** Permission-group prefix (e.g. `"Parties.Parties"`). */
+  readonly permissionGroup: string | null;
+  /** Property used to label references to this entity (e.g. `"Number"`). */
+  readonly displayProperty: string | null;
+}

--- a/packages/@granit/entities/src/types/index.ts
+++ b/packages/@granit/entities/src/types/index.ts
@@ -1,0 +1,33 @@
+export type { EntityCollectionReference, EntityCollectionsSection } from './collections.js';
+export type {
+  EntityDetailManifest,
+  EntityDetailSectionManifest,
+  EntityDetailSidePanelManifest,
+  SidePanelKind,
+} from './detail.js';
+export type {
+  EntityDiscoveryItem,
+  EntityDiscoveryLinks,
+  EntityDiscoveryResponse,
+  EntityModuleGroup,
+} from './discovery.js';
+export type {
+  EntityFormFieldManifest,
+  EntityFormManifest,
+  EntityFormSectionManifest,
+} from './form.js';
+export type { EntityIdentitySection } from './identity.js';
+export { ALL_ENTITY_FACETS, MANIFEST_SCHEMA_VERSION } from './manifest.js';
+export type { EntityFacet, EntityManifestResponse } from './manifest.js';
+export type { EntityPermissionsSection } from './permissions.js';
+export type {
+  EntityRelationAggregateManifest,
+  EntityRelationManifest,
+  RelationAggregateKind,
+  RelationAggregateValue,
+  RelationAggregatesRequest,
+  RelationAggregatesResponse,
+  RelationCardinality,
+  RelationDisplay,
+} from './relations.js';
+export type { FieldOp, VisibilityCondition } from './visibility.js';

--- a/packages/@granit/entities/src/types/manifest.ts
+++ b/packages/@granit/entities/src/types/manifest.ts
@@ -1,0 +1,68 @@
+import type { EntityCollectionsSection } from './collections.js';
+import type { EntityDetailManifest } from './detail.js';
+import type { EntityFormManifest } from './form.js';
+import type { EntityIdentitySection } from './identity.js';
+import type { EntityPermissionsSection } from './permissions.js';
+import type { EntityRelationManifest } from './relations.js';
+
+/**
+ * Selectable facets of the per-entity manifest. Wire form: comma-separated
+ * lowercase names in the `?facets=` query parameter (e.g.
+ * `?facets=identity,forms`). Default — when the query parameter is absent
+ * — returns every facet.
+ *
+ * Mirrors the `[Flags]` enum `Granit.Entities.Endpoints.Dtos.EntityFacets`.
+ * Exposed as a string-literal union here because the wire form is a CSV of
+ * tokens, not a bitmask.
+ */
+export type EntityFacet =
+  | 'identity'
+  | 'permissions'
+  | 'forms'
+  | 'details'
+  | 'collections'
+  | 'dashboards'
+  | 'exports'
+  | 'views'
+  | 'relations';
+
+/** All facets — handy default value for callers that want everything explicit. */
+export const ALL_ENTITY_FACETS: readonly EntityFacet[] = Object.freeze([
+  'identity',
+  'permissions',
+  'forms',
+  'details',
+  'collections',
+  'dashboards',
+  'exports',
+  'views',
+  'relations',
+]);
+
+/**
+ * Per-entity manifest payload returned by `GET /api/entities/{name}`. Every
+ * facet is optional in the wire form — when the caller passes `?facets=` to
+ * slim the response, the omitted facets come back as `null`. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityManifestResponse`.
+ *
+ * The `Granit-Entities-Schema-Version` response header carries the same
+ * value as {@link EntityManifestResponse.schemaVersion}.
+ */
+export interface EntityManifestResponse {
+  /** Manifest schema version (semver-major). */
+  readonly schemaVersion: number;
+  readonly identity: EntityIdentitySection | null;
+  readonly permissions: EntityPermissionsSection | null;
+  readonly forms: readonly EntityFormManifest[] | null;
+  readonly details: readonly EntityDetailManifest[] | null;
+  readonly collections: EntityCollectionsSection | null;
+  readonly relations: readonly EntityRelationManifest[] | null;
+}
+
+/**
+ * Schema version this package was compiled against. Consumers can check
+ * `manifest.schemaVersion === MANIFEST_SCHEMA_VERSION` to assert the wire
+ * shape matches what they were built for, and surface a friendly error
+ * when the backend has been bumped past the renderer.
+ */
+export const MANIFEST_SCHEMA_VERSION = 1;

--- a/packages/@granit/entities/src/types/permissions.ts
+++ b/packages/@granit/entities/src/types/permissions.ts
@@ -1,0 +1,23 @@
+/**
+ * Permissions facet — boolean snapshot of the actions the requesting user
+ * is allowed to perform on this entity. Computed server-side from the
+ * granted permissions and the entity's permission group; the renderer
+ * trusts these flags to gate UI affordances (the server still enforces
+ * permissions on every individual call — defense in depth).
+ *
+ * Mirrors `Granit.Entities.Endpoints.Dtos.EntityPermissionsSection`.
+ */
+export interface EntityPermissionsSection {
+  /** User has `{permissionGroup}.Read`. */
+  readonly canRead: boolean;
+  /** User has `{permissionGroup}.Create`. */
+  readonly canCreate: boolean;
+  /** User has `{permissionGroup}.Update`. */
+  readonly canUpdate: boolean;
+  /** User has `{permissionGroup}.Delete`. */
+  readonly canDelete: boolean;
+  /** User has `{permissionGroup}.Manage`. */
+  readonly canManage: boolean;
+  /** User has `{permissionGroup}.Execute`. */
+  readonly canExecute: boolean;
+}

--- a/packages/@granit/entities/src/types/relations.ts
+++ b/packages/@granit/entities/src/types/relations.ts
@@ -1,0 +1,100 @@
+/**
+ * Cardinality of an entity relation. Mirrors
+ * `Granit.Entities.Relations.RelationCardinality`.
+ */
+export type RelationCardinality = 'Many' | 'One';
+
+/**
+ * Display mode a relation picks on the source entity's detail view.
+ * Mirrors `Granit.Entities.Relations.RelationDisplay` (ADR-048).
+ *
+ * - `Tab` — dedicated tab, full-screen list of related rows
+ * - `SmartButton` — compact button in the detail header, click for drilldown
+ * - `Sidebar` — always-visible side panel in the right rail
+ * - `InlineChips` — chip strip embedded in a section, click-to-expand
+ */
+export type RelationDisplay = 'Tab' | 'SmartButton' | 'Sidebar' | 'InlineChips';
+
+/**
+ * Aggregate kinds a relation may surface. Mirrors
+ * `Granit.Entities.Relations.RelationAggregateKind`.
+ */
+export type RelationAggregateKind = 'Count' | 'Sum' | 'Avg' | 'Min' | 'Max';
+
+/**
+ * One aggregate declared on a relation. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityRelationAggregateManifest`.
+ */
+export interface EntityRelationAggregateManifest {
+  readonly kind: RelationAggregateKind;
+  /** Property on the related entity (or `null` for `Count`). */
+  readonly propertyName: string | null;
+  readonly labelKey: string | null;
+  /** Optional formatter hint (e.g. `"currency"`). */
+  readonly format: string | null;
+}
+
+/**
+ * One relation surfaced in the manifest's Relations facet. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityRelationManifest`.
+ */
+export interface EntityRelationManifest {
+  /** Stable relation name, unique per source entity. */
+  readonly name: string;
+  readonly cardinality: RelationCardinality;
+  readonly display: RelationDisplay;
+  /** Wire identifier of the target `EntityDefinition`. */
+  readonly targetEntityName: string;
+  readonly displayKey: string | null;
+  readonly icon: string | null;
+  readonly order: number;
+  /** Optional named QueryDefinition used for the drilldown collection. */
+  readonly queryDefinitionName: string | null;
+  readonly aggregates: readonly EntityRelationAggregateManifest[];
+  /**
+   * Assembly that contributed this relation. `null` for intra-module
+   * declarations; populated for cross-module grafts (smart buttons
+   * contributed via `IEntityRelationContributor`).
+   */
+  readonly contributorAssemblyName: string | null;
+}
+
+/**
+ * Computed aggregate values for one relation, returned by
+ * `POST /api/entities/{name}/{id}/relations/aggregates`. Each numeric slot
+ * is nullable — the runner only fills aggregates the relation declared, and
+ * `Sum`/`Avg`/`Min`/`Max` are `null` on empty sets per ADR-038.
+ *
+ * Mirrors `Granit.Entities.Relations.RelationAggregateValue`.
+ */
+export interface RelationAggregateValue {
+  readonly count: number | null;
+  readonly sum: number | null;
+  readonly avg: number | null;
+  readonly min: number | null;
+  readonly max: number | null;
+  /** ISO 4217 currency code when the aggregate's format is `"currency"`. */
+  readonly currency: string | null;
+}
+
+/**
+ * Request body for `POST /api/entities/{name}/{id}/relations/aggregates`.
+ * Mirrors `Granit.Entities.Endpoints.Dtos.RelationAggregatesRequest`.
+ *
+ * When `relations` is omitted or empty, the endpoint resolves "every
+ * relation the caller can read on the source entity" — convenient for a
+ * detail page that wants every smart-button count in one round-trip.
+ */
+export interface RelationAggregatesRequest {
+  readonly relations?: readonly string[] | null;
+}
+
+/**
+ * Response body for `POST /api/entities/{name}/{id}/relations/aggregates`,
+ * keyed by relation name. Relations the caller cannot read are absent
+ * (defense in depth). Mirrors
+ * `Granit.Entities.Endpoints.Dtos.RelationAggregatesResponse`.
+ */
+export interface RelationAggregatesResponse {
+  readonly aggregates: Readonly<Record<string, RelationAggregateValue>>;
+}

--- a/packages/@granit/entities/src/types/visibility.ts
+++ b/packages/@granit/entities/src/types/visibility.ts
@@ -1,0 +1,30 @@
+/**
+ * Closed enum of operators allowed in the manifest's visibility DSL
+ * (mirrors `Granit.Entities.Visibility.FieldOp`, ADR-040 / ADR-044).
+ *
+ * Deliberately small — sufficient for the conditional-visibility cases an
+ * admin form needs without inviting eval-string expressions. Apps that need
+ * richer logic should resolve it server-side via permissions or a domain
+ * rule, not at the manifest layer.
+ */
+export type FieldOp = 'Eq' | 'NotEq' | 'In' | 'NotIn' | 'Gt' | 'Lt' | 'IsNull' | 'IsNotNull';
+
+/**
+ * One conditional-visibility rule, as carried by `visibleIf` on a form
+ * field, detail section, or relation. Mirrors
+ * `Granit.Entities.Visibility.VisibilityCondition`.
+ *
+ * `value` semantics by operator:
+ * - `Eq` / `NotEq` / `Gt` / `Lt` — single literal
+ * - `In` / `NotIn` — array of literals
+ * - `IsNull` / `IsNotNull` — `value` is ignored
+ *
+ * `field` is the PascalCase property name on the source entity. The
+ * renderer evaluates the rule against the current form's values via
+ * {@link evaluateVisibility}.
+ */
+export interface VisibilityCondition {
+  readonly field: string;
+  readonly op: FieldOp;
+  readonly value?: unknown;
+}


### PR DESCRIPTION
## Summary

- Adds the TypeScript contracts for `/api/entities` and `/api/entities/{name}` to `@granit/entities`, mirroring the .NET DTOs from `Granit.Entities.Abstractions` + `Granit.Entities.Endpoints.Dtos`
- Discovery, manifest with all facets (identity, permissions, forms, details, collections, relations), visibility DSL, relation aggregates request/response — 11 source files, ~530 lines, no runtime logic beyond the `MANIFEST_SCHEMA_VERSION` and `ALL_ENTITY_FACETS` constants
- Wire conventions match `@granit/dashboards`: camelCase properties, PascalCase string-literal enums, `readonly` arrays / records

## What's not in here

- `evaluateVisibility()` helper — next story under #298
- `useEntityDiscovery` / `useEntityMetadata` hooks — same Feature, separate PR
- `<EntityRendererProvider>` — final story of #298

## Test plan

- [x] `pnpm tsc` green across the whole workspace
- [x] `pnpm lint --max-warnings 0` green
- [x] All types reference matching .NET DTOs in their JSDoc — easy cross-check
- [ ] Hooks consuming these types land in follow-up PRs and exercise them

## Parent

Feature #298 → Epic #242
