### PR TITLE
feat(react-entities): smart-button strip in entity detail

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx
@@ -1,0 +1,212 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { EntityDetail } from '../components/entity-detail.js';
+import { EntityRendererProvider } from '../provider/index.js';
+
+import type {
+  EntityDetailManifest,
+  EntityRelationManifest,
+  RelationAggregatesResponse,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Parties.Party';
+const ID = '8c6b1e10-0000-4000-8000-000000000001';
+const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
+
+const variant: EntityDetailManifest = {
+  name: 'default',
+  sections: [],
+  sidePanels: [],
+};
+
+function relation(
+  name: string,
+  order: number,
+  display: EntityRelationManifest['display'],
+  overrides: Partial<EntityRelationManifest> = {}
+): EntityRelationManifest {
+  return {
+    name,
+    cardinality: 'Many',
+    display,
+    targetEntityName: `Granit.${name}`,
+    displayKey: `Granit.${name}.Plural`,
+    icon: null,
+    order,
+    queryDefinitionName: null,
+    aggregates: [{ kind: 'Count', propertyName: null, labelKey: null, format: null }],
+    contributorAssemblyName: null,
+    ...overrides,
+  };
+}
+
+const RESPONSE: RelationAggregatesResponse = {
+  aggregates: {
+    Invoices: { count: 12, sum: null, avg: null, min: null, max: null, currency: null },
+    Payments: { count: 5, sum: null, avg: null, min: null, max: null, currency: null },
+  },
+};
+
+function freshHandlers() {
+  return [http.post(PATH, () => HttpResponse.json(RESPONSE))];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...freshHandlers()));
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <EntityRendererProvider>{children}</EntityRendererProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('EntityDetail smart buttons', () => {
+  it('renders one button per SmartButton relation, sorted by order', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[
+            relation('Payments', 20, 'SmartButton'),
+            relation('Invoices', 10, 'SmartButton'),
+            relation('AuditTrail', 30, 'Sidebar'),
+          ]}
+        />
+      </Wrapper>
+    );
+    const buttons = Array.from(container.querySelectorAll('[data-granit-smart-button]'));
+    expect(buttons.map((b) => b.getAttribute('data-relation'))).toEqual(['Invoices', 'Payments']);
+  });
+
+  it('shows the loading dots before the aggregate response lands', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('Invoices', 0, 'SmartButton')]}
+        />
+      </Wrapper>
+    );
+    const count = container.querySelector('[data-granit-smart-button-count]');
+    expect(count?.textContent).toBe('…');
+  });
+
+  it('renders the count from the aggregate response', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[
+            relation('Invoices', 0, 'SmartButton'),
+            relation('Payments', 1, 'SmartButton'),
+          ]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() => {
+      const counts = Array.from(container.querySelectorAll('[data-granit-smart-button-count]')).map(
+        (el) => el.textContent
+      );
+      expect(counts).toEqual(['12', '5']);
+    });
+  });
+
+  it('fires onRelationClick with the relation when a button is clicked', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const onRelationClick = vi.fn();
+    const invoices = relation('Invoices', 0, 'SmartButton');
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[invoices]}
+          onRelationClick={onRelationClick}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-smart-button]')).not.toBeNull()
+    );
+    fireEvent.click(container.querySelector('[data-granit-smart-button]') as HTMLButtonElement);
+    expect(onRelationClick).toHaveBeenCalledWith(invoices);
+  });
+
+  it('disables the button when no onRelationClick is supplied', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('Invoices', 0, 'SmartButton')]}
+        />
+      </Wrapper>
+    );
+    const button = container.querySelector('[data-granit-smart-button]') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it('omits the strip when no SmartButton relations exist', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('AuditTrail', 0, 'Sidebar')]}
+        />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-detail-smart-buttons]')).toBeNull();
+  });
+
+  it('omits the strip when entityName / entityId are missing', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          relations={[relation('Invoices', 0, 'SmartButton')]}
+        />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-detail-smart-buttons]')).toBeNull();
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -1,6 +1,7 @@
 import { evaluateVisibility } from '@granit/entities';
 import { useMemo, type ReactNode } from 'react';
 
