### PR TITLE
fix(parties,data-lookup): resolve Sonar code smells, raise hook coverage

### DIFF
--- a/packages/@granit/data-lookup/src/api/lookup-client.ts
+++ b/packages/@granit/data-lookup/src/api/lookup-client.ts
@@ -133,10 +133,13 @@ export function stringifyLookupValue(value: unknown): string {
   if (value === null || value === undefined) {
     return '';
   }
-  if (typeof value === 'object') {
-    return JSON.stringify(value);
+  if (typeof value === 'string') {
+    return value;
   }
-  return String(value);
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return value.toString();
+  }
+  return JSON.stringify(value);
 }
 
 /** Resolves the URL for a lookup descriptor (registry name or custom endpoint). */

--- a/packages/@granit/parties/src/types.ts
+++ b/packages/@granit/parties/src/types.ts
@@ -37,10 +37,12 @@ export type PartyStatus = 'Active' | 'Suspended' | 'Archived';
 export type PartyRole = 'None' | 'Customer' | 'Supplier' | 'Employee' | 'Lead';
 
 /**
- * Wire representation of {@link PartyRole} flags. Either a single role or a
- * comma-separated list (matching the JSON serialisation of a `[Flags]` enum).
+ * Wire representation of {@link PartyRole} flags. Either a single role
+ * (`"Customer"`) or a comma-separated list (`"Customer, Supplier"`),
+ * matching the JSON serialisation of a `[Flags]` enum. Typed as `string`
+ * because `[Flags]` combinations are open-ended (any subset of {@link PartyRole}).
  */
-export type PartyRoles = PartyRole | string;
+export type PartyRoles = string;
 
 /** Functional purpose of a {@link PartyAddressResponse}. Mirrors the .NET `AddressKind` enum. */
 export type AddressKind = 'Billing' | 'Shipping' | 'Other';

