### PR TITLE
feat(react-workspaces): workspace tree + landing-route hooks

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4142,7 +4142,18 @@
     {
       "name": "@granit/react-workspaces",
       "description": "React renderer for @granit/workspaces — WorkspaceNav sidebar, /w/{workspace}/... routing, Notion-style SidePeek with ⌘+⇧+. expand, and the landing-route resolver hook",
-      "exports": []
+      "exports": [
+        {
+          "name": "useWorkspaces",
+          "kind": "function",
+          "signature": "function useWorkspaces( options:"
+        },
+        {
+          "name": "workspaceTreeQueryKey",
+          "kind": "const",
+          "signature": "const workspaceTreeQueryKey"
+        }
+      ]
     },
     {
       "name": "@granit/reference-data",

--- a/packages/@granit/react-workspaces/src/__tests__/use-landing-route.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-landing-route.test.tsx
@@ -1,0 +1,124 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  landingRouteQueryKey,
+  useLandingRoute,
+  useSetLandingPin,
+} from '../api/use-landing-route.js';
+
+import type { LandingRouteResponse } from '@granit/workspaces';
+import type { ReactNode } from 'react';
+
+const ROUTE: LandingRouteResponse = {
+  route: '/w/Granit.Framework',
+  source: 'Framework',
+};
+
+let getCalls = 0;
+let lastPinBody: unknown = null;
+
+function freshHandlers() {
+  return [
+    http.get('http://localhost/me/landing-route', () => {
+      getCalls += 1;
+      return HttpResponse.json(ROUTE);
+    }),
+    http.put('http://localhost/me/landing-route/pinned', async ({ request }) => {
+      lastPinBody = await request.json();
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  getCalls = 0;
+  lastPinBody = null;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useLandingRoute', () => {
+  it('returns the resolved route + tier', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useLandingRoute(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(ROUTE);
+  });
+
+  it('caches under the landing-route query key', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useLandingRoute(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(landingRouteQueryKey())).toEqual(ROUTE);
+  });
+
+  it('honours enabled: false', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useLandingRoute({ enabled: false }), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getCalls).toBe(0);
+  });
+});
+
+describe('useSetLandingPin', () => {
+  it('PUTs the route to /me/landing-route/pinned', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSetLandingPin(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ route: '/w/Granit.Showcase.CRM' });
+    });
+
+    expect(lastPinBody).toEqual({ route: '/w/Granit.Showcase.CRM' });
+  });
+
+  it('accepts null to clear the pin', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSetLandingPin(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ route: null });
+    });
+
+    expect(lastPinBody).toEqual({ route: null });
+  });
+
+  it('invalidates the landing-route cache on success', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result: routeResult } = renderHook(() => useLandingRoute(), { wrapper });
+    await waitFor(() => expect(routeResult.current.isSuccess).toBe(true));
+    expect(getCalls).toBe(1);
+
+    const { result: pinResult } = renderHook(() => useSetLandingPin(), { wrapper });
+    await act(async () => {
+      await pinResult.current.mutateAsync({ route: '/w/X' });
+    });
+
+    await waitFor(() => expect(getCalls).toBe(2));
+    expect(queryClient.getQueryState(landingRouteQueryKey())?.isInvalidated).toBe(false);
+  });
+});

