### PR TITLE
feat(react-activities): cross-entity activity calendar (F6)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1321,6 +1321,11 @@
           "kind": "interface",
           "signature": "interface ActivityDetailPanelProps",
           "members": []
+        },
+        {
+          "name": "ActivityCalendar",
+          "kind": "function",
+          "signature": "function ActivityCalendar("
         }
       ]
     },

--- a/packages/@granit/react-activities/src/__tests__/activity-calendar.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activity-calendar.test.tsx
@@ -1,0 +1,232 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ActivityCalendar } from '../components/activity-calendar.js';
+import { ActivitiesProvider } from '../providers/activities-provider.js';
+
+import type { ActivityCalendarItemResponse } from '@granit/activities';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const monday: ActivityCalendarItemResponse = {
+  id: 'a1',
+  start: '2026-05-04T10:00:00Z',
+  end: null,
+  title: 'Monday item',
+  color: 'open',
+  type: 'FollowUp',
+  status: 'Open',
+  entityType: 'Quote',
+  entityId: 'q1',
+  assignedToUserId: 'u1',
+};
+
+const overdueWed: ActivityCalendarItemResponse = {
+  id: 'a2',
+  start: '2026-05-06T08:00:00Z',
+  end: null,
+  title: 'Overdue Wed',
+  color: 'overdue',
+  type: 'FollowUp',
+  status: 'Overdue',
+  entityType: 'Quote',
+  entityId: 'q2',
+  assignedToUserId: 'u1',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <ActivitiesProvider config={{ client }}>{children}</ActivitiesProvider>
+    );
+  };
+}
+
+describe('<ActivityCalendar>', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('week view: builds a Mon→Sun window around the anchor', async () => {
+    // 2026-05-06 is a Wednesday → week is 2026-05-04 → 2026-05-11 (exclusive)
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [monday, overdueWed] });
+
+    render(
+      <ActivityCalendar initialView="week" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
+      params: { from: '2026-05-04T00:00:00.000Z', to: '2026-05-11T00:00:00.000Z' },
+    });
+  });
+
+  it('day view: 24h window from the anchor day at UTC midnight', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(
+      <ActivityCalendar initialView="day" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
+      params: { from: '2026-05-06T00:00:00.000Z', to: '2026-05-07T00:00:00.000Z' },
+    });
+  });
+
+  it('month view: 1st of month → 1st of next month', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(
+      <ActivityCalendar initialView="month" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
+      params: { from: '2026-05-01T00:00:00.000Z', to: '2026-06-01T00:00:00.000Z' },
+    });
+  });
+
+  it('forwards optional filters as query params', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(
+      <ActivityCalendar
+        initialView="day"
+        initialAnchor={new Date('2026-05-06T12:00:00Z')}
+        filter={{ assignee: 'me', status: 'OpenOrOverdue', entityType: 'Quote' }}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities/calendar', {
+      params: {
+        from: '2026-05-06T00:00:00.000Z',
+        to: '2026-05-07T00:00:00.000Z',
+        assignee: 'me',
+        status: 'OpenOrOverdue',
+        entityType: 'Quote',
+      },
+    });
+  });
+
+  it('groups items by day; uses server-supplied color verbatim', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [monday, overdueWed] });
+
+    const { container } = render(
+      <ActivityCalendar initialView="week" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() =>
+      expect(
+        container.querySelectorAll('[data-granit-activity-calendar-item]').length
+      ).toBeGreaterThan(0)
+    );
+
+    const items = container.querySelectorAll('[data-granit-activity-calendar-item]');
+    expect(items[0]?.getAttribute('data-activity-color')).toBe('open');
+    expect(items[1]?.getAttribute('data-activity-color')).toBe('overdue');
+
+    // 7 days seeded even though only 2 carry items
+    expect(container.querySelectorAll('[data-granit-activity-calendar-day]').length).toBe(7);
+  });
+
+  it('Next button shifts the week forward by 7 days', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(
+      <ActivityCalendar initialView="week" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+    await waitFor(() => {
+      expect(client.get).toHaveBeenLastCalledWith('/api/v1/activities/calendar', {
+        params: { from: '2026-05-11T00:00:00.000Z', to: '2026-05-18T00:00:00.000Z' },
+      });
+    });
+  });
+
+  it('view switcher refetches with the new window', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(
+      <ActivityCalendar initialView="week" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    const switcher = screen.getByRole('group', { name: 'View' });
+    fireEvent.click(within(switcher).getByRole('button', { name: 'Day' }));
+
+    await waitFor(() => {
+      expect(client.get).toHaveBeenLastCalledWith('/api/v1/activities/calendar', {
+        params: { from: '2026-05-06T00:00:00.000Z', to: '2026-05-07T00:00:00.000Z' },
+      });
+    });
+  });
+
+  it('fires onItemClick with the clicked item', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [monday] });
+    const onItemClick = vi.fn();
+
+    render(
+      <ActivityCalendar
+        initialView="week"
+        initialAnchor={new Date('2026-05-06T12:00:00Z')}
+        onItemClick={onItemClick}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const item = await screen.findByRole('button', { name: 'Monday item' });
+    fireEvent.click(item);
+
+    expect(onItemClick).toHaveBeenCalledTimes(1);
+    expect(onItemClick).toHaveBeenCalledWith(monday);
+  });
+
+  it('renders error and empty states', async () => {
+    const errClient = createMockClient();
+    vi.mocked(errClient.get).mockRejectedValue(new Error('boom'));
+    const { container } = render(
+      <ActivityCalendar initialView="day" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(errClient) }
+    );
+    await waitFor(() =>
+      expect(container.querySelector('[data-granit-activity-calendar-error]')).not.toBeNull()
+    );
+
+    const okClient = createMockClient();
+    vi.mocked(okClient.get).mockResolvedValue({ data: [] });
+    const { container: emptyContainer } = render(
+      <ActivityCalendar initialView="day" initialAnchor={new Date('2026-05-06T12:00:00Z')} />,
+      { wrapper: createWrapper(okClient) }
+    );
+    await waitFor(() =>
+      expect(emptyContainer.querySelector('[data-granit-activity-calendar-empty]')).not.toBeNull()
+    );
+  });
+});

