### PR TITLE
feat(react-activities): provider + read hooks (F3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1256,6 +1256,47 @@
       ]
     },
     {
+      "name": "@granit/react-activities",
+      "description": "React bindings for @granit/activities — ActivitiesProvider and hooks",
+      "exports": [
+        {
+          "name": "API_VERSION",
+          "kind": "const",
+          "signature": "const API_VERSION"
+        },
+        {
+          "name": "DEFAULT_BASE_PATH",
+          "kind": "const",
+          "signature": "const DEFAULT_BASE_PATH"
+        },
+        {
+          "name": "DEFAULT_QUERY_KEY_PREFIX",
+          "kind": "const",
+          "signature": "const DEFAULT_QUERY_KEY_PREFIX"
+        },
+        {
+          "name": "MODULE",
+          "kind": "const",
+          "signature": "const MODULE"
+        },
+        {
+          "name": "useActivities",
+          "kind": "function",
+          "signature": "function useActivities(filter?: ActivityListFilter): UseQueryResult<ActivityListResponse>"
+        },
+        {
+          "name": "useActivitiesCalendar",
+          "kind": "function",
+          "signature": "function useActivitiesCalendar( filter: ActivityCalendarFilter ): UseQueryResult<readonly ActivityCalendarItemResponse[]>"
+        },
+        {
+          "name": "useActivity",
+          "kind": "function",
+          "signature": "function useActivity(id: string): UseQueryResult<ActivityResponse>"
+        }
+      ]
+    },
+    {
       "name": "@granit/react-ai",
       "description": "React bindings for @granit/ai — AIProvider, useAIWorkspaces, useAIChat, useAIChatStream, useAIEmbeddings, workspace CRUD mutations",
       "exports": [

--- a/packages/@granit/react-activities/package.json
+++ b/packages/@granit/react-activities/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@granit/react-activities",
+  "description": "React bindings for @granit/activities — ActivitiesProvider and hooks",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/activities": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/activities": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-activities/src/__tests__/activities-provider.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activities-provider.test.tsx
@@ -1,0 +1,76 @@
+import { createMockClient } from '@granit/testing';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  ActivitiesProvider,
+  buildActivitiesQueryKey,
+  useActivitiesConfig,
+} from '../providers/activities-provider.js';
+
+import type { ActivitiesConfig } from '../providers/activities-provider.js';
+import type { ReactNode } from 'react';
+
+describe('ActivitiesProvider', () => {
+  it('exposes the resolved config (default basePath + queryKeyPrefix)', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ActivitiesProvider config={{ client }}>{children}</ActivitiesProvider>
+    );
+
+    const { result } = renderHook(() => useActivitiesConfig(), { wrapper });
+
+    expect(result.current.basePath).toBe('/api/v1/activities');
+    expect(result.current.queryKeyPrefix).toEqual(['activities']);
+    expect(result.current.client).toBe(client);
+  });
+
+  it('honors custom basePath and queryKeyPrefix overrides', () => {
+    const client = createMockClient();
+    const config: ActivitiesConfig = {
+      client,
+      basePath: '/custom/activities',
+      queryKeyPrefix: ['tenant-a', 'activities'],
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ActivitiesProvider config={config}>{children}</ActivitiesProvider>
+    );
+
+    const { result } = renderHook(() => useActivitiesConfig(), { wrapper });
+
+    expect(result.current.basePath).toBe('/custom/activities');
+    expect(result.current.queryKeyPrefix).toEqual(['tenant-a', 'activities']);
+  });
+
+  it('throws when used outside the provider', () => {
+    expect(() => renderHook(() => useActivitiesConfig())).toThrow(/ActivitiesProvider/);
+  });
+
+  it('throws when no client is available (no config.client and no GranitClientProvider)', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ActivitiesProvider config={{}}>{children}</ActivitiesProvider>
+    );
+
+    expect(() => renderHook(() => useActivitiesConfig(), { wrapper })).toThrow(
+      /requires an Axios client/
+    );
+  });
+});
+
+describe('buildActivitiesQueryKey', () => {
+  it('prepends the configured prefix to extra segments', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <ActivitiesProvider config={{ client, queryKeyPrefix: ['p'] }}>{children}</ActivitiesProvider>
+    );
+
+    const { result } = renderHook(() => useActivitiesConfig(), { wrapper });
+
+    expect(buildActivitiesQueryKey(result.current, 'list')).toEqual(['p', 'list']);
+    expect(buildActivitiesQueryKey(result.current, 'detail', 'act-1')).toEqual([
+      'p',
+      'detail',
+      'act-1',
+    ]);
+  });
+});

