### PR TITLE
feat(react-entities): sidebar + inline-chips relation display modes

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx
@@ -1,0 +1,256 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { EntityDetail } from '../components/entity-detail.js';
+import { EntityRendererProvider } from '../provider/index.js';
+
+import type {
+  EntityDetailManifest,
+  EntityRelationManifest,
+  RelationAggregatesResponse,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Parties.Party';
+const ID = '8c6b1e10-0000-4000-8000-000000000001';
+const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
+
+const variant: EntityDetailManifest = {
+  name: 'default',
+  sections: [],
+  sidePanels: [],
+};
+
+function relation(
+  name: string,
+  order: number,
+  display: EntityRelationManifest['display']
+): EntityRelationManifest {
+  return {
+    name,
+    cardinality: 'Many',
+    display,
+    targetEntityName: `Granit.${name}`,
+    displayKey: `Granit.${name}.Plural`,
+    icon: null,
+    order,
+    queryDefinitionName: null,
+    aggregates: [{ kind: 'Count', propertyName: null, labelKey: null, format: null }],
+    contributorAssemblyName: null,
+  };
+}
+
+const RESPONSE: RelationAggregatesResponse = {
+  aggregates: {
+    Invoices: { count: 12, sum: null, avg: null, min: null, max: null, currency: null },
+    Tags: { count: 3, sum: null, avg: null, min: null, max: null, currency: null },
+    AuditTrail: { count: 47, sum: null, avg: null, min: null, max: null, currency: null },
+  },
+};
+
+let postCalls = 0;
+let lastBody: unknown = null;
+
+function freshHandlers() {
+  return [
+    http.post(PATH, async ({ request }) => {
+      postCalls += 1;
+      lastBody = await request.json();
+      return HttpResponse.json(RESPONSE);
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  postCalls = 0;
+  lastBody = null;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <EntityRendererProvider>{children}</EntityRendererProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('EntityDetail Sidebar relations', () => {
+  it('renders sidebar relations in the right rail', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('AuditTrail', 0, 'Sidebar')]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-detail-relation-sidebar]')).not.toBeNull()
+    );
+    const rail = container.querySelector('[data-granit-detail-rail]');
+    expect(rail).not.toBeNull();
+    expect(rail?.querySelector('[data-granit-detail-relation-sidebar]')).not.toBeNull();
+  });
+
+  it('shows the count after the response lands', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('AuditTrail', 0, 'Sidebar')]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() => {
+      const count = container.querySelector(
+        '[data-display="Sidebar"] [data-granit-relation-item-count]'
+      );
+      expect(count?.textContent).toBe('47');
+    });
+  });
+
+  it('omits the rail when no sidebar relations and no side panels', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('Invoices', 0, 'SmartButton')]}
+        />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-detail-rail]')).toBeNull();
+  });
+});
+
+describe('EntityDetail InlineChips relations', () => {
+  it('renders chips below the section column', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('Tags', 0, 'InlineChips')]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-detail-inline-chips]')).not.toBeNull()
+    );
+    const article = container.querySelector('[data-granit-entity-detail]') as HTMLElement;
+    const sections = article.querySelector('[data-granit-detail-sections]') as HTMLElement;
+    const chips = article.querySelector('[data-granit-detail-inline-chips]') as HTMLElement;
+    expect(sections.compareDocumentPosition(chips) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('shows the count after the response lands', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('Tags', 0, 'InlineChips')]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() => {
+      const count = container.querySelector(
+        '[data-display="InlineChips"] [data-granit-relation-item-count]'
+      );
+      expect(count?.textContent).toBe('3');
+    });
+  });
+});
+
+describe('EntityDetail batched aggregates', () => {
+  it('issues a single POST for SmartButton + Sidebar + InlineChips relations together', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[
+            relation('Invoices', 0, 'SmartButton'),
+            relation('AuditTrail', 0, 'Sidebar'),
+            relation('Tags', 0, 'InlineChips'),
+          ]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() => expect(postCalls).toBeGreaterThan(0));
+    expect(postCalls).toBe(1);
+    expect(lastBody).toEqual({ relations: ['AuditTrail', 'Invoices', 'Tags'] });
+  });
+
+  it('fires onRelationClick for any display mode', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const onRelationClick = vi.fn();
+    const tags = relation('Tags', 0, 'InlineChips');
+    const auditTrail = relation('AuditTrail', 0, 'Sidebar');
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[tags, auditTrail]}
+          onRelationClick={onRelationClick}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-detail-inline-chips]')).not.toBeNull()
+    );
+
+    fireEvent.click(
+      container.querySelector(
+        '[data-display="InlineChips"] [data-granit-relation-item]'
+      ) as HTMLButtonElement
+    );
+    fireEvent.click(
+      container.querySelector(
+        '[data-display="Sidebar"] [data-granit-relation-item]'
+      ) as HTMLButtonElement
+    );
+
+    expect(onRelationClick).toHaveBeenCalledTimes(2);
+    expect(onRelationClick).toHaveBeenNthCalledWith(1, tags);
+    expect(onRelationClick).toHaveBeenNthCalledWith(2, auditTrail);
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx
@@ -112,7 +112,7 @@ describe('EntityDetail smart buttons', () => {
         />
       </Wrapper>
     );
-    const count = container.querySelector('[data-granit-smart-button-count]');
+    const count = container.querySelector('[data-granit-relation-item-count]');
     expect(count?.textContent).toBe('…');
   });
 