--- a/packages/@granit/react-authentication-cognito/src/__tests__/use-cognito-init.test.tsx
+++ b/packages/@granit/react-authentication-cognito/src/__tests__/use-cognito-init.test.tsx
@@ -1,0 +1,310 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useCognitoInit } from '../hooks/use-cognito-init.js';
+
+import type { CognitoCoreConfig } from '@granit/authentication-cognito';
+
+const {
+  mockGetCurrentUser,
+  mockGetSession,
+  mockGetUserAttributes,
+  mockSignOut,
+  mockSetTokenGetter,
+  mockSetOnUnauthorized,
+} = vi.hoisted(() => ({
+  mockGetCurrentUser: vi.fn(),
+  mockGetSession: vi.fn(),
+  mockGetUserAttributes: vi.fn(),
+  mockSignOut: vi.fn(),
+  mockSetTokenGetter: vi.fn(),
+  mockSetOnUnauthorized: vi.fn(),
+}));
+
+vi.mock('amazon-cognito-identity-js', () => ({
+  CognitoUserPool: vi.fn(function CognitoUserPool(this: { getCurrentUser: () => unknown }) {
+    this.getCurrentUser = mockGetCurrentUser;
+  }),
+}));
+
+vi.mock('@granit/api-client', () => ({
+  setTokenGetter: mockSetTokenGetter,
+  setOnUnauthorized: mockSetOnUnauthorized,
+}));
+
+const baseConfig: CognitoCoreConfig = {
+  userPoolId: 'eu-west-1_test',
+  clientId: 'test-client-id',
+  region: 'eu-west-1',
+};
+
+function makeCognitoUser() {
+  return {
+    getSession: mockGetSession,
+    getUserAttributes: mockGetUserAttributes,
+    signOut: mockSignOut,
+  };
+}
+
+describe('useCognitoInit', () => {
+  beforeEach(() => {
+    mockGetCurrentUser.mockReset();
+    mockGetSession.mockReset();
+    mockGetUserAttributes.mockReset();
+    mockSignOut.mockReset();
+    mockSetTokenGetter.mockReset();
+    mockSetOnUnauthorized.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts in loading=true / authenticated=false', () => {
+    mockGetCurrentUser.mockReturnValue(null);
+    const { result } = renderHook(() => useCognitoInit(baseConfig));
+    expect(result.current.authenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('settles loading=false when no Cognito user is present', async () => {
+    mockGetCurrentUser.mockReturnValue(null);
+    const { result } = renderHook(() => useCognitoInit(baseConfig));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.authenticated).toBe(false);
+  });
+
+  it('triggers onSessionExpired when getSession returns an invalid session', async () => {
+    const onSessionExpired = vi.fn();
+    mockGetCurrentUser.mockReturnValue(makeCognitoUser());
+    mockGetSession.mockImplementation(
+      (cb: (err: Error | null, session: { isValid: () => boolean } | null) => void) => {
+        cb(null, { isValid: () => false });
+      }
+    );
+
+    const { result } = renderHook(() => useCognitoInit({ ...baseConfig, onSessionExpired }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(onSessionExpired).toHaveBeenCalled();
+    expect(result.current.authenticated).toBe(false);
+  });
+
+  it('triggers onSessionExpired when getSession returns an error', async () => {
+    const onSessionExpired = vi.fn();
+    mockGetCurrentUser.mockReturnValue(makeCognitoUser());
+    mockGetSession.mockImplementation((cb: (err: Error | null, session: unknown) => void) => {
+      cb(new Error('boom'), null);
+    });
+
+    const { result } = renderHook(() => useCognitoInit({ ...baseConfig, onSessionExpired }));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+
+  it('flips authenticated=true and extracts the user when session is valid', async () => {
+    mockGetCurrentUser.mockReturnValue(makeCognitoUser());
+    mockGetSession.mockImplementation(
+      (
+        cb: (
+          err: Error | null,
+          session: {
+            isValid: () => boolean;
+            getIdToken: () => { getJwtToken: () => string };
+            getAccessToken: () => { getJwtToken: () => string };
+          } | null
+        ) => void
+      ) => {
+        cb(null, {
+          isValid: () => true,
+          getIdToken: () => ({ getJwtToken: () => 'id-token' }),
+          getAccessToken: () => ({ getJwtToken: () => 'access-token' }),
+        });
+      }
+    );
+    mockGetUserAttributes.mockImplementation(
+      (cb: (err: Error | null, attrs: { Name: string; Value: string }[] | null) => void) => {
+        cb(null, [
+          { Name: 'sub', Value: 'user-1' },
+          { Name: 'email', Value: 'a@b.test' },
+          { Name: 'name', Value: 'Alice' },
+        ]);
+      }
+    );
+
+    const { result } = renderHook(() => useCognitoInit(baseConfig));
+
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
+    expect(result.current.user).toMatchObject({
+      sub: 'user-1',
+      email: 'a@b.test',
+      name: 'Alice',
+    });
+    expect(mockSetTokenGetter).toHaveBeenCalled();
+    expect(mockSetOnUnauthorized).toHaveBeenCalled();
+  });
+
+  it('still finishes loading when getUserAttributes errors out', async () => {
+    mockGetCurrentUser.mockReturnValue(makeCognitoUser());
+    mockGetSession.mockImplementation(
+      (
+        cb: (
+          err: Error | null,
+          session: {
+            isValid: () => boolean;
+            getIdToken: () => { getJwtToken: () => string };
+            getAccessToken: () => { getJwtToken: () => string };
+          } | null
+        ) => void
+      ) => {
+        cb(null, {
+          isValid: () => true,
+          getIdToken: () => ({ getJwtToken: () => '' }),
+          getAccessToken: () => ({ getJwtToken: () => '' }),
+        });
+      }
+    );
+    mockGetUserAttributes.mockImplementation((cb: (err: Error | null, attrs: unknown) => void) => {
+      cb(new Error('attr fail'), null);
+    });
+
+    const { result } = renderHook(() => useCognitoInit(baseConfig));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.authenticated).toBe(true);
+    expect(result.current.user).toBeNull();
+  });
+
+  it('login() does nothing when no domain is configured', async () => {
+    mockGetCurrentUser.mockReturnValue(null);
+    const originalHref = globalThis.location.href;
+    const { result } = renderHook(() => useCognitoInit(baseConfig));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    result.current.login();
+    expect(globalThis.location.href).toBe(originalHref);
+  });
+
+  it('login() redirects to the hosted UI with default scopes when domain is configured', async () => {
+    mockGetCurrentUser.mockReturnValue(null);
+
+    const hrefSetter = vi.fn();
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: new Proxy(originalLocation, {
+        set(target, prop, value) {
+          if (prop === 'href') {
+            hrefSetter(value);
+            return true;
+          }
+          return Reflect.set(target, prop, value);
+        },
+        get(target, prop) {
+          if (prop === 'origin') return 'https://app.example';
+          return Reflect.get(target, prop);
+        },
+      }),
+    });
+
+    try {
+      const { result } = renderHook(() =>
+        useCognitoInit({ ...baseConfig, domain: 'auth.example.com' })
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      result.current.login();
+
+      expect(hrefSetter).toHaveBeenCalledWith(
+        expect.stringContaining('https://auth.example.com/login?client_id=test-client-id')
+      );
+      expect(hrefSetter.mock.calls[0]?.[0]).toContain('scope=openid+profile+email');
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it('login() honors custom scopes and the redirectUri override', async () => {
+    mockGetCurrentUser.mockReturnValue(null);
+
+    const hrefSetter = vi.fn();
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: new Proxy(originalLocation, {
+        set(target, prop, value) {
+          if (prop === 'href') {
+            hrefSetter(value);
+            return true;
+          }
+          return Reflect.set(target, prop, value);
+        },
+      }),
+    });
+
+    try {
+      const { result } = renderHook(() =>
+        useCognitoInit({ ...baseConfig, domain: 'auth.example.com', scopes: ['openid', 'foo'] })
+      );
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      result.current.login({ redirectUri: 'https://app.example/cb' });
+
+      expect(hrefSetter.mock.calls[0]?.[0]).toContain('scope=openid+foo');
+      expect(hrefSetter.mock.calls[0]?.[0]).toContain(encodeURIComponent('https://app.example/cb'));
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it('logout() signs the user out and redirects when redirectUri is supplied', async () => {
+    const userInstance = makeCognitoUser();
+    mockGetCurrentUser.mockReturnValue(userInstance);
+    mockGetSession.mockImplementation(
+      (cb: (err: Error | null, session: { isValid: () => boolean } | null) => void) => {
+        cb(null, { isValid: () => false });
+      }
+    );
+
+    const hrefSetter = vi.fn();
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: new Proxy(originalLocation, {
+        set(target, prop, value) {
+          if (prop === 'href') {
+            hrefSetter(value);
+            return true;
+          }
+          return Reflect.set(target, prop, value);
+        },
+      }),
+    });
+
+    try {
+      const { result } = renderHook(() => useCognitoInit(baseConfig));
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      result.current.logout({ redirectUri: 'https://app.example/bye' });
+      expect(mockSignOut).toHaveBeenCalled();
+      expect(hrefSetter).toHaveBeenCalledWith('https://app.example/bye');
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it('logout() is a no-op for signOut when there is no current user', async () => {
+    mockGetCurrentUser.mockReturnValue(null);
+    const { result } = renderHook(() => useCognitoInit(baseConfig));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    result.current.logout();
+    expect(mockSignOut).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-authentication-entraid/src/__tests__/use-entraid-init.test.tsx
+++ b/packages/@granit/react-authentication-entraid/src/__tests__/use-entraid-init.test.tsx
@@ -1,0 +1,220 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useEntraIdInit } from '../hooks/use-entraid-init.js';
+
+import type { EntraIdCoreConfig } from '@granit/authentication-entraid';
+
+const {
+  mockInitialize,
+  mockHandleRedirectPromise,
+  mockGetActiveAccount,
+  mockGetAllAccounts,
+  mockSetActiveAccount,
+  mockAcquireTokenSilent,
+  mockLoginRedirect,
+  mockLogoutRedirect,
+  mockSetTokenGetter,
+  mockSetOnUnauthorized,
+  MockInteractionRequiredAuthError,
+} = vi.hoisted(() => {
+  class MockInteractionRequiredAuthError extends Error {}
+  return {
+    mockInitialize: vi.fn(),
+    mockHandleRedirectPromise: vi.fn(),
+    mockGetActiveAccount: vi.fn(),
+    mockGetAllAccounts: vi.fn(),
+    mockSetActiveAccount: vi.fn(),
+    mockAcquireTokenSilent: vi.fn(),
+    mockLoginRedirect: vi.fn(),
+    mockLogoutRedirect: vi.fn(),
+    mockSetTokenGetter: vi.fn(),
+    mockSetOnUnauthorized: vi.fn(),
+    MockInteractionRequiredAuthError,
+  };
+});
+
+vi.mock('@azure/msal-browser', () => ({
+  PublicClientApplication: vi.fn(function MockMsal() {
+    return {
+      initialize: mockInitialize,
+      handleRedirectPromise: mockHandleRedirectPromise,
+      getActiveAccount: mockGetActiveAccount,
+      getAllAccounts: mockGetAllAccounts,
+      setActiveAccount: mockSetActiveAccount,
+      acquireTokenSilent: mockAcquireTokenSilent,
+      loginRedirect: mockLoginRedirect,
+      logoutRedirect: mockLogoutRedirect,
+    };
+  }),
+  InteractionRequiredAuthError: MockInteractionRequiredAuthError,
+}));
+
+vi.mock('@granit/api-client', () => ({
+  setTokenGetter: mockSetTokenGetter,
+  setOnUnauthorized: mockSetOnUnauthorized,
+}));
+
+const baseConfig: EntraIdCoreConfig = {
+  clientId: 'app-id',
+  authority: 'https://login.microsoftonline.com/tenant',
+  redirectUri: 'https://app.example',
+};
+
+describe('useEntraIdInit', () => {
+  beforeEach(() => {
+    mockInitialize.mockResolvedValue(undefined);
+    mockHandleRedirectPromise.mockResolvedValue(null);
+    mockGetActiveAccount.mockReturnValue(null);
+    mockGetAllAccounts.mockReturnValue([]);
+    mockSetActiveAccount.mockReset();
+    mockAcquireTokenSilent.mockReset();
+    mockLoginRedirect.mockResolvedValue(undefined);
+    mockLogoutRedirect.mockResolvedValue(undefined);
+    mockSetTokenGetter.mockReset();
+    mockSetOnUnauthorized.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('starts in loading=true / authenticated=false', () => {
+    const { result } = renderHook(() => useEntraIdInit(baseConfig));
+    expect(result.current.loading).toBe(true);
+    expect(result.current.authenticated).toBe(false);
+  });
+
+  it('settles loading=false when no account exists post-init', async () => {
+    const { result } = renderHook(() => useEntraIdInit(baseConfig));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.authenticated).toBe(false);
+    expect(mockSetTokenGetter).not.toHaveBeenCalled();
+  });
+
+  it('promotes the redirect-response account to active and authenticates the user', async () => {
+    const account = {
+      username: 'alice@example.com',
+      name: 'Alice',
+      idTokenClaims: {
+        sub: 'alice-sub',
+        email: 'alice@example.com',
+        given_name: 'Alice',
+        family_name: 'Smith',
+      },
+    };
+    mockHandleRedirectPromise.mockResolvedValue({ account });
+    mockGetActiveAccount.mockReturnValue(account);
+
+    const { result } = renderHook(() => useEntraIdInit(baseConfig));
+
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
+    expect(result.current.user).toMatchObject({
+      sub: 'alice-sub',
+      email: 'alice@example.com',
+      preferred_username: 'alice@example.com',
+      given_name: 'Alice',
+      family_name: 'Smith',
+    });
+    expect(mockSetActiveAccount).toHaveBeenCalled();
+    expect(mockSetTokenGetter).toHaveBeenCalled();
+    expect(mockSetOnUnauthorized).toHaveBeenCalled();
+  });
+
+  it('falls back to the first cached account when there is no redirect response', async () => {
+    const account = { username: 'bob@example.com', idTokenClaims: { oid: 'bob-oid' } };
+    mockGetActiveAccount.mockReturnValue(null);
+    mockGetAllAccounts.mockReturnValue([account]);
+
+    const { result } = renderHook(() => useEntraIdInit(baseConfig));
+
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
+    // sub falls back to oid claim when sub is missing
+    expect(result.current.user?.sub).toBe('bob-oid');
+  });
+
+  it('exposes a token-getter that returns the silent access token', async () => {
+    const account = { username: 'a', idTokenClaims: { sub: 'a' } };
+    mockGetActiveAccount.mockReturnValue(account);
+    mockAcquireTokenSilent.mockResolvedValue({ accessToken: 'fresh-token' });
+
+    renderHook(() => useEntraIdInit(baseConfig));
+
+    await waitFor(() => expect(mockSetTokenGetter).toHaveBeenCalled());
+
+    const tokenGetter = mockSetTokenGetter.mock.calls[0]?.[0] as () => Promise<string | undefined>;
+    await expect(tokenGetter()).resolves.toBe('fresh-token');
+  });
+
+  it('triggers onAcquireTokenFailure when MSAL reports interaction-required', async () => {
+    const onAcquireTokenFailure = vi.fn();
+    const account = { username: 'a', idTokenClaims: { sub: 'a' } };
+    mockGetActiveAccount.mockReturnValue(account);
+    mockAcquireTokenSilent.mockRejectedValue(new MockInteractionRequiredAuthError('login'));
+
+    renderHook(() => useEntraIdInit({ ...baseConfig, onAcquireTokenFailure }));
+
+    await waitFor(() => expect(mockSetTokenGetter).toHaveBeenCalled());
+
+    const tokenGetter = mockSetTokenGetter.mock.calls[0]?.[0] as () => Promise<string | undefined>;
+    await expect(tokenGetter()).resolves.toBeUndefined();
+    expect(onAcquireTokenFailure).toHaveBeenCalled();
+  });
+
+  it('swallows non-interaction errors silently and returns undefined', async () => {
+    const onAcquireTokenFailure = vi.fn();
+    const account = { username: 'a', idTokenClaims: { sub: 'a' } };
+    mockGetActiveAccount.mockReturnValue(account);
+    mockAcquireTokenSilent.mockRejectedValue(new Error('network'));
+
+    renderHook(() => useEntraIdInit({ ...baseConfig, onAcquireTokenFailure }));
+
+    await waitFor(() => expect(mockSetTokenGetter).toHaveBeenCalled());
+
+    const tokenGetter = mockSetTokenGetter.mock.calls[0]?.[0] as () => Promise<string | undefined>;
+    await expect(tokenGetter()).resolves.toBeUndefined();
+    expect(onAcquireTokenFailure).not.toHaveBeenCalled();
+  });
+
+  it('still settles loading=false when MSAL initialization throws', async () => {
+    mockInitialize.mockRejectedValue(new Error('init failed'));
+    const { result } = renderHook(() => useEntraIdInit(baseConfig));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.authenticated).toBe(false);
+  });
+
+  it('login() forwards options to loginRedirect', async () => {
+    const account = { username: 'a', idTokenClaims: { sub: 'a' } };
+    mockGetActiveAccount.mockReturnValue(account);
+
+    const { result } = renderHook(() => useEntraIdInit(baseConfig));
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
+
+    await result.current.login({
+      redirectUri: 'https://app.example/cb',
+      loginHint: 'alice',
+      prompt: 'login',
+    });
+
+    expect(mockLoginRedirect).toHaveBeenCalledWith(
+      expect.objectContaining({
+        redirectUri: 'https://app.example/cb',
+        loginHint: 'alice',
+        prompt: 'login',
+      })
+    );
+  });
+
+  it('logout() forwards postLogoutRedirectUri to logoutRedirect', async () => {
+    const account = { username: 'a', idTokenClaims: { sub: 'a' } };
+    mockGetActiveAccount.mockReturnValue(account);
+
+    const { result } = renderHook(() => useEntraIdInit(baseConfig));
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
+
+    await result.current.logout({ redirectUri: 'https://app.example/bye' });
+    expect(mockLogoutRedirect).toHaveBeenCalledWith({
+      postLogoutRedirectUri: 'https://app.example/bye',
+    });
+  });
+});

--- a/packages/@granit/react-authentication-google-cloud/src/__tests__/use-google-cloud-init.test.tsx
+++ b/packages/@granit/react-authentication-google-cloud/src/__tests__/use-google-cloud-init.test.tsx
@@ -1,0 +1,268 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useGoogleCloudInit } from '../hooks/use-google-cloud-init.js';
+
+import type { GoogleCloudCoreConfig } from '@granit/authentication-google-cloud';
+
+const {
+  mockInitializeApp,
+  mockGetAuth,
+  mockOnAuthStateChanged,
+  mockSignInWithRedirect,
+  mockSignOut,
+  mockAddScope,
+  mockSetTokenGetter,
+  mockSetOnUnauthorized,
+  GoogleAuthProviderCtor,
+} = vi.hoisted(() => {
+  const mockAddScope = vi.fn();
+  return {
+    mockInitializeApp: vi.fn(),
+    mockGetAuth: vi.fn(),
+    mockOnAuthStateChanged: vi.fn(),
+    mockSignInWithRedirect: vi.fn(),
+    mockSignOut: vi.fn(),
+    mockAddScope,
+    mockSetTokenGetter: vi.fn(),
+    mockSetOnUnauthorized: vi.fn(),
+    GoogleAuthProviderCtor: vi.fn(function GoogleAuthProvider() {
+      return { addScope: mockAddScope };
+    }),
+  };
+});
+
+vi.mock('firebase/app', () => ({
+  initializeApp: mockInitializeApp,
+}));
+
+vi.mock('firebase/auth', () => ({
+  getAuth: mockGetAuth,
+  onAuthStateChanged: mockOnAuthStateChanged,
+  signInWithRedirect: mockSignInWithRedirect,
+  signOut: mockSignOut,
+  GoogleAuthProvider: GoogleAuthProviderCtor,
+}));
+
+vi.mock('@granit/api-client', () => ({
+  setTokenGetter: mockSetTokenGetter,
+  setOnUnauthorized: mockSetOnUnauthorized,
+}));
+
+const baseConfig: GoogleCloudCoreConfig = {
+  apiKey: 'fake-key',
+  authDomain: 'app.firebaseapp.com',
+  projectId: 'app-id',
+};
+
+describe('useGoogleCloudInit', () => {
+  let unsubscribe: ReturnType<typeof vi.fn>;
+  let authStateCallback:
+    | ((
+        user: {
+          uid: string;
+          email: string | null;
+          displayName: string | null;
+          photoURL: string | null;
+          getIdToken: () => Promise<string>;
+        } | null
+      ) => Promise<void> | void)
+    | null;
+
+  beforeEach(() => {
+    unsubscribe = vi.fn();
+    authStateCallback = null;
+    mockInitializeApp.mockReset();
+    mockInitializeApp.mockReturnValue({});
+    mockGetAuth.mockReset();
+    mockGetAuth.mockReturnValue({});
+    mockOnAuthStateChanged.mockReset();
+    mockOnAuthStateChanged.mockImplementation((_auth: unknown, cb: (user: unknown) => void) => {
+      authStateCallback = cb as typeof authStateCallback;
+      return unsubscribe;
+    });
+    mockSignInWithRedirect.mockReset();
+    mockSignInWithRedirect.mockResolvedValue(undefined);
+    mockSignOut.mockReset();
+    mockSignOut.mockResolvedValue(undefined);
+    mockAddScope.mockReset();
+    mockSetTokenGetter.mockReset();
+    mockSetOnUnauthorized.mockReset();
+    GoogleAuthProviderCtor.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initializes Firebase and subscribes to auth state changes', () => {
+    renderHook(() => useGoogleCloudInit(baseConfig));
+    expect(mockInitializeApp).toHaveBeenCalledWith({
+      apiKey: 'fake-key',
+      authDomain: 'app.firebaseapp.com',
+      projectId: 'app-id',
+    });
+    expect(mockOnAuthStateChanged).toHaveBeenCalled();
+  });
+
+  it('flips authenticated=true and extracts the user when a Firebase user appears', async () => {
+    const { result } = renderHook(() => useGoogleCloudInit(baseConfig));
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+    await authStateCallback!({
+      uid: 'user-1',
+      email: 'a@b.test',
+      displayName: 'Alice',
+      photoURL: 'https://cdn/x.png',
+      getIdToken: () => Promise.resolve('id-token'),
+    });
+
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
+    expect(result.current.user).toEqual({
+      sub: 'user-1',
+      email: 'a@b.test',
+      name: 'Alice',
+      picture: 'https://cdn/x.png',
+    });
+    expect(mockSetTokenGetter).toHaveBeenCalled();
+    expect(mockSetOnUnauthorized).toHaveBeenCalled();
+  });
+
+  it('coalesces nullish profile fields to undefined in the OIDC user', async () => {
+    const { result } = renderHook(() => useGoogleCloudInit(baseConfig));
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+    await authStateCallback!({
+      uid: 'user-2',
+      email: null,
+      displayName: null,
+      photoURL: null,
+      getIdToken: () => Promise.resolve(''),
+    });
+
+    await waitFor(() => expect(result.current.authenticated).toBe(true));
+    expect(result.current.user).toEqual({
+      sub: 'user-2',
+      email: undefined,
+      name: undefined,
+      picture: undefined,
+    });
+  });
+
+  it('exposes a token-getter that returns the Firebase ID token', async () => {
+    renderHook(() => useGoogleCloudInit(baseConfig));
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+    const getIdToken = vi.fn(() => Promise.resolve('id-token-1'));
+    await authStateCallback!({
+      uid: 'u',
+      email: null,
+      displayName: null,
+      photoURL: null,
+      getIdToken,
+    });
+
+    await waitFor(() => expect(mockSetTokenGetter).toHaveBeenCalled());
+    const tokenGetter = mockSetTokenGetter.mock.calls[0]?.[0] as () => Promise<string | undefined>;
+    await expect(tokenGetter()).resolves.toBe('id-token-1');
+  });
+
+  it('triggers onTokenRefreshError when getIdToken throws', async () => {
+    const onTokenRefreshError = vi.fn();
+    renderHook(() => useGoogleCloudInit({ ...baseConfig, onTokenRefreshError }));
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+    const getIdToken = vi.fn(() => Promise.reject(new Error('expired')));
+    await authStateCallback!({
+      uid: 'u',
+      email: null,
+      displayName: null,
+      photoURL: null,
+      getIdToken,
+    });
+
+    await waitFor(() => expect(mockSetTokenGetter).toHaveBeenCalled());
+    const tokenGetter = mockSetTokenGetter.mock.calls[0]?.[0] as () => Promise<string | undefined>;
+    await expect(tokenGetter()).resolves.toBeUndefined();
+    expect(onTokenRefreshError).toHaveBeenCalled();
+  });
+
+  it('clears the user and triggers onSessionExpired when the auth listener fires with null', async () => {
+    const onSessionExpired = vi.fn();
+    const { result } = renderHook(() => useGoogleCloudInit({ ...baseConfig, onSessionExpired }));
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+    await authStateCallback!(null);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.authenticated).toBe(false);
+    expect(result.current.user).toBeNull();
+    expect(onSessionExpired).toHaveBeenCalled();
+  });
+
+  it('login() registers the configured scopes and triggers signInWithRedirect', async () => {
+    const { result } = renderHook(() =>
+      useGoogleCloudInit({ ...baseConfig, scopes: ['profile', 'calendar'] })
+    );
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+    await result.current.login();
+
+    expect(GoogleAuthProviderCtor).toHaveBeenCalled();
+    expect(mockAddScope).toHaveBeenCalledWith('profile');
+    expect(mockAddScope).toHaveBeenCalledWith('calendar');
+    expect(mockSignInWithRedirect).toHaveBeenCalled();
+  });
+
+  it('login() works without configured scopes', async () => {
+    const { result } = renderHook(() => useGoogleCloudInit(baseConfig));
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+    await result.current.login();
+    expect(mockAddScope).not.toHaveBeenCalled();
+    expect(mockSignInWithRedirect).toHaveBeenCalled();
+  });
+
+  it('logout() signs out and redirects when redirectUri is supplied', async () => {
+    const hrefSetter = vi.fn();
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: new Proxy(originalLocation, {
+        set(target, prop, value) {
+          if (prop === 'href') {
+            hrefSetter(value);
+            return true;
+          }
+          return Reflect.set(target, prop, value);
+        },
+      }),
+    });
+
+    try {
+      const { result } = renderHook(() => useGoogleCloudInit(baseConfig));
+      await waitFor(() => expect(authStateCallback).not.toBeNull());
+
+      await result.current.logout({ redirectUri: 'https://app.example/bye' });
+      expect(mockSignOut).toHaveBeenCalled();
+      expect(hrefSetter).toHaveBeenCalledWith('https://app.example/bye');
+    } finally {
+      Object.defineProperty(globalThis, 'location', {
+        configurable: true,
+        value: originalLocation,
+      });
+    }
+  });
+
+  it('logout() is a no-op for signOut when authRef is null', async () => {
+    // Simulate an unmounted instance: clear authRef before logout by
+    // making getAuth return undefined.
+    mockGetAuth.mockReturnValue(undefined);
+    const { result } = renderHook(() => useGoogleCloudInit(baseConfig));
+    await waitFor(() => expect(authStateCallback).not.toBeNull());
+    // First logout: authRef.current was set to undefined → signOut should not be called.
+    // (We can't easily reset authRef post-init; this branch is exercised when authRef is null.)
+    // We assert at minimum that calling logout doesn't throw.
+    await expect(result.current.logout()).resolves.toBeUndefined();
+  });
+});

--- a/packages/@granit/react-dashboards/src/__tests__/widgets-image-text.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/widgets-image-text.test.tsx
@@ -1,0 +1,206 @@
+import { fireEvent, render } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { WidgetActionProvider } from '../components/widget-action-context.js';
+import { ImageWidget } from '../components/widgets/image-widget.js';
+import { TextWidget } from '../components/widgets/text-widget.js';
+import { defaultWidgetActionHandlers } from '../lib/default-widget-action-handlers.js';
+import { composeWidgetActionHandlers } from '../lib/widget-action-handler.js';
+
+import type { ImageWidgetDefinition, TextWidgetDefinition } from '@granit/dashboards';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: {
+    en: {
+      translation: {
+        'Widget:Logo.Alt': 'Granit logo',
+        'Widget:Caption': 'Some caption',
+        'Widget:Heading': 'Welcome',
+        'Widget:Subheading': 'Sub',
+      },
+    },
+  },
+  interpolation: { escapeValue: false },
+});
+
+function withProviders(node: ReactNode, captured: { target?: string }) {
+  const handlers = composeWidgetActionHandlers(defaultWidgetActionHandlers, {
+    OpenDetail: (action) => {
+      captured.target = action.target;
+    },
+  });
+  return render(
+    <I18nextProvider i18n={testI18n}>
+      <WidgetActionProvider handlers={handlers}>{node}</WidgetActionProvider>
+    </I18nextProvider>
+  );
+}
+
+describe('ImageWidget', () => {
+  const baseWidget: ImageWidgetDefinition = {
+    slug: 'Logo',
+    type: 'image',
+    position: 0,
+    size: { width: 4, height: 1 },
+    source: 'https://cdn.example/logo.png',
+    altLocalizationKey: 'Widget:Logo.Alt',
+  };
+
+  it('renders a non-interactive image when no Click action is wired', () => {
+    const captured: { target?: string } = {};
+    const { container } = withProviders(<ImageWidget widget={baseWidget} />, captured);
+
+    const root = container.querySelector('[data-slot="image-widget"]');
+    expect(root?.getAttribute('role')).toBeNull();
+    expect(root?.getAttribute('tabindex')).toBeNull();
+    expect(root?.getAttribute('data-interactive')).toBeNull();
+
+    const img = container.querySelector('img');
+    expect(img?.getAttribute('alt')).toBe('Granit logo');
+    expect(img?.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('uses the default Contain object-fit when fit is omitted', () => {
+    const captured: { target?: string } = {};
+    const { container } = withProviders(<ImageWidget widget={baseWidget} />, captured);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.style.objectFit).toBe('contain');
+  });
+
+  it.each([
+    ['Cover', 'cover'],
+    ['Fill', 'fill'],
+    ['Contain', 'contain'],
+  ] as const)('maps fit %s to object-fit %s', (fit, css) => {
+    const captured: { target?: string } = {};
+    const { container } = withProviders(<ImageWidget widget={{ ...baseWidget, fit }} />, captured);
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.style.objectFit).toBe(css);
+  });
+
+  it('exposes role + tabindex and dispatches the Click action on body click', () => {
+    const captured: { target?: string } = {};
+    const widget: ImageWidgetDefinition = {
+      ...baseWidget,
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'logo-detail' }],
+    };
+    const { container } = withProviders(<ImageWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="image-widget"]') as HTMLElement;
+    expect(root.getAttribute('role')).toBe('button');
+    expect(root.getAttribute('tabindex')).toBe('0');
+    expect(root.getAttribute('data-interactive')).toBe('');
+
+    fireEvent.click(root);
+    expect(captured.target).toBe('logo-detail');
+  });
+
+  it('keyboard activation (Enter / Space) dispatches the Click action and prevents default', () => {
+    const captured: { target?: string } = {};
+    const widget: ImageWidgetDefinition = {
+      ...baseWidget,
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'kb-detail' }],
+    };
+    const { container } = withProviders(<ImageWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="image-widget"]') as HTMLElement;
+
+    fireEvent.keyDown(root, { key: 'Enter' });
+    expect(captured.target).toBe('kb-detail');
+
+    captured.target = undefined;
+    fireEvent.keyDown(root, { key: ' ' });
+    expect(captured.target).toBe('kb-detail');
+  });
+
+  it('ignores irrelevant key presses', () => {
+    const captured: { target?: string } = {};
+    const widget: ImageWidgetDefinition = {
+      ...baseWidget,
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'noop' }],
+    };
+    const { container } = withProviders(<ImageWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="image-widget"]') as HTMLElement;
+    fireEvent.keyDown(root, { key: 'Escape' });
+    expect(captured.target).toBeUndefined();
+  });
+});
+
+describe('TextWidget', () => {
+  const baseWidget: TextWidgetDefinition = {
+    slug: 'Caption',
+    type: 'text',
+    position: 0,
+    size: { width: 6, height: 1 },
+    contentLocalizationKey: 'Widget:Caption',
+    style: 'Caption',
+  };
+
+  it.each([
+    ['Body', 'P', 'body'],
+    ['Caption', 'P', 'caption'],
+    ['Heading', 'H2', 'heading'],
+    ['Subheading', 'H3', 'subheading'],
+  ] as const)('renders style %s as %s with data-style %s', (style, expectedTag, expectedAttr) => {
+    const captured: { target?: string } = {};
+    const { container } = withProviders(<TextWidget widget={{ ...baseWidget, style }} />, captured);
+    const node = container.querySelector('[data-slot="text-widget"]');
+    expect(node?.tagName).toBe(expectedTag);
+    expect(node?.getAttribute('data-style')).toBe(expectedAttr);
+    expect(node?.getAttribute('role')).toBeNull();
+    expect(node?.getAttribute('tabindex')).toBeNull();
+  });
+
+  it('gains role + tabindex when a Click action is wired and dispatches on body click', () => {
+    const captured: { target?: string } = {};
+    const widget: TextWidgetDefinition = {
+      ...baseWidget,
+      style: 'Heading',
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'h-detail' }],
+    };
+    const { container } = withProviders(<TextWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="text-widget"]') as HTMLElement;
+    expect(root.getAttribute('role')).toBe('button');
+    expect(root.getAttribute('tabindex')).toBe('0');
+
+    fireEvent.click(root);
+    expect(captured.target).toBe('h-detail');
+  });
+
+  it('keyboard activation (Enter / Space) dispatches the Click action', () => {
+    const captured: { target?: string } = {};
+    const widget: TextWidgetDefinition = {
+      ...baseWidget,
+      style: 'Subheading',
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'kb-text' }],
+    };
+    const { container } = withProviders(<TextWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="text-widget"]') as HTMLElement;
+
+    fireEvent.keyDown(root, { key: 'Enter' });
+    expect(captured.target).toBe('kb-text');
+
+    captured.target = undefined;
+    fireEvent.keyDown(root, { key: ' ' });
+    expect(captured.target).toBe('kb-text');
+  });
+
+  it('ignores irrelevant key presses', () => {
+    const captured: { target?: string } = {};
+    const widget: TextWidgetDefinition = {
+      ...baseWidget,
+      style: 'Body',
+      actions: [{ trigger: 'Click', kind: 'OpenDetail', target: 'noop' }],
+    };
+    const { container } = withProviders(<TextWidget widget={widget} />, captured);
+    const root = container.querySelector('[data-slot="text-widget"]') as HTMLElement;
+    fireEvent.keyDown(root, { key: 'Tab' });
+    expect(captured.target).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-parties/src/__tests__/DuplicatesInbox.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/DuplicatesInbox.test.tsx
@@ -69,7 +69,11 @@ afterEach(() => vi.restoreAllMocks());
 
 function renderInbox(
   client: AxiosInstance,
-  onMerge?: (row: PartyDuplicateCandidateResponse) => void
+  options?: {
+    onMerge?: (row: PartyDuplicateCandidateResponse) => void;
+    pageSize?: number;
+    renderPartyLink?: (partyId: string) => ReactNode;
+  }
 ) {
   const queryClient = createTestQueryClient();
   const config: PartiesConfig = { client };
@@ -82,7 +86,14 @@ function renderInbox(
       </I18nextProvider>
     );
   }
-  return render(<DuplicatesInbox onMerge={onMerge} />, { wrapper: Wrapper });
+  return render(
+    <DuplicatesInbox
+      onMerge={options?.onMerge}
+      pageSize={options?.pageSize}
+      renderPartyLink={options?.renderPartyLink}
+    />,
+    { wrapper: Wrapper }
+  );
 }
 
 describe('DuplicatesInbox', () => {
@@ -147,7 +158,7 @@ describe('DuplicatesInbox', () => {
     );
 
     const onMerge = vi.fn();
-    const { container } = renderInbox(client, onMerge);
+    const { container } = renderInbox(client, { onMerge });
 
     await waitFor(() =>
       expect(container.querySelectorAll('[data-slot="duplicate-row"]').length).toBe(rows.length)
@@ -159,6 +170,61 @@ describe('DuplicatesInbox', () => {
     fireEvent.click(mergeButtons[1]!);
 
     expect(onMerge).toHaveBeenCalledWith(rows[1]);
+  });
+
+  it('renders the error state when the QueryEngine call fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('boom'));
+
+    renderInbox(client);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(partiesTranslationsEn.Duplicates.ErrorState);
+  });
+
+  it('renders pagination buttons when totalCount exceeds the page size', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [rows[0]!], totalCount: 5 }));
+
+    renderInbox(client, { pageSize: 1 });
+
+    const next = await waitFor(() =>
+      screen.getByRole('button', { name: partiesTranslationsEn.Duplicates.Pagination.Next })
+    );
+    const previous = screen.getByRole('button', {
+      name: partiesTranslationsEn.Duplicates.Pagination.Previous,
+    }) as HTMLButtonElement;
+    expect(previous.disabled).toBe(true);
+
+    fireEvent.click(next);
+
+    await waitFor(() => expect((previous as HTMLButtonElement).disabled).toBe(false));
+  });
+
+  it('uses renderPartyLink when provided and falls back to "—" for missing dates', async () => {
+    const client = createMockClient();
+    const rowWithoutUpdate: PartyDuplicateCandidateResponse = {
+      ...rows[1]!,
+      updatedAt: null,
+    };
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: [rowWithoutUpdate], totalCount: 1 })
+    );
+
+    const renderPartyLink = vi.fn((id: string) => <span data-slot="ext-link">{id}</span>);
+    const { container } = renderInbox(client, { renderPartyLink });
+
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-slot="duplicate-row"]').length).toBe(1)
+    );
+
+    expect(renderPartyLink).toHaveBeenCalledWith(rowWithoutUpdate.partyId);
+    expect(renderPartyLink).toHaveBeenCalledWith(rowWithoutUpdate.candidateId);
+    expect(container.querySelectorAll('[data-slot="ext-link"]').length).toBe(2);
+
+    // Refreshed column shows "—" because updatedAt is null
+    const row = container.querySelector('[data-slot="duplicate-row"]') as HTMLElement;
+    expect(row.textContent).toContain('—');
   });
 
   it('does not render Merge buttons when onMerge is omitted', async () => {

--- a/packages/@granit/react-parties/src/__tests__/MergeWizard.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/MergeWizard.test.tsx
@@ -239,6 +239,81 @@ describe('MergeWizard', () => {
     expect(alert.textContent).toBe(partiesTranslationsEn.MergeWizard.Errors.AlreadyMerged);
   });
 
+  it('renders the preview-error state when the preview request fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockImplementation((url: string) => {
+      if (url.endsWith(`/parties/${survivorId}`)) return Promise.resolve(axiosResponse(survivor));
+      if (url.endsWith(`/parties/${loserId}`)) return Promise.resolve(axiosResponse(loser));
+      return Promise.reject(new Error('preview boom'));
+    });
+    renderWizard(client);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(partiesTranslationsEn.MergeWizard.Errors.PreviewFailed);
+
+    const submitButton = screen.getByRole('button', {
+      name: partiesTranslationsEn.MergeWizard.Merge,
+    }) as HTMLButtonElement;
+    expect(submitButton.disabled).toBe(true);
+  });
+
+  it('renders the empty-conflicts message when the preview returns no conflicts', async () => {
+    const client = createMockClient();
+    stubReads(client, {
+      previewResponse: { ...previewResponse, conflicts: [], rewriteCounts: {} },
+    });
+    renderWizard(client);
+
+    await waitFor(() =>
+      expect(screen.queryByText(partiesTranslationsEn.MergeWizard.ConflictsEmpty)).not.toBeNull()
+    );
+    expect(screen.queryByText(partiesTranslationsEn.MergeWizard.RewritesEmpty)).not.toBeNull();
+  });
+
+  it('falls back to the unknown-error label on a non-axios mutation failure', async () => {
+    const client = createMockClient();
+    stubReads(client);
+    vi.mocked(client.post).mockRejectedValue(new Error('network down'));
+    renderWizard(client);
+
+    const submitButton = screen.getByRole('button', {
+      name: partiesTranslationsEn.MergeWizard.Merge,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(submitButton.disabled).toBe(false));
+
+    fireEvent.click(submitButton);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe(partiesTranslationsEn.MergeWizard.Errors.Unknown);
+  });
+
+  it('surfaces the response detail directly when the status is neither 409 nor 422', async () => {
+    const client = createMockClient();
+    stubReads(client);
+    const error: Partial<AxiosError> = {
+      isAxiosError: true,
+      response: {
+        status: 500,
+        data: { title: 'Internal Server Error' },
+        statusText: '',
+        headers: {},
+        config: {} as never,
+      },
+    };
+    vi.mocked(client.post).mockRejectedValue(error);
+    renderWizard(client);
+
+    const submitButton = screen.getByRole('button', {
+      name: partiesTranslationsEn.MergeWizard.Merge,
+    }) as HTMLButtonElement;
+    await waitFor(() => expect(submitButton.disabled).toBe(false));
+
+    fireEvent.click(submitButton);
+
+    const alert = await screen.findByRole('alert');
+    expect(alert.textContent).toBe('Internal Server Error');
+  });
+
   it('calls onCancel when the Cancel button is clicked', async () => {
     const client = createMockClient();
     stubReads(client);

--- a/packages/@granit/react-parties/src/__tests__/PartyDuplicatesBadge.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/PartyDuplicatesBadge.test.tsx
@@ -54,7 +54,13 @@ beforeAll(async () => {
 
 afterEach(() => vi.restoreAllMocks());
 
-function renderBadge(client: AxiosInstance, props?: { href?: string }) {
+function renderBadge(
+  client: AxiosInstance,
+  props?: {
+    href?: string;
+    renderLink?: (linkProps: { href: string; children: ReactNode }) => ReactNode;
+  }
+) {
   const queryClient = createTestQueryClient();
   const config: PartiesConfig = { client };
   function Wrapper({ children }: { children: ReactNode }) {
@@ -66,9 +72,10 @@ function renderBadge(client: AxiosInstance, props?: { href?: string }) {
       </I18nextProvider>
     );
   }
-  return render(<PartyDuplicatesBadge partyId={partyA} href={props?.href} />, {
-    wrapper: Wrapper,
-  });
+  return render(
+    <PartyDuplicatesBadge partyId={partyA} href={props?.href} renderLink={props?.renderLink} />,
+    { wrapper: Wrapper }
+  );
 }
 
 describe('PartyDuplicatesBadge', () => {
@@ -130,6 +137,32 @@ describe('PartyDuplicatesBadge', () => {
     const { container } = renderBadge(client);
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     expect(container.querySelector('[data-slot="party-duplicates-badge"]')).toBeNull();
+  });
+
+  it('uses renderLink when provided alongside href', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse([candidateBuilder({ tier: 'Deterministic' })])
+    );
+
+    const renderLink = vi.fn(({ href, children }: { href: string; children: ReactNode }) => (
+      <button data-slot="custom-link" data-href={href} type="button">
+        {children}
+      </button>
+    ));
+
+    const { container } = renderBadge(client, { href: '/inbox', renderLink });
+
+    const wrapper = await waitFor(() => {
+      const el = container.querySelector('[data-slot="custom-link"]');
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    });
+
+    expect(wrapper.getAttribute('data-href')).toBe('/inbox');
+    expect(renderLink).toHaveBeenCalled();
+    // The inner pill is still rendered as a span inside the consumer's wrapper.
+    expect(wrapper.querySelector('[data-slot="party-duplicates-badge"]')?.tagName).toBe('SPAN');
   });
 
   it('renders as an anchor when href is supplied', async () => {

--- a/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
@@ -9,11 +9,20 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   useActivatePartyMutation,
   useAddPartyAddressMutation,
+  useAddPartyEmailMutation,
+  useAddPartyExternalMappingMutation,
+  useAddPartyPhoneMutation,
+  useAddPartyRoleMutation,
   useArchivePartyMutation,
   useClearPartyTaxStatusMutation,
   useCreatePartyMutation,
   usePartiesQuery,
   usePartyQuery,
+  useRemovePartyAddressMutation,
+  useRemovePartyEmailMutation,
+  useRemovePartyExternalMappingMutation,
+  useRemovePartyPhoneMutation,
+  useRemovePartyRoleMutation,
   useReplacePartyMetadataMutation,
   useSetPartyTaxStatusMutation,
   useSuspendPartyMutation,
@@ -23,11 +32,17 @@ import { PartiesProvider } from '../providers/parties-provider.js';
 
 import type { PartiesConfig } from '../providers/parties-provider.js';
 import type {
+  PartyAddressId,
   PartyAddressRequest,
   PartyCreateRequest,
+  PartyEmailId,
+  PartyEmailRequest,
+  PartyExternalMappingRequest,
   PartyId,
   PartyListItemResponse,
   PartyMetadataRequest,
+  PartyPhoneId,
+  PartyPhoneRequest,
   PartyResponse,
   PartyTaxStatusRequest,
   PartyUpdateRequest,
@@ -329,6 +344,160 @@ describe('use-parties', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.delete).toHaveBeenCalledWith(`/api/v1/parties/${partyId}/tax-status`);
+    });
+  });
+
+  describe('address mutations', () => {
+    it('removes an address', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const addressId = toEntityId<'PartyAddress'>('a1') as PartyAddressId;
+      const { result } = renderHook(() => useRemovePartyAddressMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, addressId });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith(
+        `/api/v1/parties/${partyId}/addresses/${addressId}`
+      );
+    });
+  });
+
+  describe('email mutations', () => {
+    it('adds an email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleParty });
+
+      const request: PartyEmailRequest = { address: 'a@b.test', isPrimary: true };
+      const { result } = renderHook(() => useAddPartyEmailMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, request });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith(`/api/v1/parties/${partyId}/emails`, request);
+    });
+
+    it('removes an email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const emailId = toEntityId<'PartyEmail'>('e1') as PartyEmailId;
+      const { result } = renderHook(() => useRemovePartyEmailMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, emailId });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith(`/api/v1/parties/${partyId}/emails/${emailId}`);
+    });
+  });
+
+  describe('phone mutations', () => {
+    it('adds a phone', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleParty });
+
+      const request: PartyPhoneRequest = { kind: 'Mobile', number: '+32123' };
+      const { result } = renderHook(() => useAddPartyPhoneMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, request });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith(`/api/v1/parties/${partyId}/phones`, request);
+    });
+
+    it('removes a phone', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const phoneId = toEntityId<'PartyPhone'>('p1') as PartyPhoneId;
+      const { result } = renderHook(() => useRemovePartyPhoneMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, phoneId });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith(`/api/v1/parties/${partyId}/phones/${phoneId}`);
+    });
+  });
+
+  describe('external-mapping mutations', () => {
+    it('adds an external mapping', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleParty });
+
+      const request: PartyExternalMappingRequest = {
+        providerName: 'stripe',
+        externalId: 'cus_123',
+      };
+      const { result } = renderHook(() => useAddPartyExternalMappingMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, request });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith(
+        `/api/v1/parties/${partyId}/external-mappings`,
+        request
+      );
+    });
+
+    it('removes an external mapping by provider name', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useRemovePartyExternalMappingMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, providerName: 'stripe' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith(
+        `/api/v1/parties/${partyId}/external-mappings/stripe`
+      );
+    });
+  });
+
+  describe('role mutations', () => {
+    it('adds a role flag', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useAddPartyRoleMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, request: { role: 'Customer' } });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith(`/api/v1/parties/${partyId}/roles`, {
+        role: 'Customer',
+      });
+    });
+
+    it('removes a role flag', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useRemovePartyRoleMutation(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate({ id: partyId, role: 'Supplier' });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith(`/api/v1/parties/${partyId}/roles/Supplier`);
     });
   });
 

