### PR TITLE
feat(react-entities): selection bar bulk dispatch + recap UX (D2)

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
@@ -1,0 +1,272 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { EntitySelectionBar } from '../components/entity-selection-bar.js';
+import { SelectionProvider } from '../selection/selection-provider.js';
+
+import type {
+  BulkActionResponse,
+  EntityActionManifest,
+  EntityManifestResponse,
+  EntitySelectionActionManifest,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY_NAME = 'Granit.Sales.Quote';
+const BULK_PATH = `http://localhost/entities/${encodeURIComponent(ENTITY_NAME)}/bulk/approve`;
+
+const FULL_SUCCESS: BulkActionResponse = {
+  ok: ['q1', 'q2', 'q3'],
+  failed: [],
+  parents: ['Party:p1', 'Party:p2'],
+};
+
+const PARTIAL_FAILURE: BulkActionResponse = {
+  ok: ['q1', 'q3'],
+  failed: [{ id: 'q2', error: 'Workflow blocked', errorCode: 'wf.blocked' }],
+  parents: ['Party:p1'],
+};
+
+let lastBulkBody: { ids: readonly string[] } | null = null;
+let bulkCallCount = 0;
+let perRowCallCount = 0;
+
+function freshHandlers() {
+  return [
+    http.post(BULK_PATH, async ({ request }) => {
+      bulkCallCount += 1;
+      lastBulkBody = (await request.json()) as { ids: readonly string[] };
+      return HttpResponse.json(FULL_SUCCESS);
+    }),
+    // Per-row apiCall fallback (for the "predicate excludes" regression case)
+    http.post(/\/api\/.+\/[^/]+$/, () => {
+      perRowCallCount += 1;
+      return HttpResponse.json({});
+    }),
+  ];
+}
+
+const server = setupServer(...freshHandlers());
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => {
+  server.resetHandlers(...freshHandlers());
+  lastBulkBody = null;
+  bulkCallCount = 0;
+  perRowCallCount = 0;
+  vi.restoreAllMocks();
+});
+afterAll(() => server.close());
+
+function makeAction(): EntityActionManifest {
+  return {
+    name: 'approve',
+    kind: 'ApiCall',
+    displayKey: 'Sales.Quote.Approve',
+    icon: 'check',
+    order: 0,
+    urlTemplate: '/api/quotes/{id}/approve',
+    httpMethod: 'POST',
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+  };
+}
+
+function makeRef(): EntitySelectionActionManifest {
+  return {
+    name: 'approve',
+    displayKey: null,
+    icon: 'check',
+    confirmationKey: null,
+    contributorAssemblyName: null,
+  };
+}
+
+function makeManifest(): EntityManifestResponse {
+  return {
+    schemaVersion: 1,
+    identity: {
+      name: ENTITY_NAME,
+      entityClrType: 'Granit.Sales.Domain.Quote',
+      displayKey: null,
+      icon: null,
+      permissionGroup: null,
+      displayProperty: 'name',
+      subtitleProperty: null,
+    },
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: {
+      query: null,
+      export: null,
+      metrics: [],
+      dashboards: [],
+      defaultViewId: null,
+      listLayouts: [],
+      headerActions: [],
+      selectionActions: [makeRef()],
+    },
+    relations: null,
+    actions: [makeAction()],
+  };
+}
+
+function makeWrapper() {
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return ({ children }: { children: ReactNode }) => (
+    <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+  );
+}
+
+describe('EntitySelectionBar — bulk endpoint dispatch', () => {
+  it('routes a click through POST /bulk/{action} with all ids when useBulkEndpoint=true', async () => {
+    const Wrapper = makeWrapper();
+    const onComplete = vi.fn();
+
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
+          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+        </SelectionProvider>
+      </Wrapper>
+    );
+
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+    expect(bulkCallCount).toBe(1);
+    expect(perRowCallCount).toBe(0);
+    expect(lastBulkBody).toEqual({ ids: ['q1', 'q2', 'q3'] });
+  });
+
+  it('exposes parents from the response in the recap (used by D3 cache eviction)', async () => {
+    const Wrapper = makeWrapper();
+    const onComplete = vi.fn();
+
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
+          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+        </SelectionProvider>
+      </Wrapper>
+    );
+
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+
+    const recap = onComplete.mock.calls[0]?.[1];
+    expect(recap.succeeded).toEqual(['q1', 'q2', 'q3']);
+    expect(recap.failed).toHaveLength(0);
+    expect(recap.parents).toEqual(['Party:p1', 'Party:p2']);
+  });
+
+  it('keeps failed rows selected and surfaces per-id errors on partial failure', async () => {
+    server.use(http.post(BULK_PATH, () => HttpResponse.json(PARTIAL_FAILURE)));
+
+    const Wrapper = makeWrapper();
+    const onComplete = vi.fn();
+
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
+          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+        </SelectionProvider>
+      </Wrapper>
+    );
+
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+
+    const recap = onComplete.mock.calls[0]?.[1];
+    expect(recap.succeeded).toEqual(['q1', 'q3']);
+    expect(recap.failed).toHaveLength(1);
+    expect(recap.failed[0]?.id).toBe('q2');
+    expect(recap.failed[0]?.error).toMatchObject({ errorCode: 'wf.blocked' });
+
+    // After partial failure, selection narrows to the failed ids so the
+    // user can retry without re-picking the rows.
+    const bar = container.querySelector('[data-granit-entity-selection-bar]') as HTMLElement;
+    await waitFor(() => expect(bar.getAttribute('data-selected-count')).toBe('1'));
+  });
+
+  it('surfaces every id as failed against the root error when the endpoint itself rejects', async () => {
+    server.use(http.post(BULK_PATH, () => HttpResponse.text('forbidden', { status: 403 })));
+
+    const Wrapper = makeWrapper();
+    const onComplete = vi.fn();
+
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
+          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+        </SelectionProvider>
+      </Wrapper>
+    );
+
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+
+    const recap = onComplete.mock.calls[0]?.[1];
+    expect(recap.succeeded).toHaveLength(0);
+    expect(recap.failed.map((f: { id: string }) => f.id)).toEqual(['q1', 'q2', 'q3']);
+    expect(recap.parents).toBeUndefined();
+  });
+
+  it('predicate form: bulk path engaged only for matching action names', async () => {
+    const Wrapper = makeWrapper();
+    const onComplete = vi.fn();
+    const apiCall = vi.fn(async () => {});
+    const predicate = vi.fn((action: EntitySelectionActionManifest) => action.name === 'approve');
+
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2']}>
+          <EntitySelectionBar
+            manifest={makeManifest()}
+            useBulkEndpoint={predicate}
+            handlers={{ apiCall }}
+            onComplete={onComplete}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+
+    expect(predicate).toHaveBeenCalledWith(expect.objectContaining({ name: 'approve' }));
+    expect(bulkCallCount).toBe(1);
+    expect(apiCall).not.toHaveBeenCalled(); // per-row dispatcher bypassed
+  });
+
+  it('useBulkEndpoint=false keeps the per-row fan-out (regression)', async () => {
+    const Wrapper = makeWrapper();
+    const onComplete = vi.fn();
+    const apiCall = vi.fn(async () => {});
+
+    const { container } = render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
+          <EntitySelectionBar
+            manifest={makeManifest()}
+            useBulkEndpoint={false}
+            handlers={{ apiCall }}
+            onComplete={onComplete}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+
+    fireEvent.click(container.querySelector('[data-granit-entity-action]') as HTMLElement);
+    await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+
+    expect(bulkCallCount).toBe(0);
+    expect(apiCall).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
@@ -1,3 +1,4 @@
+import { useGranitClient } from '@granit/react-api-client';
 import { useCallback, useState, type KeyboardEvent, type ReactNode } from 'react';
 
 import { resolveAction } from '../actions/entity-action-button.js';
@@ -5,9 +6,11 @@ import {
   useEntityActionDispatcher,
   type EntityActionHandlers,
 } from '../actions/use-entity-action-dispatcher.js';
+import { executeBulkAction } from '../api/bulk-action.js';
 import { useSelection } from '../selection/selection-context.js';
 
 import type {
+  BulkActionResponse,
   EntityActionManifest,
   EntityManifestResponse,
   EntitySelectionActionManifest,
@@ -26,7 +29,28 @@ export interface EntitySelectionBarRecap {
   readonly succeeded: readonly string[];
   /** Per-id failures with the rejection reason (the dispatcher's thrown error). */
   readonly failed: readonly { readonly id: string; readonly error: unknown }[];
+  /**
+   * Distinct parent markers (`"{ParentEntityName}:{ParentId}"`) returned
+   * by the bulk endpoint. Present only when the click routed through
+   * `executeBulkAction()` (i.e. `useBulkEndpoint` was opt'd in for the
+   * action); `undefined` for the per-row fan-out path. Apps consume
+   * this list to invalidate exactly the impacted relation-aggregate
+   * caches in one step per parent (D3).
+   */
+  readonly parents?: readonly string[];
 }
+
+/**
+ * Predicate / flag controlling whether the selection bar should route a
+ * given action through the bulk endpoint (one batched POST) instead of
+ * the default per-row fan-out (N parallel POSTs capped at 10).
+ *
+ * Apps opt in when their backend exposes
+ * `POST /entities/{name}/bulk/{action}` for the action — the backend
+ * owns dedup, and the response surfaces the impacted parents in one
+ * step. Set `false` (the default) to keep the per-row fan-out.
+ */
+export type BulkDispatchPredicate = boolean | ((action: EntitySelectionActionManifest) => boolean);
 
 export interface EntitySelectionBarProps {
   /** Entity manifest — provides `actions[]` + `collections.selectionActions[]`. */
@@ -56,6 +80,16 @@ export interface EntitySelectionBarProps {
     action: EntitySelectionActionManifest,
     selectedIds: ReadonlySet<string>
   ) => boolean | Promise<boolean>;
+  /**
+   * Opt-in: route the click through the bulk endpoint
+   * (`POST /entities/{name}/bulk/{action}`) instead of the per-row
+   * fan-out. Pass `true` to enable for every selection action, or a
+   * predicate to enable per action (typical: a closed allow-list of
+   * action names known to support bulk on the host backend).
+   *
+   * Default: `false` (per-row fan-out — the pre-D2 behaviour).
+   */
+  readonly useBulkEndpoint?: BulkDispatchPredicate;
   /** Optional class for the root element. */
   readonly className?: string;
 }
@@ -94,9 +128,11 @@ export function EntitySelectionBar({
   handlers,
   onComplete,
   confirm,
+  useBulkEndpoint,
   className,
 }: EntitySelectionBarProps): ReactNode {
   const dispatch = useEntityActionDispatcher(handlers);
+  const client = useGranitClient();
   const selection = useSelection();
   const [running, setRunning] = useState<string | null>(null);
 
@@ -118,17 +154,24 @@ export function EntitySelectionBar({
         if (!proceed) return;
       }
 
+      const useBulk =
+        typeof useBulkEndpoint === 'function' ? useBulkEndpoint(ref) : useBulkEndpoint === true;
+      const entityName = manifest.identity?.name;
+
       setRunning(ref.name);
       try {
-        const recap = await fanOutWithCap(
-          ids,
-          (id) =>
-            dispatch(action, id, null).then(
-              () => ({ kind: 'ok' as const, id }),
-              (error: unknown) => ({ kind: 'err' as const, id, error })
-            ),
-          SELECTION_FANOUT_CONCURRENCY_CAP
-        );
+        const recap =
+          useBulk && entityName
+            ? await dispatchBulk(client, entityName, ref.name, ids)
+            : await fanOutWithCap(
+                ids,
+                (id) =>
+                  dispatch(action, id, null).then(
+                    () => ({ kind: 'ok' as const, id }),
+                    (error: unknown) => ({ kind: 'err' as const, id, error })
+                  ),
+                SELECTION_FANOUT_CONCURRENCY_CAP
+              );
         onComplete?.(ref, recap);
         // Best-effort: clear the selection on full success so the user
         // doesn't accidentally re-fire on the same set. Failures are
@@ -142,7 +185,16 @@ export function EntitySelectionBar({
         setRunning(null);
       }
     },
-    [running, selection, dispatch, confirm, onComplete]
+    [
+      running,
+      selection,
+      dispatch,
+      confirm,
+      onComplete,
+      useBulkEndpoint,
+      client,
+      manifest.identity?.name,
+    ]
   );
 
   if (selectionActions.length === 0 || selection.size === 0) return null;
@@ -154,9 +206,7 @@ export function EntitySelectionBar({
       data-selected-count={selection.size}
       className={className}
     >
-      <span data-granit-selection-bar-summary="">
-        {selection.size} selected
-      </span>
+      <span data-granit-selection-bar-summary="">{selection.size} selected</span>
       {selectionActions.map((ref) => {
         const action = resolveAction(ref, manifest.actions);
         if (!action) return null;
@@ -193,6 +243,38 @@ export function EntitySelectionBar({
       </button>
     </div>
   );
+}
+
+/**
+ * Single-shot bulk dispatch. Calls
+ * `POST /entities/{name}/bulk/{action}` with all ids and maps the
+ * response into the existing recap shape (`succeeded` / `failed`)
+ * extended with `parents` for downstream cache-eviction wiring (D3).
+ *
+ * If the endpoint itself rejects (network / 4xx / 5xx), every id is
+ * surfaced as failed against the same root error — the user-visible
+ * recap stays uniform between the bulk and fan-out paths.
+ */
+async function dispatchBulk(
+  client: Parameters<typeof executeBulkAction>[0],
+  entityName: string,
+  actionName: string,
+  ids: readonly string[]
+): Promise<EntitySelectionBarRecap> {
+  let response: BulkActionResponse;
+  try {
+    response = await executeBulkAction(client, entityName, actionName, { ids });
+  } catch (error) {
+    return {
+      succeeded: [],
+      failed: ids.map((id) => ({ id, error })),
+    };
+  }
+  return {
+    succeeded: response.ok,
+    failed: response.failed.map((f) => ({ id: f.id, error: f })),
+    parents: response.parents,
+  };
 }
 
 function swallowEnterSpace(event: KeyboardEvent<HTMLButtonElement>): void {


### PR DESCRIPTION
## Summary

Adds an **opt-in bulk-endpoint path** to `<EntitySelectionBar>`. When the new `useBulkEndpoint` prop is enabled, a click routes through `executeBulkAction()` (D1) once instead of fanning out N parallel POSTs.

## API additions

### `useBulkEndpoint?: boolean | (action) => boolean`

```tsx
// Enable for every selection action
<EntitySelectionBar manifest={…} useBulkEndpoint />

// Allow-list per action name
<EntitySelectionBar
  manifest={…}
  useBulkEndpoint={(action) => bulkSafeActions.has(action.name)}
/>
```

Default `false` → existing per-row fan-out behaviour intact (regression test asserts the per-row `apiCall` handler still fires once per id).

### `EntitySelectionBarRecap.parents?: readonly string[]`

Populated from `BulkActionResponse.parents` when the bulk path was taken; `undefined` for fan-out. **D3 (smart-button cache eviction)** reads this list to invalidate exactly the impacted relation-aggregate caches in one step per parent.

### `BulkDispatchPredicate` type

Exported for apps that allow-list which selection actions support bulk on their backend.

## Behaviour

- Confirmation flow (`confirm` slot, `globalThis.confirm` fallback) reused as-is — runs **before** path selection, so the same UX gates both flows
- Selection-after-completion semantics reused: full success → `selection.clear()`, partial failure → `selection.setSelected(failed_ids)` so the user can retry
- `dispatchBulk()` helper maps endpoint-level rejections (network / 4xx / 5xx) to "every id failed against the same root error" — recap shape stays uniform between the two paths so apps don't have to branch on path-taken

## Closes

- #410 — D2 — `<EntitySelectionBar>` bulk action dispatch + recap UX
- Parent feature: #398
- Backend: granit-fx/granit-dotnet#1792 + #1822

## Test plan

- [x] 6 new MSW tests in `selection-bar-bulk.test.tsx`
- [x] **236/236** across `@granit/entities` + `@granit/react-entities` (pre-D2 selection tests still green = regression confirmed)
- [x] Single batched POST with all ids (no per-row calls)
- [x] `recap.parents` populated on full success
- [x] Partial failure: failed ids stay selected, per-id error in `recap.failed[].error`
- [x] Endpoint 403 → all 3 ids surfaced as failed against the same root error; `recap.parents` undefined
- [x] Predicate form gates per action name
- [x] `useBulkEndpoint=false` regression: per-row dispatcher still fires once per id, bulk endpoint not hit
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-entities build` — ESM + dts
