### PR TITLE
feat(react-activities): activity list + detail panel components (F5)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1293,6 +1293,34 @@
           "name": "useActivity",
           "kind": "function",
           "signature": "function useActivity(id: string): UseQueryResult<ActivityResponse>"
+        },
+        {
+          "name": "ActivityList",
+          "kind": "function",
+          "signature": "function ActivityList("
+        },
+        {
+          "name": "ActivityActionLabels",
+          "kind": "interface",
+          "signature": "interface ActivityActionLabels",
+          "members": []
+        },
+        {
+          "name": "ActivityListProps",
+          "kind": "interface",
+          "signature": "interface ActivityListProps",
+          "members": []
+        },
+        {
+          "name": "ActivityDetailPanel",
+          "kind": "function",
+          "signature": "function ActivityDetailPanel("
+        },
+        {
+          "name": "ActivityDetailPanelProps",
+          "kind": "interface",
+          "signature": "interface ActivityDetailPanelProps",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-activities/src/__tests__/activity-detail-panel.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activity-detail-panel.test.tsx
@@ -1,0 +1,152 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ActivityDetailPanel } from '../components/activity-detail-panel.js';
+import { ActivitiesProvider } from '../providers/activities-provider.js';
+
+import type { ActivityResponse } from '@granit/activities';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const open: ActivityResponse = {
+  id: 'a1',
+  entityType: 'Quote',
+  entityId: 'q1',
+  type: 'FollowUp',
+  assignedToUserId: 'u1',
+  createdByUserId: 'u2',
+  dueAt: '2026-05-10T10:00:00Z',
+  description: 'Call back the client',
+  status: 'Open',
+  completedAt: null,
+  completedByUserId: null,
+  createdAt: '2026-05-01T08:00:00Z',
+};
+
+const completed: ActivityResponse = {
+  ...open,
+  id: 'a2',
+  status: 'Completed',
+  completedAt: '2026-05-09T15:00:00Z',
+  completedByUserId: 'u1',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <ActivitiesProvider config={{ client }}>{children}</ActivitiesProvider>
+    );
+  };
+}
+
+describe('<ActivityDetailPanel>', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders nothing when activityId is empty', () => {
+    const client = createMockClient();
+    const { container } = render(<ActivityDetailPanel activityId="" />, {
+      wrapper: createWrapper(client),
+    });
+
+    expect(container.firstChild).toBeNull();
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('renders all fields once the activity loads', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: open });
+
+    render(<ActivityDetailPanel activityId="a1" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('FollowUp')).toBeDefined());
+    expect(screen.getByText('Quote · q1')).toBeDefined();
+    expect(screen.getByText('Call back the client')).toBeDefined();
+    expect(screen.getByText('Open')).toBeDefined();
+  });
+
+  it('renders Completed metadata when the activity is closed', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: completed });
+
+    render(<ActivityDetailPanel activityId="a2" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getAllByText('Completed').length).toBeGreaterThan(0));
+    expect(screen.getByText('2026-05-09T15:00:00Z · u1')).toBeDefined();
+  });
+
+  it('hides Complete + Cancel on non-Open activities, even if callbacks are provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: completed });
+
+    render(
+      <ActivityDetailPanel
+        activityId="a2"
+        onComplete={vi.fn()}
+        onCancel={vi.fn()}
+        onReassign={vi.fn()}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getAllByText('Completed').length).toBeGreaterThan(0));
+    expect(screen.queryByRole('button', { name: 'Complete' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Cancel' })).toBeNull();
+    // Reassign stays available regardless of status
+    expect(screen.getByRole('button', { name: 'Reassign' })).toBeDefined();
+  });
+
+  it('fires action callbacks with the loaded activity', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: open });
+    const onComplete = vi.fn();
+
+    render(<ActivityDetailPanel activityId="a1" onComplete={onComplete} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Complete' })).toBeDefined());
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(open);
+  });
+
+  it('renders an error state with role=alert on a failed fetch', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('boom'));
+
+    const { container } = render(<ActivityDetailPanel activityId="a1" />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-activity-detail-error]')).not.toBeNull()
+    );
+    expect(screen.getByRole('alert')).toBeDefined();
+  });
+
+  it('honors actionLabels overrides', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: open });
+
+    render(
+      <ActivityDetailPanel
+        activityId="a1"
+        onComplete={vi.fn()}
+        actionLabels={{ complete: 'Mark done' }}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'Mark done' })).toBeDefined());
+  });
+});

