### PR TITLE
feat(react-entities): useEntityDiscovery hook

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2696,7 +2696,18 @@
     {
       "name": "@granit/react-entities",
       "description": "React renderer for @granit/entities — manifest hooks (useEntityDiscovery / useEntityMetadata) and the four generic renderers (EntityList, EntityKanban, EntityForm, EntityDetail) wired to the standard widget catalog",
-      "exports": []
+      "exports": [
+        {
+          "name": "entityDiscoveryQueryKey",
+          "kind": "const",
+          "signature": "const entityDiscoveryQueryKey"
+        },
+        {
+          "name": "useEntityDiscovery",
+          "kind": "function",
+          "signature": "function useEntityDiscovery( options:"
+        }
+      ]
     },
     {
       "name": "@granit/react-entities-views",

--- a/packages/@granit/react-entities/src/__tests__/use-entity-discovery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-discovery.test.tsx
@@ -1,0 +1,106 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { entityDiscoveryQueryKey, useEntityDiscovery } from '../api/use-entity-discovery.js';
+
+import type { EntityDiscoveryResponse } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const DISCOVERY: EntityDiscoveryResponse = {
+  schemaVersion: 1,
+  modules: [
+    {
+      module: 'Parties',
+      items: [
+        {
+          name: 'Granit.Parties.Party',
+          displayKey: 'Granit.Parties.Party.DisplayName',
+          icon: 'users',
+          permissionGroup: 'Parties.Parties',
+          links: {
+            manifest: '/api/entities/Granit.Parties.Party',
+            list: '/api/v1/parties',
+          },
+        },
+      ],
+    },
+  ],
+};
+
+let getCalls = 0;
+
+function freshHandlers() {
+  return [
+    http.get('http://localhost/entities', () => {
+      getCalls += 1;
+      return HttpResponse.json(DISCOVERY);
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  getCalls = 0;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useEntityDiscovery', () => {
+  it('returns the discovery tree on success', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityDiscovery(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(DISCOVERY);
+    expect(getCalls).toBe(1);
+  });
+
+  it('honours enabled: false', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityDiscovery({ enabled: false }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getCalls).toBe(0);
+  });
+
+  it('caches under the discovery query key', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useEntityDiscovery(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(entityDiscoveryQueryKey())).toEqual(DISCOVERY);
+  });
+
+  it('surfaces the error when the endpoint returns 500', async () => {
+    server.use(
+      http.get('http://localhost/entities', () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityDiscovery(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-entities/src/api/use-entity-discovery.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-discovery.ts
@@ -1,0 +1,42 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { EntityDiscoveryResponse } from '@granit/entities';
+
+const DISCOVERY_PATH = '/entities';
+
+/**
+ * Cache key for the entity discovery tree. Distinct from the per-entity
+ * manifest keys (see {@link entityManifestQueryKey}) — the discovery
+ * payload is shaped only by `(user-perms-hash, culture)` and only changes
+ * on deployments or permission grants, while the per-entity manifest
+ * additionally varies with the requested facets.
+ */
+export const entityDiscoveryQueryKey = () => ['entities', 'discovery'] as const;
+
+/**
+ * `GET /entities` — returns the discovery tree of every `EntityDefinition`
+ * the requesting user has Read permission on, grouped by module. Mirrors
+ * `Granit.Entities.Endpoints.EntitiesEndpoints.DiscoveryAsync`.
+ *
+ * Long staleTime — the catalogue is shaped by the host's module DI graph
+ * and the user's granted permissions, neither of which churns mid-session.
+ * The .NET handler caches the response 5 minutes per
+ * `(user-perms-hash, culture)`, so even an aggressive React Query refetch
+ * usually short-circuits at the FusionCache layer rather than hitting
+ * the registry walk.
+ */
+export function useEntityDiscovery(
+  options: { readonly enabled?: boolean } = {}
+): UseQueryResult<EntityDiscoveryResponse> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: entityDiscoveryQueryKey(),
+    queryFn: async ({ signal }) => {
+      const { data } = await api.get<EntityDiscoveryResponse>(DISCOVERY_PATH, { signal });
+      return data;
+    },
+    enabled: options.enabled ?? true,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -1,6 +1,9 @@
+// ---------------------------------------------------------------------------
 // @granit/react-entities — public API
+// ---------------------------------------------------------------------------
 //
 // React hooks + generic renderers driven by the manifest exposed by
 // @granit/entities. Implementation tracked under
 // granit-fx/granit-front#298 (hooks) and #299 (renderers).
-export {};
+
+export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';


### PR DESCRIPTION
## Summary

- Adds `useEntityDiscovery()` to `@granit/react-entities` — wraps `GET /entities` into a typed React Query hook
- Exposes `entityDiscoveryQueryKey()` so consumers can invalidate after a permission change
- 5-min `staleTime` mirrors the .NET FusionCache window — the catalogue is shaped by module DI + permission grants, neither of which churns mid-session
- 4 MSW tests: happy path, `enabled: false`, cache write under the public key, 500 surfacing

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/use-entity-discovery.test.tsx` → 4 passing

## Parent

Feature #298 → Epic #242
