### PR TITLE
feat(entities): evaluateVisibility helper for the visibility DSL

### DIFF
--- a/packages/@granit/entities/src/__tests__/evaluate-visibility.test.ts
+++ b/packages/@granit/entities/src/__tests__/evaluate-visibility.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateVisibility } from '../helpers/evaluate-visibility.js';
+
+import type { VisibilityCondition } from '../types/visibility.js';
+
+const cond = (
+  field: string,
+  op: VisibilityCondition['op'],
+  value?: unknown
+): VisibilityCondition => ({ field, op, value });
+
+describe('evaluateVisibility — Eq / NotEq', () => {
+  it('Eq is true when actual strictly equals expected', () => {
+    expect(evaluateVisibility(cond('Status', 'Eq', 'Active'), { Status: 'Active' })).toBe(true);
+  });
+
+  it('Eq is false on type mismatch (no coercion)', () => {
+    expect(evaluateVisibility(cond('Count', 'Eq', '1'), { Count: 1 })).toBe(false);
+  });
+
+  it('Eq distinguishes null from undefined', () => {
+    expect(evaluateVisibility(cond('X', 'Eq', null), { X: undefined })).toBe(false);
+    expect(evaluateVisibility(cond('X', 'Eq', null), { X: null })).toBe(true);
+  });
+
+  it('NotEq mirrors Eq', () => {
+    expect(evaluateVisibility(cond('Status', 'NotEq', 'Draft'), { Status: 'Active' })).toBe(true);
+    expect(evaluateVisibility(cond('Status', 'NotEq', 'Active'), { Status: 'Active' })).toBe(false);
+  });
+});
+
+describe('evaluateVisibility — In / NotIn', () => {
+  it('In is true when actual is in the array', () => {
+    const c = cond('Status', 'In', ['Active', 'Pending']);
+    expect(evaluateVisibility(c, { Status: 'Pending' })).toBe(true);
+  });
+
+  it('In is false when actual is missing', () => {
+    const c = cond('Status', 'In', ['Active', 'Pending']);
+    expect(evaluateVisibility(c, { Status: 'Closed' })).toBe(false);
+  });
+
+  it('NotIn mirrors In', () => {
+    const c = cond('Status', 'NotIn', ['Closed', 'Archived']);
+    expect(evaluateVisibility(c, { Status: 'Active' })).toBe(true);
+    expect(evaluateVisibility(c, { Status: 'Closed' })).toBe(false);
+  });
+
+  it('throws when the value is not an array', () => {
+    expect(() =>
+      evaluateVisibility(cond('Status', 'In', 'not-an-array'), { Status: 'Active' })
+    ).toThrow(/requires an array value/);
+    expect(() => evaluateVisibility(cond('Status', 'NotIn', null), { Status: 'Active' })).toThrow(
+      /requires an array value/
+    );
+  });
+});
+
+describe('evaluateVisibility — Gt / Lt', () => {
+  it('Gt compares numbers strictly', () => {
+    expect(evaluateVisibility(cond('Amount', 'Gt', 100), { Amount: 150 })).toBe(true);
+    expect(evaluateVisibility(cond('Amount', 'Gt', 100), { Amount: 100 })).toBe(false);
+  });
+
+  it('Lt compares numbers strictly', () => {
+    expect(evaluateVisibility(cond('Amount', 'Lt', 100), { Amount: 50 })).toBe(true);
+    expect(evaluateVisibility(cond('Amount', 'Lt', 100), { Amount: 100 })).toBe(false);
+  });
+
+  it('Gt/Lt also accept strings (lexicographic) and bigints', () => {
+    expect(evaluateVisibility(cond('Code', 'Gt', 'A'), { Code: 'B' })).toBe(true);
+    expect(evaluateVisibility(cond('N', 'Gt', 10n), { N: 11n })).toBe(true);
+  });
+
+  it('Gt/Lt return false when either side is not comparable', () => {
+    expect(evaluateVisibility(cond('Amount', 'Gt', 100), { Amount: undefined })).toBe(false);
+    expect(evaluateVisibility(cond('Amount', 'Gt', null), { Amount: 100 })).toBe(false);
+    expect(evaluateVisibility(cond('Amount', 'Gt', { x: 1 }), { Amount: 100 })).toBe(false);
+  });
+});
+
+describe('evaluateVisibility — IsNull / IsNotNull', () => {
+  it('IsNull treats null and undefined the same', () => {
+    expect(evaluateVisibility(cond('X', 'IsNull'), { X: null })).toBe(true);
+    expect(evaluateVisibility(cond('X', 'IsNull'), { X: undefined })).toBe(true);
+    expect(evaluateVisibility(cond('X', 'IsNull'), {})).toBe(true);
+  });
+
+  it('IsNull is false for any defined value, including the empty string and 0', () => {
+    expect(evaluateVisibility(cond('X', 'IsNull'), { X: '' })).toBe(false);
+    expect(evaluateVisibility(cond('X', 'IsNull'), { X: 0 })).toBe(false);
+    expect(evaluateVisibility(cond('X', 'IsNull'), { X: false })).toBe(false);
+  });
+
+  it('IsNotNull mirrors IsNull', () => {
+    expect(evaluateVisibility(cond('X', 'IsNotNull'), { X: 'hello' })).toBe(true);
+    expect(evaluateVisibility(cond('X', 'IsNotNull'), { X: null })).toBe(false);
+    expect(evaluateVisibility(cond('X', 'IsNotNull'), {})).toBe(false);
+  });
+
+  it('IsNull / IsNotNull ignore the condition value', () => {
+    expect(evaluateVisibility(cond('X', 'IsNull', 'ignored'), { X: null })).toBe(true);
+    expect(evaluateVisibility(cond('X', 'IsNotNull', 42), { X: null })).toBe(false);
+  });
+});
+
+describe('evaluateVisibility — missing field', () => {
+  it('reads a missing key as undefined', () => {
+    expect(evaluateVisibility(cond('Missing', 'IsNull'), {})).toBe(true);
+    expect(evaluateVisibility(cond('Missing', 'Eq', 'x'), {})).toBe(false);
+  });
+});

