### PR TITLE
feat(react-entities): selection bar i18n + labels override + dod (D4)

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/locales.test.ts
+++ b/packages/@granit/react-entities/src/__tests__/locales.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { entitiesTranslationsEn } from '../locales/en.js';
+import { entitiesTranslationsFr } from '../locales/fr.js';
+
+/** Walk an object tree and collect all leaf paths (`'A.B.C'`). */
+function leafPaths(obj: unknown, prefix = ''): readonly string[] {
+  if (typeof obj !== 'object' || obj === null) {
+    return [prefix];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, value]) =>
+    leafPaths(value, prefix ? `${prefix}.${key}` : key)
+  );
+}
+
+describe('entities locale bundles', () => {
+  it('en covers the SelectionBar + BulkAction.Recap surfaces', () => {
+    expect(Object.keys(entitiesTranslationsEn).sort()).toEqual(['BulkAction', 'SelectionBar']);
+    expect(entitiesTranslationsEn.SelectionBar.SelectedSummary).toContain('{{count}}');
+    expect(entitiesTranslationsEn.BulkAction.Recap.PartialFailure).toContain('{{succeeded}}');
+    expect(entitiesTranslationsEn.BulkAction.Recap.PartialFailure).toContain('{{failed}}');
+  });
+
+  it('fr provides every key declared in en (no missing translations)', () => {
+    const enPaths = new Set(leafPaths(entitiesTranslationsEn));
+    const frPaths = new Set(leafPaths(entitiesTranslationsFr));
+
+    const missingInFr = [...enPaths].filter((p) => !frPaths.has(p));
+    const extraInFr = [...frPaths].filter((p) => !enPaths.has(p));
+
+    expect(missingInFr).toEqual([]);
+    expect(extraInFr).toEqual([]);
+  });
+
+  it('preserves interpolation placeholders across locales', () => {
+    expect(entitiesTranslationsFr.SelectionBar.SelectedSummary).toContain('{{count}}');
+    expect(entitiesTranslationsFr.BulkAction.Recap.PartialFailure).toContain('{{succeeded}}');
+    expect(entitiesTranslationsFr.BulkAction.Recap.PartialFailure).toContain('{{failed}}');
+    expect(entitiesTranslationsFr.BulkAction.Recap.FullFailure).toContain('{{count}}');
+  });
+
+  it('exposes _one and _other plural variants for count-driven keys', () => {
+    // i18next plural key suffixes for every key that takes `count`
+    expect(entitiesTranslationsEn.SelectionBar.SelectedSummary_one).toBeTruthy();
+    expect(entitiesTranslationsEn.SelectionBar.SelectedSummary_other).toBeTruthy();
+    expect(entitiesTranslationsFr.SelectionBar.SelectedSummary_one).toBeTruthy();
+    expect(entitiesTranslationsFr.SelectionBar.SelectedSummary_other).toBeTruthy();
+    expect(entitiesTranslationsEn.BulkAction.Recap.Success_one).toBeTruthy();
+    expect(entitiesTranslationsEn.BulkAction.Recap.FullFailure_one).toBeTruthy();
+  });
+});

