### PR TITLE
fix(react-localization,sonar): unblock CI dts build + clear sonar batch

### DIFF
--- a/packages/@granit/react-blob-storage/src/components/blob-image.tsx
+++ b/packages/@granit/react-blob-storage/src/components/blob-image.tsx
@@ -113,6 +113,7 @@ export function BlobImage({
 
   return (
     <img
+      alt=""
       {...imgProps}
       src={resolved}
       loading={loading}

--- a/packages/@granit/react-charts/src/hooks/use-echarts-theme.ts
+++ b/packages/@granit/react-charts/src/hooks/use-echarts-theme.ts
@@ -59,7 +59,7 @@ export function useEChartsTheme(options: UseEChartsThemeOptions): string {
   const [isDark, setIsDark] = useState(() => detectDarkMode(darkModeStrategy));
 
   useEffect(() => {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
 
     if (darkModeStrategy === 'media') {
       const mq = globalThis.matchMedia('(prefers-color-scheme: dark)');
@@ -79,7 +79,7 @@ export function useEChartsTheme(options: UseEChartsThemeOptions): string {
 }
 
 function detectDarkMode(strategy: 'class' | 'media'): boolean {
-  if (typeof globalThis.window === 'undefined') return false;
+  if (globalThis.window === undefined) return false;
   if (strategy === 'media') {
     return globalThis.matchMedia('(prefers-color-scheme: dark)').matches;
   }

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-breakpoint.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-breakpoint.ts
@@ -43,7 +43,7 @@ export function resolveBreakpoint(viewportWidth: number): DashboardBreakpoint {
  * default) until the client hydrates.
  */
 function readViewportWidth(): number | null {
-  if (typeof globalThis.window === 'undefined') return null;
+  if (globalThis.window === undefined) return null;
   return globalThis.innerWidth;
 }
 
@@ -66,7 +66,7 @@ export function useDashboardBreakpoint(): DashboardBreakpoint {
   });
 
   useEffect(() => {
-    if (typeof globalThis.window === 'undefined') return undefined;
+    if (globalThis.window === undefined) return undefined;
     const handleResize = () => setBreakpoint(resolveBreakpoint(globalThis.innerWidth));
     globalThis.addEventListener('resize', handleResize);
     // Run once after mount to flip from the SSR-safe `'Xs'` to the actual

--- a/packages/@granit/react-dashboards/src/lib/default-widget-action-handlers.ts
+++ b/packages/@granit/react-dashboards/src/lib/default-widget-action-handlers.ts
@@ -22,7 +22,7 @@ function appendParamsToUrl(url: string, params: Readonly<Record<string, string>>
  * Resolved params are appended to the URL as a query string when set.
  */
 const navigateHandler: WidgetActionHandler = (action, context) => {
-  if (typeof globalThis.window === 'undefined') return;
+  if (globalThis.window === undefined) return;
   const url = appendParamsToUrl(action.target, context.params);
   globalThis.location.assign(url);
 };
@@ -44,7 +44,7 @@ const openDashboardViewHandler: WidgetActionHandler = (action, context) => {
  * with a different routing scheme override.
  */
 const openDashboardHandler: WidgetActionHandler = (action, context) => {
-  if (typeof globalThis.window === 'undefined') return;
+  if (globalThis.window === undefined) return;
   const url = appendParamsToUrl(`/dashboards/${encodeURIComponent(action.target)}`, context.params);
   globalThis.location.assign(url);
 };
@@ -60,7 +60,7 @@ const openDashboardHandler: WidgetActionHandler = (action, context) => {
  * the framework's "no opinionated UI" default.
  */
 const exportDataHandler: WidgetActionHandler = (action, context) => {
-  if (typeof globalThis.window === 'undefined') return;
+  if (globalThis.window === undefined) return;
   globalThis.dispatchEvent(
     new CustomEvent('granit:dashboard:export', {
       detail: { target: action.target, params: context.params, row: context.row ?? null },
@@ -74,7 +74,7 @@ const exportDataHandler: WidgetActionHandler = (action, context) => {
  * framework doesn't ship a default drawer UI.
  */
 const openDetailHandler: WidgetActionHandler = (action, context) => {
-  if (typeof globalThis.window === 'undefined') return;
+  if (globalThis.window === undefined) return;
   globalThis.dispatchEvent(
     new CustomEvent('granit:dashboard:open-detail', {
       detail: { target: action.target, params: context.params, row: context.row ?? null },

--- a/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
@@ -475,7 +475,7 @@ describe('EntityGallery', () => {
     expect(lastQuery?.page).toBe('1');
   });
 
-  it('threads layout.groupByPropertyName as groupBy on every page request', async () => {
+  it('falls back to layout.groupByPropertyName when ambient groupBy is unset', async () => {
     server.use(pageHandler([makeParty(1)]));
     const m = manifest();
     (
@@ -490,6 +490,30 @@ describe('EntityGallery', () => {
     await waitFor(() => expect(lastQuery).not.toBeNull());
     expect(lastQuery?.groupBy).toBe('kind');
     expect(container.querySelector('[data-granit-entity-gallery]')).not.toBeNull();
+  });
+
+  it('lets ambient groupBy from the provider override layout.groupByPropertyName', async () => {
+    server.use(pageHandler([makeParty(1)]));
+    const m = manifest();
+    (
+      m.collections!.listLayouts[0].gallery as { groupByPropertyName: string | null }
+    ).groupByPropertyName = 'kind';
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const apiClient = axios.create({ baseURL: 'http://localhost' });
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={queryClient}>
+        <GranitClientProvider client={apiClient}>
+          <QueryProvider config={{ basePath: BASE_PATH }}>
+            <QueryEndpointStateProvider initialParams={{ groupBy: 'name' }}>
+              {children}
+            </QueryEndpointStateProvider>
+          </QueryProvider>
+        </GranitClientProvider>
+      </QueryClientProvider>
+    );
+    render(<EntityGallery manifest={m} />, { wrapper });
+    await waitFor(() => expect(lastQuery).not.toBeNull());
+    expect(lastQuery?.groupBy).toBe('name');
   });
 
   it('mounts the renderImage slot per card with the row blobId', async () => {

--- a/packages/@granit/react-entities/src/api/use-entity-calendar.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-calendar.ts
@@ -34,7 +34,7 @@ export function entityCalendarQueryKey(
     filters && filters.length > 0
       ? [...filters]
           .map((f) => `${f.field}.${f.operator}=${f.value}`)
-          .sort()
+          .sort((a, b) => a.localeCompare(b))
           .join('&')
       : null;
   return [

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -248,43 +248,46 @@ function EntityDetailSection({
     [section.inheritsFromFormVariant, formVariants]
   );
 
+  let body: ReactNode;
+  if (section.inheritsFromFormVariant) {
+    body = inheritedFields ? (
+      <dl data-granit-detail-fields="" data-inherits-from={section.inheritsFromFormVariant}>
+        {inheritedFields.map((field) => (
+          <InheritedFieldRow
+            key={field.propertyName}
+            field={field}
+            values={values}
+            resolveLabel={resolveLabel}
+          />
+        ))}
+      </dl>
+    ) : (
+      <div
+        data-granit-detail-inherits-missing=""
+        data-form-variant={section.inheritsFromFormVariant}
+      />
+    );
+  } else {
+    body = (
+      <dl data-granit-detail-fields="">
+        {(section.fields ?? []).map((property) => (
+          <FreeFormFieldRow
+            key={property}
+            property={property}
+            value={values[property]}
+            componentId={propertyComponents?.[property]}
+          />
+        ))}
+      </dl>
+    );
+  }
+
   return (
     <section data-granit-detail-section="" data-section-key={section.key}>
       {section.labelKey ? (
         <header data-granit-section-header="">{resolveLabel(section.labelKey)}</header>
       ) : null}
-      {section.inheritsFromFormVariant ? (
-        inheritedFields ? (
-          <dl data-granit-detail-fields="" data-inherits-from={section.inheritsFromFormVariant}>
-            {inheritedFields.map((field) => (
-              <InheritedFieldRow
-                key={field.propertyName}
-                field={field}
-                values={values}
-                resolveLabel={resolveLabel}
-              />
-            ))}
-          </dl>
-        ) : (
-          <div
-            data-granit-detail-inherits-missing=""
-            data-form-variant={section.inheritsFromFormVariant}
-          >
-            {/* Form variant referenced by the section was not supplied via formVariants. */}
-          </div>
-        )
-      ) : (
-        <dl data-granit-detail-fields="">
-          {(section.fields ?? []).map((property) => (
-            <FreeFormFieldRow
-              key={property}
-              property={property}
-              value={values[property]}
-              componentId={propertyComponents?.[property]}
-            />
-          ))}
-        </dl>
-      )}
+      {body}
     </section>
   );
 }
@@ -418,6 +421,7 @@ function resolveInheritedFields(
 function formatValue(value: unknown): string {
   if (value === null || value === undefined) return '—';
   if (typeof value === 'boolean') return value ? '✓' : '✗';
+  if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
 }
 
@@ -486,6 +490,7 @@ function RelationItem({
   const { resolveLabel } = useEntityRenderer();
   const label = relation.displayKey ? resolveLabel(relation.displayKey) : relation.name;
   const count = value?.count ?? null;
+  const countLabel = isLoading ? '…' : (count?.toString() ?? '—');
 
   return (
     <button
@@ -500,9 +505,7 @@ function RelationItem({
       disabled={!onClick}
     >
       <span data-granit-relation-item-label="">{label}</span>
-      <span data-granit-relation-item-count="">
-        {isLoading ? '…' : count !== null ? String(count) : '—'}
-      </span>
+      <span data-granit-relation-item-count="">{countLabel}</span>
     </button>
   );
 }

--- a/packages/@granit/react-entities/src/components/entity-gallery.tsx
+++ b/packages/@granit/react-entities/src/components/entity-gallery.tsx
@@ -1,7 +1,7 @@
 import { getPage } from '@granit/query-engine';
 import { useQueryConfig, useQueryEndpointState } from '@granit/react-query-engine';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useRef, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, type KeyboardEvent, type ReactNode } from 'react';
 
 import type { EntityGalleryLayoutManifest, EntityManifestResponse } from '@granit/entities';
 import type { PagedResult, QueryRequest } from '@granit/query-engine';
@@ -64,10 +64,12 @@ const DEFAULT_PAGE_SIZE = 50;
  * back to pagination-only fetches (page / pageSize), useful for embed
  * scenarios where no toolbar is wired up.
  *
- * `groupByPropertyName` on the layout, when set, threads the property
- * through `params.groupBy` so the server returns grouped buckets the
- * renderer can paint as sections (currently flat — section rendering
- * lands in a follow-up).
+ * `groupByPropertyName` on the layout seeds the request as a default —
+ * ambient `params.groupBy` from the provider (driven by a host-side
+ * `GroupBySelector`) wins when set, so users can repivot the grid at
+ * runtime, matching the table renderer's behavior. The server returns
+ * grouped buckets the renderer threads through to the cards (currently
+ * flat — section rendering lands in a follow-up).
  *
  *
  * ```html
@@ -169,17 +171,19 @@ function EntityGalleryBody({
   const sentinelRef = useRef<HTMLLIElement | null>(null);
 
   // Compose the base request once: the host's ambient filter / sort /
-  // search / quickFilters / presets, plus the gallery's own page-size
-  // override and (optionally) the layout's `groupByPropertyName`. The
-  // infinite query owns the `page` cursor — we don't read it from the
-  // shared state because the shared `page` is single-cursor while the
-  // gallery accumulates pages through scroll.
+  // search / groupBy / quickFilters / presets, plus the gallery's own
+  // page-size override. The layout's `groupByPropertyName` only acts
+  // as a fallback when ambient `groupBy` is unset — toolbar pivots
+  // win, mirroring the table renderer. The infinite query owns the
+  // `page` cursor (the shared `page` is single-cursor while the gallery
+  // accumulates pages through scroll).
   const baseRequest = useMemo<QueryRequest>(() => {
     const rest: QueryRequest = { ...params };
     delete (rest as { page?: number }).page;
-    return layout.groupByPropertyName
-      ? { ...rest, pageSize, groupBy: layout.groupByPropertyName }
-      : { ...rest, pageSize };
+    if (rest.groupBy == null && layout.groupByPropertyName) {
+      return { ...rest, pageSize, groupBy: layout.groupByPropertyName };
+    }
+    return { ...rest, pageSize };
   }, [params, pageSize, layout.groupByPropertyName]);
 
   const query = useInfiniteQuery({
@@ -205,7 +209,7 @@ function EntityGalleryBody({
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
-          void query.fetchNextPage();
+          query.fetchNextPage().catch(() => {});
         }
       },
       { rootMargin: '256px' }
@@ -278,17 +282,30 @@ function GalleryCard({
   const subtitle = subtitleProperty ? readScalar(row[subtitleProperty]) : null;
   const rowId = readScalar(row['id'] ?? row['Id']);
 
+  const handleClick = onCardClick ? () => onCardClick(row) : undefined;
+  const handleKeyDown = onCardClick
+    ? (event: KeyboardEvent<HTMLLIElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onCardClick(row);
+        }
+      }
+    : undefined;
+
   return (
     <li
       data-granit-gallery-card=""
       data-row-id={rowId ?? undefined}
       data-image-blob-id={blobId ?? undefined}
-      onClick={onCardClick ? () => onCardClick(row) : undefined}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      role={onCardClick ? 'button' : undefined}
+      tabIndex={onCardClick ? 0 : undefined}
       style={onCardClick ? { cursor: 'pointer' } : undefined}
     >
       {renderImage ? renderImage(blobId, row) : null}
-      {title !== null ? <span data-granit-gallery-card-title="">{title}</span> : null}
-      {subtitle !== null ? <span data-granit-gallery-card-subtitle="">{subtitle}</span> : null}
+      {title === null ? null : <span data-granit-gallery-card-title="">{title}</span>}
+      {subtitle === null ? null : <span data-granit-gallery-card-subtitle="">{subtitle}</span>}
     </li>
   );
 }
@@ -336,9 +353,11 @@ function flattenPages(
 }
 
 function readScalar(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value === 'object') return null;
-  return String(value);
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return null;
 }
 
 function readRowKey(row: Readonly<Record<string, unknown>>, fallbackIndex: number): string {

--- a/packages/@granit/react-entities/src/components/entity-kanban.tsx
+++ b/packages/@granit/react-entities/src/components/entity-kanban.tsx
@@ -1,7 +1,7 @@
 import { getPage } from '@granit/query-engine';
 import { useQueryConfig, useQueryEndpointState, useQueryMeta } from '@granit/react-query-engine';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { useMemo, type ReactNode } from 'react';
+import { useMemo, type KeyboardEvent, type ReactNode } from 'react';
 
 import type { EntityManifestResponse } from '@granit/entities';
 import type { QueryRequest } from '@granit/query-engine';
@@ -138,14 +138,13 @@ function EntityKanbanBody({
           </header>
           <ul data-granit-kanban-cards="">
             {items.map((row, idx) => (
-              <li
+              <KanbanCard
                 key={readRowKey(row, idx)}
-                data-granit-kanban-card=""
-                onClick={onCardClick ? () => onCardClick(row) : undefined}
-                style={onCardClick ? { cursor: 'pointer' } : undefined}
-              >
-                {formatTitle(row[titleProperty]) ?? readRowKey(row, idx)}
-              </li>
+                row={row}
+                titleProperty={titleProperty}
+                fallbackKey={readRowKey(row, idx)}
+                onCardClick={onCardClick}
+              />
             ))}
           </ul>
         </section>
@@ -173,8 +172,9 @@ function bucketByField(
   const buckets = new Map<string, { label: string; items: Readonly<Record<string, unknown>>[] }>();
   for (const item of items) {
     const raw = item[groupBy];
-    const key = raw === null || raw === undefined ? '∅' : String(raw);
-    const label = raw === null || raw === undefined ? '—' : String(raw);
+    const stringified = stringifyScalar(raw);
+    const key = stringified ?? '∅';
+    const label = stringified ?? '—';
     let bucket = buckets.get(key);
     if (!bucket) {
       bucket = { label, items: [] };
@@ -192,7 +192,44 @@ function readRowKey(row: Readonly<Record<string, unknown>>, fallbackIndex: numbe
 }
 
 function formatTitle(value: unknown): string | null {
-  if (value === null || value === undefined) return null;
-  if (typeof value === 'object') return null;
-  return String(value);
+  return stringifyScalar(value);
+}
+
+function stringifyScalar(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return null;
+}
+
+interface KanbanCardProps {
+  readonly row: Readonly<Record<string, unknown>>;
+  readonly titleProperty: string;
+  readonly fallbackKey: string;
+  readonly onCardClick: ((row: Readonly<Record<string, unknown>>) => void) | undefined;
+}
+
+function KanbanCard({ row, titleProperty, fallbackKey, onCardClick }: KanbanCardProps): ReactNode {
+  const handleClick = onCardClick ? () => onCardClick(row) : undefined;
+  const handleKeyDown = onCardClick
+    ? (event: KeyboardEvent<HTMLLIElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onCardClick(row);
+        }
+      }
+    : undefined;
+  return (
+    <li
+      data-granit-kanban-card=""
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      role={onCardClick ? 'button' : undefined}
+      tabIndex={onCardClick ? 0 : undefined}
+      style={onCardClick ? { cursor: 'pointer' } : undefined}
+    >
+      {formatTitle(row[titleProperty]) ?? fallbackKey}
+    </li>
+  );
 }

--- a/packages/@granit/react-entities/src/components/entity-list.tsx
+++ b/packages/@granit/react-entities/src/components/entity-list.tsx
@@ -162,5 +162,7 @@ function formatCell(value: unknown): string {
   if (value === null || value === undefined) return '—';
   if (typeof value === 'boolean') return value ? '✓' : '✗';
   if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  return '—';
 }

--- a/packages/@granit/react-entities/src/field-components/standard-detail-components.tsx
+++ b/packages/@granit/react-entities/src/field-components/standard-detail-components.tsx
@@ -26,8 +26,8 @@ const BooleanDetailComponent: EntityDetailComponent = ({ value }) => {
 };
 
 const UrlDetailComponent: EntityDetailComponent = ({ value, propertyName }) => {
-  if (value === null || value === undefined || value === '') return EMPTY_DASH;
-  const href = String(value);
+  const href = readScalarString(value);
+  if (href === null || href === '') return EMPTY_DASH;
   const isExternal = /^https?:\/\//i.test(href);
   return (
     <a
@@ -43,8 +43,8 @@ const UrlDetailComponent: EntityDetailComponent = ({ value, propertyName }) => {
 };
 
 const EmailDetailComponent: EntityDetailComponent = ({ value, propertyName }) => {
-  if (value === null || value === undefined || value === '') return EMPTY_DASH;
-  const address = String(value);
+  const address = readScalarString(value);
+  if (address === null || address === '') return EMPTY_DASH;
   return (
     <a
       data-granit-detail-link=""
@@ -58,14 +58,14 @@ const EmailDetailComponent: EntityDetailComponent = ({ value, propertyName }) =>
 };
 
 const TelDetailComponent: EntityDetailComponent = ({ value, propertyName }) => {
-  if (value === null || value === undefined || value === '') return EMPTY_DASH;
-  const number = String(value);
+  const number = readScalarString(value);
+  if (number === null || number === '') return EMPTY_DASH;
   return (
     <a
       data-granit-detail-link=""
       data-property={propertyName}
       data-scheme="tel"
-      href={`tel:${number.replace(/\s+/g, '')}`}
+      href={`tel:${number.replaceAll(/\s+/g, '')}`}
     >
       {number}
     </a>
@@ -78,7 +78,15 @@ function formatText(value: unknown): string {
   if (value === null || value === undefined) return EMPTY_DASH;
   if (typeof value === 'boolean') return value ? '✓' : '✗';
   if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  return EMPTY_DASH;
+}
+
+function readScalarString(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'bigint') return String(value);
+  return null;
 }
 
 /**

--- a/packages/@granit/react-entities/src/field-components/standard-form-components.tsx
+++ b/packages/@granit/react-entities/src/field-components/standard-form-components.tsx
@@ -176,7 +176,7 @@ const SelectComponent: EntityFormComponent = ({
       </div>
     );
   }
-  const stringValue = value == null ? '' : String(value);
+  const stringValue = stringifySelectValue(value);
   return (
     <select
       {...commonProps(field, errorMessage)}
@@ -222,10 +222,20 @@ function readOptions(
     ) {
       return null;
     }
-    const labelKey = typeof record['labelKey'] === 'string' ? (record['labelKey'] as string) : null;
+    const rawLabelKey = record['labelKey'];
+    const labelKey = typeof rawLabelKey === 'string' ? rawLabelKey : null;
     options.push({ value, labelKey });
   }
   return options;
+}
+
+function stringifySelectValue(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean' || typeof value === 'bigint') {
+    return String(value);
+  }
+  return '';
 }
 
 /**

--- a/packages/@granit/react-entities/src/hooks/use-entity-form.ts
+++ b/packages/@granit/react-entities/src/hooks/use-entity-form.ts
@@ -52,7 +52,10 @@ export function useEntityForm(
   options: UseEntityFormOptions = {}
 ): UseEntityFormReturn {
   const initialDefaults = useMemo(
-    () => ({ ...deriveDefaults(variant), ...(options.defaultValues ?? {}) }),
+    () =>
+      options.defaultValues
+        ? { ...deriveDefaults(variant), ...options.defaultValues }
+        : deriveDefaults(variant),
     [variant, options.defaultValues]
   );
 

--- a/packages/@granit/react-localization/src/testing/handlers.ts
+++ b/packages/@granit/react-localization/src/testing/handlers.ts
@@ -1,5 +1,4 @@
 import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
-import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -10,6 +9,7 @@ import { buildMockLocalization, mockLanguages, mockLocalizationOverrides } from 
 
 import type { LocalizationOverride } from '@granit/localization';
 import type { QueryMetadata } from '@granit/query-engine';
+import type { RequestHandler } from 'msw';
 
 /** Mock /meta payload for the localization overrides resource. */
 export const localizationOverrideQueryMetadata: QueryMetadata = {
@@ -114,14 +114,19 @@ export const localizationOverrideQueryMetadata: QueryMetadata = {
  *
  * @param baseUrl - API base path (default: `/api/v1/localization`)
  */
-export function createLocalizationHandlers(baseUrl = DEFAULT_BASE_PATH) {
+export function createLocalizationHandlers(baseUrl = DEFAULT_BASE_PATH): RequestHandler[] {
   const languages = [...mockLanguages];
   let overrides: LocalizationOverride[] = [...mockLocalizationOverrides];
   const overridesBase = `${baseUrl}/overrides`;
 
   return [
-    // GET /overrides/meta — query metadata
-    createQueryMetaHandler(overridesBase, localizationOverrideQueryMetadata),
+    // GET /overrides/meta — query metadata. Inlined (rather than reusing
+    // `createQueryMetaHandler` from `@granit/react-query-engine/testing`)
+    // to keep this package's emitted DTS independent of that other
+    // package's MSW resolution — pnpm hoists two `msw` copies under
+    // different TS variants and the cross-package `RequestHandler` then
+    // breaks portable type emission (TS2883).
+    http.get(`${overridesBase}/meta`, () => HttpResponse.json(localizationOverrideQueryMetadata)),
 
     // GET /languages — list all languages
     http.get(`${baseUrl}/languages`, () => {

--- a/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
+++ b/packages/@granit/react-map/src/snapshot/map-snapshot-widget.tsx
@@ -120,9 +120,9 @@ function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
     // synthetic `kind: 'Custom'` only when the snapshot also asks for
     // 'Custom', which is intentional.
     const preferredLayer =
-      (snapshot.defaultLayerKind != null
-        ? layers.find((layer) => layer.kind === snapshot.defaultLayerKind)
-        : undefined) ?? layers[0];
+      (snapshot.defaultLayerKind == null
+        ? undefined
+        : layers.find((layer) => layer.kind === snapshot.defaultLayerKind)) ?? layers[0];
     const defaultTile = preferredLayer ? tileLayerById.get(preferredLayer.id) : undefined;
     defaultTile?.addTo(map);
 
@@ -190,16 +190,12 @@ function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
     let clusterGroup: L.LayerGroup | null = null;
 
     type ClusterFactory = () => L.LayerGroup;
-    type ClusterModule = { default?: ClusterFactory } | { markerClusterGroup?: ClusterFactory };
     const lWithCluster = L as unknown as { markerClusterGroup?: ClusterFactory };
     if (useCluster && typeof lWithCluster.markerClusterGroup === 'function') {
       clusterGroup = lWithCluster.markerClusterGroup();
-    } else if (useCluster) {
-      // leaflet.markercluster augments the L namespace at import time.
-      // When the optional peer isn't installed the cluster threshold
-      // becomes a soft hint — markers render unclustered.
-      void (null as unknown as ClusterModule);
     }
+    // When the optional peer isn't installed (no `markerClusterGroup` on `L`)
+    // the cluster threshold becomes a soft hint — markers render unclustered.
 
     for (const point of snapshot.points) {
       const marker = L.marker([point.latitude, point.longitude]);
@@ -213,8 +209,8 @@ function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
         const route = snapshot.detailRoute.replace('{id}', encodeURIComponent(point.id));
         marker.on('click', () => {
           // Apps wanting React Router integration override this snapshot
-          // renderer with `useNavigate()` instead of `window.location.href`.
-          window.location.href = route;
+          // renderer with `useNavigate()` instead of `globalThis.location.href`.
+          globalThis.location.href = route;
         });
         marker.options.alt = route;
       }
@@ -241,9 +237,9 @@ function MapBody({ snapshot }: { readonly snapshot: MapWidgetSnapshot }) {
 
 function escapeHtml(value: string): string {
   return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
 }

--- a/packages/@granit/react-map/src/types.ts
+++ b/packages/@granit/react-map/src/types.ts
@@ -11,7 +11,8 @@
  * authoritative ordering / spelling.
  */
 import type { MapTileLayerKind } from '@granit/analytics';
-export type { MapTileLayerKind };
+
+export type { MapTileLayerKind } from '@granit/analytics';
 
 /**
  * One tile layer offered by a {@link MapTileProvider}. Mirrors the inputs

--- a/packages/@granit/react-workspaces/src/api/use-landing-route.ts
+++ b/packages/@granit/react-workspaces/src/api/use-landing-route.ts
@@ -56,7 +56,7 @@ export function useSetLandingPin(): UseMutationResult<void, Error, SetPinnedLand
       await api.put(LANDING_ROUTE_PINNED_PATH, request);
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: landingRouteQueryKey() });
+      queryClient.invalidateQueries({ queryKey: landingRouteQueryKey() }).catch(() => {});
     },
   });
 }


### PR DESCRIPTION
## Summary

- **CI fix**: `@granit/react-localization` was failing `tsup` DTS emission with TS2883 — pnpm hoists two `msw` copies under different TS variants and `createQueryMetaHandler`'s `RequestHandler` return type leaked into `createLocalizationHandlers`'s inferred type. Inlined the trivial one-liner so this package's emitted types depend only on its own `msw` resolution.
- **`<EntityGallery />` honors ambient `groupBy`**: `params.groupBy` from `<QueryEndpointStateProvider>` now wins over `layout.groupByPropertyName` (which becomes a default fallback). Mirrors the table renderer's runtime-pivotable behavior so a host-side `GroupBySelector` repaints the grid live — showcase already wired this and was waiting on this PR.
- **Sonar batch** across charts / dashboards / entities / map / workspaces:
  - a11y: `<BlobImage>` defaults `alt=""`; gallery + kanban cards become proper buttons (`role`, `tabIndex`, Enter/Space keyDown)
  - safer scalar stringification — primitives only, objects via `JSON.stringify`, no more `[object Object]` slip-throughs in entity-detail / list / kanban / gallery, standard form/detail components
  - extracted nested ternaries (entity-detail section body, relation count label)
  - `typeof x === 'undefined'` → `x === undefined`
  - `void promise` → `promise.catch(() => {})` (gallery sentinel, useSetLandingPin)
  - `String#replace(/.../g, ...)` → `replaceAll` (map snapshot escapeHtml, tel detail component)
  - `window.location` → `globalThis.location` (map snapshot)
  - localeCompare-based sort for cache-key derivation (useEntityCalendar)
  - single `export type … from` re-export for `MapTileLayerKind`
  - redundant assertions / empty-object spreads cleaned (useEntityForm, standard-form-components)

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] `pnpm exec vitest run` — 2949 pass / 381 files
- [x] `pnpm --filter @granit/react-localization build` — DTS emits successfully
- [ ] CI green on this branch

## Cross-repo impact

- Closes the last functional gap on Epic #243 (`<EntityGallery />` runtime grouping).
- Showcase needs a one-line cleanup of the wait-comment in `workspace-entity-page.tsx` once this lands; no runtime change.