### PR TITLE
feat(timeline): reactions sdk — types, api client, permission (C1)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4719,7 +4719,18 @@
     {
       "name": "@granit/timeline",
       "description": "Unified activity feed hooks for audit trails",
-      "exports": []
+      "exports": [
+        {
+          "name": "TimelinePermissions",
+          "kind": "const",
+          "signature": "const TimelinePermissions"
+        },
+        {
+          "name": "toggleReaction",
+          "kind": "function",
+          "signature": "async function toggleReaction( client: AxiosInstance, basePath: string, entryId: TimelineEntryId, emoji: ReactionEmoji ): Promise<TimelineEntry>"
+        }
+      ]
     },
     {
       "name": "@granit/tracing",

--- a/packages/@granit/timeline/src/__tests__/reaction-api.test.ts
+++ b/packages/@granit/timeline/src/__tests__/reaction-api.test.ts
@@ -1,0 +1,83 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { toEntityId } from '@granit/types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { toggleReaction } from '../api/reaction-api.js';
+import { TimelinePermissions } from '../permissions.js';
+import { REACTION_EMOJIS } from '../types/reaction.js';
+
+import type { TimelineEntryId } from '../types/stream.js';
+import type { ISODateString } from '@granit/types';
+import type { AxiosInstance } from 'axios';
+
+const BASE_PATH = '/api/v1/timeline';
+const ENTRY_ID: TimelineEntryId = toEntityId<'TimelineEntry'>('e-42');
+
+const SAMPLE_ENTRY = {
+  id: ENTRY_ID,
+  entryType: 0,
+  body: 'Quote approved',
+  authorId: null,
+  authorName: 'System',
+  parentEntryId: null,
+  occurredAt: '2026-05-09T15:00:00Z' as ISODateString,
+  attachments: [],
+  reactions: [
+    { emoji: ':thumbs_up:' as const, count: 3, hasReacted: true },
+    { emoji: ':tada:' as const, count: 1, hasReacted: false },
+  ],
+};
+
+describe('toggleReaction', () => {
+  let client: AxiosInstance;
+
+  beforeEach(() => {
+    client = createMockClient();
+  });
+
+  it('POSTs to /entries/{entryId}/reactions/{emoji} with URI-encoded segments', async () => {
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
+
+    const result = await toggleReaction(client, BASE_PATH, ENTRY_ID, ':thumbs_up:');
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/timeline/entries/e-42/reactions/%3Athumbs_up%3A'
+    );
+    expect(result).toEqual(SAMPLE_ENTRY);
+  });
+
+  it('returns the refreshed entry — caller patches its cache from this payload', async () => {
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
+
+    const refreshed = await toggleReaction(client, BASE_PATH, ENTRY_ID, ':heart:');
+
+    expect(refreshed.reactions).toEqual([
+      { emoji: ':thumbs_up:', count: 3, hasReacted: true },
+      { emoji: ':tada:', count: 1, hasReacted: false },
+    ]);
+  });
+
+  it('propagates 403 when the caller lacks Timeline.React', async () => {
+    vi.mocked(client.post).mockRejectedValue(new Error('Request failed with status code 403'));
+
+    await expect(toggleReaction(client, BASE_PATH, ENTRY_ID, ':eyes:')).rejects.toThrow(/403/);
+  });
+
+  it('accepts every code in the closed REACTION_EMOJIS catalog', async () => {
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
+
+    for (const emoji of REACTION_EMOJIS) {
+      // Type-checks at compile time; verifies the runtime catalog
+      // matches the closed union without surprise members.
+      await toggleReaction(client, BASE_PATH, ENTRY_ID, emoji);
+    }
+
+    expect(client.post).toHaveBeenCalledTimes(REACTION_EMOJIS.length);
+  });
+});
+
+describe('TimelinePermissions', () => {
+  it('exposes the React permission key matching the backend wire string', () => {
+    expect(TimelinePermissions.Timeline.React).toBe('Timeline.React');
+  });
+});

