### PR TITLE
feat(react-entities): smart-button cache eviction listener (D3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3011,6 +3011,12 @@
           "signature": "function useEntityDiscovery( options:"
         },
         {
+          "name": "RelationAggregateParentRef",
+          "kind": "interface",
+          "signature": "interface RelationAggregateParentRef",
+          "members": []
+        },
+        {
           "name": "entityManifestQueryKey",
           "kind": "function",
           "signature": "function entityManifestQueryKey( name: string, facets?: readonly EntityFacet[] ): readonly ['entities', 'manifest', string, string | null]"

--- a/packages/@granit/react-entities/src/__tests__/use-invalidate-entity-relation-aggregates.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-invalidate-entity-relation-aggregates.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  parseRelationAggregateParentMarker,
+  useInvalidateEntityRelationAggregates,
+} from '../api/use-invalidate-entity-relation-aggregates.js';
+
+import type { ReactNode } from 'react';
+
+function makeWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { wrapper, queryClient };
+}
+
+describe('parseRelationAggregateParentMarker', () => {
+  it('splits {Entity}:{Id} on the first colon', () => {
+    expect(parseRelationAggregateParentMarker('Party:p-1')).toEqual({
+      entityName: 'Party',
+      entityId: 'p-1',
+    });
+  });
+
+  it('preserves colons inside the id (composite keys)', () => {
+    expect(parseRelationAggregateParentMarker('Party:tenant:p-1')).toEqual({
+      entityName: 'Party',
+      entityId: 'tenant:p-1',
+    });
+  });
+
+  it('returns null for malformed inputs', () => {
+    expect(parseRelationAggregateParentMarker('no-colon')).toBeNull();
+    expect(parseRelationAggregateParentMarker(':missing-entity')).toBeNull();
+    expect(parseRelationAggregateParentMarker('missing-id:')).toBeNull();
+    expect(parseRelationAggregateParentMarker('')).toBeNull();
+  });
+});
+
+describe('useInvalidateEntityRelationAggregates', () => {
+  it('invalidates exactly one prefix query per distinct parent', () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useInvalidateEntityRelationAggregates(), { wrapper });
+    result.current(['Party:p-1', 'Party:p-2', 'Party:p-1', 'Party:p-3']);
+
+    const keys = spy.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['entities', 'relations', 'Party', 'p-1'],
+      ['entities', 'relations', 'Party', 'p-2'],
+      ['entities', 'relations', 'Party', 'p-3'],
+    ]);
+  });
+
+  it('mirrors the backend invariant: 100-row bulk touching 5 parents fires 5 invalidations', () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const parents: string[] = [];
+    for (let i = 0; i < 100; i += 1) {
+      parents.push(`Party:p-${i % 5}`); // 100 markers, 5 distinct
+    }
+
+    const { result } = renderHook(() => useInvalidateEntityRelationAggregates(), { wrapper });
+    result.current(parents);
+
+    expect(spy).toHaveBeenCalledTimes(5);
+  });
+
+  it('accepts pre-parsed structured refs and string markers, mixed', () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useInvalidateEntityRelationAggregates(), { wrapper });
+    result.current([
+      { entityName: 'Party', entityId: 'p-1' },
+      'Party:p-2',
+      { entityName: 'Party', entityId: 'p-1' }, // duplicate of the first, dedup'd
+    ]);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips malformed string markers without throwing', () => {
+    const { wrapper, queryClient } = makeWrapper();
+    const spy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useInvalidateEntityRelationAggregates(), { wrapper });
+    result.current(['Party:p-1', 'no-colon', '', ':bad', 'good:id']);
+
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(spy.mock.calls[0]?.[0]?.queryKey).toEqual(['entities', 'relations', 'Party', 'p-1']);
+    expect(spy.mock.calls[1]?.[0]?.queryKey).toEqual(['entities', 'relations', 'good', 'id']);
+  });
+
+  it('targets every relations-csv variant for a parent (4-element prefix)', () => {
+    const { wrapper, queryClient } = makeWrapper();
+    queryClient.setQueryData(['entities', 'relations', 'Party', 'p-1', null], 'all');
+    queryClient.setQueryData(['entities', 'relations', 'Party', 'p-1', 'Invoices'], 'invoices');
+    queryClient.setQueryData(
+      ['entities', 'relations', 'Party', 'p-1', 'Invoices,Payments'],
+      'pair'
+    );
+    // Different parent — must survive
+    queryClient.setQueryData(['entities', 'relations', 'Party', 'p-2', null], 'untouched');
+    // Different prefix — must survive
+    queryClient.setQueryData(['entities', 'manifest', 'Party'], 'manifest-untouched');
+
+    const { result } = renderHook(() => useInvalidateEntityRelationAggregates(), { wrapper });
+    result.current(['Party:p-1']);
+
+    // The three p-1 caches should be marked stale (isInvalidated=true).
+    const queries = queryClient.getQueryCache().findAll({
+      queryKey: ['entities', 'relations', 'Party', 'p-1'],
+    });
+    expect(queries.length).toBe(3);
+    queries.forEach((q) => expect(q.state.isInvalidated).toBe(true));
+
+    // The unrelated caches stay valid.
+    expect(
+      queryClient
+        .getQueryCache()
+        .find({ queryKey: ['entities', 'relations', 'Party', 'p-2', null] })?.state.isInvalidated
+    ).toBe(false);
+    expect(
+      queryClient.getQueryCache().find({ queryKey: ['entities', 'manifest', 'Party'] })?.state
+        .isInvalidated
+    ).toBe(false);
+  });
+});

