### PR TITLE
feat(react-entities): useEntityForm React Hook Form adapter

### DIFF
--- a/packages/@granit/react-entities/package.json
+++ b/packages/@granit/react-entities/package.json
@@ -21,6 +21,7 @@
     "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0",
+    "react-hook-form": "^7.0.0",
     "react-i18next": "^17.0.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-entities/src/__tests__/use-entity-form.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-form.test.tsx
@@ -1,0 +1,137 @@
+import { act, fireEvent, render, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EntityForm } from '../components/entity-form.js';
+import { useEntityForm } from '../hooks/use-entity-form.js';
+import {
+  EntityRendererProvider,
+  type EntityFormWidget,
+  type EntityWidgetCatalog,
+} from '../provider/index.js';
+
+import type {
+  EntityFormFieldManifest,
+  EntityFormManifest,
+  EntityFormSectionManifest,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const textWidget: EntityFormWidget = ({ field, value, onChange }) => (
+  <input
+    data-testid={`widget-${field.propertyName}`}
+    value={value == null ? '' : String(value)}
+    onChange={(e) => onChange(e.target.value)}
+  />
+);
+
+const catalog: EntityWidgetCatalog = { form: { text: textWidget, integer: textWidget } };
+
+function field(
+  propertyName: string,
+  clrTypeName: string,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName,
+    clrTypeName,
+    widget: clrTypeName === 'Int32' ? 'integer' : 'text',
+    config: null,
+    labelKey: null,
+    helpKey: null,
+    order: 0,
+    readOnly: false,
+    visibleIf: null,
+    ...overrides,
+  };
+}
+
+function section(
+  fields: EntityFormFieldManifest[],
+  overrides: Partial<EntityFormSectionManifest> = {}
+): EntityFormSectionManifest {
+  return {
+    key: 'main',
+    labelKey: null,
+    order: 0,
+    collapsedByDefault: false,
+    fields,
+    ...overrides,
+  };
+}
+
+function manifest(...sections: EntityFormSectionManifest[]): EntityFormManifest {
+  return { name: 'default', customizable: false, sections };
+}
+
+function withProvider(children: ReactNode) {
+  return <EntityRendererProvider widgets={catalog}>{children}</EntityRendererProvider>;
+}
+
+describe('useEntityForm', () => {
+  it('derives type-appropriate defaults from each field', () => {
+    const variant = manifest(
+      section([
+        field('Name', 'String'),
+        field('Age', 'Int32'),
+        field('IsActive', 'Boolean'),
+        field('BirthDate', 'DateOnly'),
+      ])
+    );
+    const { result } = renderHook(() => useEntityForm(variant));
+    expect(result.current.formProps.values).toEqual({
+      Name: '',
+      Age: null,
+      IsActive: false,
+      BirthDate: null,
+    });
+  });
+
+  it('overlays user-supplied defaultValues on top of type defaults', () => {
+    const variant = manifest(section([field('Name', 'String'), field('Age', 'Int32')]));
+    const { result } = renderHook(() =>
+      useEntityForm(variant, { defaultValues: { Name: 'ACME' } })
+    );
+    expect(result.current.formProps.values).toEqual({ Name: 'ACME', Age: null });
+  });
+
+  it('flips isDirty after a value change and reverts on reset', () => {
+    const variant = manifest(section([field('Name', 'String')]));
+    const { result } = renderHook(() => useEntityForm(variant));
+
+    expect(result.current.isDirty).toBe(false);
+    act(() => result.current.formProps.onChange({ Name: 'ACME' }));
+    expect(result.current.formProps.values.Name).toBe('ACME');
+    expect(result.current.isDirty).toBe(true);
+
+    act(() => result.current.reset());
+    expect(result.current.formProps.values.Name).toBe('');
+    expect(result.current.isDirty).toBe(false);
+  });
+
+  it('plugs into <EntityForm /> for an end-to-end controlled flow', () => {
+    const variant = manifest(section([field('Name', 'String')]));
+    function Host() {
+      const { formProps } = useEntityForm(variant);
+      return <EntityForm variant={variant} {...formProps} />;
+    }
+    const { getByTestId } = render(withProvider(<Host />));
+    const input = getByTestId('widget-Name') as HTMLInputElement;
+    expect(input.value).toBe('');
+    fireEvent.change(input, { target: { value: 'Smith' } });
+    expect((getByTestId('widget-Name') as HTMLInputElement).value).toBe('Smith');
+  });
+
+  it('handleSubmit invokes the callback with current values when valid', async () => {
+    const variant = manifest(section([field('Name', 'String')]));
+    const { result } = renderHook(() => useEntityForm(variant));
+    const onValid = vi.fn();
+
+    act(() => result.current.formProps.onChange({ Name: 'ACME' }));
+    await act(async () => {
+      await result.current.handleSubmit(onValid)();
+    });
+
+    expect(onValid).toHaveBeenCalledTimes(1);
+    expect(onValid.mock.calls[0]?.[0]).toMatchObject({ Name: 'ACME' });
+  });
+});

