### PR TITLE
feat(react-entities): tab relation display mode

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx
@@ -194,8 +194,79 @@ describe('EntityDetail InlineChips relations', () => {
   });
 });
 
+describe('EntityDetail Tab relations', () => {
+  it('renders tab relations at the top of the article, above SmartButtons', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('Invoices', 0, 'SmartButton'), relation('Activities', 0, 'Tab')]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-detail-tabs]')).not.toBeNull()
+    );
+    const tabs = container.querySelector('[data-granit-detail-tabs]') as HTMLElement;
+    const smart = container.querySelector('[data-granit-detail-smart-buttons]') as HTMLElement;
+    expect(tabs.compareDocumentPosition(smart) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it('shows the count after the response lands', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[relation('Invoices', 0, 'Tab')]}
+        />
+      </Wrapper>
+    );
+    await waitFor(() => {
+      const count = container.querySelector(
+        '[data-display="Tab"] [data-granit-relation-item-count]'
+      );
+      expect(count?.textContent).toBe('12');
+    });
+  });
+
+  it('forwards onRelationClick from a tab', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const onRelationClick = vi.fn();
+    const tab = relation('Invoices', 0, 'Tab');
+    const { container } = render(
+      <Wrapper>
+        <EntityDetail
+          variant={variant}
+          values={{}}
+          entityName={ENTITY}
+          entityId={ID}
+          relations={[tab]}
+          onRelationClick={onRelationClick}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-detail-tabs]')).not.toBeNull()
+    );
+    fireEvent.click(
+      container.querySelector(
+        '[data-display="Tab"] [data-granit-relation-item]'
+      ) as HTMLButtonElement
+    );
+    expect(onRelationClick).toHaveBeenCalledWith(tab);
+  });
+});
+
 describe('EntityDetail batched aggregates', () => {
-  it('issues a single POST for SmartButton + Sidebar + InlineChips relations together', async () => {
+  it('issues a single POST for every display mode (Tab + SmartButton + Sidebar + InlineChips) together', async () => {
     const { wrapper: Wrapper } = makeWrapper();
     render(
       <Wrapper>
@@ -208,13 +279,16 @@ describe('EntityDetail batched aggregates', () => {
             relation('Invoices', 0, 'SmartButton'),
             relation('AuditTrail', 0, 'Sidebar'),
             relation('Tags', 0, 'InlineChips'),
+            relation('Activities', 0, 'Tab'),
           ]}
         />
       </Wrapper>
     );
     await waitFor(() => expect(postCalls).toBeGreaterThan(0));
     expect(postCalls).toBe(1);
-    expect(lastBody).toEqual({ relations: ['AuditTrail', 'Invoices', 'Tags'] });
+    expect(lastBody).toEqual({
+      relations: ['Activities', 'AuditTrail', 'Invoices', 'Tags'],
+    });
   });
 
   it('fires onRelationClick for any display mode', async () => {

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -43,11 +43,17 @@ export interface EntityDetailProps {
    * together with `entityName` + `entityId`, every relation surfaces in
    * the layout slot matching its `display` mode:
    *
+   * - `Tab` — full-width tab strip at the very top of the article
    * - `SmartButton` — header strip above the section column
    * - `InlineChips` — chip strip below the section column
    * - `Sidebar` — vertical group at the top of the right rail
-   * - `Tab` — passed through unchanged for now (renderer lands in a
-   *   follow-up under #302)
+   *
+   * The framework only paints the navigation surface — clicking a Tab
+   * fires `onRelationClick` like any other display mode. Apps own the
+   * decision to swap the section column for a related list (typically
+   * by routing to `/w/{workspace}/{relatedEntity}?source={sourceId}`)
+   * or to render a side-peek; the framework deliberately stays
+   * router-agnostic.
    */
   readonly relations?: readonly EntityRelationManifest[];
   /**
@@ -105,6 +111,7 @@ export function EntityDetail({
   const allDisplayedNames = useMemo(
     () =>
       [
+        ...groupedRelations.Tab,
         ...groupedRelations.SmartButton,
         ...groupedRelations.InlineChips,
         ...groupedRelations.Sidebar,
@@ -112,13 +119,14 @@ export function EntityDetail({
     [groupedRelations]
   );
 
-  // Single batched fetch covers SmartButton + InlineChips + Sidebar relations.
+  // Single batched fetch covers every display mode.
   const aggregatesQuery = useEntityRelationAggregates(entityName ?? '', entityId ?? '', {
     relations: allDisplayedNames,
     enabled: Boolean(entityName) && Boolean(entityId) && allDisplayedNames.length > 0,
   });
 
   const renderable = Boolean(entityName) && Boolean(entityId);
+  const showTabs = renderable && groupedRelations.Tab.length > 0;
   const showSmartButtons = renderable && groupedRelations.SmartButton.length > 0;
   const showInlineChips = renderable && groupedRelations.InlineChips.length > 0;
   const showSidebars = renderable && groupedRelations.Sidebar.length > 0;
@@ -126,6 +134,14 @@ export function EntityDetail({
 
   return (
     <article data-granit-entity-detail="" data-variant={variant.name} className={className}>
+      {showTabs ? (
+        <RelationGroup
+          display="Tab"
+          relations={groupedRelations.Tab}
+          aggregates={aggregatesQuery}
+          onRelationClick={onRelationClick}
+        />
+      ) : null}
       {showSmartButtons ? (
         <RelationGroup
           display="SmartButton"
@@ -304,19 +320,21 @@ function formatValue(value: unknown): string {
 }
 
 interface RelationGroupProps {
-  readonly display: Exclude<RelationDisplay, 'Tab'>;
+  readonly display: RelationDisplay;
   readonly relations: readonly EntityRelationManifest[];
   readonly aggregates: UseQueryResult<RelationAggregatesResponse>;
   readonly onRelationClick: ((relation: EntityRelationManifest) => void) | undefined;
 }
 
-const GROUP_DATA_ATTRIBUTE: Record<RelationGroupProps['display'], string> = {
+const GROUP_DATA_ATTRIBUTE: Record<RelationDisplay, string> = {
+  Tab: 'data-granit-detail-tabs',
   SmartButton: 'data-granit-detail-smart-buttons',
   InlineChips: 'data-granit-detail-inline-chips',
   Sidebar: 'data-granit-detail-relation-sidebar',
 };
 
-const GROUP_ARIA_LABEL: Record<RelationGroupProps['display'], string> = {
+const GROUP_ARIA_LABEL: Record<RelationDisplay, string> = {
+  Tab: 'Related (tabs)',
   SmartButton: 'Related',
   InlineChips: 'Related (chips)',
   Sidebar: 'Related (sidebar)',
@@ -349,7 +367,7 @@ function RelationGroup({
 }
 
 interface RelationItemProps {
-  readonly display: RelationGroupProps['display'];
+  readonly display: RelationDisplay;
   readonly relation: EntityRelationManifest;
   readonly value: RelationAggregateValue | undefined;
   readonly isLoading: boolean;


### PR DESCRIPTION
## Summary

`<EntityDetail />` now renders the fourth and final display mode from `manifest.relations`: **`Tab`**. Tab relations surface as a full-width `data-granit-detail-tabs` strip at the very top of the article, above SmartButtons.

## Why "just another navigation surface"

The framework only paints the navigation surface — clicking a tab fires `onRelationClick` like any other display mode. Apps own the decision to swap the section column for a related list (typically by routing to `/w/{workspace}/{relatedEntity}?source={sourceId}`) or to render a side-peek; the framework deliberately stays router-agnostic, consistent with the framework / app split decided in #300.

## Batched fetch covers all four modes

The aggregates fetch already lifted to `<EntityDetail />` in #329 now also covers Tab relations — every display mode sourced from one batched POST per source row.

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx` → 10 passing (3 new for Tab: rendered above SmartButtons, count after response, click forwarding; existing batched-aggregates extended to assert all four display modes share one POST)

## Closes Feature #302

This was the last story under #302 (Tab display mode). With it merged, every renderer-side concern of Phase 1 is shipped:

| Feature | State |
| --- | --- |
| #298 — manifest hooks | ✅ |
| #299 — renderers | ✅ (Storybook optional) |
| #300 — workspaces | ✅ (preset overlay blocked on backend #1554) |
| #301 — entities-views | ✅ (tab strip UI in showcase) |
| #302 — relations | ✅ |

## Parent

Feature #302 → Epic #242
