### PR TITLE
feat(react-entities): standard form widget catalog (ADR-041)

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/standard-form-widgets.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/standard-form-widgets.test.tsx
@@ -1,0 +1,223 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityForm } from '../components/entity-form.js';
+import { EntityRendererProvider } from '../provider/index.js';
+import { STANDARD_FORM_WIDGETS } from '../widgets/index.js';
+
+import type { EntityFormFieldManifest, EntityFormManifest } from '@granit/entities';
+
+function singleFieldVariant(field: EntityFormFieldManifest): EntityFormManifest {
+  return {
+    name: 'default',
+    customizable: false,
+    sections: [
+      {
+        key: 'main',
+        labelKey: null,
+        order: 0,
+        collapsedByDefault: false,
+        fields: [field],
+      },
+    ],
+  };
+}
+
+function field(
+  widget: string,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName: 'X',
+    clrTypeName: 'String',
+    widget,
+    config: null,
+    labelKey: null,
+    helpKey: null,
+    order: 0,
+    readOnly: false,
+    visibleIf: null,
+    ...overrides,
+  };
+}
+
+function harness(variant: EntityFormManifest, value: unknown) {
+  const onChange = vi.fn();
+  const utils = render(
+    <EntityRendererProvider widgets={STANDARD_FORM_WIDGETS}>
+      <EntityForm variant={variant} values={{ X: value }} onChange={onChange} />
+    </EntityRendererProvider>
+  );
+  return { ...utils, onChange };
+}
+
+describe('STANDARD_FORM_WIDGETS', () => {
+  it('text — renders a text input and forwards value', () => {
+    const { container, onChange } = harness(singleFieldVariant(field('text')), 'hello');
+    const input = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(input.value).toBe('hello');
+    fireEvent.change(input, { target: { value: 'world' } });
+    expect(onChange).toHaveBeenCalledWith({ X: 'world' });
+  });
+
+  it('textarea — multi-line input', () => {
+    const { container, onChange } = harness(singleFieldVariant(field('textarea')), 'line 1');
+    const textarea = container.querySelector('textarea') as HTMLTextAreaElement;
+    expect(textarea.value).toBe('line 1');
+    fireEvent.change(textarea, { target: { value: 'line 1\nline 2' } });
+    expect(onChange).toHaveBeenCalledWith({ X: 'line 1\nline 2' });
+  });
+
+  it('integer — parses to int, empty becomes null', () => {
+    const { container, onChange } = harness(singleFieldVariant(field('integer')), 42);
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(input.value).toBe('42');
+    fireEvent.change(input, { target: { value: '7' } });
+    expect(onChange).toHaveBeenLastCalledWith({ X: 7 });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange).toHaveBeenLastCalledWith({ X: null });
+  });
+
+  it('decimal — parses to float, empty becomes null', () => {
+    const { container, onChange } = harness(singleFieldVariant(field('decimal')), 3.14);
+    const input = container.querySelector('input[type="number"]') as HTMLInputElement;
+    expect(input.getAttribute('step')).toBe('any');
+    fireEvent.change(input, { target: { value: '2.5' } });
+    expect(onChange).toHaveBeenLastCalledWith({ X: 2.5 });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange).toHaveBeenLastCalledWith({ X: null });
+  });
+
+  it('boolean — renders a checkbox driven by `value === true`', () => {
+    const { container, onChange } = harness(singleFieldVariant(field('boolean')), false);
+    const input = container.querySelector('input[type="checkbox"]') as HTMLInputElement;
+    expect(input.checked).toBe(false);
+    fireEvent.click(input);
+    expect(onChange).toHaveBeenCalledWith({ X: true });
+  });
+
+  it('date / time / datetime — corresponding input types, empty becomes null', () => {
+    const cases: ReadonlyArray<{
+      readonly widget: string;
+      readonly inputType: string;
+      readonly seed: string;
+    }> = [
+      { widget: 'date', inputType: 'date', seed: '2026-04-30' },
+      { widget: 'time', inputType: 'time', seed: '12:30' },
+      { widget: 'datetime', inputType: 'datetime-local', seed: '2026-04-30T12:30' },
+    ];
+    for (const { widget, inputType, seed } of cases) {
+      const { container, onChange, unmount } = harness(singleFieldVariant(field(widget)), seed);
+      const input = container.querySelector(`input[type="${inputType}"]`) as HTMLInputElement;
+      expect(input).not.toBeNull();
+      fireEvent.change(input, { target: { value: '' } });
+      expect(onChange).toHaveBeenLastCalledWith({ X: null });
+      unmount();
+    }
+  });
+
+  it('select — renders options from config and emits the selected value with the original type', () => {
+    const variant = singleFieldVariant(
+      field('select', {
+        config: {
+          options: [
+            { value: 'A', labelKey: null },
+            { value: 'B', labelKey: 'Option.B.Label' },
+          ],
+        },
+      })
+    );
+    const { container, onChange } = harness(variant, 'A');
+    const select = container.querySelector('select') as HTMLSelectElement;
+    expect(select.value).toBe('A');
+    fireEvent.change(select, { target: { value: 'B' } });
+    expect(onChange).toHaveBeenCalledWith({ X: 'B' });
+  });
+
+  it('select — preserves the original value type (number / boolean) on selection', () => {
+    const variant = singleFieldVariant(
+      field('select', {
+        config: {
+          options: [
+            { value: 1, labelKey: null },
+            { value: 2, labelKey: null },
+          ],
+        },
+      })
+    );
+    const { container, onChange } = harness(variant, 1);
+    const select = container.querySelector('select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '2' } });
+    expect(onChange).toHaveBeenCalledWith({ X: 2 });
+  });
+
+  it('select — emits null when the empty option is picked', () => {
+    const variant = singleFieldVariant(
+      field('select', {
+        config: { options: [{ value: 'A', labelKey: null }] },
+      })
+    );
+    const { container, onChange } = harness(variant, 'A');
+    const select = container.querySelector('select') as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith({ X: null });
+  });
+
+  it('select — surfaces a misconfiguration marker when config.options is missing', () => {
+    const { container } = harness(singleFieldVariant(field('select')), null);
+    expect(container.querySelector('[data-granit-select-misconfigured]')).not.toBeNull();
+  });
+
+  it('readOnly — text/textarea expose readOnly, boolean/select expose disabled', () => {
+    function renderRO(widget: string) {
+      const { container, unmount } = render(
+        <EntityRendererProvider widgets={STANDARD_FORM_WIDGETS}>
+          <EntityForm
+            variant={singleFieldVariant(
+              field(widget, {
+                config: widget === 'select' ? { options: [{ value: 'A', labelKey: null }] } : null,
+              })
+            )}
+            values={{ X: widget === 'select' ? 'A' : '' }}
+            onChange={() => undefined}
+            readOnly
+          />
+        </EntityRendererProvider>
+      );
+      return { container, unmount };
+    }
+
+    const text = renderRO('text');
+    expect((text.container.querySelector('input') as HTMLInputElement).readOnly).toBe(true);
+    text.unmount();
+    const textarea = renderRO('textarea');
+    expect((textarea.container.querySelector('textarea') as HTMLTextAreaElement).readOnly).toBe(
+      true
+    );
+    textarea.unmount();
+    const checkbox = renderRO('boolean');
+    expect(
+      (checkbox.container.querySelector('input[type="checkbox"]') as HTMLInputElement).disabled
+    ).toBe(true);
+    checkbox.unmount();
+    const select = renderRO('select');
+    expect((select.container.querySelector('select') as HTMLSelectElement).disabled).toBe(true);
+    select.unmount();
+  });
+
+  it('aria-invalid — set when an errorMessage is provided', () => {
+    const variant = singleFieldVariant(field('text'));
+    const { container } = render(
+      <EntityRendererProvider widgets={STANDARD_FORM_WIDGETS}>
+        <EntityForm
+          variant={variant}
+          values={{ X: '' }}
+          onChange={() => undefined}
+          errors={{ X: 'Required' }}
+        />
+      </EntityRendererProvider>
+    );
+    const input = container.querySelector('input') as HTMLInputElement;
+    expect(input.getAttribute('aria-invalid')).toBe('true');
+  });
+});

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -8,6 +8,8 @@
 
 export { EntityForm } from './components/entity-form.js';
 export type { EntityFormProps } from './components/entity-form.js';
