### PR TITLE
feat(entities,react-entities): bulk action endpoint client + types (D1)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2986,6 +2986,11 @@
           "members": []
         },
         {
+          "name": "executeBulkAction",
+          "kind": "function",
+          "signature": "async function executeBulkAction( client: AxiosInstance, entityName: string, action: string, request: BulkActionRequest ): Promise<BulkActionResponse>"
+        },
+        {
           "name": "entityCalendarQueryKey",
           "kind": "function",
           "signature": "function entityCalendarQueryKey( entityName: string, from: string, to: string, calendar?: string | null, filters?: readonly FilterEntry[], search?: string ): readonly ["

--- a/packages/@granit/entities/src/index.ts
+++ b/packages/@granit/entities/src/index.ts
@@ -16,6 +16,9 @@
 export { evaluateVisibility } from './helpers/index.js';
 export { ALL_ENTITY_FACETS, MANIFEST_SCHEMA_VERSION } from './types/index.js';
 export type {
+  BulkActionFailure,
+  BulkActionRequest,
+  BulkActionResponse,
   CalendarItemResponse,
   CalendarRangeRequest,
   EntityActionKind,

--- a/packages/@granit/entities/src/types/bulk.ts
+++ b/packages/@granit/entities/src/types/bulk.ts
@@ -1,0 +1,51 @@
+/**
+ * Wire shapes for the bulk-action endpoint shipped by
+ * `Granit.Entities.Endpoints` (per granit-fx/granit-dotnet#1792 / #1822).
+ *
+ * `POST /entities/{name}/bulk/{action}` fans out a single action across
+ * many ids with **one batched event emitted per parent affected** —
+ * avoids the N invalidations a per-row dispatch would trigger.
+ *
+ * Request: ids of the rows to act on + an optional bag of parameters
+ * (passed through to the action executor; shape is action-specific).
+ *
+ * Response surfaces three lists so the client can:
+ * - re-render the rows the action succeeded on (`ok`),
+ * - keep the failed rows selected for retry + show their per-id error
+ *   (`failed`),
+ * - invalidate exactly the affected parents' relation-aggregate caches
+ *   for smart-button refresh (`parents`).
+ */
+export interface BulkActionRequest {
+  /** Ids of the rows the action targets. Must be non-empty. */
+  readonly ids: readonly string[];
+  /**
+   * Optional action-specific parameter bag. Wire-passed verbatim to the
+   * action executor — the shape is owned by the action's contract, not
+   * by this envelope.
+   */
+  readonly parameters?: Readonly<Record<string, unknown>>;
+}
+
+/** Per-id error captured by the bulk endpoint when a single row fails. */
+export interface BulkActionFailure {
+  readonly id: string;
+  /** Human-readable reason — backend already localizes when applicable. */
+  readonly error: string;
+  /** Optional machine-readable error code. */
+  readonly errorCode: string | null;
+}
+
+export interface BulkActionResponse {
+  /** Ids that succeeded. */
+  readonly ok: readonly string[];
+  /** Per-id failures captured without short-circuiting the batch. */
+  readonly failed: readonly BulkActionFailure[];
+  /**
+   * Distinct parent entity instances impacted by the batch — the front
+   * uses this list to invalidate the right relation-aggregate caches in
+   * exactly one step per parent, mirroring the backend's batched-event
+   * semantics. Format: `"{ParentEntityName}:{ParentId}"`.
+   */
+  readonly parents: readonly string[];
+}

--- a/packages/@granit/entities/src/types/index.ts
+++ b/packages/@granit/entities/src/types/index.ts
@@ -1,4 +1,5 @@
 export type { EntityActionKind, EntityActionManifest } from './actions.js';
+export type { BulkActionFailure, BulkActionRequest, BulkActionResponse } from './bulk.js';
 export type {
   EntityCollectionReference,
   EntityCollectionsSection,

--- a/packages/@granit/react-entities/src/__tests__/bulk-action.test.ts
+++ b/packages/@granit/react-entities/src/__tests__/bulk-action.test.ts
@@ -1,0 +1,106 @@
+import axios, { AxiosError } from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { executeBulkAction } from '../api/bulk-action.js';
+
+import type { BulkActionResponse } from '@granit/entities';
+
+const ENTITY = 'Granit.Sales.Quote';
+const ACTION = 'Approve';
+const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/bulk/${encodeURIComponent(ACTION)}`;
+
+const RESPONSE: BulkActionResponse = {
+  ok: ['q-1', 'q-2'],
+  failed: [
+    {
+      id: 'q-3',
+      error: 'Workflow transition not allowed in state Draft.',
+      errorCode: 'workflow.invalid_transition',
+    },
+  ],
+  parents: ['Party:p-1', 'Party:p-2'],
+};
+
+let lastBody: unknown = null;
+
+function freshHandlers() {
+  return [
+    http.post(PATH, async ({ request }) => {
+      lastBody = await request.json();
+      return HttpResponse.json(RESPONSE);
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastBody = null;
+});
+afterAll(() => server.close());
+
+describe('executeBulkAction', () => {
+  const client = axios.create({ baseURL: 'http://localhost' });
+
+  it('POSTs the ids + parameters bag to /entities/{name}/bulk/{action}', async () => {
+    const response = await executeBulkAction(client, ENTITY, ACTION, {
+      ids: ['q-1', 'q-2', 'q-3'],
+      parameters: { reason: 'Quarterly batch approval' },
+    });
+
+    expect(response).toEqual(RESPONSE);
+    expect(lastBody).toEqual({
+      ids: ['q-1', 'q-2', 'q-3'],
+      parameters: { reason: 'Quarterly batch approval' },
+    });
+  });
+
+  it('omits parameters from the wire body when not provided', async () => {
+    await executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'] });
+    expect(lastBody).toEqual({ ids: ['q-1'] });
+  });
+
+  it('URI-encodes the entity name and the action segment', async () => {
+    const tricky = 'Tenant.Module.Entity Name';
+    const trickyAction = 'Mark Done';
+    const url = `http://localhost/entities/${encodeURIComponent(tricky)}/bulk/${encodeURIComponent(trickyAction)}`;
+    server.use(http.post(url, () => HttpResponse.json(RESPONSE)));
+
+    const response = await executeBulkAction(client, tricky, trickyAction, { ids: ['x-1'] });
+
+    expect(response).toEqual(RESPONSE);
+  });
+
+  it('returns the partial-failure recap as-is so the caller can drive retry UX', async () => {
+    const response = await executeBulkAction(client, ENTITY, ACTION, {
+      ids: ['q-1', 'q-2', 'q-3'],
+    });
+
+    expect(response.ok).toEqual(['q-1', 'q-2']);
+    expect(response.failed).toHaveLength(1);
+    expect(response.failed[0]?.id).toBe('q-3');
+    expect(response.parents).toEqual(['Party:p-1', 'Party:p-2']);
+  });
+
+  it('propagates 422 from the backend with the AxiosError surface intact', async () => {
+    server.use(
+      http.post(PATH, () => HttpResponse.json({ title: 'Validation failed' }, { status: 422 }))
+    );
+
+    await expect(
+      executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'] })
+    ).rejects.toBeInstanceOf(AxiosError);
+  });
+
+  it('propagates 403 when the caller lacks the action permission', async () => {
+    server.use(http.post(PATH, () => HttpResponse.text('forbidden', { status: 403 })));
+
+    await expect(executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'] })).rejects.toMatchObject(
+      { response: { status: 403 } }
+    );
+  });
+});

