### PR TITLE
feat(react-blob-storage,react-entities): blob image + gallery render slot

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1964,6 +1964,17 @@
       "description": "React hooks for blob storage — useBlob, useInitiateUpload, useConfirmUpload, useBlobUpload, useDownloadUrl, useDeleteBlob",
       "exports": [
         {
+          "name": "BlobImage",
+          "kind": "function",
+          "signature": "function BlobImage("
+        },
+        {
+          "name": "BlobImageProps",
+          "kind": "interface",
+          "signature": "interface BlobImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'>",
+          "members": []
+        },
+        {
           "name": "useBlob",
           "kind": "function",
           "signature": "function useBlob( id: string, containerName: string, options: BlobStorageOptions ): UseQueryResult<BlobDescriptorResponse>"
@@ -2739,7 +2750,18 @@
           "name": "EntityGalleryProps",
           "kind": "interface",
           "signature": "interface EntityGalleryProps",
-          "members": []
+          "members": [
+            {
+              "name": "blobId",
+              "kind": "property",
+              "signature": "blobId: string | null,"
+            },
+            {
+              "name": "row",
+              "kind": "property",
+              "signature": "row: Readonly<Record<string, unknown>>"
+            }
+          ]
         },
         {
           "name": "EntityKanban",

--- a/packages/@granit/react-blob-storage/package.json
+++ b/packages/@granit/react-blob-storage/package.json
@@ -18,6 +18,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/blob-storage": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   },

--- a/packages/@granit/react-blob-storage/src/__tests__/blob-image.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/blob-image.test.tsx
@@ -1,0 +1,178 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BlobImage } from '../components/blob-image.js';
+
+import type { ReactNode } from 'react';
+
+function makeWrapper() {
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('BlobImage', () => {
+  it('builds the default BFF download URL from the axios client baseURL', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId="parties/avatars/acme.jpg" alt="ACME" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe(
+      'http://localhost/api/v1/blob-storage/blobs/parties%2Favatars%2Facme.jpg/download'
+    );
+    expect(img.getAttribute('alt')).toBe('ACME');
+    expect(img.getAttribute('loading')).toBe('lazy');
+  });
+
+  it('renders fallback when blobId is null', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId={null} fallback={<span data-testid="fallback">none</span>} />
+      </Wrapper>
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-testid="fallback"]')?.textContent).toBe('none');
+  });
+
+  it('renders fallback when blobId is undefined', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId={undefined} fallback={<span data-testid="fallback" />} />
+      </Wrapper>
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.querySelector('[data-testid="fallback"]')).not.toBeNull();
+  });
+
+  it('renders nothing when blobId is null and no fallback is supplied', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId={null} />
+      </Wrapper>
+    );
+    expect(container.querySelector('img')).toBeNull();
+    expect(container.firstElementChild).toBeNull();
+  });
+
+  it('uses a sync resolveUrl override', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId="abc" resolveUrl={(id) => `https://cdn.example.com/${id}.jpg`} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://cdn.example.com/abc.jpg'
+    );
+  });
+
+  it('awaits an async resolveUrl override (presigned URL flow)', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const resolveUrl = vi.fn((id: string) =>
+      Promise.resolve(`https://presigned.example.com/${id}?sig=abc123`)
+    );
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId="document.pdf" resolveUrl={resolveUrl} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://presigned.example.com/document.pdf?sig=abc123'
+    );
+    expect(resolveUrl).toHaveBeenCalledWith('document.pdf');
+  });
+
+  it('swaps to fallback when the underlying <img> fires onError', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container, getByTestId } = render(
+      <Wrapper>
+        <BlobImage blobId="missing.jpg" fallback={<span data-testid="fallback" />} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    const img = container.querySelector('img') as HTMLImageElement;
+    fireEvent.error(img);
+    expect(container.querySelector('img')).toBeNull();
+    expect(getByTestId('fallback')).not.toBeNull();
+  });
+
+  it('forwards arbitrary <img> attributes (className, alt, width)', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage
+          blobId="x"
+          className="rounded-full size-10"
+          alt="avatar"
+          width={40}
+          height={40}
+        />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    const img = container.querySelector('img') as HTMLImageElement;
+    expect(img.className).toBe('rounded-full size-10');
+    expect(img.getAttribute('alt')).toBe('avatar');
+    expect(img.getAttribute('width')).toBe('40');
+    expect(img.getAttribute('height')).toBe('40');
+  });
+
+  it('honours a custom basePath when resolveUrl is omitted', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId="abc" basePath="/api/v2/storage" />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'http://localhost/api/v2/storage/blobs/abc/download'
+    );
+  });
+
+  it('forwards onError after swapping to fallback', async () => {
+    const onError = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobImage blobId="x" onError={onError} fallback={<span data-testid="fallback" />} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    fireEvent.error(container.querySelector('img') as HTMLImageElement);
+    expect(onError).toHaveBeenCalledOnce();
+  });
+
+  it('clears the error state when blobId changes', async () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container, rerender } = render(
+      <Wrapper>
+        <BlobImage blobId="missing" fallback={<span data-testid="fallback" />} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    fireEvent.error(container.querySelector('img') as HTMLImageElement);
+    expect(container.querySelector('img')).toBeNull();
+    // Switch to a fresh blobId — should reset errored state and try again.
+    rerender(
+      <Wrapper>
+        <BlobImage blobId="next" fallback={<span data-testid="fallback" />} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(container.querySelector('img')).not.toBeNull());
+    expect(container.querySelector('img')?.getAttribute('src')).toContain('next');
+  });
+});

