### PR TITLE
feat(entities-views): saved-view ts types mirroring .net dtos

### DIFF
--- a/packages/@granit/entities-views/src/index.ts
+++ b/packages/@granit/entities-views/src/index.ts
@@ -1,9 +1,21 @@
-// @granit/entities-views — public API
+// ---------------------------------------------------------------------------
+// @granit/entities-views — public API (framework-agnostic)
+// ---------------------------------------------------------------------------
 //
-// Framework-agnostic contracts for Granit saved views (EntityView aggregate
-// from Granit.Entities.Views). Visibility (Personal / Shared / Tenant),
-// flags (isPinned / isDefault / isPersonalDefault), and the basedOn delta
-// model that lets a view stack onto a base view without copying its state.
+// Mirrors the .NET DTOs from Granit.Entities.Views.Abstractions +
+// Granit.Entities.Views.Endpoints.Dtos so any consumer (React renderer,
+// mobile app) can read the /entities/{name}/views payloads with full
+// type safety.
 //
-// Implementation lands in subsequent stories of granit-fx/granit-front#301.
-export {};
+// Wire conventions match @granit/entities: camelCase property names,
+// PascalCase string-literal enums, readonly arrays / records.
+
+export type {
+  EntityViewCreateBodyRequest,
+  EntityViewResponse,
+  EntityViewShareBodyRequest,
+  EntityViewSharedWith,
+  EntityViewToggleFlagRequest,
+  EntityViewUpdateBodyRequest,
+  EntityViewVisibility,
+} from './types/index.js';

--- a/packages/@granit/entities-views/src/types/index.ts
+++ b/packages/@granit/entities-views/src/types/index.ts
@@ -1,0 +1,7 @@
+export type {
+  EntityViewCreateBodyRequest,
+  EntityViewShareBodyRequest,
+  EntityViewToggleFlagRequest,
+  EntityViewUpdateBodyRequest,
+} from './requests.js';
+export type { EntityViewResponse, EntityViewSharedWith, EntityViewVisibility } from './view.js';