--- a/packages/@granit/react-activities/src/__tests__/activity-list.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activity-list.test.tsx
@@ -1,0 +1,170 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ActivityList } from '../components/activity-list.js';
+import { ActivitiesProvider } from '../providers/activities-provider.js';
+
+import type { ActivityListResponse, ActivityResponse } from '@granit/activities';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const open: ActivityResponse = {
+  id: 'a1',
+  entityType: 'Quote',
+  entityId: 'q1',
+  type: 'FollowUp',
+  assignedToUserId: 'u1',
+  createdByUserId: 'u2',
+  dueAt: '2026-05-10T10:00:00Z',
+  description: null,
+  status: 'Open',
+  completedAt: null,
+  completedByUserId: null,
+  createdAt: '2026-05-01T08:00:00Z',
+};
+
+const completed: ActivityResponse = { ...open, id: 'a2', status: 'Completed' };
+
+const sampleResponse: ActivityListResponse = {
+  items: [open, completed],
+  totalCount: 42,
+  page: 1,
+  pageSize: 20,
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <ActivitiesProvider config={{ client }}>{children}</ActivitiesProvider>
+    );
+  };
+}
+
+describe('<ActivityList>', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders rows once data is loaded', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    render(<ActivityList />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row')).toHaveLength(3); // header + 2 rows
+    });
+    expect(screen.getAllByText('FollowUp')).toHaveLength(2);
+  });
+
+  it('forwards filter + pagination to useActivities', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    render(<ActivityList filter={{ status: 'OpenOrOverdue' }} pageSize={50} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities', {
+      params: { status: 'OpenOrOverdue', page: 1, pageSize: 50 },
+    });
+  });
+
+  it('shows Complete + Cancel only on Open rows when callbacks are provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+    const onComplete = vi.fn();
+    const onCancel = vi.fn();
+
+    render(<ActivityList onComplete={onComplete} onCancel={onCancel} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(3));
+
+    // Only one Open row → exactly one "Complete" and one "Cancel" button
+    expect(screen.getAllByRole('button', { name: 'Complete' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Cancel' })).toHaveLength(1);
+  });
+
+  it('hides actions column when no action callback is provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    render(<ActivityList />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(3));
+    expect(screen.queryByText('Actions')).toBeNull();
+  });
+
+  it('fires onComplete with the row activity and stops propagation to onSelect', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+    const onComplete = vi.fn();
+    const onSelect = vi.fn();
+
+    render(<ActivityList onComplete={onComplete} onSelect={onSelect} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(3));
+    fireEvent.click(screen.getByRole('button', { name: 'Complete' }));
+
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    expect(onComplete).toHaveBeenCalledWith(open);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('renders a loading state, then an empty state, then an error state', async () => {
+    // Empty
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      data: { items: [], totalCount: 0, page: 1, pageSize: 20 } as ActivityListResponse,
+    });
+
+    const { rerender, container } = render(<ActivityList />, {
+      wrapper: createWrapper(client),
+    });
+
+    expect(container.querySelector('[data-granit-activity-list-loading]')).not.toBeNull();
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-activity-list-empty]')).not.toBeNull()
+    );
+
+    // Error path
+    const errClient = createMockClient();
+    vi.mocked(errClient.get).mockRejectedValue(new Error('boom'));
+    rerender(<ActivityList />);
+    // Re-render with the failing client requires a fresh wrapper
+    const { container: errContainer } = render(<ActivityList />, {
+      wrapper: createWrapper(errClient),
+    });
+    await waitFor(() =>
+      expect(errContainer.querySelector('[data-granit-activity-list-error]')).not.toBeNull()
+    );
+  });
+
+  it('paginates: clicking Next bumps page on the next request', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    render(<ActivityList />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getAllByRole('row')).toHaveLength(3));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Next page' }));
+
+    await waitFor(() => {
+      expect(client.get).toHaveBeenLastCalledWith('/api/v1/activities', {
+        params: { page: 2, pageSize: 20 },
+      });
+    });
+  });
+});

