### PR TITLE
feat(workspaces): tree + landing-route TS types

### DIFF
--- a/packages/@granit/workspaces/src/index.ts
+++ b/packages/@granit/workspaces/src/index.ts
@@ -1,8 +1,26 @@
-// @granit/workspaces — public API
+// ---------------------------------------------------------------------------
+// @granit/workspaces — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
 //
-// Framework-agnostic contracts for the Granit workspace tree (sidebar
-// navigation) and the landing-route resolver. Mirrors the .NET DTOs from
-// Granit.Workspaces.Abstractions + Granit.Workspaces.Endpoints.Dtos.
+// Mirrors the .NET DTOs from Granit.Workspaces.Abstractions +
+// Granit.Workspaces.Endpoints.Dtos so any consumer (React renderer, mobile
+// app, future Vue port) can read the `/workspaces` and `/me/landing-route`
+// payloads with full type safety.
 //
-// Implementation lands in subsequent stories of granit-fx/granit-front#300.
-export {};
+// Wire conventions match @granit/entities: camelCase property names
+// (System.Text.Json default), PascalCase string-literal enums (Granit
+// registers a `JsonStringEnumConverter` without naming policy),
+// `IReadOnlyList<T>` → `readonly T[]`, `IReadOnlyDictionary<string, T>` →
+// `Readonly<Record<string, T>>`.
+
+export { WORKSPACE_TREE_SCHEMA_VERSION } from './types/index.js';
+export type {
+  LandingRouteResponse,
+  LandingRouteSource,
+  SetPinnedLandingRouteRequest,
+  WorkspaceItemKind,
+  WorkspaceItemResponse,
+  WorkspaceResponse,
+  WorkspaceSectionResponse,
+  WorkspaceTreeResponse,
+} from './types/index.js';

--- a/packages/@granit/workspaces/src/types/index.ts
+++ b/packages/@granit/workspaces/src/types/index.ts
@@ -1,0 +1,13 @@
+export type {
+  LandingRouteResponse,
+  LandingRouteSource,
+  SetPinnedLandingRouteRequest,
+} from './landing.js';
+export { WORKSPACE_TREE_SCHEMA_VERSION } from './tree.js';
+export type {
+  WorkspaceItemKind,
+  WorkspaceItemResponse,
+  WorkspaceResponse,
+  WorkspaceSectionResponse,
+  WorkspaceTreeResponse,
+} from './tree.js';

--- a/packages/@granit/workspaces/src/types/landing.ts
+++ b/packages/@granit/workspaces/src/types/landing.ts
@@ -1,0 +1,40 @@
+/**
+ * Tier of the landing-route precedence chain that resolved the route
+ * returned by `GET /me/landing-route`. Mirrors
+ * `Granit.Workspaces.Endpoints.Landing.LandingRouteSource` — ADR-048's
+ * 5-tier resolver, highest to lowest:
+ *
+ * 1. `PersonalSticky` — last-visited route, sticky across sessions
+ * 2. `PersonalPinned` — set explicitly via `PUT /me/landing-route/pinned`
+ * 3. `Role` — default route attached to one of the user's roles
+ * 4. `Tenant` — tenant-wide default
+ * 5. `Framework` — fallback configured via `WorkspacesEndpointsOptions`
+ */
+export type LandingRouteSource =
+  | 'PersonalSticky'
+  | 'PersonalPinned'
+  | 'Role'
+  | 'Tenant'
+  | 'Framework';
+
+/**
+ * Response payload for `GET /me/landing-route`. Mirrors
+ * `Granit.Workspaces.Endpoints.Dtos.LandingRouteResponse`.
+ */
+export interface LandingRouteResponse {
+  /** Resolved internal route (e.g. `"/w/Granit.Framework"`). */
+  readonly route: string;
+  /** Tier of the precedence chain that produced the route. */
+  readonly source: LandingRouteSource;
+}
+
+/**
+ * Request body for `PUT /me/landing-route/pinned`. Mirrors
+ * `Granit.Workspaces.Endpoints.Dtos.SetPinnedLandingRouteRequest`.
+ *
+ * Pass `null` to clear the personal pin and let the resolver fall through
+ * to the next tier (Role / Tenant / Framework).
+ */
+export interface SetPinnedLandingRouteRequest {
+  readonly route: string | null;
+}

