### PR TITLE
feat(entities,react-entities): selection bar + drawer / modal hosts + OpenDrawer/OpenModal kinds

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2736,6 +2736,28 @@
           "members": []
         },
         {
+          "name": "EntityActionDrawerHost",
+          "kind": "function",
+          "signature": "function EntityActionDrawerHost("
+        },
+        {
+          "name": "EntityActionDrawerHostProps",
+          "kind": "interface",
+          "signature": "interface EntityActionDrawerHostProps",
+          "members": []
+        },
+        {
+          "name": "EntityActionModalHost",
+          "kind": "function",
+          "signature": "function EntityActionModalHost("
+        },
+        {
+          "name": "EntityActionModalHostProps",
+          "kind": "interface",
+          "signature": "interface EntityActionModalHostProps",
+          "members": []
+        },
+        {
           "name": "EntityCalendar",
           "kind": "function",
           "signature": "function EntityCalendar("
@@ -2821,6 +2843,33 @@
           "name": "EntityListPageHeaderProps",
           "kind": "interface",
           "signature": "interface EntityListPageHeaderProps",
+          "members": []
+        },
+        {
+          "name": "SelectionContext",
+          "kind": "const",
+          "signature": "const SelectionContext"
+        },
+        {
+          "name": "useSelection",
+          "kind": "function",
+          "signature": "function useSelection(): SelectionContextValue"
+        },
+        {
+          "name": "SelectionContextValue",
+          "kind": "interface",
+          "signature": "interface SelectionContextValue",
+          "members": []
+        },
+        {
+          "name": "SelectionProvider",
+          "kind": "function",
+          "signature": "function SelectionProvider("
+        },
+        {
+          "name": "SelectionProviderProps",
+          "kind": "interface",
+          "signature": "interface SelectionProviderProps",
           "members": []
         },
         {

--- a/packages/@granit/entities/src/index.ts
+++ b/packages/@granit/entities/src/index.ts
@@ -50,6 +50,7 @@ export type {
   EntityPermissionsSection,
   EntityRelationAggregateManifest,
   EntityRelationManifest,
+  EntitySelectionActionManifest,
   FieldOp,
   GalleryCardSize,
   KanbanColor,

--- a/packages/@granit/entities/src/types/actions.ts
+++ b/packages/@granit/entities/src/types/actions.ts
@@ -6,7 +6,13 @@
  *
  * Mirrors `Granit.Entities.Actions.EntityActionKind`.
  */
-export type EntityActionKind = 'ApiCall' | 'Download' | 'Navigate' | 'WorkflowTransition';
+export type EntityActionKind =
+  | 'ApiCall'
+  | 'Download'
+  | 'Navigate'
+  | 'WorkflowTransition'
+  | 'OpenDrawer'
+  | 'OpenModal';
 
 /**
  * Wire shape for one action exposed on an entity manifest. Carries the

--- a/packages/@granit/entities/src/types/collections.ts
+++ b/packages/@granit/entities/src/types/collections.ts
@@ -51,6 +51,22 @@ export interface EntityCollectionsSection {
    * header bar fires.
    */
   readonly headerActions: readonly EntityHeaderActionManifest[];
+  /**
+   * Compact references to actions pinned on the selection bar
+   * (visible when the row-selection set is non-empty — bulk surface).
+   * Already permission-filtered server-side.
+   *
+   * Wire-shape note: `selectionActions[]` and `headerActions[]` are
+   * mutually exclusive on the same action — `OnSelection()` requires
+   * a `{id}` placeholder (fan-out across the selected ids), while
+   * `OnListHeader()` forbids it (fire-once, no row context). The
+   * .NET builder enforces the split at host startup.
+   *
+   * The renderer iterates the selected ids, substitutes `{id}` per
+   * id, fires N requests in parallel (concurrency capped at 10 per
+   * the front matrix), then surfaces a per-id success/failure recap.
+   */
+  readonly selectionActions: readonly EntitySelectionActionManifest[];
 }
 
 /**
@@ -67,6 +83,37 @@ export interface EntityHeaderActionManifest {
   readonly displayKey: string | null;
   /** Icon name from the catalog. */
   readonly icon: string | null;
+  /** Contributing assembly. `null` for intra-module declarations. */
+  readonly contributorAssemblyName: string | null;
+}
+
+/**
+ * Compact reference to one action pinned on the selection bar (bulk
+ * surface). The full descriptor stays addressable via the entity's
+ * `actions` facet by `name`.
+ *
+ * Unlike the other compact references, this shape carries
+ * `confirmationKey` inline — bulk operations are typically destructive
+ * and the UX-critical "are you sure (about N rows)" flow needs the
+ * key without an extra round-trip through the actions facet, so the
+ * server inlines it server-side.
+ *
+ * Mirrors `Granit.Entities.Endpoints.Dtos.EntitySelectionActionManifest`.
+ */
+export interface EntitySelectionActionManifest {
+  /** Stable action name — matches the entry in `actions`. */
+  readonly name: string;
+  /** i18n key for the user-facing label. */
+  readonly displayKey: string | null;
+  /** Icon name from the catalog. */
+  readonly icon: string | null;
+  /**
+   * Optional i18n key for the confirmation modal that fires before the
+   * fan-out. Inlined here (not just on the full descriptor) because
+   * bulk destructive operations need the key without an extra
+   * actions-facet lookup at click time.
+   */
+  readonly confirmationKey: string | null;
   /** Contributing assembly. `null` for intra-module declarations. */
   readonly contributorAssemblyName: string | null;
 }

