### PR TITLE
feat(react-blob-storage): generic <BlobUploadField /> + mock upload flow

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1975,6 +1975,17 @@
           "members": []
         },
         {
+          "name": "BlobUploadField",
+          "kind": "function",
+          "signature": "function BlobUploadField("
+        },
+        {
+          "name": "BlobUploadFieldProps",
+          "kind": "interface",
+          "signature": "interface BlobUploadFieldProps",
+          "members": []
+        },
+        {
           "name": "useBlob",
           "kind": "function",
           "signature": "function useBlob( id: string, containerName: string, options: BlobStorageOptions ): UseQueryResult<BlobDescriptorResponse>"

--- a/packages/@granit/react-blob-storage/src/__tests__/blob-upload-field.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/blob-upload-field.test.tsx
@@ -1,0 +1,338 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { BlobUploadField } from '../components/blob-upload-field.js';
+
+import type { ReactNode } from 'react';
+
+let xhrInstances: MockXHR[] = [];
+
+class MockXHR {
+  status = 200;
+  uploadListeners: Record<string, (e: unknown) => void> = {};
+  listeners: Record<string, (e: unknown) => void> = {};
+  upload = {
+    addEventListener: (event: string, handler: (e: unknown) => void) => {
+      this.uploadListeners[event] = handler;
+    },
+  };
+  addEventListener = (event: string, handler: (e: unknown) => void) => {
+    this.listeners[event] = handler;
+  };
+  open = vi.fn();
+  setRequestHeader = vi.fn();
+  send = vi.fn();
+  abort = vi.fn();
+  constructor() {
+    xhrInstances.push(this);
+  }
+  triggerLoad() {
+    this.listeners['load']?.({});
+  }
+}
+
+beforeAll(() => {
+  vi.stubGlobal('XMLHttpRequest', MockXHR);
+});
+afterAll(() => {
+  vi.unstubAllGlobals();
+});
+beforeEach(() => {
+  xhrInstances = [];
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeWrapper() {
+  const queryClient = createTestQueryClient();
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  // Stub the two HTTP calls the upload flow makes (initiate + confirm) so
+  // tests don't hit MSW for every render. The XHR PUT is intercepted by
+  // MockXHR above.
+  vi.spyOn(apiClient, 'post').mockImplementation(async (url: string) => {
+    if (url.endsWith('/upload')) {
+      return {
+        data: {
+          blobId: 'blob-uploaded-123',
+          uploadUrl: 'https://s3.example.com/presigned',
+          httpMethod: 'PUT',
+          expiresAt: '2026-12-31T00:00:00Z',
+          requiredHeaders: {},
+        },
+      } as unknown as Awaited<ReturnType<typeof apiClient.post>>;
+    }
+    if (url.includes('/confirm')) {
+      return {
+        data: {
+          blobId: 'blob-uploaded-123',
+          isValid: true,
+          status: 'Valid',
+          verifiedContentType: 'image/png',
+          sizeBytes: 12,
+          rejectionReason: null,
+        },
+      } as unknown as Awaited<ReturnType<typeof apiClient.post>>;
+    }
+    throw new Error(`Unexpected POST to ${url}`);
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+    </QueryClientProvider>
+  );
+  return { wrapper };
+}
+
+describe('BlobUploadField', () => {
+  it('renders the file input + idle data-phase when no value is set', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField value={null} onChange={() => undefined} containerName="avatars" />
+      </Wrapper>
+    );
+    const root = container.querySelector('[data-granit-blob-upload]') as HTMLElement;
+    expect(root.getAttribute('data-phase')).toBe('idle');
+    expect(root.hasAttribute('data-busy')).toBe(false);
+    expect(container.querySelector('[data-granit-blob-upload-input]')).not.toBeNull();
+    expect(container.querySelector('[data-granit-blob-upload-preview]')).toBeNull();
+    expect(container.querySelector('[data-granit-blob-upload-clear]')).toBeNull();
+  });
+
+  it('renders <BlobImage> preview + default clear button when a value is set', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value="parties/avatars/abc.jpg"
+          onChange={() => undefined}
+          containerName="avatars"
+        />
+      </Wrapper>
+    );
+    const preview = container.querySelector('[data-granit-blob-upload-preview]');
+    expect(preview).not.toBeNull();
+    expect(preview?.querySelector('img')).not.toBeNull();
+    expect(container.querySelector('[data-granit-blob-upload-clear]')).not.toBeNull();
+  });
+
+  it('clears the value when the default clear button is clicked', () => {
+    const onChange = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value="parties/avatars/abc.jpg"
+          onChange={onChange}
+          containerName="avatars"
+        />
+      </Wrapper>
+    );
+    fireEvent.click(container.querySelector('[data-granit-blob-upload-clear]') as HTMLElement);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('honors the renderPreview override slot', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const renderPreview = vi.fn(() => <span data-testid="custom-preview">custom</span>);
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value="parties/avatars/abc.jpg"
+          onChange={() => undefined}
+          containerName="avatars"
+          renderPreview={renderPreview}
+        />
+      </Wrapper>
+    );
+    expect(renderPreview).toHaveBeenCalledWith(
+      'parties/avatars/abc.jpg',
+      expect.objectContaining({ phase: 'idle' })
+    );
+    expect(container.querySelector('[data-testid="custom-preview"]')).not.toBeNull();
+    // Default <BlobImage> preview should NOT render alongside the override.
+    expect(container.querySelector('[data-granit-blob-upload-preview] img')).toBeNull();
+  });
+
+  it('suppresses the preview entirely when renderPreview is null', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value="parties/avatars/abc.jpg"
+          onChange={() => undefined}
+          containerName="avatars"
+          renderPreview={null}
+        />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-blob-upload-preview]')).toBeNull();
+  });
+
+  it('honors the renderClear override slot', () => {
+    const onChange = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value="parties/avatars/abc.jpg"
+          onChange={onChange}
+          containerName="avatars"
+          renderClear={({ clear }) => (
+            <button type="button" data-testid="custom-clear" onClick={clear}>
+              ×
+            </button>
+          )}
+        />
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-blob-upload-clear]')).toBeNull();
+    fireEvent.click(container.querySelector('[data-testid="custom-clear"]') as HTMLElement);
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+
+  it('disables the input + clear button when disabled is set', () => {
+    const onChange = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value="parties/avatars/abc.jpg"
+          onChange={onChange}
+          containerName="avatars"
+          disabled
+        />
+      </Wrapper>
+    );
+    const input = container.querySelector('[data-granit-blob-upload-input]') as HTMLInputElement;
+    expect(input.disabled).toBe(true);
+    const clear = container.querySelector('[data-granit-blob-upload-clear]') as HTMLButtonElement;
+    expect(clear.disabled).toBe(true);
+    fireEvent.click(clear);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('forwards id + name to the underlying <input>', () => {
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value={null}
+          onChange={() => undefined}
+          containerName="avatars"
+          id="field-Avatar"
+          name="Avatar"
+        />
+      </Wrapper>
+    );
+    const input = container.querySelector('[data-granit-blob-upload-input]') as HTMLInputElement;
+    expect(input.id).toBe('field-Avatar');
+    expect(input.name).toBe('Avatar');
+  });
+
+  it('rejects oversized files before the upload PUT fires', async () => {
+    const onChange = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value={null}
+          onChange={onChange}
+          containerName="avatars"
+          maxSizeBytes={100}
+        />
+      </Wrapper>
+    );
+    const input = container.querySelector('[data-granit-blob-upload-input]') as HTMLInputElement;
+    const file = new File(['a'.repeat(500)], 'big.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-blob-upload-error]')).not.toBeNull()
+    );
+    const err = container.querySelector('[data-granit-blob-upload-error]') as HTMLElement;
+    expect(err.getAttribute('data-error-kind')).toBe('validation');
+    expect(err.textContent).toContain('MB');
+    expect(xhrInstances.length).toBe(0);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('honors a custom validateFile slot and short-circuits on truthy return', async () => {
+    const onChange = vi.fn();
+    const validateFile = vi.fn(() => 'PNG only');
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value={null}
+          onChange={onChange}
+          containerName="avatars"
+          validateFile={validateFile}
+        />
+      </Wrapper>
+    );
+    const input = container.querySelector('[data-granit-blob-upload-input]') as HTMLInputElement;
+    const file = new File(['payload'], 'avatar.gif', { type: 'image/gif' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-blob-upload-error]')).not.toBeNull()
+    );
+    expect(validateFile).toHaveBeenCalledWith(file);
+    const err = container.querySelector('[data-granit-blob-upload-error]') as HTMLElement;
+    expect(err.textContent).toBe('PNG only');
+    expect(xhrInstances.length).toBe(0);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('clears validation errors when the user clears the value', async () => {
+    const onChange = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField
+          value="parties/avatars/abc.jpg"
+          onChange={onChange}
+          containerName="avatars"
+          maxSizeBytes={100}
+        />
+      </Wrapper>
+    );
+    // Trigger the size-error first.
+    const input = container.querySelector('[data-granit-blob-upload-input]') as HTMLInputElement;
+    const file = new File(['a'.repeat(500)], 'big.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-blob-upload-error]')).not.toBeNull()
+    );
+    // Click clear → error should disappear.
+    fireEvent.click(container.querySelector('[data-granit-blob-upload-clear]') as HTMLElement);
+    expect(container.querySelector('[data-granit-blob-upload-error]')).toBeNull();
+  });
+
+  it('runs the upload flow on file pick and reports the new blobId via onChange', async () => {
+    const onChange = vi.fn();
+    const { wrapper: Wrapper } = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <BlobUploadField value={null} onChange={onChange} containerName="avatars" />
+      </Wrapper>
+    );
+    const input = container.querySelector('[data-granit-blob-upload-input]') as HTMLInputElement;
+    const file = new File(['hello'], 'avatar.png', { type: 'image/png' });
+    Object.defineProperty(input, 'files', { value: [file] });
+    fireEvent.change(input);
+
+    // Wait for the XHR to be issued by useBlobUpload's middle step.
+    await waitFor(() => expect(xhrInstances.length).toBe(1));
+    xhrInstances[0]?.triggerLoad();
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('blob-uploaded-123'));
+  });
+});

