### PR TITLE
feat(react-workspaces): useSidePeek hook for the notion-style peek drawer

### DIFF
--- a/packages/@granit/react-workspaces/src/__tests__/use-side-peek.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-side-peek.test.tsx
@@ -1,0 +1,170 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useSidePeek,
+  type SidePeekEntry,
+  type UseSidePeekOptions,
+} from '../hooks/use-side-peek.js';
+
+function harness(initial: Partial<UseSidePeekOptions> = {}) {
+  let search = initial.search ?? '';
+  const onSearchChange = vi.fn((next: string) => {
+    search = next;
+  });
+  const onExpand = initial.onExpand ?? vi.fn();
+  const { result, rerender } = renderHook((props: UseSidePeekOptions) => useSidePeek(props), {
+    initialProps: {
+      search,
+      onSearchChange,
+      onExpand,
+      enableShortcuts: initial.enableShortcuts,
+    },
+  });
+  const flush = () =>
+    rerender({ search, onSearchChange, onExpand, enableShortcuts: initial.enableShortcuts });
+  return { result, rerender: flush, onSearchChange, onExpand, getSearch: () => search };
+}
+
+const PARTY: SidePeekEntry = { entityName: 'Granit.Parties.Party', entityId: '42' };
+const INVOICE: SidePeekEntry = { entityName: 'Granit.Invoicing.Invoice', entityId: '100' };
+
+describe('useSidePeek — parse', () => {
+  it('returns an empty stack when no peek param is present', () => {
+    const { result } = harness({ search: '?other=1' });
+    expect(result.current.peek).toBeNull();
+    expect(result.current.stack).toEqual([]);
+  });
+
+  it('parses a single peek entry', () => {
+    const { result } = harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+    });
+    expect(result.current.peek).toEqual(PARTY);
+    expect(result.current.stack).toEqual([PARTY]);
+  });
+
+  it('parses a stacked peek and exposes the top as `peek`', () => {
+    const { result } = harness({
+      search:
+        `?peek=${encodeURIComponent('Granit.Parties.Party')}:42,` +
+        `${encodeURIComponent('Granit.Invoicing.Invoice')}:100`,
+    });
+    expect(result.current.stack).toEqual([PARTY, INVOICE]);
+    expect(result.current.peek).toEqual(INVOICE);
+  });
+
+  it('falls back to an empty stack on malformed entries', () => {
+    const { result } = harness({ search: '?peek=:nothing,broken,Party:' });
+    expect(result.current.stack).toEqual([]);
+  });
+});
+
+describe('useSidePeek — mutate', () => {
+  it('openPeek pushes an entry and writes it back through onSearchChange', () => {
+    const { result, onSearchChange } = harness();
+    act(() => result.current.openPeek(PARTY));
+    expect(onSearchChange).toHaveBeenCalledWith(
+      `?peek=${encodeURIComponent('Granit.Parties.Party')}%3A42`
+    );
+  });
+
+  it('closePeek pops the top of the stack', () => {
+    const { result, onSearchChange } = harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+    });
+    act(() => result.current.closePeek());
+    expect(onSearchChange).toHaveBeenCalledWith('');
+  });
+
+  it('closeAll empties the stack', () => {
+    const { result, onSearchChange } = harness({
+      search:
+        `?peek=${encodeURIComponent('Granit.Parties.Party')}:42,` +
+        `${encodeURIComponent('Granit.Invoicing.Invoice')}:100&other=1`,
+    });
+    act(() => result.current.closeAll());
+    expect(onSearchChange).toHaveBeenCalledWith('?other=1');
+  });
+
+  it('preserves unrelated query params when updating peek', () => {
+    const { result, onSearchChange } = harness({ search: '?other=1' });
+    act(() => result.current.openPeek(PARTY));
+    expect(onSearchChange.mock.calls[0]?.[0]).toContain('other=1');
+    expect(onSearchChange.mock.calls[0]?.[0]).toContain('peek=');
+  });
+
+  it('expandPeek calls onExpand with the canonical /entity/{id} url', () => {
+    const onExpand = vi.fn();
+    const { result } = harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+      onExpand,
+    });
+    act(() => result.current.expandPeek());
+    expect(onExpand).toHaveBeenCalledWith('/entity/42');
+  });
+
+  it('expandPeek is a no-op when no peek is active', () => {
+    const onExpand = vi.fn();
+    const { result } = harness({ onExpand });
+    act(() => result.current.expandPeek());
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+});
+
+describe('useSidePeek — keyboard shortcuts', () => {
+  it('Escape closes the top peek when one is active', () => {
+    const { result, onSearchChange } = harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+    });
+    expect(result.current.peek).toEqual(PARTY);
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    });
+    expect(onSearchChange).toHaveBeenCalledWith('');
+  });
+
+  it('Cmd+Shift+. fires expand on the top peek', () => {
+    const onExpand = vi.fn();
+    harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+      onExpand,
+    });
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '.', metaKey: true, shiftKey: true })
+      );
+    });
+    expect(onExpand).toHaveBeenCalledWith('/entity/42');
+  });
+
+  it('does nothing without a peek', () => {
+    const onExpand = vi.fn();
+    const { onSearchChange } = harness({ onExpand });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '.', ctrlKey: true, shiftKey: true })
+      );
+    });
+    expect(onExpand).not.toHaveBeenCalled();
+    expect(onSearchChange).not.toHaveBeenCalled();
+  });
+
+  it('honours enableShortcuts: false', () => {
+    const onExpand = vi.fn();
+    const { onSearchChange } = harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+      onExpand,
+      enableShortcuts: false,
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '.', metaKey: true, shiftKey: true })
+      );
+    });
+    expect(onSearchChange).not.toHaveBeenCalled();
+    expect(onExpand).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-workspaces/src/hooks/index.ts
+++ b/packages/@granit/react-workspaces/src/hooks/index.ts
@@ -1,0 +1,2 @@
+export { useSidePeek } from './use-side-peek.js';
+export type { SidePeekEntry, UseSidePeekOptions, UseSidePeekReturn } from './use-side-peek.js';