+import { useEntityRelationAggregates } from '../api/use-entity-relation-aggregates.js';
 import { useEntityRenderer } from '../provider/entity-renderer-provider.js';
 
 import type {
@@ -9,6 +10,8 @@ import type {
   EntityDetailSidePanelManifest,
   EntityFormFieldManifest,
   EntityFormManifest,
+  EntityRelationManifest,
+  RelationAggregateValue,
 } from '@granit/entities';
 
 export interface EntityDetailProps {
@@ -32,6 +35,21 @@ export interface EntityDetailProps {
    * declares side panels and the provider catalog has matching renderers.
    */
   readonly entityId?: string;
+  /**
+   * Relations declared on the entity (`manifest.relations`). When set
+   * together with `entityName` + `entityId`, every relation with
+   * `display === 'SmartButton'` renders in a header strip with its
+   * batched aggregate count. Other display modes (Tab / Sidebar /
+   * InlineChips) are emitted as placeholder slots; their renderers
+   * land in a follow-up story.
+   */
+  readonly relations?: readonly EntityRelationManifest[];
+  /**
+   * Optional handler invoked when a smart-button relation is clicked.
+   * Receives the relation manifest entry; the host typically navigates
+   * to the related list scoped to the source row.
+   */
+  readonly onRelationClick?: (relation: EntityRelationManifest) => void;
   /**
    * Optional class for the root element. The root layout is a
    * `<article>` containing the section column + side-panel rail; apps
@@ -65,6 +83,8 @@ export function EntityDetail({
   formVariants,
   entityName,
   entityId,
+  relations,
+  onRelationClick,
   className,
 }: EntityDetailProps): ReactNode {
   const sortedSections = useMemo(
@@ -75,9 +95,24 @@ export function EntityDetail({
     () => [...variant.sidePanels].sort((a, b) => a.order - b.order),
     [variant.sidePanels]
   );
+  const smartButtons = useMemo(
+    () =>
+      (relations ?? [])
+        .filter((r) => r.display === 'SmartButton')
+        .sort((a, b) => a.order - b.order),
+    [relations]
+  );
 
   return (
     <article data-granit-entity-detail="" data-variant={variant.name} className={className}>
+      {smartButtons.length > 0 && entityName && entityId ? (
+        <SmartButtonsStrip
+          entityName={entityName}
+          entityId={entityId}
+          relations={smartButtons}
+          onRelationClick={onRelationClick}
+        />
+      ) : null}
       <div data-granit-detail-sections="">
         {sortedSections.map((section) => (
           <EntityDetailSection
@@ -229,4 +264,66 @@ function formatValue(value: unknown): string {
   if (value === null || value === undefined) return '—';
   if (typeof value === 'boolean') return value ? '✓' : '✗';
   return String(value);
+}
+
+interface SmartButtonsStripProps {
+  readonly entityName: string;
+  readonly entityId: string;
+  readonly relations: readonly EntityRelationManifest[];
+  readonly onRelationClick: ((relation: EntityRelationManifest) => void) | undefined;
+}
+
+function SmartButtonsStrip({
+  entityName,
+  entityId,
+  relations,
+  onRelationClick,
+}: SmartButtonsStripProps): ReactNode {
+  const relationNames = useMemo(() => relations.map((r) => r.name), [relations]);
+  const aggregates = useEntityRelationAggregates(entityName, entityId, {
+    relations: relationNames,
+  });
+
+  return (
+    <nav data-granit-detail-smart-buttons="" aria-label="Related">
+      {relations.map((relation) => (
+        <SmartButton
+          key={relation.name}
+          relation={relation}
+          value={aggregates.data?.aggregates[relation.name]}
+          isLoading={aggregates.isLoading}
+          onClick={onRelationClick}
+        />
+      ))}
+    </nav>
+  );
+}
+
+interface SmartButtonProps {
+  readonly relation: EntityRelationManifest;
+  readonly value: RelationAggregateValue | undefined;
+  readonly isLoading: boolean;
+  readonly onClick: ((relation: EntityRelationManifest) => void) | undefined;
+}
+
+function SmartButton({ relation, value, isLoading, onClick }: SmartButtonProps): ReactNode {
+  const { resolveLabel } = useEntityRenderer();
+  const label = relation.displayKey ? resolveLabel(relation.displayKey) : relation.name;
+  const count = value?.count ?? null;
+
+  return (
+    <button
+      type="button"
+      data-granit-smart-button=""
+      data-relation={relation.name}
+      data-cardinality={relation.cardinality}
+      onClick={onClick ? () => onClick(relation) : undefined}
+      disabled={!onClick}
+    >
+      <span data-granit-smart-button-label="">{label}</span>
+      <span data-granit-smart-button-count="">
+        {isLoading ? '…' : count !== null ? String(count) : '—'}
+      </span>
+    </button>
+  );
 }


### PR DESCRIPTION
## Summary

Three new optional props on `<EntityDetail />` light up the smart-button strip above the section column:

- **`relations`** — `manifest.relations` from the entity manifest. When supplied alongside `entityName` + `entityId`, every entry with `display === 'SmartButton'` renders in a header `<nav>` strip ordered by manifest `order`
- **`onRelationClick`** — fires with the relation manifest entry when a smart button is clicked. Buttons render disabled when no handler is supplied (informational without a destination would be a UX bug)
- (`entityName` + `entityId` already existed for the side-panel registry)

The strip uses `useEntityRelationAggregates` internally to fetch every declared relation's count in **one batched POST per source row**. While the request is in-flight each button shows `…`; once it lands, the button shows `aggregates[name]?.count` or `—` if no Count aggregate was declared.

## Out of scope

Tab / Sidebar / InlineChips display modes are passed through unchanged in this PR — they get their own renderers in a follow-up under #302.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx` → 7 passing (SmartButton-only filtering with order, loading dots, count rendering after the response, click forwarding, disabled state without `onRelationClick`, strip omission when no SmartButton relations, strip omission when entity props missing)

## Parent

Feature #302 → Epic #242
