### PR TITLE
feat(react-entities): useEntityRelationAggregates batched smart-button counts

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/use-entity-relation-aggregates.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-relation-aggregates.test.tsx
@@ -1,0 +1,115 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  entityRelationAggregatesQueryKey,
+  useEntityRelationAggregates,
+} from '../api/use-entity-relation-aggregates.js';
+
+import type { RelationAggregatesResponse } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Parties.Party';
+const ID = '8c6b1e10-0000-4000-8000-000000000001';
+const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
+
+const RESPONSE: RelationAggregatesResponse = {
+  aggregates: {
+    Invoices: { count: 12, sum: 4500, avg: 375, min: 100, max: 1200, currency: 'EUR' },
+    Payments: { count: 8, sum: null, avg: null, min: null, max: null, currency: null },
+  },
+};
+
+let lastBody: unknown = null;
+
+function freshHandlers() {
+  return [
+    http.post(PATH, async ({ request }) => {
+      lastBody = (await request.text()) || null;
+      return HttpResponse.json(RESPONSE);
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastBody = null;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useEntityRelationAggregates', () => {
+  it('POSTs without a body when relations is omitted (every relation)', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useEntityRelationAggregates(ENTITY, ID), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(RESPONSE);
+    expect(lastBody).toBeNull();
+    expect(queryClient.getQueryData(entityRelationAggregatesQueryKey(ENTITY, ID))).toEqual(
+      RESPONSE
+    );
+  });
+
+  it('POSTs a sorted relations array when supplied', async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(
+      () =>
+        useEntityRelationAggregates(ENTITY, ID, {
+          relations: ['Payments', 'Invoices'],
+        }),
+      { wrapper }
+    );
+    await waitFor(() => expect(lastBody).not.toBeNull());
+    expect(lastBody).toEqual(JSON.stringify({ relations: ['Invoices', 'Payments'] }));
+  });
+
+  it('shares the cache slot regardless of relations array order', () => {
+    const a = entityRelationAggregatesQueryKey(ENTITY, ID, ['Invoices', 'Payments']);
+    const b = entityRelationAggregatesQueryKey(ENTITY, ID, ['Payments', 'Invoices']);
+    expect(a).toEqual(b);
+    expect(a).not.toEqual(entityRelationAggregatesQueryKey(ENTITY, ID));
+  });
+
+  it('honours enabled: false', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(
+      () => useEntityRelationAggregates(ENTITY, ID, { enabled: false }),
+      { wrapper }
+    );
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('skips the request when entityName or entityId is empty', () => {
+    const { wrapper } = makeWrapper();
+    const { result: a } = renderHook(() => useEntityRelationAggregates('', ID), { wrapper });
+    const { result: b } = renderHook(() => useEntityRelationAggregates(ENTITY, ''), { wrapper });
+    expect(a.current.fetchStatus).toBe('idle');
+    expect(b.current.fetchStatus).toBe('idle');
+  });
+
+  it('surfaces an error message when the endpoint returns 500', async () => {
+    server.use(http.post(PATH, () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityRelationAggregates(ENTITY, ID), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-entities/src/api/use-entity-relation-aggregates.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-relation-aggregates.ts
@@ -1,0 +1,65 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { RelationAggregatesResponse } from '@granit/entities';
+
+/**
+ * Cache key for one source row's relation aggregates. Keyed by
+ * `(entityName, entityId, relations-csv)` so a partial query for a
+ * subset of relations doesn't collide with the "every relation" call,
+ * and `queryClient.invalidateQueries({ queryKey: ['entities', 'relations', entityName, entityId] })`
+ * blasts every variant when the source row mutates.
+ *
+ * `relations` is normalised to a sorted CSV so `['Invoices', 'Payments']`
+ * and `['Payments', 'Invoices']` share one cache slot.
+ */
+export function entityRelationAggregatesQueryKey(
+  entityName: string,
+  entityId: string,
+  relations?: readonly string[]
+): readonly ['entities', 'relations', string, string, string | null] {
+  const relationsKey = relations && relations.length > 0 ? [...relations].sort().join(',') : null;
+  return ['entities', 'relations', entityName, entityId, relationsKey] as const;
+}
+
+/**
+ * `POST /entities/{name}/{id}/relations/aggregates` — returns the
+ * computed `count / sum / avg / min / max` values per relation for one
+ * source row, in a single batched round-trip. Mirrors
+ * `RelationAggregatesEndpoint.HandleAsync`.
+ *
+ * Pass `relations` to slim the response to a specific subset; omit it
+ * to get every relation the caller can read on the source entity
+ * (handy for a detail page that wants every smart-button count
+ * without replicating the manifest's relation list).
+ *
+ * The .NET handler caches the response 30 s sliding per
+ * `(source, id, relation, perms-hash, culture)` — even an aggressive
+ * refetch usually short-circuits at FusionCache rather than running
+ * the SQL again. Front-side staleTime defaults to 30 s so React Query
+ * doesn't refetch faster than the backend cache window; consumers can
+ * raise it on screens where the values are merely informational.
+ */
+export function useEntityRelationAggregates(
+  entityName: string,
+  entityId: string,
+  options: { readonly relations?: readonly string[]; readonly enabled?: boolean } = {}
+): UseQueryResult<RelationAggregatesResponse> {
+  const api = useGranitClient();
+  const relations = options.relations;
+
+  return useQuery({
+    queryKey: entityRelationAggregatesQueryKey(entityName, entityId, relations),
+    queryFn: async ({ signal }) => {
+      const body = relations && relations.length > 0 ? { relations: [...relations].sort() } : null;
+      const { data } = await api.post<RelationAggregatesResponse>(
+        `/entities/${encodeURIComponent(entityName)}/${encodeURIComponent(entityId)}/relations/aggregates`,
+        body,
+        { signal }
+      );
+      return data;
+    },
+    enabled: (options.enabled ?? true) && Boolean(entityName) && Boolean(entityId),
+    staleTime: 30_000,
+  });
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -17,6 +17,10 @@ export type { EntityListProps } from './components/entity-list.js';
 export { STANDARD_FORM_WIDGETS } from './widgets/index.js';
 export type { SelectWidgetOption } from './widgets/index.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
+export {
+  entityRelationAggregatesQueryKey,
+  useEntityRelationAggregates,
+} from './api/use-entity-relation-aggregates.js';
 export { entityManifestQueryKey, useEntityMetadata } from './api/use-entity-metadata.js';
 export { useEntityForm } from './hooks/index.js';
 export type { UseEntityFormOptions, UseEntityFormReturn } from './hooks/index.js';


### PR DESCRIPTION
## Summary

`useEntityRelationAggregates(entityName, entityId, options?)` wraps `POST /entities/{name}/{id}/relations/aggregates` into a typed React Query hook. One round-trip for every smart-button count on a detail page (Party → Invoices, Subscriptions, Payments, CustomerBalance counts in one request).

## Design choices

- **Cache key normalised to a sorted CSV** — callers passing `['Invoices', 'Payments']` and `['Payments', 'Invoices']` share one cache slot
- **Null body when `relations` is omitted** — the .NET handler reads "every relation the caller can read on the source entity" so a detail page doesn't have to replicate the manifest's relation list
- **30 s `staleTime`** mirrors the .NET FusionCache window per `(source, id, relation, perms-hash, culture)` so React Query doesn't refetch faster than the backend cache can answer
- Cache key exported (`entityRelationAggregatesQueryKey`) so source-row mutations can invalidate every variant via the prefix `['entities', 'relations', entityName, entityId]`

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/use-entity-relation-aggregates.test.tsx` → 6 passing (null body when omitted, sorted body when supplied, cache key normalisation, enabled gating, empty-param short-circuit, 500 surfacing)

## Parent

Feature #302 → Epic #242
