### PR TITLE
feat(react-query-engine,react-entities): list-alt renderers honor ambient query state

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2766,12 +2766,12 @@
         {
           "name": "entityCalendarQueryKey",
           "kind": "function",
-          "signature": "function entityCalendarQueryKey( entityName: string, from: string, to: string, calendar?: string | null ): readonly ['entities', 'calendar', string, string, string, string | null]"
+          "signature": "function entityCalendarQueryKey( entityName: string, from: string, to: string, calendar?: string | null, filters?: readonly FilterEntry[], search?: string ): readonly ["
         },
         {
           "name": "useEntityCalendar",
           "kind": "function",
-          "signature": "function useEntityCalendar( entityName: string, from: string, to: string, options:"
+          "signature": "function useEntityCalendar( entityName: string, from: string, to: string, options: UseEntityCalendarOptions ="
         },
         {
           "name": "entityDiscoveryQueryKey",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3604,6 +3604,12 @@
           "members": []
         },
         {
+          "name": "QueryEndpointStateProviderProps",
+          "kind": "interface",
+          "signature": "interface QueryEndpointStateProviderProps",
+          "members": []
+        },
+        {
           "name": "useInfiniteScroll",
           "kind": "function",
           "signature": "function useInfiniteScroll<T, P extends InfiniteScrollPage<T> = InfiniteScrollPage<T>>( options: UseInfiniteScrollOptions<T, P> ): UseInfiniteScrollReturn<T>"

--- a/packages/@granit/entities/src/types/layouts.ts
+++ b/packages/@granit/entities/src/types/layouts.ts
@@ -76,6 +76,13 @@ export interface EntityGalleryLayoutManifest {
   readonly titlePropertyName: string | null;
   /** Optional secondary line under the title, or `null` for none. */
   readonly subtitlePropertyName: string | null;
+  /**
+   * Optional categorical property used to bucket cards into sections.
+   * `null` for a flat grid. When set, the renderer threads `groupBy` into
+   * the underlying query so the server returns grouped buckets and the
+   * grid paints one section per distinct value.
+   */
+  readonly groupByPropertyName: string | null;
   /** Card size — drives CSS-grid track sizing in the renderer. */
   readonly cardSize: GalleryCardSize;
 }

--- a/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
@@ -1,5 +1,5 @@
 import { GranitClientProvider } from '@granit/react-api-client';
-import { QueryProvider } from '@granit/react-query-engine';
+import { QueryEndpointStateProvider, QueryProvider } from '@granit/react-query-engine';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import axios from 'axios';
@@ -95,10 +95,17 @@ function makeParty(idx: number): PartyRow {
   };
 }
 
+let lastQuery: Record<string, string> | null = null;
+
+beforeEach(() => {
+  lastQuery = null;
+});
+
 function pageHandler(items: PartyRow[], opts: { hasMoreOnPage1?: boolean } = {}) {
   const hasMoreOnPage1 = opts.hasMoreOnPage1 ?? false;
   return http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
     const url = new URL(request.url);
+    lastQuery = Object.fromEntries(url.searchParams.entries());
     const page = Number(url.searchParams.get('page') ?? '1');
     const pageSize = Number(url.searchParams.get('pageSize') ?? '50');
     const start = (page - 1) * pageSize;
@@ -160,6 +167,7 @@ function manifest(
                     imagePropertyName: 'avatarBlobId',
                     titlePropertyName: 'name',
                     subtitlePropertyName: 'kind',
+                    groupByPropertyName: null,
                     cardSize,
                   },
                 },
@@ -356,6 +364,7 @@ describe('EntityGallery', () => {
             imagePropertyName: 'avatarBlobId',
             titlePropertyName: 'name',
             subtitlePropertyName: null,
+            groupByPropertyName: null,
             cardSize: 'Small',
           }}
         />
@@ -408,5 +417,78 @@ describe('EntityGallery', () => {
     );
     const sentinelAfter = container.querySelector('[data-granit-gallery-sentinel]') as HTMLElement;
     expect(sentinelAfter.hasAttribute('data-exhausted')).toBe(true);
+  });
+
+  it('threads ambient filter / search / sort from QueryEndpointStateProvider into the request', async () => {
+    server.use(pageHandler([makeParty(1)]));
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const apiClient = axios.create({ baseURL: 'http://localhost' });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <QueryProvider config={{ basePath: BASE_PATH }}>
+            <QueryEndpointStateProvider
+              initialParams={{
+                page: 1,
+                pageSize: 20,
+                search: 'acme',
+                filters: [{ field: 'kind', operator: 'eq', value: 'Customer' }],
+                sort: [{ field: 'name', direction: 'asc' }],
+              }}
+            >
+              {children}
+            </QueryEndpointStateProvider>
+          </QueryProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+    const { container } = render(
+      <>
+        <EntityGallery manifest={manifest()} />
+      </>,
+      { wrapper }
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    expect(lastQuery?.search).toBe('acme');
+    expect(lastQuery?.sort).toContain('name');
+    // Filter encoded — the query-engine's serializer puts it under `filter`.
+    expect(JSON.stringify(lastQuery)).toContain('Customer');
+    // Gallery's own pageSize override (default 50) wins over the provider's 20.
+    expect(lastQuery?.pageSize).toBe('50');
+  });
+
+  it('falls back to plain pagination when no QueryEndpointStateProvider is mounted', async () => {
+    server.use(pageHandler([makeParty(1)]));
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    expect(lastQuery?.search).toBeUndefined();
+    expect(lastQuery?.pageSize).toBe('50');
+    expect(lastQuery?.page).toBe('1');
+  });
+
+  it('threads layout.groupByPropertyName as groupBy on every page request', async () => {
+    server.use(pageHandler([makeParty(1)]));
+    const m = manifest();
+    (
+      m.collections!.listLayouts[0].gallery as { groupByPropertyName: string | null }
+    ).groupByPropertyName = 'kind';
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={m} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(lastQuery).not.toBeNull());
+    expect(lastQuery?.groupBy).toBe('kind');
+    expect(container.querySelector('[data-granit-entity-gallery]')).not.toBeNull();
   });
 });

--- a/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
@@ -1,5 +1,5 @@
 import { GranitClientProvider } from '@granit/react-api-client';
-import { QueryProvider } from '@granit/react-query-engine';
+import { QueryEndpointStateProvider, QueryProvider } from '@granit/react-query-engine';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, waitFor } from '@testing-library/react';
 import axios from 'axios';
@@ -85,17 +85,26 @@ function manifest(hasQuery: boolean): EntityManifestResponse {
   };
 }
 