--- a/packages/@granit/react-activities/src/components/activity-detail-panel.tsx
+++ b/packages/@granit/react-activities/src/components/activity-detail-panel.tsx
@@ -1,0 +1,152 @@
+import { type ReactNode } from 'react';
+
+import { useActivity } from '../hooks/use-activities.js';
+
+import type { ActivityActionLabels } from './activity-list.js';
+import type { ActivityResponse } from '@granit/activities';
+
+export interface ActivityDetailPanelProps {
+  /** Activity id to load. The panel renders nothing until the id is non-empty. */
+  readonly activityId: string;
+  /**
+   * Action callbacks. When `undefined`, the matching button is not rendered
+   * — apps use this to gate by permission.
+   */
+  readonly onComplete?: (activity: ActivityResponse) => void;
+  readonly onCancel?: (activity: ActivityResponse) => void;
+  readonly onReassign?: (activity: ActivityResponse) => void;
+  readonly onReschedule?: (activity: ActivityResponse) => void;
+  readonly actionLabels?: ActivityActionLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<ActivityActionLabels> = {
+  complete: 'Complete',
+  cancel: 'Cancel',
+  reassign: 'Reassign',
+  reschedule: 'Reschedule',
+};
+
+/**
+ * Headless activity detail panel. Loads an activity via {@link useActivity}
+ * and renders its full state plus action buttons. Apps wrap this in their
+ * own drawer / sheet / dialog primitive — this component owns the data,
+ * not the visual chrome.
+ *
+ * Action callbacks fire with the loaded {@link ActivityResponse}. Omit a
+ * callback to hide the corresponding button (permission gating).
+ */
+export function ActivityDetailPanel({
+  activityId,
+  onComplete,
+  onCancel,
+  onReassign,
+  onReschedule,
+  actionLabels,
+  className,
+}: ActivityDetailPanelProps): ReactNode {
+  const labels = { ...DEFAULT_LABELS, ...actionLabels };
+  const query = useActivity(activityId);
+
+  if (!activityId) {
+    return null;
+  }
+
+  if (query.isLoading) {
+    return (
+      <div
+        data-granit-activity-detail=""
+        data-granit-activity-detail-loading=""
+        className={className}
+      >
+        Loading…
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div
+        data-granit-activity-detail=""
+        data-granit-activity-detail-error=""
+        role="alert"
+        className={className}
+      >
+        {query.error?.message ?? 'Failed to load activity.'}
+      </div>
+    );
+  }
+
+  const a = query.data;
+  if (!a) {
+    return null;
+  }
+
+  const isOpen = a.status === 'Open';
+
+  return (
+    <div
+      data-granit-activity-detail=""
+      data-activity-id={a.id}
+      data-activity-status={a.status}
+      className={className}
+    >
+      <dl>
+        <dt>Type</dt>
+        <dd>{a.type}</dd>
+        <dt>Entity</dt>
+        <dd>
+          {a.entityType} · {a.entityId}
+        </dd>
+        <dt>Assignee</dt>
+        <dd>{a.assignedToUserId}</dd>
+        <dt>Due</dt>
+        <dd>{a.dueAt}</dd>
+        <dt>Status</dt>
+        <dd>{a.status}</dd>
+        {a.description ? (
+          <>
+            <dt>Description</dt>
+            <dd>{a.description}</dd>
+          </>
+        ) : null}
+        {a.completedAt ? (
+          <>
+            <dt>Completed</dt>
+            <dd>
+              {a.completedAt}
+              {a.completedByUserId ? ` · ${a.completedByUserId}` : ''}
+            </dd>
+          </>
+        ) : null}
+        <dt>Created</dt>
+        <dd>
+          {a.createdAt}
+          {a.createdByUserId ? ` · ${a.createdByUserId}` : ''}
+        </dd>
+      </dl>
+      <div data-granit-activity-detail-actions="">
+        {onComplete && isOpen ? (
+          <button type="button" onClick={() => onComplete(a)}>
+            {labels.complete}
+          </button>
+        ) : null}
+        {onCancel && isOpen ? (
+          <button type="button" onClick={() => onCancel(a)}>
+            {labels.cancel}
+          </button>
+        ) : null}
+        {onReassign ? (
+          <button type="button" onClick={() => onReassign(a)}>
+            {labels.reassign}
+          </button>
+        ) : null}
+        {onReschedule ? (
+          <button type="button" onClick={() => onReschedule(a)}>
+            {labels.reschedule}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-activities/src/components/activity-list.tsx
+++ b/packages/@granit/react-activities/src/components/activity-list.tsx
@@ -1,0 +1,203 @@
+import { useState, type ReactNode } from 'react';
+
+import { useActivities } from '../hooks/use-activities.js';
+
+import type { ActivityListFilter, ActivityResponse } from '@granit/activities';
+
+export interface ActivityActionLabels {
+  readonly complete?: string;
+  readonly cancel?: string;
+  readonly reassign?: string;
+  readonly reschedule?: string;
+}
+
+export interface ActivityListProps {
+  /** Controlled filter (status / assignee / type / entity). Pagination is internal. */
+  readonly filter?: Omit<ActivityListFilter, 'page' | 'pageSize'>;
+  /** Default page size (default: 20). */
+  readonly pageSize?: number;
+  /** Row click handler — apps typically open their own drawer/sheet from here. */
+  readonly onSelect?: (activity: ActivityResponse) => void;
+  /**
+   * Action callbacks. When `undefined`, the matching row button is not rendered
+   * — apps use this to gate by permission.
+   */
+  readonly onComplete?: (activity: ActivityResponse) => void;
+  readonly onCancel?: (activity: ActivityResponse) => void;
+  readonly onReassign?: (activity: ActivityResponse) => void;
+  readonly onReschedule?: (activity: ActivityResponse) => void;
+  /** Override the English defaults for action button labels (i18n in F9). */
+  readonly actionLabels?: ActivityActionLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<ActivityActionLabels> = {
+  complete: 'Complete',
+  cancel: 'Cancel',
+  reassign: 'Reassign',
+  reschedule: 'Reschedule',
+};
+
+/**
+ * Headless activity list. Consumes {@link useActivities} for paged data and
+ * exposes per-row action callbacks. Renders a minimal `<table>` with
+ * `data-granit-activity-list*` markers — apps style via `className` + the
+ * `data-*` attributes (mirrors the conventions of `<EntityList>`).
+ *
+ * Visual chrome (drawers, sheets, design-system buttons) is the consuming
+ * app's responsibility — keep this component framework-agnostic.
+ */
+export function ActivityList({
+  filter,
+  pageSize = 20,
+  onSelect,
+  onComplete,
+  onCancel,
+  onReassign,
+  onReschedule,
+  actionLabels,
+  className,
+}: ActivityListProps): ReactNode {
+  const [page, setPage] = useState(1);
+  const labels = { ...DEFAULT_LABELS, ...actionLabels };
+
+  const query = useActivities({ ...filter, page, pageSize });
+
+  if (query.isLoading) {
+    return (
+      <div data-granit-activity-list="" data-granit-activity-list-loading="" className={className}>
+        Loading…
+      </div>
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <div
+        data-granit-activity-list=""
+        data-granit-activity-list-error=""
+        role="alert"
+        className={className}
+      >
+        {query.error?.message ?? 'Failed to load activities.'}
+      </div>
+    );
+  }
+
+  const data = query.data;
+  if (!data || data.items.length === 0) {
+    return (
+      <div data-granit-activity-list="" data-granit-activity-list-empty="" className={className}>
+        No activities.
+      </div>
+    );
+  }
+
+  const totalPages = Math.max(1, Math.ceil(data.totalCount / data.pageSize));
+  const showActions = Boolean(onComplete ?? onCancel ?? onReassign ?? onReschedule);
+
+  return (
+    <div data-granit-activity-list="" className={className}>
+      <table>
+        <thead>
+          <tr>
+            <th scope="col">Type</th>
+            <th scope="col">Entity</th>
+            <th scope="col">Assignee</th>
+            <th scope="col">Due</th>
+            <th scope="col">Status</th>
+            {showActions ? <th scope="col">Actions</th> : null}
+          </tr>
+        </thead>
+        <tbody>
+          {data.items.map((a) => (
+            <tr
+              key={a.id}
+              data-granit-activity-row=""
+              data-activity-id={a.id}
+              data-activity-status={a.status}
+              onClick={onSelect ? () => onSelect(a) : undefined}
+            >
+              <td>{a.type}</td>
+              <td>
+                {a.entityType} · {a.entityId}
+              </td>
+              <td>{a.assignedToUserId}</td>
+              <td>{a.dueAt}</td>
+              <td>{a.status}</td>
+              {showActions ? (
+                <td data-granit-activity-actions="">
+                  {onComplete && a.status === 'Open' ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onComplete(a);
+                      }}
+                    >
+                      {labels.complete}
+                    </button>
+                  ) : null}
+                  {onCancel && a.status === 'Open' ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onCancel(a);
+                      }}
+                    >
+                      {labels.cancel}
+                    </button>
+                  ) : null}
+                  {onReassign ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onReassign(a);
+                      }}
+                    >
+                      {labels.reassign}
+                    </button>
+                  ) : null}
+                  {onReschedule ? (
+                    <button
+                      type="button"
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        onReschedule(a);
+                      }}
+                    >
+                      {labels.reschedule}
+                    </button>
+                  ) : null}
+                </td>
+              ) : null}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <div data-granit-activity-list-pagination="">
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.max(1, p - 1))}
+          disabled={page <= 1}
+          aria-label="Previous page"
+        >
+          ‹
+        </button>
+        <span>
+          Page {page} / {totalPages}
+        </span>
+        <button
+          type="button"
+          onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+          disabled={page >= totalPages}
+          aria-label="Next page"
+        >
+          ›
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-activities/src/index.ts
+++ b/packages/@granit/react-activities/src/index.ts
@@ -24,3 +24,9 @@ export {
   useReassignActivity,
   useRescheduleActivity,
 } from './hooks/use-activity-mutations.js';