--- a/packages/@granit/workspaces/src/types/tree.ts
+++ b/packages/@granit/workspaces/src/types/tree.ts
@@ -1,0 +1,94 @@
+/**
+ * Closed enum of slot kinds the workspace tree exposes. Mirrors
+ * `Granit.Workspaces.WorkspaceItemKind`.
+ *
+ * - `Entity` — reference to an `EntityDefinition`, the renderer mounts its list / kanban view
+ * - `Dashboard` — reference to a `DashboardDefinition`
+ * - `Link` — internal SPA route or external URL
+ * - `SubWorkspace` — recurses into a child workspace
+ */
+export type WorkspaceItemKind = 'Entity' | 'Dashboard' | 'Link' | 'SubWorkspace';
+
+/**
+ * One item in a workspace section. Mirrors
+ * `Granit.Workspaces.Endpoints.Dtos.WorkspaceItemResponse`.
+ *
+ * Several fields are mutually exclusive depending on `kind` — `entityName`
+ * is set for `Entity`, `dashboardName` for `Dashboard`, etc. The wire
+ * format models this as a single shape with optional fields rather than a
+ * discriminated union; consumers should narrow on `kind` before reading
+ * the kind-specific fields.
+ *
+ * `entityPresetOverlay` carries the additive preset (filters, sort,
+ * columns) layered on top of the entity's compiled defaults. Wire shape
+ * is currently an opaque dictionary (`Readonly<Record<string, unknown>>`);
+ * a typed schema is pending on the .NET side (cross-repo correction
+ * filed against granit-fx/granit-dotnet#1554).
+ */
+export interface WorkspaceItemResponse {
+  readonly kind: WorkspaceItemKind;
+  readonly order: number;
+  readonly displayKey: string | null;
+  readonly icon: string | null;
+  /** Set when `kind` is `Entity`. */
+  readonly entityName: string | null;
+  /** Optional preferred default `EntityView` name on the entity. */
+  readonly entityViewName: string | null;
+  /** Additive preset overlay (filters / sort / columns layered on the entity). */
+  readonly entityPresetOverlay: Readonly<Record<string, unknown>> | null;
+  /** Set when `kind` is `Dashboard`. */
+  readonly dashboardName: string | null;
+  /** Set when `kind` is `Link`. */
+  readonly linkUrl: string | null;
+  /** Set when `kind` is `SubWorkspace`. */
+  readonly subWorkspaceName: string | null;
+}
+
+/**
+ * One section within a workspace. Mirrors
+ * `Granit.Workspaces.Endpoints.Dtos.WorkspaceSectionResponse`.
+ */
+export interface WorkspaceSectionResponse {
+  readonly key: string;
+  readonly displayKey: string | null;
+  readonly order: number;
+  readonly collapsedByDefault: boolean;
+  readonly items: readonly WorkspaceItemResponse[];
+}
+
+/**
+ * One workspace in the tree. Mirrors
+ * `Granit.Workspaces.Endpoints.Dtos.WorkspaceResponse`.
+ *
+ * `isShell` distinguishes Framework shells (System / Users / Automation /
+ * Data / Email / Integrations / Monitoring / Privacy — populated by the
+ * `Granit.Workspaces.Framework` contributions) from app-defined
+ * workspaces; consumers can use it to render shells under a separate
+ * "Framework" header in the sidebar.
+ */
+export interface WorkspaceResponse {
+  readonly name: string;
+  readonly displayKey: string | null;
+  readonly icon: string | null;
+  readonly order: number;
+  readonly isShell: boolean;
+  readonly sections: readonly WorkspaceSectionResponse[];
+}
+
+/**
+ * Top-level payload returned by `GET /workspaces`. Mirrors
+ * `Granit.Workspaces.Endpoints.Dtos.WorkspaceTreeResponse`.
+ */
+export interface WorkspaceTreeResponse {
+  /** Workspace tree schema version (semver-major). Bumps on breaking shape changes. */
+  readonly schemaVersion: number;
+  /** Workspaces visible to the requesting user, sorted by `order` then `name`. */
+  readonly workspaces: readonly WorkspaceResponse[];
+}
+
+/**
+ * Schema version this package was compiled against. Consumers can check
+ * `tree.schemaVersion === WORKSPACE_TREE_SCHEMA_VERSION` to assert the
+ * wire shape matches what they were built for.
+ */
+export const WORKSPACE_TREE_SCHEMA_VERSION = 1;


### PR DESCRIPTION
## Summary

- Adds the TypeScript contracts for `/workspaces` and `/me/landing-route` to `@granit/workspaces`, mirroring `Granit.Workspaces.Endpoints.Dtos`
- Tree: `WorkspaceTreeResponse`, `WorkspaceResponse`, `WorkspaceSectionResponse`, `WorkspaceItemResponse` + `WorkspaceItemKind` (`Entity` / `Dashboard` / `Link` / `SubWorkspace`)
- Landing: `LandingRouteResponse`, `LandingRouteSource` (5-tier resolver), `SetPinnedLandingRouteRequest`
- `WORKSPACE_TREE_SCHEMA_VERSION = 1` (matches the .NET `WorkspaceTreeSchema.Version` constant)

## What's not in here

- `entityPresetOverlay` stays as `Readonly<Record<string, unknown>>` — typed schema pending the .NET correction filed against granit-fx/granit-dotnet#1554
- `composeWorkspacePresetOverlay()` helper — follow-up story under #300, depends on the typed schema landing
- `useWorkspaces` / `useLandingRoute` hooks — next story in this Feature

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] All types reference matching .NET DTOs in their JSDoc — easy cross-check
- [ ] Hooks consuming these types land in follow-up PRs and exercise them

## Parent

Feature #300 → Epic #242
