### PR TITLE
feat(react-activities): i18n bundles + readme + dod close (F9)

### DIFF
--- a/packages/@granit/react-activities/README.md
+++ b/packages/@granit/react-activities/README.md
@@ -1,0 +1,55 @@
+# @granit/react-activities
+
+React bindings for `@granit/activities` — provider, hooks, and headless components for the cross-entity to-do module (`Granit.Activities`).
+
+## What's in the box
+
+- **Provider + read hooks** — `<ActivitiesProvider>`, `useActivities`, `useActivity`, `useActivitiesCalendar`
+- **Mutation hooks** — `useCreateActivity`, `useCompleteActivity`, `useCancelActivity`, `useReassignActivity`, `useRescheduleActivity` (with cache invalidation strategy isolated to `list` / `calendar` / `detail(id)` segments)
+- **Components** — `<ActivityList>`, `<ActivityDetailPanel>`, `<ActivityCalendar>`, `<ActivitiesSidePanel>` (all headless: minimal HTML + `data-granit-activity-*` markers)
+- **EntityDetail contribution** — `activitiesSidePanel({ … })` factory for `EntityComponentCatalog.sidePanels.Activities`
+- **Notifications integration** — `ActivityNotificationTypes`, type guards, `resolveActivityNotificationAction()` for click-through routing
+- **i18n bundles** — `activitiesTranslationsEn` / `activitiesTranslationsFr` (namespace: `'activities'`)
+
+## i18n
+
+Components ship English defaults baked in and accept `labels` / `actionLabels` props for overrides — apps wire `t()` results from the catalogs:
+
+```tsx
+import {
+  ActivityList,
+  activitiesTranslationsEn,
+  activitiesTranslationsFr,
+} from '@granit/react-activities';
+import { useTranslation } from 'react-i18next';
+
+// At app boot
+i18n.addResourceBundle('en', 'activities', activitiesTranslationsEn);
+i18n.addResourceBundle('fr', 'activities', activitiesTranslationsFr);
+
+// In a component
+const { t } = useTranslation('activities');
+
+<ActivityList
+  actionLabels={{
+    complete: t('Action.Complete'),
+    cancel: t('Action.Cancel'),
+    reassign: t('Action.Reassign'),
+    reschedule: t('Action.Reschedule'),
+  }}
+  onComplete={…}
+/>
+```
+
+This split (catalogs shipped, components headless) keeps the components testable without an i18n bootstrap and lets apps own when/how i18n mounts.
+
+## Permission gating
+
+Each action callback is optional. Omit a callback to hide the matching button — apps gate rendering by their own permission system. The server still enforces (`Activities.Activities.{Read,Manage,Execute}`).
+
+## Conventions
+
+- All HTTP calls route through `@granit/api-client`'s Axios instance (CSRF / auth / tenant headers inherited).
+- Verb naming mirrors the .NET backend: `get*` / `list*` (never `fetch*`).
+- Cache-key namespacing: `['activities', 'list' | 'detail' | 'calendar', …]` so mutations only invalidate the layers they affect.
+- Drag-to-reschedule on the calendar is intentionally out of scope — apps wire pointer/drag against `useRescheduleActivity`.

--- a/packages/@granit/react-activities/src/__tests__/locales.test.ts
+++ b/packages/@granit/react-activities/src/__tests__/locales.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { activitiesTranslationsEn } from '../locales/en.js';
+import { activitiesTranslationsFr } from '../locales/fr.js';
+
+/** Walk an object tree and collect all leaf paths (`'A.B.C'`). */
+function leafPaths(obj: unknown, prefix = ''): readonly string[] {
+  if (typeof obj !== 'object' || obj === null) {
+    return [prefix];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, value]) =>
+    leafPaths(value, prefix ? `${prefix}.${key}` : key)
+  );
+}
+
+describe('activities locale bundles', () => {
+  it('en has the expected top-level namespaces', () => {
+    expect(Object.keys(activitiesTranslationsEn).sort()).toEqual([
+      'Action',
+      'Calendar',
+      'Detail',
+      'List',
+      'Notification',
+      'SidePanel',
+      'Status',
+      'StatusFilter',
+    ]);
+  });
+
+  it('fr provides every key declared in en (no missing translations)', () => {
+    const enPaths = new Set(leafPaths(activitiesTranslationsEn));
+    const frPaths = new Set(leafPaths(activitiesTranslationsFr));
+
+    const missingInFr = [...enPaths].filter((p) => !frPaths.has(p));
+    const extraInFr = [...frPaths].filter((p) => !enPaths.has(p));
+
+    expect(missingInFr).toEqual([]);
+    expect(extraInFr).toEqual([]);
+  });
+
+  it('preserves interpolation placeholders across locales', () => {
+    expect(activitiesTranslationsEn.List.Pagination.Page).toContain('{{page}}');
+    expect(activitiesTranslationsEn.List.Pagination.Page).toContain('{{total}}');
+    expect(activitiesTranslationsFr.List.Pagination.Page).toContain('{{page}}');
+    expect(activitiesTranslationsFr.List.Pagination.Page).toContain('{{total}}');
+  });
+});

