### PR TITLE
feat(react-entities): entity detail skeleton

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2698,6 +2698,17 @@
       "description": "React renderer for @granit/entities — manifest hooks (useEntityDiscovery / useEntityMetadata) and the four generic renderers (EntityList, EntityKanban, EntityForm, EntityDetail) wired to the standard widget catalog",
       "exports": [
         {
+          "name": "EntityDetail",
+          "kind": "function",
+          "signature": "function EntityDetail("
+        },
+        {
+          "name": "EntityDetailProps",
+          "kind": "interface",
+          "signature": "interface EntityDetailProps",
+          "members": []
+        },
+        {
           "name": "EntityForm",
           "kind": "function",
           "signature": "function EntityForm("

--- a/packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx
@@ -1,0 +1,130 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityDetail } from '../components/entity-detail.js';
+import { EntityRendererProvider } from '../provider/index.js';
+
+import type { EntityDetailManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+function variant(overrides: Partial<EntityDetailManifest> = {}): EntityDetailManifest {
+  return {
+    name: 'default',
+    sections: [],
+    sidePanels: [],
+    ...overrides,
+  };
+}
+
+function withProvider(children: ReactNode, resolveLabel?: (key: string) => string) {
+  return <EntityRendererProvider resolveLabel={resolveLabel}>{children}</EntityRendererProvider>;
+}
+
+describe('EntityDetail', () => {
+  it('renders sections sorted by order', () => {
+    const v = variant({
+      sections: [
+        {
+          key: 'b',
+          labelKey: null,
+          order: 20,
+          inheritsFromFormVariant: null,
+          fields: ['Two'],
+        },
+        {
+          key: 'a',
+          labelKey: null,
+          order: 10,
+          inheritsFromFormVariant: null,
+          fields: ['One'],
+        },
+      ],
+    });
+    const { container } = render(withProvider(<EntityDetail variant={v} values={{}} />));
+    const keys = Array.from(container.querySelectorAll('[data-granit-detail-section]')).map((el) =>
+      el.getAttribute('data-section-key')
+    );
+    expect(keys).toEqual(['a', 'b']);
+  });
+
+  it('renders free-form fields as <dt>/<dd> rows with null collapsed to em-dash', () => {
+    const v = variant({
+      sections: [
+        {
+          key: 'main',
+          labelKey: null,
+          order: 0,
+          inheritsFromFormVariant: null,
+          fields: ['Name', 'IsActive', 'Missing'],
+        },
+      ],
+    });
+    const { container } = render(
+      withProvider(<EntityDetail variant={v} values={{ Name: 'ACME', IsActive: true }} />)
+    );
+    const rows = container.querySelectorAll('[data-granit-detail-row]');
+    expect(rows).toHaveLength(3);
+    const byProperty = (property: string) =>
+      Array.from(rows).find((r) => r.getAttribute('data-property') === property);
+    expect(byProperty('Name')?.querySelector('dd')?.textContent).toBe('ACME');
+    expect(byProperty('IsActive')?.querySelector('dd')?.textContent).toBe('✓');
+    expect(byProperty('Missing')?.querySelector('dd')?.textContent).toBe('—');
+  });
+
+  it('emits the inherits-from-form placeholder when inheritsFromFormVariant is set', () => {
+    const v = variant({
+      sections: [
+        {
+          key: 'identity',
+          labelKey: null,
+          order: 0,
+          inheritsFromFormVariant: 'default',
+          fields: null,
+        },
+      ],
+    });
+    const { container } = render(withProvider(<EntityDetail variant={v} values={{}} />));
+    const marker = container.querySelector('[data-granit-detail-inherits]');
+    expect(marker).not.toBeNull();
+    expect(marker?.getAttribute('data-form-variant')).toBe('default');
+    expect(container.querySelector('[data-granit-detail-fields]')).toBeNull();
+  });
+
+  it('renders side-panel slots sorted by order with kind data attribute', () => {
+    const v = variant({
+      sidePanels: [
+        { kind: 'Timeline', order: 20 },
+        { kind: 'Audit', order: 10 },
+      ],
+    });
+    const { container } = render(withProvider(<EntityDetail variant={v} values={{}} />));
+    const slots = container.querySelectorAll('[data-granit-side-panel-slot]');
+    expect(Array.from(slots).map((el) => el.getAttribute('data-kind'))).toEqual([
+      'Audit',
+      'Timeline',
+    ]);
+  });
+
+  it('omits the rail when no side panels are declared', () => {
+    const v = variant();
+    const { container } = render(withProvider(<EntityDetail variant={v} values={{}} />));
+    expect(container.querySelector('[data-granit-detail-rail]')).toBeNull();
+  });
+
+  it('resolves section label keys via the provider resolver', () => {
+    const v = variant({
+      sections: [
+        {
+          key: 'main',
+          labelKey: 'Section.Main.Label',
+          order: 0,
+          inheritsFromFormVariant: null,
+          fields: [],
+        },
+      ],
+    });
+    const resolve = vi.fn((key: string) => `[${key}]`);
+    const { container } = render(withProvider(<EntityDetail variant={v} values={{}} />, resolve));
+    expect(container.textContent).toContain('[Section.Main.Label]');
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -1,0 +1,114 @@
+import { useMemo, type ReactNode } from 'react';
+
+import { useEntityRenderer } from '../provider/entity-renderer-provider.js';
+
+import type {
+  EntityDetailManifest,
+  EntityDetailSectionManifest,
+  EntityDetailSidePanelManifest,
+} from '@granit/entities';
+
+export interface EntityDetailProps {
+  /** Detail variant from the manifest (one of `manifest.details`). */
+  readonly variant: EntityDetailManifest;
+  /** Current entity values keyed by PascalCase property name. */
+  readonly values: Readonly<Record<string, unknown>>;
+  /**
+   * Optional class for the root element. The root layout is a
+   * `<article>` containing the section column + side-panel rail; apps
+   * style them via this className + the `data-granit-*` attributes.
+   */
+  readonly className?: string;
+}
+
+/**
+ * Read-mode renderer driven by an `EntityDetailManifest`. Sections sorted
+ * by `order`, fields rendered as `<dt>` / `<dd>` rows, side-panel slots
+ * emitted as `<aside data-kind="...">` placeholders so apps can mount the
+ * actual panel components (Audit / Timeline / Comments / Documents /
+ * Activities) at the right position via DOM-based composition.
+ *
+ * **Skeleton scope** — supports free-form `section.fields` only. When
+ * `section.inheritsFromFormVariant` is set, the section renders a TODO
+ * marker (`<div data-granit-detail-inherits>`) that the
+ * [inheritsFromFormVariant story](https://github.com/granit-fx/granit-front/issues/299)
+ * will replace with the inherited form-variant rendering. Side-panel
+ * slots are placeholders pending the rail registry story.
+ *
+ * Values are displayed via `String(value)`, with `null` / `undefined`
+ * collapsed to `'—'`. A read-mode widget catalog (currency / date / link
+ * formatting) is a follow-up — for now apps that need richer rendering
+ * wrap or replace the row component via DOM substitution.
+ */
+export function EntityDetail({ variant, values, className }: EntityDetailProps): ReactNode {
+  const sortedSections = useMemo(
+    () => [...variant.sections].sort((a, b) => a.order - b.order),
+    [variant.sections]
+  );
+  const sortedSidePanels = useMemo(
+    () => [...variant.sidePanels].sort((a, b) => a.order - b.order),
+    [variant.sidePanels]
+  );
+
+  return (
+    <article data-granit-entity-detail="" data-variant={variant.name} className={className}>
+      <div data-granit-detail-sections="">
+        {sortedSections.map((section) => (
+          <EntityDetailSection key={section.key} section={section} values={values} />
+        ))}
+      </div>
+      {sortedSidePanels.length > 0 ? (
+        <aside data-granit-detail-rail="">
+          {sortedSidePanels.map((panel) => (
+            <EntityDetailSidePanelSlot key={panel.kind} panel={panel} />
+          ))}
+        </aside>
+      ) : null}
+    </article>
+  );
+}
+
+interface EntityDetailSectionProps {
+  readonly section: EntityDetailSectionManifest;
+  readonly values: Readonly<Record<string, unknown>>;
+}
+
+function EntityDetailSection({ section, values }: EntityDetailSectionProps): ReactNode {
+  const { resolveLabel } = useEntityRenderer();
+
+  return (
+    <section data-granit-detail-section="" data-section-key={section.key}>
+      {section.labelKey ? (
+        <header data-granit-section-header="">{resolveLabel(section.labelKey)}</header>
+      ) : null}
+      {section.inheritsFromFormVariant ? (
+        <div data-granit-detail-inherits="" data-form-variant={section.inheritsFromFormVariant}>
+          {/* Inherits-from-form rendering lands in a follow-up story under #299. */}
+        </div>
+      ) : (
+        <dl data-granit-detail-fields="">
+          {(section.fields ?? []).map((property) => (
+            <div key={property} data-granit-detail-row="" data-property={property}>
+              <dt data-granit-detail-label="">{property}</dt>
+              <dd data-granit-detail-value="">{formatValue(values[property])}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </section>
+  );
+}
+
+function EntityDetailSidePanelSlot({
+  panel,
+}: {
+  readonly panel: EntityDetailSidePanelManifest;
+}): ReactNode {
+  return <div data-granit-side-panel-slot="" data-kind={panel.kind} data-order={panel.order} />;
+}
+
+function formatValue(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'boolean') return value ? '✓' : '✗';
+  return String(value);
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -6,6 +6,8 @@
 // @granit/entities. Implementation tracked under
 // granit-fx/granit-front#298 (hooks) and #299 (renderers).
 
+export { EntityDetail } from './components/entity-detail.js';
+export type { EntityDetailProps } from './components/entity-detail.js';
 export { EntityForm } from './components/entity-form.js';
 export type { EntityFormProps } from './components/entity-form.js';
 export { STANDARD_FORM_WIDGETS } from './widgets/index.js';


### PR DESCRIPTION
## Summary

Read-mode `<EntityDetail />` driven by `EntityDetailManifest`. Sections sorted by `order`, fields rendered as `<dt>` / `<dd>` rows in a description list, side-panel slots emitted as `<aside data-kind="...">` placeholders so apps can mount the actual panel components (Audit / Timeline / Comments / Documents / Activities) at the right slot via DOM-based composition.

## Skeleton scope (intentionally tight)

- Free-form `section.fields` supported now
- `inheritsFromFormVariant` emits a `data-granit-detail-inherits` marker that the **inheritance follow-up story** under #299 will replace with the form-variant rendering — keeps this PR focused on the layout primitive
- Side-panel slots are placeholders pending the **rail registry follow-up**
- Value display: `String(value)`, `null`/`undefined` collapse to `—`, booleans render as `✓` / `✗`. A read-mode widget catalog (currency / date formatting) is the third follow-up

Layout: `<article>` wraps a `<div data-granit-detail-sections>` column and a `<aside data-granit-detail-rail>` rail. Apps style via `className` + `data-*` attributes — no opinionated CSS shipped.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx` → 6 passing (section ordering, field rendering with em-dash + boolean glyph, inheritance placeholder, side-panel slot ordering, rail omission when empty, label resolution)

## Parent

Feature #299 → Epic #242
