### PR TITLE
feat(react-activities): activity notifications integration (F8)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1348,6 +1348,12 @@
           "kind": "interface",
           "signature": "interface ActivitiesSidePanelContributionOptions",
           "members": []
+        },
+        {
+          "name": "ActivityNotificationLike",
+          "kind": "interface",
+          "signature": "interface ActivityNotificationLike",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-activities/package.json
+++ b/packages/@granit/react-activities/package.json
@@ -17,6 +17,7 @@
     "@granit/activities": "workspace:*",
     "@granit/api-client": "workspace:*",
     "@granit/entities": "workspace:*",
+    "@granit/notifications": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-entities": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
@@ -24,6 +25,9 @@
   },
   "peerDependenciesMeta": {
     "@granit/entities": {
+      "optional": true
+    },
+    "@granit/notifications": {
       "optional": true
     },
     "@granit/react-entities": {
@@ -43,6 +47,7 @@
     "@granit/activities": "workspace:*",
     "@granit/api-client": "workspace:*",
     "@granit/entities": "workspace:*",
+    "@granit/notifications": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-entities": "workspace:*",
     "@granit/react-testing": "workspace:*",

--- a/packages/@granit/react-activities/src/__tests__/notifications.test.ts
+++ b/packages/@granit/react-activities/src/__tests__/notifications.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isActivityNotification,
+  isAssignedActivityNotification,
+  isOverdueActivityNotification,
+  isReminderActivityNotification,
+  resolveActivityNotificationAction,
+} from '../notifications/register.js';
+import {
+  ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE,
+  ActivityNotificationTypes,
+} from '../notifications/types.js';
+
+import type { ActivityNotificationLike } from '../notifications/register.js';
+
+const assigned: ActivityNotificationLike = {
+  notificationTypeName: ActivityNotificationTypes.Assigned,
+  relatedEntityType: ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE,
+  relatedEntityId: 'act-1',
+};
+
+const reminder: ActivityNotificationLike = {
+  notificationTypeName: ActivityNotificationTypes.Reminder,
+  relatedEntityType: ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE,
+  relatedEntityId: 'act-2',
+};
+
+const overdue: ActivityNotificationLike = {
+  notificationTypeName: ActivityNotificationTypes.Overdue,
+  relatedEntityType: ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE,
+  relatedEntityId: 'act-3',
+};
+
+const foreign: ActivityNotificationLike = {
+  notificationTypeName: 'Granit.Sales.Quote.Approved',
+  relatedEntityType: 'Quote',
+  relatedEntityId: 'q-1',
+};
+
+describe('ActivityNotificationTypes', () => {
+  it('exposes the three wire-aligned type names', () => {
+    expect(ActivityNotificationTypes.Assigned).toBe('Activities.Activity.Assigned');
+    expect(ActivityNotificationTypes.Reminder).toBe('Activities.Activity.Reminder');
+    expect(ActivityNotificationTypes.Overdue).toBe('Activities.Activity.Overdue');
+  });
+});
+
+describe('isActivityNotification (and per-variant predicates)', () => {
+  it('identifies all three activity variants', () => {
+    expect(isActivityNotification(assigned)).toBe(true);
+    expect(isActivityNotification(reminder)).toBe(true);
+    expect(isActivityNotification(overdue)).toBe(true);
+  });
+
+  it('rejects notifications from other modules', () => {
+    expect(isActivityNotification(foreign)).toBe(false);
+  });
+
+  it('per-variant predicates discriminate correctly', () => {
+    expect(isAssignedActivityNotification(assigned)).toBe(true);
+    expect(isAssignedActivityNotification(reminder)).toBe(false);
+
+    expect(isReminderActivityNotification(reminder)).toBe(true);
+    expect(isReminderActivityNotification(overdue)).toBe(false);
+
+    expect(isOverdueActivityNotification(overdue)).toBe(true);
+    expect(isOverdueActivityNotification(assigned)).toBe(false);
+  });
+});
+
+describe('resolveActivityNotificationAction', () => {
+  it('Assigned → open-detail without scrolling to actions', () => {
+    expect(resolveActivityNotificationAction(assigned)).toEqual({
+      kind: 'open-detail',
+      activityId: 'act-1',
+      scrollToActions: false,
+    });
+  });
+
+  it('Reminder → open-detail with scrollToActions=true', () => {
+    expect(resolveActivityNotificationAction(reminder)).toEqual({
+      kind: 'open-detail',
+      activityId: 'act-2',
+      scrollToActions: true,
+    });
+  });
+
+  it('Overdue → open-overdue-calendar (assignee=me), ignoring relatedEntityId', () => {
+    expect(resolveActivityNotificationAction(overdue)).toEqual({
+      kind: 'open-overdue-calendar',
+      assignee: 'me',
+    });
+  });
+
+  it('returns null for non-activity notifications', () => {
+    expect(resolveActivityNotificationAction(foreign)).toBeNull();
+  });
+
+  it('returns null for Assigned/Reminder when relatedEntityId is missing', () => {
+    expect(
+      resolveActivityNotificationAction({
+        ...assigned,
+        relatedEntityId: null,
+      })
+    ).toBeNull();
+    expect(
+      resolveActivityNotificationAction({
+        ...reminder,
+        relatedEntityId: '',
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when relatedEntityType does not match the activity marker', () => {
+    expect(
+      resolveActivityNotificationAction({
+        ...assigned,
+        relatedEntityType: 'WrongType',
+      })
+    ).toBeNull();
+  });
+
+  it('Overdue still resolves even without relatedEntityId (calendar action is global)', () => {
+    expect(
+      resolveActivityNotificationAction({
+        ...overdue,
+        relatedEntityId: null,
+        relatedEntityType: null,
+      })
+    ).toEqual({ kind: 'open-overdue-calendar', assignee: 'me' });
+  });
+});

--- a/packages/@granit/react-activities/src/index.ts
+++ b/packages/@granit/react-activities/src/index.ts
@@ -42,3 +42,21 @@ export type { ActivitiesSidePanelProps } from './components/activities-side-pane
 // Contributions for @granit/react-entities (optional peer)
 export { activitiesSidePanel } from './contributions/entity-side-panel.js';
 export type { ActivitiesSidePanelContributionOptions } from './contributions/entity-side-panel.js';
+
+// Notifications integration (Assigned / Reminder / Overdue)
+export {
+  ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE,
+  ActivityNotificationTypes,
+} from './notifications/types.js';
+export type {
+  ActivityNotificationAction,
+  ActivityNotificationType,
+} from './notifications/types.js';
+export {
+  isActivityNotification,
+  isAssignedActivityNotification,
+  isOverdueActivityNotification,
+  isReminderActivityNotification,
+  resolveActivityNotificationAction,
+} from './notifications/register.js';
+export type { ActivityNotificationLike } from './notifications/register.js';

--- a/packages/@granit/react-activities/src/notifications/register.ts
+++ b/packages/@granit/react-activities/src/notifications/register.ts
@@ -1,0 +1,82 @@
+import { ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE, ActivityNotificationTypes } from './types.js';
+
+import type { ActivityNotificationAction, ActivityNotificationType } from './types.js';
+
+/**
+ * Minimal notification shape this module needs from
+ * `@granit/notifications` (`UserNotification` / `NotificationTransportMessage`
+ * both satisfy it). Inlined to keep `@granit/notifications` an optional
+ * peer — apps without the notifications package can still consume the
+ * type registry constants.
+ */
+export interface ActivityNotificationLike {
+  readonly notificationTypeName: string;
+  readonly relatedEntityType: string | null;
+  readonly relatedEntityId: string | null;
+}
+
+/** Returns true when the notification was emitted by `Granit.Activities.Notifications`. */
+export function isActivityNotification(
+  n: ActivityNotificationLike
+): n is ActivityNotificationLike & { notificationTypeName: ActivityNotificationType } {
+  return (
+    n.notificationTypeName === ActivityNotificationTypes.Assigned ||
+    n.notificationTypeName === ActivityNotificationTypes.Reminder ||
+    n.notificationTypeName === ActivityNotificationTypes.Overdue
+  );
+}
+
+/** True when the notification is the `Assigned` variant. */
+export function isAssignedActivityNotification(n: ActivityNotificationLike): boolean {
+  return n.notificationTypeName === ActivityNotificationTypes.Assigned;
+}
+
+/** True when the notification is the `Reminder` variant. */
+export function isReminderActivityNotification(n: ActivityNotificationLike): boolean {
+  return n.notificationTypeName === ActivityNotificationTypes.Reminder;
+}
+
+/** True when the notification is the `Overdue` variant. */
+export function isOverdueActivityNotification(n: ActivityNotificationLike): boolean {
+  return n.notificationTypeName === ActivityNotificationTypes.Overdue;
+}
+
+/**
+ * Resolve the canonical click-through action for an activity notification.
+ *
+ * - `Assigned` → `open-detail` (no scroll)
+ * - `Reminder` → `open-detail` (scrolled to the action area)
+ * - `Overdue` → `open-overdue-calendar` filtered on the current user
+ *
+ * Returns `null` when the notification is not an activity notification, or
+ * when it lacks the `relatedEntityId` carrying the activity id (defensive —
+ * malformed payloads should not crash the click handler).
+ *
+ * Labels and bodies are **not** owned here: the backend serializes them via
+ * the standard localization pipeline. This resolver only owns the
+ * navigation contract.
+ */
+export function resolveActivityNotificationAction(
+  n: ActivityNotificationLike
+): ActivityNotificationAction | null {
+  if (!isActivityNotification(n)) {
+    return null;
+  }
+
+  if (n.notificationTypeName === ActivityNotificationTypes.Overdue) {
+    return { kind: 'open-overdue-calendar', assignee: 'me' };
+  }
+
+  if (n.relatedEntityType !== ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE) {
+    return null;
+  }
+  if (n.relatedEntityId === null || n.relatedEntityId.length === 0) {
+    return null;
+  }
+
+  return {
+    kind: 'open-detail',
+    activityId: n.relatedEntityId,
+    scrollToActions: n.notificationTypeName === ActivityNotificationTypes.Reminder,
+  };
+}

--- a/packages/@granit/react-activities/src/notifications/types.ts
+++ b/packages/@granit/react-activities/src/notifications/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Wire-aligned notification type names emitted by `Granit.Activities.Notifications`.
+ * Apps match these strings against the `notificationTypeName` field of any
+ * `UserNotification` / `NotificationTransportMessage` to identify activity
+ * notifications. Keep these in sync with the .NET backend.
+ */
+export const ActivityNotificationTypes = {
+  Assigned: 'Activities.Activity.Assigned',
+  Reminder: 'Activities.Activity.Reminder',
+  Overdue: 'Activities.Activity.Overdue',
+} as const;
+
+/** Compile-time union of the three activity notification type names. */
+export type ActivityNotificationType =
+  (typeof ActivityNotificationTypes)[keyof typeof ActivityNotificationTypes];
+
+/**
+ * The wire `relatedEntityType` carried by activity notifications. Apps may
+ * receive notifications for many entities; only those carrying this type
+ * marker are activity notifications.
+ */
+export const ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE = 'Activity';
+
+/**
+ * Canonical click-through action for an activity notification. Apps wire
+ * each variant to their own router/UI:
+ *
+ * - `open-detail` → typically open `<ActivityDetailPanel activityId={…} />`
+ *   in a drawer/sheet. `scrollToActions` is set for `Reminder` notifications
+ *   so the user lands directly on the action area.
+ * - `open-overdue-calendar` → typically navigate to a calendar view filtered
+ *   by `assignee=me, status=Overdue`.
+ */
+export type ActivityNotificationAction =
+  | { readonly kind: 'open-detail'; readonly activityId: string; readonly scrollToActions: boolean }
+  | { readonly kind: 'open-overdue-calendar'; readonly assignee: 'me' };

--- a/packages/@granit/react-activities/tsconfig.json
+++ b/packages/@granit/react-activities/tsconfig.json
@@ -4,6 +4,7 @@
     "paths": {
       "@granit/activities": ["../activities/src/index.ts"],
       "@granit/entities": ["../entities/src/index.ts"],
+      "@granit/notifications": ["../notifications/src/index.ts"],
       "@granit/react-entities": ["../react-entities/src/index.ts"]
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -649,6 +649,9 @@ importers:
       '@granit/entities':
         specifier: workspace:*
         version: link:../entities
+      '@granit/notifications':
+        specifier: workspace:*
+        version: link:../notifications
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client


### PR DESCRIPTION
## Summary

Three deliberately small, render-free building blocks for the activity notifications emitted by `Granit.Activities.Notifications` (Assigned / Reminder / Overdue). Apps own the toast / icon / notification-center rendering — this module owns identification + navigation contract only.

### `ActivityNotificationTypes` — wire-aligned constants

```ts
ActivityNotificationTypes.Assigned // 'Activities.Activity.Assigned'
ActivityNotificationTypes.Reminder // 'Activities.Activity.Reminder'
ActivityNotificationTypes.Overdue  // 'Activities.Activity.Overdue'
```

Apps match these against `UserNotification.notificationTypeName` / `NotificationTransportMessage.notificationTypeName` to identify activity notifications. Keep in sync with the .NET backend.

### Type guards

`isActivityNotification(n)`, plus per-variant `isAssigned/Reminder/Overdue ActivityNotification(n)`. Predicates accept any `{ notificationTypeName, relatedEntityType, relatedEntityId }` shape — apps can drop them into render branches without importing the full notifications package.

### `resolveActivityNotificationAction(n)` — click-through contract

Returns a discriminated action descriptor matching the story's navigation rules:

| Type | Action |
| ---- | ------ |
| `Assigned` | `{ kind: 'open-detail', activityId, scrollToActions: false }` |
| `Reminder` | `{ kind: 'open-detail', activityId, scrollToActions: true }` |
| `Overdue` | `{ kind: 'open-overdue-calendar', assignee: 'me' }` |

Returns `null` for non-activity notifications and for Assigned/Reminder payloads that lack `relatedEntityId` (defensive — malformed payloads should not crash the click handler). Overdue resolves even without `relatedEntityId` since the calendar action is global.

Apps wire each variant to their router (`<ActivityDetailPanel activityId={…} />` for `open-detail`, calendar route for `open-overdue-calendar`).

### What's NOT here (deliberately)

- **Labels / bodies** — the .NET localization pipeline serializes them server-side. No hardcoded strings.
- **Icons / severity** — severity comes from the wire (`UserNotification.severity`); icons are app-level.
- **Toast renderers / notification-center entries** — apps render their own UI from the typed building blocks.

`@granit/notifications` is declared as an **optional peer** so apps without the notifications package can still import the type-name constants for filtering / routing without resolution warnings.

## Closes

- #372 — F8 — Activities notifications (Assigned / Reminder / Overdue)
- Parent feature: #364
- Backend reference: granit-fx/granit-dotnet#1802 (Notifications), #1803 (BackgroundJobs — Reminder + MarkOverdue)

## Notes / deviations from the original story

- Story said "Register them in `@granit/react-notifications`" — the framework doesn't have a runtime registry to register *into* (no `register(typeName, { icon, severity, onClick })` API exists in `@granit/react-notifications`). Resolved by shipping typed building blocks the consumer wires into its own UI, which is consistent with how the rest of the framework works (headless primitives, app-level chrome).
- Click-through contract honored verbatim from the story: Assigned → detail, Reminder → detail (+ scrollToActions), Overdue → calendar filtered on me.

## Test plan

- [x] 13 new unit tests; 59/59 across the package
- [x] Constants match the wire-aligned strings
- [x] Type guards: positive on all three variants, negative on foreign notifications, per-variant discrimination
- [x] Resolver: each variant produces the expected action; null on non-activity; null when Assigned/Reminder lacks `relatedEntityId`; null on wrong `relatedEntityType`; Overdue resolves regardless of `relatedEntityId`
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-activities build` — ESM 22.61 KB / dts 17.95 KB
