### PR TITLE
feat(react-entities): detail-widget catalog + url / email / tel formatters

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-detail-widget-catalog.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail-widget-catalog.test.tsx
@@ -1,0 +1,246 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import axios from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import { EntityDetail } from '../components/entity-detail.js';
+import { EntityRendererProvider } from '../provider/index.js';
+import { STANDARD_DETAIL_WIDGETS } from '../widgets/standard-detail-widgets.js';
+
+import type {
+  EntityDetailManifest,
+  EntityFormFieldManifest,
+  EntityFormManifest,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+function withProvider(children: ReactNode, detail = STANDARD_DETAIL_WIDGETS.detail) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>
+        <EntityRendererProvider widgets={{ form: {}, detail }}>{children}</EntityRendererProvider>
+      </GranitClientProvider>
+    </QueryClientProvider>
+  );
+}
+
+function freeForm(...fields: string[]): EntityDetailManifest {
+  return {
+    name: 'default',
+    sections: [
+      {
+        key: 'main',
+        labelKey: null,
+        order: 0,
+        inheritsFromFormVariant: null,
+        fields,
+      },
+    ],
+    sidePanels: [],
+  };
+}
+
+function inherited(formVariant: string): EntityDetailManifest {
+  return {
+    name: 'default',
+    sections: [
+      {
+        key: 'main',
+        labelKey: null,
+        order: 0,
+        inheritsFromFormVariant: formVariant,
+        fields: null,
+      },
+    ],
+    sidePanels: [],
+  };
+}
+
+function field(
+  propertyName: string,
+  widget: string,
+  overrides: Partial<EntityFormFieldManifest> = {}
+): EntityFormFieldManifest {
+  return {
+    propertyName,
+    clrTypeName: 'String',
+    widget,
+    config: null,
+    labelKey: null,
+    helpKey: null,
+    order: 0,
+    readOnly: false,
+    visibleIf: null,
+    ...overrides,
+  };
+}
+
+function formVariantWith(name: string, fields: EntityFormFieldManifest[]): EntityFormManifest {
+  return {
+    name,
+    customizable: false,
+    sections: [{ key: 'main', labelKey: null, order: 0, collapsedByDefault: false, fields }],
+  };
+}
+
+describe('STANDARD_DETAIL_WIDGETS — url widget', () => {
+  it('renders an external URL with target=_blank rel=noreferrer', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Website')}
+          values={{ Website: 'https://example.com' }}
+          propertyWidgets={{ Website: 'url' }}
+        />
+      )
+    );
+    const link = container.querySelector('[data-property="Website"] a') as HTMLAnchorElement;
+    expect(link).not.toBeNull();
+    expect(link.getAttribute('href')).toBe('https://example.com');
+    expect(link.getAttribute('target')).toBe('_blank');
+    expect(link.getAttribute('rel')).toBe('noreferrer');
+    expect(link.getAttribute('data-external')).toBe('');
+    expect(link.textContent).toBe('https://example.com');
+  });
+
+  it('renders an internal URL in-tab (no target / rel)', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Website')}
+          values={{ Website: '/parties/42' }}
+          propertyWidgets={{ Website: 'url' }}
+        />
+      )
+    );
+    const link = container.querySelector('[data-property="Website"] a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('/parties/42');
+    expect(link.hasAttribute('target')).toBe(false);
+    expect(link.hasAttribute('rel')).toBe(false);
+    expect(link.hasAttribute('data-external')).toBe(false);
+  });
+
+  it('falls back to em-dash when value is null / empty', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Website')}
+          values={{ Website: null }}
+          propertyWidgets={{ Website: 'url' }}
+        />
+      )
+    );
+    const dd = container.querySelector('[data-property="Website"] dd');
+    expect(dd?.textContent).toBe('—');
+    expect(dd?.querySelector('a')).toBeNull();
+  });
+});
+
+describe('STANDARD_DETAIL_WIDGETS — email widget', () => {
+  it('renders a mailto: link', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Email')}
+          values={{ Email: 'jane@example.com' }}
+          propertyWidgets={{ Email: 'email' }}
+        />
+      )
+    );
+    const link = container.querySelector('[data-property="Email"] a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('mailto:jane@example.com');
+    expect(link.getAttribute('data-scheme')).toBe('mailto');
+  });
+});
+
+describe('STANDARD_DETAIL_WIDGETS — tel widget', () => {
+  it('renders a tel: link with whitespace stripped from the href', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Phone')}
+          values={{ Phone: '+32 471 23 45 67' }}
+          propertyWidgets={{ Phone: 'tel' }}
+        />
+      )
+    );
+    const link = container.querySelector('[data-property="Phone"] a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('tel:+32471234567');
+    expect(link.getAttribute('data-scheme')).toBe('tel');
+    // Display label keeps the human-readable spacing.
+    expect(link.textContent).toBe('+32 471 23 45 67');
+  });
+});
+
+describe('EntityDetail — propertyWidgets free-form fallback', () => {
+  it('falls back to text formatter when widget id not in catalog', () => {
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={freeForm('Mystery')}
+          values={{ Mystery: 'just text' }}
+          propertyWidgets={{ Mystery: 'unknown-widget' }}
+        />
+      )
+    );
+    const dd = container.querySelector('[data-property="Mystery"] dd');
+    expect(dd?.textContent).toBe('just text');
+    expect(dd?.querySelector('a')).toBeNull();
+  });
+
+  it('falls back to text when no widget is mapped for the property', () => {
+    const { container } = render(
+      withProvider(<EntityDetail variant={freeForm('Notes')} values={{ Notes: 'plain' }} />)
+    );
+    const dd = container.querySelector('[data-property="Notes"] dd');
+    expect(dd?.textContent).toBe('plain');
+  });
+
+  it('em-dash for null in default text mode', () => {
+    const { container } = render(
+      withProvider(<EntityDetail variant={freeForm('Notes')} values={{}} />)
+    );
+    const dd = container.querySelector('[data-property="Notes"] dd');
+    expect(dd?.textContent).toBe('—');
+  });
+});
+
+describe('EntityDetail — inherited mode reads field.widget', () => {
+  it('uses the form field widget id to look up the detail widget', () => {
+    const variant = inherited('default');
+    const formVariants = [formVariantWith('default', [field('Website', 'url')])];
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={variant}
+          values={{ Website: 'https://example.com' }}
+          formVariants={formVariants}
+        />
+      )
+    );
+    const link = container.querySelector('[data-property="Website"] a') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('https://example.com');
+    expect(link.getAttribute('target')).toBe('_blank');
+  });
+
+  it('falls back to text formatter when the field widget id is unknown', () => {
+    const variant = inherited('default');
+    const formVariants = [formVariantWith('default', [field('Notes', 'text')])];
+    const { container } = render(
+      withProvider(
+        <EntityDetail
+          variant={variant}
+          values={{ Notes: 'plain text' }}
+          formVariants={formVariants}
+        />
+      )
+    );
+    const dd = container.querySelector('[data-property="Notes"] dd');
+    // STANDARD_DETAIL_WIDGETS maps 'text' → text formatter, so it renders plainly.
+    expect(dd?.textContent).toBe('plain text');
+    expect(dd?.querySelector('a')).toBeNull();
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -63,6 +63,20 @@ export interface EntityDetailProps {
    */
   readonly onRelationClick?: (relation: EntityRelationManifest) => void;
   /**
+   * Maps free-form section property names (`section.fields: string[]`)
+   * to detail-widget ids registered on the provider. Lets apps render
+   * `Website` as a clickable URL or `Phone` as a `tel:` link without
+   * switching the section to inheritsFromFormVariant. Inherited-mode
+   * sections take their widget id from `field.widget` and ignore this
+   * map.
+   *
+   * @example
+   * ```tsx
+   * <EntityDetail propertyWidgets={{ Website: 'url', Email: 'email' }} />
+   * ```
+   */
+  readonly propertyWidgets?: Readonly<Record<string, string>>;
+  /**
    * Optional class for the root element. The root layout is a
    * `<article>` containing the section column + side-panel rail; apps
    * style them via this className + the `data-granit-*` attributes.
@@ -97,6 +111,7 @@ export function EntityDetail({
   entityId,
   relations,
   onRelationClick,
+  propertyWidgets,
   className,
 }: EntityDetailProps): ReactNode {
   const sortedSections = useMemo(
@@ -157,6 +172,7 @@ export function EntityDetail({
             section={section}
             values={values}
             formVariants={formVariants}
+            propertyWidgets={propertyWidgets}
           />
         ))}
       </div>
@@ -196,12 +212,14 @@ interface EntityDetailSectionProps {
   readonly section: EntityDetailSectionManifest;
   readonly values: Readonly<Record<string, unknown>>;
   readonly formVariants: readonly EntityFormManifest[] | undefined;
+  readonly propertyWidgets: Readonly<Record<string, string>> | undefined;
 }
 
 function EntityDetailSection({
   section,
   values,
   formVariants,
+  propertyWidgets,
 }: EntityDetailSectionProps): ReactNode {
   const { resolveLabel } = useEntityRenderer();
   const inheritedFields = useMemo(
@@ -240,10 +258,12 @@ function EntityDetailSection({
       ) : (
         <dl data-granit-detail-fields="">
           {(section.fields ?? []).map((property) => (
-            <div key={property} data-granit-detail-row="" data-property={property}>
-              <dt data-granit-detail-label="">{property}</dt>
-              <dd data-granit-detail-value="">{formatValue(values[property])}</dd>
-            </div>
+            <FreeFormFieldRow
+              key={property}
+              property={property}
+              value={values[property]}
+              widgetId={propertyWidgets?.[property]}
+            />
           ))}
         </dl>
       )}
@@ -258,14 +278,42 @@ interface InheritedFieldRowProps {
 }
 
 function InheritedFieldRow({ field, values, resolveLabel }: InheritedFieldRowProps): ReactNode {
+  const { widgets } = useEntityRenderer();
   if (field.visibleIf && !evaluateVisibility(field.visibleIf, values)) {
     return null;
   }
   const label = field.labelKey ? resolveLabel(field.labelKey) : field.propertyName;
+  const value = values[field.propertyName];
+  const Widget = widgets.detail?.[field.widget];
   return (
     <div data-granit-detail-row="" data-property={field.propertyName} data-inherited="">
       <dt data-granit-detail-label="">{label}</dt>
-      <dd data-granit-detail-value="">{formatValue(values[field.propertyName])}</dd>
+      <dd data-granit-detail-value="">
+        {Widget ? (
+          <Widget propertyName={field.propertyName} value={value} field={field} />
+        ) : (
+          formatValue(value)
+        )}
+      </dd>
+    </div>
+  );
+}
+
+interface FreeFormFieldRowProps {
+  readonly property: string;
+  readonly value: unknown;
+  readonly widgetId: string | undefined;
+}
+
+function FreeFormFieldRow({ property, value, widgetId }: FreeFormFieldRowProps): ReactNode {
+  const { widgets } = useEntityRenderer();
+  const Widget = widgetId ? widgets.detail?.[widgetId] : undefined;
+  return (
+    <div data-granit-detail-row="" data-property={property}>
+      <dt data-granit-detail-label="">{property}</dt>
+      <dd data-granit-detail-value="">
+        {Widget ? <Widget propertyName={property} value={value} /> : formatValue(value)}
+      </dd>
     </div>
   );
 }

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -14,7 +14,11 @@ export { EntityKanban } from './components/entity-kanban.js';
 export type { EntityKanbanProps } from './components/entity-kanban.js';
 export { EntityList } from './components/entity-list.js';
 export type { EntityListProps } from './components/entity-list.js';
-export { STANDARD_FORM_WIDGETS } from './widgets/index.js';
+export {
+  defaultDetailFormat,
+  STANDARD_DETAIL_WIDGETS,
+  STANDARD_FORM_WIDGETS,
+} from './widgets/index.js';
 export type { SelectWidgetOption } from './widgets/index.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export {
@@ -30,6 +34,8 @@ export {
   useEntityRenderer,
 } from './provider/index.js';
 export type {
+  EntityDetailWidget,
+  EntityDetailWidgetProps,
   EntityFormWidget,
   EntityFormWidgetProps,
   EntityRendererContextValue,

--- a/packages/@granit/react-entities/src/provider/index.ts
+++ b/packages/@granit/react-entities/src/provider/index.ts
@@ -6,6 +6,8 @@ export type {
   ResolveLabel,
 } from './entity-renderer-provider.js';
 export type {
+  EntityDetailWidget,
+  EntityDetailWidgetProps,
   EntityFormWidget,
   EntityFormWidgetProps,
   EntitySidePanel,

--- a/packages/@granit/react-entities/src/provider/widget-catalog.ts
+++ b/packages/@granit/react-entities/src/provider/widget-catalog.ts
@@ -1,6 +1,10 @@
 import type { EntityFormFieldManifest, SidePanelKind } from '@granit/entities';
 import type { ReactNode } from 'react';
 
+// ---------------------------------------------------------------------------
+// Form widgets
+// ---------------------------------------------------------------------------
+
 /**
  * Props passed to a form-widget renderer when `<EntityForm />` paints one
  * field. The renderer is fully controlled — `<EntityForm />` owns the
@@ -35,11 +39,37 @@ export interface EntitySidePanelProps {
 /** Renderer for one side panel kind in `<EntityDetail />`. */
 export type EntitySidePanel = (props: EntitySidePanelProps) => ReactNode;
 
+// ---------------------------------------------------------------------------
+// Detail widgets (read-mode formatters)
+// ---------------------------------------------------------------------------
+
+/**
+ * Props passed to a detail-widget renderer when `<EntityDetail />` paints
+ * one read-mode field. The field manifest is **only present in inherited
+ * mode** (when the section reuses a form variant via
+ * `inheritsFromFormVariant`); free-form sections (`section.fields:
+ * string[]`) carry just the property name.
+ */
+export interface EntityDetailWidgetProps {
+  readonly propertyName: string;
+  readonly value: unknown;
+  /** Field manifest — present in inherited-mode rendering, undefined otherwise. */
+  readonly field?: EntityFormFieldManifest;
+}
+
+/** Renderer for one read-mode field in `<EntityDetail />`. */
+export type EntityDetailWidget = (props: EntityDetailWidgetProps) => ReactNode;
+
+// ---------------------------------------------------------------------------
+// Catalog
+// ---------------------------------------------------------------------------
+
 /**
  * Catalog mapping widget identifiers (the `field.widget` value from the
  * manifest) → renderers, plus the optional side-panel registry keyed by
- * `SidePanelKind`. Apps register the standard catalog plus any
- * `custom:`-namespaced widgets they own (per ADR-041).
+ * `SidePanelKind`, plus the optional read-mode detail registry. Apps
+ * register the standard catalog plus any `custom:`-namespaced widgets
+ * they own (per ADR-041).
  */
 export interface EntityWidgetCatalog {
   /** Form-context widgets, keyed by `field.widget`. */
@@ -50,6 +80,14 @@ export interface EntityWidgetCatalog {
    * falls back to an empty slot placeholder.
    */
   readonly sidePanels?: Partial<Readonly<Record<SidePanelKind, EntitySidePanel>>>;
+  /**
+   * Detail-context (read-mode) widgets keyed by widget id — same key
+   * namespace as `form`, so a widget id like `'url'` or `'currency'`
+   * reuses the same string in both contexts. Optional — when a widget
+   * isn't registered, `<EntityDetail />` falls back to a default text
+   * formatter.
+   */
+  readonly detail?: Readonly<Record<string, EntityDetailWidget>>;
 }
 
 /** Empty catalog — useful as a default and in tests. */

--- a/packages/@granit/react-entities/src/widgets/index.ts
+++ b/packages/@granit/react-entities/src/widgets/index.ts
@@ -1,2 +1,3 @@
+export { defaultDetailFormat, STANDARD_DETAIL_WIDGETS } from './standard-detail-widgets.js';
 export { STANDARD_FORM_WIDGETS } from './standard-form-widgets.js';
 export type { SelectWidgetOption } from './standard-form-widgets.js';

--- a/packages/@granit/react-entities/src/widgets/standard-detail-widgets.tsx
+++ b/packages/@granit/react-entities/src/widgets/standard-detail-widgets.tsx
@@ -1,0 +1,121 @@
+import type { EntityDetailWidget, EntityWidgetCatalog } from '../provider/widget-catalog.js';
+import type { ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Standard detail-widget catalog (read-mode formatters).
+//
+// Mirrors the form-widget id set so a field declaring widget="text" in
+// the manifest renders through the matching detail formatter without
+// extra wiring. Apps that want richer rendering (currency, locale-aware
+// dates) register their own widgets via the same key namespace and
+// override at the provider level.
+//
+// Widgets stay unstyled — they emit minimal markup with `data-granit-*`
+// attributes so the host app can style them with the rest of its
+// EntityDetail tree.
+// ---------------------------------------------------------------------------
+
+const TextDetailWidget: EntityDetailWidget = ({ value }) => formatText(value);
+
+const BooleanDetailWidget: EntityDetailWidget = ({ value }) => {
+  if (value === null || value === undefined) return EMPTY_DASH;
+  return value ? '✓' : '✗';
+};
+
+const UrlDetailWidget: EntityDetailWidget = ({ value, propertyName }) => {
+  if (value === null || value === undefined || value === '') return EMPTY_DASH;
+  const href = String(value);
+  const isExternal = /^https?:\/\//i.test(href);
+  return (
+    <a
+      data-granit-detail-link=""
+      data-property={propertyName}
+      data-external={isExternal ? '' : undefined}
+      href={href}
+      {...(isExternal ? { target: '_blank', rel: 'noreferrer' } : {})}
+    >
+      {href}
+    </a>
+  );
+};
+
+const EmailDetailWidget: EntityDetailWidget = ({ value, propertyName }) => {
+  if (value === null || value === undefined || value === '') return EMPTY_DASH;
+  const address = String(value);
+  return (
+    <a
+      data-granit-detail-link=""
+      data-property={propertyName}
+      data-scheme="mailto"
+      href={`mailto:${address}`}
+    >
+      {address}
+    </a>
+  );
+};
+
+const TelDetailWidget: EntityDetailWidget = ({ value, propertyName }) => {
+  if (value === null || value === undefined || value === '') return EMPTY_DASH;
+  const number = String(value);
+  // tel: URIs ignore most non-digit chars but accept '+', '-', spaces.
+  // We surface the raw value so screen readers / dialers handle it; the
+  // displayed label is the same string.
+  return (
+    <a
+      data-granit-detail-link=""
+      data-property={propertyName}
+      data-scheme="tel"
+      href={`tel:${number.replace(/\s+/g, '')}`}
+    >
+      {number}
+    </a>
+  );
+};
+
+const EMPTY_DASH = '—';
+
+function formatText(value: unknown): string {
+  if (value === null || value === undefined) return EMPTY_DASH;
+  if (typeof value === 'boolean') return value ? '✓' : '✗';
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+
+/**
+ * Standard detail-widget catalog. Pass it to
+ * `<EntityRendererProvider widgets={{ form, detail: STANDARD_DETAIL_WIDGETS.detail }}>`
+ * to get URL / email / tel / boolean formatting out of the box. Apps
+ * spread + override entries they want to customise:
+ *
+ * ```tsx
+ * <EntityRendererProvider widgets={{
+ *   form: STANDARD_FORM_WIDGETS.form,
+ *   detail: { ...STANDARD_DETAIL_WIDGETS.detail, currency: MyCurrencyWidget },
+ * }}>
+ * ```
+ *
+ * Widget keys mirror the form-widget catalog ids so a field declaring
+ * `widget: 'text'` in the manifest reuses the same string in both
+ * contexts.
+ */
+export const STANDARD_DETAIL_WIDGETS: EntityWidgetCatalog = Object.freeze({
+  form: Object.freeze({}),
+  detail: Object.freeze({
+    text: TextDetailWidget,
+    textarea: TextDetailWidget,
+    integer: TextDetailWidget,
+    decimal: TextDetailWidget,
+    boolean: BooleanDetailWidget,
+    date: TextDetailWidget,
+    time: TextDetailWidget,
+    datetime: TextDetailWidget,
+    url: UrlDetailWidget,
+    email: EmailDetailWidget,
+    tel: TelDetailWidget,
+  }) as Readonly<Record<string, EntityDetailWidget>>,
+});
+
+/** Default formatter used by `<EntityDetail />` when no widget is registered. */
+export function defaultDetailFormat(value: unknown): ReactNode {
+  return formatText(value);
+}


### PR DESCRIPTION
## Summary

Closes the framework limitation flagged from showcase: `<EntityDetail />` had no read-mode widget catalog, so `format: 'url'` on a `Website` field couldn't be made clickable without forking the renderer. Adds the missing piece.

## API

`EntityWidgetCatalog` gains an optional `detail` map keyed by widget id, parallel to `form`. `<EntityDetail />` dispatches to it:

- **Inherited mode** (`section.inheritsFromFormVariant`): looks up `widgets.detail[field.widget]` — same widget id used by `<EntityForm />` for editing reuses for read display
- **Free-form mode** (`section.fields: string[]`): new `propertyWidgets` prop maps property name → widget id without forcing the section into inherited mode:

```tsx
<EntityDetail
  variant={...}
  values={...}
  propertyWidgets={{ Website: 'url', Email: 'email', Phone: 'tel' }}
/>
```

Both modes fall back to the existing text formatter (`null → '—'`, `boolean → ✓/✗`) when no widget is registered, so consumers that don't opt in see no behaviour change.

## STANDARD_DETAIL_WIDGETS

Five concrete formatters:

- `text` / `textarea` / `integer` / `decimal` / `date` / `time` / `datetime` — alias to the default text formatter (placeholders for future locale-aware versions)
- `boolean` — ✓/✗ glyphs, em-dash on null
- **`url`** — `<a href>`; **external (http/https) gets `target="_blank" rel="noreferrer"`, internal gets in-tab navigation**. Both carry `data-granit-detail-link` + `data-property`; external also gets `data-external=""` for styling
- **`email`** — `mailto:` link with `data-scheme="mailto"`
- **`tel`** — `tel:` link with whitespace stripped from the href so dialers parse it cleanly, while the visible label keeps the human-readable spacing. `data-scheme="tel"`

```tsx
<EntityRendererProvider widgets={{
  form: STANDARD_FORM_WIDGETS.form,
  detail: STANDARD_DETAIL_WIDGETS.detail,
}}>
```

## Test plan

- [x] `pnpm tsc` green
- [x] `pnpm lint --max-warnings 0` green
- [x] `pnpm test --run packages/@granit/react-entities/src/__tests__/entity-detail-widget-catalog.test.tsx` → 10 passing (external URL with target/rel + data-external, internal URL bare, em-dash on null URL, mailto rendering, tel: with whitespace-stripped href but human-readable label, free-form fallback to text on missing widget id, free-form fallback when no propertyWidgets, em-dash for null in default mode, inherited-mode `field.widget` lookup, inherited-mode fallback to text)

## Showcase usage

```tsx
<EntityDetail
  variant={detailVariant}
  values={values}
  propertyWidgets={{ Website: 'url', Email: 'email', Phone: 'tel' }}
/>
```

## Parent

Phase 1 follow-up — Epic #242