--- a/packages/@granit/entities/src/helpers/evaluate-visibility.ts
+++ b/packages/@granit/entities/src/helpers/evaluate-visibility.ts
@@ -1,0 +1,64 @@
+import type { VisibilityCondition } from '../types/visibility.js';
+
+/**
+ * Evaluate one {@link VisibilityCondition} against the current form values.
+ * Pure function — no logging, no side effects, no I/O. Closed over the
+ * eight `FieldOp` operators; throws on a malformed condition (e.g. `In`
+ * with a non-array value) so misuse surfaces as a bug rather than a silent
+ * "field is hidden" mystery.
+ *
+ * Equality is strict (`===`) — the wire form carries JSON literals, so
+ * primitives are the realistic input. Deep equality on objects / arrays is
+ * intentionally not supported; if you need it, branch on the field's CLR
+ * type and resolve it server-side.
+ *
+ * @param condition - The rule from the manifest (`field.visibleIf`).
+ * @param formValues - Current form values keyed by PascalCase property name.
+ *                     Missing keys read as `undefined`.
+ * @returns `true` when the field should be visible.
+ */
+export function evaluateVisibility(
+  condition: VisibilityCondition,
+  formValues: Readonly<Record<string, unknown>>
+): boolean {
+  const actual = formValues[condition.field];
+  const expected = condition.value;
+
+  switch (condition.op) {
+    case 'Eq':
+      return actual === expected;
+    case 'NotEq':
+      return actual !== expected;
+    case 'In':
+      return asArray(expected, condition.op).includes(actual);
+    case 'NotIn':
+      return !asArray(expected, condition.op).includes(actual);
+    case 'Gt':
+      return isComparable(actual) && isComparable(expected) && actual > expected;
+    case 'Lt':
+      return isComparable(actual) && isComparable(expected) && actual < expected;
+    case 'IsNull':
+      return actual == null;
+    case 'IsNotNull':
+      return actual != null;
+    default: {
+      const exhaustive: never = condition.op;
+      throw new Error(`Unknown FieldOp: ${String(exhaustive)}`);
+    }
+  }
+}
+
+function asArray(value: unknown, op: 'In' | 'NotIn'): readonly unknown[] {
+  if (!Array.isArray(value)) {
+    throw new TypeError(
+      `VisibilityCondition with op=${op} requires an array value, received ${typeof value}.`
+    );
+  }
+  return value;
+}
+
+type Comparable = number | string | bigint;
+
+function isComparable(value: unknown): value is Comparable {
+  return typeof value === 'number' || typeof value === 'string' || typeof value === 'bigint';
+}

--- a/packages/@granit/entities/src/helpers/index.ts
+++ b/packages/@granit/entities/src/helpers/index.ts
@@ -1,0 +1,1 @@
+export { evaluateVisibility } from './evaluate-visibility.js';

--- a/packages/@granit/entities/src/index.ts
+++ b/packages/@granit/entities/src/index.ts
@@ -13,6 +13,7 @@
 // `readonly T[]`, `IReadOnlyDictionary<string, T>` →
 // `Readonly<Record<string, T>>`.
 
+export { evaluateVisibility } from './helpers/index.js';
 export { ALL_ENTITY_FACETS, MANIFEST_SCHEMA_VERSION } from './types/index.js';
 export type {
   EntityCollectionReference,


### PR DESCRIPTION
## Summary

- Adds `evaluateVisibility(condition, formValues)` to `@granit/entities` — pure switch over the eight `FieldOp` operators with exhaustive type narrowing
- Throws on a malformed `In`/`NotIn` (non-array value) so manifest violations surface as bugs rather than silent hidden fields
- 17 Vitest cases cover every operator + the edge cases that bit me on the .NET side: null-vs-undefined under `Eq`, falsy-but-defined values under `IsNull`, type-mismatched `Gt`/`Lt` returning `false` instead of NaN-coerced truthy, missing keys read as `undefined`

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/entities/src/__tests__/evaluate-visibility.test.ts` → 17 passing

## Parent

Feature #298 → Epic #242
