### PR TITLE
feat(react-entities): entity calendar agenda renderer

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2698,6 +2698,17 @@
       "description": "React renderer for @granit/entities — manifest hooks (useEntityDiscovery / useEntityMetadata) and the four generic renderers (EntityList, EntityKanban, EntityForm, EntityDetail) wired to the standard widget catalog",
       "exports": [
         {
+          "name": "EntityCalendar",
+          "kind": "function",
+          "signature": "function EntityCalendar("
+        },
+        {
+          "name": "EntityCalendarProps",
+          "kind": "interface",
+          "signature": "interface EntityCalendarProps",
+          "members": []
+        },
+        {
           "name": "EntityDetail",
           "kind": "function",
           "signature": "function EntityDetail("

--- a/packages/@granit/react-entities/src/__tests__/entity-calendar.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-calendar.test.tsx
@@ -1,0 +1,218 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { EntityCalendar } from '../components/entity-calendar.js';
+
+import type { CalendarItemResponse, EntityCalendarLayoutManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY = 'Granit.Invoicing.Invoice';
+const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/calendar`;
+const FROM = '2026-05-01T00:00:00Z';
+const TO = '2026-05-31T23:59:59Z';
+
+const LAYOUT: EntityCalendarLayoutManifest = {
+  startPropertyName: 'StartDate',
+  endPropertyName: 'EndDate',
+  titlePropertyName: 'Number',
+  colorByPropertyName: 'Status',
+};
+
+const ITEMS: readonly CalendarItemResponse[] = [
+  {
+    id: '8c6b1e10-0000-4000-8000-000000000003',
+    start: '2026-05-12T00:00:00Z',
+    end: null,
+    title: 'INV-002',
+    color: null,
+  },
+  {
+    id: '8c6b1e10-0000-4000-8000-000000000001',
+    start: '2026-05-04T09:00:00Z',
+    end: '2026-05-04T10:30:00Z',
+    title: 'INV-001',
+    color: 'Blue',
+  },
+  {
+    id: '8c6b1e10-0000-4000-8000-000000000002',
+    start: '2026-05-04T15:00:00Z',
+    end: null,
+    title: 'INV-003',
+    color: 'Green',
+  },
+];
+
+function freshHandlers(items: readonly CalendarItemResponse[] = ITEMS) {
+  return [http.get(PATH, () => HttpResponse.json(items))];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers(...freshHandlers()));
+afterAll(() => server.close());
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('EntityCalendar', () => {
+  it('exposes range + layout property names as data attributes on the root', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar entityName={ENTITY} layout={LAYOUT} range={{ from: FROM, to: TO }} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-calendar-day]')).not.toBeNull()
+    );
+    const root = container.querySelector('[data-granit-entity-calendar]') as HTMLElement;
+    expect(root.getAttribute('data-entity')).toBe(ENTITY);
+    expect(root.getAttribute('data-from')).toBe(FROM);
+    expect(root.getAttribute('data-to')).toBe(TO);
+    expect(root.getAttribute('data-start-property')).toBe('StartDate');
+    expect(root.getAttribute('data-end-property')).toBe('EndDate');
+    expect(root.getAttribute('data-color-property')).toBe('Status');
+  });
+
+  it('groups events by start-day and sorts the day list ascending', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar entityName={ENTITY} layout={LAYOUT} range={{ from: FROM, to: TO }} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-calendar-day]').length).toBe(2)
+    );
+    const days = Array.from(container.querySelectorAll('[data-granit-calendar-day]'));
+    expect(days.map((d) => d.getAttribute('data-day'))).toEqual(['2026-05-04', '2026-05-12']);
+    const may4Events = days[0].querySelectorAll('[data-granit-calendar-event]');
+    expect(may4Events).toHaveLength(2);
+    expect(Array.from(may4Events).map((e) => e.textContent)).toEqual(['INV-001', 'INV-003']);
+  });
+
+  it('forwards start / end / color data attrs onto each event node', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar entityName={ENTITY} layout={LAYOUT} range={{ from: FROM, to: TO }} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-calendar-event]')).not.toBeNull()
+    );
+    const inv001 = container.querySelector(
+      '[data-event-id="8c6b1e10-0000-4000-8000-000000000001"]'
+    ) as HTMLElement;
+    expect(inv001.getAttribute('data-start')).toBe('2026-05-04T09:00:00Z');
+    expect(inv001.getAttribute('data-end')).toBe('2026-05-04T10:30:00Z');
+    expect(inv001.getAttribute('data-color')).toBe('Blue');
+
+    const inv002 = container.querySelector(
+      '[data-event-id="8c6b1e10-0000-4000-8000-000000000003"]'
+    ) as HTMLElement;
+    expect(inv002.hasAttribute('data-end')).toBe(false);
+    expect(inv002.hasAttribute('data-color')).toBe(false);
+  });
+
+  it('emits a loading marker before the response lands', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar entityName={ENTITY} layout={LAYOUT} range={{ from: FROM, to: TO }} />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-calendar-loading]')).not.toBeNull();
+  });
+
+  it('emits an empty marker when the endpoint returns no items', async () => {
+    server.use(...freshHandlers([]));
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar entityName={ENTITY} layout={LAYOUT} range={{ from: FROM, to: TO }} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-calendar-empty]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-calendar-day]')).toBeNull();
+  });
+
+  it('emits an error marker with role=alert when the endpoint returns 500', async () => {
+    server.use(http.get(PATH, () => HttpResponse.json({ error: 'boom' }, { status: 500 })));
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar entityName={ENTITY} layout={LAYOUT} range={{ from: FROM, to: TO }} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-calendar-error]')).not.toBeNull()
+    );
+    expect(container.querySelector('[data-granit-calendar-error]')?.getAttribute('role')).toBe(
+      'alert'
+    );
+  });
+
+  it('invokes onItemClick with the full event object', async () => {
+    const onItemClick = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar
+          entityName={ENTITY}
+          layout={LAYOUT}
+          range={{ from: FROM, to: TO }}
+          onItemClick={onItemClick}
+        />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-calendar-event]')).not.toBeNull()
+    );
+    const inv001 = container.querySelector(
+      '[data-event-id="8c6b1e10-0000-4000-8000-000000000001"]'
+    ) as HTMLElement;
+    fireEvent.click(inv001);
+    expect(onItemClick).toHaveBeenCalledWith(
+      expect.objectContaining({ id: '8c6b1e10-0000-4000-8000-000000000001', title: 'INV-001' })
+    );
+  });
+
+  it('omits optional layout data attrs when the manifest leaves them null', async () => {
+    const slimLayout: EntityCalendarLayoutManifest = {
+      startPropertyName: 'StartDate',
+      endPropertyName: null,
+      titlePropertyName: null,
+      colorByPropertyName: null,
+    };
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityCalendar entityName={ENTITY} layout={slimLayout} range={{ from: FROM, to: TO }} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-calendar-day]')).not.toBeNull()
+    );
+    const root = container.querySelector('[data-granit-entity-calendar]') as HTMLElement;
+    expect(root.getAttribute('data-start-property')).toBe('StartDate');
+    expect(root.hasAttribute('data-end-property')).toBe(false);
+    expect(root.hasAttribute('data-color-property')).toBe(false);
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-calendar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-calendar.tsx
@@ -1,0 +1,178 @@
+import { useMemo, type ReactNode } from 'react';
+
+import { useEntityCalendar } from '../api/use-entity-calendar.js';
+
+import type { CalendarItemResponse, EntityCalendarLayoutManifest } from '@granit/entities';
+
+export interface EntityCalendarProps {
+  /** Wire identifier of the entity (e.g. `"Granit.Invoicing.Invoice"`). */
+  readonly entityName: string;
+  /**
+   * Calendar layout from the manifest (one of
+   * `manifest.collections.listLayouts` whose `kind === 'Calendar'`). The
+   * renderer reads `startPropertyName` etc. to surface them as data
+   * attributes; the actual values come from
+   * `useEntityCalendar`'s response and are already projected server-side.
+   */
+  readonly layout: EntityCalendarLayoutManifest;
+  /**
+   * Visible window — ISO 8601 datetime offset strings. The host owns the
+   * window state (a "next month" button lives in the host's toolbar, not
+   * in the framework); the renderer just paints what falls inside.
+   */
+  readonly range: { readonly from: string; readonly to: string };
+  /**
+   * Optional name selector when the entity declares more than one
+   * calendar layout. Reserved for future kinds — leave undefined today.
+   */
+  readonly calendar?: string;
+  /** Optional event activation handler — receives the full item. */
+  readonly onItemClick?: (item: CalendarItemResponse) => void;
+  /** Optional class for the root element. */
+  readonly className?: string;
+}
+
+/**
+ * Generic read-only calendar renderer. Bridges the entity manifest's
+ * calendar layout to the `GET /entities/{name}/calendar` range endpoint
+ * via `useEntityCalendar`, then paints the result as a flat agenda
+ * grouped by start-day:
+ *
+ * ```html
+ * <div data-granit-entity-calendar data-entity="…" data-from="…" data-to="…">
+ *   <ol data-granit-calendar-days>
+ *     <li data-granit-calendar-day data-day="2026-05-04">
+ *       <ol data-granit-calendar-events>
+ *         <li data-granit-calendar-event
+ *             data-event-id="…"
+ *             data-start="…" data-end="…"
+ *             data-color="Blue">
+ *           INV-001
+ *         </li>
+ *       </ol>
+ *     </li>
+ *   </ol>
+ * </div>
+ * ```
+ *
+ * Apps style the day cells via CSS (typically a 7-column grid) and read
+ * `data-start` / `data-end` on the event nodes to position multi-day
+ * events. Multi-day events appear only in their start-day bucket — the
+ * spanning visualisation is the host's responsibility, not the
+ * framework's. Showing a richer month / week / day grid (with padding
+ * cells, cross-day spans, drag-and-drop) is a follow-up; this story
+ * ships the data path + a structured DOM scaffold deliberately neutral
+ * about visual layout.
+ *
+ * Loading / error / empty states surface via dedicated data attributes
+ * (`data-granit-calendar-loading`, `…-error`, `…-empty`) so apps can
+ * render their own placeholders without inspecting React state.
+ */
+export function EntityCalendar({
+  entityName,
+  layout,
+  range,
+  calendar,
+  onItemClick,
+  className,
+}: EntityCalendarProps): ReactNode {
+  const query = useEntityCalendar(entityName, range.from, range.to, { calendar });
+  const days = useMemo(() => groupItemsByStartDay(query.data ?? []), [query.data]);
+
+  if (query.isError) {
+    return (
+      <div
+        data-granit-entity-calendar=""
+        data-granit-calendar-error=""
+        data-entity={entityName}
+        role="alert"
+        className={className}
+      >
+        {String(query.error?.message ?? 'Failed to load')}
+      </div>
+    );
+  }
+
+  if (query.isLoading) {
+    return (
+      <div
+        data-granit-entity-calendar=""
+        data-granit-calendar-loading=""
+        data-entity={entityName}
+        className={className}
+      />
+    );
+  }
+
+  return (
+    <div
+      data-granit-entity-calendar=""
+      data-entity={entityName}
+      data-from={range.from}
+      data-to={range.to}
+      data-start-property={layout.startPropertyName}
+      data-end-property={layout.endPropertyName ?? undefined}
+      data-color-property={layout.colorByPropertyName ?? undefined}
+      className={className}
+    >
+      {days.length === 0 ? (
+        <div data-granit-calendar-empty="" />
+      ) : (
+        <ol data-granit-calendar-days="">
+          {days.map(({ day, events }) => (
+            <li key={day} data-granit-calendar-day="" data-day={day}>
+              <ol data-granit-calendar-events="">
+                {events.map((event) => (
+                  <li
+                    key={event.id}
+                    data-granit-calendar-event=""
+                    data-event-id={event.id}
+                    data-start={event.start}
+                    data-end={event.end ?? undefined}
+                    data-color={event.color ?? undefined}
+                    onClick={onItemClick ? () => onItemClick(event) : undefined}
+                    style={onItemClick ? { cursor: 'pointer' } : undefined}
+                  >
+                    {event.title}
+                  </li>
+                ))}
+              </ol>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+interface CalendarDay {
+  readonly day: string;
+  readonly events: readonly CalendarItemResponse[];
+}
+
+/**
+ * Buckets items by start-day (`YYYY-MM-DD`) keeping declaration order
+ * within a day, then sorts the day list ascending. Multi-day events
+ * appear only in their start-day bucket; consumers reconstruct the
+ * spanning cells by reading `data-end` on the event node.
+ */
+function groupItemsByStartDay(items: readonly CalendarItemResponse[]): readonly CalendarDay[] {
+  const buckets = new Map<string, CalendarItemResponse[]>();
+  for (const item of items) {
+    const day = startDay(item.start);
+    let bucket = buckets.get(day);
+    if (!bucket) {
+      bucket = [];
+      buckets.set(day, bucket);
+    }
+    bucket.push(item);
+  }
+  return Array.from(buckets, ([day, events]) => ({ day, events })).sort((a, b) =>
+    a.day.localeCompare(b.day)
+  );
+}
+
+function startDay(iso: string): string {
+  // Cheap path — ISO 8601 always emits `YYYY-MM-DD` as the first ten chars.
+  return iso.slice(0, 10);
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -6,6 +6,8 @@
 // @granit/entities. Implementation tracked under
 // granit-fx/granit-front#298 (hooks) and #299 (renderers).
 
+export { EntityCalendar } from './components/entity-calendar.js';
+export type { EntityCalendarProps } from './components/entity-calendar.js';
 export { EntityDetail } from './components/entity-detail.js';
 export type { EntityDetailProps } from './components/entity-detail.js';
 export { EntityForm } from './components/entity-form.js';


### PR DESCRIPTION
## Summary

Phase 1.5 Story 3 — generic read-only `<EntityCalendar />` renderer that closes the loop between the manifest's calendar layout (granit-fx/granit-front#335) and the range-query endpoint via \`useEntityCalendar\` (#336).

### Surface

- Props: \`entityName\`, \`layout\` (\`EntityCalendarLayoutManifest\`), \`range\` ({ from, to }), optional \`calendar\` selector, \`onItemClick\`, \`className\`.
- Host owns the visible-window state — the renderer just paints what falls inside \`[from, to]\`. The \"next month\" toolbar lives in the host's chrome, not in the framework.

### DOM scaffold (apps style this)

\`\`\`html
<div data-granit-entity-calendar data-entity=… data-from=… data-to=…>
  <ol data-granit-calendar-days>
    <li data-granit-calendar-day data-day=\"2026-05-04\">
      <ol data-granit-calendar-events>
        <li data-granit-calendar-event
            data-event-id=…
            data-start=… data-end=…
            data-color=\"Blue\">
          INV-001
        </li>
      </ol>
    </li>
  </ol>
</div>
\`\`\`

Apps style via CSS Grid; multi-day spans are reconstructed by reading \`data-end\` on the event nodes. Loading / error / empty surface as dedicated data attributes (\`data-granit-calendar-loading\`, \`…-error\`, \`…-empty\`) so apps render their own placeholders without inspecting React state.

### Deliberate scope cuts (follow-ups)

- Multi-day visual spanning — events appear only in their start-day bucket today; the spanning visualisation is the host's responsibility.
- Week / day / month grid variants — this story ships an agenda-style scaffold; richer view modes ship later if a consumer asks for them.
- Drag-and-drop — read-only for now, mirrors the kanban renderer's first cut.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm exec vitest run packages/@granit/entities packages/@granit/react-entities\` — 20 files, 153 tests, all passing

The 8 new \`entity-calendar.test.tsx\` cases cover:
- root data attributes (\`data-from\`, \`data-to\`, \`data-start-property\`, …)
- day grouping + ascending sort
- per-event data attrs with null end / color omitted
- loading + empty + error markers (incl. \`role=\"alert\"\`)
- \`onItemClick\` forwarding the full event
- slim-layout variant (only \`startPropertyName\` set)