--- a/packages/@granit/react-blob-storage/src/components/blob-image.tsx
+++ b/packages/@granit/react-blob-storage/src/components/blob-image.tsx
@@ -1,0 +1,125 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useEffect, useState, type ImgHTMLAttributes, type ReactNode } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+export interface BlobImageProps extends Omit<ImgHTMLAttributes<HTMLImageElement>, 'src'> {
+  /**
+   * Stable identifier of the blob to render. `null` / `undefined` are
+   * treated the same as a load failure: the `fallback` is rendered (or
+   * nothing, if no fallback is supplied) so callers don't have to
+   * special-case missing avatars / images.
+   */
+  readonly blobId: string | null | undefined;
+  /**
+   * Rendered when `blobId` is `null` / `undefined` OR when the underlying
+   * `<img>` fails to load. `null` / undefined fallback renders nothing
+   * — apps that prefer a CSS-only placeholder rely on the parent's
+   * background / `[data-blob-image-empty]` selector.
+   */
+  readonly fallback?: ReactNode;
+  /**
+   * Override the URL strategy. Default builds
+   * `${client.defaults.baseURL}/api/v1/blob-storage/blobs/{id}/download`,
+   * which works for hosts running behind a BFF that authenticates via
+   * cookie. Bearer / direct-S3 hosts pass an async resolver that calls
+   * `useDownloadUrl` (or any custom presign) and returns the URL.
+   */
+  readonly resolveUrl?: (blobId: string) => string | Promise<string>;
+  /**
+   * Override the BFF base path. Defaults to `/api/v1/blob-storage`. Only
+   * relevant when `resolveUrl` is omitted (the default path-builder
+   * uses it).
+   */
+  readonly basePath?: string;
+}
+
+/**
+ * Renders an `<img>` for a `BlobReference`. Replaces the manual
+ * `${baseUrl}/api/v1/blob-storage/blobs/{id}/download` URL composition
+ * + `MutationObserver` decoration patterns hosts had to write before:
+ * apps drop a `<BlobImage blobId={…} />` and the framework owns auth,
+ * URL composition, lazy loading, and error fallback.
+ *
+ * Default URL strategy (BFF / cookie auth):
+ *
+ * ```tsx
+ * <BlobImage blobId={party.avatarBlobId} fallback={<UserIcon />} />
+ * ```
+ *
+ * Override for bearer / pre-signed URLs:
+ *
+ * ```tsx
+ * const downloadUrl = useDownloadUrl({ client });
+ * <BlobImage
+ *   blobId={blob.id}
+ *   resolveUrl={async (id) =>
+ *     (await downloadUrl.mutateAsync({ id, request: { containerName: 'docs' } }))
+ *       .downloadUrl
+ *   }
+ * />
+ * ```
+ *
+ * The component reads the host's axios client via `useGranitClient()`
+ * to derive the default `baseURL`; all other `<img>` HTML attributes
+ * (`alt`, `className`, `loading`, `width` / `height`, `onClick`, …)
+ * pass through unchanged. `loading="lazy"` defaults so off-screen
+ * gallery cards don't trigger a network call until they scroll into
+ * view.
+ */
+export function BlobImage({
+  blobId,
+  fallback,
+  resolveUrl,
+  basePath = DEFAULT_BASE_PATH,
+  loading = 'lazy',
+  ...imgProps
+}: BlobImageProps): ReactNode {
+  const client = useGranitClient();
+  const [resolved, setResolved] = useState<string | null>(null);
+  const [errored, setErrored] = useState(false);
+
+  useEffect(() => {
+    setErrored(false);
+    if (!blobId) {
+      setResolved(null);
+      return;
+    }
+    let cancelled = false;
+
+    if (resolveUrl) {
+      const result = resolveUrl(blobId);
+      if (typeof result === 'string') {
+        setResolved(result);
+      } else {
+        setResolved(null);
+        result.then((url) => {
+          if (!cancelled) setResolved(url);
+        });
+      }
+    } else {
+      const baseURL = client.defaults.baseURL ?? '';
+      setResolved(`${baseURL}${basePath}/blobs/${encodeURIComponent(blobId)}/download`);
+    }
+
+    return () => {
+      cancelled = true;
+    };
+  }, [blobId, resolveUrl, basePath, client]);
+
+  if (!blobId || errored || !resolved) {
+    return <>{fallback ?? null}</>;
+  }
+
+  return (
+    <img
+      {...imgProps}
+      src={resolved}
+      loading={loading}
+      onError={(event) => {
+        setErrored(true);
+        imgProps.onError?.(event);
+      }}
+    />
+  );
+}