--- a/packages/@granit/react-workspaces/src/hooks/use-side-peek.ts
+++ b/packages/@granit/react-workspaces/src/hooks/use-side-peek.ts
@@ -1,0 +1,181 @@
+import { buildEntityUrl } from '@granit/workspaces';
+import { useCallback, useEffect, useMemo } from 'react';
+
+const PEEK_PARAM = 'peek';
+const ENTRY_SEPARATOR = ',';
+const FIELD_SEPARATOR = ':';
+
+/** One peek entry — the entity name + id surfaced in the side drawer. */
+export interface SidePeekEntry {
+  readonly entityName: string;
+  readonly entityId: string;
+}
+
+export interface UseSidePeekOptions {
+  /**
+   * Current URL search string (incl. leading `?` or not), typically
+   * `useLocation().search` from React Router or
+   * `window.location.search`.
+   */
+  readonly search: string;
+  /**
+   * Callback invoked when the peek stack changes — receives the next
+   * search string. Hosts wrap their router's navigate / push so the URL
+   * updates and the rest of the app re-renders.
+   */
+  readonly onSearchChange: (nextSearch: string) => void;
+  /**
+   * Optional handler invoked when the user expands the top peek to a
+   * full page via `⌘+⇧+.`. Receives the workspace-agnostic detail URL
+   * (`/entity/{id}`); the host typically calls `navigate(url)`.
+   *
+   * When omitted, the shortcut is a no-op.
+   */
+  readonly onExpand?: (fullPath: string) => void;
+  /**
+   * Keyboard shortcuts opt-out. Defaults to `true`. Tests + hosts that
+   * own their own shortcut handling can disable the global listeners.
+   */
+  readonly enableShortcuts?: boolean;
+}
+
+export interface UseSidePeekReturn {
+  /** Top-of-stack peek, or `null` when no peek is active. */
+  readonly peek: SidePeekEntry | null;
+  /** Full peek stack — earliest first, top is last. */
+  readonly stack: readonly SidePeekEntry[];
+  /** Push a new peek onto the stack. */
+  readonly openPeek: (entry: SidePeekEntry) => void;
+  /** Pop the top peek (closes the drawer when stack becomes empty). */
+  readonly closePeek: () => void;
+  /** Empty the stack — closes every nested peek at once. */
+  readonly closeAll: () => void;
+  /** Expand the top peek to the canonical `/entity/{id}` page. */
+  readonly expandPeek: () => void;
+}
+
+/**
+ * Stateless URL-bound side-peek state. Reads `?peek=...` from the
+ * supplied search string, exposes the parsed stack + operations, and
+ * round-trips updates back through `onSearchChange`.
+ *
+ * Wire format: `?peek=entityName:id[,entityName:id]*`. Each
+ * `entityName` and `id` is URL-encoded individually so dots in entity
+ * names (`Granit.Parties.Party`) and slashes in ids round-trip cleanly.
+ *
+ * Keyboard shortcuts (when `enableShortcuts !== false` and a peek is
+ * active):
+ *
+ * - `Esc` — close the top peek
+ * - `⌘+⇧+.` (or `Ctrl+Shift+.` on non-mac) — expand to full page
+ *
+ * Stays router-agnostic: the host owns navigation. `onSearchChange`
+ * typically wraps `navigate({ search: next })`; `onExpand` typically
+ * wraps `navigate(fullPath)`.
+ */
+export function useSidePeek({
+  search,
+  onSearchChange,
+  onExpand,
+  enableShortcuts = true,
+}: UseSidePeekOptions): UseSidePeekReturn {
+  const stack = useMemo(() => parsePeekStack(search), [search]);
+  const peek = stack.length > 0 ? (stack[stack.length - 1] ?? null) : null;
+
+  const updateStack = useCallback(
+    (next: readonly SidePeekEntry[]) => {
+      onSearchChange(rewritePeekParam(search, next));
+    },
+    [search, onSearchChange]
+  );
+
+  const openPeek = useCallback(
+    (entry: SidePeekEntry) => updateStack([...stack, entry]),
+    [stack, updateStack]
+  );
+  const closePeek = useCallback(() => updateStack(stack.slice(0, -1)), [stack, updateStack]);
+  const closeAll = useCallback(() => updateStack([]), [updateStack]);
+  const expandPeek = useCallback(() => {
+    if (!peek || !onExpand) return;
+    onExpand(buildEntityUrl(peek.entityId));
+  }, [peek, onExpand]);
+
+  useEffect(() => {
+    if (!enableShortcuts || !peek) return undefined;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        closePeek();
+        return;
+      }
+      if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === '.') {
+        e.preventDefault();
+        expandPeek();
+      }
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [enableShortcuts, peek, closePeek, expandPeek]);
+
+  return { peek, stack, openPeek, closePeek, closeAll, expandPeek };
+}
+
+/**
+ * Parse the `?peek=` query parameter into a list of entries. Returns
+ * an empty array for missing / malformed values rather than throwing,
+ * so a hand-typed URL never crashes the renderer.
+ */
+function parsePeekStack(search: string): readonly SidePeekEntry[] {
+  const params = readSearchParams(search);
+  const raw = params.get(PEEK_PARAM);
+  if (!raw) return [];
+  const entries: SidePeekEntry[] = [];
+  for (const segment of raw.split(ENTRY_SEPARATOR)) {
+    const trimmed = segment.trim();
+    if (!trimmed) continue;
+    const sepIdx = trimmed.indexOf(FIELD_SEPARATOR);
+    if (sepIdx <= 0 || sepIdx >= trimmed.length - 1) continue;
+    const entityName = safeDecode(trimmed.slice(0, sepIdx));
+    const entityId = safeDecode(trimmed.slice(sepIdx + 1));
+    if (!entityName || !entityId) continue;
+    entries.push({ entityName, entityId });
+  }
+  return entries;
+}
+
+/**
+ * Replace the `peek` parameter in the search string with the serialised
+ * stack, preserving every other query parameter so we don't clobber
+ * filters / view selectors that share the URL.
+ */
+function rewritePeekParam(search: string, stack: readonly SidePeekEntry[]): string {
+  const params = readSearchParams(search);
+  if (stack.length === 0) {
+    params.delete(PEEK_PARAM);
+  } else {
+    params.set(PEEK_PARAM, serialiseStack(stack));
+  }
+  const out = params.toString();
+  return out === '' ? '' : `?${out}`;
+}
+
+function serialiseStack(stack: readonly SidePeekEntry[]): string {
+  return stack
+    .map(
+      (entry) =>
+        `${encodeURIComponent(entry.entityName)}${FIELD_SEPARATOR}${encodeURIComponent(entry.entityId)}`
+    )
+    .join(ENTRY_SEPARATOR);
+}
+
+function readSearchParams(search: string): URLSearchParams {
+  const trimmed = search.startsWith('?') ? search.slice(1) : search;
+  return new URLSearchParams(trimmed);
+}
+
+function safeDecode(segment: string): string {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}