--- a/packages/@granit/entities/src/types/index.ts
+++ b/packages/@granit/entities/src/types/index.ts
@@ -3,6 +3,7 @@ export type {
   EntityCollectionReference,
   EntityCollectionsSection,
   EntityHeaderActionManifest,
+  EntitySelectionActionManifest,
 } from './collections.js';
 export type {
   EntityDetailManifest,

--- a/packages/@granit/react-entities/src/__tests__/entity-action-overlay-hosts.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-action-overlay-hosts.test.tsx
@@ -1,0 +1,152 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { act, fireEvent, render, renderHook } from '@testing-library/react';
+import axios from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import {
+  useEntityActionDrawer,
+  useEntityActionModal,
+} from '../actions/entity-action-overlay-context.js';
+import { useEntityActionDispatcher } from '../actions/use-entity-action-dispatcher.js';
+import { EntityActionDrawerHost } from '../components/entity-action-drawer-host.js';
+import { EntityActionModalHost } from '../components/entity-action-modal-host.js';
+
+import type { EntityActionManifest } from '@granit/entities';
+import type { ReactNode } from 'react';
+
+function makeAction(overrides: Partial<EntityActionManifest> = {}): EntityActionManifest {
+  return {
+    name: 'edit',
+    kind: 'OpenModal',
+    displayKey: null,
+    icon: null,
+    order: 0,
+    urlTemplate: null,
+    httpMethod: null,
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+    ...overrides,
+  };
+}
+
+function makeWrapper() {
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return ({ children }: { children: ReactNode }) => (
+    <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+  );
+}
+
+describe('EntityActionDrawerHost / useEntityActionDrawer', () => {
+  it('starts with current = null and exposes open/close', () => {
+    const Wrapper = makeWrapper();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Wrapper>
+        <EntityActionDrawerHost>{children}</EntityActionDrawerHost>
+      </Wrapper>
+    );
+    const { result } = renderHook(() => useEntityActionDrawer(), { wrapper });
+    expect(result.current.current).toBeNull();
+    act(() => result.current.open({ action: makeAction({ kind: 'OpenDrawer' }), rowId: 'r1', row: null }));
+    expect(result.current.current?.rowId).toBe('r1');
+    act(() => result.current.close());
+    expect(result.current.current).toBeNull();
+  });
+
+  it('throws when used outside <EntityActionDrawerHost>', () => {
+    expect(() => renderHook(() => useEntityActionDrawer())).toThrow(/EntityActionDrawerHost/);
+  });
+
+  it('integration: dispatcher OpenDrawer pushes through the host context', () => {
+    const Wrapper = makeWrapper();
+    let captured: ReturnType<typeof useEntityActionDrawer> | null = null;
+    function Probe() {
+      captured = useEntityActionDrawer();
+      return null;
+    }
+    function Trigger() {
+      const dispatch = useEntityActionDispatcher();
+      return (
+        <button
+          type="button"
+          data-testid="trigger"
+          onClick={() => {
+            dispatch(
+              makeAction({ kind: 'OpenDrawer', urlTemplate: null }),
+              'row-42',
+              { id: 'row-42' }
+            ).catch(() => undefined);
+          }}
+        />
+      );
+    }
+    const { container } = render(
+      <Wrapper>
+        <EntityActionDrawerHost>
+          <Probe />
+          <Trigger />
+        </EntityActionDrawerHost>
+      </Wrapper>
+    );
+    expect(captured!.current).toBeNull();
+    fireEvent.click(container.querySelector('[data-testid="trigger"]') as HTMLElement);
+    expect(captured!.current?.rowId).toBe('row-42');
+    expect(captured!.current?.action.kind).toBe('OpenDrawer');
+  });
+});
+
+describe('EntityActionModalHost / useEntityActionModal', () => {
+  it('starts with current = null and exposes open/close', () => {
+    const Wrapper = makeWrapper();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <Wrapper>
+        <EntityActionModalHost>{children}</EntityActionModalHost>
+      </Wrapper>
+    );
+    const { result } = renderHook(() => useEntityActionModal(), { wrapper });
+    expect(result.current.current).toBeNull();
+    act(() =>
+      result.current.open({ action: makeAction({ kind: 'OpenModal' }), rowId: 'm1', row: null })
+    );
+    expect(result.current.current?.rowId).toBe('m1');
+  });
+
+  it('throws when used outside <EntityActionModalHost>', () => {
+    expect(() => renderHook(() => useEntityActionModal())).toThrow(/EntityActionModalHost/);
+  });
+
+  it('integration: dispatcher OpenModal pushes through the host context (URL-fallback case)', () => {
+    const Wrapper = makeWrapper();
+    let captured: ReturnType<typeof useEntityActionModal> | null = null;
+    function Probe() {
+      captured = useEntityActionModal();
+      return null;
+    }
+    function Trigger() {
+      const dispatch = useEntityActionDispatcher();
+      return (
+        <button
+          type="button"
+          data-testid="trigger"
+          onClick={() => {
+            dispatch(
+              makeAction({ kind: 'OpenModal', urlTemplate: '/import?ids=…' }),
+              null,
+              null
+            ).catch(() => undefined);
+          }}
+        />
+      );
+    }
+    const { container } = render(
+      <Wrapper>
+        <EntityActionModalHost>
+          <Probe />
+          <Trigger />
+        </EntityActionModalHost>
+      </Wrapper>
+    );
+    fireEvent.click(container.querySelector('[data-testid="trigger"]') as HTMLElement);
+    expect(captured!.current?.action.urlTemplate).toBe('/import?ids=…');
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
@@ -175,6 +175,7 @@ function manifest(
               ]
             : [],
           headerActions: [],
+          selectionActions: [],
         }
       : null,
     relations: null,

--- a/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
@@ -80,6 +80,7 @@ function manifest(hasQuery: boolean): EntityManifestResponse {
           defaultViewId: null,
           listLayouts: [],
           headerActions: [],
+          selectionActions: [],
         }
       : null,
     relations: null,

--- a/packages/@granit/react-entities/src/__tests__/entity-list-page-header.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-list-page-header.test.tsx
@@ -56,6 +56,7 @@ function makeManifest(args: {
       defaultViewId: null,
       listLayouts: [],
       headerActions: args.headerActions,
+      selectionActions: [],
     },
     relations: null,
     actions: args.actions,

--- a/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-list.test.tsx
@@ -90,6 +90,7 @@ function manifest(hasQuery: boolean): EntityManifestResponse {
           defaultViewId: null,
           listLayouts: [],
           headerActions: [],
+          selectionActions: [],
         }
       : null,
     relations: null,

--- a/packages/@granit/react-entities/src/__tests__/selection.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/selection.test.tsx
@@ -1,0 +1,484 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { act, fireEvent, render, renderHook, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  EntitySelectionBar,
+  fanOutWithCap,
+  SELECTION_FANOUT_CONCURRENCY_CAP,
+} from '../components/entity-selection-bar.js';
+import { SelectionContext, useSelection } from '../selection/selection-context.js';
+import { SelectionProvider } from '../selection/selection-provider.js';
+
+import type {
+  EntityActionManifest,
+  EntityManifestResponse,
+  EntitySelectionActionManifest,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY_NAME = 'Granit.Parties.Party';
+
+function makeAction(overrides: Partial<EntityActionManifest> = {}): EntityActionManifest {
+  return {
+    name: 'archive',
+    kind: 'ApiCall',
+    displayKey: 'Parties.Action.Archive',
+    icon: 'archive',
+    order: 0,
+    urlTemplate: '/api/parties/{id}/archive',
+    httpMethod: 'POST',
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+    ...overrides,
+  };
+}
+
+function makeManifest(args: {
+  selectionActions: readonly EntitySelectionActionManifest[];
+  actions: readonly EntityActionManifest[] | null;
+}): EntityManifestResponse {
+  return {
+    schemaVersion: 1,
+    identity: {
+      name: ENTITY_NAME,
+      entityClrType: 'Granit.Parties.Domain.Party',
+      displayKey: null,
+      icon: null,
+      permissionGroup: null,
+      displayProperty: 'name',
+      subtitleProperty: null,
+    },
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: {
+      query: null,
+      export: null,
+      metrics: [],
+      dashboards: [],
+      defaultViewId: null,
+      listLayouts: [],
+      headerActions: [],
+      selectionActions: args.selectionActions,
+    },
+    relations: null,
+    actions: args.actions,
+  };
+}
+
+function makeWrapper() {
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return ({ children }: { children: ReactNode }) => (
+    <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+  );
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// SelectionProvider + useSelection
+// ---------------------------------------------------------------------------
+
+describe('useSelection', () => {
+  it('returns a no-op default outside a provider', () => {
+    const { result } = renderHook(() => useSelection());
+    expect(result.current.size).toBe(0);
+    expect(result.current.mode).toBe('explicit');
+    expect(() => result.current.toggle('a')).not.toThrow();
+  });
+
+  it('toggles ids on/off via the provider', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SelectionProvider>{children}</SelectionProvider>
+    );
+    const { result } = renderHook(() => useSelection(), { wrapper });
+    expect(result.current.size).toBe(0);
+    act(() => result.current.toggle('a'));
+    expect(result.current.size).toBe(1);
+    expect(result.current.selectedIds.has('a')).toBe(true);
+    act(() => result.current.toggle('b'));
+    expect(result.current.size).toBe(2);
+    act(() => result.current.toggle('a'));
+    expect(result.current.size).toBe(1);
+    expect(result.current.selectedIds.has('a')).toBe(false);
+  });
+
+  it('replaces and clears the selection', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <SelectionProvider initialSelectedIds={['x']}>{children}</SelectionProvider>
+    );
+    const { result } = renderHook(() => useSelection(), { wrapper });
+    expect(result.current.size).toBe(1);
+    act(() => result.current.setSelected(['p', 'q', 'r']));
+    expect(result.current.size).toBe(3);
+    act(() => result.current.clear());
+    expect(result.current.size).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fanOutWithCap helper
+// ---------------------------------------------------------------------------
+
+describe('fanOutWithCap', () => {
+  it('respects the concurrency cap (never more than `cap` in-flight)', async () => {
+    const ids = Array.from({ length: 25 }, (_, i) => `id-${i}`);
+    let inFlight = 0;
+    let peak = 0;
+    const recap = await fanOutWithCap(
+      ids,
+      async (id) => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise<void>((resolve) => setTimeout(resolve, 5));
+        inFlight -= 1;
+        return { kind: 'ok', id };
+      },
+      4
+    );
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(recap.succeeded).toHaveLength(25);
+    expect(recap.failed).toHaveLength(0);
+  });
+
+  it('captures err results without short-circuiting', async () => {
+    const ids = ['a', 'b', 'c', 'd'];
+    const recap = await fanOutWithCap(
+      ids,
+      async (id) =>
+        id === 'b' || id === 'd' ? { kind: 'err', id, error: new Error('nope') } : { kind: 'ok', id },
+      2
+    );
+    expect(recap.succeeded.sort()).toEqual(['a', 'c']);
+    expect(recap.failed.map((f) => f.id).sort()).toEqual(['b', 'd']);
+  });
+
+  it('exposes the concurrency cap constant at 10', () => {
+    expect(SELECTION_FANOUT_CONCURRENCY_CAP).toBe(10);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EntitySelectionBar
+// ---------------------------------------------------------------------------
+
+describe('EntitySelectionBar', () => {
+  it('renders nothing when the manifest declares no selectionActions', () => {
+    const Wrapper = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['a']}>
+          <EntitySelectionBar manifest={makeManifest({ selectionActions: [], actions: [] })} />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-entity-selection-bar]')).toBeNull();
+  });
+
+  it('renders nothing when nothing is selected, even if the manifest has selectionActions', () => {
+    const Wrapper = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: 'Parties.Action.Archive',
+                  icon: 'archive',
+                  confirmationKey: null,
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    expect(container.querySelector('[data-granit-entity-selection-bar]')).toBeNull();
+  });
+
+  it('shows the bar with metadata data-attrs when selection is non-empty', () => {
+    const Wrapper = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['a', 'b', 'c']}>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: 'Parties.Action.Archive',
+                  icon: 'archive',
+                  confirmationKey: null,
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    const bar = container.querySelector('[data-granit-entity-selection-bar]') as HTMLElement;
+    expect(bar.getAttribute('data-entity')).toBe(ENTITY_NAME);
+    expect(bar.getAttribute('data-selected-count')).toBe('3');
+    const button = container.querySelector('[data-granit-entity-action]') as HTMLElement;
+    expect(button.getAttribute('data-action-name')).toBe('archive');
+    expect(button.getAttribute('data-action-kind')).toBe('ApiCall');
+  });
+
+  it('fans out the action across selected ids and surfaces a recap on completion', async () => {
+    const Wrapper = makeWrapper();
+    const dispatched: string[] = [];
+    const apiCall = vi.fn(async (_action, rowId: string | null) => {
+      dispatched.push(rowId ?? '<null>');
+    });
+    const onComplete = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['p1', 'p2', 'p3']}>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: null,
+                  icon: 'archive',
+                  confirmationKey: null,
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+            handlers={{ apiCall }}
+            onComplete={onComplete}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    expect(dispatched.sort()).toEqual(['p1', 'p2', 'p3']);
+    const recap = onComplete.mock.calls[0]?.[1];
+    expect(recap.succeeded.sort()).toEqual(['p1', 'p2', 'p3']);
+    expect(recap.failed).toHaveLength(0);
+  });
+
+  it('partitions succeeded vs. failed in the recap when some calls reject', async () => {
+    const Wrapper = makeWrapper();
+    const apiCall = vi.fn(async (_action, rowId: string | null) => {
+      if (rowId === 'p2') throw new Error('boom');
+    });
+    const onComplete = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['p1', 'p2', 'p3']}>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: null,
+                  icon: null,
+                  confirmationKey: null,
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+            handlers={{ apiCall }}
+            onComplete={onComplete}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    const recap = onComplete.mock.calls[0]?.[1];
+    expect(recap.succeeded.sort()).toEqual(['p1', 'p3']);
+    expect(recap.failed.map((f: { id: string }) => f.id)).toEqual(['p2']);
+  });
+
+  it('confirms via globalThis.confirm when confirmationKey is set and short-circuits on cancel', () => {
+    const Wrapper = makeWrapper();
+    const confirmStub = vi.spyOn(globalThis, 'confirm').mockReturnValue(false);
+    const apiCall = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['p1']}>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: null,
+                  icon: null,
+                  confirmationKey: 'Parties.Confirm.BulkArchive',
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+            handlers={{ apiCall }}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    expect(confirmStub).toHaveBeenCalledWith('Parties.Confirm.BulkArchive');
+    expect(apiCall).not.toHaveBeenCalled();
+  });
+
+  it('honors a custom confirm slot and aborts when it returns false', async () => {
+    const Wrapper = makeWrapper();
+    const confirm = vi.fn(async () => false);
+    const apiCall = vi.fn();
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['p1', 'p2']}>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: null,
+                  icon: null,
+                  confirmationKey: 'Parties.Confirm.BulkArchive',
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+            handlers={{ apiCall }}
+            confirm={confirm}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(confirm).toHaveBeenCalledOnce());
+    expect(apiCall).not.toHaveBeenCalled();
+  });
+
+  it('clears the selection on full success and keeps failed ids selected', async () => {
+    const Wrapper = makeWrapper();
+    const apiCall = vi.fn(async (_action, rowId: string | null) => {
+      if (rowId === 'p2') throw new Error('nope');
+    });
+    let observedSize = -1;
+    function ObserveSelection() {
+      const sel = useSelection();
+      observedSize = sel.size;
+      return null;
+    }
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['p1', 'p2']}>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: null,
+                  icon: null,
+                  confirmationKey: null,
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+            handlers={{ apiCall }}
+          />
+          <ObserveSelection />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(observedSize).toBe(1));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Selection-aware UI integrated with mounted SelectionContext
+// ---------------------------------------------------------------------------
+
+describe('SelectionContext + EntitySelectionBar interplay', () => {
+  it('clear-selection button drops the size to 0', () => {
+    const Wrapper = makeWrapper();
+    let observedSize = -1;
+    function Observe() {
+      const sel = useSelection();
+      observedSize = sel.size;
+      return null;
+    }
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['p1', 'p2']}>
+          <Observe />
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: null,
+                  icon: null,
+                  confirmationKey: null,
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    expect(observedSize).toBe(2);
+    fireEvent.click(
+      container.querySelector('[data-granit-selection-bar-clear]') as HTMLElement
+    );
+    expect(observedSize).toBe(0);
+  });
+
+  it('uses an external SelectionContext value when SelectionProvider is replaced', () => {
+    const noOp = (): void => undefined;
+    const externalCtx = {
+      selectedIds: new Set(['ext-1']),
+      mode: 'explicit' as const,
+      size: 1,
+      toggle: noOp,
+      setSelected: noOp,
+      clear: noOp,
+    };
+    const Wrapper = makeWrapper();
+    const { container } = render(
+      <Wrapper>
+        <SelectionContext.Provider value={externalCtx}>
+          <EntitySelectionBar
+            manifest={makeManifest({
+              selectionActions: [
+                {
+                  name: 'archive',
+                  displayKey: null,
+                  icon: null,
+                  confirmationKey: null,
+                  contributorAssemblyName: null,
+                },
+              ],
+              actions: [makeAction()],
+            })}
+          />
+        </SelectionContext.Provider>
+      </Wrapper>
+    );
+    const bar = container.querySelector('[data-granit-entity-selection-bar]') as HTMLElement;
+    expect(bar.getAttribute('data-selected-count')).toBe('1');
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/use-entity-action-dispatcher.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-action-dispatcher.test.tsx
@@ -6,6 +6,10 @@ import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  EntityActionDrawerContext,
+  EntityActionModalContext,
+} from '../actions/entity-action-overlay-context.js';
+import {
   resolveActionUrl,
   useEntityActionDispatcher,
   type EntityActionHandlers,
@@ -196,6 +200,61 @@ describe('useEntityActionDispatcher — WorkflowTransition', () => {
     const row = { id: 'abc', workflowState: 'Draft' };
     await result.current(action, 'abc', row);
     expect(workflowTransition).toHaveBeenCalledWith(action, 'abc', row, expect.anything());
+  });
+});
+
+describe('useEntityActionDispatcher — OpenDrawer / OpenModal', () => {
+  it('OpenDrawer opens the drawer host context when mounted', async () => {
+    const { wrapper: BaseWrapper } = makeWrapper();
+    const drawerStub = { open: vi.fn(), close: vi.fn(), current: null };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <BaseWrapper>
+        <EntityActionDrawerContext.Provider value={drawerStub}>
+          {children}
+        </EntityActionDrawerContext.Provider>
+      </BaseWrapper>
+    );
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    const action = makeAction({ kind: 'OpenDrawer', urlTemplate: null });
+    await result.current(action, 'abc', { id: 'abc' });
+    expect(drawerStub.open).toHaveBeenCalledOnce();
+    expect(drawerStub.open).toHaveBeenCalledWith(
+      expect.objectContaining({ action, rowId: 'abc', row: expect.objectContaining({ id: 'abc' }) })
+    );
+  });
+
+  it('OpenDrawer warns when no host context and no handler is supplied', async () => {
+    const warn = vi.spyOn(globalThis.console, 'warn').mockImplementation(() => undefined);
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    await result.current(makeAction({ kind: 'OpenDrawer' }), 'abc', null);
+    expect(warn).toHaveBeenCalledOnce();
+    expect(String(warn.mock.calls[0]?.[0])).toContain('OpenDrawer');
+  });
+
+  it('OpenModal delegates to the openModal handler override when supplied', async () => {
+    const openModal = vi.fn();
+    const { wrapper } = makeWrapper();
+    const { result } = renderHook(() => useEntityActionDispatcher({ openModal }), { wrapper });
+    const action = makeAction({ kind: 'OpenModal', urlTemplate: '/import?ids=1,2' });
+    await result.current(action, null, null);
+    expect(openModal).toHaveBeenCalledOnce();
+    expect(openModal).toHaveBeenCalledWith(action, null, null, expect.anything());
+  });
+
+  it('OpenModal opens the modal host context when mounted', async () => {
+    const { wrapper: BaseWrapper } = makeWrapper();
+    const modalStub = { open: vi.fn(), close: vi.fn(), current: null };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <BaseWrapper>
+        <EntityActionModalContext.Provider value={modalStub}>
+          {children}
+        </EntityActionModalContext.Provider>
+      </BaseWrapper>
+    );
+    const { result } = renderHook(() => useEntityActionDispatcher(), { wrapper });
+    await result.current(makeAction({ kind: 'OpenModal' }), 'abc', null);
+    expect(modalStub.open).toHaveBeenCalledOnce();
   });
 });
 

--- a/packages/@granit/react-entities/src/actions/entity-action-overlay-context.ts
+++ b/packages/@granit/react-entities/src/actions/entity-action-overlay-context.ts
@@ -1,0 +1,69 @@
+import { createContext, useContext } from 'react';
+
+import type { EntityActionManifest } from '@granit/entities';
+
+/**
+ * Snapshot of the action that triggered an overlay (drawer or modal).
+ * Stored in `<EntityActionDrawerHost>` / `<EntityActionModalHost>`
+ * context so the host's UI (Radix Dialog, shadcn Sheet, …) can read
+ * the active action and render the right body — typically
+ * `<EntityDetail variant="default" />` for `OpenDrawer` with a null
+ * `urlTemplate`, or `<EntityForm variant="default" />` for `OpenModal`
+ * with a null `urlTemplate`.
+ */
+export interface EntityActionOverlayState {
+  readonly action: EntityActionManifest;
+  /** Row id substituted into the action's URL template via `{id}`. */
+  readonly rowId: string | null;
+  /** Optional row context — passed through for custom renderers. */
+  readonly row: Readonly<Record<string, unknown>> | null;
+}
+
+/**
+ * Shape exposed by `<EntityActionDrawerHost>` / `<EntityActionModalHost>`
+ * via context. The dispatcher calls `open()` when the matching
+ * `EntityActionKind` fires; the host's UI reads `current` to know what
+ * to render and calls `close()` when the user dismisses.
+ */
+export interface EntityActionOverlayContextValue {
+  readonly current: EntityActionOverlayState | null;
+  readonly open: (state: EntityActionOverlayState) => void;
+  readonly close: () => void;
+}
+
+export const EntityActionDrawerContext =
+  createContext<EntityActionOverlayContextValue | null>(null);
+
+export const EntityActionModalContext =
+  createContext<EntityActionOverlayContextValue | null>(null);
+
+/**
+ * Read the drawer host's context inside an app component (typically
+ * the host's actual drawer UI). Throws when the component tree is not
+ * wrapped in `<EntityActionDrawerHost>` — apps that don't surface a
+ * drawer simply don't mount the host, and the dispatcher falls back to
+ * a `console.warn` for `OpenDrawer` actions instead.
+ */
+export function useEntityActionDrawer(): EntityActionOverlayContextValue {
+  const ctx = useContext(EntityActionDrawerContext);
+  if (!ctx) {
+    throw new Error(
+      'useEntityActionDrawer must be used within <EntityActionDrawerHost>'
+    );
+  }
+  return ctx;
+}
+
+/**
+ * Symmetric counterpart of {@link useEntityActionDrawer} for the
+ * modal host.
+ */
+export function useEntityActionModal(): EntityActionOverlayContextValue {
+  const ctx = useContext(EntityActionModalContext);
+  if (!ctx) {
+    throw new Error(
+      'useEntityActionModal must be used within <EntityActionModalHost>'
+    );
+  }
+  return ctx;
+}

--- a/packages/@granit/react-entities/src/actions/use-entity-action-dispatcher.ts
+++ b/packages/@granit/react-entities/src/actions/use-entity-action-dispatcher.ts
@@ -1,5 +1,10 @@
 import { useGranitClient } from '@granit/react-api-client';
-import { useCallback } from 'react';
+import { useCallback, useContext } from 'react';
+
+import {
+  EntityActionDrawerContext,
+  EntityActionModalContext,
+} from './entity-action-overlay-context.js';
 
 import type { AxiosInstance } from '@granit/api-client';
 import type { EntityActionManifest } from '@granit/entities';
@@ -39,6 +44,21 @@ export interface EntityActionHandlers {
    * with workflow-bearing entities must wire this slot.
    */
   readonly workflowTransition?: EntityActionHandler;
+  /**
+   * `OpenDrawer` — opens a side drawer on the row. Default delegates
+   * to the nearest `<EntityActionDrawerHost>` context (when mounted)
+   * by calling its `open()` callback; without the host context, the
+   * default short-circuits with a `console.warn`. Apps that want
+   * direct dispatch (no host) override this slot to mount their own
+   * drawer state.
+   */
+  readonly openDrawer?: EntityActionHandler;
+  /**
+   * `OpenModal` — opens a modal on the row. Symmetric counterpart of
+   * `openDrawer` — defaults to the nearest `<EntityActionModalHost>`
+   * context.
+   */
+  readonly openModal?: EntityActionHandler;
 }
 
 /**
@@ -88,10 +108,14 @@ export function useEntityActionDispatcher(
   handlers: EntityActionHandlers = {}
 ): EntityActionDispatch {
   const client = useGranitClient();
+  const drawerCtx = useContext(EntityActionDrawerContext);
+  const modalCtx = useContext(EntityActionModalContext);
   const apiCall = handlers.apiCall ?? defaultApiCall;
   const download = handlers.download ?? defaultDownload;
   const navigate = handlers.navigate ?? defaultNavigate;
   const workflowTransition = handlers.workflowTransition ?? defaultWorkflowTransition;
+  const openDrawer = handlers.openDrawer;
+  const openModal = handlers.openModal;
 
   return useCallback<EntityActionDispatch>(
     async (action, rowId, row) => {
@@ -108,9 +132,41 @@ export function useEntityActionDispatcher(
         case 'WorkflowTransition':
           await workflowTransition(action, rowId, row, client);
           return;
+        case 'OpenDrawer':
+          if (openDrawer) {
+            await openDrawer(action, rowId, row, client);
+          } else if (drawerCtx) {
+            drawerCtx.open({ action, rowId, row });
+          } else {
+            globalThis.console.warn(
+              `EntityAction "${action.name}" is OpenDrawer but no <EntityActionDrawerHost> is mounted in the tree and no \`openDrawer\` handler override was supplied.`
+            );
+          }
+          return;
+        case 'OpenModal':
+          if (openModal) {
+            await openModal(action, rowId, row, client);
+          } else if (modalCtx) {
+            modalCtx.open({ action, rowId, row });
+          } else {
+            globalThis.console.warn(
+              `EntityAction "${action.name}" is OpenModal but no <EntityActionModalHost> is mounted in the tree and no \`openModal\` handler override was supplied.`
+            );
+          }
+          return;
       }
     },
-    [client, apiCall, download, navigate, workflowTransition]
+    [
+      client,
+      apiCall,
+      download,
+      navigate,
+      workflowTransition,
+      openDrawer,
+      openModal,
+      drawerCtx,
+      modalCtx,
+    ]
   );
 }
 

--- a/packages/@granit/react-entities/src/components/entity-action-drawer-host.tsx
+++ b/packages/@granit/react-entities/src/components/entity-action-drawer-host.tsx
@@ -1,0 +1,50 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+
+import {
+  EntityActionDrawerContext,
+  type EntityActionOverlayContextValue,
+  type EntityActionOverlayState,
+} from '../actions/entity-action-overlay-context.js';
+
+export interface EntityActionDrawerHostProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Mounts the side-drawer overlay context for `OpenDrawer` actions.
+ * The provider stores which action is currently driving the drawer
+ * (or `null` when none); the dispatcher calls `open()` when an
+ * `EntityActionKind === 'OpenDrawer'` action fires, and the host's
+ * actual UI (Radix Dialog, shadcn Sheet, custom drawer …) reads
+ * `useEntityActionDrawer()` to know what to render.
+ *
+ * Per the wire contract, the drawer body depends on
+ * `action.urlTemplate`:
+ *
+ * - **`urlTemplate === null`** — render the entity's
+ *   `details["default"]` for the row (typical inline-detail flow).
+ *   Apps mount `<EntityDetail variant="default" entityId={rowId} />`
+ *   inside their drawer when this branch is active.
+ * - **`urlTemplate !== null`** — fetch the URL (with `{id}` substituted
+ *   from `rowId`) and render the response in the drawer (wizards,
+ *   custom server-rendered overlays). Apps' drawer bodies handle the
+ *   fetch + rendering via the URL surfaced through context.
+ *
+ * Mount once at the top of the tree (typically alongside
+ * `<EntityActionModalHost>`); the framework supports a single drawer
+ * at a time — stacked side-peeks belong to a follow-up Story.
+ */
+export function EntityActionDrawerHost({ children }: EntityActionDrawerHostProps): ReactNode {
+  const [current, setCurrent] = useState<EntityActionOverlayState | null>(null);
+  const open = useCallback((state: EntityActionOverlayState) => setCurrent(state), []);
+  const close = useCallback(() => setCurrent(null), []);
+  const value = useMemo<EntityActionOverlayContextValue>(
+    () => ({ current, open, close }),
+    [current, open, close]
+  );
+  return (
+    <EntityActionDrawerContext.Provider value={value}>
+      {children}
+    </EntityActionDrawerContext.Provider>
+  );
+}

--- a/packages/@granit/react-entities/src/components/entity-action-modal-host.tsx
+++ b/packages/@granit/react-entities/src/components/entity-action-modal-host.tsx
@@ -1,0 +1,47 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+
+import {
+  EntityActionModalContext,
+  type EntityActionOverlayContextValue,
+  type EntityActionOverlayState,
+} from '../actions/entity-action-overlay-context.js';
+
+export interface EntityActionModalHostProps {
+  readonly children: ReactNode;
+}
+
+/**
+ * Mounts the modal overlay context for `OpenModal` actions. Symmetric
+ * counterpart of {@link EntityActionDrawerHost} for the form-style
+ * surface.
+ *
+ * Per the wire contract, the modal body depends on
+ * `action.urlTemplate`:
+ *
+ * - **`urlTemplate === null`** — render the entity's `forms["default"]`
+ *   for the row (inline-edit flow). Apps mount
+ *   `<EntityForm variant="default" entityId={rowId} />` inside their
+ *   modal when this branch is active.
+ * - **`urlTemplate !== null`** — fetch the URL (with `{id}` substituted
+ *   from `rowId`) and render the response in the modal (Import /
+ *   Export wizards, custom server-rendered overlays).
+ *
+ * The selection-bar's bulk actions also dispatch through this host —
+ * fan-out targets either an `ApiCall` or an `OpenModal` per action;
+ * the modal variant pre-fills the dialog with `?ids=…` so the body
+ * can act on every selected row in one go.
+ */
+export function EntityActionModalHost({ children }: EntityActionModalHostProps): ReactNode {
+  const [current, setCurrent] = useState<EntityActionOverlayState | null>(null);
+  const open = useCallback((state: EntityActionOverlayState) => setCurrent(state), []);
+  const close = useCallback(() => setCurrent(null), []);
+  const value = useMemo<EntityActionOverlayContextValue>(
+    () => ({ current, open, close }),
+    [current, open, close]
+  );
+  return (
+    <EntityActionModalContext.Provider value={value}>
+      {children}
+    </EntityActionModalContext.Provider>
+  );
+}

--- a/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
@@ -1,0 +1,255 @@
+import { useCallback, useState, type KeyboardEvent, type ReactNode } from 'react';
+
+import { resolveAction } from '../actions/entity-action-button.js';
+import {
+  useEntityActionDispatcher,
+  type EntityActionHandlers,
+} from '../actions/use-entity-action-dispatcher.js';
+import { useSelection } from '../selection/selection-context.js';
+
+import type {
+  EntityActionManifest,
+  EntityManifestResponse,
+  EntitySelectionActionManifest,
+} from '@granit/entities';
+
+/**
+ * Concurrency cap for selection-bar bulk fan-out. Mirrors the spec
+ * pinned in granit-dotnet #1846 — high enough that small selections
+ * complete near-instantly, low enough that a 1000-row "archive all"
+ * doesn't saturate the host's connection pool.
+ */
+export const SELECTION_FANOUT_CONCURRENCY_CAP = 10;
+
+export interface EntitySelectionBarRecap {
+  /** Ids the fan-out completed without throwing. */
+  readonly succeeded: readonly string[];
+  /** Per-id failures with the rejection reason (the dispatcher's thrown error). */
+  readonly failed: readonly { readonly id: string; readonly error: unknown }[];
+}
+
+export interface EntitySelectionBarProps {
+  /** Entity manifest — provides `actions[]` + `collections.selectionActions[]`. */
+  readonly manifest: EntityManifestResponse;
+  /**
+   * Per-kind handler overrides forwarded to the underlying
+   * `useEntityActionDispatcher`. Apps wire `navigate` / `openModal` /
+   * `workflowTransition` here.
+   */
+  readonly handlers?: EntityActionHandlers;
+  /**
+   * Called once the fan-out finishes (every id either resolved or
+   * rejected). Apps surface a recap toast — typically
+   * `{succeeded.length} archived, {failed.length} failed`.
+   */
+  readonly onComplete?: (
+    action: EntitySelectionActionManifest,
+    recap: EntitySelectionBarRecap
+  ) => void;
+  /**
+   * Called when the user accepts a confirmation prompt. Apps that want
+   * a richer dialog than `globalThis.confirm()` override this slot;
+   * return `false` to abort the dispatch (typical: user clicks Cancel).
+   * Default uses `globalThis.confirm(action.confirmationKey)`.
+   */
+  readonly confirm?: (
+    action: EntitySelectionActionManifest,
+    selectedIds: ReadonlySet<string>
+  ) => boolean | Promise<boolean>;
+  /** Optional class for the root element. */
+  readonly className?: string;
+}
+
+/**
+ * Selection-bar surface — appears whenever the row-selection set is
+ * non-empty (driven by `<SelectionProvider>`). Reads
+ * `manifest.collections.selectionActions[]` (compact references) and
+ * looks each entry up in `manifest.actions` to dispatch fan-out clicks.
+ *
+ * Click semantics per the wire contract (granit-dotnet PR #1882):
+ *
+ * 1. Confirm via `confirm()` slot when `action.confirmationKey` is set
+ *    (default uses `globalThis.confirm`). Bail out if the user declines.
+ * 2. Iterate `selectedIds`, substitute `{id}` per id into
+ *    `action.urlTemplate`, fire the dispatcher per id with concurrency
+ *    capped at {@link SELECTION_FANOUT_CONCURRENCY_CAP}.
+ * 3. Emit a per-id recap (succeeded / failed) through `onComplete`.
+ *    Hosts surface the recap as a toast; the framework leaves the
+ *    visual to the app since toast UX is host-specific.
+ *
+ * Renders `null` when the manifest declares no selection actions OR
+ * when nothing is selected — apps don't need to gate the mount
+ * themselves.
+ *
+ * ```html
+ * <div data-granit-entity-selection-bar data-entity="…" data-selected-count="3">
+ *   <span data-granit-selection-bar-summary>3 selected</span>
+ *   <button data-granit-entity-action data-action-name="archive" …>archive</button>
+ *   <button data-granit-selection-bar-clear>Clear selection</button>
+ * </div>
+ * ```
+ */
+export function EntitySelectionBar({
+  manifest,
+  handlers,
+  onComplete,
+  confirm,
+  className,
+}: EntitySelectionBarProps): ReactNode {
+  const dispatch = useEntityActionDispatcher(handlers);
+  const selection = useSelection();
+  const [running, setRunning] = useState<string | null>(null);
+
+  const selectionActions = manifest.collections?.selectionActions ?? [];
+
+  const handleClick = useCallback(
+    async (ref: EntitySelectionActionManifest, action: EntityActionManifest) => {
+      if (running) return;
+      const ids = Array.from(selection.selectedIds);
+      if (ids.length === 0) return;
+
+      // Confirmation dialog — defaults to globalThis.confirm; apps can
+      // override for shadcn / Radix dialogs.
+      const confirmationKey = ref.confirmationKey ?? action.confirmationKey;
+      if (confirmationKey) {
+        const proceed = confirm
+          ? await confirm(ref, selection.selectedIds)
+          : globalThis.confirm(confirmationKey);
+        if (!proceed) return;
+      }
+
+      setRunning(ref.name);
+      try {
+        const recap = await fanOutWithCap(
+          ids,
+          (id) =>
+            dispatch(action, id, null).then(
+              () => ({ kind: 'ok' as const, id }),
+              (error: unknown) => ({ kind: 'err' as const, id, error })
+            ),
+          SELECTION_FANOUT_CONCURRENCY_CAP
+        );
+        onComplete?.(ref, recap);
+        // Best-effort: clear the selection on full success so the user
+        // doesn't accidentally re-fire on the same set. Failures are
+        // kept selected so the user can retry.
+        if (recap.failed.length === 0) {
+          selection.clear();
+        } else {
+          selection.setSelected(recap.failed.map((f) => f.id));
+        }
+      } finally {
+        setRunning(null);
+      }
+    },
+    [running, selection, dispatch, confirm, onComplete]
+  );
+
+  if (selectionActions.length === 0 || selection.size === 0) return null;
+
+  return (
+    <div
+      data-granit-entity-selection-bar=""
+      data-entity={manifest.identity?.name}
+      data-selected-count={selection.size}
+      className={className}
+    >
+      <span data-granit-selection-bar-summary="">
+        {selection.size} selected
+      </span>
+      {selectionActions.map((ref) => {
+        const action = resolveAction(ref, manifest.actions);
+        if (!action) return null;
+        const isRunning = running === ref.name;
+        return (
+          <button
+            key={ref.name}
+            type="button"
+            data-granit-entity-action=""
+            data-action-name={action.name}
+            data-action-kind={action.kind}
+            data-action-icon={action.icon ?? undefined}
+            data-display-key={ref.displayKey ?? action.displayKey ?? undefined}
+            data-running={isRunning ? '' : undefined}
+            disabled={isRunning || running !== null}
+            onClick={() => {
+              handleClick(ref, action).catch((error: unknown) => {
+                globalThis.console.error(`Selection action "${ref.name}" failed:`, error);
+              });
+            }}
+            onKeyDown={swallowEnterSpace}
+          >
+            {ref.icon ?? ref.displayKey ?? ref.name}
+          </button>
+        );
+      })}
+      <button
+        type="button"
+        data-granit-selection-bar-clear=""
+        onClick={() => selection.clear()}
+        disabled={running !== null}
+      >
+        Clear selection
+      </button>
+    </div>
+  );
+}
+
+function swallowEnterSpace(event: KeyboardEvent<HTMLButtonElement>): void {
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.stopPropagation();
+  }
+}
+
+interface FanOutOk {
+  readonly kind: 'ok';
+  readonly id: string;
+}
+interface FanOutErr {
+  readonly kind: 'err';
+  readonly id: string;
+  readonly error: unknown;
+}
+type FanOutResult = FanOutOk | FanOutErr;
+
+/**
+ * Concurrency-capped fan-out over the supplied ids. `task` is called
+ * with each id and must always resolve (never throw) to a tagged
+ * `FanOutResult` — the dispatcher's `dispatch().then(ok, err)` pattern
+ * does that conversion. The function maintains at most `cap` in-flight
+ * tasks at any time; results land in declaration order via the recap
+ * groupings. Used by `<EntitySelectionBar>` for the
+ * granit-dotnet #1882 selection-bar bulk fan-out.
+ */
+export async function fanOutWithCap(
+  ids: readonly string[],
+  task: (id: string) => Promise<FanOutResult>,
+  cap: number
+): Promise<EntitySelectionBarRecap> {
+  const succeeded: string[] = [];
+  const failed: { id: string; error: unknown }[] = [];
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < ids.length) {
+      const idx = cursor++;
+      const id = ids[idx];
+      if (id === undefined) continue;
+      const result = await task(id);
+      if (result.kind === 'ok') {
+        succeeded.push(result.id);
+      } else {
+        failed.push({ id: result.id, error: result.error });
+      }
+    }
+  }
+
+  const workerCount = Math.max(1, Math.min(cap, ids.length));
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < workerCount; i += 1) {
+    workers.push(worker());
+  }
+  await Promise.all(workers);
+
+  return { succeeded, failed };
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -9,6 +9,16 @@
 export { EntityActionButton, resolveAction } from './actions/entity-action-button.js';
 export type { EntityActionButtonProps } from './actions/entity-action-button.js';
 export {
+  EntityActionDrawerContext,
+  EntityActionModalContext,
+  useEntityActionDrawer,
+  useEntityActionModal,
+} from './actions/entity-action-overlay-context.js';
+export type {
+  EntityActionOverlayContextValue,
+  EntityActionOverlayState,
+} from './actions/entity-action-overlay-context.js';
+export {
   resolveActionUrl,
   useEntityActionDispatcher,
 } from './actions/use-entity-action-dispatcher.js';
