### PR TITLE
feat(react-workspaces): useLandingRedirect one-shot post-login redirect

### DIFF
--- a/packages/@granit/react-workspaces/src/__tests__/use-landing-redirect.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-landing-redirect.test.tsx
@@ -1,0 +1,95 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { useLandingRedirect } from '../hooks/use-landing-redirect.js';
+
+import type { LandingRouteResponse } from '@granit/workspaces';
+import type { ReactNode } from 'react';
+
+const ROUTE: LandingRouteResponse = {
+  route: '/w/Granit.Showcase.CRM',
+  source: 'PersonalSticky',
+};
+
+let getCalls = 0;
+
+function freshHandlers() {
+  return [
+    http.get('http://localhost/me/landing-route', () => {
+      getCalls += 1;
+      return HttpResponse.json(ROUTE);
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  getCalls = 0;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('useLandingRedirect', () => {
+  it('navigates once with the resolved route after the query lands', async () => {
+    const { wrapper } = makeWrapper();
+    const navigate = vi.fn();
+    const { result } = renderHook(() => useLandingRedirect(navigate), { wrapper });
+
+    expect(result.current.isResolving).toBe(true);
+    expect(result.current.hasRedirected).toBe(false);
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
+    expect(navigate).toHaveBeenCalledWith(ROUTE.route);
+    expect(result.current.resolved).toEqual(ROUTE);
+  });
+
+  it('only fires once even on re-renders', async () => {
+    const { wrapper } = makeWrapper();
+    const navigate = vi.fn();
+    const { rerender } = renderHook(() => useLandingRedirect(navigate), { wrapper });
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
+    rerender();
+    rerender();
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the redirect when enabled is false', async () => {
+    const { wrapper } = makeWrapper();
+    const navigate = vi.fn();
+    renderHook(() => useLandingRedirect(navigate, { enabled: false }), { wrapper });
+
+    // Wait long enough for a fetch to have happened if it were going to.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(navigate).not.toHaveBeenCalled();
+    expect(getCalls).toBe(0);
+  });
+
+  it('invokes onResolved before navigating', async () => {
+    const { wrapper } = makeWrapper();
+    const navigate = vi.fn();
+    const onResolved = vi.fn();
+    renderHook(() => useLandingRedirect(navigate, { onResolved }), { wrapper });
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledTimes(1));
+    expect(onResolved).toHaveBeenCalledWith(ROUTE);
+  });
+});

--- a/packages/@granit/react-workspaces/src/hooks/index.ts
+++ b/packages/@granit/react-workspaces/src/hooks/index.ts
@@ -1,2 +1,7 @@
+export { useLandingRedirect } from './use-landing-redirect.js';
+export type {
+  UseLandingRedirectOptions,
+  UseLandingRedirectReturn,
+} from './use-landing-redirect.js';
 export { useSidePeek } from './use-side-peek.js';
 export type { SidePeekEntry, UseSidePeekOptions, UseSidePeekReturn } from './use-side-peek.js';

--- a/packages/@granit/react-workspaces/src/hooks/use-landing-redirect.ts
+++ b/packages/@granit/react-workspaces/src/hooks/use-landing-redirect.ts
@@ -1,0 +1,66 @@
+import { useEffect, useRef } from 'react';
+
+import { useLandingRoute } from '../api/use-landing-route.js';
+
+import type { LandingRouteResponse } from '@granit/workspaces';
+
+export interface UseLandingRedirectOptions {
+  /**
+   * Disable the redirect (e.g. when the user is already navigating
+   * somewhere explicit). Defaults to `true`. Setting it to `false`
+   * keeps the underlying `useLandingRoute` query enabled so the
+   * resolved route stays warm in the cache.
+   */
+  readonly enabled?: boolean;
+  /**
+   * When provided, called instead of `navigate` once the route
+   * resolves. Useful when the host wants to filter or log the
+   * destination before redirecting.
+   */
+  readonly onResolved?: (route: LandingRouteResponse) => void;
+}
+
+export interface UseLandingRedirectReturn {
+  /** True until the underlying query resolves. */
+  readonly isResolving: boolean;
+  /** The resolved landing route, or `undefined` while loading. */
+  readonly resolved: LandingRouteResponse | undefined;
+  /** True after the redirect has fired (one-shot guard). */
+  readonly hasRedirected: boolean;
+}
+
+/**
+ * One-shot redirect to the route resolved by the .NET 5-tier landing
+ * resolver (`GET /me/landing-route`). Mount once on the post-login
+ * layout — the hook fires `navigate(route)` exactly once after the
+ * query lands, then stays inert.
+ *
+ * Stays router-agnostic: the host owns navigation. Pass
+ * `(path) => navigate(path)` from React Router, or any equivalent
+ * imperative API.
+ *
+ * The redirect short-circuits if `enabled` is false (or flips to
+ * false) — apps can disable it on routes the user explicitly typed
+ * to so a deep link isn't clobbered by the resolver.
+ */
+export function useLandingRedirect(
+  navigate: (path: string) => void,
+  options: UseLandingRedirectOptions = {}
+): UseLandingRedirectReturn {
+  const enabled = options.enabled ?? true;
+  const { data: resolved, isLoading } = useLandingRoute({ enabled });
+  const firedRef = useRef(false);
+
+  useEffect(() => {
+    if (!enabled || !resolved || firedRef.current) return;
+    firedRef.current = true;
+    options.onResolved?.(resolved);
+    navigate(resolved.route);
+  }, [enabled, resolved, navigate, options]);
+
+  return {
+    isResolving: isLoading,
+    resolved,
+    hasRedirected: firedRef.current,
+  };
+}

--- a/packages/@granit/react-workspaces/src/index.ts
+++ b/packages/@granit/react-workspaces/src/index.ts
@@ -14,5 +14,11 @@ export {
   useSetLandingPin,
 } from './api/use-landing-route.js';
 export { useWorkspaces, workspaceTreeQueryKey } from './api/use-workspaces.js';
-export { useSidePeek } from './hooks/index.js';
-export type { SidePeekEntry, UseSidePeekOptions, UseSidePeekReturn } from './hooks/index.js';
+export { useLandingRedirect, useSidePeek } from './hooks/index.js';
+export type {
+  SidePeekEntry,
+  UseLandingRedirectOptions,
+  UseLandingRedirectReturn,
+  UseSidePeekOptions,
+  UseSidePeekReturn,
+} from './hooks/index.js';


### PR DESCRIPTION
## Summary

`useLandingRedirect(navigate, options?)` mounts on the post-login layout and fires `navigate(route)` exactly once after the .NET 5-tier resolver lands (`GET /me/landing-route`). Subsequent re-renders are inert via a `useRef` guard, so app navigation away from the landing route isn't clobbered.

```tsx
function PostLoginLayout() {
  const navigate = useNavigate();
  useLandingRedirect((path) => navigate(path));
  return <Outlet />;
}
```

## Notable behaviour

- **One-shot guard via `useRef`** — only the first resolved route fires `navigate`; cache refetches (e.g. after a permission change invalidation) don't redirect again
- **`enabled: false` short-circuits both the redirect and the underlying query** — useful on routes the user typed explicitly so a deep link isn't replaced by the resolver
- **Optional `onResolved` callback** fires before navigation, handy for logging or filtering the destination
- **Stays router-agnostic** — same split as `useSidePeek` (#320): the visual `<LandingRedirect />` wrapper lives in showcase, the framework ships the headless logic

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-workspaces/src/__tests__/use-landing-redirect.test.tsx` → 4 passing (happy path + correct route, re-render idempotence, `enabled: false` skipping the fetch, `onResolved` firing before navigate)

## Note on the cross-repo bonus

While checking alignment for this PR I cross-referenced `granit-showcase-admin-react/src/api/generated/granitShowcaseAPI.schemas.ts` (Orval was re-run) — the hand-written types in `@granit/entities` and `@granit/workspaces` match the generated schemas field-for-field. No drift. The framework keeps hand-rolled contracts because Orval-generated types ship per-app and are heavier than the framework needs.

## Parent

Feature #300 → Epic #242