--- a/packages/@granit/react-entities/src/api/use-invalidate-entity-relation-aggregates.ts
+++ b/packages/@granit/react-entities/src/api/use-invalidate-entity-relation-aggregates.ts
@@ -1,0 +1,92 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+/**
+ * Parsed shape of one parent marker. Apps may pass either the raw
+ * `"{ParentEntityName}:{ParentId}"` wire form (e.g.
+ * `BulkActionResponse.parents` from D1) or this structured form when
+ * they already have it.
+ */
+export interface RelationAggregateParentRef {
+  readonly entityName: string;
+  readonly entityId: string;
+}
+
+/**
+ * Parse a `"{ParentEntityName}:{ParentId}"` marker as emitted by the
+ * bulk endpoint (granit-fx/granit-dotnet#1792 + #1822). Returns `null`
+ * when the input is malformed (missing colon, empty segments) — apps
+ * should not treat malformed markers as a hard failure since the same
+ * recap can mix valid and malformed entries.
+ *
+ * Ids may legitimately contain `:` (composite keys), so the parse uses
+ * `indexOf` to keep everything after the **first** `:` as the id.
+ */
+export function parseRelationAggregateParentMarker(
+  marker: string
+): RelationAggregateParentRef | null {
+  const i = marker.indexOf(':');
+  if (i <= 0 || i === marker.length - 1) {
+    return null;
+  }
+  return {
+    entityName: marker.slice(0, i),
+    entityId: marker.slice(i + 1),
+  };
+}
+
+/**
+ * Hook returning a function that invalidates **exactly one** relation
+ * aggregate query per distinct parent, given a list of parent markers
+ * (raw `"{Entity}:{Id}"` strings, structured refs, or a mix).
+ *
+ * Mirrors the backend `RelationAggregateCacheInvalidator<TRelated>`
+ * (granit-fx/granit-dotnet#1792) in spirit: a 100-row bulk update
+ * touching 5 parents fires exactly 5 invalidations on the front,
+ * never 100.
+ *
+ * Typical wiring with D2's selection-bar bulk recap:
+ *
+ * ```tsx
+ * const invalidateParents = useInvalidateEntityRelationAggregates();
+ * <EntitySelectionBar
+ *   manifest={…}
+ *   useBulkEndpoint
+ *   onComplete={(_action, recap) => {
+ *     if (recap.parents) invalidateParents(recap.parents);
+ *   }}
+ * />
+ * ```
+ *
+ * Apps that own per-row mutations (no bulk path) call this with the
+ * parent refs they computed from their typed payload — the framework
+ * intentionally doesn't ship a child→parent topology resolver since
+ * the wire manifest doesn't expose the FK predicate.
+ */
+export function useInvalidateEntityRelationAggregates(): (
+  parents: readonly (string | RelationAggregateParentRef)[]
+) => void {
+  const queryClient = useQueryClient();
+
+  return useCallback(
+    (parents) => {
+      const seen = new Set<string>();
+      for (const raw of parents) {
+        const ref = typeof raw === 'string' ? parseRelationAggregateParentMarker(raw) : raw;
+        if (!ref) continue;
+        const dedupKey = `${ref.entityName}:${ref.entityId}`;
+        if (seen.has(dedupKey)) continue;
+        seen.add(dedupKey);
+        // 4-element prefix invalidates every relations-csv variant
+        // (full-relation pull + any subset query) for this parent in
+        // one call. Mirrors the comment on
+        // entityRelationAggregatesQueryKey(): a 4-element prefix
+        // "blasts every variant when the source row mutates".
+        queryClient.invalidateQueries({
+          queryKey: ['entities', 'relations', ref.entityName, ref.entityId],
+        });
+      }
+    },
+    [queryClient]
+  );
+}

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -71,6 +71,11 @@ export {
   entityRelationAggregatesQueryKey,
   useEntityRelationAggregates,
 } from './api/use-entity-relation-aggregates.js';
