### PR TITLE
feat(react-entities): entity kanban board (read-only)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2720,6 +2720,17 @@
           "members": []
         },
         {
+          "name": "EntityKanban",
+          "kind": "function",
+          "signature": "function EntityKanban("
+        },
+        {
+          "name": "EntityKanbanProps",
+          "kind": "interface",
+          "signature": "interface EntityKanbanProps",
+          "members": []
+        },
+        {
           "name": "EntityList",
           "kind": "function",
           "signature": "function EntityList("

--- a/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
@@ -1,0 +1,209 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryProvider } from '@granit/react-query-engine';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { EntityKanban } from '../components/entity-kanban.js';
+import { EntityRendererProvider } from '../provider/index.js';
+
+import type { EntityManifestResponse } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const BASE_PATH = '/api/v1/parties';
+const ENTITY_NAME = 'Granit.Parties.Party';
+
+const META = {
+  columns: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [],
+  sortableFields: [],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [{ name: 'status', type: 'String' }],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10000,
+    supportsCursor: false,
+  },
+};
+
+const PAGE = {
+  items: [
+    { id: '1', name: 'ACME', status: 'Active' },
+    { id: '2', name: 'Globex', status: 'Active' },
+    { id: '3', name: 'Initech', status: 'Pending' },
+    { id: '4', name: 'Hooli', status: null },
+  ],
+  totalCount: 4,
+  page: 1,
+  pageSize: 20,
+};
+
+function manifest(hasQuery: boolean): EntityManifestResponse {
+  return {
+    schemaVersion: 1,
+    identity: hasQuery
+      ? {
+          name: ENTITY_NAME,
+          entityClrType: 'Granit.Parties.Domain.Party',
+          displayKey: null,
+          icon: null,
+          permissionGroup: null,
+          displayProperty: 'name',
+        }
+      : null,
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: hasQuery
+      ? {
+          query: { name: 'Granit.Parties.PartyQuery', clrTypeName: 'PartyQuery' },
+          export: null,
+          metrics: [],
+          dashboards: [],
+          defaultViewId: null,
+        }
+      : null,
+    relations: null,
+  };
+}
+
+function freshHandlers() {
+  return [
+    http.get(`http://localhost${BASE_PATH}/meta`, () => HttpResponse.json(META)),
+    http.get(`http://localhost${BASE_PATH}`, () => HttpResponse.json(PAGE)),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...freshHandlers()));
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <QueryProvider config={{ basePath: BASE_PATH }}>
+          <EntityRendererProvider>{children}</EntityRendererProvider>
+        </QueryProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('EntityKanban', () => {
+  it('renders the empty marker when the manifest declares no list collection', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityKanban manifest={manifest(false)} groupBy="status" />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-entity-kanban-empty]')).not.toBeNull();
+    expect(container.querySelector('[data-granit-entity-kanban-board]')).toBeNull();
+  });
+
+  it('buckets items into one column per distinct groupBy value', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityKanban manifest={manifest(true)} groupBy="status" />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-kanban-board]')).not.toBeNull()
+    );
+    const columns = Array.from(container.querySelectorAll('[data-granit-kanban-column]'));
+    expect(columns.map((c) => c.getAttribute('data-group-key'))).toEqual([
+      'Active',
+      'Pending',
+      '∅',
+    ]);
+    const counts = columns.map(
+      (c) => c.querySelector('[data-granit-kanban-column-count]')?.textContent
+    );
+    expect(counts).toEqual(['2', '1', '1']);
+  });
+
+  it('uses identity.displayProperty as card title by default', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityKanban manifest={manifest(true)} groupBy="status" />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-kanban-card]')).not.toBeNull()
+    );
+    const firstCard = container.querySelector('[data-granit-kanban-card]');
+    expect(firstCard?.textContent).toBe('ACME');
+  });
+
+  it('honours an explicit titleProperty', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityKanban manifest={manifest(true)} groupBy="status" titleProperty="id" />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-kanban-card]')).not.toBeNull()
+    );
+    const titles = Array.from(container.querySelectorAll('[data-granit-kanban-card]')).map(
+      (el) => el.textContent
+    );
+    expect(titles).toEqual(['1', '2', '3', '4']);
+  });
+
+  it('fires onCardClick with the row when a card is clicked', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const onCardClick = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <EntityKanban manifest={manifest(true)} groupBy="status" onCardClick={onCardClick} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-kanban-card]')).not.toBeNull()
+    );
+    fireEvent.click(container.querySelector('[data-granit-kanban-card]') as HTMLLIElement);
+    expect(onCardClick).toHaveBeenCalledWith(PAGE.items[0]);
+  });
+
+  it('surfaces an error message when the page endpoint fails', async () => {
+    server.use(
+      http.get(`http://localhost${BASE_PATH}`, () =>
+        HttpResponse.json({ error: 'boom' }, { status: 500 })
+      )
+    );
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityKanban manifest={manifest(true)} groupBy="status" />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-entity-kanban-error]')).not.toBeNull()
+    );
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-kanban.tsx
+++ b/packages/@granit/react-entities/src/components/entity-kanban.tsx
@@ -1,0 +1,176 @@
+import { useQueryEndpoint, useQueryMeta } from '@granit/react-query-engine';
+import { useMemo, type ReactNode } from 'react';
+
+import type { EntityManifestResponse } from '@granit/entities';
+
+export interface EntityKanbanProps {
+  /** The entity manifest (typically from `useEntityMetadata`). */
+  readonly manifest: EntityManifestResponse;
+  /**
+   * Property name used to bucket cards into columns. Should be a
+   * categorical field (typically `Status`); the renderer reads
+   * `row[groupBy]` for every fetched item and groups them client-side.
+   */
+  readonly groupBy: string;
+  /**
+   * Property used as the card title. Defaults to
+   * `manifest.identity.displayProperty`, falling back to the row's `name`
+   * / `Name` field if neither is available.
+   */
+  readonly titleProperty?: string;
+  /** Optional card activation handler — receives the full row object. */
+  readonly onCardClick?: (row: Readonly<Record<string, unknown>>) => void;
+  /** Optional class for the root element. */
+  readonly className?: string;
+}
+
+/**
+ * Generic read-only kanban board. Bridges the entity manifest's
+ * `collections.query` to the host's ambient `<QueryProvider>`, fetches a
+ * page of items via `useQueryEndpoint`, and buckets them client-side by
+ * `row[groupBy]` to produce one column per distinct value.
+ *
+ * **Read-only scope** — drag-and-drop status transitions land in a
+ * follow-up story once the manifest exposes a workflow / mutation
+ * contract (per ADR-048 §5). For now the kanban surfaces the board
+ * shape; transitions go through whatever action surface the entity
+ * provides (smart buttons, action bar, etc.).
+ *
+ * Pagination is intentionally omitted: kanban boards are dense by
+ * design, and adding it now would require deciding between "infinite
+ * scroll within a column" vs "global page bar across all columns" — a
+ * UX choice that's better made once a real consumer asks for it.
+ */
+export function EntityKanban({
+  manifest,
+  groupBy,
+  titleProperty,
+  onCardClick,
+  className,
+}: EntityKanbanProps): ReactNode {
+  const hasQuery = manifest.collections?.query != null;
+  if (!hasQuery) {
+    return (
+      <div
+        data-granit-entity-kanban=""
+        data-granit-entity-kanban-empty=""
+        data-entity={manifest.identity?.name}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <div
+      data-granit-entity-kanban=""
+      data-entity={manifest.identity?.name}
+      data-group-by={groupBy}
+      className={className}
+    >
+      <EntityKanbanBody
+        groupBy={groupBy}
+        titleProperty={titleProperty ?? manifest.identity?.displayProperty ?? 'Name'}
+        onCardClick={onCardClick}
+      />
+    </div>
+  );
+}
+
+interface EntityKanbanBodyProps {
+  readonly groupBy: string;
+  readonly titleProperty: string;
+  readonly onCardClick: ((row: Readonly<Record<string, unknown>>) => void) | undefined;
+}
+
+function EntityKanbanBody({
+  groupBy,
+  titleProperty,
+  onCardClick,
+}: EntityKanbanBodyProps): ReactNode {
+  const meta = useQueryMeta();
+  const { query } = useQueryEndpoint<Readonly<Record<string, unknown>>>();
+
+  const groups = useMemo(
+    () => bucketByField(query.data?.items ?? [], groupBy),
+    [query.data, groupBy]
+  );
+
+  if (meta.isError || query.isError) {
+    return (
+      <div data-granit-entity-kanban-error="" role="alert">
+        {String((meta.error ?? query.error)?.message ?? 'Failed to load')}
+      </div>
+    );
+  }
+  if (query.isLoading) {
+    return <div data-granit-entity-kanban-loading="">Loading…</div>;
+  }
+
+  return (
+    <div data-granit-entity-kanban-board="">
+      {groups.map(({ key, label, items }) => (
+        <section key={key} data-granit-kanban-column="" data-group-key={key}>
+          <header data-granit-kanban-column-header="">
+            <span data-granit-kanban-column-title="">{label}</span>
+            <span data-granit-kanban-column-count="">{items.length}</span>
+          </header>
+          <ul data-granit-kanban-cards="">
+            {items.map((row, idx) => (
+              <li
+                key={readRowKey(row, idx)}
+                data-granit-kanban-card=""
+                onClick={onCardClick ? () => onCardClick(row) : undefined}
+                style={onCardClick ? { cursor: 'pointer' } : undefined}
+              >
+                {formatTitle(row[titleProperty]) ?? readRowKey(row, idx)}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+interface KanbanGroup {
+  readonly key: string;
+  readonly label: string;
+  readonly items: readonly Readonly<Record<string, unknown>>[];
+}
+
+/**
+ * Walks the items once, buckets them by `row[groupBy]` value, and
+ * preserves first-seen order so the column layout is stable across
+ * refetches (rather than alphabetical, which would jump as new values
+ * appear).
+ */
+function bucketByField(
+  items: readonly Readonly<Record<string, unknown>>[],
+  groupBy: string
+): readonly KanbanGroup[] {
+  const buckets = new Map<string, { label: string; items: Readonly<Record<string, unknown>>[] }>();
+  for (const item of items) {
+    const raw = item[groupBy];
+    const key = raw === null || raw === undefined ? '∅' : String(raw);
+    const label = raw === null || raw === undefined ? '—' : String(raw);
+    let bucket = buckets.get(key);
+    if (!bucket) {
+      bucket = { label, items: [] };
+      buckets.set(key, bucket);
+    }
+    bucket.items.push(item);
+  }
+  return Array.from(buckets, ([key, value]) => ({ key, label: value.label, items: value.items }));
+}
+
+function readRowKey(row: Readonly<Record<string, unknown>>, fallbackIndex: number): string {
+  const id = row['id'] ?? row['Id'];
+  if (typeof id === 'string' || typeof id === 'number') return String(id);
+  return String(fallbackIndex);
+}
+
+function formatTitle(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === 'object') return null;
+  return String(value);
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -10,6 +10,8 @@ export { EntityDetail } from './components/entity-detail.js';
 export type { EntityDetailProps } from './components/entity-detail.js';
 export { EntityForm } from './components/entity-form.js';
 export type { EntityFormProps } from './components/entity-form.js';
+export { EntityKanban } from './components/entity-kanban.js';
+export type { EntityKanbanProps } from './components/entity-kanban.js';
 export { EntityList } from './components/entity-list.js';
 export type { EntityListProps } from './components/entity-list.js';
 export { STANDARD_FORM_WIDGETS } from './widgets/index.js';


### PR DESCRIPTION
## Summary

Generic `<EntityKanban />` consuming the entity manifest's `collections.query` + the host's ambient `<QueryProvider>`. Fetches a page via `useQueryEndpoint`, buckets items client-side by `row[groupBy]` to produce one column per distinct value. Card title defaults to `manifest.identity.displayProperty`, overridable via `titleProperty` prop. `onCardClick` fires with the full row.

## Notable choices

- **Read-only by design** — drag-and-drop status transitions land in a follow-up once the manifest exposes a workflow / mutation contract (per ADR-048 §5). For now transitions go through whatever action surface the entity provides (smart buttons, action bar, …)
- **Pagination intentionally omitted** — kanban boards are dense by design; the choice between "infinite scroll within a column" vs "global page bar across all columns" is a UX call worth deferring until a real consumer pushes back
- **`null` / `undefined` groupBy values land in a synthesised `∅` column** rather than being silently dropped — preserves visibility of malformed data
- **First-seen iteration order** preserves column layout across refetches (alphabetical would jump as new values appear)

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx` → 6 passing (empty marker on missing query, distinct-value bucketing with stable order, default title from `displayProperty`, explicit `titleProperty`, `onCardClick` payload, error surfacing)

## Parent

Feature #299 → Epic #242
