### PR TITLE
feat(react-entities): useEntityMetadata hook with ETag + facets

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2706,6 +2706,16 @@
           "name": "useEntityDiscovery",
           "kind": "function",
           "signature": "function useEntityDiscovery( options:"
+        },
+        {
+          "name": "entityManifestQueryKey",
+          "kind": "function",
+          "signature": "function entityManifestQueryKey( name: string, facets?: readonly EntityFacet[] ): readonly ['entities', 'manifest', string, string | null]"
+        },
+        {
+          "name": "useEntityMetadata",
+          "kind": "function",
+          "signature": "function useEntityMetadata( name: string, options:"
         }
       ]
     },

--- a/packages/@granit/react-entities/src/__tests__/use-entity-metadata.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-metadata.test.tsx
@@ -1,0 +1,153 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { entityManifestQueryKey, useEntityMetadata } from '../api/use-entity-metadata.js';
+
+import type { EntityManifestResponse } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY_NAME = 'Granit.Parties.Party';
+const ENCODED = encodeURIComponent(ENTITY_NAME);
+const ETAG = '"f1d2d2f924e986ac86fdf7b36c94bcdf32beec15"';
+
+const FULL: EntityManifestResponse = {
+  schemaVersion: 1,
+  identity: {
+    name: ENTITY_NAME,
+    entityClrType: 'Granit.Parties.Domain.Party',
+    displayKey: 'Granit.Parties.Party.DisplayName',
+    icon: 'users',
+    permissionGroup: 'Parties.Parties',
+    displayProperty: 'Number',
+  },
+  permissions: {
+    canRead: true,
+    canCreate: true,
+    canUpdate: true,
+    canDelete: false,
+    canManage: false,
+    canExecute: false,
+  },
+  forms: [],
+  details: [],
+  collections: null,
+  relations: [],
+};
+
+let lastRequest: { url: string; ifNoneMatch: string | null } | null = null;
+let getCalls = 0;
+
+function freshHandlers() {
+  return [
+    http.get(`http://localhost/entities/${ENCODED}`, ({ request }) => {
+      getCalls += 1;
+      const url = new URL(request.url);
+      lastRequest = {
+        url: `${url.pathname}${url.search}`,
+        ifNoneMatch: request.headers.get('if-none-match'),
+      };
+      if (lastRequest.ifNoneMatch === ETAG) {
+        return new HttpResponse(null, { status: 304, headers: { ETag: ETAG } });
+      }
+      return HttpResponse.json(FULL, { headers: { ETag: ETAG } });
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastRequest = null;
+  getCalls = 0;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useEntityMetadata', () => {
+  it('returns the manifest and URL-encodes the name', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityMetadata(ENTITY_NAME), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(FULL);
+    expect(lastRequest?.url).toBe(`/entities/${ENCODED}`);
+  });
+
+  it('serialises facets as a sorted CSV under ?facets=', async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useEntityMetadata(ENTITY_NAME, { facets: ['forms', 'identity'] }), {
+      wrapper,
+    });
+    await waitFor(() => expect(lastRequest?.url.includes('facets=')).toBe(true));
+    expect(lastRequest?.url).toBe(`/entities/${ENCODED}?facets=forms,identity`);
+  });
+
+  it('shares the cache slot regardless of the facets array order', () => {
+    const a = entityManifestQueryKey(ENTITY_NAME, ['forms', 'identity']);
+    const b = entityManifestQueryKey(ENTITY_NAME, ['identity', 'forms']);
+    expect(a).toEqual(b);
+    expect(a).not.toEqual(entityManifestQueryKey(ENTITY_NAME));
+  });
+
+  it('honours enabled: false', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityMetadata(ENTITY_NAME, { enabled: false }), {
+      wrapper,
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getCalls).toBe(0);
+  });
+
+  it('skips the request when name is empty', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityMetadata(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getCalls).toBe(0);
+  });
+
+  it('sends If-None-Match on refetch and keeps cached data on 304', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useEntityMetadata(ENTITY_NAME), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getCalls).toBe(1);
+
+    await queryClient.refetchQueries({ queryKey: entityManifestQueryKey(ENTITY_NAME) });
+
+    expect(lastRequest?.ifNoneMatch).toBe(ETAG);
+    expect(getCalls).toBe(2);
+    expect(result.current.data).toEqual(FULL);
+  });
+
+  it('surfaces the error when the endpoint returns 500', async () => {
+    server.use(
+      http.get(`http://localhost/entities/${ENCODED}`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityMetadata(ENTITY_NAME), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-entities/src/api/use-entity-metadata.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-metadata.ts
@@ -1,0 +1,85 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
+
+import type { EntityFacet, EntityManifestResponse } from '@granit/entities';
+
+/**
+ * Cache key for one per-entity manifest. Keyed by `(name, facets-csv)` so a
+ * caller asking for the slim `?facets=identity` payload doesn't collide
+ * with a prior request that fetched the full manifest, and a permission
+ * change that bumps the manifest version invalidates both at once via
+ * `queryClient.invalidateQueries({ queryKey: ['entities', 'manifest'] })`.
+ *
+ * `facets` is normalised to a sorted CSV so callers passing
+ * `['forms', 'identity']` and `['identity', 'forms']` share one cache slot.
+ */
+export function entityManifestQueryKey(
+  name: string,
+  facets?: readonly EntityFacet[]
+): readonly ['entities', 'manifest', string, string | null] {
+  const facetsKey = facets && facets.length > 0 ? [...facets].sort().join(',') : null;
+  return ['entities', 'manifest', name, facetsKey] as const;
+}
+
+interface ManifestCacheEntry {
+  readonly manifest: EntityManifestResponse;
+  readonly etag: string | null;
+}
+
+/**
+ * `GET /entities/{name}` — returns the per-entity manifest. Mirrors
+ * `Granit.Entities.Endpoints.EntitiesEndpoints.ManifestAsync`.
+ *
+ * Wired for HTTP 304: the .NET handler emits a strong ETag computed over
+ * `(manifest, user-perms-hash, culture)`. The hook stashes that ETag
+ * alongside the manifest in the React Query cache, sends it back as
+ * `If-None-Match` on subsequent fetches, and recovers the cached manifest
+ * when the server short-circuits with 304. That's the bandwidth saver
+ * FusionCache aims for, and it works even after `staleTime` lapses.
+ *
+ * Pass `facets` to slim the response — the .NET handler omits the unwanted
+ * sections from the payload (returns `null` for them), saving payload
+ * size on screens that only need (say) identity + permissions.
+ */
+export function useEntityMetadata(
+  name: string,
+  options: { readonly facets?: readonly EntityFacet[]; readonly enabled?: boolean } = {}
+): UseQueryResult<EntityManifestResponse> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  const facets = options.facets;
+  const queryKey = entityManifestQueryKey(name, facets);
+
+  return useQuery({
+    queryKey,
+    queryFn: async ({ signal }): Promise<ManifestCacheEntry> => {
+      const cached = queryClient.getQueryData<ManifestCacheEntry>(queryKey);
+      const headers: Record<string, string> = {};
+      if (cached?.etag) {
+        headers['If-None-Match'] = cached.etag;
+      }
+
+      const response = await api.get<EntityManifestResponse>(
+        `/entities/${encodeURIComponent(name)}`,
+        {
+          signal,
+          params:
+            facets && facets.length > 0 ? { facets: [...facets].sort().join(',') } : undefined,
+          headers,
+          validateStatus: (status) => status === 304 || (status >= 200 && status < 300),
+        }
+      );
+
+      if (response.status === 304 && cached) {
+        return cached;
+      }
+
+      const etagHeader = response.headers['etag'];
+      const etag = typeof etagHeader === 'string' ? etagHeader : null;
+      return { manifest: response.data, etag };
+    },
+    select: (entry) => entry.manifest,
+    enabled: (options.enabled ?? true) && Boolean(name),
+    staleTime: 10 * 60_000,
+  });
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -7,3 +7,4 @@
 // granit-fx/granit-front#298 (hooks) and #299 (renderers).
 
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
+export { entityManifestQueryKey, useEntityMetadata } from './api/use-entity-metadata.js';


### PR DESCRIPTION
## Summary

- Adds `useEntityMetadata(name, { facets?, enabled? })` to `@granit/react-entities` — wraps `GET /entities/{name}` into a typed React Query hook
- **ETag round-trip**: stashes the strong ETag from the response alongside the manifest in the cache, sends it as `If-None-Match` on refetch, and recovers cached data on a 304. Pays off after `staleTime` lapses since React Query's own cache doesn't speak HTTP cache headers
- **Facets**: `?facets=` is auto-built from the optional facets array, sorted so callers passing `['forms', 'identity']` and `['identity', 'forms']` share one cache slot
- Cache key (`['entities', 'manifest', name, facets-csv]`) exported so permission changes can invalidate every variant via the prefix `['entities', 'manifest']`

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/use-entity-metadata.test.tsx` → 7 passing (URL encoding, facet serialisation, key normalisation, enabled gating, empty-name short-circuit, ETag → 304, 500 surfacing)

## Parent

Feature #298 → Epic #242