--- a/packages/@granit/react-blob-storage/src/index.ts
+++ b/packages/@granit/react-blob-storage/src/index.ts
@@ -1,3 +1,7 @@
+// Components
+export { BlobImage } from './components/blob-image.js';
+export type { BlobImageProps } from './components/blob-image.js';
+
 // Hooks
 export { useBlob } from './hooks/use-blob.js';
 export { useConfirmUpload, useDeleteBlob, useInitiateUpload } from './hooks/use-blob-mutations.js';

--- a/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
@@ -491,4 +491,58 @@ describe('EntityGallery', () => {
     expect(lastQuery?.groupBy).toBe('kind');
     expect(container.querySelector('[data-granit-entity-gallery]')).not.toBeNull();
   });
+
+  it('mounts the renderImage slot per card with the row blobId', async () => {
+    server.use(pageHandler([makeParty(1), makeParty(2)]));
+    const { wrapper: Wrapper } = makeWrapper();
+    const renderImage = vi.fn((blobId: string | null) =>
+      blobId ? <img data-testid="card-img" src={`https://cdn.example.com/${blobId}`} /> : null
+    );
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} renderImage={renderImage} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelectorAll('[data-granit-gallery-card]').length).toBe(2)
+    );
+    // Both rows in the fixture have a blobId — both calls receive a non-null value.
+    expect(renderImage).toHaveBeenCalledWith('parties/avatars/p1.jpg', expect.any(Object));
+    expect(renderImage).toHaveBeenCalledWith('parties/avatars/p2.jpg', expect.any(Object));
+    const imgs = container.querySelectorAll('[data-testid="card-img"]');
+    expect(imgs).toHaveLength(2);
+    expect(imgs[0].getAttribute('src')).toBe('https://cdn.example.com/parties/avatars/p1.jpg');
+  });
+
+  it('passes null to the renderImage slot when the row has no blob reference', async () => {
+    server.use(pageHandler([makeParty(3)])); // idx 3 → avatarBlobId null
+    const { wrapper: Wrapper } = makeWrapper();
+    const renderImage = vi.fn(() => null);
+    render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} renderImage={renderImage} />
+      </Wrapper>
+    );
+    await waitFor(() => expect(renderImage).toHaveBeenCalled());
+    expect(renderImage).toHaveBeenCalledWith(null, expect.objectContaining({ name: 'Party 3' }));
+  });
+
+  it('omits the renderImage call entirely when the slot is not provided', async () => {
+    server.use(pageHandler([makeParty(1)]));
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <EntityGallery manifest={manifest()} />
+      </Wrapper>
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
+    );
+    // Card structure still rendered (data-image-blob-id attr stays for CSS hooks),
+    // but no <img> is mounted by the framework.
+    expect(container.querySelector('[data-granit-gallery-card] img')).toBeNull();
+    expect(
+      container.querySelector('[data-granit-gallery-card]')?.getAttribute('data-image-blob-id')
+    ).toBe('parties/avatars/p1.jpg');
+  });
 });