+export { STANDARD_FORM_WIDGETS } from './widgets/index.js';
+export type { SelectWidgetOption } from './widgets/index.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export { entityManifestQueryKey, useEntityMetadata } from './api/use-entity-metadata.js';
 export {

--- a/packages/@granit/react-entities/src/widgets/index.ts
+++ b/packages/@granit/react-entities/src/widgets/index.ts
@@ -1,0 +1,2 @@
+export { STANDARD_FORM_WIDGETS } from './standard-form-widgets.js';
+export type { SelectWidgetOption } from './standard-form-widgets.js';

--- a/packages/@granit/react-entities/src/widgets/standard-form-widgets.tsx
+++ b/packages/@granit/react-entities/src/widgets/standard-form-widgets.tsx
@@ -1,0 +1,223 @@
+import type { EntityFormWidget, EntityWidgetCatalog } from '../provider/widget-catalog.js';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Standard widget catalog (ADR-041 minimum set).
+//
+// Ids match the defaults emitted by Granit.Entities.Abstractions.FieldBuilder
+// .ChooseDefaultWidget(): text / integer / decimal / boolean / date / time /
+// datetime / select. textarea is an explicit opt-in via .Widget("textarea")
+// on the .NET side.
+//
+// Widgets are intentionally unstyled HTML inputs. Apps that want shadcn /
+// Tailwind / Material flavour wrap or replace them via the catalog they
+// pass to <EntityRendererProvider widgets={...} />.
+// ---------------------------------------------------------------------------
+
+function commonProps(field: { propertyName: string }, errorMessage?: string) {
+  return {
+    id: `field-${field.propertyName}`,
+    name: field.propertyName,
+    'aria-invalid': errorMessage ? true : undefined,
+  } as const;
+}
+
+const TextWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <input
+    type="text"
+    {...commonProps(field, errorMessage)}
+    value={typeof value === 'string' ? value : ''}
+    readOnly={readOnly}
+    onChange={(e) => onChange(e.target.value)}
+  />
+);
+
+const TextareaWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <textarea
+    {...commonProps(field, errorMessage)}
+    value={typeof value === 'string' ? value : ''}
+    readOnly={readOnly}
+    onChange={(e) => onChange(e.target.value)}
+  />
+);
+
+const IntegerWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <input
+    type="number"
+    step={1}
+    {...commonProps(field, errorMessage)}
+    value={typeof value === 'number' ? String(value) : ''}
+    readOnly={readOnly}
+    onChange={(e) => {
+      const raw = e.target.value;
+      if (raw === '') {
+        onChange(null);
+        return;
+      }
+      const parsed = Number.parseInt(raw, 10);
+      onChange(Number.isNaN(parsed) ? null : parsed);
+    }}
+  />
+);
+
+const DecimalWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <input
+    type="number"
+    step="any"
+    {...commonProps(field, errorMessage)}
+    value={typeof value === 'number' ? String(value) : ''}
+    readOnly={readOnly}
+    onChange={(e) => {
+      const raw = e.target.value;
+      if (raw === '') {
+        onChange(null);
+        return;
+      }
+      const parsed = Number.parseFloat(raw);
+      onChange(Number.isNaN(parsed) ? null : parsed);
+    }}
+  />
+);
+
+const BooleanWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <input
+    type="checkbox"
+    {...commonProps(field, errorMessage)}
+    checked={value === true}
+    disabled={readOnly}
+    onChange={(e) => onChange(e.target.checked)}
+  />
+);
+
+const DateWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <input
+    type="date"
+    {...commonProps(field, errorMessage)}
+    value={typeof value === 'string' ? value : ''}
+    readOnly={readOnly}
+    onChange={(e) => onChange(e.target.value === '' ? null : e.target.value)}
+  />
+);
+
+const TimeWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <input
+    type="time"
+    {...commonProps(field, errorMessage)}
+    value={typeof value === 'string' ? value : ''}
+    readOnly={readOnly}
+    onChange={(e) => onChange(e.target.value === '' ? null : e.target.value)}
+  />
+);
+
+const DatetimeWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => (
+  <input
+    type="datetime-local"
+    {...commonProps(field, errorMessage)}
+    value={typeof value === 'string' ? value : ''}
+    readOnly={readOnly}
+    onChange={(e) => onChange(e.target.value === '' ? null : e.target.value)}
+  />
+);
+
+/**
+ * Option shape consumed by {@link SelectWidget}. The `config.options` array
+ * on the field manifest must follow this shape; `value` is the wire value
+ * sent back to the server, `labelKey` is the i18n key for the human
+ * label (or `null` to fall back to `String(value)`).
+ */
+export interface SelectWidgetOption {
+  readonly value: string | number | boolean | null;
+  readonly labelKey: string | null;
+}
+
+const SelectWidget: EntityFormWidget = ({ field, value, onChange, readOnly, errorMessage }) => {
+  const options = readOptions(field.config);
+  if (!options) {
+    return (
+      <div data-granit-select-misconfigured="" data-property={field.propertyName}>
+        Select widget on {field.propertyName} requires <code>config.options</code> with the
+        documented shape.
+      </div>
+    );
+  }
+  const stringValue = value == null ? '' : String(value);
+  return (
+    <select
+      {...commonProps(field, errorMessage)}
+      value={stringValue}
+      disabled={readOnly}
+      onChange={(e) => {
+        if (e.target.value === '') {
+          onChange(null);
+          return;
+        }
+        const next = options.find((o) => String(o.value) === e.target.value);
+        onChange(next ? next.value : e.target.value);
+      }}
+    >
+      <option value="">—</option>
+      {options.map((option) => (
+        <SelectOption key={String(option.value)} option={option} />
+      ))}
+    </select>
+  );
+};
+
+function SelectOption({ option }: { readonly option: SelectWidgetOption }): ReactNode {
+  // resolveLabel lookup happens here so each option is reactive to provider changes
+  // without forcing a re-render of the parent widget.
+  return <option value={String(option.value)}>{option.labelKey ?? String(option.value)}</option>;
+}
+
+function readOptions(
+  config: Readonly<Record<string, unknown>> | null
+): readonly SelectWidgetOption[] | null {
+  if (!config) return null;
+  const raw = config['options'];
+  if (!Array.isArray(raw)) return null;
+  const options: SelectWidgetOption[] = [];
+  for (const entry of raw) {
+    if (entry == null || typeof entry !== 'object') return null;
+    const record = entry as Record<string, unknown>;
+    const value = record['value'];
+    if (
+      value !== null &&
+      typeof value !== 'string' &&
+      typeof value !== 'number' &&
+      typeof value !== 'boolean'
+    ) {
+      return null;
+    }
+    const labelKey = typeof record['labelKey'] === 'string' ? (record['labelKey'] as string) : null;
+    options.push({ value, labelKey });
+  }
+  return options;
+}
+
+/**
+ * Standard form-widget catalog (ADR-041 minimum set). Pass it to
+ * `<EntityRendererProvider widgets={STANDARD_FORM_WIDGETS}>` to get
+ * working unstyled HTML inputs out of the box. Apps that want richer UI
+ * spread it and override the entries they care about:
+ *
+ * ```tsx
+ * <EntityRendererProvider
+ *   widgets={{
+ *     form: { ...STANDARD_FORM_WIDGETS.form, text: MyShadcnTextWidget },
+ *   }}
+ * >
+ * ```
+ */
+export const STANDARD_FORM_WIDGETS: EntityWidgetCatalog = Object.freeze({
+  form: Object.freeze({
+    text: TextWidget,
+    textarea: TextareaWidget,
+    integer: IntegerWidget,
+    decimal: DecimalWidget,
+    boolean: BooleanWidget,
+    date: DateWidget,
+    time: TimeWidget,
+    datetime: DatetimeWidget,
+    select: SelectWidget,
+  }),
+});


### PR DESCRIPTION
## Summary

Nine unstyled HTML form widgets matching the ids the .NET `FieldBuilder.ChooseDefaultWidget()` emits as defaults: **text / textarea / integer / decimal / boolean / date / time / datetime / select**. Apps drop in `STANDARD_FORM_WIDGETS` for working inputs out of the box; richer flavours (shadcn / Tailwind / Material) spread the catalog and override the entries they care about — that part lives in showcase per the framework / app split decided in #300.

## Notable behaviours

- **Number widgets** parse empty → `null` rather than emitting `NaN`
- **Date / time / datetime** also collapse empty → `null` so the wire format stays clean
- **Select** reads `config.options: { value, labelKey? }[]` from the manifest, preserves the original value type on selection (string / number / boolean), surfaces a `data-granit-select-misconfigured` marker when the shape isn't met
- **Read-only** routes through `readOnly` for text inputs, `disabled` for boolean / select (matches DOM semantics)
- **`aria-invalid`** wires from `errorMessage` for accessible validation feedback

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/standard-form-widgets.test.tsx` → 12 passing (per-widget value forwarding, empty → null on numerics + dates, select option type preservation + misconfiguration marker, readOnly / aria-invalid plumbing)

## Parent

Feature #299 → Epic #242