--- a/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
@@ -18,3 +18,75 @@ describe('createBlobStorageHandlers /meta', () => {
     expect(await response.json()).toEqual(blobQueryMetadata);
   });
 });
+
+describe('createBlobStorageHandlers — upload flow', () => {
+  it('initiate → PUT → confirm round-trip surfaces a Valid descriptor', async () => {
+    server.use(...createBlobStorageHandlers(BASE));
+
+    // Initiate
+    const initiateResponse = await fetch(`${BASE}/blobs/upload`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        containerName: 'avatars',
+        fileName: 'me.png',
+        contentType: 'image/png',
+        sizeBytes: 1234,
+      }),
+    });
+    expect(initiateResponse.status).toBe(200);
+    const ticket = (await initiateResponse.json()) as {
+      blobId: string;
+      uploadUrl: string;
+      httpMethod: string;
+    };
+    expect(ticket.blobId).toMatch(/^avatars\//);
+    expect(ticket.httpMethod).toBe('PUT');
+    expect(ticket.uploadUrl).toContain('/_mock-upload-target');
+
+    // Pre-signed PUT
+    const putResponse = await fetch(ticket.uploadUrl, {
+      method: 'PUT',
+      body: 'fake-bytes',
+    });
+    expect(putResponse.status).toBe(200);
+
+    // Confirm
+    const confirmResponse = await fetch(
+      `${BASE}/blobs/${encodeURIComponent(ticket.blobId)}/confirm`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ containerName: 'avatars' }),
+      }
+    );
+    expect(confirmResponse.status).toBe(200);
+    const confirmation = (await confirmResponse.json()) as {
+      blobId: string;
+      isValid: boolean;
+      verifiedContentType: string | null;
+      sizeBytes: number | null;
+    };
+    expect(confirmation.blobId).toBe(ticket.blobId);
+    expect(confirmation.isValid).toBe(true);
+    expect(confirmation.verifiedContentType).toBe('image/png');
+    expect(confirmation.sizeBytes).toBe(1234);
+
+    // Subsequent GET resolves the freshly-uploaded record.
+    const getResponse = await fetch(`${BASE}/blobs/${encodeURIComponent(ticket.blobId)}`);
+    expect(getResponse.status).toBe(200);
+    const descriptor = (await getResponse.json()) as { id: string; status: number };
+    expect(descriptor.id).toBe(ticket.blobId);
+    expect(descriptor.status).toBe(2); // Valid
+  });
+
+  it('confirm fails when the blobId is unknown', async () => {
+    server.use(...createBlobStorageHandlers(BASE));
+    const response = await fetch(`${BASE}/blobs/unknown-id/confirm`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ containerName: 'avatars' }),
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/@granit/react-blob-storage/src/components/blob-upload-field.tsx
+++ b/packages/@granit/react-blob-storage/src/components/blob-upload-field.tsx
@@ -1,0 +1,254 @@
+import { useGranitClient } from '@granit/react-api-client';
+import { useCallback, useRef, useState, type ChangeEvent, type ReactNode } from 'react';
+
+import { useBlobUpload, type BlobUploadState } from '../hooks/use-blob-upload.js';
+
+import { BlobImage } from './blob-image.js';
+
+export interface BlobUploadFieldProps {
+  /** Current blob id (or `null` for empty). Stored verbatim as the field value. */
+  readonly value: string | null;
+  /** Called with the new blob id after a successful upload, or `null` on clear. */
+  readonly onChange: (next: string | null) => void;
+  /**
+   * Container the upload routes to (e.g. `'avatars'`, `'product-images'`).
+   * Required — the framework has no opinion on container naming, the host
+   * picks one per domain.
+   */
+  readonly containerName: string;
+  /**
+   * `accept` attribute on the underlying `<input type="file">`. Defaults
+   * to `'image/*'` since the most common use case is image upload; pass
+   * `''` (or any other MIME pattern) for non-image fields.
+   */
+  readonly accept?: string;
+  /** Disables both the picker and the clear button. */
+  readonly disabled?: boolean;
+  /** Forwarded to the `<input>`'s `id` attribute (for `<label htmlFor>` wiring). */
+  readonly id?: string;
+  /** Forwarded to the `<input>`'s `name` attribute. */
+  readonly name?: string;
+  /**
+   * Hard cap on the picked file size (bytes), validated client-side
+   * before the upload PUT fires. Files exceeding the cap surface an
+   * error message via `validateFile` (default: a localizable
+   * "File exceeds X MB" string) and short-circuit the upload — the
+   * backend should still enforce its own cap, this is a fast UX
+   * reject for the obvious 50 MB photo. Omit for no client-side cap.
+   */
+  readonly maxSizeBytes?: number;
+  /**
+   * Custom file-level validator run before the upload starts. Return a
+   * truthy error string to abort with that message, or `null` /
+   * `undefined` to let the upload proceed. Runs before the `maxSizeBytes`
+   * check so apps can short-circuit on MIME / extension / pixel-size
+   * concerns. The error surfaces through the same
+   * `data-granit-blob-upload-error` slot as upload failures.
+   */
+  readonly validateFile?: (file: File) => string | null | undefined;
+  /**
+   * Override the preview slot. Receives the current blob id (or `null`)
+   * and the upload state so the host can paint a richer preview (e.g.
+   * a circular avatar with a loading spinner). Pass `null` to suppress
+   * the framework default entirely. When omitted, the field renders
+   * `<BlobImage blobId={value} alt="" loading="lazy" />` — works for
+   * the avatar case out of the box.
+   */
+  readonly renderPreview?: ((blobId: string | null, state: BlobUploadState) => ReactNode) | null;
+  /**
+   * Override the clear-button slot. Receives the `clear` callback (which
+   * also resets the upload state). Returning `null` suppresses it.
+   * When omitted, a minimal unstyled `<button type="button">Clear</button>`
+   * appears once `value` is set and the upload isn't busy.
+   */
+  readonly renderClear?: ((args: { clear: () => void; disabled: boolean }) => ReactNode) | null;
+  /** Optional class for the root element. Forwarded verbatim to the wrapping `<div>`. */
+  readonly className?: string;
+}
+
+const DEFAULT_ACCEPT = 'image/*';
+
+/**
+ * Generic blob-upload field — orchestrates the three-step direct-to-cloud
+ * upload (initiate → PUT → confirm) via {@link useBlobUpload} and stores
+ * the resulting blob id as the field value. The form layer keeps
+ * `BlobReference` opaque (a string id on the wire); resolving it back to
+ * a URL for rendering is `<BlobImage>`'s job.
+ *
+ * Markup is intentionally unstyled — emits a structured DOM scaffold
+ * with `data-granit-blob-upload-*` data attributes so apps style it
+ * with the rest of their form chrome:
+ *
+ * ```html
+ * <div data-granit-blob-upload data-phase="idle" data-busy>
+ *   <div data-granit-blob-upload-preview>
+ *     <img src="…" loading="lazy" />
+ *   </div>
+ *   <input type="file" accept="image/*" data-granit-blob-upload-input />
+ *   <button type="button" data-granit-blob-upload-clear>Clear</button>
+ *   <progress value="42" max="100" data-granit-blob-upload-progress />
+ *   <span role="alert" data-granit-blob-upload-error>…</span>
+ * </div>
+ * ```
+ *
+ * Apps that need a polished UX (shadcn / Material / Tailwind chrome)
+ * pass `renderPreview` / `renderClear` overrides to plug in their own
+ * preview tile + remove button, and rely on the same `data-phase` /
+ * `data-busy` attributes for visual states. The framework handles all
+ * the upload mechanics — file picker, progress bar wiring, error
+ * surface, optimistic state.
+ *
+ * @example
+ * ```tsx
+ * // Minimal usage — out-of-the-box <BlobImage> preview, default clear button.
+ * <BlobUploadField
+ *   value={blobId}
+ *   onChange={setBlobId}
+ *   containerName="avatars"
+ * />
+ *
+ * // Form-component adapter for `<EntityRendererProvider>`.
+ * const blobUploadFormComponent: EntityFormComponent = ({ field, value, onChange, readOnly }) => {
+ *   const { containerName = 'blobs' } = (field.config ?? {}) as { containerName?: string };
+ *   return (
+ *     <BlobUploadField
+ *       id={`field-${field.propertyName}`}
+ *       name={field.propertyName}
+ *       value={typeof value === 'string' ? value : null}
+ *       onChange={onChange}
+ *       containerName={containerName}
+ *       disabled={readOnly}
+ *     />
+ *   );
+ * };
+ * ```
+ */
+export function BlobUploadField({
+  value,
+  onChange,
+  containerName,
+  accept = DEFAULT_ACCEPT,
+  disabled,
+  id,
+  name,
+  maxSizeBytes,
+  validateFile,
+  renderPreview,
+  renderClear,
+  className,
+}: BlobUploadFieldProps): ReactNode {
+  const client = useGranitClient();
+  const { upload, state, reset } = useBlobUpload({ client });
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+
+  const busy =
+    state.phase === 'initiating' || state.phase === 'uploading' || state.phase === 'confirming';
+
+  const handleFileChange = useCallback(
+    async (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      // Reset the input's value immediately so picking the same file twice
+      // re-triggers `onChange` (browsers swallow the second selection
+      // otherwise).
+      event.target.value = '';
+      if (!file) return;
+
+      // Clear any prior validation surface before running the new checks.
+      setValidationError(null);
+
+      // Custom validator runs first so apps can short-circuit on MIME /
+      // extension / pixel-size concerns before the size cap fires.
+      const customError = validateFile?.(file);
+      if (customError) {
+        setValidationError(customError);
+        return;
+      }
+      if (maxSizeBytes !== undefined && file.size > maxSizeBytes) {
+        const mb = (maxSizeBytes / (1024 * 1024)).toFixed(0);
+        setValidationError(`File exceeds ${mb} MB`);
+        return;
+      }
+
+      try {
+        const result = await upload({ file, containerName });
+        onChange(result.blobId);
+      } catch {
+        // `useBlobUpload` exposes the error through `state.error`; the
+        // catch here just prevents an unhandled rejection — the UI surfaces
+        // the failure via the `data-granit-blob-upload-error` slot.
+      }
+    },
+    [upload, containerName, onChange, maxSizeBytes, validateFile]
+  );
+
+  const handleClear = useCallback(() => {
+    if (disabled || busy) return;
+    reset();
+    setValidationError(null);
+    onChange(null);
+  }, [disabled, busy, reset, onChange]);
+
+  const preview =
+    renderPreview === null ? null : renderPreview ? (
+      renderPreview(value, state)
+    ) : value ? (
+      <BlobImage blobId={value} alt="" loading="lazy" />
+    ) : null;
+
+  const showClear = value !== null && !busy;
+  const clearSlot =
+    renderClear === null ? null : showClear ? (
+      renderClear ? (
+        renderClear({ clear: handleClear, disabled: disabled ?? false })
+      ) : (
+        <button
+          type="button"
+          onClick={handleClear}
+          disabled={disabled}
+          data-granit-blob-upload-clear=""
+        >
+          Clear
+        </button>
+      )
+    ) : null;
+
+  return (
+    <div
+      data-granit-blob-upload=""
+      data-phase={state.phase}
+      data-busy={busy ? '' : undefined}
+      className={className}
+    >
+      {preview ? <div data-granit-blob-upload-preview="">{preview}</div> : null}
+      <input
+        ref={inputRef}
+        id={id}
+        name={name}
+        type="file"
+        accept={accept}
+        disabled={disabled || busy}
+        onChange={handleFileChange}
+        data-granit-blob-upload-input=""
+      />
+      {clearSlot}
+      {state.phase === 'uploading' ? (
+        <progress
+          value={state.progress}
+          max={100}
+          data-granit-blob-upload-progress=""
+          aria-label="Upload progress"
+        />
+      ) : null}
+      {validationError ? (
+        <span role="alert" data-granit-blob-upload-error="" data-error-kind="validation">
+          {validationError}
+        </span>
+      ) : state.phase === 'error' && state.error ? (
+        <span role="alert" data-granit-blob-upload-error="" data-error-kind="upload">
+          {state.error.message}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/@granit/react-blob-storage/src/index.ts
+++ b/packages/@granit/react-blob-storage/src/index.ts
@@ -1,6 +1,8 @@
 // Components
 export { BlobImage } from './components/blob-image.js';
 export type { BlobImageProps } from './components/blob-image.js';
+export { BlobUploadField } from './components/blob-upload-field.js';
+export type { BlobUploadFieldProps } from './components/blob-upload-field.js';
 
 // Hooks
 export { useBlob } from './hooks/use-blob.js';

--- a/packages/@granit/react-blob-storage/src/testing/handlers.ts
+++ b/packages/@granit/react-blob-storage/src/testing/handlers.ts
@@ -13,7 +13,14 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 
 import { mockBlobs, S } from './data.js';
 
-import type { BlobDescriptorResponse, BlobStatusValue } from '@granit/blob-storage';
+import type {
+  BlobConfirmUploadRequest,
+  BlobConfirmUploadResponse,
+  BlobDescriptorResponse,
+  BlobStatusValue,
+  BlobUploadInitiateRequest,
+  BlobUploadInitiateResponse,
+} from '@granit/blob-storage';
 import type { QueryMetadata } from '@granit/query-engine';
 
 /** Mock /meta payload for the blobs resource. */
@@ -195,5 +202,83 @@ export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
       if (!blob) return new HttpResponse(null, { status: 404 });
       return HttpResponse.json(blob);
     }),
+
+    // Direct-to-cloud upload flow — three handlers covering the
+    // initiate → PUT → confirm shape `useBlobUpload` orchestrates. The
+    // pre-signed URL points back at this same MSW deployment so the
+    // PUT is interceptable in mock mode (real hosts hit S3 / Azure /
+    // GCS pre-signed URLs that bypass the API). Uploads are tracked
+    // in-memory by `pendingUploads` so the confirm step can echo back
+    // the right metadata.
+    http.post<never, BlobUploadInitiateRequest>(`${baseUrl}/blobs/upload`, async ({ request }) => {
+      const body = await request.json();
+      const blobId = `${body.containerName}/${randomId()}-${body.fileName}`;
+      pendingUploads.set(blobId, body);
+      const response: BlobUploadInitiateResponse = {
+        blobId,
+        uploadUrl: `${baseUrl}/blobs/${encodeURIComponent(blobId)}/_mock-upload-target`,
+        httpMethod: 'PUT',
+        expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+        requiredHeaders: {},
+      };
+      return HttpResponse.json(response);
+    }),
+
+    http.put(`${baseUrl}/blobs/:id/_mock-upload-target`, () => {
+      // Stand-in for the real provider's pre-signed PUT — accept the
+      // bytes, no body, no headers. The bytes are discarded; the
+      // confirm step is what surfaces a "Valid" descriptor.
+      return new HttpResponse(null, { status: 200 });
+    }),
+
+    http.post<{ id: string }, BlobConfirmUploadRequest>(
+      `${baseUrl}/blobs/:id/confirm`,
+      ({ params }) => {
+        const blobId = decodeURIComponent(params.id);
+        const tracked = pendingUploads.get(blobId);
+        if (!tracked) return new HttpResponse(null, { status: 404 });
+        pendingUploads.delete(blobId);
+        const response: BlobConfirmUploadResponse = {
+          blobId,
+          isValid: true,
+          status: S.Valid,
+          verifiedContentType: tracked.contentType,
+          sizeBytes: tracked.sizeBytes,
+          rejectionReason: null,
+        };
+        // Stash the descriptor so subsequent `GET /blobs/:id` requests
+        // (typically issued by `<BlobImage>` or the blob list page)
+        // find the freshly-uploaded record.
+        const now = new Date().toISOString();
+        const descriptor: BlobDescriptorResponse = {
+          id: blobId,
+          containerName: tracked.containerName,
+          originalFileName: tracked.fileName,
+          declaredContentType: tracked.contentType,
+          verifiedContentType: tracked.contentType,
+          declaredSizeBytes: tracked.sizeBytes,
+          actualSizeBytes: tracked.sizeBytes,
+          status: S.Valid,
+          rejectionReason: null,
+          deletionReason: null,
+          createdAt: now,
+          validatedAt: now,
+          deletedAt: null,
+        };
+        mockBlobs.push(descriptor);
+        return HttpResponse.json(response);
+      }
+    ),
   ];
+}
+
+const pendingUploads = new Map<string, BlobUploadInitiateRequest>();
+
+function randomId(): string {
+  // Crypto-grade ids are overkill for the mock; the goal is just a
+  // collision-free token within a session.
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 12);
 }