--- a/packages/@granit/react-entities/src/api/bulk-action.ts
+++ b/packages/@granit/react-entities/src/api/bulk-action.ts
@@ -1,0 +1,33 @@
+import type { AxiosInstance } from '@granit/api-client';
+import type { BulkActionRequest, BulkActionResponse } from '@granit/entities';
+
+/**
+ * `POST /entities/{name}/bulk/{action}` — fan out one action across many
+ * ids in a single round-trip. Mirrors the dotnet bulk endpoint shipped in
+ * granit-fx/granit-dotnet#1792 / #1822.
+ *
+ * The backend captures per-id failures without short-circuiting and
+ * returns them in `BulkActionResponse.failed`; success ids land in `ok`.
+ * `BulkActionResponse.parents` carries the distinct
+ * `"{ParentEntityName}:{ParentId}"` markers impacted by the batch — the
+ * client uses this list to invalidate exactly the right
+ * relation-aggregate caches in one step per parent (mirror of the
+ * backend's batched-event semantics).
+ *
+ * Intentionally a plain async function: the selection-bar dispatcher
+ * (D2) wraps this in its own controlled state + recap UX. Apps that
+ * need cache wiring layer it on top via the smart-button cache eviction
+ * listener (D3).
+ */
+export async function executeBulkAction(
+  client: AxiosInstance,
+  entityName: string,
+  action: string,
+  request: BulkActionRequest
+): Promise<BulkActionResponse> {
+  const response = await client.post<BulkActionResponse>(
+    `/entities/${encodeURIComponent(entityName)}/bulk/${encodeURIComponent(action)}`,
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -64,6 +64,7 @@ export {
   STANDARD_FORM_COMPONENTS,
 } from './field-components/index.js';
 export type { SelectComponentOption } from './field-components/index.js';
+export { executeBulkAction } from './api/bulk-action.js';
 export { entityCalendarQueryKey, useEntityCalendar } from './api/use-entity-calendar.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export {


### PR DESCRIPTION
## Summary

Wires the front side of the bulk-action endpoint shipped on the dotnet side ([granit-fx/granit-dotnet#1792](https://github.com/granit-fx/granit-dotnet/issues/1792) + [#1822](https://github.com/granit-fx/granit-dotnet/issues/1822)). The endpoint fans out one action across many ids with **one batched event per parent**, so the front consumes:

```ts
POST /entities/{name}/bulk/{action}
body:     BulkActionRequest  { ids, parameters? }
response: BulkActionResponse { ok, failed: [{id, error, errorCode}], parents }
```

`parents` is encoded as `"{ParentEntityName}:{ParentId}"` so D3 (smart-button cache eviction) can invalidate **exactly** the impacted relation-aggregate caches in one step per parent — mirror of the backend's batched-event semantics.

## Deliverables

- `@granit/entities` — `BulkActionRequest` / `BulkActionFailure` / `BulkActionResponse` wire types
- `@granit/react-entities` — `executeBulkAction(client, entityName, action, request)` plain async function
- 6 MSW tests

## Why a plain function (not a hook)

D2 (selection-bar dispatch + recap UX) wraps this in its own controlled state machine; D3 (smart-button cache eviction) layers `parent`-scoped invalidation on top. Keeping D1 a stateless function lets both consume it without a hook coupling — matches the `payments-api.ts` / `activities-api.ts` precedent.

## Closes

- #409 — D1 — Bulk action endpoint client + types
- Parent feature: #398
- Backend: granit-fx/granit-dotnet#1792 / #1822

## Test plan

- [x] 6 MSW tests, **230/230** across `@granit/entities` + `@granit/react-entities`
- [x] Happy path: ids + parameters bag round-trip
- [x] `parameters` omitted when not provided (no empty `{}`)
- [x] URI encoding on both segments (`Tenant.Module.Entity Name` + `Mark Done`)
- [x] Partial-failure recap surfaced as-is
- [x] 422 → `AxiosError` instance preserved
- [x] 403 → `response.status === 403` propagated
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/entities build` + `pnpm -F @granit/react-entities build` — ESM + dts
