### PR TITLE
feat(react-entities): entity list bridging to query-engine

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2720,6 +2720,17 @@
           "members": []
         },
         {
+          "name": "EntityList",
+          "kind": "function",
+          "signature": "function EntityList("
+        },
+        {
+          "name": "EntityListProps",
+          "kind": "interface",
+          "signature": "interface EntityListProps",
+          "members": []
+        },
+        {
           "name": "entityDiscoveryQueryKey",
           "kind": "const",
           "signature": "const entityDiscoveryQueryKey"

--- a/packages/@granit/react-entities/package.json
+++ b/packages/@granit/react-entities/package.json
@@ -16,7 +16,9 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/entities": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0",
     "react-i18next": "^17.0.0"
@@ -33,7 +35,9 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/entities": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   }

--- a/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
@@ -1,0 +1,233 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryProvider } from '@granit/react-query-engine';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { EntityList } from '../components/entity-list.js';
+import { EntityRendererProvider } from '../provider/index.js';
+
+import type { EntityManifestResponse } from '@granit/entities';
+import type { QueryMetadata } from '@granit/query-engine';
+import type { ReactNode } from 'react';
+
+const BASE_PATH = '/api/v1/parties';
+const ENTITY_NAME = 'Granit.Parties.Party';
+
+const META: QueryMetadata = {
+  columns: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'isActive',
+      label: 'Active',
+      type: 'Boolean',
+      order: 2,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'internalCode',
+      label: 'Internal',
+      type: 'String',
+      order: 1,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [],
+  sortableFields: [],
+  presets: [],
+  quickFilters: [],
+  defaultSort: [],
+};
+
+const PAGE = {
+  items: [
+    { id: '1', name: 'ACME', isActive: true, internalCode: 'AC' },
+    { id: '2', name: 'Globex', isActive: false, internalCode: 'GL' },
+  ],
+  totalCount: 2,
+  page: 1,
+  pageSize: 20,
+};
+
+function manifest(hasQuery: boolean): EntityManifestResponse {
+  return {
+    schemaVersion: 1,
+    identity: hasQuery
+      ? {
+          name: ENTITY_NAME,
+          entityClrType: 'Granit.Parties.Domain.Party',
+          displayKey: null,
+          icon: null,
+          permissionGroup: null,
+          displayProperty: null,
+        }
+      : null,
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: hasQuery
+      ? {
+          query: { name: 'Granit.Parties.PartyQuery', clrTypeName: 'PartyQuery' },
+          export: null,
+          metrics: [],
+          dashboards: [],
+          defaultViewId: null,
+        }
+      : null,
+    relations: null,
+  };
+}
+
+function freshHandlers() {
+  return [
+    http.get(`http://localhost${BASE_PATH}/meta`, () => HttpResponse.json(META)),
+    http.get(`http://localhost${BASE_PATH}`, () => HttpResponse.json(PAGE)),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <QueryProvider config={{ basePath: BASE_PATH }}>
+          <EntityRendererProvider>{children}</EntityRendererProvider>
+        </QueryProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('EntityList', () => {
+  it('renders the empty marker when the manifest declares no list collection', () => {
+    const { wrapper } = makeWrapper();
+    const Wrapped = wrapper;
+    const { container } = render(
+      <Wrapped>
+        <EntityList manifest={manifest(false)} />
+      </Wrapped>
+    );
+    expect(container.querySelector('[data-granit-entity-list-empty]')).not.toBeNull();
+    expect(container.querySelector('[data-granit-entity-list-table]')).toBeNull();
+  });
+
+  it('renders rows with visible columns sorted by order, hides invisible ones', async () => {
+    const { wrapper } = makeWrapper();
+    const Wrapped = wrapper;
+    const { container } = render(
+      <Wrapped>
+        <EntityList manifest={manifest(true)} />
+      </Wrapped>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-list-table]')).not.toBeNull()
+    );
+    const headers = Array.from(container.querySelectorAll('thead th')).map((th) =>
+      th.getAttribute('data-column')
+    );
+    expect(headers).toEqual(['name', 'isActive']);
+    const firstRowCells = Array.from(container.querySelectorAll('tbody tr:first-of-type td')).map(
+      (td) => td.textContent
+    );
+    expect(firstRowCells).toEqual(['ACME', '✓']);
+  });
+
+  it('fires onRowClick with the row when a row is clicked', async () => {
+    const { wrapper } = makeWrapper();
+    const Wrapped = wrapper;
+    const onRowClick = vi.fn();
+    const { container } = render(
+      <Wrapped>
+        <EntityList manifest={manifest(true)} onRowClick={onRowClick} />
+      </Wrapped>
+    );
+    await waitFor(() => expect(container.querySelectorAll('tbody tr').length).toBeGreaterThan(0));
+    fireEvent.click(container.querySelector('tbody tr') as HTMLTableRowElement);
+    expect(onRowClick).toHaveBeenCalledWith(PAGE.items[0]);
+  });
+
+  it('disables prev on the first page and enables next when more pages exist', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({ items: PAGE.items, totalCount: 50, page: 1, pageSize: 20 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const Wrapped = wrapper;
+    const { container } = render(
+      <Wrapped>
+        <EntityList manifest={manifest(true)} />
+      </Wrapped>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-pagination-prev]')).not.toBeNull()
+    );
+    expect(
+      (container.querySelector('[data-granit-pagination-prev]') as HTMLButtonElement).disabled
+    ).toBe(true);
+    expect(
+      (container.querySelector('[data-granit-pagination-next]') as HTMLButtonElement).disabled
+    ).toBe(false);
+  });
+
+  it('surfaces an error message when the meta endpoint fails', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}/meta`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const Wrapped = wrapper;
+    const { container } = render(
+      <Wrapped>
+        <EntityList manifest={manifest(true)} />
+      </Wrapped>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-list-error]')).not.toBeNull()
+    );
+  });
+
+  it('shows a single empty-row when the page returns zero items', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({ items: [], totalCount: 0, page: 1, pageSize: 20 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const Wrapped = wrapper;
+    const { container } = render(
+      <Wrapped>
+        <EntityList manifest={manifest(true)} />
+      </Wrapped>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-list-empty-row]')).not.toBeNull()
+    );
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-list.tsx
+++ b/packages/@granit/react-entities/src/components/entity-list.tsx
@@ -1,0 +1,166 @@
+import { useQueryEndpoint, useQueryMeta } from '@granit/react-query-engine';
+import { useMemo, type ReactNode } from 'react';
+
+import { useEntityRenderer } from '../provider/entity-renderer-provider.js';
+
+import type { EntityManifestResponse } from '@granit/entities';
+import type { ColumnDefinition } from '@granit/query-engine';
+
+export interface EntityListProps {
+  /** The entity manifest (typically from `useEntityMetadata`). */
+  readonly manifest: EntityManifestResponse;
+  /** Optional row activation handler — receives the full row object. */
+  readonly onRowClick?: (row: Readonly<Record<string, unknown>>) => void;
+  /** Optional class for the root element. */
+  readonly className?: string;
+}
+
+/**
+ * Generic list renderer. Bridges the entity manifest's `collections.query`
+ * reference to the host's `<QueryProvider>` ambient configuration: column
+ * definitions come from `useQueryMeta()`, paged rows from
+ * `useQueryEndpoint()`, and the renderer paints a minimal HTML `<table>`.
+ *
+ * Wrap with the right `<QueryProvider>` for the entity's list endpoint:
+ *
+ * ```tsx
+ * <QueryProvider config={{ basePath: '/api/v1/parties' }}>
+ *   <EntityList manifest={partyManifest} />
+ * </QueryProvider>
+ * ```
+ *
+ * Manifests without a list collection (`collections.query === null`) render
+ * a `data-granit-entity-list-empty` marker rather than an empty table —
+ * the manifest itself is the source of truth for whether the entity is
+ * even listable. Apps style via `className` + `data-*` attributes; full
+ * filter / sort / search / saved-views UI lands in follow-up stories.
+ */
+export function EntityList({ manifest, onRowClick, className }: EntityListProps): ReactNode {
+  const hasQuery = manifest.collections?.query != null;
+
+  if (!hasQuery) {
+    return (
+      <div
+        data-granit-entity-list=""
+        data-granit-entity-list-empty=""
+        data-entity={manifest.identity?.name}
+        className={className}
+      >
+        {/* Manifest declares no list collection for this entity. */}
+      </div>
+    );
+  }
+
+  return (
+    <div data-granit-entity-list="" data-entity={manifest.identity?.name} className={className}>
+      <EntityListBody onRowClick={onRowClick} />
+    </div>
+  );
+}
+
+interface EntityListBodyProps {
+  readonly onRowClick: ((row: Readonly<Record<string, unknown>>) => void) | undefined;
+}
+
+function EntityListBody({ onRowClick }: EntityListBodyProps): ReactNode {
+  const { resolveLabel } = useEntityRenderer();
+  const meta = useQueryMeta();
+  const { query, params, setPage } = useQueryEndpoint<Readonly<Record<string, unknown>>>();
+
+  const visibleColumns = useMemo<readonly ColumnDefinition[]>(
+    () =>
+      meta.data
+        ? [...meta.data.columns].filter((c) => c.isVisible).sort((a, b) => a.order - b.order)
+        : [],
+    [meta.data]
+  );
+
+  if (meta.isError || query.isError) {
+    return (
+      <div data-granit-entity-list-error="" role="alert">
+        {String((meta.error ?? query.error)?.message ?? 'Failed to load')}
+      </div>
+    );
+  }
+  if (meta.isLoading || !meta.data) {
+    return <div data-granit-entity-list-loading="">Loading…</div>;
+  }
+
+  const items = query.data?.items ?? [];
+  const totalCount = query.data?.totalCount ?? 0;
+  const pageSize = params.pageSize ?? 20;
+  const page = params.page ?? 1;
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  return (
+    <>
+      <table data-granit-entity-list-table="">
+        <thead>
+          <tr>
+            {visibleColumns.map((column) => (
+              <th key={column.name} data-column={column.name}>
+                {resolveLabel(column.label, column.label)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {items.length === 0 && !query.isLoading ? (
+            <tr data-granit-entity-list-empty-row="">
+              <td colSpan={visibleColumns.length}>—</td>
+            </tr>
+          ) : (
+            items.map((row, idx) => (
+              <tr
+                key={readRowKey(row, idx)}
+                data-granit-entity-list-row=""
+                onClick={onRowClick ? () => onRowClick(row) : undefined}
+                style={onRowClick ? { cursor: 'pointer' } : undefined}
+              >
+                {visibleColumns.map((column) => (
+                  <td key={column.name} data-column={column.name}>
+                    {formatCell(row[column.name])}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+      <nav data-granit-entity-list-pagination="" aria-label="Pagination">
+        <button
+          type="button"
+          data-granit-pagination-prev=""
+          disabled={page <= 1 || query.isFetching}
+          onClick={() => setPage(page - 1)}
+        >
+          ‹
+        </button>
+        <span data-granit-pagination-status="">
+          {page} / {totalPages} · {totalCount}
+        </span>
+        <button
+          type="button"
+          data-granit-pagination-next=""
+          disabled={page >= totalPages || query.isFetching}
+          onClick={() => setPage(page + 1)}
+        >
+          ›
+        </button>
+      </nav>
+    </>
+  );
+}
+
+function readRowKey(row: Readonly<Record<string, unknown>>, fallbackIndex: number): string {
+  const id = row['id'] ?? row['Id'];
+  if (typeof id === 'string' || typeof id === 'number') return String(id);
+  return String(fallbackIndex);
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return '—';
+  if (typeof value === 'boolean') return value ? '✓' : '✗';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -10,6 +10,8 @@ export { EntityDetail } from './components/entity-detail.js';
 export type { EntityDetailProps } from './components/entity-detail.js';
 export { EntityForm } from './components/entity-form.js';
 export type { EntityFormProps } from './components/entity-form.js';
+export { EntityList } from './components/entity-list.js';
+export type { EntityListProps } from './components/entity-list.js';
 export { STANDARD_FORM_WIDGETS } from './widgets/index.js';
 export type { SelectWidgetOption } from './widgets/index.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1271,9 +1271,15 @@ importers:
       '@granit/entities':
         specifier: workspace:*
         version: link:../entities
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Summary

Generic `<EntityList />` consuming the entity manifest's `collections.query` reference + the host's ambient `<QueryProvider>`. Column definitions come from `useQueryMeta` (visible columns sorted by `order`, hidden ones dropped), paged rows from `useQueryEndpoint`, basic prev/next pagination. Click-to-activate via `onRowClick` prop (typically wired to open the detail or the side peek).

```tsx
<QueryProvider config={{ basePath: '/api/v1/parties' }}>
  <EntityList manifest={partyManifest} onRowClick={openParty} />
</QueryProvider>
```

## Notable choices

- **Manifest is the source of truth** — manifests with `collections.query === null` render a `data-granit-entity-list-empty` marker rather than an empty table. Backend wiring mistakes surface visibly instead of producing silent blanks
- **Cell formatting matches `<EntityDetail />`** — `null`/`undefined` → `—`, booleans → `✓`/`✗`, objects via `JSON.stringify` (debug fallback). Date / currency / link formatting will land with the read-mode widget catalog story
- **Filter / sort / search / saved-views UI deliberately deferred** — self-contained follow-ups that don't block consuming apps from displaying a working list. Apps that need them today can drop down to `@granit/react-query-engine` directly
- **Adds `@granit/query-engine` + `@granit/react-query-engine`** as peer deps on `@granit/react-entities`

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-list.test.tsx` → 6 passing (empty marker on missing query, sorted visible columns + hidden columns dropped, `onRowClick` payload, prev disabled on page 1 + next enabled when more pages, meta error surfacing, zero-items empty row)

## Parent

Feature #299 → Epic #242