--- a/packages/@granit/react-entities/src/components/entity-gallery.tsx
+++ b/packages/@granit/react-entities/src/components/entity-gallery.tsx
@@ -24,6 +24,26 @@ export interface EntityGalleryProps {
    * `QueryDefinition`.
    */
   readonly pageSize?: number;
+  /**
+   * Slot that mounts the actual image inside each card. Receives the
+   * raw `BlobReference` value read off the row at
+   * `layout.imagePropertyName` (a string id, or `null` when the row
+   * has no image) plus the full row object for context.
+   *
+   * Apps typically pass `<BlobImage blobId={…} fallback={…} />` from
+   * `@granit/react-blob-storage`, but the slot stays renderer-agnostic
+   * — hosts with non-blob backends (CDN URLs, data-URI thumbnails,
+   * SVG icons …) plug in their own component.
+   *
+   * When omitted, the renderer paints the card structure (title /
+   * subtitle slots, `data-image-blob-id` data attribute, sentinel)
+   * but no `<img>` tag — useful for data-only screens or hosts that
+   * still need to migrate their image layer.
+   */
+  readonly renderImage?: (
+    blobId: string | null,
+    row: Readonly<Record<string, unknown>>
+  ) => ReactNode;
   /** Optional card activation handler — receives the full row object. */
   readonly onCardClick?: (row: Readonly<Record<string, unknown>>) => void;
   /** Optional class for the root element. */
@@ -73,11 +93,14 @@ const DEFAULT_PAGE_SIZE = 50;
  * gains `data-exhausted` so apps can render their own end-of-list marker
  * (or rely on the absence of further reflow).
  *
- * The framework deliberately does **not** mount `<img>` tags directly —
- * `BlobReference` properties are opaque IDs the host resolves through its
- * own blob-storage URL scheme (auth, presigning, CDN). Apps wrap the
- * `data-image-blob-id` attribute with their own `<BlobImage />` (see
- * `@granit/react-blob-storage`).
+ * Image mounting goes through the `renderImage` slot — the renderer
+ * passes the row's `BlobReference` (read off `layout.imagePropertyName`)
+ * to the slot, which decides how to turn the id into pixels. Hosts
+ * typically pass `<BlobImage blobId={id} fallback={…} />` from
+ * `@granit/react-blob-storage`; apps with non-blob backends plug in
+ * their own component. When the slot is omitted the renderer paints
+ * the card structure (title / subtitle / `data-image-blob-id`) but
+ * no `<img>` tag.
  *
  * Title and subtitle project from the layout's `titlePropertyName`
  * (falling back to `manifest.identity.displayProperty`) and
@@ -89,6 +112,7 @@ export function EntityGallery({
   manifest,
   layout,
   pageSize = DEFAULT_PAGE_SIZE,
+  renderImage,
   onCardClick,
   className,
 }: EntityGalleryProps): ReactNode {
@@ -116,6 +140,7 @@ export function EntityGallery({
         layout={resolvedLayout}
         titleFallback={manifest.identity?.displayProperty}
         pageSize={pageSize}
+        renderImage={renderImage}
         onCardClick={onCardClick}
       />
     </div>
@@ -126,6 +151,9 @@ interface EntityGalleryBodyProps {
   readonly layout: EntityGalleryLayoutManifest;
   readonly titleFallback: string | null | undefined;
   readonly pageSize: number;
+  readonly renderImage:
+    | ((blobId: string | null, row: Readonly<Record<string, unknown>>) => ReactNode)
+    | undefined;
   readonly onCardClick: ((row: Readonly<Record<string, unknown>>) => void) | undefined;
 }
 
@@ -133,6 +161,7 @@ function EntityGalleryBody({
   layout,
   titleFallback,
   pageSize,
+  renderImage,
   onCardClick,
 }: EntityGalleryBodyProps): ReactNode {
   const config = useQueryConfig();
@@ -210,6 +239,7 @@ function EntityGalleryBody({
           imageProperty={layout.imagePropertyName}
           titleProperty={titleProperty}
           subtitleProperty={layout.subtitlePropertyName}
+          renderImage={renderImage}
           onCardClick={onCardClick}
         />
       ))}
@@ -229,6 +259,9 @@ interface GalleryCardProps {
   readonly imageProperty: string;
   readonly titleProperty: string | null;
   readonly subtitleProperty: string | null;
+  readonly renderImage:
+    | ((blobId: string | null, row: Readonly<Record<string, unknown>>) => ReactNode)
+    | undefined;
   readonly onCardClick: ((row: Readonly<Record<string, unknown>>) => void) | undefined;
 }
 
@@ -237,6 +270,7 @@ function GalleryCard({
   imageProperty,
   titleProperty,
   subtitleProperty,
+  renderImage,
   onCardClick,
 }: GalleryCardProps): ReactNode {
   const blobId = readScalar(row[imageProperty]);
@@ -252,6 +286,7 @@ function GalleryCard({
       onClick={onCardClick ? () => onCardClick(row) : undefined}
       style={onCardClick ? { cursor: 'pointer' } : undefined}
     >
+      {renderImage ? renderImage(blobId, row) : null}
       {title !== null ? <span data-granit-gallery-card-title="">{title}</span> : null}
       {subtitle !== null ? <span data-granit-gallery-card-subtitle="">{subtitle}</span> : null}
     </li>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1016,6 +1016,9 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Summary

Closes out the gallery image-mounting story the showcase QA opened:

1. **`<BlobImage />`** — new standalone component in `@granit/react-blob-storage` that owns blob URL composition + `<img>` mounting + error fallback, replacing the per-host pattern of hand-building `${baseUrl}/api/v1/blob-storage/blobs/{id}/download`.
2. **`renderImage` slot on `<EntityGallery />`** — explicit slot that delegates the actual image rendering to whatever component the host wants. Replaces the implicit `data-image-blob-id`-only contract.

Together they let showcase delete the `MutationObserver` hack in `entity-gallery-view.tsx` and replace it with one line: `renderImage={(id) => <BlobImage blobId={id} />}`.

## `<BlobImage />` (new)

```tsx
// Default: BFF / cookie auth — builds /api/v1/blob-storage/blobs/{id}/download
<BlobImage blobId={party.avatarBlobId} fallback={<UserIcon />} />

// Bearer / pre-signed — async resolver
<BlobImage
  blobId={blob.id}
  resolveUrl={async (id) => (await downloadUrl.mutateAsync({ id, request: { containerName: 'docs' } })).downloadUrl}
/>
```

- Reads the host's axios client via `useGranitClient()` to derive `baseURL`.
- `loading="lazy"` defaults so off-screen gallery cards don't trigger network until they scroll into view.
- `<img onError>` swaps the render to `fallback` and forwards the host's `onError` handler.
- All standard `<img>` attributes pass through unchanged (`alt`, `className`, `width`, `onClick`, …).
- `null` / `undefined` `blobId` renders the fallback (or nothing if no fallback).

## `renderImage` slot on `<EntityGallery />` (new)

```tsx
<EntityGallery
  manifest={manifest}
  renderImage={(blobId) => (
    <BlobImage blobId={blobId} fallback={<UserIcon className=\"size-10\" />} />
  )}
/>
```

The slot receives `(blobId: string | null, row: Readonly<Record<string, unknown>>)` and decides what to mount. When omitted the renderer paints the card structure (title / subtitle / `data-image-blob-id`) but no `<img>` — useful for data-only screens or hosts mid-migration. Renderer stays infrastructure-agnostic — non-blob backends (CDN, data-URI, SVG icons) plug in their own component.

The `data-image-blob-id` attribute remains as a CSS hook even when `renderImage` is provided.

## Out of scope

- Showcase migration PR (delete `entity-gallery-view.tsx`'s MutationObserver, swap to `renderImage`) — separate PR on `granit-showcase-admin-react`.
- Bearer-auth helper hook (\`useBlobImageUrl\`) that automates the `useDownloadUrl` + caching dance — not needed yet, the inline async resolver is enough for the few bearer-auth screens.

## Test plan

- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean
- [x] \`pnpm exec vitest run packages/@granit/react-blob-storage packages/@granit/react-entities\` — 27 files, 196 tests, all passing

11 new BlobImage cases cover: default URL build, null/undefined fallback, no-fallback empty render, sync + async resolveUrl, error swap, attribute pass-through, basePath override, onError forwarding, blobId-change error reset. 3 new gallery cases cover: slot per-card with blobId + row, null blobId forwarded, slot omitted = no `<img>` but data attrs intact.