### PR TITLE
feat(react-entities): entity renderer provider + widget catalog

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-renderer-provider.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-renderer-provider.test.tsx
@@ -1,0 +1,81 @@
+import { render, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  EMPTY_WIDGET_CATALOG,
+  EntityRendererProvider,
+  useEntityRenderer,
+  type EntityFormWidget,
+  type EntityWidgetCatalog,
+} from '../provider/index.js';
+
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const dummyField: EntityFormFieldManifest = {
+  propertyName: 'Number',
+  clrTypeName: 'String',
+  widget: 'text',
+  config: null,
+  labelKey: 'Granit.Parties.Party.Number.Label',
+  helpKey: null,
+  order: 0,
+  readOnly: false,
+  visibleIf: null,
+};
+
+const textWidget: EntityFormWidget = ({ value }) => <span>{String(value)}</span>;
+
+const catalog: EntityWidgetCatalog = {
+  form: { text: textWidget },
+};
+
+describe('EntityRendererProvider', () => {
+  it('throws when useEntityRenderer is called outside a provider', () => {
+    expect(() => renderHook(() => useEntityRenderer())).toThrow(
+      /must be called inside an <EntityRendererProvider>/
+    );
+  });
+
+  it('exposes the catalog and resolver supplied by the provider', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <EntityRendererProvider widgets={catalog} resolveLabel={(_, fallback) => fallback ?? 'X'}>
+        {children}
+      </EntityRendererProvider>
+    );
+    const { result } = renderHook(() => useEntityRenderer(), { wrapper });
+
+    expect(result.current.widgets).toBe(catalog);
+    expect(result.current.resolveLabel('any.key', 'fallback')).toBe('fallback');
+    expect(result.current.resolveLabel('any.key')).toBe('X');
+  });
+
+  it('defaults to an empty catalog and identity resolver', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <EntityRendererProvider>{children}</EntityRendererProvider>
+    );
+    const { result } = renderHook(() => useEntityRenderer(), { wrapper });
+
+    expect(result.current.widgets).toBe(EMPTY_WIDGET_CATALOG);
+    expect(result.current.resolveLabel('Granit.Foo.Bar')).toBe('Granit.Foo.Bar');
+    expect(result.current.resolveLabel('Granit.Foo.Bar', 'Bar label')).toBe('Bar label');
+  });
+
+  it('lets a child component look up a registered widget and render it', () => {
+    function Sample() {
+      const { widgets } = useEntityRenderer();
+      const Widget = widgets.form[dummyField.widget];
+      return Widget ? (
+        <Widget field={dummyField} value="ACME-001" onChange={() => undefined} readOnly={false} />
+      ) : null;
+    }
+
+    const { container } = render(
+      <EntityRendererProvider widgets={catalog}>
+        <Sample />
+      </EntityRendererProvider>
+    );
+
+    expect(container.textContent).toBe('ACME-001');
+  });
+});

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -8,3 +8,16 @@
 
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export { entityManifestQueryKey, useEntityMetadata } from './api/use-entity-metadata.js';
+export {
+  EMPTY_WIDGET_CATALOG,
+  EntityRendererProvider,
+  useEntityRenderer,
+} from './provider/index.js';
+export type {
+  EntityFormWidget,
+  EntityFormWidgetProps,
+  EntityRendererContextValue,
+  EntityRendererProviderProps,
+  EntityWidgetCatalog,
+  ResolveLabel,
+} from './provider/index.js';

--- a/packages/@granit/react-entities/src/provider/entity-renderer-provider.tsx
+++ b/packages/@granit/react-entities/src/provider/entity-renderer-provider.tsx
@@ -1,0 +1,62 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+import { EMPTY_WIDGET_CATALOG, type EntityWidgetCatalog } from './widget-catalog.js';
+
+/**
+ * Resolves an i18n key (as carried by the manifest) into a localised
+ * string. Apps wire react-i18next or their own resolver here so the
+ * renderers stay framework-agnostic.
+ */
+export type ResolveLabel = (key: string, fallback?: string) => string;
+
+const defaultResolveLabel: ResolveLabel = (key, fallback) => fallback ?? key;
+
+/** Context value carried by `<EntityRendererProvider>`. */
+export interface EntityRendererContextValue {
+  readonly widgets: EntityWidgetCatalog;
+  readonly resolveLabel: ResolveLabel;
+}
+
+const EntityRendererContext = createContext<EntityRendererContextValue | null>(null);
+
+export interface EntityRendererProviderProps {
+  /** Widget catalog. Defaults to an empty catalog (renderers will fall back to a generic widget when one isn't registered). */
+  readonly widgets?: EntityWidgetCatalog;
+  /** i18n bridge. Default returns `fallback ?? key` so the UI shows the key while the app wires translations. */
+  readonly resolveLabel?: ResolveLabel;
+  readonly children: ReactNode;
+}
+
+/**
+ * Carries the widget catalog + i18n bridge consumed by `<EntityForm />`,
+ * `<EntityDetail />`, `<EntityList />`, `<EntityKanban />`. The provider
+ * is intentionally lean — i18n / theming / layout primitives stay in the
+ * host app's concern, and renderers ask for the two things they cannot
+ * resolve themselves: which React component to mount for `field.widget`,
+ * and how to translate a manifest label key.
+ */
+export function EntityRendererProvider({
+  widgets = EMPTY_WIDGET_CATALOG,
+  resolveLabel = defaultResolveLabel,
+  children,
+}: EntityRendererProviderProps): ReactNode {
+  const value = useMemo<EntityRendererContextValue>(
+    () => ({ widgets, resolveLabel }),
+    [widgets, resolveLabel]
+  );
+  return <EntityRendererContext.Provider value={value}>{children}</EntityRendererContext.Provider>;
+}
+
+/**
+ * Reads the renderer context. Throws when used outside an
+ * `<EntityRendererProvider>` — the renderers depend on the catalog being
+ * present, so a missing provider is a programming error worth surfacing
+ * loudly rather than rendering silently against an empty catalog.
+ */
+export function useEntityRenderer(): EntityRendererContextValue {
+  const ctx = useContext(EntityRendererContext);
+  if (!ctx) {
+    throw new Error('useEntityRenderer must be called inside an <EntityRendererProvider>.');
+  }
+  return ctx;
+}

