### PR TITLE
feat(entities): add SubtitleProperty to EntityIdentitySection

### DIFF
--- a/packages/@granit/entities/src/types/identity.ts
+++ b/packages/@granit/entities/src/types/identity.ts
@@ -15,4 +15,11 @@ export interface EntityIdentitySection {
   readonly permissionGroup: string | null;
   /** Property used to label references to this entity (e.g. `"Number"`). */
   readonly displayProperty: string | null;
+  /**
+   * Optional secondary property displayed alongside `displayProperty`
+   * for context. E.g. an Invoice's `displayProperty: 'Number'` +
+   * `subtitleProperty: 'PartyName'` renders "INV-001 — Acme Corp".
+   * `null` when the entity declares no subtitle.
+   */
+  readonly subtitleProperty: string | null;
 }

--- a/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
@@ -65,6 +65,7 @@ function manifest(hasQuery: boolean): EntityManifestResponse {
           icon: null,
           permissionGroup: null,
           displayProperty: 'name',
+          subtitleProperty: null,
         }
       : null,
     permissions: null,

--- a/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
@@ -75,6 +75,7 @@ function manifest(hasQuery: boolean): EntityManifestResponse {
           icon: null,
           permissionGroup: null,
           displayProperty: null,
+          subtitleProperty: null,
         }
       : null,
     permissions: null,

--- a/packages/@granit/react-entities/src/__tests__/use-entity-metadata.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-metadata.test.tsx
@@ -24,6 +24,7 @@ const FULL: EntityManifestResponse = {
     icon: 'users',
     permissionGroup: 'Parties.Parties',
     displayProperty: 'Number',
+    subtitleProperty: 'Kind',
   },
   permissions: {
     canRead: true,


### PR DESCRIPTION
## Summary

- Mirrors granit-fx/granit-dotnet#1703 by adding `subtitleProperty: string | null` to `EntityIdentitySection`. Apps can now read the secondary label property the manifest exposes alongside `displayProperty` (e.g. Invoice → \`displayProperty: 'Number'\` + \`subtitleProperty: 'PartyName'\` renders \"INV-001 — Acme Corp\").
- Type-only change. Renderer wiring (detail header, list-row labels, reference chips) is a deliberate follow-up — this PR keeps scope minimal so apps aren't blocked from reading the field.
- Test fixtures updated (`use-entity-metadata`, `entity-list`, `entity-kanban`) for type consistency, even though tests are excluded from tsc by the package config.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm exec vitest run packages/@granit\` — 372 files, 2830 tests, all passing