--- a/packages/@granit/react-activities/src/__tests__/use-activities.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/use-activities.test.tsx
@@ -1,0 +1,184 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useActivities, useActivitiesCalendar, useActivity } from '../hooks/use-activities.js';
+import { ActivitiesProvider } from '../providers/activities-provider.js';
+
+import type {
+  ActivityCalendarItemResponse,
+  ActivityListResponse,
+  ActivityResponse,
+} from '@granit/activities';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const sampleActivity: ActivityResponse = {
+  id: 'act-1',
+  entityType: 'Quote',
+  entityId: 'quote-1',
+  type: 'FollowUp',
+  assignedToUserId: 'user-1',
+  createdByUserId: 'user-2',
+  dueAt: '2026-05-10T10:00:00Z',
+  description: null,
+  status: 'Open',
+  completedAt: null,
+  completedByUserId: null,
+  createdAt: '2026-05-01T08:00:00Z',
+};
+
+const sampleListResponse: ActivityListResponse = {
+  items: [sampleActivity],
+  totalCount: 1,
+  page: 1,
+  pageSize: 20,
+};
+
+const sampleCalendarItem: ActivityCalendarItemResponse = {
+  id: 'act-1',
+  start: '2026-05-10T10:00:00Z',
+  end: null,
+  title: 'Quote · FollowUp',
+  color: 'open',
+  type: 'FollowUp',
+  status: 'Open',
+  entityType: 'Quote',
+  entityId: 'quote-1',
+  assignedToUserId: 'user-1',
+};
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <ActivitiesProvider config={{ client, basePath }}>{children}</ActivitiesProvider>
+    );
+  };
+}
+
+describe('useActivities', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs the default base path and returns the paginated payload', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleListResponse });
+
+    const { result } = renderHook(() => useActivities(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities', undefined);
+    expect(result.current.data).toEqual(sampleListResponse);
+  });
+
+  it('forwards filters as query params (only defined axes)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleListResponse });
+
+    const { result } = renderHook(
+      () =>
+        useActivities({
+          status: 'OpenOrOverdue',
+          assignedToUserId: 'user-1',
+          page: 2,
+          pageSize: 50,
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities', {
+      params: {
+        status: 'OpenOrOverdue',
+        assignedToUserId: 'user-1',
+        page: 2,
+        pageSize: 50,
+      },
+    });
+  });
+
+  it('respects a custom basePath from the provider', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleListResponse });
+
+    const { result } = renderHook(() => useActivities(), {
+      wrapper: createWrapper(client, '/custom/activities'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/custom/activities', undefined);
+  });
+});
+
+describe('useActivity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs the activity by id', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleActivity });
+
+    const { result } = renderHook(() => useActivity('act-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities/act-1');
+    expect(result.current.data).toEqual(sampleActivity);
+  });
+
+  it('does not fire when id is empty', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleActivity });
+
+    const { result } = renderHook(() => useActivity(''), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useActivitiesCalendar', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /calendar with the time window and optional filters', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleCalendarItem] });
+
+    const { result } = renderHook(
+      () =>
+        useActivitiesCalendar({
+          from: '2026-05-01T00:00:00Z',
+          to: '2026-05-31T23:59:59Z',
+          assignee: 'me',
+          status: 'OpenOrOverdue',
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
+      params: {
+        from: '2026-05-01T00:00:00Z',
+        to: '2026-05-31T23:59:59Z',
+        assignee: 'me',
+        status: 'OpenOrOverdue',
+      },
+    });
+    expect(result.current.data).toEqual([sampleCalendarItem]);
+  });
+});

