### PR TITLE
feat(react-activities): per-entity side panel + EntityDetail contribution (F7)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1326,6 +1326,28 @@
           "name": "ActivityCalendar",
           "kind": "function",
           "signature": "function ActivityCalendar("
+        },
+        {
+          "name": "ActivitiesSidePanel",
+          "kind": "function",
+          "signature": "function ActivitiesSidePanel("
+        },
+        {
+          "name": "ActivitiesSidePanelProps",
+          "kind": "interface",
+          "signature": "interface ActivitiesSidePanelProps",
+          "members": []
+        },
+        {
+          "name": "activitiesSidePanel",
+          "kind": "function",
+          "signature": "function activitiesSidePanel( options: ActivitiesSidePanelContributionOptions ="
+        },
+        {
+          "name": "ActivitiesSidePanelContributionOptions",
+          "kind": "interface",
+          "signature": "interface ActivitiesSidePanelContributionOptions",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-activities/package.json
+++ b/packages/@granit/react-activities/package.json
@@ -16,9 +16,19 @@
   "peerDependencies": {
     "@granit/activities": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/entities": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-entities": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@granit/entities": {
+      "optional": true
+    },
+    "@granit/react-entities": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "exports": {
@@ -32,7 +42,9 @@
   "devDependencies": {
     "@granit/activities": "workspace:*",
     "@granit/api-client": "workspace:*",
+    "@granit/entities": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/react-entities": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*"
   }

--- a/packages/@granit/react-activities/src/__tests__/activities-side-panel.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activities-side-panel.test.tsx
@@ -1,0 +1,149 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { ActivitiesSidePanel } from '../components/activities-side-panel.js';
+import { activitiesSidePanel } from '../contributions/entity-side-panel.js';
+import { ActivitiesProvider } from '../providers/activities-provider.js';
+
+import type { ActivityListResponse } from '@granit/activities';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+const sampleResponse: ActivityListResponse = {
+  items: [],
+  totalCount: 0,
+  page: 1,
+  pageSize: 10,
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <ActivitiesProvider config={{ client }}>{children}</ActivitiesProvider>
+    );
+  };
+}
+
+describe('<ActivitiesSidePanel>', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('filters the list to entity + OpenOrOverdue by default', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    render(<ActivitiesSidePanel entityName="Granit.Sales.Quote" entityId="q-1" />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities', {
+      params: {
+        entityType: 'Granit.Sales.Quote',
+        entityId: 'q-1',
+        status: 'OpenOrOverdue',
+        page: 1,
+        pageSize: 10,
+      },
+    });
+  });
+
+  it('exposes entityName + entityId as data-attrs and a labelled section', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    const { container } = render(
+      <ActivitiesSidePanel entityName="Granit.Sales.Quote" entityId="q-1" />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const section = container.querySelector('[data-granit-activities-side-panel]');
+    expect(section?.getAttribute('data-entity-name')).toBe('Granit.Sales.Quote');
+    expect(section?.getAttribute('data-entity-id')).toBe('q-1');
+    expect(section?.getAttribute('aria-label')).toBe('Activities');
+  });
+
+  it('hides the create CTA when no onCreate callback is provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    render(<ActivitiesSidePanel entityName="Granit.Sales.Quote" entityId="q-1" />, {
+      wrapper: createWrapper(client),
+    });
+
+    expect(screen.queryByRole('button', { name: '+ Activity' })).toBeNull();
+  });
+
+  it('fires onCreate with the entity context when the CTA is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+    const onCreate = vi.fn();
+
+    render(
+      <ActivitiesSidePanel entityName="Granit.Sales.Quote" entityId="q-1" onCreate={onCreate} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Activity' }));
+    expect(onCreate).toHaveBeenCalledTimes(1);
+    expect(onCreate).toHaveBeenCalledWith({
+      entityName: 'Granit.Sales.Quote',
+      entityId: 'q-1',
+    });
+  });
+});
+
+describe('activitiesSidePanel (EntityDetail contribution)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns an EntitySidePanel renderer matching the (entityName, entityId) contract', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    const onCreate = vi.fn();
+    const Renderer = activitiesSidePanel({ onCreate });
+
+    render(<Renderer entityName="Granit.Sales.Quote" entityId="q-1" />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/activities', {
+      params: {
+        entityType: 'Granit.Sales.Quote',
+        entityId: 'q-1',
+        status: 'OpenOrOverdue',
+        page: 1,
+        pageSize: 10,
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: '+ Activity' }));
+    expect(onCreate).toHaveBeenCalledWith({
+      entityName: 'Granit.Sales.Quote',
+      entityId: 'q-1',
+    });
+  });
+
+  it('hides the CTA when no onCreate option is supplied to the factory', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleResponse });
+
+    const Renderer = activitiesSidePanel();
+    render(<Renderer entityName="Granit.Sales.Quote" entityId="q-1" />, {
+      wrapper: createWrapper(client),
+    });
+
+    expect(screen.queryByRole('button', { name: '+ Activity' })).toBeNull();
+  });
+});