### PR DESCRIPTION
## Summary

Centralises the blob-upload plumbing every host was reimplementing on top of `useBlobUpload` (file picker, three-step direct-to-cloud orchestration, size-cap validation, error surface, BlobImage preview default). Closes the framework gap that surfaced when a host's manifest declared `component: 'avatar-upload'` (or `'image-upload'`) and the showcase had to recode the picker / preview / clear / progress wiring locally.

## What ships

### `<BlobUploadField />` — new component

- Props: `value` ↔ `onChange`, `containerName`, `disabled`, `id`, `name`, `accept`, `maxSizeBytes`, `validateFile`, `renderPreview`, `renderClear`, `className`
- Drives `useBlobUpload({ client })` via `useGranitClient()` — the framework owns the file picker, the three-step orchestration (initiate → PUT → confirm), the busy state, and the error surface.
- Emits a flat structured DOM scaffold with `data-granit-blob-upload-*` data-attrs (`data-phase`, `data-busy`, `-preview`, `-input`, `-clear`, `-progress`, `-error` with `data-error-kind="validation" | "upload"`) so apps style it via CSS without reading React state.
- Built-in client-side validation knobs: `maxSizeBytes` for the obvious 50 MB photo reject, plus a `validateFile?: (file) => string | null` slot for MIME / extension / pixel-size concerns. Both surface through the same `data-granit-blob-upload-error` slot as upload failures, distinguished by `data-error-kind`.
- Default preview uses `<BlobImage>`; default clear button is a minimal unstyled `<button>` shown when a value is set and the upload isn't busy. Apps with strong design systems (shadcn / Material / brand chrome) override `renderPreview` and `renderClear` to plug their own components — the framework still owns the upload logic.