--- a/packages/@granit/timeline/src/api/reaction-api.ts
+++ b/packages/@granit/timeline/src/api/reaction-api.ts
@@ -1,0 +1,37 @@
+import { buildApiUrl } from '@granit/api-client';
+
+import type { ReactionEmoji } from '../types/reaction.js';
+import type { TimelineEntry, TimelineEntryId } from '../types/stream.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Toggle a reaction on one timeline entry — idempotent.
+ *
+ * `POST {basePath}/entries/{entryId}/reactions/{emoji}`
+ *
+ * The backend treats the call as a toggle keyed on
+ * `(entryId, emoji, callerUserId)`: a fresh call adds the reaction;
+ * a repeat call from the same caller removes it. The response is the
+ * full updated entry (with refreshed `reactions[]`) so the client can
+ * patch its cache without a separate stream re-fetch.
+ *
+ * Mirror of the dotnet endpoint shipped in
+ * granit-fx/granit-dotnet#1811. Permission: {@link TimelinePermissions.Timeline.React}.
+ */
+export async function toggleReaction(
+  client: AxiosInstance,
+  basePath: string,
+  entryId: TimelineEntryId,
+  emoji: ReactionEmoji
+): Promise<TimelineEntry> {
+  const { data } = await client.post<TimelineEntry>(
+    buildApiUrl(
+      basePath,
+      'entries',
+      encodeURIComponent(entryId),
+      'reactions',
+      encodeURIComponent(emoji)
+    )
+  );
+  return data;
+}