--- a/packages/@granit/react-workspaces/src/index.ts
+++ b/packages/@granit/react-workspaces/src/index.ts
@@ -14,3 +14,5 @@ export {
   useSetLandingPin,
 } from './api/use-landing-route.js';
 export { useWorkspaces, workspaceTreeQueryKey } from './api/use-workspaces.js';
+export { useSidePeek } from './hooks/index.js';
+export type { SidePeekEntry, UseSidePeekOptions, UseSidePeekReturn } from './hooks/index.js';


### PR DESCRIPTION
## Summary

Stateless URL-bound state hook for the Notion-style side peek (ADR-048 §3). Reads `?peek=...` from the supplied search string, exposes the parsed stack + operations, round-trips updates through `onSearchChange`.

```tsx
const location = useLocation();
const navigate = useNavigate();

const peek = useSidePeek({
  search: location.search,
  onSearchChange: (search) => navigate({ search }),
  onExpand: (path) => navigate(path),
});
```

## Wire format

`?peek=entityName:id[,entityName:id]*` — names and ids URL-encoded individually so dots in entity names (`Granit.Parties.Party`) and slashes in ids round-trip cleanly. Unrelated query params on the URL are preserved when the peek changes — no clobbering filters or view selectors.

## Keyboard shortcuts

When `enableShortcuts !== false` and a peek is active:
- `Escape` — closes the top peek
- `⌘+⇧+.` (or `Ctrl+Shift+.`) — calls `onExpand` with `/entity/{id}`

Listener is bound to the document and only attached when a peek is open, so global keyboard handling is dormant on pages without a drawer.

## Stays router-agnostic

The host owns navigation. `onSearchChange` wraps `navigate({ search })`; `onExpand` wraps `navigate(fullPath)`. Matches the framework / app split decided in #300 — the visual `<SidePeek />` drawer lives in showcase, the framework ships the headless logic.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-workspaces/src/__tests__/use-side-peek.test.tsx` → 14 passing (parse single / stacked / malformed / missing, mutate open / close / closeAll / preserving unrelated params / no-op expand-while-empty, shortcuts Escape / ⌘+⇧+. / dormant when empty / `enableShortcuts: false`)

## Parent

Feature #300 → Epic #242