--- a/packages/@granit/react-entities/src/provider/index.ts
+++ b/packages/@granit/react-entities/src/provider/index.ts
@@ -1,0 +1,12 @@
+export { EntityRendererProvider, useEntityRenderer } from './entity-renderer-provider.js';
+export { EMPTY_WIDGET_CATALOG } from './widget-catalog.js';
+export type {
+  EntityRendererContextValue,
+  EntityRendererProviderProps,
+  ResolveLabel,
+} from './entity-renderer-provider.js';
+export type {
+  EntityFormWidget,
+  EntityFormWidgetProps,
+  EntityWidgetCatalog,
+} from './widget-catalog.js';

--- a/packages/@granit/react-entities/src/provider/widget-catalog.ts
+++ b/packages/@granit/react-entities/src/provider/widget-catalog.ts
@@ -1,0 +1,34 @@
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+/**
+ * Props passed to a form-widget renderer when `<EntityForm />` paints one
+ * field. The renderer is fully controlled — `<EntityForm />` owns the
+ * value via React Hook Form and just hands it down.
+ */
+export interface EntityFormWidgetProps {
+  readonly field: EntityFormFieldManifest;
+  readonly value: unknown;
+  readonly onChange: (next: unknown) => void;
+  readonly readOnly: boolean;
+  /** First validation message for this field, when any. */
+  readonly errorMessage?: string;
+}
+
+/** Renderer for one field in `<EntityForm />`. */
+export type EntityFormWidget = (props: EntityFormWidgetProps) => ReactNode;
+
+/**
+ * Catalog mapping widget identifiers (the `field.widget` value from the
+ * manifest) → renderers. Apps register the standard catalog plus any
+ * `custom:`-namespaced widgets they own (per ADR-041).
+ */
+export interface EntityWidgetCatalog {
+  /** Form-context widgets, keyed by `field.widget`. */
+  readonly form: Readonly<Record<string, EntityFormWidget>>;
+}
+
+/** Empty catalog — useful as a default and in tests. */
+export const EMPTY_WIDGET_CATALOG: EntityWidgetCatalog = Object.freeze({
+  form: Object.freeze({}),
+});


### PR DESCRIPTION
## Summary

- Adds `<EntityRendererProvider>` + `useEntityRenderer()` to `@granit/react-entities` — the context that carries the widget catalog and the i18n bridge into the four generic renderers landing under #299
- Provider stays lean: only the two things renderers cannot resolve themselves — widget lookup (manifest gives a string identifier; only the host app knows which React component to mount) and label resolution (manifest carries i18n keys; only the host knows which translator is wired)
- Defaults: `resolveLabel` returns `fallback ?? key` so widgets work out-of-the-box during dev; catalog defaults to a frozen empty catalog. `useEntityRenderer` throws when called outside the provider so a missing provider surfaces at first render rather than silently rendering nothing

## Closes Feature #298

This is the seventh and last story listed in the Feature body. After merge:

- [x] Scaffold @granit/entities package (#303)
- [x] Scaffold @granit/react-entities package + `<EntityRendererProvider>` (#303 + this PR)
- [x] Manifest TS types (form / detail / discovery / collections / relations) (#304)
- [x] Visibility DSL types + evaluateVisibility helper (#304 + #305)
- [x] useEntityDiscovery hook + tests against MSW (#306)
- [x] useEntityMetadata hook with ETag + facets support + tests (#307)
- [x] React Query key factory + invalidation helpers (`entityDiscoveryQueryKey()` and `entityManifestQueryKey()` exported alongside their hooks)

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-renderer-provider.test.tsx` → 4 passing (throw outside provider, value pass-through, defaults, end-to-end widget mount)

## Parent

Feature #298 → Epic #242