--- a/packages/@granit/react-entities/src/__tests__/selection-bar-labels.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/selection-bar-labels.test.tsx
@@ -1,0 +1,112 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { render, screen } from '@testing-library/react';
+import axios from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import { EntitySelectionBar } from '../components/entity-selection-bar.js';
+import { SelectionProvider } from '../selection/selection-provider.js';
+
+import type {
+  EntityActionManifest,
+  EntityManifestResponse,
+  EntitySelectionActionManifest,
+} from '@granit/entities';
+import type { ReactNode } from 'react';
+
+const ENTITY_NAME = 'Granit.Sales.Quote';
+
+function makeAction(): EntityActionManifest {
+  return {
+    name: 'archive',
+    kind: 'ApiCall',
+    displayKey: null,
+    icon: null,
+    order: 0,
+    urlTemplate: '/api/quotes/{id}/archive',
+    httpMethod: 'POST',
+    confirmationKey: null,
+    workflowTransitionName: null,
+    contributorAssemblyName: null,
+  };
+}
+
+function makeRef(): EntitySelectionActionManifest {
+  return {
+    name: 'archive',
+    displayKey: null,
+    icon: null,
+    confirmationKey: null,
+    contributorAssemblyName: null,
+  };
+}
+
+function makeManifest(): EntityManifestResponse {
+  return {
+    schemaVersion: 1,
+    identity: {
+      name: ENTITY_NAME,
+      entityClrType: 'Granit.Sales.Domain.Quote',
+      displayKey: null,
+      icon: null,
+      permissionGroup: null,
+      displayProperty: 'name',
+      subtitleProperty: null,
+    },
+    permissions: null,
+    forms: null,
+    details: null,
+    collections: {
+      query: null,
+      export: null,
+      metrics: [],
+      dashboards: [],
+      defaultViewId: null,
+      listLayouts: [],
+      headerActions: [],
+      selectionActions: [makeRef()],
+    },
+    relations: null,
+    actions: [makeAction()],
+  };
+}
+
+function makeWrapper() {
+  const apiClient = axios.create({ baseURL: 'http://localhost' });
+  return ({ children }: { children: ReactNode }) => (
+    <GranitClientProvider client={apiClient}>{children}</GranitClientProvider>
+  );
+}
+
+describe('<EntitySelectionBar> — labels', () => {
+  it('renders the English defaults when no labels prop is supplied', () => {
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
+          <EntitySelectionBar manifest={makeManifest()} />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    expect(screen.getByText('3 selected')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Clear selection' })).toBeDefined();
+  });
+
+  it('honors selectedSummary + clearSelection overrides (e.g. wired from t())', () => {
+    const Wrapper = makeWrapper();
+    render(
+      <Wrapper>
+        <SelectionProvider initialSelectedIds={['q1', 'q2']}>
+          <EntitySelectionBar
+            manifest={makeManifest()}
+            labels={{
+              selectedSummary: (n) => `${n} sélectionnés`,
+              clearSelection: 'Effacer la sélection',
+            }}
+          />
+        </SelectionProvider>
+      </Wrapper>
+    );
+    expect(screen.getByText('2 sélectionnés')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Effacer la sélection' })).toBeDefined();
+  });
+});

--- a/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
@@ -90,9 +90,38 @@ export interface EntitySelectionBarProps {
    * Default: `false` (per-row fan-out — the pre-D2 behaviour).
    */
   readonly useBulkEndpoint?: BulkDispatchPredicate;
+  /**
+   * Override the English defaults for the visible labels (selection
+   * summary + clear button). Apps wire `t('entities:SelectionBar.*')`
+   * results here from the bundles shipped under `@granit/react-entities`'s
+   * `'entities'` namespace.
+   */
+  readonly labels?: EntitySelectionBarLabels;
   /** Optional class for the root element. */
   readonly className?: string;
 }
+
+/**
+ * App-supplied label overrides for `<EntitySelectionBar>`. Each entry
+ * is optional — omitted keys fall back to English defaults. Shipped
+ * separately from the catalog so apps can pass `t()` results directly
+ * (with i18next plural resolution baked in via `t('…', { count })`).
+ */
+export interface EntitySelectionBarLabels {
+  /**
+   * Summary string rendered next to the selected count. Receives the
+   * count so apps can pluralize via `t('entities:SelectionBar.SelectedSummary', { count })`.
+   * Default: `"{count} selected"`.
+   */
+  readonly selectedSummary?: (count: number) => string;
+  /** Label for the clear-selection button. Default: `"Clear selection"`. */
+  readonly clearSelection?: string;
+}
+
+const DEFAULT_LABELS: Required<EntitySelectionBarLabels> = {
+  selectedSummary: (count) => `${count} selected`,
+  clearSelection: 'Clear selection',
+};
 
 /**
  * Selection-bar surface — appears whenever the row-selection set is
@@ -129,8 +158,10 @@ export function EntitySelectionBar({
   onComplete,
   confirm,
   useBulkEndpoint,
+  labels,
   className,
 }: EntitySelectionBarProps): ReactNode {
+  const mergedLabels = { ...DEFAULT_LABELS, ...labels };
   const dispatch = useEntityActionDispatcher(handlers);
   const client = useGranitClient();
   const selection = useSelection();
@@ -206,7 +237,9 @@ export function EntitySelectionBar({
       data-selected-count={selection.size}
       className={className}
     >
-      <span data-granit-selection-bar-summary="">{selection.size} selected</span>
+      <span data-granit-selection-bar-summary="">
+        {mergedLabels.selectedSummary(selection.size)}
+      </span>
       {selectionActions.map((ref) => {
         const action = resolveAction(ref, manifest.actions);
         if (!action) return null;
@@ -239,7 +272,7 @@ export function EntitySelectionBar({
         onClick={() => selection.clear()}
         disabled={running !== null}
       >
-        Clear selection
+        {mergedLabels.clearSelection}
       </button>
     </div>
   );

--- a/packages/@granit/react-entities/src/index.ts
+++ b/packages/@granit/react-entities/src/index.ts
@@ -51,6 +51,8 @@ export {
   SELECTION_FANOUT_CONCURRENCY_CAP,
 } from './components/entity-selection-bar.js';
 export type {
+  BulkDispatchPredicate,
+  EntitySelectionBarLabels,
   EntitySelectionBarProps,
   EntitySelectionBarRecap,
 } from './components/entity-selection-bar.js';
@@ -65,6 +67,10 @@ export {
 } from './field-components/index.js';
 export type { SelectComponentOption } from './field-components/index.js';
 export { executeBulkAction } from './api/bulk-action.js';
+
+// i18n resource bundles (namespace: 'entities')
+export { entitiesTranslationsEn, entitiesTranslationsFr } from './locales/index.js';
+export type { EntitiesTranslations } from './locales/index.js';
 export { entityCalendarQueryKey, useEntityCalendar } from './api/use-entity-calendar.js';
 export { entityDiscoveryQueryKey, useEntityDiscovery } from './api/use-entity-discovery.js';
 export {

--- a/packages/@granit/react-entities/src/locales/en.ts
+++ b/packages/@granit/react-entities/src/locales/en.ts
@@ -1,0 +1,57 @@
+/**
+ * English translation bundle for `@granit/react-entities`. Consumers
+ * register it via:
+ *
+ *   i18n.addResourceBundle('en', 'entities', entitiesTranslationsEn);
+ *
+ * Components in this package don't call `useTranslation` directly —
+ * they expose `labels` props (when needed) that apps populate from
+ * `t()` calls. This keeps components testable without an i18next
+ * bootstrap and consistent with the headless conventions of the rest
+ * of the framework (see `@granit/react-activities`).
+ *
+ * Scope of the v1 catalog: surfaces shipped through Phase 2 streams
+ * (selection bar + bulk action recap UX). Future stories extend the
+ * bundle in place.
+ */
+export const entitiesTranslationsEn: EntitiesTranslations = {
+  SelectionBar: {
+    SelectedSummary: '{{count}} selected',
+    SelectedSummary_one: '1 selected',
+    SelectedSummary_other: '{{count}} selected',
+    ClearSelection: 'Clear selection',
+  },
+  BulkAction: {
+    Recap: {
+      Success: 'All {{count}} succeeded',
+      Success_one: '1 succeeded',
+      Success_other: 'All {{count}} succeeded',
+      PartialFailure: '{{succeeded}} succeeded, {{failed}} failed',
+      FullFailure: '{{count}} failed',
+      FullFailure_one: '1 failed',
+      FullFailure_other: '{{count}} failed',
+      Rejected: 'Action rejected — none of the rows could be processed',
+    },
+  },
+};
+
+export interface EntitiesTranslations {
+  readonly SelectionBar: {
+    readonly SelectedSummary: string;
+    readonly SelectedSummary_one: string;
+    readonly SelectedSummary_other: string;
+    readonly ClearSelection: string;
+  };
+  readonly BulkAction: {
+    readonly Recap: {
+      readonly Success: string;
+      readonly Success_one: string;
+      readonly Success_other: string;
+      readonly PartialFailure: string;
+      readonly FullFailure: string;
+      readonly FullFailure_one: string;
+      readonly FullFailure_other: string;
+      readonly Rejected: string;
+    };
+  };
+}

--- a/packages/@granit/react-entities/src/locales/fr.ts
+++ b/packages/@granit/react-entities/src/locales/fr.ts
@@ -1,0 +1,28 @@
+import type { EntitiesTranslations } from './en.js';
+
+/**
+ * French translation bundle for `@granit/react-entities`. Consumers
+ * register it via:
+ *
+ *   i18n.addResourceBundle('fr', 'entities', entitiesTranslationsFr);
+ */
+export const entitiesTranslationsFr: EntitiesTranslations = {
+  SelectionBar: {
+    SelectedSummary: '{{count}} sélectionnés',
+    SelectedSummary_one: '1 sélectionné',
+    SelectedSummary_other: '{{count}} sélectionnés',
+    ClearSelection: 'Effacer la sélection',
+  },
+  BulkAction: {
+    Recap: {
+      Success: 'Les {{count}} lignes ont été traitées',
+      Success_one: '1 ligne traitée',
+      Success_other: 'Les {{count}} lignes ont été traitées',
+      PartialFailure: '{{succeeded}} traitées, {{failed}} en échec',
+      FullFailure: '{{count}} en échec',
+      FullFailure_one: '1 en échec',
+      FullFailure_other: '{{count}} en échec',
+      Rejected: 'Action refusée — aucune ligne n’a pu être traitée',
+    },
+  },
+};

--- a/packages/@granit/react-entities/src/locales/index.ts
+++ b/packages/@granit/react-entities/src/locales/index.ts
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------------
+// @granit/react-entities — i18next resource bundles (namespace: "entities")
+// ---------------------------------------------------------------------------
+//
+// Consumers register the bundles with their i18n instance:
+//
+//   import { entitiesTranslationsEn, entitiesTranslationsFr } from '@granit/react-entities';
+//   i18n.addResourceBundle('en', 'entities', entitiesTranslationsEn);
+//   i18n.addResourceBundle('fr', 'entities', entitiesTranslationsFr);
+//
+// Components in this package don't call `useTranslation` directly — they
+// expose `labels` props (when needed) that apps populate from `t()`
+// results. This keeps components testable without an i18next bootstrap
+// and consistent with the headless conventions of the rest of the
+// framework.
+// ---------------------------------------------------------------------------
+
+export { entitiesTranslationsEn } from './en.js';
+export type { EntitiesTranslations } from './en.js';
+export { entitiesTranslationsFr } from './fr.js';


### PR DESCRIPTION
## Summary

Closes the **D stream** of Phase 2 (D1 → D4 — bulk action + relation-cache eviction).

## What's in this PR

### i18n bundles (en + fr) — `entities` namespace

`@granit/react-entities` now ships en + fr resource bundles, scoped to the v1 surfaces touched by D:

```
SelectionBar.SelectedSummary       (with _one / _other plurals)
SelectionBar.ClearSelection
BulkAction.Recap.Success           (with _one / _other plurals)
BulkAction.Recap.PartialFailure    ({{succeeded}} / {{failed}})
BulkAction.Recap.FullFailure       (with _one / _other plurals)
BulkAction.Recap.Rejected
```

Apps register via:

```ts
import { entitiesTranslationsEn, entitiesTranslationsFr } from '@granit/react-entities';
i18n.addResourceBundle('en', 'entities', entitiesTranslationsEn);
i18n.addResourceBundle('fr', 'entities', entitiesTranslationsFr);
```

Both bundles satisfy a shared `EntitiesTranslations` interface — adding a locale is one typed file checked at compile time. Future Phase 2/3 stories extend the bundle in place.

### `<EntitySelectionBar>` — `labels` override prop

```tsx
const { t } = useTranslation('entities');

<EntitySelectionBar
  manifest={…}
  labels={{
    selectedSummary: (count) => t('SelectionBar.SelectedSummary', { count }),
    clearSelection: t('SelectionBar.ClearSelection'),
  }}
/>
```

`selectedSummary` is a function so apps can resolve plurals via `t('…', { count })`. Defaults match the pre-D4 English literals — existing consumers see no behaviour change.

`BulkAction.Recap.*` keys are app-rendered (the framework only emits `recap` through `onComplete`); apps wire their toast/notification UI from those strings.

### Other

`BulkDispatchPredicate` type now also exported from the package barrel (DX fix surfaced while the i18n surface was being added).

## Closes

- #412 — D4 — i18n + DoD
- Parent feature: #398
- Wraps the full D-stream front delivery (D1 → D4)

## Cumulative DoD (D-stream)

- [x] `pnpm tsc` — green workspace-wide
- [x] `pnpm lint --max-warnings 0` — green
- [x] `pnpm vitest run packages/@granit/react-entities` — **233/233**, 29 test files (all D-stream prior tests still green)
- [x] `pnpm -F @granit/entities build` + `pnpm -F @granit/react-entities build` — ESM + dts
- [x] No new third-party deps introduced
- [x] All 4 PRs targeted `develop`, never `main`

## Test plan

- [x] `locales.test.ts` — 4 tests: top-level keys, en/fr leaf-path drift, placeholder preservation, plural variants present
- [x] `selection-bar-labels.test.tsx` — 2 tests: English defaults render, `labels` override rendering
- [x] No regression on `selection-bar-bulk.test.tsx` (D2) or `selection.test.tsx`