+let lastQuery: Record<string, string> | null = null;
+
 function freshHandlers() {
   return [
     http.get(`http://localhost${BASE_PATH}/meta`, () => HttpResponse.json(META)),
-    http.get(`http://localhost${BASE_PATH}`, () => HttpResponse.json(PAGE)),
+    http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
+      const url = new URL(request.url);
+      lastQuery = Object.fromEntries(url.searchParams.entries());
+      return HttpResponse.json(PAGE);
+    }),
   ];
 }
 
 const server = setupServer(...freshHandlers());
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => server.resetHandlers(...freshHandlers()));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastQuery = null;
+});
 afterAll(() => server.close());
 
 function makeWrapper() {
@@ -207,5 +216,72 @@ describe('EntityKanban', () => {
     await waitFor(() =>
       expect(container.querySelector('[data-granit-entity-kanban-error]')).not.toBeNull()
     );
+  });
+
+  it('strips ambient params.groupBy before fetching (layout-locked per matrix)', async () => {
+    // Wrap with a QueryEndpointStateProvider that sets groupBy='status' (a
+    // List-view toolbar might do that). Kanban must ignore it so the server
+    // returns flat rows that the renderer can bucket client-side.
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const apiClient = axios.create({ baseURL: 'http://localhost' });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <QueryProvider config={{ basePath: BASE_PATH }}>
+            <QueryEndpointStateProvider
+              initialParams={{ page: 1, pageSize: 20, groupBy: 'status' }}
+            >
+              <EntityRendererProvider>{children}</EntityRendererProvider>
+            </QueryEndpointStateProvider>
+          </QueryProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+    const { container } = render(
+      <>
+        <EntityKanban manifest={manifest(true)} groupBy="status" />
+      </>,
+      { wrapper }
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-kanban-card]')).not.toBeNull()
+    );
+    expect(lastQuery?.groupBy).toBeUndefined();
+  });
+
+  it('forwards ambient filter / search / sort from QueryEndpointStateProvider', async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const apiClient = axios.create({ baseURL: 'http://localhost' });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <QueryProvider config={{ basePath: BASE_PATH }}>
+            <QueryEndpointStateProvider
+              initialParams={{
+                page: 1,
+                pageSize: 20,
+                search: 'acme',
+                filters: [{ field: 'status', operator: 'eq', value: 'Active' }],
+                sort: [{ field: 'name', direction: 'asc' }],
+              }}
+            >
+              <EntityRendererProvider>{children}</EntityRendererProvider>
+            </QueryEndpointStateProvider>
+          </QueryProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+    const { container } = render(
+      <>
+        <EntityKanban manifest={manifest(true)} groupBy="status" />
+      </>,
+      { wrapper }
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-kanban-card]')).not.toBeNull()
+    );
+    expect(lastQuery?.search).toBe('acme');
+    expect(lastQuery?.sort).toContain('name');
+    expect(JSON.stringify(lastQuery)).toContain('Active');
   });
 });

--- a/packages/@granit/react-entities/src/__tests__/use-entity-calendar.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-calendar.test.tsx
@@ -137,4 +137,39 @@ describe('useEntityCalendar', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual([]);
   });
+
+  it('forwards filters as filter[field.op]=value query params', async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(
+      () =>
+        useEntityCalendar(ENTITY, FROM, TO, {
+          filters: [
+            { field: 'status', operator: 'eq', value: 'Active' },
+            { field: 'kind', operator: 'eq', value: 'Customer' },
+          ],
+        }),
+      { wrapper }
+    );
+    await waitFor(() => expect(lastQuery).not.toBeNull());
+    expect(lastQuery?.['filter[status.eq]']).toBe('Active');
+    expect(lastQuery?.['filter[kind.eq]']).toBe('Customer');
+  });
+
+  it('forwards search as a top-level query param', async () => {
+    const { wrapper } = makeWrapper();
+    renderHook(() => useEntityCalendar(ENTITY, FROM, TO, { search: 'acme' }), { wrapper });
+    await waitFor(() => expect(lastQuery).not.toBeNull());
+    expect(lastQuery?.search).toBe('acme');
+  });
+
+  it('uses different cache slots when filters or search change', () => {
+    const a = entityCalendarQueryKey(ENTITY, FROM, TO);
+    const b = entityCalendarQueryKey(ENTITY, FROM, TO, null, [
+      { field: 'status', operator: 'eq', value: 'Active' },
+    ]);
+    const c = entityCalendarQueryKey(ENTITY, FROM, TO, null, undefined, 'acme');
+    expect(a).not.toEqual(b);
+    expect(a).not.toEqual(c);
+    expect(b).not.toEqual(c);
+  });
 });

