### PR TITLE
feat(react-entities): useEntityCalendar range-query hook

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2742,6 +2742,16 @@
           "members": []
         },
         {
+          "name": "entityCalendarQueryKey",
+          "kind": "function",
+          "signature": "function entityCalendarQueryKey( entityName: string, from: string, to: string, calendar?: string | null ): readonly ['entities', 'calendar', string, string, string, string | null]"
+        },
+        {
+          "name": "useEntityCalendar",
+          "kind": "function",
+          "signature": "function useEntityCalendar( entityName: string, from: string, to: string, options:"
+        },
+        {
           "name": "entityDiscoveryQueryKey",
           "kind": "const",
           "signature": "const entityDiscoveryQueryKey"

--- a/packages/@granit/entities/src/index.ts
+++ b/packages/@granit/entities/src/index.ts
@@ -16,6 +16,8 @@
 export { evaluateVisibility } from './helpers/index.js';
 export { ALL_ENTITY_FACETS, MANIFEST_SCHEMA_VERSION } from './types/index.js';
 export type {
+  CalendarItemResponse,
+  CalendarRangeRequest,
   EntityCalendarLayoutManifest,
   EntityCollectionReference,
   EntityCollectionsSection,

--- a/packages/@granit/entities/src/types/index.ts
+++ b/packages/@granit/entities/src/types/index.ts
@@ -18,6 +18,8 @@ export type {
 } from './form.js';
 export type { EntityIdentitySection } from './identity.js';
 export type {
+  CalendarItemResponse,
+  CalendarRangeRequest,
   EntityCalendarLayoutManifest,
   EntityKanbanCardActionManifest,
   EntityKanbanCardManifest,

--- a/packages/@granit/entities/src/types/layouts.ts
+++ b/packages/@granit/entities/src/types/layouts.ts
@@ -162,3 +162,50 @@ export interface EntityKanbanColumnManifest {
   /** Open / Collapsed / Hidden — initial render state per ADR-040. */
   readonly defaultState: KanbanColumnState;
 }
+
+/**
+ * Wire shape for the range-query parameters of
+ * `GET /api/entities/{name}/calendar`. Bound from the query string.
+ *
+ * The server enforces `to >= from` and a window cap of 366 days; out-of-range
+ * requests come back as a 400 ValidationProblem.
+ *
+ * Mirrors `Granit.Entities.Endpoints.Dtos.CalendarRangeRequest`.
+ */
+export interface CalendarRangeRequest {
+  /** Inclusive start of the requested window (ISO 8601 datetime offset). */
+  readonly from: string;
+  /** Inclusive end of the requested window (ISO 8601 datetime offset). */
+  readonly to: string;
+  /**
+   * Optional name of the target calendar layout when the entity declares
+   * more than one. Reserved for future kinds — leaving `null` always
+   * picks the entity's single calendar today.
+   */
+  readonly calendar: string | null;
+}
+
+/**
+ * One event positioned on the calendar's time axis. The renderer reads
+ * this shape to lay out tiles.
+ *
+ * Mirrors `Granit.Entities.Endpoints.Dtos.CalendarItemResponse`.
+ */
+export interface CalendarItemResponse {
+  /** Stable identifier of the underlying entity row — drives the detail-page link. */
+  readonly id: string;
+  /** Event start (ISO 8601 datetime offset). */
+  readonly start: string;
+  /** Event end (ISO 8601 datetime offset). `null` renders a point-in-time marker. */
+  readonly end: string | null;
+  /**
+   * Event headline — projected from the calendar's `titlePropertyName` when
+   * set, else from the entity's `displayProperty`.
+   */
+  readonly title: string;
+  /**
+   * Stable colour bucket projected from `colorByPropertyName`. `null`
+   * falls back to the theme default.
+   */
+  readonly color: string | null;
+}

--- a/packages/@granit/react-entities/src/__tests__/use-entity-calendar.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-calendar.test.tsx
@@ -1,0 +1,140 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { entityCalendarQueryKey, useEntityCalendar } from '../api/use-entity-calendar.js';
+
+import type { CalendarItemResponse } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Invoicing.Invoice';
+const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/calendar`;
+const FROM = '2026-05-01T00:00:00Z';
+const TO = '2026-05-31T23:59:59Z';
+
+const ITEMS: readonly CalendarItemResponse[] = [
+  {
+    id: '8c6b1e10-0000-4000-8000-000000000001',
+    start: '2026-05-04T09:00:00Z',
+    end: '2026-05-04T10:30:00Z',
+    title: 'INV-001',
+    color: 'Blue',
+  },
+  {
+    id: '8c6b1e10-0000-4000-8000-000000000002',
+    start: '2026-05-12T00:00:00Z',
+    end: null,
+    title: 'INV-002',
+    color: null,
+  },
+];
+
+let lastQuery: Record<string, string> | null = null;
+
+function freshHandlers() {
+  return [
+    http.get(PATH, ({ request }) => {
+      const url = new URL(request.url);
+      lastQuery = Object.fromEntries(url.searchParams.entries());
+      return HttpResponse.json(ITEMS);
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastQuery = null;
+});
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('useEntityCalendar', () => {
+  it('GETs the calendar endpoint with from / to query params', async () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const { result } = renderHook(() => useEntityCalendar(ENTITY, FROM, TO), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(ITEMS);
+    expect(lastQuery).toEqual({ from: FROM, to: TO });
+    expect(queryClient.getQueryData(entityCalendarQueryKey(ENTITY, FROM, TO))).toEqual(ITEMS);
+  });
+
+  it('forwards calendar=<name> when supplied', async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useEntityCalendar(ENTITY, FROM, TO, { calendar: 'team' }), { wrapper });
+    await waitFor(() => expect(lastQuery).not.toBeNull());
+    expect(lastQuery).toEqual({ from: FROM, to: TO, calendar: 'team' });
+  });
+
+  it('omits calendar param when null / undefined', async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useEntityCalendar(ENTITY, FROM, TO, { calendar: null }), { wrapper });
+    await waitFor(() => expect(lastQuery).not.toBeNull());
+    expect(lastQuery).toEqual({ from: FROM, to: TO });
+  });
+
+  it('uses different cache slots per (from, to, calendar)', () => {
+    const a = entityCalendarQueryKey(ENTITY, FROM, TO);
+    const b = entityCalendarQueryKey(ENTITY, FROM, '2026-06-30T23:59:59Z');
+    const c = entityCalendarQueryKey(ENTITY, FROM, TO, 'team');
+    expect(a).not.toEqual(b);
+    expect(a).not.toEqual(c);
+  });
+
+  it('honours enabled: false', () => {
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityCalendar(ENTITY, FROM, TO, { enabled: false }), {
+      wrapper,
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+
+  it('skips the request when entityName / from / to is empty', () => {
+    const { wrapper } = makeWrapper();
+    const { result: a } = renderHook(() => useEntityCalendar('', FROM, TO), { wrapper });
+    const { result: b } = renderHook(() => useEntityCalendar(ENTITY, '', TO), { wrapper });
+    const { result: c } = renderHook(() => useEntityCalendar(ENTITY, FROM, ''), { wrapper });
+    expect(a.current.fetchStatus).toBe('idle');
+    expect(b.current.fetchStatus).toBe('idle');
+    expect(c.current.fetchStatus).toBe('idle');
+  });
+
+  it('surfaces an error when the endpoint returns 500', async () => {
+    server.use(http.get(PATH, () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityCalendar(ENTITY, FROM, TO), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.data).toBeUndefined();
+  });
+
+  it('surfaces a 403 (read denied) as an error', async () => {
+    server.use(http.get(PATH, () => HttpResponse.json({ detail: 'forbidden' }, { status: 403 })));
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityCalendar(ENTITY, FROM, TO), { wrapper });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+
+  it('returns an empty list when the entity has no calendar layout', async () => {
+    server.use(http.get(PATH, () => HttpResponse.json([])));
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityCalendar(ENTITY, FROM, TO), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+});

--- a/packages/@granit/react-entities/src/api/use-entity-calendar.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-calendar.ts
@@ -1,0 +1,68 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import type { CalendarItemResponse } from '@granit/entities';
+
+/**
+ * Cache key for one calendar range query. Keyed by
+ * `(entityName, from, to, calendar)` so distinct windows or
+ * named-calendar selections don't collide. Calling
+ * `queryClient.invalidateQueries({ queryKey: ['entities', 'calendar', entityName] })`
+ * blasts every cached window for one entity, which is what apps typically
+ * want after a relevant mutation.
+ */
+export function entityCalendarQueryKey(
+  entityName: string,
+  from: string,
+  to: string,
+  calendar?: string | null
+): readonly ['entities', 'calendar', string, string, string, string | null] {
+  return ['entities', 'calendar', entityName, from, to, calendar ?? null] as const;
+}
+
+/**
+ * `GET /entities/{name}/calendar?from=&to=&calendar=` — returns calendar
+ * items whose start/end overlaps `[from, to]`. Mirrors
+ * `Granit.Entities.Endpoints.CalendarRangeEndpoint.HandleAsync`.
+ *
+ * `from` / `to` are ISO 8601 datetime offset strings — the same shape the
+ * .NET handler binds via `[AsParameters] CalendarRangeRequest`. Apps
+ * typically build them by serialising the renderer's current visible
+ * window; the server enforces `to >= from` and a 366-day cap and surfaces
+ * out-of-range windows as 400 ValidationProblem.
+ *
+ * Pass `calendar` to disambiguate when the entity declares multiple
+ * calendar layouts; omitted when there's only one (the common case
+ * today). The cache key splits per `(from, to, calendar)` so paging the
+ * window forward keeps prior tiles cached for back-navigation.
+ *
+ * The handler returns an empty array — not 404 — when the entity has no
+ * calendar layout, so the renderer can mount the endpoint generically
+ * from the manifest without special-casing missing layouts.
+ */
+export function useEntityCalendar(
+  entityName: string,
+  from: string,
+  to: string,
+  options: { readonly calendar?: string | null; readonly enabled?: boolean } = {}
+): UseQueryResult<readonly CalendarItemResponse[]> {
+  const api = useGranitClient();
+  const calendar = options.calendar ?? null;
+
+  return useQuery({
+    queryKey: entityCalendarQueryKey(entityName, from, to, calendar),
+    queryFn: async ({ signal }) => {
+      const params: Record<string, string> = { from, to };
+      if (calendar) {
+        params.calendar = calendar;
+      }
+      const { data } = await api.get<readonly CalendarItemResponse[]>(
+        `/entities/${encodeURIComponent(entityName)}/calendar`,
+        { params, signal }
+      );
+      return data;
+    },
+    enabled: (options.enabled ?? true) && Boolean(entityName) && Boolean(from) && Boolean(to),
+    staleTime: 30_000,
+  });
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -20,6 +20,7 @@ export {
   STANDARD_FORM_COMPONENTS,
 } from './field-components/index.js';
 export type { SelectComponentOption } from './field-components/index.js';
+export { entityCalendarQueryKey, useEntityCalendar } from './api/use-entity-calendar.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export {
   entityRelationAggregatesQueryKey,


### PR DESCRIPTION
## Summary

Phase 1.5 Story 2 — front consumer for the `GET /api/entities/{name}/calendar` range endpoint shipped in granit-fx/granit-dotnet#1699 (handler) + #1701 (filter builder) + #1702 (permission gate). Addresses the `EntityCalendarLayoutManifest` type added in #335.

### Hook surface

- \`useEntityCalendar(entityName, from, to, { calendar?, enabled? })\` — React Query wrapper, axios via the shared \`GranitClient\`. Returns \`UseQueryResult<readonly CalendarItemResponse[]>\`.
- \`entityCalendarQueryKey(entityName, from, to, calendar?)\` — cache-keyed per `(name, from, to, calendar)` so paging the visible window forward keeps prior tiles cached for back-navigation.
- 30 s \`staleTime\` matches the typical FusionCache window the .NET handler will gain in the upcoming #1691 story.

### Wire types (in \`@granit/entities\`)

- \`CalendarRangeRequest\` — `from` / `to` (ISO 8601 strings) + optional `calendar` selector
- \`CalendarItemResponse\` — `id` / `start` / `end?` / `title` / `color?`

### Deliberately out of scope

- The renderer (\`<EntityCalendar />\`) is Story 3 — this PR ships only the data path.
- 304 / ETag handling — the calendar endpoint isn't ETagged on the .NET side.
- FusionCache integration — backend-only concern.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm exec vitest run packages/@granit/entities packages/@granit/react-entities\` — 19 files, 145 tests, all passing

The 9 new \`use-entity-calendar.test.tsx\` cases cover:
- query-string assembly (\`from\` / \`to\` / optional \`calendar\`)
- cache-slot separation per (\`from\` / \`to\` / \`calendar\`)
- \`enabled: false\` + empty-string skip
- 500 / 403 error surfacing
- the empty-list path the handler returns when the entity has no calendar layout