--- a/packages/@granit/react-activities/src/components/activity-calendar.tsx
+++ b/packages/@granit/react-activities/src/components/activity-calendar.tsx
@@ -1,0 +1,222 @@
+import { useMemo, useState, type ReactNode } from 'react';
+
+import { useActivitiesCalendar } from '../hooks/use-activities.js';
+
+import type { ActivityCalendarFilter, ActivityCalendarItemResponse } from '@granit/activities';
+
+export type ActivityCalendarView = 'day' | 'week' | 'month';
+
+export interface ActivityCalendarLabels {
+  readonly previous?: string;
+  readonly next?: string;
+  readonly today?: string;
+  readonly day?: string;
+  readonly week?: string;
+  readonly month?: string;
+}
+
+const DEFAULT_LABELS: Required<ActivityCalendarLabels> = {
+  previous: 'Previous',
+  next: 'Next',
+  today: 'Today',
+  day: 'Day',
+  week: 'Week',
+  month: 'Month',
+};
+
+export interface ActivityCalendarProps {
+  /** Initial view mode (default: 'week'). */
+  readonly initialView?: ActivityCalendarView;
+  /** Initial anchor date (default: now). Window is computed around this anchor. */
+  readonly initialAnchor?: Date;
+  /** Server-side filters (assignee / entityType / type / status). `from` / `to` are computed from the anchor + view. */
+  readonly filter?: Omit<ActivityCalendarFilter, 'from' | 'to'>;
+  /** Click handler — apps typically open their detail panel here. */
+  readonly onItemClick?: (item: ActivityCalendarItemResponse) => void;
+  /** Override English defaults for header / view-switcher labels (i18n in F9). */
+  readonly labels?: ActivityCalendarLabels;
+  readonly className?: string;
+}
+
+/**
+ * Headless cross-entity activity calendar. Consumes
+ * {@link useActivitiesCalendar}; the time window is computed from the
+ * current view + anchor. Items are rendered grouped by day with
+ * `data-granit-activity-calendar-*` markers — apps style via `className`
+ * + the `data-*` attributes.
+ *
+ * Color is **server-supplied** (`'open' | 'overdue' | 'done' | 'cancelled'`)
+ * and exposed verbatim as `data-activity-color` — never recomputed
+ * client-side. Title is also server-composed.
+ *
+ * Drag-to-reschedule is intentionally out of scope: apps wire it through
+ * `useRescheduleActivity` against their own pointer/drag primitives.
+ */
+export function ActivityCalendar({
+  initialView = 'week',
+  initialAnchor,
+  filter,
+  onItemClick,
+  labels,
+  className,
+}: ActivityCalendarProps): ReactNode {
+  const [view, setView] = useState<ActivityCalendarView>(initialView);
+  const [anchor, setAnchor] = useState<Date>(() => initialAnchor ?? new Date());
+  const merged = { ...DEFAULT_LABELS, ...labels };
+
+  const window = useMemo(() => computeWindow(anchor, view), [anchor, view]);
+
+  const query = useActivitiesCalendar({
+    ...filter,
+    from: window.from.toISOString(),
+    to: window.to.toISOString(),
+  });
+
+  const days = useMemo(() => groupByDay(query.data ?? [], window), [query.data, window]);
+
+  return (
+    <div data-granit-activity-calendar="" data-activity-calendar-view={view} className={className}>
+      <div data-granit-activity-calendar-header="">
+        <button
+          type="button"
+          onClick={() => setAnchor((a) => shiftAnchor(a, view, -1))}
+          aria-label={merged.previous}
+        >
+          ‹
+        </button>
+        <button type="button" onClick={() => setAnchor(new Date())}>
+          {merged.today}
+        </button>
+        <button
+          type="button"
+          onClick={() => setAnchor((a) => shiftAnchor(a, view, 1))}
+          aria-label={merged.next}
+        >
+          ›
+        </button>
+        <span data-granit-activity-calendar-range="">
+          {window.from.toISOString().slice(0, 10)} → {window.to.toISOString().slice(0, 10)}
+        </span>
+        <div data-granit-activity-calendar-view-switcher="" role="group" aria-label="View">
+          {(['day', 'week', 'month'] as const).map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setView(v)}
+              aria-pressed={view === v}
+              data-active={view === v ? '' : undefined}
+            >
+              {merged[v]}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {query.isLoading ? (
+        <div data-granit-activity-calendar-loading="">Loading…</div>
+      ) : query.isError ? (
+        <div data-granit-activity-calendar-error="" role="alert">
+          {query.error?.message ?? 'Failed to load calendar.'}
+        </div>
+      ) : days.length === 0 || days.every((d) => d.items.length === 0) ? (
+        <div data-granit-activity-calendar-empty="">No activities in this window.</div>
+      ) : (
+        <ol data-granit-activity-calendar-grid="">
+          {days.map((d) => (
+            <li
+              key={d.iso}
+              data-granit-activity-calendar-day=""
+              data-activity-calendar-date={d.iso}
+            >
+              <header>{d.iso}</header>
+              <ul data-granit-activity-calendar-items="">
+                {d.items.map((item) => (
+                  <li key={item.id}>
+                    <button
+                      type="button"
+                      data-granit-activity-calendar-item=""
+                      data-activity-id={item.id}
+                      data-activity-color={item.color}
+                      data-activity-status={item.status}
+                      onClick={onItemClick ? () => onItemClick(item) : undefined}
+                    >
+                      {item.title}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+}
+
+interface CalendarWindow {
+  readonly from: Date;
+  readonly to: Date;
+}
+
+interface CalendarDay {
+  readonly iso: string;
+  readonly items: readonly ActivityCalendarItemResponse[];
+}
+
+/** Compute a [from, to) window for the given anchor + view, in UTC. */
+function computeWindow(anchor: Date, view: ActivityCalendarView): CalendarWindow {
+  const a = new Date(Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth(), anchor.getUTCDate()));
+  if (view === 'day') {
+    return { from: a, to: addDays(a, 1) };
+  }
+  if (view === 'week') {
+    // Monday-anchored. JS getUTCDay: Sun=0..Sat=6 → Mon offset.
+    const dow = a.getUTCDay();
+    const offset = (dow + 6) % 7; // Mon → 0, Tue → 1, …, Sun → 6
+    const from = addDays(a, -offset);
+    return { from, to: addDays(from, 7) };
+  }
+  // month
+  const from = new Date(Date.UTC(a.getUTCFullYear(), a.getUTCMonth(), 1));
+  const to = new Date(Date.UTC(a.getUTCFullYear(), a.getUTCMonth() + 1, 1));
+  return { from, to };
+}
+
+function addDays(d: Date, days: number): Date {
+  const next = new Date(d.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function shiftAnchor(anchor: Date, view: ActivityCalendarView, direction: 1 | -1): Date {
+  if (view === 'day') return addDays(anchor, direction);
+  if (view === 'week') return addDays(anchor, 7 * direction);
+  // month
+  return new Date(
+    Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth() + direction, anchor.getUTCDate())
+  );
+}
+
+function groupByDay(
+  items: readonly ActivityCalendarItemResponse[],
+  window: CalendarWindow
+): readonly CalendarDay[] {
+  const buckets = new Map<string, ActivityCalendarItemResponse[]>();
+
+  // Pre-seed every day in the window so empty days still render with a header.
+  for (let d = new Date(window.from); d < window.to; d = addDays(d, 1)) {
+    buckets.set(d.toISOString().slice(0, 10), []);
+  }
+
+  for (const item of items) {
+    const iso = item.start.slice(0, 10);
+    const bucket = buckets.get(iso);
+    if (bucket) {
+      bucket.push(item);
+    }
+  }
+
+  return [...buckets.entries()]
+    .sort(([a], [b]) => (a < b ? -1 : 1))
+    .map(([iso, dayItems]) => ({ iso, items: dayItems }));
+}

--- a/packages/@granit/react-activities/src/index.ts
+++ b/packages/@granit/react-activities/src/index.ts
@@ -30,3 +30,9 @@ export { ActivityList } from './components/activity-list.js';
 export type { ActivityActionLabels, ActivityListProps } from './components/activity-list.js';
 export { ActivityDetailPanel } from './components/activity-detail-panel.js';
 export type { ActivityDetailPanelProps } from './components/activity-detail-panel.js';
+export { ActivityCalendar } from './components/activity-calendar.js';
+export type {
+  ActivityCalendarLabels,
+  ActivityCalendarProps,
+  ActivityCalendarView,
+} from './components/activity-calendar.js';


### PR DESCRIPTION
## Summary

Headless `<ActivityCalendar>` consuming `useActivitiesCalendar`. Window is computed from a `(view, anchor)` pair so apps don't need to do their own date math:

| View | Window (UTC) |
| ---- | ------------ |
| `day` | `[anchor 00:00, anchor 00:00 + 1d)` |
| `week` | `[Mon 00:00, Mon 00:00 + 7d)` (Monday-anchored) |
| `month` | `[1st of month 00:00, 1st of next month 00:00)` |

Header offers Prev / Today / Next + a `day`/`week`/`month` switcher (`role="group"`, `aria-pressed`). Items grouped by day with empty days **pre-seeded** so headers render even when nothing is scheduled.

## Wire contract honored

- **Color is server-supplied** (`'open' | 'overdue' | 'done' | 'cancelled'`) and exposed verbatim as `data-activity-color` — never recomputed client-side
- **Title is server-composed** and rendered as-is (apps can override copy via the `labels` prop for header/switcher chrome only)

`onItemClick` fires with the full `ActivityCalendarItemResponse` so apps can chain into `<ActivityDetailPanel>`.

## Out of scope (deliberate)

**Drag-to-reschedule** — the framework stays headless; apps wire pointer/drag against `useRescheduleActivity` from F4. Adding native HTML5 drag here would couple the framework to a UI gesture model + permission gating concerns that are app-level.

## Closes

- #370 — F6 — `<ActivityCalendar>`
- Parent feature: #364
- Backend reference: granit-fx/granit-dotnet#1801

## Test plan

- [x] 9 unit tests, 42/42 across the package incl. F3/F4/F5
- [x] Window math: 3 views, asserted exact `from`/`to` ISO strings
- [x] Filter forwarding: optional axes appear only when defined
- [x] Color rendering: `data-activity-color` matches server payload
- [x] Day pre-seeding: 7-day grid renders even with 2 items in a week
- [x] Navigation: Next bumps the window by view's stride and refetches
- [x] View switching: Day → narrows the window, refetch fires
- [x] `onItemClick` callback fires with the clicked item
- [x] Error + empty states
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-activities build` — ESM 19.14 KB / dts 10.14 KB