--- a/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
@@ -1,0 +1,119 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { useWorkspaces, workspaceTreeQueryKey } from '../api/use-workspaces.js';
+
+import type { WorkspaceTreeResponse } from '@granit/workspaces';
+import type { ReactNode } from 'react';
+
+const TREE: WorkspaceTreeResponse = {
+  schemaVersion: 1,
+  workspaces: [
+    {
+      name: 'Granit.Showcase.CRM',
+      displayKey: 'Granit.Showcase.CRM.DisplayName',
+      icon: 'briefcase',
+      order: 100,
+      isShell: false,
+      sections: [
+        {
+          key: 'parties',
+          displayKey: 'Granit.Showcase.CRM.Parties',
+          order: 0,
+          collapsedByDefault: false,
+          items: [
+            {
+              kind: 'Entity',
+              order: 0,
+              displayKey: null,
+              icon: null,
+              entityName: 'Granit.Parties.Party',
+              entityViewName: null,
+              entityPresetOverlay: null,
+              dashboardName: null,
+              linkUrl: null,
+              subWorkspaceName: null,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+let getCalls = 0;
+
+function freshHandlers() {
+  return [
+    http.get('http://localhost/workspaces', () => {
+      getCalls += 1;
+      return HttpResponse.json(TREE);
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  getCalls = 0;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useWorkspaces', () => {
+  it('returns the workspace tree on success', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(TREE);
+    expect(getCalls).toBe(1);
+  });
+
+  it('honours enabled: false', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useWorkspaces({ enabled: false }), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getCalls).toBe(0);
+  });
+
+  it('caches under the tree query key', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryClient.getQueryData(workspaceTreeQueryKey())).toEqual(TREE);
+  });
+
+  it('surfaces the error when the endpoint returns 500', async () => {
+    server.use(
+      http.get('http://localhost/workspaces', () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useWorkspaces(), { wrapper });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-workspaces/src/api/use-landing-route.ts
+++ b/packages/@granit/react-workspaces/src/api/use-landing-route.ts
@@ -1,0 +1,62 @@
+import { useGranitClient } from '@granit/react-api-client';
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+  type UseQueryResult,
+} from '@tanstack/react-query';
+
+import type { LandingRouteResponse, SetPinnedLandingRouteRequest } from '@granit/workspaces';
+
+const LANDING_ROUTE_PATH = '/me/landing-route';
+const LANDING_ROUTE_PINNED_PATH = '/me/landing-route/pinned';
+
+/** Cache key for the resolved landing route. */
+export const landingRouteQueryKey = () => ['workspaces', 'landing-route'] as const;
+
+/**
+ * `GET /me/landing-route` — returns the route the user should be sent to
+ * after login, plus the tier of the 5-tier resolver that produced it
+ * (PersonalSticky / PersonalPinned / Role / Tenant / Framework). Mirrors
+ * `Granit.Workspaces.Endpoints.LandingRouteEndpoints.GetAsync`.
+ *
+ * Short staleTime — the landing route changes whenever the user pins a
+ * new one or visits a workspace (PersonalSticky updates server-side), so
+ * we don't want to keep stale answers around past a minute.
+ */
+export function useLandingRoute(
+  options: { readonly enabled?: boolean } = {}
+): UseQueryResult<LandingRouteResponse> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: landingRouteQueryKey(),
+    queryFn: async ({ signal }) => {
+      const { data } = await api.get<LandingRouteResponse>(LANDING_ROUTE_PATH, { signal });
+      return data;
+    },
+    enabled: options.enabled ?? true,
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * `PUT /me/landing-route/pinned` — sets (or clears, with `route: null`)
+ * the user's personal pin in the precedence chain. Mirrors
+ * `Granit.Workspaces.Endpoints.LandingRouteEndpoints.SetPinnedAsync`.
+ *
+ * Invalidates the cached landing-route on success so a subsequent
+ * `useLandingRoute()` reads the updated tier.
+ */
+export function useSetLandingPin(): UseMutationResult<void, Error, SetPinnedLandingRouteRequest> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request: SetPinnedLandingRouteRequest) => {
+      await api.put(LANDING_ROUTE_PINNED_PATH, request);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: landingRouteQueryKey() });
+    },
+  });
+}

--- a/packages/@granit/react-workspaces/src/api/use-workspaces.ts
+++ b/packages/@granit/react-workspaces/src/api/use-workspaces.ts
@@ -1,0 +1,38 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { WorkspaceTreeResponse } from '@granit/workspaces';
+
+const WORKSPACES_PATH = '/workspaces';
+
+/**
+ * Cache key for the workspace tree. Bumped via
+ * `queryClient.invalidateQueries({ queryKey: ['workspaces', 'tree'] })`
+ * whenever a permission change should re-filter the visible workspaces.
+ */
+export const workspaceTreeQueryKey = () => ['workspaces', 'tree'] as const;
+
+/**
+ * `GET /workspaces` — returns the workspace tree the requesting user can
+ * see, with permission-filtered sections / items, sorted by `order` then
+ * `name`. Mirrors `Granit.Workspaces.Endpoints.WorkspacesEndpoints`.
+ *
+ * 5-minute staleTime — the tree is shaped by module DI + permission
+ * grants, neither of which churns mid-session. The .NET handler caches
+ * the response per `(user-perms-hash, culture)` so even an aggressive
+ * refetch usually short-circuits server-side.
+ */
+export function useWorkspaces(
+  options: { readonly enabled?: boolean } = {}
+): UseQueryResult<WorkspaceTreeResponse> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: workspaceTreeQueryKey(),
+    queryFn: async ({ signal }) => {
+      const { data } = await api.get<WorkspaceTreeResponse>(WORKSPACES_PATH, { signal });
+      return data;
+    },
+    enabled: options.enabled ?? true,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/packages/@granit/react-workspaces/src/index.ts
+++ b/packages/@granit/react-workspaces/src/index.ts
@@ -1,8 +1,16 @@
+// ---------------------------------------------------------------------------
 // @granit/react-workspaces — public API
+// ---------------------------------------------------------------------------
 //
 // React shell for the workspace tree: WorkspaceNav sidebar, route helpers
 // (/w/{workspace}/... and /entity/{id}), the Notion-style SidePeek drawer,
 // and the LandingRedirect that consumes the .NET 5-tier resolver.
 //
 // Implementation lands in subsequent stories of granit-fx/granit-front#300.
-export {};
+
+export {
+  landingRouteQueryKey,
+  useLandingRoute,
+  useSetLandingPin,
+} from './api/use-landing-route.js';
+export { useWorkspaces, workspaceTreeQueryKey } from './api/use-workspaces.js';


### PR DESCRIPTION
## Summary

Three React Query hooks against `Granit.Workspaces.Endpoints`:

- **`useWorkspaces()`** — `GET /workspaces`, 5-min staleTime mirroring the .NET FusionCache window
- **`useLandingRoute()`** — `GET /me/landing-route`, 1-min staleTime since the `PersonalSticky` tier updates server-side on every visited workspace
- **`useSetLandingPin()`** — `PUT /me/landing-route/pinned` with `{ route }` body (null clears the pin). Invalidates `landingRouteQueryKey` on success

Cache keys exported (`workspaceTreeQueryKey`, `landingRouteQueryKey`) so permission changes can invalidate them via the prefix `['workspaces']`.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-workspaces/src/__tests__/` → 10 passing (happy paths, enabled gating, cache writes, error surfacing, mutation body, null clearing, invalidation round-trip)

## Parent

Feature #300 → Epic #242
