### PR TITLE
feat(react-entities-views): saved-view crud mutations

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2778,6 +2778,12 @@
           "signature": "function useDefaultEntityView( entityName: string, options:"
         },
         {
+          "name": "UpdateEntityViewVariables",
+          "kind": "interface",
+          "signature": "interface UpdateEntityViewVariables",
+          "members": []
+        },
+        {
           "name": "entityViewQueryKey",
           "kind": "const",
           "signature": "const entityViewQueryKey"

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-view-crud.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-view-crud.test.tsx
@@ -1,0 +1,195 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { defaultEntityViewQueryKey } from '../api/use-default-entity-view.js';
+import {
+  useCreateEntityView,
+  useDeleteEntityView,
+  useUpdateEntityView,
+} from '../api/use-entity-view-crud.js';
+import { entityViewQueryKey } from '../api/use-entity-view.js';
+import { entityViewsQueryKey, useEntityViews } from '../api/use-entity-views.js';
+
+import type { EntityViewResponse } from '@granit/entities-views';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Parties.Party';
+const ENCODED = encodeURIComponent(ENTITY);
+const VIEW_ID = '8c6b1e10-0000-4000-8000-000000000001';
+
+const VIEW: EntityViewResponse = {
+  id: VIEW_ID,
+  entityName: ENTITY,
+  basedOn: 'default',
+  kind: 'list',
+  name: 'My open parties',
+  description: null,
+  icon: null,
+  state: { filters: [] },
+  visibility: 'Personal',
+  ownerId: '00000000-0000-0000-0000-000000000010',
+  sharedWith: null,
+  isPinned: false,
+  isDefault: false,
+  isPersonalDefault: false,
+  sortOrder: 0,
+};
+
+let lastBody: unknown = null;
+let listCalls = 0;
+
+function freshHandlers() {
+  return [
+    http.get(`http://localhost/entities/${ENCODED}/views`, () => {
+      listCalls += 1;
+      return HttpResponse.json([VIEW]);
+    }),
+    http.post(`http://localhost/entities/${ENCODED}/views`, async ({ request }) => {
+      lastBody = await request.json();
+      return HttpResponse.json(VIEW, { status: 201 });
+    }),
+    http.put(
+      `http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`,
+      async ({ request }) => {
+        lastBody = await request.json();
+        return HttpResponse.json({ ...VIEW, name: 'Renamed' });
+      }
+    ),
+    http.delete(
+      `http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`,
+      () => new HttpResponse(null, { status: 204 })
+    ),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastBody = null;
+  listCalls = 0;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useCreateEntityView', () => {
+  it('POSTs the body and returns the persisted descriptor', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useCreateEntityView(ENTITY), { wrapper });
+    let returned: EntityViewResponse | undefined;
+    await act(async () => {
+      returned = await result.current.mutateAsync({
+        basedOn: 'default',
+        kind: 'list',
+        name: 'My open parties',
+        description: null,
+        icon: null,
+        state: { filters: [] },
+      });
+    });
+    expect(returned).toEqual(VIEW);
+    expect(lastBody).toMatchObject({ name: 'My open parties', kind: 'list' });
+  });
+
+  it('invalidates the list and default-view caches on success', async () => {
+    const { wrapper } = makeWrapper();
+    const { result: list } = renderHook(() => useEntityViews(ENTITY), { wrapper });
+    await waitFor(() => expect(list.current.isSuccess).toBe(true));
+    expect(listCalls).toBe(1);
+
+    const { result: create } = renderHook(() => useCreateEntityView(ENTITY), { wrapper });
+    await act(async () => {
+      await create.current.mutateAsync({
+        basedOn: 'default',
+        kind: 'list',
+        name: 'X',
+        description: null,
+        icon: null,
+        state: {},
+      });
+    });
+    await waitFor(() => expect(listCalls).toBe(2));
+  });
+});
+
+describe('useUpdateEntityView', () => {
+  it('PUTs the body and writes the response into the single-view cache', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useUpdateEntityView(ENTITY), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: VIEW_ID,
+        request: {
+          name: 'Renamed',
+          description: null,
+          icon: null,
+          state: { filters: [] },
+        },
+      });
+    });
+    expect(lastBody).toMatchObject({ name: 'Renamed' });
+    expect(queryClient.getQueryData(entityViewQueryKey(ENTITY, VIEW_ID))).toEqual({
+      ...VIEW,
+      name: 'Renamed',
+    });
+  });
+
+  it('invalidates the list + default-view caches on success', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(entityViewsQueryKey(ENTITY), [VIEW]);
+    queryClient.setQueryData(defaultEntityViewQueryKey(ENTITY), VIEW);
+
+    const { result } = renderHook(() => useUpdateEntityView(ENTITY), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: VIEW_ID,
+        request: { name: 'X', description: null, icon: null, state: {} },
+      });
+    });
+    expect(queryClient.getQueryState(entityViewsQueryKey(ENTITY))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(defaultEntityViewQueryKey(ENTITY))?.isInvalidated).toBe(true);
+  });
+});
+
+describe('useDeleteEntityView', () => {
+  it('DELETEs and removes the single-view cache entry', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(entityViewQueryKey(ENTITY, VIEW_ID), VIEW);
+    const { result } = renderHook(() => useDeleteEntityView(ENTITY), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync(VIEW_ID);
+    });
+    expect(queryClient.getQueryData(entityViewQueryKey(ENTITY, VIEW_ID))).toBeUndefined();
+  });
+
+  it('invalidates the list cache on success', async () => {
+    const { wrapper } = makeWrapper();
+    const { result: list } = renderHook(() => useEntityViews(ENTITY), { wrapper });
+    await waitFor(() => expect(list.current.isSuccess).toBe(true));
+    expect(listCalls).toBe(1);
+
+    const { result: del } = renderHook(() => useDeleteEntityView(ENTITY), { wrapper });
+    await act(async () => {
+      await del.current.mutateAsync(VIEW_ID);
+    });
+    await waitFor(() => expect(listCalls).toBe(2));
+  });
+});

