### PR TITLE
feat(react-entities-views): saved-view flag + share mutations

### DIFF
--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-view-flags.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-view-flags.test.tsx
@@ -1,0 +1,170 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { defaultEntityViewQueryKey } from '../api/use-default-entity-view.js';
+import {
+  useSetEntityViewPersonalDefault,
+  useSetEntityViewPinned,
+  useSetEntityViewTenantDefault,
+  useShareEntityView,
+} from '../api/use-entity-view-flags.js';
+import { entityViewQueryKey } from '../api/use-entity-view.js';
+import { entityViewsQueryKey } from '../api/use-entity-views.js';
+
+import type { EntityViewResponse } from '@granit/entities-views';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Parties.Party';
+const ENCODED = encodeURIComponent(ENTITY);
+const VIEW_ID = '8c6b1e10-0000-4000-8000-000000000001';
+const VIEW_PATH = `http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`;
+
+const VIEW: EntityViewResponse = {
+  id: VIEW_ID,
+  entityName: ENTITY,
+  basedOn: 'default',
+  kind: 'list',
+  name: 'My open parties',
+  description: null,
+  icon: null,
+  state: {},
+  visibility: 'Personal',
+  ownerId: '00000000-0000-0000-0000-000000000010',
+  sharedWith: null,
+  isPinned: false,
+  isDefault: false,
+  isPersonalDefault: false,
+  sortOrder: 0,
+};
+
+const lastBodyByEndpoint = new Map<string, unknown>();
+
+function freshHandlers() {
+  return [
+    http.post(`${VIEW_PATH}/pin`, async ({ request }) => {
+      lastBodyByEndpoint.set('pin', await request.json());
+      return HttpResponse.json({ ...VIEW, isPinned: true });
+    }),
+    http.post(`${VIEW_PATH}/set-default`, async ({ request }) => {
+      lastBodyByEndpoint.set('set-default', await request.json());
+      return HttpResponse.json({ ...VIEW, isDefault: true });
+    }),
+    http.post(`${VIEW_PATH}/star`, async ({ request }) => {
+      lastBodyByEndpoint.set('star', await request.json());
+      return HttpResponse.json({ ...VIEW, isPersonalDefault: true });
+    }),
+    http.post(`${VIEW_PATH}/share`, async ({ request }) => {
+      lastBodyByEndpoint.set('share', await request.json());
+      return HttpResponse.json({
+        ...VIEW,
+        visibility: 'Shared',
+        sharedWith: { roles: ['admin'], users: [] },
+      });
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastBodyByEndpoint.clear();
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useSetEntityViewPinned', () => {
+  it('POSTs the pin flag and updates the single-view + list caches', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(entityViewsQueryKey(ENTITY), [VIEW]);
+    const { result } = renderHook(() => useSetEntityViewPinned(ENTITY), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: VIEW_ID, value: true });
+    });
+
+    expect(lastBodyByEndpoint.get('pin')).toEqual({ value: true });
+    expect(queryClient.getQueryData(entityViewQueryKey(ENTITY, VIEW_ID))).toEqual({
+      ...VIEW,
+      isPinned: true,
+    });
+    expect(queryClient.getQueryState(entityViewsQueryKey(ENTITY))?.isInvalidated).toBe(true);
+  });
+});
+
+describe('useSetEntityViewTenantDefault', () => {
+  it('POSTs the tenant-default flag', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(defaultEntityViewQueryKey(ENTITY), VIEW);
+    const { result } = renderHook(() => useSetEntityViewTenantDefault(ENTITY), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: VIEW_ID, value: true });
+    });
+
+    expect(lastBodyByEndpoint.get('set-default')).toEqual({ value: true });
+    expect(queryClient.getQueryState(defaultEntityViewQueryKey(ENTITY))?.isInvalidated).toBe(true);
+  });
+});
+
+describe('useSetEntityViewPersonalDefault', () => {
+  it('POSTs the personal-default flag', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSetEntityViewPersonalDefault(ENTITY), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: VIEW_ID, value: true });
+    });
+
+    expect(lastBodyByEndpoint.get('star')).toEqual({ value: true });
+  });
+
+  it('accepts false to clear the flag', async () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useSetEntityViewPersonalDefault(ENTITY), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: VIEW_ID, value: false });
+    });
+
+    expect(lastBodyByEndpoint.get('star')).toEqual({ value: false });
+  });
+});
+
+describe('useShareEntityView', () => {
+  it('POSTs the audience and writes the response to the single-view cache', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useShareEntityView(ENTITY), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: VIEW_ID,
+        request: { roles: ['admin'], users: [] },
+      });
+    });
+
+    expect(lastBodyByEndpoint.get('share')).toEqual({ roles: ['admin'], users: [] });
+    expect(queryClient.getQueryData(entityViewQueryKey(ENTITY, VIEW_ID))).toMatchObject({
+      visibility: 'Shared',
+      sharedWith: { roles: ['admin'], users: [] },
+    });
+  });
+});