--- a/packages/@granit/react-activities/src/constants.ts
+++ b/packages/@granit/react-activities/src/constants.ts
@@ -1,0 +1,4 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'activities';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+export const DEFAULT_QUERY_KEY_PREFIX = ['activities'] as const;

--- a/packages/@granit/react-activities/src/hooks/use-activities.ts
+++ b/packages/@granit/react-activities/src/hooks/use-activities.ts
@@ -1,0 +1,76 @@
+import { getActivitiesCalendar, getActivity, listActivities } from '@granit/activities';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildActivitiesQueryKey, useActivitiesConfig } from '../providers/activities-provider.js';
+
+import type {
+  ActivityCalendarFilter,
+  ActivityCalendarItemResponse,
+  ActivityListFilter,
+  ActivityListResponse,
+  ActivityResponse,
+} from '@granit/activities';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List activities, paginated. The query key includes the serialized `filter`
+ * so distinct filter combinations maintain independent caches.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useActivities({ status: 'OpenOrOverdue', page: 1, pageSize: 20 });
+ * ```
+ */
+export function useActivities(filter?: ActivityListFilter): UseQueryResult<ActivityListResponse> {
+  const config = useActivitiesConfig();
+  const baseKey = buildActivitiesQueryKey(config, 'list');
+  const queryKey = filter ? [...baseKey, filter] : baseKey;
+
+  return useQuery({
+    queryKey,
+    queryFn: () => listActivities(config.client, config.basePath, filter),
+  });
+}
+
+/**
+ * Get a single activity by ID. Disabled when `id` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: activity } = useActivity(selectedId);
+ * ```
+ */
+export function useActivity(id: string): UseQueryResult<ActivityResponse> {
+  const config = useActivitiesConfig();
+
+  return useQuery({
+    queryKey: buildActivitiesQueryKey(config, 'detail', id),
+    queryFn: () => getActivity(config.client, config.basePath, id),
+    enabled: id.length > 0,
+  });
+}
+
+/**
+ * Cross-entity calendar window of activities. `from` and `to` are required;
+ * other axes (assignee, entityType, type, status) are optional.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useActivitiesCalendar({
+ *   from: '2026-05-01T00:00:00Z',
+ *   to: '2026-05-31T23:59:59Z',
+ *   assignee: 'me',
+ *   status: 'OpenOrOverdue',
+ * });
+ * ```
+ */
+export function useActivitiesCalendar(
+  filter: ActivityCalendarFilter
+): UseQueryResult<readonly ActivityCalendarItemResponse[]> {
+  const config = useActivitiesConfig();
+
+  return useQuery({
+    queryKey: buildActivitiesQueryKey(config, 'calendar', filter),
+    queryFn: () => getActivitiesCalendar(config.client, config.basePath, filter),
+  });
+}

--- a/packages/@granit/react-activities/src/index.ts
+++ b/packages/@granit/react-activities/src/index.ts
@@ -1,0 +1,17 @@
+// Provider
+export {
+  ActivitiesProvider,
+  buildActivitiesQueryKey,
+  useActivitiesConfig,
+} from './providers/activities-provider.js';
+export type {
+  ActivitiesConfig,
+  ActivitiesProviderProps,
+  ResolvedActivitiesConfig,
+} from './providers/activities-provider.js';
+
+// Constants
+export { API_VERSION, DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX, MODULE } from './constants.js';
+
+// Read hooks
+export { useActivities, useActivitiesCalendar, useActivity } from './hooks/use-activities.js';

