### PR TITLE
feat(workspaces): url helpers for /w/{workspace} and /entity/{id}

### DIFF
--- a/packages/@granit/workspaces/src/__tests__/url-helpers.test.ts
+++ b/packages/@granit/workspaces/src/__tests__/url-helpers.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildEntityUrl,
+  buildWorkspaceUrl,
+  parseEntityUrl,
+  parseWorkspaceUrl,
+} from '../url/url-helpers.js';
+
+describe('buildWorkspaceUrl', () => {
+  it('returns /w/{name} for a workspace root', () => {
+    expect(buildWorkspaceUrl('CRM')).toBe('/w/CRM');
+  });
+
+  it('encodes dots and special characters in the workspace name', () => {
+    expect(buildWorkspaceUrl('Granit.Showcase.CRM')).toBe('/w/Granit.Showcase.CRM');
+    expect(buildWorkspaceUrl('My Workspace')).toBe('/w/My%20Workspace');
+  });
+
+  it('appends segments encoded individually', () => {
+    expect(buildWorkspaceUrl('CRM', 'parties', '42')).toBe('/w/CRM/parties/42');
+    expect(buildWorkspaceUrl('CRM', 'a/b')).toBe('/w/CRM/a%2Fb');
+  });
+});
+
+describe('buildEntityUrl', () => {
+  it('returns /entity/{id} with the id encoded', () => {
+    expect(buildEntityUrl('abc')).toBe('/entity/abc');
+    expect(buildEntityUrl('a/b')).toBe('/entity/a%2Fb');
+  });
+});
+
+describe('parseWorkspaceUrl', () => {
+  it('parses a workspace root', () => {
+    expect(parseWorkspaceUrl('/w/CRM')).toEqual({ workspace: 'CRM', segments: [] });
+  });
+
+  it('decodes the workspace name and segments', () => {
+    expect(parseWorkspaceUrl('/w/Granit.Showcase.CRM/parties/42')).toEqual({
+      workspace: 'Granit.Showcase.CRM',
+      segments: ['parties', '42'],
+    });
+    expect(parseWorkspaceUrl('/w/My%20Workspace')).toEqual({
+      workspace: 'My Workspace',
+      segments: [],
+    });
+  });
+
+  it('returns null for unrelated pathnames', () => {
+    expect(parseWorkspaceUrl('/entity/42')).toBeNull();
+    expect(parseWorkspaceUrl('/dashboards')).toBeNull();
+    expect(parseWorkspaceUrl('/w/')).toBeNull();
+  });
+
+  it('round-trips with buildWorkspaceUrl', () => {
+    const built = buildWorkspaceUrl('Granit.Framework', 'system', 'users');
+    expect(parseWorkspaceUrl(built)).toEqual({
+      workspace: 'Granit.Framework',
+      segments: ['system', 'users'],
+    });
+  });
+});
+
+describe('parseEntityUrl', () => {
+  it('parses /entity/{id}', () => {
+    expect(parseEntityUrl('/entity/abc-123')).toEqual({ id: 'abc-123' });
+  });
+
+  it('decodes the id', () => {
+    expect(parseEntityUrl('/entity/a%2Fb')).toEqual({ id: 'a/b' });
+  });
+
+  it('returns null for malformed pathnames', () => {
+    expect(parseEntityUrl('/entity/')).toBeNull();
+    expect(parseEntityUrl('/entity/a/b')).toBeNull();
+    expect(parseEntityUrl('/w/CRM')).toBeNull();
+  });
+
+  it('round-trips with buildEntityUrl', () => {
+    const built = buildEntityUrl('8c6b1e10-0000-4000-8000-000000000001');
+    expect(parseEntityUrl(built)).toEqual({
+      id: '8c6b1e10-0000-4000-8000-000000000001',
+    });
+  });
+});

--- a/packages/@granit/workspaces/src/index.ts
+++ b/packages/@granit/workspaces/src/index.ts
@@ -13,6 +13,13 @@
 // `IReadOnlyList<T>` → `readonly T[]`, `IReadOnlyDictionary<string, T>` →
 // `Readonly<Record<string, T>>`.
 