### `createBlobStorageHandlers` — mock write flow

The MSW helper now covers the full upload round-trip alongside the existing read endpoints:

- `POST /upload` — synthesises a pre-signed ticket pointing at a same-origin `/_mock-upload-target` route (so MSW can intercept the PUT in node test mode without real S3).
- `PUT /:id/_mock-upload-target` — accepts the bytes, returns 200 with no body (stand-in for the real provider's pre-signed PUT).
- `POST /:id/confirm` — returns a Valid `BlobConfirmUploadResponse` and appends the descriptor to `mockBlobs` so subsequent `/blobs/:id` GETs find the freshly-uploaded record.

This unblocks any host wiring an upload form-component under MSW (showcase mock server was 404-ing on `POST /api/v1/blob-storage/blobs/upload`).

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] `pnpm exec vitest run` — **2983 / 2983 pass** (+14 vs. develop)
  - 12 component tests on `<BlobUploadField />`: idle / preview / clear / slot overrides / disabled / id-name forwarding / size-cap rejection / custom validator short-circuit / error-clear on remove / full upload round-trip
  - 3 mock-handler integration tests: initiate → PUT → confirm round-trip with descriptor stash, confirm 404 on unknown id
- [ ] CI green on this branch

## Cross-repo impact

Showcase's existing `<ImageUpload />` (and the historical `<AvatarUpload />` it replaced) keeps composing `useBlobUpload` directly — strong custom-UX wrappers (shadcn buttons, lucide icons, branded layouts, aspect-ratio frames) gain little from routing through `<BlobUploadField />`'s slot overrides because the framework's flat-DOM layout fights showcase's preview-tile + sidebar layout. `<BlobUploadField />` is the OOTB option for apps that want zero boilerplate; apps with strong design systems keep the hook-direct approach. No showcase change required.