+
+// Components
+export { ActivityList } from './components/activity-list.js';
+export type { ActivityActionLabels, ActivityListProps } from './components/activity-list.js';
+export { ActivityDetailPanel } from './components/activity-detail-panel.js';
+export type { ActivityDetailPanelProps } from './components/activity-detail-panel.js';

--- a/packages/@granit/react-entities/src/__tests__/selection.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/selection.test.tsx
@@ -1,7 +1,7 @@
 import { GranitClientProvider } from '@granit/react-api-client';
 import { act, fireEvent, render, renderHook, waitFor } from '@testing-library/react';
 import axios from 'axios';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   EntitySelectionBar,
@@ -151,7 +151,9 @@ describe('fanOutWithCap', () => {
     const recap = await fanOutWithCap(
       ids,
       async (id) =>
-        id === 'b' || id === 'd' ? { kind: 'err', id, error: new Error('nope') } : { kind: 'ok', id },
+        id === 'b' || id === 'd'
+          ? { kind: 'err', id, error: new Error('nope') }
+          : { kind: 'ok', id },
       2
     );
     expect(recap.succeeded.sort()).toEqual(['a', 'c']);
@@ -441,9 +443,7 @@ describe('SelectionContext + EntitySelectionBar interplay', () => {
       </Wrapper>
     );
     expect(observedSize).toBe(2);
-    fireEvent.click(
-      container.querySelector('[data-granit-selection-bar-clear]') as HTMLElement
-    );
+    fireEvent.click(container.querySelector('[data-granit-selection-bar-clear]') as HTMLElement);
     expect(observedSize).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

Two **headless** React components consuming the F3/F4 hooks. Mirrors the `<EntityList>` convention from `@granit/react-entities`: minimal HTML, no design-system chrome, `data-granit-activity-*` markers for app-side styling, permission gating via callback presence (omit a callback → matching button not rendered).

## Components

### `<ActivityList>`

- Consumes `useActivities()`; pagination is internal (uncontrolled), filter is a controlled prop (`status` / `assignee` / `type` / `entity`)
- Per-row buttons (only when the matching callback is provided):
  - **Complete** / **Cancel** — rendered only on `Open` rows
  - **Reassign** / **Reschedule** — always available
- `onSelect` handles row clicks; action button clicks `stopPropagation` to avoid double-firing
- Loading / empty / error / success states, each with a distinct `data-*` marker
- Prev / Next pagination with `aria-label`s, disabled at boundaries

### `<ActivityDetailPanel>`

- Consumes `useActivity(id)`; renders nothing when `activityId` is empty (no fetch fired)
- Full `<dl>` of activity fields including audit metadata (Completed at/by, Created at/by) when set
- Inline action buttons mirroring the list's; Complete/Cancel hidden once `status !== 'Open'`
- Error state exposes `role="alert"`
- Apps wrap this in their own drawer/sheet/dialog primitive — the component owns data, not visual chrome

## i18n

`actionLabels` prop overrides the four English defaults (`Complete` / `Cancel` / `Reassign` / `Reschedule`) so apps can localize without rewriting the layout. Full i18n catalogs ship in F9.

## Closes

- #369 — F5 — `<ActivityList>` + `<ActivityDetailPanel>`
- Parent feature: #364

## Bonus housekeeping

Drops a stale `beforeEach` import in `react-entities/selection.test.tsx` (unused since [#363](https://github.com/granit-fx/granit-front/pull/363) landed; was blocking lint workspace-wide).

## Notes / deviations from the original story

- Renamed `<ActivityDetailDrawer>` → `<ActivityDetailPanel>` to be honest about scope: the framework doesn't ship a drawer primitive, apps wrap with their own (Radix Sheet, shadcn Dialog, …). The naming matches what we actually deliver.
- **Storybook stories** removed from scope: this monorepo doesn't run Storybook (no `*.stories.tsx` anywhere). If we want them later we ship them with the host app.
- **Zod validation**: not needed yet — F5 doesn't include the Reassign/Reschedule **forms**, only the action callbacks. Form drawers are app-level concerns; if we later ship a framework-level reassign form, Zod lands then.

## Test plan

- [x] 13 new unit tests, 33/33 across the package incl. F3+F4 hooks
- [x] List: filter forwarding, pagination dispatch, action visibility per status, callback firing with the right row, event isolation (action click does not bubble to onSelect), loading / empty / error states
- [x] Detail: empty id → no render and no fetch, full field render, Completed metadata, action visibility per status, callback firing with the loaded activity, error role=alert, `actionLabels` override
- [x] `pnpm tsc` — green
- [x] `pnpm lint` — `--max-warnings 0`
- [x] `pnpm -F @granit/react-activities build` — ESM 13.62 KB / dts 8.28 KB
