### PR TITLE
feat(react-entities): inheritsFromFormVariant read-mode reuse

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx
@@ -4,8 +4,48 @@ import { describe, expect, it, vi } from 'vitest';
 import { EntityDetail } from '../components/entity-detail.js';
 import { EntityRendererProvider } from '../provider/index.js';
 
-import type { EntityDetailManifest } from '@granit/entities';
+import type {
+  EntityDetailManifest,
+  EntityFormFieldManifest,
+  EntityFormManifest,
+} from '@granit/entities';
 import type { ReactNode } from 'react';
+
+function field(
+  propertyName: string,
+  order: number,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName,
+    clrTypeName: 'String',
+    widget: 'text',
+    config: null,
+    labelKey: `Field.${propertyName}.Label`,
+    helpKey: null,
+    order,
+    readOnly: false,
+    visibleIf: null,
+    ...overrides,
+  };
+}
+
+function formVariant(
+  name: string,
+  sections: ReadonlyArray<{ key: string; order: number; fields: EntityFormFieldManifest[] }>
+): EntityFormManifest {
+  return {
+    name,
+    customizable: false,
+    sections: sections.map((s) => ({
+      key: s.key,
+      labelKey: null,
+      order: s.order,
+      collapsedByDefault: false,
+      fields: s.fields,
+    })),
+  };
+}
 
 function variant(overrides: Partial<EntityDetailManifest> = {}): EntityDetailManifest {
   return {
@@ -71,7 +111,7 @@ describe('EntityDetail', () => {
     expect(byProperty('Missing')?.querySelector('dd')?.textContent).toBe('—');
   });
 
-  it('emits the inherits-from-form placeholder when inheritsFromFormVariant is set', () => {
+  it('emits a missing-variant marker when formVariants is not provided', () => {
     const v = variant({
       sections: [
         {
@@ -84,10 +124,110 @@ describe('EntityDetail', () => {
       ],
     });
     const { container } = render(withProvider(<EntityDetail variant={v} values={{}} />));
-    const marker = container.querySelector('[data-granit-detail-inherits]');
+    const marker = container.querySelector('[data-granit-detail-inherits-missing]');
     expect(marker).not.toBeNull();
     expect(marker?.getAttribute('data-form-variant')).toBe('default');
-    expect(container.querySelector('[data-granit-detail-fields]')).toBeNull();
+  });
+
+  it('emits a missing-variant marker when the named variant is absent from formVariants', () => {
+    const v = variant({
+      sections: [
+        {
+          key: 'identity',
+          labelKey: null,
+          order: 0,
+          inheritsFromFormVariant: 'wizard',
+          fields: null,
+        },
+      ],
+    });
+    const { container } = render(
+      withProvider(
+        <EntityDetail variant={v} values={{}} formVariants={[formVariant('default', [])]} />
+      )
+    );
+    expect(container.querySelector('[data-granit-detail-inherits-missing]')).not.toBeNull();
+  });
+
+  it('flattens inherited form variant fields in section order then field order', () => {
+    const v = variant({
+      sections: [
+        {
+          key: 'identity',
+          labelKey: null,
+          order: 0,
+          inheritsFromFormVariant: 'default',
+          fields: null,
+        },
+      ],
+    });
+    const variants = [
+      formVariant('default', [
+        { key: 'b', order: 20, fields: [field('Email', 10), field('Phone', 0)] },
+        { key: 'a', order: 10, fields: [field('Number', 0), field('Name', 1)] },
+      ]),
+    ];
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={v}
+          values={{ Number: '001', Name: 'ACME', Phone: '555', Email: 'a@b' }}
+          formVariants={variants}
+        />
+      )
+    );
+    const rows = Array.from(container.querySelectorAll('[data-granit-detail-row][data-inherited]'));
+    expect(rows.map((r) => r.getAttribute('data-property'))).toEqual([
+      'Number',
+      'Name',
+      'Phone',
+      'Email',
+    ]);
+  });
+
+  it('renders inherited field labels via the provider resolver and skips visibleIf=false', () => {
+    const v = variant({
+      sections: [
+        {
+          key: 'identity',
+          labelKey: null,
+          order: 0,
+          inheritsFromFormVariant: 'default',
+          fields: null,
+        },
+      ],
+    });
+    const variants = [
+      formVariant('default', [
+        {
+          key: 'main',
+          order: 0,
+          fields: [
+            field('Status', 0),
+            field('ClosureReason', 1, {
+              visibleIf: { field: 'Status', op: 'Eq', value: 'Closed' },
+            }),
+          ],
+        },
+      ]),
+    ];
+    const resolve = vi.fn((key: string) => `[${key}]`);
+    const { container, rerender } = render(
+      withProvider(
+        <EntityDetail variant={v} values={{ Status: 'Active' }} formVariants={variants} />,
+        resolve
+      )
+    );
+    expect(container.textContent).toContain('[Field.Status.Label]');
+    expect(container.querySelector('[data-property="ClosureReason"]')).toBeNull();
+
+    rerender(
+      withProvider(
+        <EntityDetail variant={v} values={{ Status: 'Closed' }} formVariants={variants} />,
+        resolve
+      )
+    );
+    expect(container.querySelector('[data-property="ClosureReason"]')).not.toBeNull();
   });
 
   it('renders side-panel slots sorted by order with kind data attribute', () => {

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -1,3 +1,4 @@
+import { evaluateVisibility } from '@granit/entities';
 import { useMemo, type ReactNode } from 'react';
 
 import { useEntityRenderer } from '../provider/entity-renderer-provider.js';
@@ -6,6 +7,8 @@ import type {
   EntityDetailManifest,
   EntityDetailSectionManifest,
   EntityDetailSidePanelManifest,
+  EntityFormFieldManifest,
+  EntityFormManifest,
 } from '@granit/entities';
 
 export interface EntityDetailProps {
@@ -13,6 +16,11 @@ export interface EntityDetailProps {
   readonly variant: EntityDetailManifest;
   /** Current entity values keyed by PascalCase property name. */
   readonly values: Readonly<Record<string, unknown>>;
+  /**
+   * Form variants from the manifest (`manifest.forms`). Required when any
+   * detail section sets `inheritsFromFormVariant`; ignored otherwise.
+   */
+  readonly formVariants?: readonly EntityFormManifest[];
   /**
    * Optional class for the root element. The root layout is a
    * `<article>` containing the section column + side-panel rail; apps
@@ -28,19 +36,24 @@ export interface EntityDetailProps {
  * actual panel components (Audit / Timeline / Comments / Documents /
  * Activities) at the right position via DOM-based composition.
  *
- * **Skeleton scope** — supports free-form `section.fields` only. When
- * `section.inheritsFromFormVariant` is set, the section renders a TODO
- * marker (`<div data-granit-detail-inherits>`) that the
- * [inheritsFromFormVariant story](https://github.com/granit-fx/granit-front/issues/299)
- * will replace with the inherited form-variant rendering. Side-panel
- * slots are placeholders pending the rail registry story.
+ * Sections may inherit a form variant's structure via
+ * `inheritsFromFormVariant` — the form's fields (across all its sections)
+ * are flattened into the detail section in declaration order, with their
+ * `labelKey` resolved via the provider and `visibleIf` evaluated against
+ * the current values. The form's section grouping is dropped on purpose:
+ * the detail section already provides one header, nesting two would
+ * surprise readers.
  *
  * Values are displayed via `String(value)`, with `null` / `undefined`
  * collapsed to `'—'`. A read-mode widget catalog (currency / date / link
- * formatting) is a follow-up — for now apps that need richer rendering
- * wrap or replace the row component via DOM substitution.
+ * formatting) is a follow-up.
  */
-export function EntityDetail({ variant, values, className }: EntityDetailProps): ReactNode {
+export function EntityDetail({
+  variant,
+  values,
+  formVariants,
+  className,
+}: EntityDetailProps): ReactNode {
   const sortedSections = useMemo(
     () => [...variant.sections].sort((a, b) => a.order - b.order),
     [variant.sections]
@@ -54,7 +67,12 @@ export function EntityDetail({ variant, values, className }: EntityDetailProps):
     <article data-granit-entity-detail="" data-variant={variant.name} className={className}>
       <div data-granit-detail-sections="">
         {sortedSections.map((section) => (
-          <EntityDetailSection key={section.key} section={section} values={values} />
+          <EntityDetailSection
+            key={section.key}
+            section={section}
+            values={values}
+            formVariants={formVariants}
+          />
         ))}
       </div>
       {sortedSidePanels.length > 0 ? (
@@ -71,10 +89,22 @@ export function EntityDetail({ variant, values, className }: EntityDetailProps):
 interface EntityDetailSectionProps {
   readonly section: EntityDetailSectionManifest;
   readonly values: Readonly<Record<string, unknown>>;
+  readonly formVariants: readonly EntityFormManifest[] | undefined;
 }
 
-function EntityDetailSection({ section, values }: EntityDetailSectionProps): ReactNode {
+function EntityDetailSection({
+  section,
+  values,
+  formVariants,
+}: EntityDetailSectionProps): ReactNode {
   const { resolveLabel } = useEntityRenderer();
+  const inheritedFields = useMemo(
+    () =>
+      section.inheritsFromFormVariant
+        ? resolveInheritedFields(section.inheritsFromFormVariant, formVariants)
+        : null,
+    [section.inheritsFromFormVariant, formVariants]
+  );
 
   return (
     <section data-granit-detail-section="" data-section-key={section.key}>
@@ -82,9 +112,25 @@ function EntityDetailSection({ section, values }: EntityDetailSectionProps): Rea
         <header data-granit-section-header="">{resolveLabel(section.labelKey)}</header>
       ) : null}
       {section.inheritsFromFormVariant ? (
-        <div data-granit-detail-inherits="" data-form-variant={section.inheritsFromFormVariant}>
-          {/* Inherits-from-form rendering lands in a follow-up story under #299. */}
-        </div>
+        inheritedFields ? (
+          <dl data-granit-detail-fields="" data-inherits-from={section.inheritsFromFormVariant}>
+            {inheritedFields.map((field) => (
+              <InheritedFieldRow
+                key={field.propertyName}
+                field={field}
+                values={values}
+                resolveLabel={resolveLabel}
+              />
+            ))}
+          </dl>
+        ) : (
+          <div
+            data-granit-detail-inherits-missing=""
+            data-form-variant={section.inheritsFromFormVariant}
+          >
+            {/* Form variant referenced by the section was not supplied via formVariants. */}
+          </div>
+        )
       ) : (
         <dl data-granit-detail-fields="">
           {(section.fields ?? []).map((property) => (
@@ -99,12 +145,53 @@ function EntityDetailSection({ section, values }: EntityDetailSectionProps): Rea
   );
 }
 
+interface InheritedFieldRowProps {
+  readonly field: EntityFormFieldManifest;
+  readonly values: Readonly<Record<string, unknown>>;
+  readonly resolveLabel: (key: string, fallback?: string) => string;
+}
+
+function InheritedFieldRow({ field, values, resolveLabel }: InheritedFieldRowProps): ReactNode {
+  if (field.visibleIf && !evaluateVisibility(field.visibleIf, values)) {
+    return null;
+  }
+  const label = field.labelKey ? resolveLabel(field.labelKey) : field.propertyName;
+  return (
+    <div data-granit-detail-row="" data-property={field.propertyName} data-inherited="">
+      <dt data-granit-detail-label="">{label}</dt>
+      <dd data-granit-detail-value="">{formatValue(values[field.propertyName])}</dd>
+    </div>
+  );
+}
+
 function EntityDetailSidePanelSlot({
   panel,
 }: {
   readonly panel: EntityDetailSidePanelManifest;
 }): ReactNode {
   return <div data-granit-side-panel-slot="" data-kind={panel.kind} data-order={panel.order} />;
+}
+
+/**
+ * Walks a form variant in declaration order (sections sorted by `order`,
+ * fields sorted by `order` within each section) and returns the flat
+ * field list. Returns `null` when the variant is unknown so the caller
+ * can render a missing-variant marker.
+ */
+function resolveInheritedFields(
+  variantName: string,
+  formVariants: readonly EntityFormManifest[] | undefined
+): readonly EntityFormFieldManifest[] | null {
+  if (!formVariants) return null;
+  const variant = formVariants.find((v) => v.name === variantName);
+  if (!variant) return null;
+  const sortedSections = [...variant.sections].sort((a, b) => a.order - b.order);
+  const fields: EntityFormFieldManifest[] = [];
+  for (const section of sortedSections) {
+    const sortedFields = [...section.fields].sort((a, b) => a.order - b.order);
+    fields.push(...sortedFields);
+  }
+  return fields;
 }
 
 function formatValue(value: unknown): string {


### PR DESCRIPTION
## Summary

Detail sections that set `inheritsFromFormVariant` now resolve the named form variant from the new optional `formVariants` prop and render its fields flat, in declaration order (sections sorted by `order`, fields sorted by `order` within each section).

## Design choices

- **Flat output, not nested** — the form's section grouping is intentionally collapsed. The detail section already provides one header; nesting two would surprise readers
- **`data-inherited=""`** on each inherited row so apps can style inherited rows differently from free-form rows
- **`visibleIf`** evaluated against the current values, identical semantics to `<EntityForm />`
- **`labelKey`** resolved via the provider's `resolveLabel`; missing labelKey falls back to the property name
- **Two failure modes surface as `data-granit-detail-inherits-missing` markers** rather than empty content — `formVariants` prop not supplied, or the named variant isn't in the list. Makes a wiring mistake visible at first render rather than shrinking the detail page silently

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx` → 9 passing (3 new on top of the existing 6: missing-prop fallback, missing-variant fallback, ordering across multiple form sections, visibleIf gating + label resolution end-to-end)

## Parent

Feature #299 → Epic #242