+export {
+  buildEntityUrl,
+  buildWorkspaceUrl,
+  parseEntityUrl,
+  parseWorkspaceUrl,
+} from './url/index.js';
+export type { ParsedEntityUrl, ParsedWorkspaceUrl } from './url/index.js';
 export { WORKSPACE_TREE_SCHEMA_VERSION } from './types/index.js';
 export type {
   LandingRouteResponse,

--- a/packages/@granit/workspaces/src/url/index.ts
+++ b/packages/@granit/workspaces/src/url/index.ts
@@ -1,0 +1,7 @@
+export {
+  buildEntityUrl,
+  buildWorkspaceUrl,
+  parseEntityUrl,
+  parseWorkspaceUrl,
+} from './url-helpers.js';
+export type { ParsedEntityUrl, ParsedWorkspaceUrl } from './url-helpers.js';

--- a/packages/@granit/workspaces/src/url/url-helpers.ts
+++ b/packages/@granit/workspaces/src/url/url-helpers.ts
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------
+// URL helpers — pure routing primitives shared across consumer apps.
+// ---------------------------------------------------------------------------
+//
+// The framework deliberately stays router-agnostic; these helpers produce
+// and parse the canonical Granit URL shapes:
+//
+//   /w/{workspace}              workspace root
+//   /w/{workspace}/{...segments} workspace-scoped sub-routes
+//   /entity/{id}                workspace-agnostic detail page
+//
+// Apps wire these into React Router (or whichever router they use)
+// without taking a runtime dependency on the framework router contract.
+
+const WORKSPACE_PREFIX = '/w/';
+const ENTITY_PREFIX = '/entity/';
+
+/**
+ * Build a workspace-scoped URL.
+ *
+ * - `buildWorkspaceUrl('Granit.Showcase.CRM')` → `/w/Granit.Showcase.CRM`
+ * - `buildWorkspaceUrl('CRM', 'parties')` → `/w/CRM/parties`
+ * - `buildWorkspaceUrl('CRM', 'parties', '42')` → `/w/CRM/parties/42`
+ *
+ * Each segment is `encodeURIComponent`-ed so workspace names containing
+ * dots / spaces / non-ASCII characters round-trip cleanly.
+ */
+export function buildWorkspaceUrl(workspaceName: string, ...segments: readonly string[]): string {
+  const encoded = [encodeURIComponent(workspaceName), ...segments.map(encodeURIComponent)];
+  return `${WORKSPACE_PREFIX}${encoded.join('/')}`;
+}
+
+/**
+ * Build a workspace-agnostic entity-detail URL.
+ *
+ * `buildEntityUrl('8c6b1e10-...')` → `/entity/8c6b1e10-...`
+ */
+export function buildEntityUrl(entityId: string): string {
+  return `${ENTITY_PREFIX}${encodeURIComponent(entityId)}`;
+}
+
+/**
+ * Result of parsing a workspace-scoped pathname.
+ *
+ * `workspace` is the decoded workspace name; `segments` carries the
+ * decoded sub-segments after it (typically `[entityName?, viewName?, ...]`,
+ * but the framework deliberately leaves segment semantics to the app).
+ */
+export interface ParsedWorkspaceUrl {
+  readonly workspace: string;
+  readonly segments: readonly string[];
+}
+
+/**
+ * Parse `/w/{workspace}/{...segments}`. Returns `null` for any pathname
+ * that doesn't start with `/w/` or that has an empty workspace slot —
+ * letting the caller fall through to the default routing tree rather
+ * than redirecting to a malformed workspace.
+ */
+export function parseWorkspaceUrl(pathname: string): ParsedWorkspaceUrl | null {
+  if (!pathname.startsWith(WORKSPACE_PREFIX)) return null;
+  const tail = pathname.slice(WORKSPACE_PREFIX.length);
+  if (tail.length === 0) return null;
+  const parts = tail.split('/').map(safeDecode);
+  const [workspace, ...segments] = parts;
+  if (!workspace) return null;
+  return { workspace, segments };
+}
+
+/** Result of parsing an entity-detail pathname. */
+export interface ParsedEntityUrl {
+  readonly id: string;
+}
+
+/**
+ * Parse `/entity/{id}`. Returns `null` when the pathname doesn't match
+ * (e.g. the user landed on `/w/CRM/...` or a custom app route) so the
+ * caller can keep its existing routing fall-through.
+ */
+export function parseEntityUrl(pathname: string): ParsedEntityUrl | null {
+  if (!pathname.startsWith(ENTITY_PREFIX)) return null;
+  const tail = pathname.slice(ENTITY_PREFIX.length);
+  if (tail.length === 0 || tail.includes('/')) return null;
+  const id = safeDecode(tail);
+  if (!id) return null;
+  return { id };
+}
+
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}


### PR DESCRIPTION
## Summary

Pure routing primitives in `@granit/workspaces` for the canonical Granit URL shapes:

- `buildWorkspaceUrl(name, ...segments)` → `/w/{name}/{segments...}` with each segment URL-encoded
- `buildEntityUrl(id)` → `/entity/{id}`
- `parseWorkspaceUrl(pathname)` → `{ workspace, segments }` or `null`
- `parseEntityUrl(pathname)` → `{ id }` or `null`

No runtime dependency on a specific router — the framework stays router-agnostic, and the showcase wires these into React Router on its side (per the framework / app split decided in #300).

## Notable choices

- **Parsers return `null` on unrelated pathnames** — apps can fall through to their existing routing tree without try/catch
- **`safeDecode` shields against malformed percent-encoding** so a user-typed URL never crashes the parser
- **Each path segment is encoded individually** so a workspace name containing slashes (rare but possible) doesn't get split by the router

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/workspaces/src/__tests__/url-helpers.test.ts` → 12 passing (happy paths, encoding round-trips, malformed inputs, unrelated pathnames falling through to null)

## Parent

Feature #300 → Epic #242