--- a/packages/@granit/react-activities/src/components/activities-side-panel.tsx
+++ b/packages/@granit/react-activities/src/components/activities-side-panel.tsx
@@ -1,0 +1,95 @@
+import { type ReactNode } from 'react';
+
+import { ActivityList } from './activity-list.js';
+
+import type { ActivityActionLabels, ActivityListProps } from './activity-list.js';
+import type { ActivityResponse } from '@granit/activities';
+
+export interface ActivitiesSidePanelProps {
+  /** Wire identifier of the host entity (matches `EntitySidePanelProps.entityName`). */
+  readonly entityName: string;
+  /** Id of the current entity instance. */
+  readonly entityId: string;
+  /**
+   * Action callbacks. When `undefined`, the matching button is not rendered
+   * — apps use this to gate by permission.
+   */
+  readonly onSelect?: ActivityListProps['onSelect'];
+  readonly onComplete?: (activity: ActivityResponse) => void;
+  readonly onCancel?: (activity: ActivityResponse) => void;
+  readonly onReassign?: (activity: ActivityResponse) => void;
+  readonly onReschedule?: (activity: ActivityResponse) => void;
+  /**
+   * "+ Activity" CTA handler. When `undefined`, the button is not rendered —
+   * apps gate creation by permission and own the create form/flow (drawer,
+   * sheet, …). The framework intentionally doesn't ship a create dialog.
+   */
+  readonly onCreate?: (context: { entityName: string; entityId: string }) => void;
+  /** Override English defaults for action button labels (i18n in F9). */
+  readonly actionLabels?: ActivityActionLabels;
+  /** Default page size for the embedded list (default: 10). */
+  readonly pageSize?: number;
+  readonly className?: string;
+}
+
+const DEFAULT_CREATE_LABEL = '+ Activity';
+
+/**
+ * Per-entity activities side panel. Filters the activity list to
+ * `entityType` + `entityId`, defaulting to `OpenOrOverdue` so the panel
+ * shows what's actionable.
+ *
+ * Designed to plug into the `<EntityDetail />` side-panel pipeline of
+ * `@granit/react-entities` via {@link activitiesSidePanelContribution} —
+ * the manifest declares `SidePanelKind === 'Activities'` and the catalog
+ * provides this renderer.
+ */
+export function ActivitiesSidePanel({
+  entityName,
+  entityId,
+  onSelect,
+  onComplete,
+  onCancel,
+  onReassign,
+  onReschedule,
+  onCreate,
+  actionLabels,
+  pageSize = 10,
+  className,
+}: ActivitiesSidePanelProps): ReactNode {
+  return (
+    <section
+      data-granit-activities-side-panel=""
+      data-entity-name={entityName}
+      data-entity-id={entityId}
+      className={className}
+      aria-label="Activities"
+    >
+      {onCreate ? (
+        <header data-granit-activities-side-panel-header="">
+          <button
+            type="button"
+            data-granit-activities-side-panel-create=""
+            onClick={() => onCreate({ entityName, entityId })}
+          >
+            {DEFAULT_CREATE_LABEL}
+          </button>
+        </header>
+      ) : null}
+      <ActivityList
+        filter={{
+          entityType: entityName,
+          entityId,
+          status: 'OpenOrOverdue',
+        }}
+        pageSize={pageSize}
+        onSelect={onSelect}
+        onComplete={onComplete}
+        onCancel={onCancel}
+        onReassign={onReassign}
+        onReschedule={onReschedule}
+        actionLabels={actionLabels}
+      />
+    </section>
+  );
+}