--- a/packages/@granit/react-activities/src/providers/activities-provider.tsx
+++ b/packages/@granit/react-activities/src/providers/activities-provider.tsx
@@ -1,0 +1,69 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for the activities provider. */
+export interface ActivitiesConfig {
+  readonly client?: AxiosInstance;
+  /** Base path for activity endpoints (default: `/api/v1/activities`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * ActivitiesConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedActivitiesConfig extends ActivitiesConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
+}
+
+export interface ActivitiesProviderProps {
+  readonly config: ActivitiesConfig;
+  readonly children: ReactNode;
+}
+
+const ActivitiesConfigContext = createContext<ResolvedActivitiesConfig | null>(null);
+
+/** Provides activities configuration to child components and hooks. */
+export function ActivitiesProvider({ config, children }: Readonly<ActivitiesProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedActivitiesConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'ActivitiesProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      client,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+    };
+  }, [config, contextClient]);
+  return <ActivitiesConfigContext value={value}>{children}</ActivitiesConfigContext>;
+}
+
+/** Returns the activities configuration from the nearest `ActivitiesProvider`. */
+export function useActivitiesConfig(): ResolvedActivitiesConfig {
+  const ctx = useContext(ActivitiesConfigContext);
+  if (!ctx) {
+    throw new Error('useActivitiesConfig must be used within an ActivitiesProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for activities operations. */
+export function buildActivitiesQueryKey(
+  config: ResolvedActivitiesConfig,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...config.queryKeyPrefix, ...segments];
+}

--- a/packages/@granit/react-activities/tsconfig.json
+++ b/packages/@granit/react-activities/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/activities": ["../activities/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-activities/tsup.config.ts
+++ b/packages/@granit/react-activities/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,6 +631,31 @@ importers:
         specifier: workspace:*
         version: link:../types
 
+  packages/@granit/react-activities:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.5
+        version: 5.100.5(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@granit/activities':
+        specifier: workspace:*
+        version: link:../activities
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-ai:
     dependencies:
       '@granit/ai':


### PR DESCRIPTION
## Summary

Scaffolds `@granit/react-activities` (third story of Granit.Activities front). Mirrors the `@granit/react-payments` shape — provider, query-key helper, and React Query read hooks built on the F2 API client.

**Ships**

- `<ActivitiesProvider>` + `useActivitiesConfig()` + `buildActivitiesQueryKey()`
  - resolves Axios client from `config.client` or the nearest `<GranitClientProvider>`
  - defaults: `basePath = /api/v1/activities`, `queryKeyPrefix = ['activities']`
- `useActivities(filter?)` — paginated list, filter is part of the query key for distinct-cache semantics
- `useActivity(id)` — detail, automatically disabled when id is empty
- `useActivitiesCalendar(filter)` — cross-entity calendar window

**Query-key strategy** (sets up F4 invalidation cleanly)

```
['activities', 'list', filter?]
['activities', 'detail', id]
['activities', 'calendar', filter]
```

F4 will be able to invalidate `['activities', 'list']` and `['activities', 'calendar']` on mutation success without nuking detail caches.

## Closes

- #367 — F3 — `@granit/react-activities` provider + read hooks
- Parent feature: #364

## Test plan

- [x] 11/11 unit tests green (`pnpm vitest run packages/@granit/react-activities`)
  - provider: defaults, custom basePath/prefix, no-provider error, no-client error, query-key prefix application
  - `useActivities`: default base path, filter forwarding, custom basePath
  - `useActivity`: GET by id, disabled when id is empty
  - `useActivitiesCalendar`: time window + optional axes
- [x] `pnpm tsc` — green across the workspace
- [x] `pnpm lint` — `--max-warnings 0`
- [x] `pnpm -F @granit/react-activities build` — ESM 2.60 KB / dts 3.08 KB