--- a/packages/@granit/react-parties/src/__tests__/use-party-duplicates.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-party-duplicates.test.tsx
@@ -151,6 +151,41 @@ describe('useMergePartyFromDuplicateMutation', () => {
     expect(invalidatedKeys).toContainEqual(['parties', 'detail', partyB]);
   });
 
+  it('falls back to a Math.random UUID when crypto.randomUUID is unavailable', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(mergeResponse));
+
+    const originalRandomUUID = globalThis.crypto.randomUUID;
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    try {
+      const { result } = renderHook(() => useMergePartyFromDuplicateMutation(), {
+        wrapper: makeWrapper(client),
+      });
+
+      result.current.mutate({ id: dupId, request: { survivorId: partyA } });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      const call = vi.mocked(client.post).mock.calls[0]!;
+      const idempotencyKey = (call[2] as { headers: { 'Idempotency-Key': string } }).headers[
+        'Idempotency-Key'
+      ];
+      expect(idempotencyKey).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    } finally {
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        writable: true,
+        value: originalRandomUUID,
+      });
+    }
+  });
+
   it('uses an explicit idempotencyKey when supplied', async () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValue(axiosResponse(mergeResponse));

--- a/packages/@granit/react-parties/src/__tests__/use-party-merge.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-party-merge.test.tsx
@@ -158,6 +158,41 @@ describe('useMergePartyMutation', () => {
     expect(invalidatedKeys).toContainEqual(['parties', 'merge', 'preview', survivorId, loserId]);
   });
 
+  it('falls back to a Math.random UUID when crypto.randomUUID is unavailable', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue({ data: { ...previewResponse, dryRun: false } });
+
+    const originalRandomUUID = globalThis.crypto.randomUUID;
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+
+    try {
+      const { result } = renderHook(() => useMergePartyMutation(survivorId), {
+        wrapper: makeWrapper(client),
+      });
+
+      result.current.mutate({ request: { loserId } });
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+      const call = vi.mocked(client.post).mock.calls[0]!;
+      const idempotencyKey = (call[2] as { headers: { 'Idempotency-Key': string } }).headers[
+        'Idempotency-Key'
+      ];
+      expect(idempotencyKey).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    } finally {
+      Object.defineProperty(globalThis.crypto, 'randomUUID', {
+        configurable: true,
+        writable: true,
+        value: originalRandomUUID,
+      });
+    }
+  });
+
   it('does NOT invalidate caches when dryRun is true', async () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValue({ data: previewResponse });

--- a/packages/@granit/react-parties/src/components/DuplicatesInbox.tsx
+++ b/packages/@granit/react-parties/src/components/DuplicatesInbox.tsx
@@ -107,26 +107,14 @@ function DuplicatesInboxBody({
             </tr>
           </thead>
           <tbody>
-            {query.isLoading ? (
-              <tr>
-                <td colSpan={7} className="px-3 py-8 text-center text-muted-foreground">
-                  {t('Duplicates.LoadingState')}
-                </td>
-              </tr>
-            ) : query.isError ? (
-              <tr>
-                <td colSpan={7} role="alert" className="px-3 py-8 text-center text-destructive">
-                  {t('Duplicates.ErrorState')}
-                </td>
-              </tr>
-            ) : items.length === 0 ? (
-              <tr>
-                <td colSpan={7} className="px-3 py-8 text-center text-muted-foreground">
-                  {t('Duplicates.EmptyState')}
-                </td>
-              </tr>
-            ) : (
-              items.map((row) => (
+            {renderTableBody({
+              isLoading: query.isLoading,
+              isError: query.isError,
+              items,
+              loadingLabel: t('Duplicates.LoadingState'),
+              errorLabel: t('Duplicates.ErrorState'),
+              emptyLabel: t('Duplicates.EmptyState'),
+              renderRow: (row) => (
                 <DuplicateRow
                   key={row.id}
                   row={row}
@@ -142,8 +130,8 @@ function DuplicatesInboxBody({
                     Fuzzy: t('Duplicates.Tier.Fuzzy'),
                   }}
                 />
-              ))
-            )}
+              ),
+            })}
           </tbody>
         </table>
       </div>
@@ -255,4 +243,53 @@ function formatDate(value: string | null | undefined): string {
   // formatting via their own theming layer if needed. The framework package
   // intentionally avoids pulling in date-fns / Intl here.
   return value.slice(0, 10);
+}
+
+interface RenderTableBodyArgs {
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly items: readonly PartyDuplicateCandidateResponse[];
+  readonly loadingLabel: string;
+  readonly errorLabel: string;
+  readonly emptyLabel: string;
+  readonly renderRow: (row: PartyDuplicateCandidateResponse) => ReactNode;
+}
+
+function renderTableBody({
+  isLoading,
+  isError,
+  items,
+  loadingLabel,
+  errorLabel,
+  emptyLabel,
+  renderRow,
+}: RenderTableBodyArgs): ReactNode {
+  if (isLoading) {
+    return (
+      <tr>
+        <td colSpan={7} className="px-3 py-8 text-center text-muted-foreground">
+          {loadingLabel}
+        </td>
+      </tr>
+    );
+  }
+  if (isError) {
+    return (
+      <tr>
+        <td colSpan={7} className="px-3 py-8 text-center text-destructive">
+          <span role="alert">{errorLabel}</span>
+        </td>
+      </tr>
+    );
+  }
+  if (items.length === 0) {
+    return (
+      <tr>
+        <td colSpan={7} className="px-3 py-8 text-center text-muted-foreground">
+          {emptyLabel}
+        </td>
+      </tr>
+    );
+  }
+  return items.map(renderRow);
 }

--- a/packages/@granit/react-parties/src/components/MergeWizard.tsx
+++ b/packages/@granit/react-parties/src/components/MergeWizard.tsx
@@ -136,32 +136,22 @@ export function MergeWizard({
       {/* Conflicts */}
       <section data-slot="merge-conflicts" className="space-y-3">
         <h3 className="text-base font-semibold">{t('MergeWizard.Conflicts')}</h3>
-        {previewLoading ? (
-          <p className="text-sm text-muted-foreground">{t('MergeWizard.Loading')}</p>
-        ) : previewQuery.isError ? (
-          <p role="alert" className="text-sm text-destructive">
-            {t('MergeWizard.Errors.PreviewFailed')}
-          </p>
-        ) : conflicts.length === 0 ? (
-          <p className="text-sm text-muted-foreground">{t('MergeWizard.ConflictsEmpty')}</p>
-        ) : (
-          <ul className="space-y-2">
-            {conflicts.map((conflict) => (
-              <ConflictRow
-                key={conflict.fieldPath}
-                conflict={conflict}
-                selected={choices[conflict.fieldPath] ?? conflict.default}
-                onChange={handleChoiceChange}
-                survivorLabel={t('MergeWizard.Survivor')}
-                loserLabel={t('MergeWizard.Loser')}
-                emptyLabel={t('MergeWizard.ValueEmpty')}
-                fieldLabel={t(`MergeWizard.Fields.${conflict.fieldPath}`, {
-                  defaultValue: conflict.fieldPath,
-                })}
-              />
-            ))}
-          </ul>
-        )}
+        <ConflictsBody
+          isLoading={previewLoading}
+          isError={previewQuery.isError}
+          conflicts={conflicts}
+          choices={choices}
+          onChange={handleChoiceChange}
+          loadingLabel={t('MergeWizard.Loading')}
+          errorLabel={t('MergeWizard.Errors.PreviewFailed')}
+          emptyLabel={t('MergeWizard.ConflictsEmpty')}
+          survivorLabel={t('MergeWizard.Survivor')}
+          loserLabel={t('MergeWizard.Loser')}
+          valueEmptyLabel={t('MergeWizard.ValueEmpty')}
+          translateField={(fieldPath) =>
+            t(`MergeWizard.Fields.${fieldPath}`, { defaultValue: fieldPath })
+          }
+        />
       </section>
 
       {/* Rewrite counts */}
@@ -225,6 +215,66 @@ export function MergeWizard({
 }
 
 // ── Sub-components ─────────────────────────────────────────────────────────
+
+interface ConflictsBodyProps {
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly conflicts: readonly FieldConflictResponse[];
+  readonly choices: Readonly<Record<string, MergeWinner>>;
+  readonly onChange: (fieldPath: string, winner: MergeWinner) => void;
+  readonly loadingLabel: string;
+  readonly errorLabel: string;
+  readonly emptyLabel: string;
+  readonly survivorLabel: string;
+  readonly loserLabel: string;
+  readonly valueEmptyLabel: string;
+  readonly translateField: (fieldPath: string) => string;
+}
+
+function ConflictsBody({
+  isLoading,
+  isError,
+  conflicts,
+  choices,
+  onChange,
+  loadingLabel,
+  errorLabel,
+  emptyLabel,
+  survivorLabel,
+  loserLabel,
+  valueEmptyLabel,
+  translateField,
+}: Readonly<ConflictsBodyProps>) {
+  if (isLoading) {
+    return <p className="text-sm text-muted-foreground">{loadingLabel}</p>;
+  }
+  if (isError) {
+    return (
+      <p role="alert" className="text-sm text-destructive">
+        {errorLabel}
+      </p>
+    );
+  }
+  if (conflicts.length === 0) {
+    return <p className="text-sm text-muted-foreground">{emptyLabel}</p>;
+  }
+  return (
+    <ul className="space-y-2">
+      {conflicts.map((conflict) => (
+        <ConflictRow
+          key={conflict.fieldPath}
+          conflict={conflict}
+          selected={choices[conflict.fieldPath] ?? conflict.default}
+          onChange={onChange}
+          survivorLabel={survivorLabel}
+          loserLabel={loserLabel}
+          emptyLabel={valueEmptyLabel}
+          fieldLabel={translateField(conflict.fieldPath)}
+        />
+      ))}
+    </ul>
+  );
+}
 
 interface PartyCardProps {
   readonly variant: 'survivor' | 'loser';
@@ -360,6 +410,7 @@ function ChoiceRadio({
     <label
       data-slot="choice-radio"
       data-checked={checked || undefined}
+      aria-label={`${label}: ${displayValue}`}
       className="flex cursor-pointer items-start gap-2 rounded-md border bg-background p-2 text-sm has-checked:border-primary"
     >
       <input

--- a/packages/@granit/react-parties/src/hooks/use-parties.ts
+++ b/packages/@granit/react-parties/src/hooks/use-parties.ts
@@ -101,11 +101,13 @@ function useInvalidator() {
       queryClient.invalidateQueries({ queryKey: buildPartiesQueryKey(config, 'list') }),
     invalidateDetail: (id: PartyId) =>
       queryClient.invalidateQueries({ queryKey: buildPartiesQueryKey(config, 'detail', id) }),
-    invalidateAll: (id: PartyId) => {
-      void queryClient.invalidateQueries({ queryKey: buildPartiesQueryKey(config, 'list') });
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'detail', id),
-      });
+    invalidateAll: async (id: PartyId) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: buildPartiesQueryKey(config, 'list') }),
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'detail', id),
+        }),
+      ]);
     },
   };
 }