--- a/packages/@granit/react-activities/src/contributions/entity-side-panel.tsx
+++ b/packages/@granit/react-activities/src/contributions/entity-side-panel.tsx
@@ -1,0 +1,67 @@
+import { ActivitiesSidePanel } from '../components/activities-side-panel.js';
+
+import type { EntitySidePanel, EntitySidePanelProps } from '@granit/react-entities';
+
+export interface ActivitiesSidePanelContributionOptions {
+  /**
+   * Override the default `<ActivitiesSidePanel>` action callbacks. The
+   * `EntitySidePanel` signature only carries `(entityName, entityId)`, so
+   * action wiring must come from this opt-in factory rather than per-render
+   * props. Omit a callback to hide the matching button (permission gating).
+   */
+  readonly onSelect?: Parameters<typeof ActivitiesSidePanel>[0]['onSelect'];
+  readonly onComplete?: Parameters<typeof ActivitiesSidePanel>[0]['onComplete'];
+  readonly onCancel?: Parameters<typeof ActivitiesSidePanel>[0]['onCancel'];
+  readonly onReassign?: Parameters<typeof ActivitiesSidePanel>[0]['onReassign'];
+  readonly onReschedule?: Parameters<typeof ActivitiesSidePanel>[0]['onReschedule'];
+  readonly onCreate?: Parameters<typeof ActivitiesSidePanel>[0]['onCreate'];
+  readonly actionLabels?: Parameters<typeof ActivitiesSidePanel>[0]['actionLabels'];
+  readonly pageSize?: number;
+  readonly className?: string;
+}
+
+/**
+ * Factory producing the `EntitySidePanel` renderer for
+ * `SidePanelKind === 'Activities'`. Apps merge this into their
+ * `EntityComponentCatalog.sidePanels` map when wiring `<EntityDetail />`:
+ *
+ * ```tsx
+ * import { activitiesSidePanel } from '@granit/react-activities';
+ *
+ * const catalog: EntityComponentCatalog = {
+ *   form: { … },
+ *   sidePanels: {
+ *     Activities: activitiesSidePanel({
+ *       onComplete: (a) => completeMutation.mutate({ id: a.id, request: { … } }),
+ *       onCreate: ({ entityName, entityId }) => openCreateDrawer(entityName, entityId),
+ *     }),
+ *   },
+ * };
+ * ```
+ *
+ * The manifest's `EntityDetailSidePanelManifest` (with `kind: 'Activities'`)
+ * is the opt-in surface — declaring it on the entity makes the panel slot
+ * appear; this catalog entry tells `<EntityDetail />` *what* to render
+ * inside that slot.
+ */
+export function activitiesSidePanel(
+  options: ActivitiesSidePanelContributionOptions = {}
+): EntitySidePanel {
+  return function ActivitiesSidePanelRenderer({ entityName, entityId }: EntitySidePanelProps) {
+    return (
+      <ActivitiesSidePanel
+        entityName={entityName}
+        entityId={entityId}
+        onSelect={options.onSelect}
+        onComplete={options.onComplete}
+        onCancel={options.onCancel}
+        onReassign={options.onReassign}
+        onReschedule={options.onReschedule}
+        onCreate={options.onCreate}
+        actionLabels={options.actionLabels}
+        pageSize={options.pageSize}
+        className={options.className}
+      />
+    );
+  };
+}

--- a/packages/@granit/react-activities/src/index.ts
+++ b/packages/@granit/react-activities/src/index.ts
@@ -36,3 +36,9 @@ export type {
   ActivityCalendarProps,
   ActivityCalendarView,
 } from './components/activity-calendar.js';
+export { ActivitiesSidePanel } from './components/activities-side-panel.js';
+export type { ActivitiesSidePanelProps } from './components/activities-side-panel.js';
+
+// Contributions for @granit/react-entities (optional peer)
+export { activitiesSidePanel } from './contributions/entity-side-panel.js';
+export type { ActivitiesSidePanelContributionOptions } from './contributions/entity-side-panel.js';

