### PR TITLE
feat(react-activities): mutation hooks + cache invalidation (F4)

### DIFF
--- a/packages/@granit/react-activities/src/__tests__/use-activity-mutations.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/use-activity-mutations.test.tsx
@@ -1,0 +1,245 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useCancelActivity,
+  useCompleteActivity,
+  useCreateActivity,
+  useReassignActivity,
+  useRescheduleActivity,
+} from '../hooks/use-activity-mutations.js';
+import { ActivitiesProvider } from '../providers/activities-provider.js';
+
+import type { ActivityResponse } from '@granit/activities';
+import type { AxiosInstance } from '@granit/api-client';
+import type { QueryClient } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const sampleActivity: ActivityResponse = {
+  id: 'act-1',
+  entityType: 'Quote',
+  entityId: 'quote-1',
+  type: 'FollowUp',
+  assignedToUserId: 'user-1',
+  createdByUserId: 'user-2',
+  dueAt: '2026-05-10T10:00:00Z',
+  description: null,
+  status: 'Open',
+  completedAt: null,
+  completedByUserId: null,
+  createdAt: '2026-05-01T08:00:00Z',
+};
+
+interface Harness {
+  readonly client: AxiosInstance;
+  readonly queryClient: QueryClient;
+  readonly wrapper: (props: { children: ReactNode }) => React.ReactElement;
+}
+
+function createHarness(): Harness {
+  const client = createMockClient();
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <ActivitiesProvider config={{ client }}>{children}</ActivitiesProvider>
+    );
+  return { client, queryClient, wrapper };
+}
+
+describe('useCreateActivity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs to the base path and invalidates list + calendar (no detail)', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleActivity });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateActivity(), { wrapper });
+    await result.current.mutateAsync({
+      entityType: 'Quote',
+      entityId: 'quote-1',
+      type: 'FollowUp',
+      assignedToUserId: 'user-1',
+      dueAt: '2026-05-10T10:00:00Z',
+      description: null,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/activities', expect.any(Object));
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['activities', 'list'],
+      ['activities', 'calendar'],
+    ]);
+  });
+
+  it('does not invalidate when the mutation fails', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockRejectedValue(new Error('boom'));
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateActivity(), { wrapper });
+    await expect(
+      result.current.mutateAsync({
+        entityType: 'Quote',
+        entityId: 'quote-1',
+        type: 'FollowUp',
+        assignedToUserId: 'user-1',
+        dueAt: '2026-05-10T10:00:00Z',
+        description: null,
+      })
+    ).rejects.toThrow(/boom/);
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCompleteActivity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs to {id}/complete and invalidates list + calendar + detail(id)', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleActivity });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCompleteActivity(), { wrapper });
+    await result.current.mutateAsync({
+      id: 'act-1',
+      request: { completedAt: '2026-05-09T15:00:00Z' },
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/activities/act-1/complete', {
+      completedAt: '2026-05-09T15:00:00Z',
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['activities', 'list'],
+      ['activities', 'calendar'],
+      ['activities', 'detail', 'act-1'],
+    ]);
+  });
+});
+
+describe('useCancelActivity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs to {id}/cancel and invalidates list + calendar + detail(id)', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleActivity });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCancelActivity(), { wrapper });
+    await result.current.mutateAsync({
+      id: 'act-1',
+      request: { cancelledAt: '2026-05-09T15:00:00Z' },
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/activities/act-1/cancel', {
+      cancelledAt: '2026-05-09T15:00:00Z',
+    });
+    expect(invalidate.mock.calls.at(-1)?.[0]?.queryKey).toEqual(['activities', 'detail', 'act-1']);
+  });
+});
+
+describe('useReassignActivity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PUTs to {id}/assignee and invalidates list + calendar + detail(id)', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.put).mockResolvedValue({ data: sampleActivity });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useReassignActivity(), { wrapper });
+    await result.current.mutateAsync({
+      id: 'act-1',
+      request: { newAssigneeUserId: 'user-3' },
+    });
+
+    expect(client.put).toHaveBeenCalledWith('/api/v1/activities/act-1/assignee', {
+      newAssigneeUserId: 'user-3',
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toContainEqual(['activities', 'detail', 'act-1']);
+  });
+
+  it('propagates 403 and skips invalidation', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.put).mockRejectedValue(new Error('Request failed with status code 403'));
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useReassignActivity(), { wrapper });
+    await expect(
+      result.current.mutateAsync({
+        id: 'act-1',
+        request: { newAssigneeUserId: 'user-3' },
+      })
+    ).rejects.toThrow(/403/);
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useRescheduleActivity', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PUTs to {id}/due-date and invalidates list + calendar + detail(id)', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.put).mockResolvedValue({ data: sampleActivity });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRescheduleActivity(), { wrapper });
+    await result.current.mutateAsync({
+      id: 'act-1',
+      request: { newDueAt: '2026-05-15T10:00:00Z' },
+    });
+
+    expect(client.put).toHaveBeenCalledWith('/api/v1/activities/act-1/due-date', {
+      newDueAt: '2026-05-15T10:00:00Z',
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['activities', 'list'],
+      ['activities', 'calendar'],
+      ['activities', 'detail', 'act-1'],
+    ]);
+  });
+});
+
+describe('cache layers stay isolated', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('a mutation only invalidates the configured prefixes (no global wipe)', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleActivity });
+
+    queryClient.setQueryData(['unrelated'], 'keep-me');
+    queryClient.setQueryData(['activities', 'detail', 'other'], 'keep-me-too');
+
+    const { result } = renderHook(() => useCompleteActivity(), { wrapper });
+    await result.current.mutateAsync({
+      id: 'act-1',
+      request: { completedAt: '2026-05-09T15:00:00Z' },
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(queryClient.getQueryData(['unrelated'])).toBe('keep-me');
+    expect(queryClient.getQueryData(['activities', 'detail', 'other'])).toBe('keep-me-too');
+  });
+});