--- a/packages/@granit/react-activities/src/index.ts
+++ b/packages/@granit/react-activities/src/index.ts
@@ -43,6 +43,10 @@ export type { ActivitiesSidePanelProps } from './components/activities-side-pane
 export { activitiesSidePanel } from './contributions/entity-side-panel.js';
 export type { ActivitiesSidePanelContributionOptions } from './contributions/entity-side-panel.js';
 
+// i18n resource bundles (namespace: 'activities')
+export { activitiesTranslationsEn, activitiesTranslationsFr } from './locales/index.js';
+export type { ActivitiesTranslations } from './locales/index.js';
+
 // Notifications integration (Assigned / Reminder / Overdue)
 export {
   ACTIVITY_NOTIFICATION_RELATED_ENTITY_TYPE,

--- a/packages/@granit/react-activities/src/locales/en.ts
+++ b/packages/@granit/react-activities/src/locales/en.ts
@@ -1,0 +1,165 @@
+/**
+ * English translation bundle for `@granit/react-activities`. Consumers
+ * register it via:
+ *
+ *   i18n.addResourceBundle('en', 'activities', activitiesTranslationsEn);
+ *
+ * Components in this package don't call `useTranslation` directly — they
+ * expose `labels` / `actionLabels` props that apps populate from `t()`.
+ * This keeps the components testable without i18next bootstrap.
+ */
+export const activitiesTranslationsEn: ActivitiesTranslations = {
+  Action: {
+    Complete: 'Complete',
+    Cancel: 'Cancel',
+    Reassign: 'Reassign',
+    Reschedule: 'Reschedule',
+    Create: '+ Activity',
+  },
+  Status: {
+    Open: 'Open',
+    Completed: 'Completed',
+    Cancelled: 'Cancelled',
+    Overdue: 'Overdue',
+  },
+  StatusFilter: {
+    All: 'All',
+    OpenOrOverdue: 'Open or overdue',
+  },
+  List: {
+    Loading: 'Loading…',
+    Error: 'Failed to load activities.',
+    Empty: 'No activities.',
+    Header: {
+      Type: 'Type',
+      Entity: 'Entity',
+      Assignee: 'Assignee',
+      Due: 'Due',
+      Status: 'Status',
+      Actions: 'Actions',
+    },
+    Pagination: {
+      Previous: 'Previous page',
+      Next: 'Next page',
+      Page: 'Page {{page}} / {{total}}',
+    },
+  },
+  Detail: {
+    Loading: 'Loading…',
+    Error: 'Failed to load activity.',
+    Field: {
+      Type: 'Type',
+      Entity: 'Entity',
+      Assignee: 'Assignee',
+      Due: 'Due',
+      Status: 'Status',
+      Description: 'Description',
+      Completed: 'Completed',
+      Created: 'Created',
+    },
+  },
+  Calendar: {
+    Loading: 'Loading…',
+    Error: 'Failed to load calendar.',
+    Empty: 'No activities in this window.',
+    Nav: {
+      Previous: 'Previous',
+      Next: 'Next',
+      Today: 'Today',
+    },
+    View: {
+      Day: 'Day',
+      Week: 'Week',
+      Month: 'Month',
+      Label: 'View',
+    },
+  },
+  SidePanel: {
+    Title: 'Activities',
+  },
+  Notification: {
+    Type: {
+      Assigned: 'Activity assigned',
+      Reminder: 'Activity reminder',
+      Overdue: 'Activity overdue',
+    },
+  },
+};
+
+export interface ActivitiesTranslations {
+  readonly Action: {
+    readonly Complete: string;
+    readonly Cancel: string;
+    readonly Reassign: string;
+    readonly Reschedule: string;
+    readonly Create: string;
+  };
+  readonly Status: {
+    readonly Open: string;
+    readonly Completed: string;
+    readonly Cancelled: string;
+    readonly Overdue: string;
+  };
+  readonly StatusFilter: {
+    readonly All: string;
+    readonly OpenOrOverdue: string;
+  };
+  readonly List: {
+    readonly Loading: string;
+    readonly Error: string;
+    readonly Empty: string;
+    readonly Header: {
+      readonly Type: string;
+      readonly Entity: string;
+      readonly Assignee: string;
+      readonly Due: string;
+      readonly Status: string;
+      readonly Actions: string;
+    };
+    readonly Pagination: {
+      readonly Previous: string;
+      readonly Next: string;
+      readonly Page: string;
+    };
+  };
+  readonly Detail: {
+    readonly Loading: string;
+    readonly Error: string;
+    readonly Field: {
+      readonly Type: string;
+      readonly Entity: string;
+      readonly Assignee: string;
+      readonly Due: string;
+      readonly Status: string;
+      readonly Description: string;
+      readonly Completed: string;
+      readonly Created: string;
+    };
+  };
+  readonly Calendar: {
+    readonly Loading: string;
+    readonly Error: string;
+    readonly Empty: string;
+    readonly Nav: {
+      readonly Previous: string;
+      readonly Next: string;
+      readonly Today: string;
+    };
+    readonly View: {
+      readonly Day: string;
+      readonly Week: string;
+      readonly Month: string;
+      readonly Label: string;
+    };
+  };
+  readonly SidePanel: {
+    readonly Title: string;
+  };
+  readonly Notification: {
+    readonly Type: {
+      readonly Assigned: string;
+      readonly Reminder: string;
+      readonly Overdue: string;
+    };
+  };
+}

--- a/packages/@granit/react-activities/src/locales/fr.ts
+++ b/packages/@granit/react-activities/src/locales/fr.ts
@@ -1,0 +1,85 @@
+import type { ActivitiesTranslations } from './en.js';
+
+/**
+ * French translation bundle for `@granit/react-activities`. Consumers
+ * register it via:
+ *
+ *   i18n.addResourceBundle('fr', 'activities', activitiesTranslationsFr);
+ */
+export const activitiesTranslationsFr: ActivitiesTranslations = {
+  Action: {
+    Complete: 'Terminer',
+    Cancel: 'Annuler',
+    Reassign: 'Réassigner',
+    Reschedule: 'Replanifier',
+    Create: '+ Activité',
+  },
+  Status: {
+    Open: 'Ouverte',
+    Completed: 'Terminée',
+    Cancelled: 'Annulée',
+    Overdue: 'En retard',
+  },
+  StatusFilter: {
+    All: 'Toutes',
+    OpenOrOverdue: 'Ouvertes ou en retard',
+  },
+  List: {
+    Loading: 'Chargement…',
+    Error: 'Échec du chargement des activités.',
+    Empty: 'Aucune activité.',
+    Header: {
+      Type: 'Type',
+      Entity: 'Entité',
+      Assignee: 'Assignée à',
+      Due: 'Échéance',
+      Status: 'Statut',
+      Actions: 'Actions',
+    },
+    Pagination: {
+      Previous: 'Page précédente',
+      Next: 'Page suivante',
+      Page: 'Page {{page}} / {{total}}',
+    },
+  },
+  Detail: {
+    Loading: 'Chargement…',
+    Error: 'Échec du chargement de l’activité.',
+    Field: {
+      Type: 'Type',
+      Entity: 'Entité',
+      Assignee: 'Assignée à',
+      Due: 'Échéance',
+      Status: 'Statut',
+      Description: 'Description',
+      Completed: 'Terminée le',
+      Created: 'Créée le',
+    },
+  },
+  Calendar: {
+    Loading: 'Chargement…',
+    Error: 'Échec du chargement du calendrier.',
+    Empty: 'Aucune activité sur cette période.',
+    Nav: {
+      Previous: 'Précédent',
+      Next: 'Suivant',
+      Today: 'Aujourd’hui',
+    },
+    View: {
+      Day: 'Jour',
+      Week: 'Semaine',
+      Month: 'Mois',
+      Label: 'Vue',
+    },
+  },
+  SidePanel: {
+    Title: 'Activités',
+  },
+  Notification: {
+    Type: {
+      Assigned: 'Activité assignée',
+      Reminder: 'Rappel d’activité',
+      Overdue: 'Activité en retard',
+    },
+  },
+};

--- a/packages/@granit/react-activities/src/locales/index.ts
+++ b/packages/@granit/react-activities/src/locales/index.ts
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------------------
+// @granit/react-activities — i18next resource bundles (namespace: "activities")
+// ---------------------------------------------------------------------------
+//
+// Consumers register the bundles with their i18n instance:
+//
+//   import { activitiesTranslationsEn, activitiesTranslationsFr } from '@granit/react-activities';
+//   i18n.addResourceBundle('en', 'activities', activitiesTranslationsEn);
+//   i18n.addResourceBundle('fr', 'activities', activitiesTranslationsFr);
+//
+// Components in this package don't call `useTranslation` directly — they
+// expose `labels` / `actionLabels` props that apps populate from `t()`.
+// This keeps the components testable without i18next bootstrap, and keeps
+// the framework headless: apps own when and how to mount i18n.
+// ---------------------------------------------------------------------------
+
+export { activitiesTranslationsEn } from './en.js';
+export type { ActivitiesTranslations } from './en.js';
+export { activitiesTranslationsFr } from './fr.js';


### PR DESCRIPTION
## Summary

Final story for the `Granit.Activities` front-end feature. Ships **en + fr** i18n bundles for the `'activities'` namespace, the package README, and a cumulative DoD pass.

## i18n bundles

```ts
import {
  activitiesTranslationsEn,
  activitiesTranslationsFr,
} from '@granit/react-activities';

i18n.addResourceBundle('en', 'activities', activitiesTranslationsEn);
i18n.addResourceBundle('fr', 'activities', activitiesTranslationsFr);
```

Both bundles satisfy a shared `ActivitiesTranslations` interface — adding a new locale is a single new file that the type-checker enforces against the schema. A smoke test walks the leaf paths to assert **no missing or stale keys** and that interpolation placeholders (`{{page}}`, `{{total}}`) survive translation.

## Bundle layout

8 namespaces:

- `Action` — `Complete` / `Cancel` / `Reassign` / `Reschedule` / `Create`
- `Status` — `Open` / `Completed` / `Cancelled` / `Overdue`
- `StatusFilter` — `All` / `OpenOrOverdue`
- `List` — Loading / Error / Empty / Header / Pagination
- `Detail` — Loading / Error / Field
- `Calendar` — Loading / Error / Empty / Nav / View
- `SidePanel` — Title (mirrors `<section aria-label>`)
- `Notification` — `Type.{Assigned,Reminder,Overdue}` (front-only friendly labels; bodies stay backend-localized per F8)

## Architecture choice (vs original story)

| Story said | Delivered | Reason |
| ---------- | --------- | ------ |
| 18 cultures (15 + 3) | en + fr | Actual repo convention is en + fr (see `@granit/react-parties`); 18 was speculative in the story description. Adding a locale is now a single typed file. |
| Storybook stories | — | This monorepo doesn't run Storybook (no `*.stories.tsx` anywhere). Confirmed in F5 / F6. |
| Components call `useTranslation` directly | Catalogs shipped, components stay headless | Apps wire `t()` results into the existing `labels` / `actionLabels` override props. Keeps components testable without i18next bootstrap and consistent with the headless pattern from F5–F8. |

The README documents the registration recipe end-to-end.

## Closes

- #373 — F9 — i18n + DoD
- Parent feature: #364
- Wraps the full Granit.Activities front delivery (F1 → F9)

## Cumulative DoD (feature-wide)

- [x] `pnpm -F @granit/activities build` — ESM 2.91 KB / dts 4.96 KB
- [x] `pnpm -F @granit/react-activities build` — ESM 26.01 KB / dts 20.85 KB
- [x] `pnpm tsc` — green workspace-wide
- [x] `pnpm lint` — `--max-warnings 0`
- [x] `pnpm vitest run packages/@granit/react-activities` — **62/62**, 9 test files
- [x] `pnpm vitest run packages/@granit/activities` — **24/24**, 3 test files
- [x] No new third-party deps were introduced (no `THIRD-PARTY-NOTICES.md` change needed)
- [x] All 9 PRs targeted `develop`, never `main`
- [x] `.mcp-front-index.json` regenerated automatically by pre-commit on every feature PR

## Test plan

- [x] 3 locale tests:
  - `en` exposes the expected top-level namespaces
  - `fr` matches `en` leaf-path-for-leaf-path (no drift)
  - Pagination placeholders preserved across both
- [x] All prior tests still pass

## What's next (out of scope for this feature)

- Custom-activity-type builder UI (Phase ultérieure per master plan)
- `granit-showcase-admin-react` integration pages (separate repo)
- Drag-to-reschedule on `<ActivityCalendar>` — apps wire it on top of `useRescheduleActivity` if needed