--- a/packages/@granit/react-entities-views/src/api/use-entity-view-flags.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-view-flags.ts
@@ -1,0 +1,132 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { defaultEntityViewQueryKey } from './use-default-entity-view.js';
+import { entityViewQueryKey } from './use-entity-view.js';
+import { entityViewsQueryKey } from './use-entity-views.js';
+
+import type { EntityViewResponse, EntityViewShareBodyRequest } from '@granit/entities-views';
+
+/** Variables shared by every boolean-flag mutation (pin / star / set-default). */
+export interface ToggleEntityViewFlagVariables {
+  readonly id: string;
+  readonly value: boolean;
+}
+
+/** Variables for the share mutation. */
+export interface ShareEntityViewVariables {
+  readonly id: string;
+  readonly request: EntityViewShareBodyRequest;
+}
+
+/**
+ * `POST /entities/{entityName}/views/{id}/pin` — sets or clears the
+ * pinned-as-tab flag (admin-promoted). Mirrors
+ * `EntityViewsEndpoints.SetPinnedAsync`. Requires
+ * `Entities.Views.Manage`. Independent from `IsDefault` /
+ * `IsPersonalDefault`.
+ */
+export function useSetEntityViewPinned(
+  entityName: string
+): UseMutationResult<EntityViewResponse, Error, ToggleEntityViewFlagVariables> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, value }) => {
+      const { data } = await api.post<EntityViewResponse>(
+        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/pin`,
+        { value }
+      );
+      return data;
+    },
+    onSuccess: (updated, { id }) => {
+      queryClient.setQueryData(entityViewQueryKey(entityName, id), updated);
+      void queryClient.invalidateQueries({ queryKey: entityViewsQueryKey(entityName) });
+      void queryClient.invalidateQueries({ queryKey: defaultEntityViewQueryKey(entityName) });
+    },
+  });
+}
+
+/**
+ * `POST /entities/{entityName}/views/{id}/set-default` — sets or clears
+ * the tenant-default flag. Mirrors
+ * `EntityViewsEndpoints.SetTenantDefaultAsync`. Requires
+ * `Entities.Views.Manage`. Setting one tenant default clears any
+ * existing one server-side; the cache invalidation here forces every
+ * other view's cached copy to refetch on next read.
+ */
+export function useSetEntityViewTenantDefault(
+  entityName: string
+): UseMutationResult<EntityViewResponse, Error, ToggleEntityViewFlagVariables> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, value }) => {
+      const { data } = await api.post<EntityViewResponse>(
+        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/set-default`,
+        { value }
+      );
+      return data;
+    },
+    onSuccess: (updated, { id }) => {
+      queryClient.setQueryData(entityViewQueryKey(entityName, id), updated);
+      void queryClient.invalidateQueries({ queryKey: entityViewsQueryKey(entityName) });
+      void queryClient.invalidateQueries({ queryKey: defaultEntityViewQueryKey(entityName) });
+    },
+  });
+}
+
+/**
+ * `POST /entities/{entityName}/views/{id}/star` — sets or clears the
+ * personal-default flag for the current user. Mirrors
+ * `EntityViewsEndpoints.SetPersonalDefaultAsync`. Requires the caller
+ * to own the view. At most one personal default per (entity, user) —
+ * setting one clears the previous one server-side.
+ */
+export function useSetEntityViewPersonalDefault(
+  entityName: string
+): UseMutationResult<EntityViewResponse, Error, ToggleEntityViewFlagVariables> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, value }) => {
+      const { data } = await api.post<EntityViewResponse>(
+        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/star`,
+        { value }
+      );
+      return data;
+    },
+    onSuccess: (updated, { id }) => {
+      queryClient.setQueryData(entityViewQueryKey(entityName, id), updated);
+      void queryClient.invalidateQueries({ queryKey: entityViewsQueryKey(entityName) });
+      void queryClient.invalidateQueries({ queryKey: defaultEntityViewQueryKey(entityName) });
+    },
+  });
+}
+
+/**
+ * `POST /entities/{entityName}/views/{id}/share` — promotes a Personal
+ * view to Shared, or updates the audience (roles + users) of an
+ * already-Shared view. Mirrors `EntityViewsEndpoints.ShareAsync`.
+ * Requires `Entities.Views.Share`.
+ */
+export function useShareEntityView(
+  entityName: string
+): UseMutationResult<EntityViewResponse, Error, ShareEntityViewVariables> {
+  const api = useGranitClient();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ id, request }) => {
+      const { data } = await api.post<EntityViewResponse>(
+        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/share`,
+        request
+      );
+      return data;
+    },
+    onSuccess: (updated, { id }) => {
+      queryClient.setQueryData(entityViewQueryKey(entityName, id), updated);
+      void queryClient.invalidateQueries({ queryKey: entityViewsQueryKey(entityName) });
+      void queryClient.invalidateQueries({ queryKey: defaultEntityViewQueryKey(entityName) });
+    },
+  });
+}