--- a/packages/@granit/react-activities/tsconfig.json
+++ b/packages/@granit/react-activities/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
     "paths": {
-      "@granit/activities": ["../activities/src/index.ts"]
+      "@granit/activities": ["../activities/src/index.ts"],
+      "@granit/entities": ["../entities/src/index.ts"],
+      "@granit/react-entities": ["../react-entities/src/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,9 +646,15 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/entities':
+        specifier: workspace:*
+        version: link:../entities
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
+      '@granit/react-entities':
+        specifier: workspace:*
+        version: link:../react-entities
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -3570,36 +3576,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -3697,36 +3709,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
@@ -3791,66 +3809,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -4103,41 +4134,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -5210,24 +5249,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}


### PR DESCRIPTION
## Summary

Two pieces wiring activities into the entity detail layer of `@granit/react-entities`:

### `<ActivitiesSidePanel>` — drop-in side panel

Per-entity activities surface for an entity detail page. Filters `useActivities` to:

```
{ entityType: entityName, entityId, status: 'OpenOrOverdue' }
```

…so the panel shows actionable items only by default. Re-uses `<ActivityList>` from F5 for the table + per-row actions; adds a `+ Activity` CTA gated by `onCreate` callback presence (apps own the create form/flow). Wraps in a `<section aria-label="Activities">` with `data-entity-name` / `data-entity-id` markers.

### `activitiesSidePanel({ onComplete, onCreate, … })` — EntityDetail contribution

Factory returning an `EntitySidePanel` renderer for the `@granit/react-entities` catalog. Apps merge it into `EntityComponentCatalog.sidePanels.Activities`:

```tsx
import { activitiesSidePanel } from '@granit/react-activities';

const catalog: EntityComponentCatalog = {
  form: { … },
  sidePanels: {
    Activities: activitiesSidePanel({
      onComplete: (a) => completeMutation.mutate({ id: a.id, request: { … } }),
      onCreate: ({ entityName, entityId }) => openCreateDrawer(entityName, entityId),
    }),
  },
};
```

The opt-in surface is the **manifest** (`EntityDetailSidePanelManifest` with `kind: 'Activities'`) — declaring it on the entity makes the panel slot appear; this catalog entry tells `<EntityDetail />` *what* to render in that slot. The `EntitySidePanel` signature only carries `(entityName, entityId)`, so action wiring lives at factory time, not per-render.

## Peer dep wiring

`@granit/react-entities` and `@granit/entities` are declared **optional** peer deps so apps that don't ship the entity-detail layer can still consume the rest of `@granit/react-activities` without resolution warnings.

## Closes

- #371 — F7 — `<ActivitiesSidePanel>` + `EntityDefinition.activities()` contribution
- Parent feature: #364
- Backend reference: granit-fx/granit-dotnet#1800

## Notes / deviations from the original story

- Story said "+ Activity CTA opens the create form" — F5 didn't ship a create form (callbacks only). Resolved via `onCreate` callback: apps own the create drawer/sheet/form. The framework intentionally doesn't ship a create dialog (consistent with F5).
- Story said "EntityDefinition.activities()" — the actual contribution surface is `EntityComponentCatalog.sidePanels.Activities` (a runtime catalog map, not a builder method). The factory function `activitiesSidePanel(opts)` is the equivalent opt-in entry point.
- Permission gating: identical pattern to F5 — omit a callback to hide the matching button. Server still enforces.

## Test plan

- [x] 8 new unit tests, 48/48 across the package
- [x] Default filter forwards `entityType` / `entityId` / `status='OpenOrOverdue'`
- [x] `<section>` carries `data-entity-name`, `data-entity-id`, `aria-label="Activities"`
- [x] Create CTA: hidden without `onCreate`, fires with `{ entityName, entityId }` payload
- [x] Factory contribution: matches `EntitySidePanel` signature, propagates options end-to-end, hides CTA when `onCreate` is omitted at factory time
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-activities build` — ESM 20.94 KB / dts 14.14 KB