@@ -133,9 +133,9 @@ describe('EntityDetail smart buttons', () => {
       </Wrapper>
     );
     await waitFor(() => {
-      const counts = Array.from(container.querySelectorAll('[data-granit-smart-button-count]')).map(
-        (el) => el.textContent
-      );
+      const counts = Array.from(
+        container.querySelectorAll('[data-granit-relation-item-count]')
+      ).map((el) => el.textContent);
       expect(counts).toEqual(['12', '5']);
     });
   });

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -12,7 +12,10 @@ import type {
   EntityFormManifest,
   EntityRelationManifest,
   RelationAggregateValue,
+  RelationAggregatesResponse,
+  RelationDisplay,
 } from '@granit/entities';
+import type { UseQueryResult } from '@tanstack/react-query';
 
 export interface EntityDetailProps {
   /** Detail variant from the manifest (one of `manifest.details`). */
@@ -37,17 +40,20 @@ export interface EntityDetailProps {
   readonly entityId?: string;
   /**
    * Relations declared on the entity (`manifest.relations`). When set
-   * together with `entityName` + `entityId`, every relation with
-   * `display === 'SmartButton'` renders in a header strip with its
-   * batched aggregate count. Other display modes (Tab / Sidebar /
-   * InlineChips) are emitted as placeholder slots; their renderers
-   * land in a follow-up story.
+   * together with `entityName` + `entityId`, every relation surfaces in
+   * the layout slot matching its `display` mode:
+   *
+   * - `SmartButton` — header strip above the section column
+   * - `InlineChips` — chip strip below the section column
+   * - `Sidebar` — vertical group at the top of the right rail
+   * - `Tab` — passed through unchanged for now (renderer lands in a
+   *   follow-up under #302)
    */
   readonly relations?: readonly EntityRelationManifest[];
   /**
-   * Optional handler invoked when a smart-button relation is clicked.
-   * Receives the relation manifest entry; the host typically navigates
-   * to the related list scoped to the source row.
+   * Optional handler invoked when a relation is clicked. Receives the
+   * relation manifest entry; the host typically navigates to the
+   * related list scoped to the source row.
    */
   readonly onRelationClick?: (relation: EntityRelationManifest) => void;
   /**
@@ -95,21 +101,36 @@ export function EntityDetail({
     () => [...variant.sidePanels].sort((a, b) => a.order - b.order),
     [variant.sidePanels]
   );
-  const smartButtons = useMemo(
+  const groupedRelations = useMemo(() => groupRelationsByDisplay(relations ?? []), [relations]);
+  const allDisplayedNames = useMemo(
     () =>
-      (relations ?? [])
-        .filter((r) => r.display === 'SmartButton')
-        .sort((a, b) => a.order - b.order),
-    [relations]
+      [
+        ...groupedRelations.SmartButton,
+        ...groupedRelations.InlineChips,
+        ...groupedRelations.Sidebar,
+      ].map((r) => r.name),
+    [groupedRelations]
   );
+
+  // Single batched fetch covers SmartButton + InlineChips + Sidebar relations.
+  const aggregatesQuery = useEntityRelationAggregates(entityName ?? '', entityId ?? '', {
+    relations: allDisplayedNames,
+    enabled: Boolean(entityName) && Boolean(entityId) && allDisplayedNames.length > 0,
+  });
+
+  const renderable = Boolean(entityName) && Boolean(entityId);
+  const showSmartButtons = renderable && groupedRelations.SmartButton.length > 0;
+  const showInlineChips = renderable && groupedRelations.InlineChips.length > 0;
+  const showSidebars = renderable && groupedRelations.Sidebar.length > 0;
+  const showRail = showSidebars || sortedSidePanels.length > 0;
 
   return (
     <article data-granit-entity-detail="" data-variant={variant.name} className={className}>
-      {smartButtons.length > 0 && entityName && entityId ? (
-        <SmartButtonsStrip
-          entityName={entityName}
-          entityId={entityId}
-          relations={smartButtons}
+      {showSmartButtons ? (
+        <RelationGroup
+          display="SmartButton"
+          relations={groupedRelations.SmartButton}
+          aggregates={aggregatesQuery}
           onRelationClick={onRelationClick}
         />
       ) : null}
@@ -123,8 +144,24 @@ export function EntityDetail({
           />
         ))}
       </div>
-      {sortedSidePanels.length > 0 ? (
+      {showInlineChips ? (
+        <RelationGroup
+          display="InlineChips"
+          relations={groupedRelations.InlineChips}
+          aggregates={aggregatesQuery}
+          onRelationClick={onRelationClick}
+        />
+      ) : null}
+      {showRail ? (
         <aside data-granit-detail-rail="">
+          {showSidebars ? (
+            <RelationGroup
+              display="Sidebar"
+              relations={groupedRelations.Sidebar}
+              aggregates={aggregatesQuery}
+              onRelationClick={onRelationClick}
+            />
+          ) : null}
           {sortedSidePanels.map((panel) => (
             <EntityDetailSidePanelSlot
               key={panel.kind}
@@ -266,29 +303,41 @@ function formatValue(value: unknown): string {
   return String(value);
 }
 
-interface SmartButtonsStripProps {
-  readonly entityName: string;
-  readonly entityId: string;
+interface RelationGroupProps {
+  readonly display: Exclude<RelationDisplay, 'Tab'>;
   readonly relations: readonly EntityRelationManifest[];
+  readonly aggregates: UseQueryResult<RelationAggregatesResponse>;
   readonly onRelationClick: ((relation: EntityRelationManifest) => void) | undefined;
 }
 
-function SmartButtonsStrip({
-  entityName,
-  entityId,
-  relations,
-  onRelationClick,
-}: SmartButtonsStripProps): ReactNode {
-  const relationNames = useMemo(() => relations.map((r) => r.name), [relations]);
-  const aggregates = useEntityRelationAggregates(entityName, entityId, {
-    relations: relationNames,
-  });
+const GROUP_DATA_ATTRIBUTE: Record<RelationGroupProps['display'], string> = {
+  SmartButton: 'data-granit-detail-smart-buttons',
+  InlineChips: 'data-granit-detail-inline-chips',
+  Sidebar: 'data-granit-detail-relation-sidebar',
+};
 
+const GROUP_ARIA_LABEL: Record<RelationGroupProps['display'], string> = {
+  SmartButton: 'Related',
+  InlineChips: 'Related (chips)',
+  Sidebar: 'Related (sidebar)',
+};
+
+function RelationGroup({
+  display,
+  relations,
+  aggregates,
+  onRelationClick,
+}: RelationGroupProps): ReactNode {
   return (
-    <nav data-granit-detail-smart-buttons="" aria-label="Related">
+    <nav
+      {...{ [GROUP_DATA_ATTRIBUTE[display]]: '' }}
+      data-display={display}
+      aria-label={GROUP_ARIA_LABEL[display]}
+    >
       {relations.map((relation) => (
-        <SmartButton
+        <RelationItem
           key={relation.name}
+          display={display}
           relation={relation}
           value={aggregates.data?.aggregates[relation.name]}
           isLoading={aggregates.isLoading}
@@ -299,14 +348,21 @@ function SmartButtonsStrip({
   );
 }
 
-interface SmartButtonProps {
+interface RelationItemProps {
+  readonly display: RelationGroupProps['display'];
   readonly relation: EntityRelationManifest;
   readonly value: RelationAggregateValue | undefined;
   readonly isLoading: boolean;
   readonly onClick: ((relation: EntityRelationManifest) => void) | undefined;
 }
 
-function SmartButton({ relation, value, isLoading, onClick }: SmartButtonProps): ReactNode {
+function RelationItem({
+  display,
+  relation,
+  value,
+  isLoading,
+  onClick,
+}: RelationItemProps): ReactNode {
   const { resolveLabel } = useEntityRenderer();
   const label = relation.displayKey ? resolveLabel(relation.displayKey) : relation.name;
   const count = value?.count ?? null;
@@ -314,16 +370,42 @@ function SmartButton({ relation, value, isLoading, onClick }: SmartButtonProps):
   return (
     <button
       type="button"
-      data-granit-smart-button=""
+      data-granit-relation-item=""
+      data-display={display}
       data-relation={relation.name}
       data-cardinality={relation.cardinality}
+      // SmartButton retains its legacy data attribute so existing styles + tests stay valid.
+      {...(display === 'SmartButton' ? { 'data-granit-smart-button': '' } : {})}
       onClick={onClick ? () => onClick(relation) : undefined}
       disabled={!onClick}
     >
-      <span data-granit-smart-button-label="">{label}</span>
-      <span data-granit-smart-button-count="">
+      <span data-granit-relation-item-label="">{label}</span>
+      <span data-granit-relation-item-count="">
         {isLoading ? '…' : count !== null ? String(count) : '—'}
       </span>
     </button>
   );
+}
+
+interface GroupedRelations {
+  readonly SmartButton: readonly EntityRelationManifest[];
+  readonly InlineChips: readonly EntityRelationManifest[];
+  readonly Sidebar: readonly EntityRelationManifest[];
+  readonly Tab: readonly EntityRelationManifest[];
+}
+
+function groupRelationsByDisplay(relations: readonly EntityRelationManifest[]): GroupedRelations {
+  const grouped: { [K in RelationDisplay]: EntityRelationManifest[] } = {
+    SmartButton: [],
+    InlineChips: [],
+    Sidebar: [],
+    Tab: [],
+  };
+  for (const relation of relations) {
+    grouped[relation.display].push(relation);
+  }
+  for (const key of Object.keys(grouped) as RelationDisplay[]) {
+    grouped[key].sort((a, b) => a.order - b.order);
+  }
+  return grouped;
 }


### PR DESCRIPTION
## Summary

`<EntityDetail />` now lights up the remaining display modes from `manifest.relations` beyond SmartButton (#328):

- **`Sidebar`** — vertical group at the top of the right rail, before the side panel slots
- **`InlineChips`** — chip strip below the section column, after the sections and before the rail

Both modes reuse the same `<RelationItem>` (label + count + click) used by SmartButton, with a `data-display` attribute (`SmartButton` / `InlineChips` / `Sidebar`) so apps can style each mode differently.

## Batched fetch

Aggregates fetch was lifted to `<EntityDetail />` and is now shared across the three modes — **one batched POST per source row** covers SmartButton + Sidebar + InlineChips relations together rather than three separate requests. `Tab` mode is intentionally still passed through unchanged; its renderer is the next story under #302.

## Internal refactor

- `groupRelationsByDisplay` buckets relations by mode upfront
- `<RelationGroup>` encapsulates the strip layout per mode
- The `data-granit-smart-button-*` attribute namespace was renamed to the generic `data-granit-relation-item-*` (Sidebar + InlineChips share the same items); SmartButton retains `data-granit-smart-button=""` on the button element for backward-compatible styling hooks

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx` → 7 passing (sidebar in the rail + count after response + rail omission heuristic, inline chips below sections + count, single-POST batching across the three modes, `onRelationClick` dispatch from any mode)
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx` → 7 still passing after attribute rename

## Parent

Feature #302 → Epic #242