@@ -17,6 +27,10 @@ export type {
   EntityActionHandler,
   EntityActionHandlers,
 } from './actions/use-entity-action-dispatcher.js';
+export { EntityActionDrawerHost } from './components/entity-action-drawer-host.js';
+export type { EntityActionDrawerHostProps } from './components/entity-action-drawer-host.js';
+export { EntityActionModalHost } from './components/entity-action-modal-host.js';
+export type { EntityActionModalHostProps } from './components/entity-action-modal-host.js';
 export { EntityCalendar } from './components/entity-calendar.js';
 export type { EntityCalendarProps } from './components/entity-calendar.js';
 export { EntityDetail } from './components/entity-detail.js';
@@ -31,6 +45,19 @@ export { EntityList } from './components/entity-list.js';
 export type { EntityListProps } from './components/entity-list.js';
 export { EntityListPageHeader } from './components/entity-list-page-header.js';
 export type { EntityListPageHeaderProps } from './components/entity-list-page-header.js';
+export {
+  EntitySelectionBar,
+  fanOutWithCap,
+  SELECTION_FANOUT_CONCURRENCY_CAP,
+} from './components/entity-selection-bar.js';
+export type {
+  EntitySelectionBarProps,
+  EntitySelectionBarRecap,
+} from './components/entity-selection-bar.js';
+export { SelectionContext, useSelection } from './selection/selection-context.js';
+export type { SelectionContextValue } from './selection/selection-context.js';
+export { SelectionProvider } from './selection/selection-provider.js';
+export type { SelectionProviderProps } from './selection/selection-provider.js';
 export {
   defaultDetailFormat,
   STANDARD_DETAIL_COMPONENTS,

--- a/packages/@granit/react-entities/src/selection/selection-context.ts
+++ b/packages/@granit/react-entities/src/selection/selection-context.ts
@@ -1,0 +1,59 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Selection state exposed by `<SelectionProvider>` and consumed by
+ * `<EntitySelectionBar>` (and any custom row-level checkbox the host
+ * wires up).
+ *
+ * Mode 1 ('explicit') is the only mode shipped today — `selectedIds`
+ * carries every id the user has individually toggled. Mode 2
+ * ('all-matching-filter') is reserved for the bulk-on-large-result-set
+ * case and lands in a follow-up Story; the field is exposed in the
+ * shape today so host-side checkbox UIs can pre-emptively branch on
+ * it without breaking on a future bump.
+ */
+export interface SelectionContextValue {
+  readonly selectedIds: ReadonlySet<string>;
+  /**
+   * Mode 1 — `selectedIds` is the literal set of ids the user picked.
+   * Mode 2 — `selectedIds` is the explicit *override* set under the
+   * "all matching filter" bulk-mode (NOT YET SHIPPED — reserved).
+   */
+  readonly mode: 'explicit' | 'all-matching-filter';
+  /** Number of selected rows. In `'all-matching-filter'` mode this returns the override-set size. */
+  readonly size: number;
+  /** Toggle a row's selection. */
+  readonly toggle: (id: string) => void;
+  /** Replace the selection set with the supplied ids. */
+  readonly setSelected: (ids: Iterable<string>) => void;
+  /** Clear every selected id. */
+  readonly clear: () => void;
+}
+
+export const SelectionContext = createContext<SelectionContextValue | null>(null);
+
+/**
+ * Returns a no-op default when the consumer isn't wrapped in
+ * `<SelectionProvider>` so renderers that read selection state for
+ * an optional checkbox UI don't blow up in scenarios where selection
+ * isn't wired (e.g. embedded list previews, drilldown drawers). The
+ * `<EntitySelectionBar>` itself short-circuits to render `null` when
+ * the size is 0, so the no-op default keeps it inert by design.
+ */
+const NO_OP_SELECTION: SelectionContextValue = Object.freeze({
+  selectedIds: new Set<string>(),
+  mode: 'explicit' as const,
+  size: 0,
+  toggle: () => undefined,
+  setSelected: () => undefined,
+  clear: () => undefined,
+});
+
+/**
+ * Read the selection state from the nearest `<SelectionProvider>`.
+ * Returns a no-op default outside the provider so renderers stay
+ * safe to mount in embed scenarios where selection isn't wired.
+ */
+export function useSelection(): SelectionContextValue {
+  return useContext(SelectionContext) ?? NO_OP_SELECTION;
+}

--- a/packages/@granit/react-entities/src/selection/selection-provider.tsx
+++ b/packages/@granit/react-entities/src/selection/selection-provider.tsx
@@ -1,0 +1,74 @@
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+
+import { SelectionContext, type SelectionContextValue } from './selection-context.js';
+
+export interface SelectionProviderProps {
+  readonly children: ReactNode;
+  /**
+   * Optional initial selection — typically empty. Useful for tests and
+   * for restoring state after a route change.
+   */
+  readonly initialSelectedIds?: Iterable<string>;
+}
+
+/**
+ * Provides per-list row-selection state to `<EntitySelectionBar>` and
+ * any custom row-level checkbox the host wires up. Mount once per
+ * list scope (typically alongside `<QueryEndpointStateProvider>`);
+ * mounting it deeper resets the selection on remount.
+ *
+ * The provider is intentionally minimal — toggle / replace / clear,
+ * no master "select-all matching filter" mode yet (reserved on the
+ * context shape; lands once the bulk-on-large-set Story is scheduled).
+ *
+ * ```tsx
+ * <SelectionProvider>
+ *   <QueryEndpointStateProvider initialParams={…}>
+ *     <EntityList … />
+ *     <EntitySelectionBar manifest={manifest} onComplete={…} />
+ *   </QueryEndpointStateProvider>
+ * </SelectionProvider>
+ * ```
+ */
+export function SelectionProvider({
+  children,
+  initialSelectedIds,
+}: SelectionProviderProps): ReactNode {
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(
+    () => new Set(initialSelectedIds ?? [])
+  );
+
+  const toggle = useCallback((id: string) => {
+    setSelectedIds((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) {
+        next.delete(id);
+      } else {
+        next.add(id);
+      }
+      return next;
+    });
+  }, []);
+
+  const setSelected = useCallback((ids: Iterable<string>) => {
+    setSelectedIds(new Set(ids));
+  }, []);
+
+  const clear = useCallback(() => {
+    setSelectedIds(new Set());
+  }, []);
+
+  const value = useMemo<SelectionContextValue>(
+    () => ({
+      selectedIds,
+      mode: 'explicit',
+      size: selectedIds.size,
+      toggle,
+      setSelected,
+      clear,
+    }),
+    [selectedIds, toggle, setSelected, clear]
+  );
+
+  return <SelectionContext.Provider value={value}>{children}</SelectionContext.Provider>;
+}


