### PR TITLE
feat(react-entities): side-panel rail registry

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx
@@ -2,7 +2,11 @@ import { render } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { EntityDetail } from '../components/entity-detail.js';
-import { EntityRendererProvider } from '../provider/index.js';
+import {
+  EntityRendererProvider,
+  type EntitySidePanel,
+  type EntityWidgetCatalog,
+} from '../provider/index.js';
 
 import type {
   EntityDetailManifest,
@@ -56,8 +60,16 @@ function variant(overrides: Partial<EntityDetailManifest> = {}): EntityDetailMan
   };
 }
 
-function withProvider(children: ReactNode, resolveLabel?: (key: string) => string) {
-  return <EntityRendererProvider resolveLabel={resolveLabel}>{children}</EntityRendererProvider>;
+function withProvider(
+  children: ReactNode,
+  resolveLabel?: (key: string) => string,
+  widgets?: EntityWidgetCatalog
+) {
+  return (
+    <EntityRendererProvider resolveLabel={resolveLabel} widgets={widgets}>
+      {children}
+    </EntityRendererProvider>
+  );
 }
 
 describe('EntityDetail', () => {
@@ -249,6 +261,43 @@ describe('EntityDetail', () => {
     const v = variant();
     const { container } = render(withProvider(<EntityDetail variant={v} values={{}} />));
     expect(container.querySelector('[data-granit-detail-rail]')).toBeNull();
+  });
+
+  it('mounts a registered side-panel renderer when entityName + entityId are supplied', () => {
+    const v = variant({
+      sidePanels: [
+        { kind: 'Timeline', order: 20 },
+        { kind: 'Audit', order: 10 },
+      ],
+    });
+    const audit: EntitySidePanel = ({ entityName, entityId }) => (
+      <div data-testid="audit-panel">
+        {entityName}#{entityId}
+      </div>
+    );
+    const widgets: EntityWidgetCatalog = { form: {}, sidePanels: { Audit: audit } };
+    const { container, getByTestId } = render(
+      withProvider(
+        <EntityDetail variant={v} values={{}} entityName="Granit.Parties.Party" entityId="42" />,
+        undefined,
+        widgets
+      )
+    );
+    expect(getByTestId('audit-panel').textContent).toBe('Granit.Parties.Party#42');
+    // Timeline has no registered renderer — slot stays empty but present.
+    const timelineSlot = container.querySelector('[data-kind="Timeline"]');
+    expect(timelineSlot).not.toBeNull();
+    expect(timelineSlot?.children.length).toBe(0);
+  });
+
+  it('falls back to an empty slot when entityName / entityId are missing', () => {
+    const v = variant({ sidePanels: [{ kind: 'Audit', order: 0 }] });
+    const audit: EntitySidePanel = () => <div data-testid="audit-panel" />;
+    const widgets: EntityWidgetCatalog = { form: {}, sidePanels: { Audit: audit } };
+    const { queryByTestId } = render(
+      withProvider(<EntityDetail variant={v} values={{}} />, undefined, widgets)
+    );
+    expect(queryByTestId('audit-panel')).toBeNull();
   });
 
   it('resolves section label keys via the provider resolver', () => {

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -22,6 +22,17 @@ export interface EntityDetailProps {
    */
   readonly formVariants?: readonly EntityFormManifest[];
   /**
+   * Wire identifier of the entity (e.g. `"Granit.Parties.Party"`,
+   * available from `manifest.identity.name`). Required when the variant
+   * declares side panels and the provider catalog has matching renderers.
+   */
+  readonly entityName?: string;
+  /**
+   * Id of the current entity instance. Required when the variant
+   * declares side panels and the provider catalog has matching renderers.
+   */
+  readonly entityId?: string;
+  /**
    * Optional class for the root element. The root layout is a
    * `<article>` containing the section column + side-panel rail; apps
    * style them via this className + the `data-granit-*` attributes.
@@ -52,6 +63,8 @@ export function EntityDetail({
   variant,
   values,
   formVariants,
+  entityName,
+  entityId,
   className,
 }: EntityDetailProps): ReactNode {
   const sortedSections = useMemo(
@@ -78,7 +91,12 @@ export function EntityDetail({
       {sortedSidePanels.length > 0 ? (
         <aside data-granit-detail-rail="">
           {sortedSidePanels.map((panel) => (
-            <EntityDetailSidePanelSlot key={panel.kind} panel={panel} />
+            <EntityDetailSidePanelSlot
+              key={panel.kind}
+              panel={panel}
+              entityName={entityName}
+              entityId={entityId}
+            />
           ))}
         </aside>
       ) : null}
@@ -164,12 +182,25 @@ function InheritedFieldRow({ field, values, resolveLabel }: InheritedFieldRowPro
   );
 }
 
+interface EntityDetailSidePanelSlotProps {
+  readonly panel: EntityDetailSidePanelManifest;
+  readonly entityName: string | undefined;
+  readonly entityId: string | undefined;
+}
+
 function EntityDetailSidePanelSlot({
   panel,
-}: {
-  readonly panel: EntityDetailSidePanelManifest;
-}): ReactNode {
-  return <div data-granit-side-panel-slot="" data-kind={panel.kind} data-order={panel.order} />;
+  entityName,
+  entityId,
+}: EntityDetailSidePanelSlotProps): ReactNode {
+  const { widgets } = useEntityRenderer();
+  const Renderer = widgets.sidePanels?.[panel.kind];
+  const canRender = Renderer && entityName && entityId;
+  return (
+    <div data-granit-side-panel-slot="" data-kind={panel.kind} data-order={panel.order}>
+      {canRender ? <Renderer entityName={entityName} entityId={entityId} /> : null}
+    </div>
+  );
 }
 
 /**

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -24,6 +24,8 @@ export type {
   EntityFormWidgetProps,
   EntityRendererContextValue,
   EntityRendererProviderProps,
+  EntitySidePanel,
+  EntitySidePanelProps,
   EntityWidgetCatalog,
   ResolveLabel,
 } from './provider/index.js';

--- a/packages/@granit/react-entities/src/provider/index.ts
+++ b/packages/@granit/react-entities/src/provider/index.ts
@@ -8,5 +8,7 @@ export type {
 export type {
   EntityFormWidget,
   EntityFormWidgetProps,
+  EntitySidePanel,
+  EntitySidePanelProps,
   EntityWidgetCatalog,
 } from './widget-catalog.js';

--- a/packages/@granit/react-entities/src/provider/widget-catalog.ts
+++ b/packages/@granit/react-entities/src/provider/widget-catalog.ts
@@ -1,4 +1,4 @@
-import type { EntityFormFieldManifest } from '@granit/entities';
+import type { EntityFormFieldManifest, SidePanelKind } from '@granit/entities';
 import type { ReactNode } from 'react';
 
 /**
@@ -19,13 +19,37 @@ export interface EntityFormWidgetProps {
 export type EntityFormWidget = (props: EntityFormWidgetProps) => ReactNode;
 
 /**
+ * Props passed to a side-panel renderer mounted by `<EntityDetail />` in
+ * one of the right-rail slots declared by the manifest. The kinds map to
+ * existing Granit modules (Audit / Timeline / Comments / Documents /
+ * Activities); apps that have those modules wired register the matching
+ * components in the catalog.
+ */
+export interface EntitySidePanelProps {
+  /** Wire identifier of the entity (e.g. `"Granit.Parties.Party"`). */
+  readonly entityName: string;
+  /** Id of the current entity instance. */
+  readonly entityId: string;
+}
+
+/** Renderer for one side panel kind in `<EntityDetail />`. */
+export type EntitySidePanel = (props: EntitySidePanelProps) => ReactNode;
+
+/**
  * Catalog mapping widget identifiers (the `field.widget` value from the
- * manifest) → renderers. Apps register the standard catalog plus any
+ * manifest) → renderers, plus the optional side-panel registry keyed by
+ * `SidePanelKind`. Apps register the standard catalog plus any
  * `custom:`-namespaced widgets they own (per ADR-041).
  */
 export interface EntityWidgetCatalog {
   /** Form-context widgets, keyed by `field.widget`. */
   readonly form: Readonly<Record<string, EntityFormWidget>>;
+  /**
+   * Side-panel renderers keyed by `SidePanelKind`. Optional — when a
+   * side-panel kind is missing or the registry is absent, `<EntityDetail />`
+   * falls back to an empty slot placeholder.
+   */
+  readonly sidePanels?: Partial<Readonly<Record<SidePanelKind, EntitySidePanel>>>;
 }
 
 /** Empty catalog — useful as a default and in tests. */


### PR DESCRIPTION
## Summary

Extends `EntityWidgetCatalog` with an optional `sidePanels` registry keyed by `SidePanelKind`. `<EntityDetail />` now accepts `entityName` + `entityId` props and mounts the registered renderer for each declared slot, passing them through to the panel component.

Slots without a registered renderer (or without entity props) keep the existing empty-slot placeholder so the layout doesn't shift when an app hasn't wired Timeline / Audit / etc.

## Wiring

Apps that have `Granit.Auditing` / `Granit.Timeline` / etc. wired register their components via the catalog passed to the provider:

```tsx
<EntityRendererProvider widgets={{
  form: { ...STANDARD_FORM_WIDGETS.form },
  sidePanels: { Audit: AuditPanel, Timeline: TimelinePanel },
}}>
```

The renderer component receives `{ entityName, entityId }` — enough for it to call its module's data hooks (`useAuditTrail(entityName, entityId)`, etc.).

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail.test.tsx` → 11 passing (2 new on top of the existing 9: registered renderer mounts with the right entity props + unregistered kind keeps an empty slot, missing entity props fall back gracefully)

## Parent

Feature #299 → Epic #242
