### PR TITLE
feat(react-entities-views): saved-view read hooks

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2766,7 +2766,38 @@
     {
       "name": "@granit/react-entities-views",
       "description": "React hooks + view tab strip for @granit/entities-views — CRUD / pin / star / share / set-default hooks plus the EntityViewTabStrip component (dirty badge, save-as-new, Notion-style 'Save for everyone' promotion)",
-      "exports": []
+      "exports": [
+        {
+          "name": "defaultEntityViewQueryKey",
+          "kind": "const",
+          "signature": "const defaultEntityViewQueryKey"
+        },
+        {
+          "name": "useDefaultEntityView",
+          "kind": "function",
+          "signature": "function useDefaultEntityView( entityName: string, options:"
+        },
+        {
+          "name": "entityViewQueryKey",
+          "kind": "const",
+          "signature": "const entityViewQueryKey"
+        },
+        {
+          "name": "useEntityView",
+          "kind": "function",
+          "signature": "function useEntityView( entityName: string, id: string, options:"
+        },
+        {
+          "name": "entityViewsQueryKey",
+          "kind": "const",
+          "signature": "const entityViewsQueryKey"
+        },
+        {
+          "name": "useEntityViews",
+          "kind": "function",
+          "signature": "function useEntityViews( entityName: string, options:"
+        }
+      ]
     },
     {
       "name": "@granit/react-error-boundary",

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-views.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-views.test.tsx
@@ -1,0 +1,142 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { defaultEntityViewQueryKey, useDefaultEntityView } from '../api/use-default-entity-view.js';
+import { entityViewQueryKey, useEntityView } from '../api/use-entity-view.js';
+import { entityViewsQueryKey, useEntityViews } from '../api/use-entity-views.js';
+
+import type { EntityViewResponse } from '@granit/entities-views';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Parties.Party';
+const ENCODED = encodeURIComponent(ENTITY);
+
+const VIEW_A: EntityViewResponse = {
+  id: '8c6b1e10-0000-4000-8000-000000000001',
+  entityName: ENTITY,
+  basedOn: 'default',
+  kind: 'list',
+  name: 'My open parties',
+  description: null,
+  icon: null,
+  state: { filters: [] },
+  visibility: 'Personal',
+  ownerId: '00000000-0000-0000-0000-000000000001',
+  sharedWith: null,
+  isPinned: false,
+  isDefault: false,
+  isPersonalDefault: true,
+  sortOrder: 0,
+};
+
+const VIEW_B: EntityViewResponse = {
+  ...VIEW_A,
+  id: '8c6b1e10-0000-4000-8000-000000000002',
+  name: 'Tenant overdue',
+  visibility: 'Tenant',
+  ownerId: null,
+  isPersonalDefault: false,
+  isDefault: true,
+  sortOrder: 10,
+};
+
+function freshHandlers() {
+  return [
+    http.get(`http://localhost/entities/${ENCODED}/views`, () =>
+      HttpResponse.json([VIEW_A, VIEW_B])
+    ),
+    http.get(`http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_A.id)}`, () =>
+      HttpResponse.json(VIEW_A)
+    ),
+    http.get(`http://localhost/entities/${ENCODED}/views/_default`, () =>
+      HttpResponse.json(VIEW_A)
+    ),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...freshHandlers()));
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useEntityViews', () => {
+  it('returns the list of accessible views', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useEntityViews(ENTITY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([VIEW_A, VIEW_B]);
+    expect(queryClient.getQueryData(entityViewsQueryKey(ENTITY))).toEqual([VIEW_A, VIEW_B]);
+  });
+
+  it('skips the request when entityName is empty', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityViews(''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useEntityView', () => {
+  it('fetches a single view by id', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useEntityView(ENTITY, VIEW_A.id), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(VIEW_A);
+    expect(queryClient.getQueryData(entityViewQueryKey(ENTITY, VIEW_A.id))).toEqual(VIEW_A);
+  });
+
+  it('reports 404 as an error', async () => {
+    server.use(
+      http.get(`http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_A.id)}`, () =>
+        HttpResponse.json({ error: 'not found' }, { status: 404 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityView(ENTITY, VIEW_A.id), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('skips the request when id is empty', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityView(ENTITY, ''), { wrapper });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('useDefaultEntityView', () => {
+  it('returns the resolved default view', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useDefaultEntityView(ENTITY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(VIEW_A);
+    expect(queryClient.getQueryData(defaultEntityViewQueryKey(ENTITY))).toEqual(VIEW_A);
+  });
+
+  it('normalises 204 No Content into null', async () => {
+    server.use(
+      http.get(`http://localhost/entities/${ENCODED}/views/_default`, () =>
+        HttpResponse.text('', { status: 204 })
+      )
+    );
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDefaultEntityView(ENTITY), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/packages/@granit/react-entities-views/src/api/use-default-entity-view.ts
+++ b/packages/@granit/react-entities-views/src/api/use-default-entity-view.ts
@@ -1,0 +1,44 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { EntityViewResponse } from '@granit/entities-views';
+
+/** Cache key for the resolved default saved view for an entity. */
+export const defaultEntityViewQueryKey = (entityName: string) =>
+  ['entities', 'views', entityName, 'default'] as const;
+
+/**
+ * `GET /entities/{entityName}/views/_default` — resolves the user's
+ * effective default saved view per ADR-047 §4 precedence
+ * (`isPersonalDefault` > `isDefault` > compiled fallback). Mirrors
+ * `EntityViewsEndpoints.GetDefaultAsync`.
+ *
+ * The endpoint returns **204 No Content** when no saved or pinned view
+ * exists — the renderer should fall back to the compiled default
+ * collection. The hook normalises that into `null` so consumers can
+ * just check `data === null` without inspecting the HTTP layer.
+ *
+ * 60-second staleTime so the answer is fresh after a personal-default
+ * star change or a tenant-default flip elsewhere in the UI.
+ */
+export function useDefaultEntityView(
+  entityName: string,
+  options: { readonly enabled?: boolean } = {}
+): UseQueryResult<EntityViewResponse | null> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: defaultEntityViewQueryKey(entityName),
+    queryFn: async ({ signal }) => {
+      const response = await api.get<EntityViewResponse | ''>(
+        `/entities/${encodeURIComponent(entityName)}/views/_default`,
+        { signal }
+      );
+      if (response.status === 204) {
+        return null;
+      }
+      return response.data as EntityViewResponse;
+    },
+    enabled: (options.enabled ?? true) && Boolean(entityName),
+    staleTime: 60_000,
+  });
+}

--- a/packages/@granit/react-entities-views/src/api/use-entity-view.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-view.ts
@@ -1,0 +1,37 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { EntityViewResponse } from '@granit/entities-views';
+
+/** Cache key for one saved view. */
+export const entityViewQueryKey = (entityName: string, id: string) =>
+  ['entities', 'views', entityName, 'item', id] as const;
+
+/**
+ * `GET /entities/{entityName}/views/{id}` — fetches one saved view by
+ * id. Mirrors `EntityViewsEndpoints.GetByIdAsync`.
+ *
+ * 404 surfaces both for missing views and for views the caller cannot
+ * access (defense-in-depth: same response shape, no scope leakage). The
+ * underlying React Query result reports it as `isError`; consumers can
+ * branch on `error.response.status === 404` for the not-found case.
+ */
+export function useEntityView(
+  entityName: string,
+  id: string,
+  options: { readonly enabled?: boolean } = {}
+): UseQueryResult<EntityViewResponse> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: entityViewQueryKey(entityName, id),
+    queryFn: async ({ signal }) => {
+      const { data } = await api.get<EntityViewResponse>(
+        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`,
+        { signal }
+      );
+      return data;
+    },
+    enabled: (options.enabled ?? true) && Boolean(entityName) && Boolean(id),
+    staleTime: 60_000,
+  });
+}

--- a/packages/@granit/react-entities-views/src/api/use-entity-views.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-views.ts
@@ -1,0 +1,43 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { EntityViewResponse } from '@granit/entities-views';
+
+/**
+ * Cache key for the saved-view list of one entity. Keyed by the
+ * entity's wire identifier so a permission change can invalidate every
+ * variant via the prefix `['entities', 'views', entityName]`.
+ */
+export const entityViewsQueryKey = (entityName: string) =>
+  ['entities', 'views', entityName, 'list'] as const;
+
+/**
+ * `GET /entities/{entityName}/views` — returns every saved view the
+ * caller can access for the given entity (Personal owned by them,
+ * Shared targeted at them by role / user id, every Tenant). Sorted by
+ * `sortOrder` ascending then `name`. Mirrors
+ * `Granit.Entities.Views.Endpoints.EntityViewsEndpoints.ListAsync`.
+ *
+ * Short staleTime (60 s) — saved views change quickly through the tab
+ * strip (save-as-new, pin, share), so a stale list would surface a
+ * deleted or freshly-promoted view to the renderer. The CRUD hooks in
+ * this package invalidate the prefix on every mutation.
+ */
+export function useEntityViews(
+  entityName: string,
+  options: { readonly enabled?: boolean } = {}
+): UseQueryResult<readonly EntityViewResponse[]> {
+  const api = useGranitClient();
+  return useQuery({
+    queryKey: entityViewsQueryKey(entityName),
+    queryFn: async ({ signal }) => {
+      const { data } = await api.get<readonly EntityViewResponse[]>(
+        `/entities/${encodeURIComponent(entityName)}/views`,
+        { signal }
+      );
+      return data;
+    },
+    enabled: (options.enabled ?? true) && Boolean(entityName),
+    staleTime: 60_000,
+  });
+}

--- a/packages/@granit/react-entities-views/src/index.ts
+++ b/packages/@granit/react-entities-views/src/index.ts
@@ -1,9 +1,12 @@
+// ---------------------------------------------------------------------------
 // @granit/react-entities-views — public API
+// ---------------------------------------------------------------------------
 //
-// React hooks for the EntityView CRUD + flag endpoints, plus the view tab
-// strip with dirty badge and "Save for everyone" promotion.
-//
-// Implementation lands in subsequent stories of granit-fx/granit-front#301
-// — including the clean-break removal of the legacy useSavedViews hook
-// from @granit/react-query-engine.
-export {};
+// React hooks for the EntityView CRUD + flag endpoints, plus the view
+// tab strip (the visual layer ships in the consuming app per the
+// framework / app split). Implementation lands across the stories in
+// granit-fx/granit-front#301.
+
+export { defaultEntityViewQueryKey, useDefaultEntityView } from './api/use-default-entity-view.js';
+export { entityViewQueryKey, useEntityView } from './api/use-entity-view.js';
+export { entityViewsQueryKey, useEntityViews } from './api/use-entity-views.js';


### PR DESCRIPTION
## Summary

Three React Query read hooks against `/entities/{entityName}/views`:

- **`useEntityViews(entityName)`** — `GET /` — list of accessible views (Personal owned by user + Shared targeted at user + every Tenant), 60 s `staleTime`
- **`useEntityView(entityName, id)`** — `GET /{id}` — single view; 404 surfaces for both missing and inaccessible views (defense-in-depth: same response shape, no scope leakage)
- **`useDefaultEntityView(entityName)`** — `GET /_default` — normalises the endpoint's **204 No Content** into a typed `null` so consumers branch on `data === null` without inspecting HTTP status

Cache keys exported (`entityViewsQueryKey`, `entityViewQueryKey`, `defaultEntityViewQueryKey`) so the upcoming mutation hooks can invalidate them precisely. Empty `entityName` / `id` short-circuit the query (idle, no fetch).

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities-views/src/__tests__/use-entity-views.test.tsx` → 7 passing (happy paths for each hook, 404 surfacing on the single hook, 204 → null normalisation on the default hook, idle short-circuit when params are empty)

## Parent

Feature #301 → Epic #242