### PR DESCRIPTION
## Summary

Closes the front side of #353 by wiring the four remaining action surface hosts on top of the wire-shape shipped in granit-dotnet [#1880](https://github.com/granit-fx/granit-dotnet/pull/1880) (`OpenDrawer` / `OpenModal` kinds), [#1881](https://github.com/granit-fx/granit-dotnet/pull/1881) (RouteBase shortcuts — no wire change), and [#1882](https://github.com/granit-fx/granit-dotnet/pull/1882) (`OnSelection` selection bar).

## What ships

### `@granit/entities` — wire-shape mirror

- `EntityActionKind` union extended with `'OpenDrawer'` and `'OpenModal'`
- New `EntitySelectionActionManifest` (compact ref) — `confirmationKey` is **inlined** per the .NET wire contract since bulk destructive ops need the key without an extra actions-facet round-trip
- `EntityCollectionsSection.selectionActions` slot

### `@granit/react-entities` — runtime

| Component / hook | Role |
| --- | --- |
| `useEntityActionDispatcher` (extended) | Adds `OpenDrawer` / `OpenModal` branches. Default delegates to the nearest `<EntityActionDrawerHost>` / `<EntityActionModalHost>` context; without a host the default emits a `console.warn`. Apps override via the `openDrawer` / `openModal` handler slots. |
| `<EntityActionDrawerHost />` + `useEntityActionDrawer` | Context provider storing `{ current, open, close }`. Apps mount their actual drawer UI (Radix Dialog, shadcn Sheet, …) and read state via the hook. Per wire contract: `urlTemplate === null` → host renders `<EntityDetail variant="default">`; `urlTemplate !== null` → host fetches + renders. |
| `<EntityActionModalHost />` + `useEntityActionModal` | Symmetric for modals. URL-null fallback → `<EntityForm variant="default">`. |
| `<SelectionProvider>` + `useSelection` | Minimal explicit-mode selection state (toggle / setSelected / clear / size). The `mode: 'explicit' \| 'all-matching-filter'` shape is forward-compatible — mode 2 lands with the bulk-on-large-set Story. |
| `<EntitySelectionBar />` | Appears when `selection.size > 0` AND `manifest.collections.selectionActions[]` is non-empty. Click semantics: confirm (default `globalThis.confirm` or custom slot) → fan-out at concurrency cap **10** (`SELECTION_FANOUT_CONCURRENCY_CAP`) → recap callback. Clears the selection on full success; keeps failed ids selected for retry. |
| `fanOutWithCap` (exported helper) | Worker-pool primitive used by the selection bar; available standalone for apps that want bulk semantics outside the bar. |

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] `pnpm exec vitest run` — **3009 / 3009 pass** (+26 vs. develop)
  - Dispatcher: 4 new (OpenDrawer / OpenModal × {host context, handler override, no-host warn})
  - Selection: 16 (no-op default outside provider, toggle / replace / clear, fanout concurrency cap respected up to 4 in-flight on 25 items, error capture in recap, partial-failure retry-set behavior, custom `confirm` slot short-circuit, external `SelectionContext` injection)
  - Drawer / Modal hosts: 6 (lifecycle, throw-outside-provider, end-to-end dispatcher integration through the host context)
- [ ] CI green on this branch

## Cross-repo follow-up

- Showcase fixtures patched in the working tree (`selectionActions: []` on both `collections` sections) so `pnpm tsc` stays green post-merge — separate showcase commit.
- Showcase wiring (mount `<SelectionProvider>` + `<EntitySelectionBar>` + per-row checkbox UI + actual drawer / modal mounts via Radix) is its own follow-up prompt — framework primitives are ready.

## Wire-shape note

`OnListHeader()` (URL without `{id}`, fire-once) and `OnSelection()` (URL with `{id}`, fan-out) remain mutually exclusive on the same action — the .NET builder enforces it at host startup, so the front trusts the manifest split (`headerActions[]` vs `selectionActions[]`) without a runtime guard.