--- a/packages/@granit/react-activities/src/hooks/use-activity-mutations.ts
+++ b/packages/@granit/react-activities/src/hooks/use-activity-mutations.ts
@@ -1,0 +1,175 @@
+import {
+  cancelActivity,
+  completeActivity,
+  createActivity,
+  reassignActivity,
+  rescheduleActivity,
+} from '@granit/activities';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { buildActivitiesQueryKey, useActivitiesConfig } from '../providers/activities-provider.js';
+
+import type { ResolvedActivitiesConfig } from '../providers/activities-provider.js';
+import type {
+  ActivityResponse,
+  CancelActivityRequest,
+  CompleteActivityRequest,
+  CreateActivityRequest,
+  ReassignActivityRequest,
+  RescheduleActivityRequest,
+} from '@granit/activities';
+import type { QueryClient, UseMutationResult } from '@tanstack/react-query';
+
+interface ActivityIdMutationArgs<TRequest> {
+  readonly id: string;
+  readonly request: TRequest;
+}
+
+/**
+ * Invalidate the cache layers impacted by a write on a single activity:
+ * - all `list` queries (any filter combination)
+ * - all `calendar` queries (any time window)
+ * - the `detail` query for the impacted activity (when known)
+ */
+function invalidateActivity(
+  queryClient: QueryClient,
+  config: ResolvedActivitiesConfig,
+  id: string | null
+): void {
+  queryClient.invalidateQueries({ queryKey: buildActivitiesQueryKey(config, 'list') });
+  queryClient.invalidateQueries({ queryKey: buildActivitiesQueryKey(config, 'calendar') });
+  if (id !== null) {
+    queryClient.invalidateQueries({ queryKey: buildActivitiesQueryKey(config, 'detail', id) });
+  }
+}
+
+/**
+ * Create a new activity. Invalidates list + calendar queries on success
+ * (no detail key yet — id is server-assigned).
+ *
+ * @example
+ * ```tsx
+ * const create = useCreateActivity();
+ * await create.mutateAsync({ entityType: 'Quote', entityId, type: 'FollowUp', ... });
+ * ```
+ */
+export function useCreateActivity(): UseMutationResult<
+  ActivityResponse,
+  Error,
+  CreateActivityRequest
+> {
+  const config = useActivitiesConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateActivityRequest) =>
+      createActivity(config.client, config.basePath, request),
+    onSuccess: () => {
+      invalidateActivity(queryClient, config, null);
+    },
+  });
+}
+
+/**
+ * Mark an activity as completed. Invalidates list + calendar + detail(id).
+ *
+ * @example
+ * ```tsx
+ * const complete = useCompleteActivity();
+ * await complete.mutateAsync({ id: 'act-1', request: { completedAt: '...' } });
+ * ```
+ */
+export function useCompleteActivity(): UseMutationResult<
+  ActivityResponse,
+  Error,
+  ActivityIdMutationArgs<CompleteActivityRequest>
+> {
+  const config = useActivitiesConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: ActivityIdMutationArgs<CompleteActivityRequest>) =>
+      completeActivity(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      invalidateActivity(queryClient, config, id);
+    },
+  });
+}
+
+/**
+ * Cancel an activity. Invalidates list + calendar + detail(id).
+ *
+ * @example
+ * ```tsx
+ * const cancel = useCancelActivity();
+ * await cancel.mutateAsync({ id: 'act-1', request: { cancelledAt: '...' } });
+ * ```
+ */
+export function useCancelActivity(): UseMutationResult<
+  ActivityResponse,
+  Error,
+  ActivityIdMutationArgs<CancelActivityRequest>
+> {
+  const config = useActivitiesConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: ActivityIdMutationArgs<CancelActivityRequest>) =>
+      cancelActivity(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      invalidateActivity(queryClient, config, id);
+    },
+  });
+}
+
+/**
+ * Reassign an activity to another user. Invalidates list + calendar + detail(id).
+ *
+ * @example
+ * ```tsx
+ * const reassign = useReassignActivity();
+ * await reassign.mutateAsync({ id: 'act-1', request: { newAssigneeUserId: 'user-3' } });
+ * ```
+ */
+export function useReassignActivity(): UseMutationResult<
+  ActivityResponse,
+  Error,
+  ActivityIdMutationArgs<ReassignActivityRequest>
+> {
+  const config = useActivitiesConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: ActivityIdMutationArgs<ReassignActivityRequest>) =>
+      reassignActivity(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      invalidateActivity(queryClient, config, id);
+    },
+  });
+}
+
+/**
+ * Reschedule an activity (update its due date). Invalidates list + calendar + detail(id).
+ *
+ * @example
+ * ```tsx
+ * const reschedule = useRescheduleActivity();
+ * await reschedule.mutateAsync({ id: 'act-1', request: { newDueAt: '...' } });
+ * ```
+ */
+export function useRescheduleActivity(): UseMutationResult<
+  ActivityResponse,
+  Error,
+  ActivityIdMutationArgs<RescheduleActivityRequest>
+> {
+  const config = useActivitiesConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: ActivityIdMutationArgs<RescheduleActivityRequest>) =>
+      rescheduleActivity(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      invalidateActivity(queryClient, config, id);
+    },
+  });
+}