--- a/packages/@granit/react-entities-views/src/api/use-entity-view-crud.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-view-crud.ts
@@ -1,0 +1,99 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { defaultEntityViewQueryKey } from './use-default-entity-view.js';
+import { entityViewQueryKey } from './use-entity-view.js';
+import { entityViewsQueryKey } from './use-entity-views.js';
+
+import type {
+  EntityViewCreateBodyRequest,
+  EntityViewResponse,
+  EntityViewUpdateBodyRequest,
+} from '@granit/entities-views';
+
+/**
+ * Variables passed to `useUpdateEntityView().mutate()` — the view id
+ * plus the new body. Kept separate from `EntityViewUpdateBodyRequest`
+ * so the id stays in the URL and out of the wire payload.
+ */
+export interface UpdateEntityViewVariables {
+  readonly id: string;
+  readonly request: EntityViewUpdateBodyRequest;
+}
+
+/**
+ * `POST /entities/{entityName}/views` — creates a new Personal saved
+ * view owned by the caller. Mirrors
+ * `EntityViewsEndpoints.CreateAsync`. Returns the persisted descriptor
+ * on 201; the cached list + default for the entity are invalidated so
+ * the next render picks the new view up.
+ */
+export function useCreateEntityView(
+  entityName: string
+): UseMutationResult<EntityViewResponse, Error, EntityViewCreateBodyRequest> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (request) => {
+      const { data } = await api.post<EntityViewResponse>(
+        `/entities/${encodeURIComponent(entityName)}/views`,
+        request
+      );
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: entityViewsQueryKey(entityName) });
+      void queryClient.invalidateQueries({ queryKey: defaultEntityViewQueryKey(entityName) });
+    },
+  });
+}
+
+/**
+ * `PUT /entities/{entityName}/views/{id}` — updates the editable fields
+ * (`name`, `description`, `icon`, `state`) of an existing saved view.
+ * Mirrors `EntityViewsEndpoints.UpdateAsync`. `basedOn` and `kind` are
+ * immutable post-creation and aren't accepted by the endpoint — see
+ * `EntityViewUpdateBodyRequest`.
+ */
+export function useUpdateEntityView(
+  entityName: string
+): UseMutationResult<EntityViewResponse, Error, UpdateEntityViewVariables> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, request }) => {
+      const { data } = await api.put<EntityViewResponse>(
+        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`,
+        request
+      );
+      return data;
+    },
+    onSuccess: (updated, { id }) => {
+      queryClient.setQueryData(entityViewQueryKey(entityName, id), updated);
+      void queryClient.invalidateQueries({ queryKey: entityViewsQueryKey(entityName) });
+      void queryClient.invalidateQueries({ queryKey: defaultEntityViewQueryKey(entityName) });
+    },
+  });
+}
+
+/**
+ * `DELETE /entities/{entityName}/views/{id}` — deletes a saved view.
+ * Mirrors `EntityViewsEndpoints.DeleteAsync`. Owners can delete their
+ * own views; moderation deletes require `Entities.Views.Delete.Any`.
+ */
+export function useDeleteEntityView(entityName: string): UseMutationResult<void, Error, string> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id) => {
+      await api.delete(
+        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`
+      );
+    },
+    onSuccess: (_void, id) => {
+      queryClient.removeQueries({ queryKey: entityViewQueryKey(entityName, id) });
+      void queryClient.invalidateQueries({ queryKey: entityViewsQueryKey(entityName) });
+      void queryClient.invalidateQueries({ queryKey: defaultEntityViewQueryKey(entityName) });
+    },
+  });
+}

--- a/packages/@granit/react-entities-views/src/index.ts
+++ b/packages/@granit/react-entities-views/src/index.ts
@@ -8,5 +8,11 @@
 // granit-fx/granit-front#301.
 
 export { defaultEntityViewQueryKey, useDefaultEntityView } from './api/use-default-entity-view.js';
+export {
+  useCreateEntityView,
+  useDeleteEntityView,
+  useUpdateEntityView,
+} from './api/use-entity-view-crud.js';
+export type { UpdateEntityViewVariables } from './api/use-entity-view-crud.js';
 export { entityViewQueryKey, useEntityView } from './api/use-entity-view.js';
 export { entityViewsQueryKey, useEntityViews } from './api/use-entity-views.js';


### PR DESCRIPTION
## Summary

Three React Query mutations against `/entities/{entityName}/views`:

- **`useCreateEntityView`** — `POST /` returns 201 with the persisted descriptor. Invalidates the list + default-view caches so the new view shows up on next render
- **`useUpdateEntityView`** — `PUT /{id}` with editable fields (`name` / `description` / `icon` / `state`). Writes the response directly into the single-view cache (avoids a follow-up fetch) and invalidates the list + default-view caches in case `sortOrder` / flags changed
- **`useDeleteEntityView`** — `DELETE /{id}` returns 204. Drops the single-view cache entry and invalidates the list + default-view caches

`basedOn` / `kind` are immutable post-creation and absent from the update body — enforced server-side, mirrored by the `EntityViewUpdateBodyRequest` type. `UpdateEntityViewVariables` exported so consumers using devtools / persistors get a typed payload shape.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities-views/src/__tests__/use-entity-view-crud.test.tsx` → 6 passing (happy paths for each mutation, body forwarding, single-view cache write on update, single-view cache removal on delete, list + default-view invalidation round-trips)

## Parent

Feature #301 → Epic #242
