### PR TITLE
feat(activities): api client for crud + actions + calendar (F2)

### DIFF
--- a/packages/@granit/activities/src/__tests__/activities-api.test.ts
+++ b/packages/@granit/activities/src/__tests__/activities-api.test.ts
@@ -1,0 +1,260 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  cancelActivity,
+  completeActivity,
+  createActivity,
+  getActivitiesCalendar,
+  getActivity,
+  listActivities,
+  reassignActivity,
+  rescheduleActivity,
+} from '../api/activities-api.js';
+
+import type {
+  ActivityCalendarFilter,
+  ActivityCalendarItemResponse,
+  ActivityListResponse,
+  ActivityResponse,
+  CancelActivityRequest,
+  CompleteActivityRequest,
+  CreateActivityRequest,
+  ReassignActivityRequest,
+  RescheduleActivityRequest,
+} from '../types.js';
+
+const basePath = '/activities';
+
+const sampleActivity: ActivityResponse = {
+  id: 'act-1',
+  entityType: 'Quote',
+  entityId: 'quote-1',
+  type: 'FollowUp',
+  assignedToUserId: 'user-1',
+  createdByUserId: 'user-2',
+  dueAt: '2026-05-10T10:00:00Z',
+  description: 'Call back the client',
+  status: 'Open',
+  completedAt: null,
+  completedByUserId: null,
+  createdAt: '2026-05-01T08:00:00Z',
+};
+
+const sampleListResponse: ActivityListResponse = {
+  items: [sampleActivity],
+  totalCount: 1,
+  page: 1,
+  pageSize: 20,
+};
+
+const sampleCalendarItem: ActivityCalendarItemResponse = {
+  id: 'act-1',
+  start: '2026-05-10T10:00:00Z',
+  end: null,
+  title: 'Quote · FollowUp',
+  color: 'open',
+  type: 'FollowUp',
+  status: 'Open',
+  entityType: 'Quote',
+  entityId: 'quote-1',
+  assignedToUserId: 'user-1',
+};
+
+describe('listActivities', () => {
+  it('GETs the base path without params when no filter is provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleListResponse));
+
+    const result = await listActivities(client, basePath);
+
+    expect(client.get).toHaveBeenCalledWith(basePath, undefined);
+    expect(result).toEqual(sampleListResponse);
+  });
+
+  it('omits undefined filter axes from query params', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleListResponse));
+
+    await listActivities(client, basePath, {
+      status: 'OpenOrOverdue',
+      assignedToUserId: 'user-1',
+      page: 2,
+      pageSize: 50,
+    });
+
+    expect(client.get).toHaveBeenCalledWith(basePath, {
+      params: { status: 'OpenOrOverdue', assignedToUserId: 'user-1', page: 2, pageSize: 50 },
+    });
+  });
+
+  it('returns no params object when the filter is present but empty', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleListResponse));
+
+    await listActivities(client, basePath, {});
+
+    expect(client.get).toHaveBeenCalledWith(basePath, undefined);
+  });
+});
+
+describe('getActivity', () => {
+  it('GETs a single activity by id with URI-encoded path', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleActivity));
+
+    const result = await getActivity(client, basePath, 'act/with slash');
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/act%2Fwith%20slash`);
+    expect(result).toEqual(sampleActivity);
+  });
+
+  it('propagates Axios errors (404)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Request failed with status code 404'));
+
+    await expect(getActivity(client, basePath, 'missing')).rejects.toThrow(/404/);
+  });
+});
+
+describe('createActivity', () => {
+  it('POSTs to the base path', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleActivity));
+    const request: CreateActivityRequest = {
+      entityType: 'Quote',
+      entityId: 'quote-1',
+      type: 'FollowUp',
+      assignedToUserId: 'user-1',
+      dueAt: '2026-05-10T10:00:00Z',
+      description: null,
+    };
+
+    const result = await createActivity(client, basePath, request);
+
+    expect(client.post).toHaveBeenCalledWith(basePath, request);
+    expect(result).toEqual(sampleActivity);
+  });
+});
+
+describe('completeActivity', () => {
+  it('POSTs to {id}/complete', async () => {
+    const client = createMockClient();
+    const completed: ActivityResponse = {
+      ...sampleActivity,
+      status: 'Completed',
+      completedAt: '2026-05-09T15:00:00Z',
+      completedByUserId: 'user-1',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(completed));
+    const request: CompleteActivityRequest = { completedAt: '2026-05-09T15:00:00Z' };
+
+    const result = await completeActivity(client, basePath, 'act-1', request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/act-1/complete`, request);
+    expect(result).toEqual(completed);
+  });
+
+  it('rejects on 422 from the backend', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Request failed with status code 422'));
+    const request: CompleteActivityRequest = { completedAt: '2026-05-09T15:00:00Z' };
+
+    await expect(completeActivity(client, basePath, 'act-1', request)).rejects.toThrow(/422/);
+  });
+});
+
+describe('cancelActivity', () => {
+  it('POSTs to {id}/cancel', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleActivity));
+    const request: CancelActivityRequest = { cancelledAt: '2026-05-09T15:00:00Z' };
+
+    await cancelActivity(client, basePath, 'act-1', request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/act-1/cancel`, request);
+  });
+});
+
+describe('reassignActivity', () => {
+  it('PUTs to {id}/assignee', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleActivity));
+    const request: ReassignActivityRequest = { newAssigneeUserId: 'user-3' };
+
+    await reassignActivity(client, basePath, 'act-1', request);
+
+    expect(client.put).toHaveBeenCalledWith(`${basePath}/act-1/assignee`, request);
+  });
+
+  it('propagates 403 when the caller lacks Manage', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockRejectedValue(new Error('Request failed with status code 403'));
+    const request: ReassignActivityRequest = { newAssigneeUserId: 'user-3' };
+
+    await expect(reassignActivity(client, basePath, 'act-1', request)).rejects.toThrow(/403/);
+  });
+});
+
+describe('rescheduleActivity', () => {
+  it('PUTs to {id}/due-date', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleActivity));
+    const request: RescheduleActivityRequest = { newDueAt: '2026-05-15T10:00:00Z' };
+
+    await rescheduleActivity(client, basePath, 'act-1', request);
+
+    expect(client.put).toHaveBeenCalledWith(`${basePath}/act-1/due-date`, request);
+  });
+});
+
+describe('getActivitiesCalendar', () => {
+  it('always sends from + to and includes only defined optional axes', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleCalendarItem]));
+    const filter: ActivityCalendarFilter = {
+      from: '2026-05-01T00:00:00Z',
+      to: '2026-05-31T23:59:59Z',
+      assignee: 'me',
+      status: 'OpenOrOverdue',
+    };
+
+    const result = await getActivitiesCalendar(client, basePath, filter);
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/calendar`, {
+      params: {
+        from: '2026-05-01T00:00:00Z',
+        to: '2026-05-31T23:59:59Z',
+        assignee: 'me',
+        status: 'OpenOrOverdue',
+      },
+    });
+    expect(result).toEqual([sampleCalendarItem]);
+  });
+
+  it('omits all optional axes when the caller only supplies the time window', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    await getActivitiesCalendar(client, basePath, {
+      from: '2026-05-01T00:00:00Z',
+      to: '2026-05-31T23:59:59Z',
+    });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/calendar`, {
+      params: { from: '2026-05-01T00:00:00Z', to: '2026-05-31T23:59:59Z' },
+    });
+  });
+
+  it('rejects with 401 when the caller is unauthenticated', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Request failed with status code 401'));
+
+    await expect(
+      getActivitiesCalendar(client, basePath, {
+        from: '2026-05-01T00:00:00Z',
+        to: '2026-05-31T23:59:59Z',
+      })
+    ).rejects.toThrow(/401/);
+  });
+});

--- a/packages/@granit/activities/src/api/activities-api.ts
+++ b/packages/@granit/activities/src/api/activities-api.ts
@@ -1,0 +1,178 @@
+import type {
+  ActivityCalendarFilter,
+  ActivityCalendarItemResponse,
+  ActivityListFilter,
+  ActivityListResponse,
+  ActivityResponse,
+  CancelActivityRequest,
+  CompleteActivityRequest,
+  CreateActivityRequest,
+  ReassignActivityRequest,
+  RescheduleActivityRequest,
+} from '../types.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List activities, paginated. Filters are passed as query parameters; only
+ * defined keys are sent — undefined axes are treated as wildcards by the
+ * backend.
+ *
+ * `GET {basePath}/`
+ */
+export async function listActivities(
+  client: AxiosInstance,
+  basePath: string,
+  filter?: ActivityListFilter
+): Promise<ActivityListResponse> {
+  const params = buildListParams(filter);
+  const response = await client.get<ActivityListResponse>(
+    basePath,
+    params ? { params } : undefined
+  );
+  return response.data;
+}
+
+/**
+ * Get a single activity by ID.
+ *
+ * `GET {basePath}/{id}`
+ */
+export async function getActivity(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<ActivityResponse> {
+  const response = await client.get<ActivityResponse>(`${basePath}/${encodeURIComponent(id)}`);
+  return response.data;
+}
+
+/**
+ * Create a new activity.
+ *
+ * `POST {basePath}/`
+ */
+export async function createActivity(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreateActivityRequest
+): Promise<ActivityResponse> {
+  const response = await client.post<ActivityResponse>(basePath, request);
+  return response.data;
+}
+
+/**
+ * Mark an activity as completed.
+ *
+ * `POST {basePath}/{id}/complete`
+ */
+export async function completeActivity(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: CompleteActivityRequest
+): Promise<ActivityResponse> {
+  const response = await client.post<ActivityResponse>(
+    `${basePath}/${encodeURIComponent(id)}/complete`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Cancel an activity.
+ *
+ * `POST {basePath}/{id}/cancel`
+ */
+export async function cancelActivity(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: CancelActivityRequest
+): Promise<ActivityResponse> {
+  const response = await client.post<ActivityResponse>(
+    `${basePath}/${encodeURIComponent(id)}/cancel`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Reassign an activity to another user.
+ *
+ * `PUT {basePath}/{id}/assignee`
+ */
+export async function reassignActivity(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: ReassignActivityRequest
+): Promise<ActivityResponse> {
+  const response = await client.put<ActivityResponse>(
+    `${basePath}/${encodeURIComponent(id)}/assignee`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Reschedule an activity (update its due date).
+ *
+ * `PUT {basePath}/{id}/due-date`
+ */
+export async function rescheduleActivity(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: RescheduleActivityRequest
+): Promise<ActivityResponse> {
+  const response = await client.put<ActivityResponse>(
+    `${basePath}/${encodeURIComponent(id)}/due-date`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Cross-entity calendar view of activities. `from` and `to` are required;
+ * other axes are optional and only included when defined.
+ *
+ * `GET {basePath}/calendar`
+ */
+export async function getActivitiesCalendar(
+  client: AxiosInstance,
+  basePath: string,
+  filter: ActivityCalendarFilter
+): Promise<readonly ActivityCalendarItemResponse[]> {
+  const params = buildCalendarParams(filter);
+  const response = await client.get<readonly ActivityCalendarItemResponse[]>(
+    `${basePath}/calendar`,
+    { params }
+  );
+  return response.data;
+}
+
+function buildListParams(
+  filter: ActivityListFilter | undefined
+): Record<string, string | number> | undefined {
+  if (!filter) {
+    return undefined;
+  }
+  const params: Record<string, string | number> = {};
+  if (filter.status !== undefined) params.status = filter.status;
+  if (filter.assignedToUserId !== undefined) params.assignedToUserId = filter.assignedToUserId;
+  if (filter.entityType !== undefined) params.entityType = filter.entityType;
+  if (filter.entityId !== undefined) params.entityId = filter.entityId;
+  if (filter.type !== undefined) params.type = filter.type;
+  if (filter.page !== undefined) params.page = filter.page;
+  if (filter.pageSize !== undefined) params.pageSize = filter.pageSize;
+  return Object.keys(params).length > 0 ? params : undefined;
+}
+
+function buildCalendarParams(filter: ActivityCalendarFilter): Record<string, string> {
+  const params: Record<string, string> = { from: filter.from, to: filter.to };
+  if (filter.assignee !== undefined) params.assignee = filter.assignee;
+  if (filter.entityType !== undefined) params.entityType = filter.entityType;
+  if (filter.type !== undefined) params.type = filter.type;
+  if (filter.status !== undefined) params.status = filter.status;
+  return params;
+}

--- a/packages/@granit/activities/src/index.ts
+++ b/packages/@granit/activities/src/index.ts
@@ -17,3 +17,15 @@ export type {
 
 // Permissions
 export { ActivitiesPermissions } from './permissions.js';
+
+// API
+export {
+  cancelActivity,
+  completeActivity,
+  createActivity,
+  getActivitiesCalendar,
+  getActivity,
+  listActivities,
+  reassignActivity,
+  rescheduleActivity,
+} from './api/activities-api.js';


### PR DESCRIPTION
## Summary

Adds the `@granit/activities` API client — second story of the front-end half of `Granit.Activities`. Mirrors the `payments-api.ts` shape: stateless module functions `(client, basePath, …)`, ESM-only, source-direct.

**8 endpoints typed end-to-end**

| Method | Route | Function |
| ------ | ----- | -------- |
| GET | `/` | `listActivities(filter?)` |
| GET | `/{id}` | `getActivity(id)` |
| POST | `/` | `createActivity(req)` |
| POST | `/{id}/complete` | `completeActivity(id, req)` |
| POST | `/{id}/cancel` | `cancelActivity(id, req)` |
| PUT | `/{id}/assignee` | `reassignActivity(id, req)` |
| PUT | `/{id}/due-date` | `rescheduleActivity(id, req)` |
| GET | `/calendar` | `getActivitiesCalendar(filter)` |

Filter helpers omit `undefined` axes — backend treats them as wildcards (same convention as `getAvailablePaymentMethods`).

## Closes

- #366 — F2 — `@granit/activities` API client
- Parent feature: #364
- Backend reference: granit-fx/granit-dotnet#1799 (Endpoints) + #1801 (Calendar)

## Test plan

- [x] `pnpm vitest run packages/@granit/activities` — 22/22 green (3 files)
- [x] Happy path covered for all 8 functions
- [x] Error propagation tested: 401, 403, 404, 422
- [x] URI encoding asserted (`getActivity` with `/` and space in id)
- [x] Filter omission asserted (empty filter object → no `params`, partial filter → only defined keys)
- [x] `pnpm tsc` — green
- [x] `pnpm lint` — `--max-warnings 0` green
- [x] `pnpm -F @granit/activities build` — ESM 2.91 KB / dts 4.96 KB