+export {
+  parseRelationAggregateParentMarker,
+  useInvalidateEntityRelationAggregates,
+} from './api/use-invalidate-entity-relation-aggregates.js';
+export type { RelationAggregateParentRef } from './api/use-invalidate-entity-relation-aggregates.js';
 export { entityManifestQueryKey, useEntityMetadata } from './api/use-entity-metadata.js';
 export { useEntityForm } from './hooks/index.js';
 export type { UseEntityFormOptions, UseEntityFormReturn } from './hooks/index.js';


### PR DESCRIPTION
## Summary

Closes the front side of relation-aggregate invalidation ([granit-fx/granit-dotnet#1792](https://github.com/granit-fx/granit-dotnet/issues/1792)). Mirrors the backend `RelationAggregateCacheInvalidator<TRelated>` in spirit: **a 100-row bulk update touching 5 parents fires exactly 5 invalidations on the front, never 100**.

## API

### `useInvalidateEntityRelationAggregates()`

Returns a function `(parents: readonly (string | RelationAggregateParentRef)[]) => void` that:

1. Dedups by `entityName + entityId`
2. Fires `queryClient.invalidateQueries({ queryKey: ['entities', 'relations', name, id] })`

The **4-element prefix** matches every relations-csv variant (full pull + any subset query) cached for that parent in one call — apps don't have to track which subset queries were active.

### `parseRelationAggregateParentMarker(marker)`

Parses the `"{Entity}:{Id}"` wire form returned by `BulkActionResponse.parents` (D1). Tolerant of composite ids (colons inside the id are preserved past the **first** colon); returns `null` on malformed input so a single bad marker doesn't crash the recap handler.

### `RelationAggregateParentRef` type

Pre-parsed shape; the hook accepts a mix of strings and structured refs in one call.

## Wiring with D2

```tsx
const invalidateParents = useInvalidateEntityRelationAggregates();

<EntitySelectionBar
  manifest={…}
  useBulkEndpoint
  onComplete={(_action, recap) => {
    if (recap.parents) invalidateParents(recap.parents);
  }}
/>
```

For per-row mutations (no bulk path), apps call the invalidator from their typed mutation `onSuccess` with the parent refs they computed from the response payload.

## Topology resolver out of scope (deliberately)

The wire `EntityRelationManifest` carries `targetEntityName` and `aggregates` but **not** the FK predicate (typed C# on backend). Without that, the framework can't derive the parent id from a child write payload. The bulk endpoint already returns the resolved parents — that's the only path where the framework owns the resolution. Per-row mutations rely on app-supplied mapping (the app already has the typed payload).

## Closes

- #411 — D3 — Smart-button cache eviction listener
- Parent feature: #398
- Backend: granit-fx/granit-dotnet#1792

## Test plan

- [x] 8 new unit tests, **227/227** across `@granit/react-entities`
- [x] Dedup: 100 markers (5 distinct) → 5 invalidations
- [x] Parser: split on first colon, composite ids preserved, null on malformed (no-colon, empty entity, empty id, empty input)
- [x] Mixed inputs (strings + structured refs) dedup'd correctly
- [x] Malformed strings skipped, valid markers in the same call still fire
- [x] **Prefix isolation**: all relations-csv variants for the target parent stale; unrelated parent + foreign cache prefix (`['entities', 'manifest', …]`) survive
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-entities build` — ESM + dts