@@ -137,9 +139,7 @@ export function useCreatePartyMutation(): UseMutationResult<
   return useMutation({
     mutationFn: ({ request, options }: CreatePartyMutationVariables) =>
       createParty(config.client, basePath, request, options),
-    onSuccess: () => {
-      void invalidateList();
-    },
+    onSuccess: () => invalidateList(),
   });
 }
 

--- a/packages/@granit/react-parties/src/hooks/use-party-duplicates.ts
+++ b/packages/@granit/react-parties/src/hooks/use-party-duplicates.ts
@@ -25,8 +25,8 @@ function newIdempotencyKey(): string {
   if (typeof globalThis.crypto?.randomUUID === 'function') {
     return globalThis.crypto.randomUUID();
   }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replaceAll(/[xy]/g, (c) => {
+    const r = Math.trunc(Math.random() * 16);
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });
@@ -75,15 +75,14 @@ export function useDismissPartyDuplicateMutation(): UseMutationResult<
 
   return useMutation({
     mutationFn: ({ id }) => dismissPartyDuplicate(config.client, basePath, id),
-    onSuccess: () => {
-      // Covers both the per-party badge (`[parties, 'duplicates', 'for-party', …]`)
-      // and the inbox grid when its `<QueryProvider>` is configured with
-      // `queryKeyPrefix: ['parties', 'duplicates', 'inbox']` — the default
-      // <DuplicatesInbox> below wires that automatically.
-      void queryClient.invalidateQueries({
+    // Covers both the per-party badge (`[parties, 'duplicates', 'for-party', …]`)
+    // and the inbox grid when its `<QueryProvider>` is configured with
+    // `queryKeyPrefix: ['parties', 'duplicates', 'inbox']` — the default
+    // <DuplicatesInbox> below wires that automatically.
+    onSuccess: () =>
+      queryClient.invalidateQueries({
         queryKey: buildPartiesQueryKey(config, 'duplicates'),
-      });
-    },
+      }),
   });
 }
 
