### PR TITLE
feat(activities): scaffold @granit/activities — types + permissions (F1)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -68,6 +68,17 @@
       ]
     },
     {
+      "name": "@granit/activities",
+      "description": "Cross-entity polymorphic to-do module — types, API client, and permissions",
+      "exports": [
+        {
+          "name": "ActivitiesPermissions",
+          "kind": "const",
+          "signature": "const ActivitiesPermissions"
+        }
+      ]
+    },
+    {
       "name": "@granit/ai",
       "description": "AI workspace management, chat completion, embedding generation, and usage tracking types and API functions — mirrors Granit.AI.Endpoints .NET",
       "exports": [

--- a/packages/@granit/activities/package.json
+++ b/packages/@granit/activities/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/activities",
+  "description": "Cross-entity polymorphic to-do module — types, API client, and permissions",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/activities/src/__tests__/permissions.test.ts
+++ b/packages/@granit/activities/src/__tests__/permissions.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { ActivitiesPermissions } from '../permissions.js';
+
+describe('ActivitiesPermissions', () => {
+  it('exposes the three Activities permissions matching the backend keys', () => {
+    expect(ActivitiesPermissions.Activities.Read).toBe('Activities.Activities.Read');
+    expect(ActivitiesPermissions.Activities.Manage).toBe('Activities.Activities.Manage');
+    expect(ActivitiesPermissions.Activities.Execute).toBe('Activities.Activities.Execute');
+  });
+});

--- a/packages/@granit/activities/src/__tests__/types.test.ts
+++ b/packages/@granit/activities/src/__tests__/types.test.ts
@@ -1,0 +1,51 @@
+import { describe, expectTypeOf, it } from 'vitest';
+
+import type {
+  ActivityCalendarColor,
+  ActivityCalendarItemResponse,
+  ActivityListResponse,
+  ActivityResponse,
+  ActivityStatus,
+  ActivityStatusFilter,
+} from '../types.js';
+
+describe('Activity types', () => {
+  it('ActivityStatus is the closed PascalCase union shipped by the backend', () => {
+    expectTypeOf<ActivityStatus>().toEqualTypeOf<'Open' | 'Completed' | 'Cancelled' | 'Overdue'>();
+  });
+
+  it('ActivityStatusFilter widens ActivityStatus with All + OpenOrOverdue', () => {
+    expectTypeOf<ActivityStatusFilter>().toEqualTypeOf<
+      'Open' | 'Completed' | 'Cancelled' | 'Overdue' | 'All' | 'OpenOrOverdue'
+    >();
+  });
+
+  it('ActivityCalendarColor mirrors the lowercase server-mapped values', () => {
+    expectTypeOf<ActivityCalendarColor>().toEqualTypeOf<
+      'open' | 'overdue' | 'done' | 'cancelled'
+    >();
+  });
+
+  it('ActivityResponse fields are readonly and audit timestamps are nullable', () => {
+    expectTypeOf<ActivityResponse>().toMatchTypeOf<{
+      readonly id: string;
+      readonly status: ActivityStatus;
+      readonly dueAt: string;
+      readonly completedAt: string | null;
+      readonly completedByUserId: string | null;
+    }>();
+  });
+
+  it('ActivityListResponse exposes a readonly items array + pagination metadata', () => {
+    expectTypeOf<ActivityListResponse>().toMatchTypeOf<{
+      readonly items: readonly ActivityResponse[];
+      readonly totalCount: number;
+      readonly page: number;
+      readonly pageSize: number;
+    }>();
+  });
+
+  it('ActivityCalendarItemResponse uses the server-supplied color (no client recompute)', () => {
+    expectTypeOf<ActivityCalendarItemResponse['color']>().toEqualTypeOf<ActivityCalendarColor>();
+  });
+});

--- a/packages/@granit/activities/src/index.ts
+++ b/packages/@granit/activities/src/index.ts
@@ -1,0 +1,19 @@
+// Types
+export type {
+  ActivityCalendarColor,
+  ActivityCalendarFilter,
+  ActivityCalendarItemResponse,
+  ActivityListFilter,
+  ActivityListResponse,
+  ActivityResponse,
+  ActivityStatus,
+  ActivityStatusFilter,
+  CancelActivityRequest,
+  CompleteActivityRequest,
+  CreateActivityRequest,
+  ReassignActivityRequest,
+  RescheduleActivityRequest,
+} from './types.js';
+
+// Permissions
+export { ActivitiesPermissions } from './permissions.js';

--- a/packages/@granit/activities/src/permissions.ts
+++ b/packages/@granit/activities/src/permissions.ts
@@ -1,0 +1,7 @@
+export const ActivitiesPermissions = {
+  Activities: {
+    Read: 'Activities.Activities.Read',
+    Manage: 'Activities.Activities.Manage',
+    Execute: 'Activities.Activities.Execute',
+  },
+} as const;

--- a/packages/@granit/activities/src/types.ts
+++ b/packages/@granit/activities/src/types.ts
@@ -1,0 +1,85 @@
+export type ActivityStatus = 'Open' | 'Completed' | 'Cancelled' | 'Overdue';
+
+export type ActivityStatusFilter = ActivityStatus | 'All' | 'OpenOrOverdue';
+
+export type ActivityCalendarColor = 'open' | 'overdue' | 'done' | 'cancelled';
+
+export interface ActivityResponse {
+  readonly id: string;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly type: string;
+  readonly assignedToUserId: string;
+  readonly createdByUserId: string | null;
+  readonly dueAt: string;
+  readonly description: string | null;
+  readonly status: ActivityStatus;
+  readonly completedAt: string | null;
+  readonly completedByUserId: string | null;
+  readonly createdAt: string;
+}
+
+export interface ActivityListResponse {
+  readonly items: readonly ActivityResponse[];
+  readonly totalCount: number;
+  readonly page: number;
+  readonly pageSize: number;
+}
+
+export interface ActivityListFilter {
+  readonly status?: ActivityStatusFilter;
+  readonly assignedToUserId?: string;
+  readonly entityType?: string;
+  readonly entityId?: string;
+  readonly type?: string;
+  readonly page?: number;
+  readonly pageSize?: number;
+}
+
+export interface CreateActivityRequest {
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly type: string;
+  readonly assignedToUserId: string;
+  readonly dueAt: string;
+  readonly description: string | null;
+}
+
+export interface CompleteActivityRequest {
+  readonly completedAt: string;
+}
+
+export interface CancelActivityRequest {
+  readonly cancelledAt: string;
+}
+
+export interface ReassignActivityRequest {
+  readonly newAssigneeUserId: string;
+}
+
+export interface RescheduleActivityRequest {
+  readonly newDueAt: string;
+}
+
+export interface ActivityCalendarItemResponse {
+  readonly id: string;
+  readonly start: string;
+  readonly end: string | null;
+  readonly title: string;
+  readonly color: ActivityCalendarColor;
+  readonly type: string;
+  readonly status: ActivityStatus;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly assignedToUserId: string;
+}
+
+export interface ActivityCalendarFilter {
+  readonly from: string;
+  readonly to: string;
+  /** Either the literal `'me'` or a user GUID. */
+  readonly assignee?: string;
+  readonly entityType?: string;
+  readonly type?: string;
+  readonly status?: ActivityStatusFilter;
+}

--- a/packages/@granit/activities/tsconfig.json
+++ b/packages/@granit/activities/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/activities/tsup.config.ts
+++ b/packages/@granit/activities/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,6 +179,15 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/activities:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/ai:
     dependencies:
       '@granit/types':


### PR DESCRIPTION
## Summary

Scaffolds `@granit/activities` (SDK core) — first story of the front-end half of the `Granit.Activities` module. Mirrors the `@granit/payments` package structure exactly.

**Ships**
- DTO types (`ActivityResponse`, `ActivityListResponse`, all `*Request` bodies, `ActivityCalendarItemResponse`, filter shapes)
- Status unions: `ActivityStatus`, `ActivityStatusFilter`, `ActivityCalendarColor`
- `ActivitiesPermissions` registry matching backend keys (`Activities.Activities.{Read,Manage,Execute}`)

**Out of scope (next stories)**
- API client → F2 (#366)
- React provider + hooks → F3 (#367) onwards

## Closes

- #365 — F1 — `@granit/activities` package skeleton + types + permissions
- Parent feature: #364
- Backend reference: granit-fx/granit-dotnet#1796 (Granit.Activities.Abstractions)

## Test plan

- [x] `pnpm -F @granit/activities build` — tsup ESM + dts OK
- [x] `pnpm tsc` — green across the workspace
- [x] `pnpm lint` — `--max-warnings 0`, green
- [x] `pnpm test` — 2990/2990 green (incl. new permission + type-level tests)
- [x] Pre-commit regenerated `.mcp-front-index.json`
