### PR TITLE
feat(react-entities): entity form skeleton

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2698,6 +2698,17 @@
       "description": "React renderer for @granit/entities — manifest hooks (useEntityDiscovery / useEntityMetadata) and the four generic renderers (EntityList, EntityKanban, EntityForm, EntityDetail) wired to the standard widget catalog",
       "exports": [
         {
+          "name": "EntityForm",
+          "kind": "function",
+          "signature": "function EntityForm("
+        },
+        {
+          "name": "EntityFormProps",
+          "kind": "interface",
+          "signature": "interface EntityFormProps",
+          "members": []
+        },
+        {
           "name": "entityDiscoveryQueryKey",
           "kind": "const",
           "signature": "const entityDiscoveryQueryKey"

--- a/packages/@granit/react-entities/src/__tests__/entity-form.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-form.test.tsx
@@ -1,0 +1,214 @@
+import { fireEvent, render } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityForm } from '../components/entity-form.js';
+import {
+  EntityRendererProvider,
+  type EntityFormWidget,
+  type EntityWidgetCatalog,
+} from '../provider/index.js';
+
+import type {
+  EntityFormFieldManifest,
+  EntityFormManifest,
+  EntityFormSectionManifest,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const textWidget: EntityFormWidget = ({ field, value, onChange, readOnly }) => (
+  <input
+    data-testid={`widget-${field.propertyName}`}
+    value={typeof value === 'string' ? value : ''}
+    onChange={(e) => onChange(e.target.value)}
+    readOnly={readOnly}
+  />
+);
+
+const catalog: EntityWidgetCatalog = {
+  form: { text: textWidget },
+};
+
+function field(
+  propertyName: string,
+  order: number,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName,
+    clrTypeName: 'String',
+    widget: 'text',
+    config: null,
+    labelKey: `Field.${propertyName}.Label`,
+    helpKey: null,
+    order,
+    readOnly: false,
+    visibleIf: null,
+    ...overrides,
+  };
+}
+
+function section(
+  key: string,
+  order: number,
+  fields: EntityFormFieldManifest[],
+  overrides: Partial<EntityFormSectionManifest> = {}
+): EntityFormSectionManifest {
+  return {
+    key,
+    labelKey: `Section.${key}.Label`,
+    order,
+    collapsedByDefault: false,
+    fields,
+    ...overrides,
+  };
+}
+
+function manifest(...sections: EntityFormSectionManifest[]): EntityFormManifest {
+  return { name: 'default', customizable: false, sections };
+}
+
+function withProvider(
+  children: ReactNode,
+  widgets: EntityWidgetCatalog = catalog,
+  resolveLabel?: (key: string, fallback?: string) => string
+) {
+  return (
+    <EntityRendererProvider widgets={widgets} resolveLabel={resolveLabel}>
+      {children}
+    </EntityRendererProvider>
+  );
+}
+
+describe('EntityForm', () => {
+  it('renders sections sorted by order, fields sorted by order', () => {
+    const variant = manifest(
+      section('details', 20, [field('Email', 10), field('Name', 0)]),
+      section('identity', 10, [field('Number', 0)])
+    );
+    const { container } = render(
+      withProvider(<EntityForm variant={variant} values={{}} onChange={() => undefined} />)
+    );
+    const sectionEls = container.querySelectorAll('[data-granit-form-section]');
+    expect(Array.from(sectionEls).map((el) => el.getAttribute('data-section-key'))).toEqual([
+      'identity',
+      'details',
+    ]);
+    const fieldEls = container.querySelectorAll(
+      '[data-granit-form-section][data-section-key="details"] [data-granit-form-field]'
+    );
+    expect(Array.from(fieldEls).map((el) => el.getAttribute('data-property'))).toEqual([
+      'Name',
+      'Email',
+    ]);
+  });
+
+  it('hides fields whose visibleIf evaluates false', () => {
+    const variant = manifest(
+      section('main', 0, [
+        field('Status', 0),
+        field('ClosureReason', 1, {
+          visibleIf: { field: 'Status', op: 'Eq', value: 'Closed' },
+        }),
+      ])
+    );
+    const { queryByTestId, rerender } = render(
+      withProvider(
+        <EntityForm variant={variant} values={{ Status: 'Active' }} onChange={() => undefined} />
+      )
+    );
+    expect(queryByTestId('widget-ClosureReason')).toBeNull();
+
+    rerender(
+      withProvider(
+        <EntityForm variant={variant} values={{ Status: 'Closed' }} onChange={() => undefined} />
+      )
+    );
+    expect(queryByTestId('widget-ClosureReason')).not.toBeNull();
+  });
+
+  it('renders MissingWidget when the catalog has no widget for the id', () => {
+    const variant = manifest(
+      section('main', 0, [field('Number', 0, { widget: 'unknown-widget' })])
+    );
+    const { container } = render(
+      withProvider(<EntityForm variant={variant} values={{}} onChange={() => undefined} />)
+    );
+    const missing = container.querySelector('[data-granit-missing-widget]');
+    expect(missing).not.toBeNull();
+    expect(missing?.getAttribute('data-widget')).toBe('unknown-widget');
+  });
+
+  it('forwards readOnly to widgets (form prop OR field flag)', () => {
+    const variant = manifest(
+      section('main', 0, [field('Editable', 0), field('LockedByField', 1, { readOnly: true })])
+    );
+    const { getByTestId, rerender, unmount } = render(
+      withProvider(<EntityForm variant={variant} values={{}} onChange={() => undefined} />)
+    );
+    expect((getByTestId('widget-Editable') as HTMLInputElement).readOnly).toBe(false);
+    expect((getByTestId('widget-LockedByField') as HTMLInputElement).readOnly).toBe(true);
+
+    rerender(
+      withProvider(<EntityForm variant={variant} values={{}} onChange={() => undefined} readOnly />)
+    );
+    expect((getByTestId('widget-Editable') as HTMLInputElement).readOnly).toBe(true);
+    expect((getByTestId('widget-LockedByField') as HTMLInputElement).readOnly).toBe(true);
+    unmount();
+  });
+
+  it('forwards widget changes through onChange merged with prior values', () => {
+    const variant = manifest(section('main', 0, [field('Name', 0)]));
+    const onChange = vi.fn();
+    const { getByTestId } = render(
+      withProvider(
+        <EntityForm variant={variant} values={{ Number: 'ACME-001' }} onChange={onChange} />
+      )
+    );
+    fireEvent.change(getByTestId('widget-Name'), { target: { value: 'ACME' } });
+    expect(onChange).toHaveBeenCalledWith({ Number: 'ACME-001', Name: 'ACME' });
+  });
+
+  it('supports a controlled-state integration end to end', () => {
+    const variant = manifest(section('main', 0, [field('Name', 0)]));
+    function Host() {
+      const [values, setValues] = useState<Readonly<Record<string, unknown>>>({});
+      return <EntityForm variant={variant} values={values} onChange={setValues} />;
+    }
+    const { getByTestId } = render(withProvider(<Host />));
+    const input = getByTestId('widget-Name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Smith' } });
+    expect((getByTestId('widget-Name') as HTMLInputElement).value).toBe('Smith');
+  });
+
+  it('resolves label keys via the provider resolver', () => {
+    const variant = manifest(section('identity', 0, [field('Number', 0)]));
+    const resolve = vi.fn((key: string) => `[${key}]`);
+    const { container } = render(
+      withProvider(
+        <EntityForm variant={variant} values={{}} onChange={() => undefined} />,
+        catalog,
+        resolve
+      )
+    );
+    expect(container.textContent).toContain('[Section.identity.Label]');
+    expect(container.textContent).toContain('[Field.Number.Label]');
+  });
+
+  it('renders the error message when one is provided for a field', () => {
+    const variant = manifest(section('main', 0, [field('Email', 0)]));
+    const { container } = render(
+      withProvider(
+        <EntityForm
+          variant={variant}
+          values={{}}
+          onChange={() => undefined}
+          errors={{ Email: 'Required' }}
+        />
+      )
+    );
+    const error = container.querySelector('[data-granit-field-error]');
+    expect(error?.textContent).toBe('Required');
+    expect(error?.getAttribute('role')).toBe('alert');
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-form.tsx
+++ b/packages/@granit/react-entities/src/components/entity-form.tsx
@@ -1,0 +1,175 @@
+import { evaluateVisibility } from '@granit/entities';
+import { useCallback, useMemo, type ReactNode } from 'react';
+
+import { useEntityRenderer } from '../provider/entity-renderer-provider.js';
+
+import { MissingWidget } from './missing-widget.js';
+
+import type {
+  EntityFormFieldManifest,
+  EntityFormManifest,
+  EntityFormSectionManifest,
+} from '@granit/entities';
+
+export interface EntityFormProps {
+  /** Form variant from the manifest (one of `manifest.forms`). */
+  readonly variant: EntityFormManifest;
+  /** Current form values keyed by PascalCase property name. */
+  readonly values: Readonly<Record<string, unknown>>;
+  /** Called whenever a widget changes its field — receives the next full values bag. */
+  readonly onChange: (next: Readonly<Record<string, unknown>>) => void;
+  /** When `true`, every widget renders read-only regardless of `field.readOnly`. */
+  readonly readOnly?: boolean;
+  /** First validation message keyed by property name, when any. */
+  readonly errors?: Readonly<Record<string, string | undefined>>;
+  /** Optional class for the root form element. */
+  readonly className?: string;
+}
+
+/**
+ * Generic form renderer driven by an `EntityFormManifest`. Reads the widget
+ * catalog + i18n bridge from `<EntityRendererProvider>`, sorts sections /
+ * fields by their declared `order`, evaluates `visibleIf` against the
+ * current values to gate fields, and forwards `readOnly` to every widget
+ * (a field is read-only if either the form prop or the manifest field
+ * declares it).
+ *
+ * The component is **fully controlled** — it owns no state. The host
+ * wires React Hook Form, Zod validation, autosave, etc. above it. That
+ * keeps the renderer pure and testable, and lets a parent reuse the same
+ * `<EntityForm />` against different state strategies.
+ *
+ * Sections render unconditionally — `collapsedByDefault` surfaces as a
+ * `data-collapsed-by-default` attribute so a wrapping component or
+ * stylesheet can layer collapsibility without forking the renderer.
+ */
+export function EntityForm({
+  variant,
+  values,
+  onChange,
+  readOnly = false,
+  errors,
+  className,
+}: EntityFormProps): ReactNode {
+  const sortedSections = useMemo(
+    () => [...variant.sections].sort((a, b) => a.order - b.order),
+    [variant.sections]
+  );
+
+  const handleFieldChange = useCallback(
+    (property: string, next: unknown) => {
+      onChange({ ...values, [property]: next });
+    },
+    [values, onChange]
+  );
+
+  return (
+    <div data-granit-entity-form="" data-variant={variant.name} className={className}>
+      {sortedSections.map((section) => (
+        <EntityFormSection
+          key={section.key}
+          section={section}
+          values={values}
+          onFieldChange={handleFieldChange}
+          readOnly={readOnly}
+          errors={errors}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface EntityFormSectionProps {
+  readonly section: EntityFormSectionManifest;
+  readonly values: Readonly<Record<string, unknown>>;
+  readonly onFieldChange: (property: string, next: unknown) => void;
+  readonly readOnly: boolean;
+  readonly errors: Readonly<Record<string, string | undefined>> | undefined;
+}
+
+function EntityFormSection({
+  section,
+  values,
+  onFieldChange,
+  readOnly,
+  errors,
+}: EntityFormSectionProps): ReactNode {
+  const { resolveLabel } = useEntityRenderer();
+  const sortedFields = useMemo(
+    () => [...section.fields].sort((a, b) => a.order - b.order),
+    [section.fields]
+  );
+
+  return (
+    <section
+      data-granit-form-section=""
+      data-section-key={section.key}
+      data-collapsed-by-default={section.collapsedByDefault ? '' : undefined}
+    >
+      {section.labelKey ? (
+        <header data-granit-section-header="">{resolveLabel(section.labelKey)}</header>
+      ) : null}
+      {sortedFields.map((field) => (
+        <EntityFormField
+          key={field.propertyName}
+          field={field}
+          values={values}
+          onFieldChange={onFieldChange}
+          readOnly={readOnly}
+          errorMessage={errors?.[field.propertyName]}
+        />
+      ))}
+    </section>
+  );
+}
+
+interface EntityFormFieldProps {
+  readonly field: EntityFormFieldManifest;
+  readonly values: Readonly<Record<string, unknown>>;
+  readonly onFieldChange: (property: string, next: unknown) => void;
+  readonly readOnly: boolean;
+  readonly errorMessage: string | undefined;
+}
+
+function EntityFormField({
+  field,
+  values,
+  onFieldChange,
+  readOnly,
+  errorMessage,
+}: EntityFormFieldProps): ReactNode {
+  const { widgets, resolveLabel } = useEntityRenderer();
+
+  if (field.visibleIf && !evaluateVisibility(field.visibleIf, values)) {
+    return null;
+  }
+
+  const Widget = widgets.form[field.widget];
+
+  return (
+    <div data-granit-form-field="" data-property={field.propertyName} data-widget={field.widget}>
+      {field.labelKey ? (
+        <label data-granit-field-label="">{resolveLabel(field.labelKey)}</label>
+      ) : null}
+      {Widget ? (
+        <Widget
+          field={field}
+          value={values[field.propertyName]}
+          onChange={(next) => onFieldChange(field.propertyName, next)}
+          readOnly={readOnly || field.readOnly}
+          errorMessage={errorMessage}
+        />
+      ) : (
+        <MissingWidget field={field} />
+      )}
+      {field.helpKey ? (
+        <small data-granit-field-help="">{resolveLabel(field.helpKey)}</small>
+      ) : null}
+      {errorMessage ? (
+        <p data-granit-field-error="" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/@granit/react-entities/src/components/missing-widget.tsx
+++ b/packages/@granit/react-entities/src/components/missing-widget.tsx
@@ -1,0 +1,23 @@
+import type { EntityFormFieldManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+interface MissingWidgetProps {
+  readonly field: EntityFormFieldManifest;
+}
+
+/**
+ * Fallback rendered when `field.widget` isn't registered in the catalog.
+ * Surfaces the offending widget id so a misconfigured catalog shows up at
+ * a glance — silent omission would let the bug rot in production.
+ */
+export function MissingWidget({ field }: MissingWidgetProps): ReactNode {
+  return (
+    <div
+      data-granit-missing-widget=""
+      data-widget={field.widget}
+      data-property={field.propertyName}
+    >
+      Missing widget &ldquo;{field.widget}&rdquo; for {field.propertyName}
+    </div>
+  );
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -6,6 +6,8 @@
 // @granit/entities. Implementation tracked under
 // granit-fx/granit-front#298 (hooks) and #299 (renderers).
 
+export { EntityForm } from './components/entity-form.js';
+export type { EntityFormProps } from './components/entity-form.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export { entityManifestQueryKey, useEntityMetadata } from './api/use-entity-metadata.js';
 export {


### PR DESCRIPTION
## Summary

Generic, fully-controlled `<EntityForm />` driven by an `EntityFormManifest`. First story under Feature #299.

- **Section + field ordering** — sorted by manifest `order`, stable across re-renders (only re-sort on manifest changes)
- **Widget catalog lookup** via `useEntityRenderer()` from #308's provider; `<MissingWidget />` fallback that surfaces the offending widget id rather than rendering nothing
- **`visibleIf` gating** — evaluated via `@granit/entities`'s `evaluateVisibility` against the current values bag; hidden fields are unmounted (not just hidden via CSS) so their values can't leak through `onSubmit`
- **`readOnly` OR semantics** — true if either the form prop or `field.readOnly` is true
- **Label / help / error** — `labelKey` / `helpKey` resolved via the provider's `resolveLabel`; errors render with `role="alert"` for a11y
- **Stateless** — fully controlled (`values` + `onChange` props). React Hook Form / Zod / autosave wiring lands in a follow-up story; the renderer stays pure for predictable testing

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-form.test.tsx` → 8 passing (section + field ordering, visibleIf gating, MissingWidget fallback, readOnly OR semantics, onChange merge, controlled-state round-trip, label resolution, error message rendering)

## Parent

Feature #299 → Epic #242