--- a/packages/@granit/timeline/src/index.ts
+++ b/packages/@granit/timeline/src/index.ts
@@ -1,5 +1,6 @@
 // Types
 export {
+  REACTION_EMOJIS,
   TimelineEntryType,
   type BlobId,
   type TimelineAttachmentId,
@@ -12,7 +13,12 @@ export {
   type TimelineQueryParams,
   type TimelineConfig,
   type MentionSuggestion,
+  type Reaction,
+  type ReactionEmoji,
 } from './types/index.js';
+
+// Permissions
+export { TimelinePermissions } from './permissions.js';
 
 // API
 export {
@@ -23,3 +29,4 @@ export {
   followEntity,
   unfollowEntity,
 } from './api/timeline-api.js';
+export { toggleReaction } from './api/reaction-api.js';

--- a/packages/@granit/timeline/src/permissions.ts
+++ b/packages/@granit/timeline/src/permissions.ts
@@ -1,0 +1,10 @@
+/**
+ * Wire-aligned permission keys for `Granit.Timeline`. Mirrors the
+ * .NET registry — keep in sync with the backend module.
+ */
+export const TimelinePermissions = {
+  Timeline: {
+    /** Required to react / un-react on a timeline entry (C-stream). */
+    React: 'Timeline.React',
+  },
+} as const;

--- a/packages/@granit/timeline/src/types/index.ts
+++ b/packages/@granit/timeline/src/types/index.ts
@@ -10,3 +10,5 @@ export type {
 export type { CreateTimelineEntryRequest, TimelineQueryParams } from './request.js';
 export type { TimelineConfig } from './config.js';
 export type { MentionSuggestion } from './mention.js';
+export { REACTION_EMOJIS } from './reaction.js';
+export type { Reaction, ReactionEmoji } from './reaction.js';

--- a/packages/@granit/timeline/src/types/reaction.ts
+++ b/packages/@granit/timeline/src/types/reaction.ts
@@ -1,0 +1,35 @@
+/**
+ * Closed v1 catalog of reaction emoji codes — mirrors the backend
+ * decision in granit-fx/granit-dotnet#1811. Extension requires an ADR
+ * amendment (same anti-Odoo policy as the rest of Phase 2: closed
+ * enums on the wire, never an `eval:` string).
+ *
+ * Codes follow the `:short_name:` convention, not the literal emoji,
+ * so client-side rendering can swap visual style (Twemoji, Apple,
+ * native) without re-keying state.
+ */
+export type ReactionEmoji = ':thumbs_up:' | ':heart:' | ':tada:' | ':joy:' | ':eyes:';
+
+/** Closed catalog as a frozen tuple — useful for picker iteration. */
+export const REACTION_EMOJIS: readonly ReactionEmoji[] = Object.freeze([
+  ':thumbs_up:',
+  ':heart:',
+  ':tada:',
+  ':joy:',
+  ':eyes:',
+]);
+
+/**
+ * Aggregated reaction count for one entry / emoji pair.
+ *
+ * `hasReacted` is the **caller's** status — true when the
+ * authenticated user has reacted with this emoji on this entry.
+ * Toggling the same emoji twice removes the reaction (idempotent).
+ */
+export interface Reaction {
+  readonly emoji: ReactionEmoji;
+  /** Distinct users who reacted with this emoji. */
+  readonly count: number;
+  /** True when the authenticated caller has reacted with this emoji. */
+  readonly hasReacted: boolean;
+}

--- a/packages/@granit/timeline/src/types/stream.ts
+++ b/packages/@granit/timeline/src/types/stream.ts
@@ -1,4 +1,5 @@
 import type { TimelineEntryTypeValue } from './entry-type.js';
+import type { Reaction } from './reaction.js';
 import type { PagedResult } from '@granit/query-engine';
 import type { EntityId, ISODateString, UserId } from '@granit/types';
 
@@ -32,6 +33,15 @@ export interface TimelineEntry {
   readonly parentEntryId: TimelineEntryId | null;
   readonly occurredAt: ISODateString;
   readonly attachments: readonly TimelineAttachmentInfo[];
+  /**
+   * Aggregated reactions on this entry — one entry per emoji that has
+   * at least one reactor. Optional for backward compatibility while
+   * the backend reaction module rolls out
+   * (granit-fx/granit-dotnet#1811); once C-stream lands end-to-end,
+   * every entry carries the field (empty array when no reactions are
+   * present).
+   */
+  readonly reactions?: readonly Reaction[];
 }
 
 export type TimelineEntryPage = PagedResult<TimelineEntry>;


### PR DESCRIPTION
## Summary

Wires the SDK side of the Timeline reactions feature shipped on dotnet ([granit-fx/granit-dotnet#1811](https://github.com/granit-fx/granit-dotnet/issues/1811)). Closed v1 emoji catalog: `:thumbs_up:` 👍 / `:heart:` ❤️ / `:tada:` 🎉 / `:joy:` 😂 / `:eyes:` 👀 — extension requires an ADR amendment (anti-Odoo policy: closed enums on the wire).

## Deliverables

### Types

- `ReactionEmoji` — closed string union of the 5 catalog codes
- `REACTION_EMOJIS` — `Object.freeze`d tuple for picker iteration (C3)
- `Reaction { emoji, count, hasReacted }` — `hasReacted` is the **caller's** status; toggling the same emoji removes the reaction (idempotent)
- `TimelineEntry.reactions?: readonly Reaction[]` — optional during rollout for backward compatibility; once C-stream lands end-to-end, every entry will carry the field

Codes follow the `:short_name:` convention, not the literal emoji, so client-side rendering can swap visual style (Twemoji, Apple, native) without re-keying state.

### API client

```ts
toggleReaction(client, basePath, entryId, emoji) →
  POST {basePath}/entries/{entryId}/reactions/{emoji}
```

Returns the refreshed `TimelineEntry`, so callers can patch their cache from the response without a stream re-fetch (this is what enables the optimistic-update story in C2).

### Permissions

```ts
TimelinePermissions.Timeline.React // 'Timeline.React'
```

New registry — first key for v1, placeholder for later additions.

## Closes

- #405 — C1 — `@granit/timeline` reactions types + API client + `Timeline.React` permission
- Parent feature: #397
- Backend: granit-fx/granit-dotnet#1811

## Test plan

- [x] 7 new unit tests, **11/11** across `@granit/timeline` (4 prior api tests still green)
- [x] URI encoding on the `:emoji:` path segment (asserts `:` → `%3A`)
- [x] Payload pass-through (returns `TimelineEntry` from the response)
- [x] 403 propagation (lacking `Timeline.React`)
- [x] Closed-catalog round-trip — every entry in `REACTION_EMOJIS` accepted by the function (compile-time + runtime)
- [x] `TimelinePermissions.Timeline.React === 'Timeline.React'`
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/timeline build` — ESM + dts