--- a/packages/@granit/react-entities-views/src/index.ts
+++ b/packages/@granit/react-entities-views/src/index.ts
@@ -14,5 +14,15 @@ export {
   useUpdateEntityView,
 } from './api/use-entity-view-crud.js';
 export type { UpdateEntityViewVariables } from './api/use-entity-view-crud.js';
+export {
+  useSetEntityViewPersonalDefault,
+  useSetEntityViewPinned,
+  useSetEntityViewTenantDefault,
+  useShareEntityView,
+} from './api/use-entity-view-flags.js';
+export type {
+  ShareEntityViewVariables,
+  ToggleEntityViewFlagVariables,
+} from './api/use-entity-view-flags.js';
 export { entityViewQueryKey, useEntityView } from './api/use-entity-view.js';
 export { entityViewsQueryKey, useEntityViews } from './api/use-entity-views.js';


### PR DESCRIPTION
## Summary

Four React Query mutations against the boolean-toggle and share endpoints under `/entities/{entityName}/views/{id}`:

- **`useSetEntityViewPinned`** — `POST /pin`, body `{ value }`. Requires `Entities.Views.Manage`. Independent from the default flags
- **`useSetEntityViewTenantDefault`** — `POST /set-default`, body `{ value }`. Requires `Entities.Views.Manage`. At most one tenant default per (entity, tenant) — server clears the previous one, the cache invalidation forces stale copies to refetch
- **`useSetEntityViewPersonalDefault`** — `POST /star`, body `{ value }`. Requires the caller to own the view. At most one personal default per (entity, user)
- **`useShareEntityView`** — `POST /share`, body `{ roles, users }`. Requires `Entities.Views.Share`. Promotes Personal → Shared or updates the audience of an already-Shared view

All four follow the same invalidation pattern as `useUpdateEntityView`: write the response to the single-view cache (avoids a follow-up fetch), invalidate the list + default-view caches in case `sortOrder` / `visibility` changed.

`ToggleEntityViewFlagVariables` + `ShareEntityViewVariables` exported so typed payloads carry through devtools / persistors.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities-views/src/__tests__/use-entity-view-flags.test.tsx` → 5 passing (body forwarding for pin / tenant-default / personal-default true and false, single-view + list cache writes on pin, default-view invalidation on tenant-default, share audience updating cached visibility + sharedWith)

## Parent

Feature #301 → Epic #242