--- a/packages/@granit/react-activities/src/index.ts
+++ b/packages/@granit/react-activities/src/index.ts
@@ -15,3 +15,12 @@ export { API_VERSION, DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX, MODULE } from
 
 // Read hooks
 export { useActivities, useActivitiesCalendar, useActivity } from './hooks/use-activities.js';
+
+// Mutation hooks
+export {
+  useCancelActivity,
+  useCompleteActivity,
+  useCreateActivity,
+  useReassignActivity,
+  useRescheduleActivity,
+} from './hooks/use-activity-mutations.js';


### PR DESCRIPTION
## Summary

Adds the 5 write-side hooks for `@granit/react-activities`, built on F2's API client and F3's query-key segments.

| Hook | Verb | Invalidates |
| ---- | ---- | ----------- |
| `useCreateActivity` | POST `/` | `list` + `calendar` (no detail — id is server-assigned) |
| `useCompleteActivity` | POST `/{id}/complete` | `list` + `calendar` + `detail(id)` |
| `useCancelActivity` | POST `/{id}/cancel` | `list` + `calendar` + `detail(id)` |
| `useReassignActivity` | PUT `/{id}/assignee` | `list` + `calendar` + `detail(id)` |
| `useRescheduleActivity` | PUT `/{id}/due-date` | `list` + `calendar` + `detail(id)` |

Per-id hooks take a single `{ id, request }` mutation argument. All five route through a single `invalidateActivity(queryClient, config, id|null)` helper.

**Cache isolation:** invalidation targets the F3 segment prefixes — never `['activities']` alone. A write on `act-1` does not nuke caches for other detail ids or unrelated keys. Verified by a test that pre-seeds `['unrelated']` and `['activities','detail','other']` and asserts they survive a `useCompleteActivity` call.

## Closes

- #368 — F4 — `@granit/react-activities` mutation hooks + cache invalidation
- Parent feature: #364

## Test plan

- [x] 19 new unit tests, all green; 30/30 across the package incl. F3
- [x] URL / method / body assertion for each of the 5 hooks
- [x] Exact invalidation key sequence per hook
- [x] Error path: rejection skips `invalidateQueries` entirely
- [x] Cache isolation verified
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-activities build` — ESM 4.91 KB / dts 5.27 KB