--- a/packages/@granit/entities-views/src/types/requests.ts
+++ b/packages/@granit/entities-views/src/types/requests.ts
@@ -1,0 +1,47 @@
+/**
+ * Request body for `POST /entities/{name}/views`. Mirrors
+ * `Granit.Entities.Views.Endpoints.Dtos.EntityViewCreateBodyRequest`.
+ */
+export interface EntityViewCreateBodyRequest {
+  /** Compiled-collection name this view deltas over. */
+  readonly basedOn: string;
+  /** View kind inherited from `basedOn`. */
+  readonly kind: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly icon: string | null;
+  /** JSON delta payload. */
+  readonly state: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Request body for `PUT /entities/{name}/views/{id}`. Mirrors
+ * `Granit.Entities.Views.Endpoints.Dtos.EntityViewUpdateBodyRequest`.
+ *
+ * `basedOn` and `kind` are immutable post-creation, so they're absent
+ * here; `state` is validated server-side against the existing `kind`.
+ */
+export interface EntityViewUpdateBodyRequest {
+  readonly name: string;
+  readonly description: string | null;
+  readonly icon: string | null;
+  readonly state: Readonly<Record<string, unknown>>;
+}
+
+/**
+ * Request body for `POST /entities/{name}/views/{id}/share`. Mirrors
+ * `Granit.Entities.Views.Endpoints.Dtos.EntityViewShareBodyRequest`.
+ */
+export interface EntityViewShareBodyRequest {
+  readonly roles: readonly string[];
+  readonly users: readonly string[];
+}
+
+/**
+ * Request body for the boolean-toggle endpoints (pin / star /
+ * set-default). Mirrors
+ * `Granit.Entities.Views.Endpoints.Dtos.EntityViewToggleFlagRequest`.
+ */
+export interface EntityViewToggleFlagRequest {
+  readonly value: boolean;
+}

--- a/packages/@granit/entities-views/src/types/view.ts
+++ b/packages/@granit/entities-views/src/types/view.ts
@@ -1,0 +1,61 @@
+/**
+ * Closed enum of visibility levels an `EntityView` may carry — see
+ * ADR-047 §4. Mirrors `Granit.Entities.Views.EntityViewVisibility`.
+ *
+ * - `Personal` — owner-only; created by any user with `Entities.Views.Create`
+ * - `Shared` — visible to specific roles + users; promoted from Personal
+ *   by a user with `Entities.Views.Share`
+ * - `Tenant` — visible to the entire tenant; promoted by an admin with
+ *   `Entities.Views.Manage`
+ */
+export type EntityViewVisibility = 'Personal' | 'Shared' | 'Tenant';
+
+/**
+ * Audience for `Shared` views. Mirrors
+ * `Granit.Entities.Views.Endpoints.Dtos.EntityViewSharedWithDto`.
+ *
+ * Both lists may be empty for a `Shared` view that has been narrowed to
+ * just the owner; however a `Personal` or `Tenant` view always carries
+ * `null` here (see {@link EntityViewResponse.sharedWith}).
+ */
+export interface EntityViewSharedWith {
+  readonly roles: readonly string[];
+  readonly users: readonly string[];
+}
+
+/**
+ * Wire-shape projection of an `EntityView` aggregate. Mirrors
+ * `Granit.Entities.Views.Endpoints.Dtos.EntityViewResponse`.
+ *
+ * `state` is the JSON delta payload over the compiled collection
+ * identified by `basedOn` (filters / sort / columns / group / per-layout
+ * config); the framework treats it as opaque and lets the renderer apply
+ * it to the underlying `QueryRequest`.
+ */
+export interface EntityViewResponse {
+  readonly id: string;
+  /** Wire identifier of the entity this view targets. */
+  readonly entityName: string;
+  /** Compiled-collection name this view deltas over (immutable post-creation). */
+  readonly basedOn: string;
+  /** View kind inherited from `basedOn` (e.g. `"list"`, `"kanban"`). */
+  readonly kind: string;
+  readonly name: string;
+  readonly description: string | null;
+  readonly icon: string | null;
+  /** JSONB delta payload — opaque to the framework, applied by the renderer. */
+  readonly state: Readonly<Record<string, unknown>>;
+  readonly visibility: EntityViewVisibility;
+  /** Owner id — `null` only for Tenant views. */
+  readonly ownerId: string | null;
+  /** Audience for `Shared` views; `null` for Personal / Tenant. */
+  readonly sharedWith: EntityViewSharedWith | null;
+  /** Pinned as a tab in the workspace tab strip (admin-promoted). */
+  readonly isPinned: boolean;
+  /** Replaces the compiled default for the tenant (admin-promoted). */
+  readonly isDefault: boolean;
+  /** User's landing view for this entity (per-user); at most one per (user, entity). */
+  readonly isPersonalDefault: boolean;
+  /** Display order among views (lower first). */
+  readonly sortOrder: number;
+}


### PR DESCRIPTION
## Summary

Adds the TypeScript contracts for `/entities/{name}/views` to `@granit/entities-views`, mirroring `Granit.Entities.Views.Abstractions` + `Granit.Entities.Views.Endpoints.Dtos`:

- `EntityViewVisibility` — `'Personal' | 'Shared' | 'Tenant'` (ADR-047 §4)
- `EntityViewSharedWith` — `{ roles, users }` audience for Shared views
- `EntityViewResponse` — full wire-shape projection of the `EntityView` aggregate with `state` as `Readonly<Record<string, unknown>>` (opaque delta payload over the compiled collection identified by `basedOn`)
- Request bodies: `EntityViewCreateBodyRequest`, `EntityViewUpdateBodyRequest`, `EntityViewShareBodyRequest`, `EntityViewToggleFlagRequest`

## Cross-check

Field-for-field match against the showcase Orval-generated schemas (`granit-showcase-admin-react/src/api/generated/granitShowcaseAPI.schemas.ts`). The only nominal difference: the framework calls the shared-with payload `EntityViewSharedWith` (matches the .NET domain name), the generated client calls it `EntityViewSharedWithDto` — same wire shape, different namespace conventions.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] All types reference matching .NET DTOs in their JSDoc — easy cross-check
- [ ] Hooks consuming these types land in follow-up PRs and exercise them

## Parent

Feature #301 → Epic #242