@@ -125,19 +124,21 @@ export function useMergePartyFromDuplicateMutation(): UseMutationResult<
         request,
         idempotencyKey ?? newIdempotencyKey()
       ),
-    onSuccess: (data, { request }) => {
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'duplicates'),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'list'),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'detail', request.survivorId),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'detail', data.loserId),
-      });
+    onSuccess: async (data, { request }) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'duplicates'),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'list'),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'detail', request.survivorId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'detail', data.loserId),
+        }),
+      ]);
     },
   });
 }

--- a/packages/@granit/react-parties/src/hooks/use-party-merge.ts
+++ b/packages/@granit/react-parties/src/hooks/use-party-merge.ts
@@ -15,8 +15,8 @@ function newIdempotencyKey(): string {
   if (typeof globalThis.crypto?.randomUUID === 'function') {
     return globalThis.crypto.randomUUID();
   }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replaceAll(/[xy]/g, (c) => {
+    const r = Math.trunc(Math.random() * 16);
     const v = c === 'x' ? r : (r & 0x3) | 0x8;
     return v.toString(16);
   });
@@ -90,22 +90,24 @@ export function useMergePartyMutation(
         request,
         idempotencyKey ?? newIdempotencyKey()
       ),
-    onSuccess: (_data, { request }) => {
+    onSuccess: async (_data, { request }) => {
       // Live merges only — dry-runs never commit so don't invalidate caches.
       if (request.dryRun) return;
 
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'list'),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'detail', survivorId),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'detail', request.loserId),
-      });
-      void queryClient.invalidateQueries({
-        queryKey: buildPartiesQueryKey(config, 'merge', 'preview', survivorId, request.loserId),
-      });
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'list'),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'detail', survivorId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'detail', request.loserId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: buildPartiesQueryKey(config, 'merge', 'preview', survivorId, request.loserId),
+        }),
+      ]);
     },
   });
 }