--- a/packages/@granit/react-entities/src/api/use-entity-calendar.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-calendar.ts
@@ -2,59 +2,129 @@ import { useGranitClient } from '@granit/react-api-client';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import type { CalendarItemResponse } from '@granit/entities';
+import type { FilterEntry } from '@granit/query-engine';
 
 /**
  * Cache key for one calendar range query. Keyed by
- * `(entityName, from, to, calendar)` so distinct windows or
- * named-calendar selections don't collide. Calling
+ * `(entityName, from, to, calendar, filtersKey, search)` so distinct
+ * windows, named-calendar selections, or filter / search criteria
+ * don't collide. Calling
  * `queryClient.invalidateQueries({ queryKey: ['entities', 'calendar', entityName] })`
- * blasts every cached window for one entity, which is what apps typically
- * want after a relevant mutation.
+ * blasts every cached window for one entity, which is what apps
+ * typically want after a relevant mutation.
  */
 export function entityCalendarQueryKey(
   entityName: string,
   from: string,
   to: string,
-  calendar?: string | null
-): readonly ['entities', 'calendar', string, string, string, string | null] {
-  return ['entities', 'calendar', entityName, from, to, calendar ?? null] as const;
+  calendar?: string | null,
+  filters?: readonly FilterEntry[],
+  search?: string
+): readonly [
+  'entities',
+  'calendar',
+  string,
+  string,
+  string,
+  string | null,
+  string | null,
+  string | null,
+] {
+  const filtersKey =
+    filters && filters.length > 0
+      ? [...filters]
+          .map((f) => `${f.field}.${f.operator}=${f.value}`)
+          .sort()
+          .join('&')
+      : null;
+  return [
+    'entities',
+    'calendar',
+    entityName,
+    from,
+    to,
+    calendar ?? null,
+    filtersKey,
+    search ?? null,
+  ] as const;
+}
+
+export interface UseEntityCalendarOptions {
+  /**
+   * Optional name selector when the entity declares more than one
+   * calendar layout. Reserved for future kinds — leaving `null`
+   * always picks the entity's single calendar today.
+   */
+  readonly calendar?: string | null;
+  readonly enabled?: boolean;
+  /**
+   * Filter entries forwarded as `filter[field.op]=value` query params.
+   * Filters narrow the events surfaced inside the visible window;
+   * the time bounds remain owned by `from` / `to`. Per the Phase 1.5
+   * matrix, the calendar endpoint accepts the same filter wire shape
+   * as the standard list endpoint.
+   */
+  readonly filters?: readonly FilterEntry[];
+  /**
+   * Free-text search forwarded as `search=…`. Same role as `filters`
+   * — narrows the events inside the visible window.
+   */
+  readonly search?: string;
 }
 
 /**
- * `GET /entities/{name}/calendar?from=&to=&calendar=` — returns calendar
- * items whose start/end overlaps `[from, to]`. Mirrors
+ * `GET /entities/{name}/calendar?from=&to=&calendar=&filter[…]=&search=`
+ * — returns calendar items whose start/end overlaps `[from, to]`,
+ * narrowed by the optional filter / search criteria. Mirrors
  * `Granit.Entities.Endpoints.CalendarRangeEndpoint.HandleAsync`.
  *
- * `from` / `to` are ISO 8601 datetime offset strings — the same shape the
- * .NET handler binds via `[AsParameters] CalendarRangeRequest`. Apps
- * typically build them by serialising the renderer's current visible
- * window; the server enforces `to >= from` and a 366-day cap and surfaces
+ * `from` / `to` are ISO 8601 datetime offset strings — the same shape
+ * the .NET handler binds via `[AsParameters] CalendarRangeRequest`.
+ * The server enforces `to >= from` and a 366-day cap and surfaces
  * out-of-range windows as 400 ValidationProblem.
+ *
+ * `filters` / `search` follow the standard list endpoint's wire shape
+ * (`filter[field.op]=value`, `search=…`); per the Phase 1.5 renderer
+ * matrix they narrow which events surface inside the visible window
+ * but never widen / shift the window itself. `sort` / `groupBy` /
+ * `page` / `pageSize` have no meaning on a time-axis layout and are
+ * deliberately not part of the request shape.
  *
  * Pass `calendar` to disambiguate when the entity declares multiple
  * calendar layouts; omitted when there's only one (the common case
- * today). The cache key splits per `(from, to, calendar)` so paging the
- * window forward keeps prior tiles cached for back-navigation.
+ * today). The cache key splits per
+ * `(from, to, calendar, filters, search)` so paging the window
+ * forward keeps prior tiles cached for back-navigation and toggling
+ * a filter doesn't invalidate other windows.
  *
- * The handler returns an empty array — not 404 — when the entity has no
- * calendar layout, so the renderer can mount the endpoint generically
- * from the manifest without special-casing missing layouts.
+ * The handler returns an empty array — not 404 — when the entity has
+ * no calendar layout, so the renderer can mount the endpoint
+ * generically from the manifest without special-casing missing
+ * layouts.
  */
 export function useEntityCalendar(
   entityName: string,
   from: string,
   to: string,
-  options: { readonly calendar?: string | null; readonly enabled?: boolean } = {}
+  options: UseEntityCalendarOptions = {}
 ): UseQueryResult<readonly CalendarItemResponse[]> {
   const api = useGranitClient();
   const calendar = options.calendar ?? null;
+  const filters = options.filters;
+  const search = options.search;
 
   return useQuery({
-    queryKey: entityCalendarQueryKey(entityName, from, to, calendar),
+    queryKey: entityCalendarQueryKey(entityName, from, to, calendar, filters, search),
     queryFn: async ({ signal }) => {
-      const params: Record<string, string> = { from, to };
-      if (calendar) {
-        params.calendar = calendar;
+      const params = new URLSearchParams();
+      params.set('from', from);
+      params.set('to', to);
+      if (calendar) params.set('calendar', calendar);
+      if (search) params.set('search', search);
+      if (filters) {
+        for (const filter of filters) {
+          params.append(`filter[${filter.field}.${filter.operator}]`, filter.value);
+        }
       }
       const { data } = await api.get<readonly CalendarItemResponse[]>(
         `/entities/${encodeURIComponent(entityName)}/calendar`,

--- a/packages/@granit/react-entities/src/components/entity-calendar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-calendar.tsx
@@ -1,3 +1,4 @@
+import { useQueryEndpointState } from '@granit/react-query-engine';
 import { useMemo, type ReactNode } from 'react';
 
 import { useEntityCalendar } from '../api/use-entity-calendar.js';
@@ -67,6 +68,13 @@ export interface EntityCalendarProps {
  * Loading / error / empty states surface via dedicated data attributes
  * (`data-granit-calendar-loading`, `…-error`, `…-empty`) so apps can
  * render their own placeholders without inspecting React state.
+ *
+ * When wrapped in a `<QueryEndpointStateProvider>`, automatically
+ * forwards the ambient `filter` and `search` to the calendar range
+ * endpoint so SmartFilterBar tokens narrow which events surface
+ * inside the visible window. `sort` / `groupBy` / `page` / `pageSize`
+ * are deliberately ignored — they have no meaning on a time-axis
+ * layout (the time-axis IS the bucketing).
  */
 export function EntityCalendar({
   entityName,
@@ -76,7 +84,16 @@ export function EntityCalendar({
   onItemClick,
   className,
 }: EntityCalendarProps): ReactNode {
-  const query = useEntityCalendar(entityName, range.from, range.to, { calendar });
+  // Per the Phase 1.5 renderer matrix the calendar consumes only
+  // `filter` and `search` from ambient query state — `sort`, `groupBy`,
+  // `page`, `pageSize` have no meaning on a time-axis layout. The
+  // visible window stays owned by `range`.
+  const { params } = useQueryEndpointState();
+  const query = useEntityCalendar(entityName, range.from, range.to, {
+    calendar,
+    filters: params.filters,
+    search: params.search,
+  });
   const days = useMemo(() => groupItemsByStartDay(query.data ?? []), [query.data]);
 
   if (query.isError) {

--- a/packages/@granit/react-entities/src/components/entity-gallery.tsx
+++ b/packages/@granit/react-entities/src/components/entity-gallery.tsx
@@ -1,10 +1,10 @@
 import { getPage } from '@granit/query-engine';
-import { useQueryConfig } from '@granit/react-query-engine';
+import { useQueryConfig, useQueryEndpointState } from '@granit/react-query-engine';
 import { useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 
 import type { EntityGalleryLayoutManifest, EntityManifestResponse } from '@granit/entities';
-import type { PagedResult } from '@granit/query-engine';
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
 
 export interface EntityGalleryProps {
   /** The entity manifest (typically from `useEntityMetadata`). */
@@ -35,7 +35,20 @@ const DEFAULT_PAGE_SIZE = 50;
 /**
  * Generic read-only image-card grid renderer. Bridges the entity manifest's
  * gallery layout to the host's ambient `<QueryProvider>` and paginates via
- * `useInfiniteQuery` + an `IntersectionObserver` sentinel:
+ * `useInfiniteQuery` + an `IntersectionObserver` sentinel.
+ *
+ * When wrapped in a `<QueryEndpointStateProvider>`, automatically subscribes
+ * to the shared filter / sort / search / quickFilters / presets — host-side
+ * controls (SmartFilterBar, SortSelector, preset toggles) work transparently
+ * without per-renderer wiring. Without that provider the renderer falls
+ * back to pagination-only fetches (page / pageSize), useful for embed
+ * scenarios where no toolbar is wired up.
+ *
+ * `groupByPropertyName` on the layout, when set, threads the property
+ * through `params.groupBy` so the server returns grouped buckets the
+ * renderer can paint as sections (currently flat — section rendering
+ * lands in a follow-up).
+ *
  *
  * ```html
  * <div data-granit-entity-gallery data-entity="…" data-card-size="Medium">
@@ -123,14 +136,29 @@ function EntityGalleryBody({
   onCardClick,
 }: EntityGalleryBodyProps): ReactNode {
   const config = useQueryConfig();
+  const { params } = useQueryEndpointState();
   const sentinelRef = useRef<HTMLLIElement | null>(null);
 
+  // Compose the base request once: the host's ambient filter / sort /
+  // search / quickFilters / presets, plus the gallery's own page-size
+  // override and (optionally) the layout's `groupByPropertyName`. The
+  // infinite query owns the `page` cursor — we don't read it from the
+  // shared state because the shared `page` is single-cursor while the
+  // gallery accumulates pages through scroll.
+  const baseRequest = useMemo<QueryRequest>(() => {
+    const rest: QueryRequest = { ...params };
+    delete (rest as { page?: number }).page;
+    return layout.groupByPropertyName
+      ? { ...rest, pageSize, groupBy: layout.groupByPropertyName }
+      : { ...rest, pageSize };
+  }, [params, pageSize, layout.groupByPropertyName]);
+
   const query = useInfiniteQuery({
-    queryKey: ['granit', 'entity-gallery', config.basePath, pageSize] as const,
+    queryKey: ['granit', 'entity-gallery', config.basePath, baseRequest] as const,
     queryFn: ({ pageParam }) =>
       getPage<Readonly<Record<string, unknown>>>(config.client, config.basePath, {
+        ...baseRequest,
         page: pageParam,
-        pageSize,
       }),
     initialPageParam: 1,
     getNextPageParam: nextPageParam,

--- a/packages/@granit/react-entities/src/components/entity-kanban.tsx
+++ b/packages/@granit/react-entities/src/components/entity-kanban.tsx
@@ -1,7 +1,10 @@
-import { useQueryEndpoint, useQueryMeta } from '@granit/react-query-engine';
+import { getPage } from '@granit/query-engine';
+import { useQueryConfig, useQueryEndpointState, useQueryMeta } from '@granit/react-query-engine';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 import { useMemo, type ReactNode } from 'react';
 
 import type { EntityManifestResponse } from '@granit/entities';
+import type { QueryRequest } from '@granit/query-engine';
 
 export interface EntityKanbanProps {
   /** The entity manifest (typically from `useEntityMetadata`). */
@@ -88,7 +91,26 @@ function EntityKanbanBody({
   onCardClick,
 }: EntityKanbanBodyProps): ReactNode {
   const meta = useQueryMeta();
-  const { query } = useQueryEndpoint<Readonly<Record<string, unknown>>>();
+  const config = useQueryConfig();
+  const { params } = useQueryEndpointState();
+
+  // Kanban's groupBy is layout-locked: the `groupBy` prop drives client-side
+  // bucketing per `manifest.collections.listLayouts[].kanban.groupByPropertyName`;
+  // any ambient `params.groupBy` (e.g. set by a List-view toolbar in the
+  // same `<QueryEndpointStateProvider>`) is deliberately stripped before
+  // the request so Kanban keeps fetching flat rows it can bucket itself.
+  const baseRequest = useMemo<QueryRequest>(() => {
+    const next: QueryRequest = { ...params };
+    delete (next as { groupBy?: string }).groupBy;
+    return next;
+  }, [params]);
+
+  const query = useQuery({
+    queryKey: ['granit', 'entity-kanban', config.basePath, baseRequest] as const,
+    queryFn: () =>
+      getPage<Readonly<Record<string, unknown>>>(config.client, config.basePath, baseRequest),
+    placeholderData: keepPreviousData,
+  });
 
   const groups = useMemo(
     () => bucketByField(query.data?.items ?? [], groupBy),

--- a/packages/@granit/react-query-engine/src/__tests__/query-endpoint-state-provider.test.tsx
+++ b/packages/@granit/react-query-engine/src/__tests__/query-endpoint-state-provider.test.tsx
@@ -1,0 +1,118 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import {
+  QueryEndpointStateProvider,
+  QueryProvider,
+  useQueryEndpoint,
+  useQueryEndpointState,
+} from '../index.js';
+
+import type { ReactNode } from 'react';
+
+const BASE_PATH = '/api/v1/parties';
+
+let lastQuery: Record<string, string> | null = null;
+
+const server = setupServer(
+  http.get(`http://localhost${BASE_PATH}`, ({ request }) => {
+    const url = new URL(request.url);
+    lastQuery = Object.fromEntries(url.searchParams.entries());
+    return HttpResponse.json({ items: [], totalCount: 0, page: 1, pageSize: 20 });
+  })
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers();
+  lastQuery = null;
+});
+afterAll(() => server.close());
+
+function makeWrapper(opts: { withProvider?: boolean } = {}) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => {
+    const tree = (
+      <QueryProvider config={{ basePath: BASE_PATH }}>
+        {opts.withProvider ? (
+          <QueryEndpointStateProvider>{children}</QueryEndpointStateProvider>
+        ) : (
+          children
+        )}
+      </QueryProvider>
+    );
+    return (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>{tree}</GranitClientProvider>
+      </QueryClientProvider>
+    );
+  };
+  return wrapper;
+}
+
+describe('QueryEndpointStateProvider', () => {
+  it('useQueryEndpointState returns a no-op default outside any provider', () => {
+    const wrapper = makeWrapper({ withProvider: false });
+    const { result } = renderHook(() => useQueryEndpointState(), { wrapper });
+    expect(result.current.params).toEqual({ page: 1, pageSize: 20 });
+    // Dispatchers are noops; calling them must not throw.
+    expect(() => result.current.setSearch('hello')).not.toThrow();
+  });
+
+  it('shares params + dispatchers across two useQueryEndpoint calls below the provider', async () => {
+    const wrapper = makeWrapper({ withProvider: true });
+    const { result } = renderHook(
+      () => {
+        const a = useQueryEndpoint();
+        const b = useQueryEndpoint();
+        return { a, b };
+      },
+      { wrapper }
+    );
+    expect(result.current.a.params).toEqual(result.current.b.params);
+    act(() => result.current.a.setSearch('acme'));
+    await waitFor(() => expect(result.current.b.params.search).toBe('acme'));
+    // Single fetch even with two callers — React Query dedupes by queryKey.
+    await waitFor(() => expect(lastQuery?.search).toBe('acme'));
+  });
+
+  it('useQueryEndpoint creates an independent reducer when no provider is mounted', () => {
+    const wrapper = makeWrapper({ withProvider: false });
+    const { result } = renderHook(
+      () => {
+        const a = useQueryEndpoint();
+        const b = useQueryEndpoint();
+        return { a, b };
+      },
+      { wrapper }
+    );
+    act(() => result.current.a.setSearch('foo'));
+    // Separate reducers — `a` gets the change, `b` keeps the default.
+    expect(result.current.a.params.search).toBe('foo');
+    expect(result.current.b.params.search).toBeUndefined();
+  });
+
+  it('seeds the shared reducer from initialParams when supplied', () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const apiClient = axios.create({ baseURL: 'http://localhost' });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <QueryProvider config={{ basePath: BASE_PATH }}>
+            <QueryEndpointStateProvider initialParams={{ page: 1, pageSize: 25, search: 'preset' }}>
+              {children}
+            </QueryEndpointStateProvider>
+          </QueryProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+    const { result } = renderHook(() => useQueryEndpointState(), { wrapper });
+    expect(result.current.params).toEqual({ page: 1, pageSize: 25, search: 'preset' });
+  });
+});

--- a/packages/@granit/react-query-engine/src/hooks/use-query-endpoint-reducer.ts
+++ b/packages/@granit/react-query-engine/src/hooks/use-query-endpoint-reducer.ts
@@ -1,0 +1,259 @@
+// ---------------------------------------------------------------------------
+// useQueryEndpointReducer — shared state machine for useQueryEndpoint and the
+// QueryEndpointStateProvider context. Exposes params + memoised dispatchers
+// without touching the network — the actual `useQuery` call lives in
+// `useQueryEndpoint` so the reducer can be reused both for solo callers
+// (one component fetches + dispatches) and for shared host setups
+// (toolbar dispatches, body fetches).
+// ---------------------------------------------------------------------------
+
+import { useCallback, useMemo, useReducer } from 'react';
+
+import type { FilterEntry, QueryRequest, SortEntry } from '@granit/query-engine';
+
+// ---------------------------------------------------------------------------
+// Reducer
+// ---------------------------------------------------------------------------
+
+type QueryAction =
+  | { type: 'SET_PAGE'; page: number }
+  | { type: 'SET_PAGE_SIZE'; pageSize: number }
+  | { type: 'SET_SEARCH'; search: string }
+  | { type: 'SET_FILTERS'; filters: readonly FilterEntry[] }
+  | { type: 'ADD_FILTER'; filter: FilterEntry }
+  | { type: 'REMOVE_FILTER'; field: string; operator?: string }
+  | { type: 'SET_SORT'; sort: readonly SortEntry[] }
+  | { type: 'TOGGLE_SORT'; field: string }
+  | { type: 'SET_PRESETS'; group: string; names: readonly string[] }
+  | { type: 'SET_QUICK_FILTERS'; quickFilters: readonly string[] }
+  | { type: 'TOGGLE_QUICK_FILTER'; name: string }
+  | { type: 'SET_GROUP_BY'; groupBy: string | undefined }
+  | { type: 'SET_PARAMS'; params: QueryRequest }
+  | { type: 'RESET' };
+
+interface QueryState {
+  readonly params: QueryRequest;
+  readonly initialParams: QueryRequest;
+}
+
+/**
+ * Pure reducer managing query state transitions.
+ *
+ * All filter/search/preset/quick-filter changes reset page to 1 so the user
+ * always sees the first page of matching results after changing criteria.
+ * Sort and groupBy changes keep the current page (intentional).
+ */
+function queryReducer(state: QueryState, action: QueryAction): QueryState {
+  const { params } = state;
+
+  switch (action.type) {
+    case 'SET_PAGE':
+      return { ...state, params: { ...params, page: action.page } };
+
+    case 'SET_PAGE_SIZE':
+      return { ...state, params: { ...params, pageSize: action.pageSize, page: 1 } };
+
+    case 'SET_SEARCH':
+      return { ...state, params: { ...params, search: action.search || undefined, page: 1 } };
+
+    case 'SET_FILTERS':
+      return { ...state, params: { ...params, filters: action.filters, page: 1 } };
+
+    /** Upsert: replaces existing filter with same field+operator, otherwise appends. */
+    case 'ADD_FILTER': {
+      const existing = params.filters ?? [];
+      const filtered = existing.filter(
+        (f) => !(f.field === action.filter.field && f.operator === action.filter.operator)
+      );
+      return {
+        ...state,
+        params: { ...params, filters: [...filtered, action.filter], page: 1 },
+      };
+    }
+
+    /** Removes by field+operator pair, or all filters for a field if operator is omitted. */
+    case 'REMOVE_FILTER': {
+      const existing = params.filters ?? [];
+      const filtered = existing.filter((f) => {
+        if (f.field !== action.field) return true;
+        if (action.operator === undefined) return false;
+        return f.operator !== action.operator;
+      });
+      return { ...state, params: { ...params, filters: filtered, page: 1 } };
+    }
+
+    case 'SET_SORT':
+      return { ...state, params: { ...params, sort: action.sort } };
+
+    /** Three-state toggle: asc → desc → off. */
+    case 'TOGGLE_SORT': {
+      const current = params.sort ?? [];
+      const existing = current.find((s) => s.field === action.field);
+      let newSort: readonly SortEntry[];
+      if (!existing) {
+        newSort = [{ field: action.field, direction: 'asc' }];
+      } else if (existing.direction === 'asc') {
+        newSort = [{ field: action.field, direction: 'desc' }];
+      } else {
+        newSort = current.filter((s) => s.field !== action.field);
+      }
+      return { ...state, params: { ...params, sort: newSort } };
+    }
+
+    /** Merges preset names into existing presets map by group key. */
+    case 'SET_PRESETS': {
+      const presets = { ...params.presets, [action.group]: action.names };
+      return { ...state, params: { ...params, presets, page: 1 } };
+    }
+
+    case 'SET_QUICK_FILTERS':
+      return { ...state, params: { ...params, quickFilters: action.quickFilters, page: 1 } };
+
+    /** Toggles a quick filter on/off by name. */
+    case 'TOGGLE_QUICK_FILTER': {
+      const current = params.quickFilters ?? [];
+      const isActive = current.includes(action.name);
+      const quickFilters = isActive
+        ? current.filter((n) => n !== action.name)
+        : [...current, action.name];
+      return { ...state, params: { ...params, quickFilters, page: 1 } };
+    }
+
+    case 'SET_GROUP_BY':
+      return { ...state, params: { ...params, groupBy: action.groupBy } };
+
+    case 'SET_PARAMS':
+      return { ...state, params: action.params };
+
+    case 'RESET':
+      return { ...state, params: state.initialParams };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default initial params
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_QUERY_PARAMS: QueryRequest = { page: 1, pageSize: 20 };
+
+// ---------------------------------------------------------------------------
+// Dispatcher surface (returned alongside `params`)
+// ---------------------------------------------------------------------------
+
+export interface QueryEndpointDispatchers {
+  readonly setPage: (page: number) => void;
+  readonly setPageSize: (pageSize: number) => void;
+  readonly setSearch: (search: string) => void;
+  readonly setFilters: (filters: readonly FilterEntry[]) => void;
+  readonly addFilter: (filter: FilterEntry) => void;
+  readonly removeFilter: (field: string, operator?: string) => void;
+  readonly setSort: (sort: readonly SortEntry[]) => void;
+  readonly toggleSort: (field: string) => void;
+  readonly setPresets: (group: string, names: readonly string[]) => void;
+  readonly setQuickFilters: (quickFilters: readonly string[]) => void;
+  readonly toggleQuickFilter: (name: string) => void;
+  readonly setGroupBy: (groupBy: string | undefined) => void;
+  readonly setParams: (params: QueryRequest) => void;
+  readonly reset: () => void;
+}
+
+export interface QueryEndpointState extends QueryEndpointDispatchers {
+  readonly params: QueryRequest;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Owns the mutable `params` of a query endpoint plus all the dispatchers
+ * that mutate it. Used internally by `useQueryEndpoint` (solo mode) and
+ * by `<QueryEndpointStateProvider>` (shared mode); rarely needed by app
+ * code directly. Pure state — no network.
+ */
+export function useQueryEndpointReducer(initialParams?: QueryRequest): QueryEndpointState {
+  const seed = initialParams ?? DEFAULT_QUERY_PARAMS;
+  const [state, dispatch] = useReducer(queryReducer, { params: seed, initialParams: seed });
+
+  const setPage = useCallback((page: number) => dispatch({ type: 'SET_PAGE', page }), []);
+  const setPageSize = useCallback(
+    (pageSize: number) => dispatch({ type: 'SET_PAGE_SIZE', pageSize }),
+    []
+  );
+  const setSearch = useCallback((search: string) => dispatch({ type: 'SET_SEARCH', search }), []);
+  const setFilters = useCallback(
+    (filters: readonly FilterEntry[]) => dispatch({ type: 'SET_FILTERS', filters }),
+    []
+  );
+  const addFilter = useCallback(
+    (filter: FilterEntry) => dispatch({ type: 'ADD_FILTER', filter }),
+    []
+  );
+  const removeFilter = useCallback(
+    (field: string, operator?: string) => dispatch({ type: 'REMOVE_FILTER', field, operator }),
+    []
+  );
+  const setSort = useCallback(
+    (sort: readonly SortEntry[]) => dispatch({ type: 'SET_SORT', sort }),
+    []
+  );
+  const toggleSort = useCallback((field: string) => dispatch({ type: 'TOGGLE_SORT', field }), []);
+  const setPresets = useCallback(
+    (group: string, names: readonly string[]) => dispatch({ type: 'SET_PRESETS', group, names }),
+    []
+  );
+  const setQuickFilters = useCallback(
+    (quickFilters: readonly string[]) => dispatch({ type: 'SET_QUICK_FILTERS', quickFilters }),
+    []
+  );
+  const toggleQuickFilter = useCallback(
+    (name: string) => dispatch({ type: 'TOGGLE_QUICK_FILTER', name }),
+    []
+  );
+  const setGroupBy = useCallback(
+    (groupBy: string | undefined) => dispatch({ type: 'SET_GROUP_BY', groupBy }),
+    []
+  );
+  const setParams = useCallback(
+    (p: QueryRequest) => dispatch({ type: 'SET_PARAMS', params: p }),
+    []
+  );
+  const reset = useCallback(() => dispatch({ type: 'RESET' }), []);
+
+  return useMemo(
+    () => ({
+      params: state.params,
+      setPage,
+      setPageSize,
+      setSearch,
+      setFilters,
+      addFilter,
+      removeFilter,
+      setSort,
+      toggleSort,
+      setPresets,
+      setQuickFilters,
+      toggleQuickFilter,
+      setGroupBy,
+      setParams,
+      reset,
+    }),
+    [
+      state.params,
+      setPage,
+      setPageSize,
+      setSearch,
+      setFilters,
+      addFilter,
+      removeFilter,
+      setSort,
+      toggleSort,
+      setPresets,
+      setQuickFilters,
+      toggleQuickFilter,
+      setGroupBy,
+      setParams,
+      reset,
+    ]
+  );
+}

--- a/packages/@granit/react-query-engine/src/hooks/use-query-endpoint.ts
+++ b/packages/@granit/react-query-engine/src/hooks/use-query-endpoint.ts
@@ -1,154 +1,45 @@
 // ---------------------------------------------------------------------------
 // useQueryEndpoint — main data fetching hook (Story #49)
+//
+// Wraps the shared reducer (`useQueryEndpointReducer`) with a `useQuery` /
+// grouped-query call against the host's `<QueryProvider>`. When the tree
+// also mounts a `<QueryEndpointStateProvider>`, the hook reads its
+// `params` + dispatchers from that shared reducer so toolbar changes
+// (SmartFilterBar, SortSelector, preset toggles) propagate to every
+// renderer below without prop-drilling.
 // ---------------------------------------------------------------------------
 
 import { buildQueryKey, getGrouped, getPage } from '@granit/query-engine';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { useCallback, useMemo, useReducer } from 'react';
+import { useMemo } from 'react';
 
+import { useQueryEndpointStateContext } from '../providers/query-endpoint-state-provider.js';
 import { useQueryConfig } from '../providers/query-provider.js';
 
-import type {
-  FilterEntry,
-  GroupedResult,
-  PagedResult,
-  QueryRequest,
-  SortEntry,
-} from '@granit/query-engine';
+import {
+  useQueryEndpointReducer,
+  type QueryEndpointDispatchers,
+} from './use-query-endpoint-reducer.js';
+
+import type { GroupedResult, PagedResult, QueryRequest } from '@granit/query-engine';
 import type { UseQueryResult } from '@tanstack/react-query';
-
-// ---------------------------------------------------------------------------
-// State & actions
-// ---------------------------------------------------------------------------
-
-type QueryAction =
-  | { type: 'SET_PAGE'; page: number }
-  | { type: 'SET_PAGE_SIZE'; pageSize: number }
-  | { type: 'SET_SEARCH'; search: string }
-  | { type: 'SET_FILTERS'; filters: readonly FilterEntry[] }
-  | { type: 'ADD_FILTER'; filter: FilterEntry }
-  | { type: 'REMOVE_FILTER'; field: string; operator?: string }
-  | { type: 'SET_SORT'; sort: readonly SortEntry[] }
-  | { type: 'TOGGLE_SORT'; field: string }
-  | { type: 'SET_PRESETS'; group: string; names: readonly string[] }
-  | { type: 'SET_QUICK_FILTERS'; quickFilters: readonly string[] }
-  | { type: 'TOGGLE_QUICK_FILTER'; name: string }
-  | { type: 'SET_GROUP_BY'; groupBy: string | undefined }
-  | { type: 'SET_PARAMS'; params: QueryRequest }
-  | { type: 'RESET' };
-
-interface QueryState {
-  readonly params: QueryRequest;
-  readonly initialParams: QueryRequest;
-}
-
-/**
- * Pure reducer managing query state transitions.
- *
- * All filter/search/preset/quick-filter changes reset page to 1 so the user
- * always sees the first page of matching results after changing criteria.
- * Sort and groupBy changes keep the current page (intentional).
- */
-function queryReducer(state: QueryState, action: QueryAction): QueryState {
-  const { params } = state;
-
-  switch (action.type) {
-    case 'SET_PAGE':
-      return { ...state, params: { ...params, page: action.page } };
-
-    case 'SET_PAGE_SIZE':
-      return { ...state, params: { ...params, pageSize: action.pageSize, page: 1 } };
-
-    case 'SET_SEARCH':
-      return { ...state, params: { ...params, search: action.search || undefined, page: 1 } };
-
-    case 'SET_FILTERS':
-      return { ...state, params: { ...params, filters: action.filters, page: 1 } };
-
-    /** Upsert: replaces existing filter with same field+operator, otherwise appends. */
-    case 'ADD_FILTER': {
-      const existing = params.filters ?? [];
-      const filtered = existing.filter(
-        (f) => !(f.field === action.filter.field && f.operator === action.filter.operator)
-      );
-      return {
-        ...state,
-        params: { ...params, filters: [...filtered, action.filter], page: 1 },
-      };
-    }
-
-    /** Removes by field+operator pair, or all filters for a field if operator is omitted. */
-    case 'REMOVE_FILTER': {
-      const existing = params.filters ?? [];
-      const filtered = action.operator
-        ? existing.filter((f) => !(f.field === action.field && f.operator === action.operator))
-        : existing.filter((f) => f.field !== action.field);
-      return {
-        ...state,
-        params: { ...params, filters: filtered, page: 1 },
-      };
-    }
-
-    case 'SET_SORT':
-      return { ...state, params: { ...params, sort: action.sort } };
-
-    /** Three-state cycle: none → asc → desc → none (removes from sort list). */
-    case 'TOGGLE_SORT': {
-      const current = params.sort ?? [];
-      const existing = current.find((s) => s.field === action.field);
-      let newSort: readonly SortEntry[];
-      if (!existing) {
-        newSort = [{ field: action.field, direction: 'asc' }];
-      } else if (existing.direction === 'asc') {
-        newSort = [{ field: action.field, direction: 'desc' }];
-      } else {
-        newSort = current.filter((s) => s.field !== action.field);
-      }
-      return { ...state, params: { ...params, sort: newSort } };
-    }
-
-    /** Merges preset names into existing presets map by group key. */
-    case 'SET_PRESETS': {
-      const presets = { ...params.presets, [action.group]: action.names };
-      return { ...state, params: { ...params, presets, page: 1 } };
-    }
-
-    case 'SET_QUICK_FILTERS':
-      return { ...state, params: { ...params, quickFilters: action.quickFilters, page: 1 } };
-
-    /** Toggles a quick filter on/off by name. */
-    case 'TOGGLE_QUICK_FILTER': {
-      const current = params.quickFilters ?? [];
-      const isActive = current.includes(action.name);
-      const quickFilters = isActive
-        ? current.filter((n) => n !== action.name)
-        : [...current, action.name];
-      return { ...state, params: { ...params, quickFilters, page: 1 } };
-    }
-
-    case 'SET_GROUP_BY':
-      return { ...state, params: { ...params, groupBy: action.groupBy } };
-
-    case 'SET_PARAMS':
-      return { ...state, params: action.params };
-
-    case 'RESET':
-      return { ...state, params: state.initialParams };
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Hook options & return type
 // ---------------------------------------------------------------------------
 
 export interface UseQueryEndpointOptions {
-  /** Initial query parameters. */
+  /**
+   * Initial query parameters. Ignored when the tree mounts a
+   * `<QueryEndpointStateProvider>` — the provider's seed wins so toolbar
+   * and renderer share a single reducer.
+   */
   readonly initialParams?: QueryRequest;
   /** Whether the query is enabled. Defaults to true. */
   readonly enabled?: boolean;
 }
 
-export interface UseQueryEndpointReturn<T> {
+export interface UseQueryEndpointReturn<T> extends QueryEndpointDispatchers {
   /** Current query parameters. */
   readonly params: QueryRequest;
   /** Query result for flat (paged) data. */
@@ -157,28 +48,7 @@ export interface UseQueryEndpointReturn<T> {
   readonly groupedQuery: UseQueryResult<GroupedResult<T>>;
   /** Whether grouped mode is active. */
   readonly isGrouped: boolean;
-  // Dispatchers
-  readonly setPage: (page: number) => void;
-  readonly setPageSize: (pageSize: number) => void;
-  readonly setSearch: (search: string) => void;
-  readonly setFilters: (filters: readonly FilterEntry[]) => void;
-  readonly addFilter: (filter: FilterEntry) => void;
-  readonly removeFilter: (field: string, operator?: string) => void;
-  readonly setSort: (sort: readonly SortEntry[]) => void;
-  readonly toggleSort: (field: string) => void;
-  readonly setPresets: (group: string, names: readonly string[]) => void;
-  readonly setQuickFilters: (quickFilters: readonly string[]) => void;
-  readonly toggleQuickFilter: (name: string) => void;
-  readonly setGroupBy: (groupBy: string | undefined) => void;
-  readonly setParams: (params: QueryRequest) => void;
-  readonly reset: () => void;
 }
-
-// ---------------------------------------------------------------------------
-// Default initial params
-// ---------------------------------------------------------------------------
-
-const DEFAULT_PARAMS: QueryRequest = { page: 1, pageSize: 20 };
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -187,8 +57,18 @@ const DEFAULT_PARAMS: QueryRequest = { page: 1, pageSize: 20 };
 /**
  * Main hook for querying a data endpoint.
  *
- * Manages query state via useReducer and fetches data via TanStack Query.
- * Uses `placeholderData: keepPreviousData` for smooth pagination transitions.
+ * Manages query state via `useQueryEndpointReducer` and fetches data via
+ * TanStack Query. Uses `placeholderData: keepPreviousData` for smooth
+ * pagination transitions.
+ *
+ * Solo mode (no provider): every call creates its own reducer. Useful
+ * for self-contained list pages where the toolbar lives in the same
+ * component as the data fetch.
+ *
+ * Shared mode (with `<QueryEndpointStateProvider>`): the hook reads
+ * `params` + dispatchers from the provider's reducer. Multiple components
+ * below the provider see the same `params`; each runs `useQuery` with
+ * the same query key, so React Query dedupes the actual network call.
  *
  * @example
  * ```tsx
@@ -200,13 +80,14 @@ const DEFAULT_PARAMS: QueryRequest = { page: 1, pageSize: 20 };
  */
 export function useQueryEndpoint<T>(options?: UseQueryEndpointOptions): UseQueryEndpointReturn<T> {
   const config = useQueryConfig();
-  const initialParams = options?.initialParams ?? DEFAULT_PARAMS;
   const enabled = options?.enabled ?? true;
 
-  const [state, dispatch] = useReducer(queryReducer, {
-    params: initialParams,
-    initialParams,
-  });
+  // Always create a local reducer to satisfy rules-of-hooks. When a
+  // QueryEndpointStateProvider is present, the local copy is ignored and
+  // the provider's state wins.
+  const local = useQueryEndpointReducer(options?.initialParams);
+  const shared = useQueryEndpointStateContext();
+  const state = shared ?? local;
 
   const { params } = state;
   const isGrouped = params.groupBy != null;
@@ -234,70 +115,24 @@ export function useQueryEndpoint<T>(options?: UseQueryEndpointOptions): UseQuery
     placeholderData: keepPreviousData,
   });
 
-  // Memoized dispatchers
-  const setPage = useCallback((page: number) => dispatch({ type: 'SET_PAGE', page }), []);
-  const setPageSize = useCallback(
-    (pageSize: number) => dispatch({ type: 'SET_PAGE_SIZE', pageSize }),
-    []
-  );
-  const setSearch = useCallback((search: string) => dispatch({ type: 'SET_SEARCH', search }), []);
-  const setFilters = useCallback(
-    (filters: readonly FilterEntry[]) => dispatch({ type: 'SET_FILTERS', filters }),
-    []
-  );
-  const addFilter = useCallback(
-    (filter: FilterEntry) => dispatch({ type: 'ADD_FILTER', filter }),
-    []
-  );
-  const removeFilter = useCallback(
-    (field: string, operator?: string) => dispatch({ type: 'REMOVE_FILTER', field, operator }),
-    []
-  );
-  const setSort = useCallback(
-    (sort: readonly SortEntry[]) => dispatch({ type: 'SET_SORT', sort }),
-    []
-  );
-  const toggleSort = useCallback((field: string) => dispatch({ type: 'TOGGLE_SORT', field }), []);
-  const setPresets = useCallback(
-    (group: string, names: readonly string[]) => dispatch({ type: 'SET_PRESETS', group, names }),
-    []
-  );
-  const setQuickFilters = useCallback(
-    (quickFilters: readonly string[]) => dispatch({ type: 'SET_QUICK_FILTERS', quickFilters }),
-    []
-  );
-  const toggleQuickFilter = useCallback(
-    (name: string) => dispatch({ type: 'TOGGLE_QUICK_FILTER', name }),
-    []
-  );
-  const setGroupBy = useCallback(
-    (groupBy: string | undefined) => dispatch({ type: 'SET_GROUP_BY', groupBy }),
-    []
-  );
-  const setParams = useCallback(
-    (p: QueryRequest) => dispatch({ type: 'SET_PARAMS', params: p }),
-    []
-  );
-  const reset = useCallback(() => dispatch({ type: 'RESET' }), []);
-
   return {
     params,
     query,
     groupedQuery,
     isGrouped,
-    setPage,
-    setPageSize,
-    setSearch,
-    setFilters,
-    addFilter,
-    removeFilter,
-    setSort,
-    toggleSort,
-    setPresets,
-    setQuickFilters,
-    toggleQuickFilter,
-    setGroupBy,
-    setParams,
-    reset,
+    setPage: state.setPage,
+    setPageSize: state.setPageSize,
+    setSearch: state.setSearch,
+    setFilters: state.setFilters,
+    addFilter: state.addFilter,
+    removeFilter: state.removeFilter,
+    setSort: state.setSort,
+    toggleSort: state.toggleSort,
+    setPresets: state.setPresets,
+    setQuickFilters: state.setQuickFilters,
+    toggleQuickFilter: state.toggleQuickFilter,
+    setGroupBy: state.setGroupBy,
+    setParams: state.setParams,
+    reset: state.reset,
   };
 }

--- a/packages/@granit/react-query-engine/src/index.ts
+++ b/packages/@granit/react-query-engine/src/index.ts
@@ -1,6 +1,12 @@
 // Provider
 export { QueryProvider, useQueryConfig } from './providers/query-provider.js';
 export type { QueryProviderProps } from './providers/query-provider.js';
+export {
+  QueryEndpointStateProvider,
+  useQueryEndpointState,
+  useQueryEndpointStateContext,
+} from './providers/query-endpoint-state-provider.js';
+export type { QueryEndpointStateProviderProps } from './providers/query-endpoint-state-provider.js';
 
 // Pagination primitives
 export { useInfiniteScroll } from './hooks/use-infinite-scroll.js';
@@ -22,6 +28,14 @@ export type {
   UseQueryEndpointOptions,
   UseQueryEndpointReturn,
 } from './hooks/use-query-endpoint.js';
+export {
+  DEFAULT_QUERY_PARAMS,
+  useQueryEndpointReducer,
+} from './hooks/use-query-endpoint-reducer.js';
+export type {
+  QueryEndpointDispatchers,
+  QueryEndpointState,
+} from './hooks/use-query-endpoint-reducer.js';
 export { useQueryMeta } from './hooks/use-query-meta.js';
 export { useSmartFilter } from './hooks/use-smart-filter.js';
 export type { UseSmartFilterOptions, UseSmartFilterReturn } from './hooks/use-smart-filter.js';

--- a/packages/@granit/react-query-engine/src/providers/query-endpoint-state-provider.tsx
+++ b/packages/@granit/react-query-engine/src/providers/query-endpoint-state-provider.tsx
@@ -1,0 +1,122 @@
+// ---------------------------------------------------------------------------
+// QueryEndpointStateProvider — lifts the query-endpoint reducer into a React
+// context so a host's chrome (SmartFilterBar, SortSelector, preset toggles)
+// and its body (the renderer that paints rows — list / kanban / gallery /
+// calendar) can share a single source of truth for filter, sort, search,
+// presets, quickFilters, groupBy, page and pageSize.
+//
+// Without this provider every `useQueryEndpoint()` call creates its own
+// reducer; toolbar dispatches and renderer reads happen against
+// independent copies and the renderer never reacts. Wrap the screen tree
+// with this provider and they sync transparently.
+// ---------------------------------------------------------------------------
+
+import { createContext, useContext, type ReactNode } from 'react';
+
+import {
+  DEFAULT_QUERY_PARAMS,
+  useQueryEndpointReducer,
+  type QueryEndpointState,
+} from '../hooks/use-query-endpoint-reducer.js';
+
+import type { QueryRequest } from '@granit/query-engine';
+
+const QueryEndpointStateContext = createContext<QueryEndpointState | null>(null);
+
+export interface QueryEndpointStateProviderProps {
+  /**
+   * Initial parameters seeded into the shared reducer. Defaults to
+   * `{ page: 1, pageSize: 20 }`. Rarely needed unless the host wants to
+   * pre-fill a search or preset before mount.
+   */
+  readonly initialParams?: QueryRequest;
+  readonly children: ReactNode;
+}
+
+/**
+ * Owns a shared `useQueryEndpointReducer` and publishes its `params` +
+ * dispatchers via context. Components beneath this provider that call
+ * `useQueryEndpoint()` (or read params directly via
+ * `useQueryEndpointState()`) talk to this single reducer instead of
+ * creating their own.
+ *
+ * Mount once per screen — typically in the page layout that owns both
+ * the toolbar (which writes filter / sort / search) and the renderer
+ * (which reads them):
+ *
+ * ```tsx
+ * <QueryProvider config={{ basePath: '/api/v1/parties' }}>
+ *   <QueryEndpointStateProvider>
+ *     <SmartFilterBar />            // dispatches setFilters / setSearch
+ *     <SortSelector />              // dispatches toggleSort
+ *     <EntityGallery manifest={…} />  // reads filter / sort via params
+ *   </QueryEndpointStateProvider>
+ * </QueryProvider>
+ * ```
+ *
+ * Backwards compatible — pages that don't wrap with this provider keep
+ * the previous local-state behaviour. Adding it later is non-breaking.
+ */
+export function QueryEndpointStateProvider({
+  initialParams,
+  children,
+}: QueryEndpointStateProviderProps) {
+  const state = useQueryEndpointReducer(initialParams);
+  return (
+    <QueryEndpointStateContext.Provider value={state}>
+      {children}
+    </QueryEndpointStateContext.Provider>
+  );
+}
+
+/**
+ * Reads the shared query-endpoint state (params + dispatchers) from the
+ * nearest `<QueryEndpointStateProvider>`. Returns `null` when no provider
+ * is present so callers can decide whether to fall back to local state
+ * or to a default.
+ *
+ * Most callers want `useQueryEndpointState()` instead — that hook returns
+ * a guaranteed non-null state (defaulting `params` to the standard
+ * `{ page: 1, pageSize: 20 }` outside a provider) and is the right tool
+ * for renderers that just need to read params.
+ */
+export function useQueryEndpointStateContext(): QueryEndpointState | null {
+  return useContext(QueryEndpointStateContext);
+}
+
+const DEFAULT_STATE: QueryEndpointState = {
+  params: DEFAULT_QUERY_PARAMS,
+  setPage: noop,
+  setPageSize: noop,
+  setSearch: noop,
+  setFilters: noop,
+  addFilter: noop,
+  removeFilter: noop,
+  setSort: noop,
+  toggleSort: noop,
+  setPresets: noop,
+  setQuickFilters: noop,
+  toggleQuickFilter: noop,
+  setGroupBy: noop,
+  setParams: noop,
+  reset: noop,
+};
+
+function noop(): void {
+  /* no-op fallback when no provider is mounted */
+}
+
+/**
+ * Returns the current shared query-endpoint state — `params` plus every
+ * dispatcher (`setSearch`, `setFilters`, `toggleSort`, …). Outside a
+ * `<QueryEndpointStateProvider>` returns a no-op default so renderers
+ * that read `params` keep working in embed scenarios where no toolbar
+ * is wired up.
+ *
+ * Renderers like `<EntityGallery />` use this hook to thread the host's
+ * filter / sort / search / groupBy into their own data-fetch calls
+ * without needing the host to plumb props down by hand.
+ */
+export function useQueryEndpointState(): QueryEndpointState {
+  return useContext(QueryEndpointStateContext) ?? DEFAULT_STATE;
+}


### PR DESCRIPTION
## Summary

Showcase QA flagged that `<EntityGallery />`, `<EntityKanban />`, and `<EntityCalendar />` ignored filter / sort / search / groupBy from the host's chrome. SmartFilterBar's `useQueryEndpoint` reducer and the renderer's were independent state machines: typing in the search box re-emitted an identical request, the same cards came back. Same root cause for any component that calls `useQueryEndpoint` twice in the same tree — toolbar dispatches and renderer reads happen against separate copies.

This PR fixes the plumbing per the renderer matrix below, applying each layout's contract precisely so a single `<QueryEndpointStateProvider>` drives chrome + body without per-renderer wiring.

## Renderer matrix (delivered)

| Renderer | Endpoint | filter | search | sort | groupBy | page / pageSize |
| --- | --- | --- | --- | --- | --- | --- |
| `<EntityList />` | `MapGranitQueryEndpoint` (paged) | ✓ | ✓ | ✓ | ✓ | ✓ |
| `<EntityGallery />` | `MapGranitQueryEndpoint` (paged) | ✓ | ✓ | ✓ | ✓ (layout) | ✓ |
| `<EntityKanban />` | `MapGranitQueryEndpoint` (paged) | ✓ | ✓ | ✓ | layout-locked, ambient stripped | ✓ |
| `<EntityCalendar />` | `MapGranitCalendarRangeEndpoint` (range) | ✓ | ✓ | n/a | n/a | n/a (window owned by `from` / `to`) |

## Changes

### `@granit/react-query-engine`

- New `<QueryEndpointStateProvider>` lifts the query-endpoint reducer into a React context so chrome (SmartFilterBar, SortSelector, preset toggles) and body (renderer) share one source of truth.
- New `useQueryEndpointState()` reads the shared `params` + dispatchers from the provider, falling back to a no-op default when no provider is mounted (embed scenarios stay valid).
- `useQueryEndpointReducer` extracted so both the provider and `useQueryEndpoint`'s solo path reuse the same state machine.
- `useQueryEndpoint()` is now context-aware: subscribes to the provider's reducer when present, otherwise creates its own (current behaviour). Backwards compatible — every existing call site keeps the same return shape.

### `@granit/entities`

- `EntityGalleryLayoutManifest` gains `groupByPropertyName: string | null` to mirror granit-fx/granit-dotnet#1825.

### `@granit/react-entities`

- **Gallery** reads ambient `params` via `useQueryEndpointState`, threads filter / sort / search / quickFilters / presets into `useInfiniteQuery`. The gallery still owns its own `pageSize` (default 50) and the page cursor — the provider's `page` is meaningless under infinite scroll. `groupByPropertyName` on the layout, when set, is forwarded as `params.groupBy` on every page request (server returns grouped buckets; section-rendering of those buckets is a follow-up PR).
- **Kanban** refactored: drops `useQueryEndpoint` for `useQueryEndpointState` + a local `useQuery`. Reads ambient filter / sort / search but explicitly strips `groupBy` before the fetch — kanban's groupBy is layout-locked (driven by the `groupBy` prop against `manifest.collections.listLayouts[].kanban.groupByPropertyName`). Without the strip, a host that wraps a List view + a Kanban view in the same provider could set ambient `groupBy` from a List toolbar and silently break kanban's fetch shape.
- **Calendar** reads ambient `params` and forwards exactly `filters` + `search` into `useEntityCalendar`. The hook serialises them as `filter[field.op]=value` + `search=…` query params on `GET /entities/{name}/calendar`. `sort` / `groupBy` / `page` / `pageSize` are ignored — they have no meaning on a time-axis layout (the time-axis IS the bucketing). The cache key splits per `(from, to, calendar, filters, search)` so toggling a filter doesn't invalidate other windows' tiles.

The `.NET` `CalendarRangeRequest` DTO doesn't bind filter / search yet — the front sends them anyway so the wire is forward-compat, the server's model binder ignores until the endpoint adds support.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm exec vitest run packages/@granit/entities packages/@granit/react-entities packages/@granit/react-query-engine\` — 28 files, 250 tests, all passing (was 238 — added 12 new cases)

New tests cover:
- Provider sharing state across two `useQueryEndpoint` calls (single fetch via React Query dedupe)
- No-provider fallback to a no-op default
- Independent reducers when no provider is mounted (backwards-compat)
- Seeded `initialParams` on the provider
- Gallery: ambient filter / sort / search threading, no-provider fallback, `groupByPropertyName` forwarding
- Kanban: ambient `groupBy='status'` stripped before request, ambient filter / sort / search forwarded
- Calendar: filter forwarding (`filter[field.op]=value`), search forwarding, cache-key splitting per filters / search

## Out of scope (separate PRs to follow)

- Section rendering for gallery `groupByPropertyName` (paint one section per bucket).
- `<BlobImage />` standalone component in `@granit/react-blob-storage` (showcase ask, replaces the MutationObserver hack).
- `renderImage` slot on `<EntityGallery />` (consumer of `<BlobImage />`).