### PR TITLE
feat(react-entities): infinite scroll for entity gallery

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
@@ -5,7 +5,7 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import axios from 'axios';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EntityGallery } from '../components/entity-gallery.js';
 
@@ -15,51 +15,108 @@ import type { ReactNode } from 'react';
 const BASE_PATH = '/api/v1/parties';
 const ENTITY_NAME = 'Granit.Parties.Party';
 
-const META = {
-  columns: [
-    {
-      name: 'name',
-      label: 'Name',
-      type: 'String',
-      order: 0,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-  ],
-  filterableFields: [],
-  sortableFields: [],
-  presetFilterGroups: [],
-  quickFilters: [],
-  dateFilters: [],
-  groupByFields: [],
-  pagination: {
-    defaultPageSize: 20,
-    maxPageSize: 100,
-    maxStreamSize: 10000,
-    supportsCursor: false,
-  },
-};
+// ---------------------------------------------------------------------------
+// IntersectionObserver mock — drives the auto-fetch sentinel deterministically.
+// ---------------------------------------------------------------------------
 
-const PAGE = {
-  items: [
-    {
-      id: '8c6b1e10-0000-4000-8000-000000000001',
-      name: 'ACME Corp',
-      kind: 'Customer',
-      avatarBlobId: 'parties/avatars/acme.jpg',
-    },
-    {
-      id: '8c6b1e10-0000-4000-8000-000000000002',
-      name: 'Globex',
-      kind: 'Customer',
-      avatarBlobId: null,
-    },
-  ],
-  totalCount: 2,
-  page: 1,
-  pageSize: 20,
-};
+interface FakeObserver {
+  readonly observed: Element[];
+  trigger(intersecting?: boolean): void;
+}
+
+const observers: FakeObserver[] = [];
+
+class MockIntersectionObserver implements FakeObserver {
+  readonly observed: Element[] = [];
+  constructor(private readonly cb: IntersectionObserverCallback) {
+    observers.push(this);
+  }
+  observe(node: Element): void {
+    this.observed.push(node);
+  }
+  unobserve(node: Element): void {
+    const idx = this.observed.indexOf(node);
+    if (idx >= 0) this.observed.splice(idx, 1);
+  }
+  disconnect(): void {
+    this.observed.length = 0;
+    const idx = observers.indexOf(this);
+    if (idx >= 0) observers.splice(idx, 1);
+  }
+  takeRecords(): IntersectionObserverEntry[] {
+    return [];
+  }
+  trigger(intersecting = true): void {
+    const entries = this.observed.map(
+      (target) =>
+        ({
+          target,
+          isIntersecting: intersecting,
+          intersectionRatio: intersecting ? 1 : 0,
+          time: Date.now(),
+          rootBounds: null,
+          boundingClientRect: target.getBoundingClientRect(),
+          intersectionRect: target.getBoundingClientRect(),
+        }) as IntersectionObserverEntry
+    );
+    this.cb(entries, this as unknown as IntersectionObserver);
+  }
+}
+
+beforeAll(() => {
+  vi.stubGlobal('IntersectionObserver', MockIntersectionObserver);
+});
+beforeEach(() => {
+  observers.length = 0;
+});
+
+function triggerLastObserver(intersecting = true): void {
+  const last = observers[observers.length - 1];
+  if (last) last.trigger(intersecting);
+}
+
+// ---------------------------------------------------------------------------
+// Server fixtures
+// ---------------------------------------------------------------------------
+
+interface PartyRow {
+  readonly id: string;
+  readonly name: string;
+  readonly kind: string;
+  readonly avatarBlobId: string | null;
+}
+
+function makeParty(idx: number): PartyRow {
+  return {
+    id: `00000000-0000-4000-8000-${String(idx).padStart(12, '0')}`,
+    name: `Party ${idx}`,
+    kind: idx % 2 === 0 ? 'Customer' : 'Supplier',
+    avatarBlobId: idx % 3 === 0 ? null : `parties/avatars/p${idx}.jpg`,
+  };
+}
+
+function pageHandler(items: PartyRow[], opts: { hasMoreOnPage1?: boolean } = {}) {
+  const hasMoreOnPage1 = opts.hasMoreOnPage1 ?? false;
+  return http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
+    const url = new URL(request.url);
+    const page = Number(url.searchParams.get('page') ?? '1');
+    const pageSize = Number(url.searchParams.get('pageSize') ?? '50');
+    const start = (page - 1) * pageSize;
+    const slice = items.slice(start, start + pageSize);
+    const hasMore = start + slice.length < items.length;
+    return HttpResponse.json({
+      items: slice,
+      totalCount: items.length,
+      hasMore: page === 1 && hasMoreOnPage1 ? true : hasMore,
+    });
+  });
+}
+
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
 
 function manifest(
   options: {
@@ -114,19 +171,6 @@ function manifest(
   };
 }
 
-function freshHandlers() {
-  return [
-    http.get(`http://localhost${BASE_PATH}/meta`, () => HttpResponse.json(META)),
-    http.get(`http://localhost${BASE_PATH}`, () => HttpResponse.json(PAGE)),
-  ];
-}
-
-const server = setupServer(...freshHandlers());
-
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => server.resetHandlers(...freshHandlers()));
-afterAll(() => server.close());
-
 function makeWrapper() {
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   const apiClient = axios.create({ baseURL: 'http://localhost' });
@@ -163,6 +207,7 @@ describe('EntityGallery', () => {
   });
 
   it('exposes card-size + entity name as data attributes on the root', async () => {
+    server.use(pageHandler([makeParty(1)]));
     const { wrapper: Wrapper } = makeWrapper();
     const { container } = render(
       <Wrapper>
@@ -178,6 +223,7 @@ describe('EntityGallery', () => {
   });
 
   it('renders one card per row with image-blob-id, title and subtitle slots', async () => {
+    server.use(pageHandler([makeParty(1), makeParty(2)]));
     const { wrapper: Wrapper } = makeWrapper();
     const { container } = render(
       <Wrapper>
@@ -187,15 +233,16 @@ describe('EntityGallery', () => {
     await waitFor(() =>
       expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
     );
-    const acme = container.querySelector(
-      '[data-row-id="8c6b1e10-0000-4000-8000-000000000001"]'
-    ) as HTMLElement;
-    expect(acme.getAttribute('data-image-blob-id')).toBe('parties/avatars/acme.jpg');
-    expect(acme.querySelector('[data-granit-gallery-card-title]')?.textContent).toBe('ACME Corp');
-    expect(acme.querySelector('[data-granit-gallery-card-subtitle]')?.textContent).toBe('Customer');
+    const first = container.querySelector(`[data-row-id="${makeParty(1).id}"]`) as HTMLElement;
+    expect(first.getAttribute('data-image-blob-id')).toBe('parties/avatars/p1.jpg');
+    expect(first.querySelector('[data-granit-gallery-card-title]')?.textContent).toBe('Party 1');
+    expect(first.querySelector('[data-granit-gallery-card-subtitle]')?.textContent).toBe(
+      'Supplier'
+    );
   });
 
   it('omits data-image-blob-id when the row has no blob reference', async () => {
+    server.use(pageHandler([makeParty(3)])); // idx 3 → avatarBlobId null
     const { wrapper: Wrapper } = makeWrapper();
     const { container } = render(
       <Wrapper>
@@ -203,17 +250,15 @@ describe('EntityGallery', () => {
       </Wrapper>
     );
     await waitFor(() =>
-      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
     );
-    const globex = container.querySelector(
-      '[data-row-id="8c6b1e10-0000-4000-8000-000000000002"]'
-    ) as HTMLElement;
-    expect(globex.hasAttribute('data-image-blob-id')).toBe(false);
+    const card = container.querySelector('[data-granit-gallery-card]') as HTMLElement;
+    expect(card.hasAttribute('data-image-blob-id')).toBe(false);
   });
 
   it('falls back to identity.displayProperty when titlePropertyName is null', async () => {
+    server.use(pageHandler([makeParty(1)]));
     const m = manifest();
-    // mutate the layout to drop the title pointer
     (
       m.collections!.listLayouts[0].gallery as { titlePropertyName: string | null }
     ).titlePropertyName = null;
@@ -226,14 +271,13 @@ describe('EntityGallery', () => {
     await waitFor(() =>
       expect(container.querySelector('[data-granit-gallery-card-title]')).not.toBeNull()
     );
-    // identity.displayProperty === 'name', so first card shows ACME Corp.
-    const titles = Array.from(container.querySelectorAll('[data-granit-gallery-card-title]')).map(
-      (n) => n.textContent
+    expect(container.querySelector('[data-granit-gallery-card-title]')?.textContent).toBe(
+      'Party 1'
     );
-    expect(titles).toEqual(['ACME Corp', 'Globex']);
   });
 
   it('omits the subtitle slot when subtitlePropertyName is null', async () => {
+    server.use(pageHandler([makeParty(1)]));
     const m = manifest();
     (
       m.collections!.listLayouts[0].gallery as { subtitlePropertyName: string | null }
@@ -251,6 +295,7 @@ describe('EntityGallery', () => {
   });
 
   it('emits a loading marker before the response lands', () => {
+    server.use(pageHandler([makeParty(1)]));
     const { wrapper: Wrapper } = makeWrapper();
     const { container } = render(
       <Wrapper>
@@ -281,6 +326,7 @@ describe('EntityGallery', () => {
   });
 
   it('invokes onCardClick with the full row object', async () => {
+    server.use(pageHandler([makeParty(1)]));
     const onCardClick = vi.fn();
     const { wrapper: Wrapper } = makeWrapper();
     const { container } = render(
@@ -291,16 +337,15 @@ describe('EntityGallery', () => {
     await waitFor(() =>
       expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
     );
-    const acme = container.querySelector(
-      '[data-row-id="8c6b1e10-0000-4000-8000-000000000001"]'
-    ) as HTMLElement;
-    fireEvent.click(acme);
+    const card = container.querySelector('[data-granit-gallery-card]') as HTMLElement;
+    fireEvent.click(card);
     expect(onCardClick).toHaveBeenCalledWith(
-      expect.objectContaining({ id: '8c6b1e10-0000-4000-8000-000000000001', name: 'ACME Corp' })
+      expect.objectContaining({ id: makeParty(1).id, name: 'Party 1' })
     );
   });
 
   it('uses an explicit layout prop over the manifest auto-pick', async () => {
+    server.use(pageHandler([makeParty(1)]));
     const { wrapper: Wrapper } = makeWrapper();
     const m = manifest({ hasGallery: false });
     const { container } = render(
@@ -321,5 +366,47 @@ describe('EntityGallery', () => {
     );
     const root = container.querySelector('[data-granit-entity-gallery]') as HTMLElement;
     expect(root.getAttribute('data-card-size')).toBe('Small');
+  });
+
+  it('renders a sentinel marked exhausted when the first page returns every item', async () => {
+    server.use(pageHandler([makeParty(1), makeParty(2)]));
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-sentinel]')).not.toBeNull()
+    );
+    const sentinel = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(sentinel.hasAttribute('data-exhausted')).toBe(true);
+    expect(sentinel.hasAttribute('data-fetching')).toBe(false);
+  });
+
+  it('fetches the next page when the sentinel intersects the viewport', async () => {
+    // 60 rows ⇒ 2 pages of 50 + 10
+    const rows = Array.from({ length: 60 }, (_, i) => makeParty(i + 1));
+    server.use(pageHandler(rows));
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} />
+      </Wrapper>
+    );
+    // First page (50 rows) lands.
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(50)
+    );
+    const sentinelBefore = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(sentinelBefore.hasAttribute('data-exhausted')).toBe(false);
+
+    // Trigger the IntersectionObserver — second page should fetch and append.
+    triggerLastObserver(true);
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(60)
+    );
+    const sentinelAfter = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
+    expect(sentinelAfter.hasAttribute('data-exhausted')).toBe(true);
   });
 });

--- a/packages/@granit/react-entities/src/components/entity-gallery.tsx
+++ b/packages/@granit/react-entities/src/components/entity-gallery.tsx
@@ -1,7 +1,10 @@
-import { useQueryEndpoint } from '@granit/react-query-engine';
-import { useMemo, type ReactNode } from 'react';
+import { getPage } from '@granit/query-engine';
+import { useQueryConfig } from '@granit/react-query-engine';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 
 import type { EntityGalleryLayoutManifest, EntityManifestResponse } from '@granit/entities';
+import type { PagedResult } from '@granit/query-engine';
 
 export interface EntityGalleryProps {
   /** The entity manifest (typically from `useEntityMetadata`). */
@@ -13,17 +16,26 @@ export interface EntityGalleryProps {
    * declares multiple galleries (reserved for a future kind today).
    */
   readonly layout?: EntityGalleryLayoutManifest;
+  /**
+   * Items per page fetched from the server. Defaults to 50 — higher than
+   * the standard list pageSize so each scroll batch covers a meaningful
+   * viewport without thrashing the API. The server caps via the
+   * `Pagination.MaxPageSize` limit declared by the entity's
+   * `QueryDefinition`.
+   */
+  readonly pageSize?: number;
   /** Optional card activation handler — receives the full row object. */
   readonly onCardClick?: (row: Readonly<Record<string, unknown>>) => void;
   /** Optional class for the root element. */
   readonly className?: string;
 }
 
+const DEFAULT_PAGE_SIZE = 50;
+
 /**
  * Generic read-only image-card grid renderer. Bridges the entity manifest's
- * gallery layout to the host's ambient `<QueryProvider>`, fetches a page of
- * rows via `useQueryEndpoint`, and surfaces each row as a card slot the
- * host styles via CSS Grid:
+ * gallery layout to the host's ambient `<QueryProvider>` and paginates via
+ * `useInfiniteQuery` + an `IntersectionObserver` sentinel:
  *
  * ```html
  * <div data-granit-entity-gallery data-entity="…" data-card-size="Medium">
@@ -34,27 +46,36 @@ export interface EntityGalleryProps {
  *       <span data-granit-gallery-card-title>ACME Corp</span>
  *       <span data-granit-gallery-card-subtitle>Customer</span>
  *     </li>
+ *     …
+ *     <li data-granit-gallery-sentinel
+ *         data-fetching=""
+ *         data-exhausted="" />
  *   </ol>
  * </div>
  * ```
  *
- * The framework does **not** mount `<img>` tags directly — `BlobReference`
- * properties are opaque IDs the host resolves through its own blob-storage
- * URL scheme (auth, presigning, CDN). Apps wrap the `data-image-blob-id`
- * attribute with their own `<BlobImage />` component (see
- * `@granit/react-blob-storage`). The renderer surfaces the ID; the host
- * decides how to resolve it.
+ * The sentinel is the last child of the cards list. When it scrolls into
+ * view it calls `fetchNextPage()`, append the new items, and re-arm itself
+ * for the next scroll. Once `hasNextPage` flips to `false` the sentinel
+ * gains `data-exhausted` so apps can render their own end-of-list marker
+ * (or rely on the absence of further reflow).
  *
- * Title and subtitle are projected from the layout's `titlePropertyName`
+ * The framework deliberately does **not** mount `<img>` tags directly —
+ * `BlobReference` properties are opaque IDs the host resolves through its
+ * own blob-storage URL scheme (auth, presigning, CDN). Apps wrap the
+ * `data-image-blob-id` attribute with their own `<BlobImage />` (see
+ * `@granit/react-blob-storage`).
+ *
+ * Title and subtitle project from the layout's `titlePropertyName`
  * (falling back to `manifest.identity.displayProperty`) and
- * `subtitlePropertyName`. Loading / error / empty states surface as
- * dedicated data attributes (`data-granit-gallery-loading`, `…-error`,
- * `…-empty`) so apps render their own placeholders without inspecting
- * React state.
+ * `subtitlePropertyName`. Loading / error / empty surface as dedicated
+ * data attributes so apps render their own placeholders without
+ * inspecting React state.
  */
 export function EntityGallery({
   manifest,
   layout,
+  pageSize = DEFAULT_PAGE_SIZE,
   onCardClick,
   className,
 }: EntityGalleryProps): ReactNode {
@@ -81,6 +102,7 @@ export function EntityGallery({
       <EntityGalleryBody
         layout={resolvedLayout}
         titleFallback={manifest.identity?.displayProperty}
+        pageSize={pageSize}
         onCardClick={onCardClick}
       />
     </div>
@@ -90,16 +112,50 @@ export function EntityGallery({
 interface EntityGalleryBodyProps {
   readonly layout: EntityGalleryLayoutManifest;
   readonly titleFallback: string | null | undefined;
+  readonly pageSize: number;
   readonly onCardClick: ((row: Readonly<Record<string, unknown>>) => void) | undefined;
 }
 
 function EntityGalleryBody({
   layout,
   titleFallback,
+  pageSize,
   onCardClick,
 }: EntityGalleryBodyProps): ReactNode {
-  const { query } = useQueryEndpoint<Readonly<Record<string, unknown>>>();
-  const items = query.data?.items ?? [];
+  const config = useQueryConfig();
+  const sentinelRef = useRef<HTMLLIElement | null>(null);
+
+  const query = useInfiniteQuery({
+    queryKey: ['granit', 'entity-gallery', config.basePath, pageSize] as const,
+    queryFn: ({ pageParam }) =>
+      getPage<Readonly<Record<string, unknown>>>(config.client, config.basePath, {
+        page: pageParam,
+        pageSize,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: nextPageParam,
+  });
+
+  const items = useMemo(() => flattenPages(query.data?.pages), [query.data]);
+  const exhausted = !query.hasNextPage && !query.isLoading;
+
+  useEffect(() => {
+    const node = sentinelRef.current;
+    if (!node) return;
+    if (!query.hasNextPage || query.isFetchingNextPage) return;
+    if (typeof IntersectionObserver === 'undefined') return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          void query.fetchNextPage();
+        }
+      },
+      { rootMargin: '256px' }
+    );
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [query.hasNextPage, query.isFetchingNextPage, query.fetchNextPage, items.length]);
 
   if (query.isError) {
     return (
@@ -129,6 +185,13 @@ function EntityGalleryBody({
           onCardClick={onCardClick}
         />
       ))}
+      <li
+        ref={sentinelRef}
+        data-granit-gallery-sentinel=""
+        data-fetching={query.isFetchingNextPage ? '' : undefined}
+        data-exhausted={exhausted ? '' : undefined}
+        aria-hidden="true"
+      />
     </ol>
   );
 }
@@ -175,6 +238,38 @@ function pickGalleryLayout(manifest: EntityManifestResponse): EntityGalleryLayou
     }
   }
   return null;
+}
+
+/**
+ * Decides whether to fetch another page. Honours `hasMore` when the server
+ * sets it (preferred — works with both keyset and offset paging). Falls
+ * back to comparing `items.length` against `totalCount` for hosts that
+ * don't surface `hasMore` yet.
+ */
+function nextPageParam(
+  last: PagedResult<Readonly<Record<string, unknown>>>,
+  pages: readonly PagedResult<Readonly<Record<string, unknown>>>[]
+): number | undefined {
+  if (last.hasMore !== undefined) {
+    return last.hasMore ? pages.length + 1 : undefined;
+  }
+  if (last.totalCount !== null) {
+    const fetched = pages.reduce((sum, page) => sum + page.items.length, 0);
+    return fetched < last.totalCount ? pages.length + 1 : undefined;
+  }
+  // No bound — stop after one page rather than loop forever on a buggy server.
+  return undefined;
+}
+
+function flattenPages(
+  pages: readonly PagedResult<Readonly<Record<string, unknown>>>[] | undefined
+): readonly Readonly<Record<string, unknown>>[] {
+  if (!pages) return [];
+  const out: Readonly<Record<string, unknown>>[] = [];
+  for (const page of pages) {
+    out.push(...page.items);
+  }
+  return out;
 }
 
 function readScalar(value: unknown): string | null {


### PR DESCRIPTION
## Summary

Replaces the first-page-only fetch in `<EntityGallery />` with an infinite-scroll loader. Required because Gallery is the natural list view for entities like Party where tenants routinely have hundreds of rows; capping at the first page made the renderer effectively unusable beyond toy datasets.

The change is internal to `<EntityGallery />` — public prop API stays compatible (one new optional `pageSize` prop, default 50). Showcase wiring shipped under granit-fx/granit-showcase-admin-react#79 doesn't need to change.

## Implementation

- Switches the body from `useQueryEndpoint` to `useInfiniteQuery`, reading basePath + axios client straight from the ambient `<QueryProvider>` config.
- New `pageSize` prop, defaults to 50 — higher than the standard list pageSize so each scroll batch covers a meaningful viewport without thrashing the API. The server caps via `Pagination.MaxPageSize` declared by the entity's `QueryDefinition`.
- Sentinel `<li data-granit-gallery-sentinel>` rendered as the last child of the cards list. An `IntersectionObserver` (256px rootMargin) calls `fetchNextPage()` when the sentinel scrolls into view.
- Sentinel surfaces its state via:
  - `data-fetching` — present while the next page is in-flight
  - `data-exhausted` — present once every page has been fetched
  
  Apps render their own end-of-list / spinner placeholders against those attributes — no React state inspection.
- `getNextPageParam` honours the server's `hasMore` flag when set, falls back to `items.length < totalCount` otherwise; returns `undefined` on unbounded servers so we don't loop forever on a buggy API.

## DOM scaffold

\`\`\`html
<div data-granit-entity-gallery data-entity="…" data-card-size="Medium">
  <ol data-granit-gallery-cards>
    <li data-granit-gallery-card data-row-id data-image-blob-id>…</li>
    <li data-granit-gallery-card data-row-id data-image-blob-id>…</li>
    …
    <li data-granit-gallery-sentinel data-fetching></li>  <!-- or data-exhausted once done -->
  </ol>
</div>
\`\`\`

## Tests

- Added IntersectionObserver mock that exposes `trigger()` to fire the callback deterministically in jsdom (jsdom doesn't ship the API).
- New test covers exhausted-after-first-page case (sentinel marked `data-exhausted` when `totalCount` fits in one page).
- New test paginates 60 rows across 2 pages of 50 + 10 and verifies the second page lands after firing the observer.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm exec vitest run packages/@granit/entities packages/@granit/react-entities\` — 21 files, 166 tests, all passing (was 164 — +2 sentinel cases)