--- a/packages/@granit/react-entities/src/hooks/index.ts
+++ b/packages/@granit/react-entities/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useEntityForm } from './use-entity-form.js';
+export type { UseEntityFormOptions, UseEntityFormReturn } from './use-entity-form.js';

--- a/packages/@granit/react-entities/src/hooks/use-entity-form.ts
+++ b/packages/@granit/react-entities/src/hooks/use-entity-form.ts
@@ -1,0 +1,135 @@
+import { useCallback, useMemo } from 'react';
+import { useForm, type UseFormReturn } from 'react-hook-form';
+
+import type { EntityFormManifest } from '@granit/entities';
+
+export interface UseEntityFormOptions {
+  /** Initial values, overlaid on top of the type-derived defaults. */
+  readonly defaultValues?: Readonly<Record<string, unknown>>;
+  /**
+   * Validation mode forwarded to RHF. Default `onSubmit` matches the
+   * server-authoritative model — the .NET endpoints run FluentValidation
+   * on every write, so client-side checks are UX hints rather than
+   * authoritative gates.
+   */
+  readonly mode?: 'onChange' | 'onBlur' | 'onSubmit' | 'onTouched' | 'all';
+}
+
+export interface UseEntityFormReturn {
+  /** Spread these onto `<EntityForm />` directly. */
+  readonly formProps: {
+    readonly values: Readonly<Record<string, unknown>>;
+    readonly onChange: (next: Readonly<Record<string, unknown>>) => void;
+    readonly errors: Readonly<Record<string, string | undefined>>;
+  };
+  /** Underlying React Hook Form instance for advanced use cases. */
+  readonly form: UseFormReturn<Record<string, unknown>>;
+  /** RHF submit-handler factory. */
+  readonly handleSubmit: UseFormReturn<Record<string, unknown>>['handleSubmit'];
+  readonly isDirty: boolean;
+  readonly isSubmitting: boolean;
+  /** Resets the form to the initial defaults (or the supplied values). */
+  readonly reset: UseFormReturn<Record<string, unknown>>['reset'];
+}
+
+/**
+ * Wires a `<EntityForm />` to a React Hook Form instance. Default values
+ * are derived from each field's `clrTypeName` so number / date inputs
+ * start empty (`null`) rather than as the string `"undefined"`, and
+ * boolean inputs render unchecked.
+ *
+ * Validation: server-authoritative. The .NET endpoints run
+ * FluentValidation on every write, so this hook deliberately doesn't
+ * synthesise client-side rules from the manifest yet — the manifest
+ * doesn't carry required / min / max metadata. Apps that want
+ * immediate-feedback validation today can pass a Zod resolver via
+ * `useForm`'s `resolver` option through `form.<...>` directly. A
+ * built-in schema generator lands once the manifest exposes the
+ * validation contract.
+ */
+export function useEntityForm(
+  variant: EntityFormManifest,
+  options: UseEntityFormOptions = {}
+): UseEntityFormReturn {
+  const initialDefaults = useMemo(
+    () => ({ ...deriveDefaults(variant), ...(options.defaultValues ?? {}) }),
+    [variant, options.defaultValues]
+  );
+
+  const form = useForm<Record<string, unknown>>({
+    defaultValues: initialDefaults,
+    mode: options.mode ?? 'onSubmit',
+  });
+
+  const values = form.watch();
+  const errors = form.formState.errors;
+
+  const onChange = useCallback(
+    (next: Readonly<Record<string, unknown>>) => {
+      for (const [key, val] of Object.entries(next)) {
+        if (val !== values[key]) {
+          form.setValue(key, val, { shouldDirty: true, shouldValidate: false });
+        }
+      }
+    },
+    [form, values]
+  );
+
+  const errorMessages = useMemo<Record<string, string | undefined>>(() => {
+    const out: Record<string, string | undefined> = {};
+    for (const [key, err] of Object.entries(errors)) {
+      const message = (err as { message?: unknown } | undefined)?.message;
+      if (typeof message === 'string') {
+        out[key] = message;
+      }
+    }
+    return out;
+  }, [errors]);
+
+  return {
+    formProps: { values, onChange, errors: errorMessages },
+    form,
+    handleSubmit: form.handleSubmit,
+    isDirty: form.formState.isDirty,
+    isSubmitting: form.formState.isSubmitting,
+    reset: form.reset,
+  };
+}
+
+/**
+ * Derives a reasonable empty-state for each field based on its CLR type.
+ * String → `''`, boolean → `false`, numerics + dates → `null`.
+ */
+function deriveDefaults(variant: EntityFormManifest): Record<string, unknown> {
+  const defaults: Record<string, unknown> = {};
+  for (const section of variant.sections) {
+    for (const field of section.fields) {
+      defaults[field.propertyName] = defaultForType(field.clrTypeName);
+    }
+  }
+  return defaults;
+}
+
+function defaultForType(clrTypeName: string): unknown {
+  switch (clrTypeName) {
+    case 'String':
+      return '';
+    case 'Boolean':
+      return false;
+    case 'Int16':
+    case 'Int32':
+    case 'Int64':
+    case 'Decimal':
+    case 'Double':
+    case 'Single':
+    case 'Byte':
+      return null;
+    case 'DateOnly':
+    case 'DateTime':
+    case 'DateTimeOffset':
+    case 'TimeOnly':
+      return null;
+    default:
+      return null;
+  }
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -18,6 +18,8 @@ export { STANDARD_FORM_WIDGETS } from './widgets/index.js';
 export type { SelectWidgetOption } from './widgets/index.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export { entityManifestQueryKey, useEntityMetadata } from './api/use-entity-metadata.js';
+export { useEntityForm } from './hooks/index.js';
+export type { UseEntityFormOptions, UseEntityFormReturn } from './hooks/index.js';
 export {
   EMPTY_WIDGET_CATALOG,
   EntityRendererProvider,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1261,6 +1261,9 @@ importers:
       react:
         specifier: ^19.0.0
         version: 19.2.5
+      react-hook-form:
+        specifier: ^7.0.0
+        version: 7.74.0(react@19.2.5)
       react-i18next:
         specifier: ^17.0.0
         version: 17.0.4(i18next@26.0.8(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

`useEntityForm(variant, options?)` wraps React Hook Form's `useForm` into an entity-aware hook. Auto-derives `defaultValues` from each field's `clrTypeName` (`String → ''`, `Boolean → false`, numerics + dates → `null`) so number / date inputs start empty rather than as `"undefined"` or NaN-coerced. Returns:

- `formProps: { values, onChange, errors }` — spread directly onto `<EntityForm />` for the controlled flow
- `form` — the underlying RHF instance for advanced use cases (`register` / `watch` / `trigger` / …)
- `handleSubmit` / `isDirty` / `isSubmitting` / `reset` — convenience pass-through

## Why no built-in Zod schema generation yet

Server-authoritative validation: the .NET endpoints run FluentValidation on every write, and the manifest doesn't yet carry `required` / `min` / `max` metadata. Apps that want immediate-feedback validation today wire a Zod resolver via `form.<...>` directly. A built-in schema generator lands once the manifest exposes the validation contract — the alternative would be ship a Zod schema that only enforces types (which RHF's TypeScript already does at compile-time).

## Adds peer dep

`react-hook-form ^7.0.0` on `@granit/react-entities`.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/use-entity-form.test.tsx` → 5 passing (type-derived defaults, defaultValues overlay, isDirty + reset round-trip, end-to-end `<EntityForm />` integration, handleSubmit payload)

## Parent

Feature #299 → Epic #242