### PR DESCRIPTION
## Summary

Fixes the open Sonar code smells flagged on `@granit/data-lookup`, `@granit/parties`, and `@granit/react-parties`, and raises hook test coverage above 80% on every touched file.

### Sonar fixes

- **`lookup-client.ts`** — `stringifyLookupValue` now branches on primitive types explicitly (string / number / boolean / bigint), JSON for the rest. No more `String(unknown)` flagged with the default-stringification warning.
- **`parties/types.ts`** — `PartyRoles = PartyRole | string` was redundant. Simplified to `string` with a JSDoc note that the wire format is the comma-separated `[Flags]` serialization.
- **`DuplicatesInbox.tsx`** — extracted the nested ternary into a `renderTableBody` helper. Moved `role=""alert""` from the `<td>` (non-interactive cell) to a child `<span>` so the cell keeps its semantic role.
- **`MergeWizard.tsx`** — extracted the conflicts-section nested ternary into a `<ConflictsBody>` sub-component. Added `aria-label` on the `ChoiceRadio` `<label>` to satisfy the form-label-has-text rule (the inline span text was not enough for Sonar).
- **`use-parties.ts`, `use-party-duplicates.ts`, `use-party-merge.ts`** — replaced every `void queryClient.invalidateQueries(...)` with `await Promise.all([...])` (or direct return for single calls). React Query's `onSuccess` now actually waits for invalidation to settle before resolving — same effect, no `void`-operator smell.
- **UUID fallback (both `use-party-*.ts`)** — `replace` → `replaceAll`, `(Math.random() * 16) | 0` → `Math.trunc(Math.random() * 16)`.

### Coverage

| File | Before | After |
| --- | --- | --- |
| `lookup-client.ts` | 96.15% | 96.15% |
| `use-parties.ts` | **55.28%** | **99.18%** |
| `use-party-duplicates.ts` | 81.81% (50% br) | 100% |
| `use-party-merge.ts` | **77.77%** | 100% |
| `DuplicatesInbox.tsx` | 90% | 90% |
| `MergeWizard.tsx` | 88.73% | 88.73% |
| **3-package aggregate** | — | **95.79% lines / 86.04% branches** |

11 new tests covering the previously-uncovered party sub-resource mutations (email / phone / address / role / external-mapping) and the `crypto.randomUUID`-unavailable fallback in both merge hooks.

## Test plan
- [x] `pnpm vitest run packages/@granit/data-lookup packages/@granit/parties packages/@granit/react-parties` — 117 tests pass
- [x] `pnpm tsc` — full repo typecheck clean
- [x] ESLint — clean on all modified files
- [x] Coverage above 80% on every touched file