### PR TITLE
feat(react-timeline): useToggleReaction with scoped optimistic cache + rollback (C2)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4272,6 +4272,22 @@
           "name": "useTimelineFollowers",
           "kind": "function",
           "signature": "function useTimelineFollowers("
+        },
+        {
+          "name": "toggleReactionList",
+          "kind": "function",
+          "signature": "function toggleReactionList( reactions: readonly Reaction[] | undefined, emoji: ReactionEmoji ): readonly Reaction[]"
+        },
+        {
+          "name": "useToggleReaction",
+          "kind": "function",
+          "signature": "function useToggleReaction(): UseMutationResult< TimelineEntry, Error, ToggleReactionVariables, ToggleReactionContext >"
+        },
+        {
+          "name": "ToggleReactionVariables",
+          "kind": "interface",
+          "signature": "interface ToggleReactionVariables",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
@@ -1,0 +1,201 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { toEntityId } from '@granit/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { toggleReactionList, useToggleReaction } from '../hooks/use-toggle-reaction.js';
+import { TimelineProvider } from '../providers/timeline-provider.js';
+
+import type { Reaction, TimelineEntry, TimelineEntryId, TimelineEntryPage } from '@granit/timeline';
+import type { ISODateString } from '@granit/types';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const ENTRY_ID = toEntityId<'TimelineEntry'>('e-1') as TimelineEntryId;
+const OTHER_ENTRY_ID = toEntityId<'TimelineEntry'>('e-99') as TimelineEntryId;
+
+function makeEntry(id: TimelineEntryId, reactions: readonly Reaction[] = []): TimelineEntry {
+  return {
+    id,
+    entryType: 0,
+    body: `entry ${id}`,
+    authorId: null,
+    authorName: null,
+    parentEntryId: null,
+    occurredAt: '2026-05-09T15:00:00Z' as ISODateString,
+    attachments: [],
+    reactions,
+  };
+}
+
+function makePage(items: readonly TimelineEntry[]): TimelineEntryPage {
+  return { items, totalCount: items.length, nextCursor: null };
+}
+
+interface Harness {
+  readonly client: AxiosInstance;
+  readonly queryClient: QueryClient;
+  readonly wrapper: (props: { children: ReactNode }) => React.ReactElement;
+}
+
+function createHarness(): Harness {
+  const client = createMockClient();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <TimelineProvider config={{ client }}>{children}</TimelineProvider>
+    );
+  return { client, queryClient, wrapper };
+}
+
+describe('toggleReactionList', () => {
+  it('adds a fresh reaction with count=1, hasReacted=true', () => {
+    expect(toggleReactionList(undefined, ':thumbs_up:')).toEqual([
+      { emoji: ':thumbs_up:', count: 1, hasReacted: true },
+    ]);
+  });
+
+  it('increments count + flips hasReacted when caller had not reacted', () => {
+    const before: Reaction[] = [{ emoji: ':heart:', count: 5, hasReacted: false }];
+    expect(toggleReactionList(before, ':heart:')).toEqual([
+      { emoji: ':heart:', count: 6, hasReacted: true },
+    ]);
+  });
+
+  it('decrements count + flips hasReacted when caller had reacted', () => {
+    const before: Reaction[] = [{ emoji: ':tada:', count: 3, hasReacted: true }];
+    expect(toggleReactionList(before, ':tada:')).toEqual([
+      { emoji: ':tada:', count: 2, hasReacted: false },
+    ]);
+  });
+
+  it('removes the entry entirely when toggling off the last reactor', () => {
+    const before: Reaction[] = [{ emoji: ':eyes:', count: 1, hasReacted: true }];
+    expect(toggleReactionList(before, ':eyes:')).toEqual([]);
+  });
+});
+
+describe('useToggleReaction — optimistic update', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('patches every cached page in the surrounding stream before the network resolves', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    const initial = makePage([makeEntry(ENTRY_ID), makeEntry(OTHER_ENTRY_ID)]);
+    queryClient.setQueryData(['timeline', 'Quote', 'q-1'], initial);
+
+    let resolveNetwork: (value: TimelineEntry) => void = () => {};
+    const networkPromise = new Promise<TimelineEntry>((resolve) => {
+      resolveNetwork = resolve;
+    });
+    vi.mocked(client.post).mockImplementation(
+      async () => axiosResponse(await networkPromise) as Awaited<ReturnType<typeof client.post>>
+    );
+
+    const { result } = renderHook(() => useToggleReaction(), { wrapper });
+
+    // Fire and forget so we can observe the mid-flight cache state.
+    result.current.mutate({
+      entityType: 'Quote',
+      entityId: 'q-1',
+      entryId: ENTRY_ID,
+      emoji: ':thumbs_up:',
+    });
+
+    // Optimistic patch is synchronous after onMutate runs.
+    await waitFor(() => {
+      const page = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
+      expect(page?.items[0]?.reactions).toEqual([
+        { emoji: ':thumbs_up:', count: 1, hasReacted: true },
+      ]);
+    });
+    // The unrelated entry in the same page is untouched.
+    const page = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
+    expect(page?.items[1]?.reactions).toEqual([]);
+
+    // Resolve the network with server truth (count overrides optimistic).
+    resolveNetwork(makeEntry(ENTRY_ID, [{ emoji: ':thumbs_up:', count: 7, hasReacted: true }]));
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const finalPage = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
+    expect(finalPage?.items[0]?.reactions).toEqual([
+      { emoji: ':thumbs_up:', count: 7, hasReacted: true },
+    ]);
+  });
+
+  it('rolls back to the snapshot when the mutation rejects', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    const initial = makePage([
+      makeEntry(ENTRY_ID, [{ emoji: ':heart:', count: 5, hasReacted: false }]),
+    ]);
+    queryClient.setQueryData(['timeline', 'Quote', 'q-1'], initial);
+
+    vi.mocked(client.post).mockRejectedValue(new Error('Request failed with status code 403'));
+
+    const { result } = renderHook(() => useToggleReaction(), { wrapper });
+    result.current.mutate({
+      entityType: 'Quote',
+      entityId: 'q-1',
+      entryId: ENTRY_ID,
+      emoji: ':heart:',
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    const page = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
+    expect(page?.items[0]?.reactions).toEqual([{ emoji: ':heart:', count: 5, hasReacted: false }]);
+  });
+});
+
+describe('useToggleReaction — scoped invalidation', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("does not touch unrelated streams' caches", async () => {
+    const { client, queryClient, wrapper } = createHarness();
+
+    // Target stream
+    queryClient.setQueryData(['timeline', 'Quote', 'q-1'], makePage([makeEntry(ENTRY_ID)]));
+    // Sibling stream — different entityId
+    queryClient.setQueryData(
+      ['timeline', 'Quote', 'q-2'],
+      makePage([makeEntry(toEntityId<'TimelineEntry'>('e-other-1') as TimelineEntryId)])
+    );
+    // Sibling stream — different entityType
+    queryClient.setQueryData(
+      ['timeline', 'Party', 'p-7'],
+      makePage([makeEntry(toEntityId<'TimelineEntry'>('e-other-2') as TimelineEntryId)])
+    );
+    // Foreign cache prefix entirely
+    queryClient.setQueryData(['unrelated'], 'keep-me');
+
+    vi.mocked(client.post).mockResolvedValue(
+      axiosResponse(makeEntry(ENTRY_ID, [{ emoji: ':eyes:', count: 1, hasReacted: true }]))
+    );
+
+    const { result } = renderHook(() => useToggleReaction(), { wrapper });
+    result.current.mutate({
+      entityType: 'Quote',
+      entityId: 'q-1',
+      entryId: ENTRY_ID,
+      emoji: ':eyes:',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    // Sibling caches are not invalidated.
+    const sibling1 = queryClient.getQueryCache().find({
+      queryKey: ['timeline', 'Quote', 'q-2'],
+    });
+    expect(sibling1?.state.isInvalidated).toBe(false);
+    const sibling2 = queryClient.getQueryCache().find({
+      queryKey: ['timeline', 'Party', 'p-7'],
+    });
+    expect(sibling2?.state.isInvalidated).toBe(false);
+    expect(queryClient.getQueryData(['unrelated'])).toBe('keep-me');
+  });
+});

--- a/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
@@ -1,0 +1,187 @@
+import { toggleReaction } from '@granit/timeline';
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { buildTimelineQueryKey, useTimelineConfig } from '../providers/timeline-provider.js';
+
+import type {
+  Reaction,
+  ReactionEmoji,
+  TimelineEntry,
+  TimelineEntryId,
+  TimelineEntryPage,
+} from '@granit/timeline';
+
+/**
+ * Mutation arguments for {@link useToggleReaction}. Apps pass the
+ * surrounding stream's `(entityType, entityId)` so the hook scopes
+ * cache patches + invalidation to that stream's query keys —
+ * unrelated streams' caches survive untouched.
+ */
+export interface ToggleReactionVariables {
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly entryId: TimelineEntryId;
+  readonly emoji: ReactionEmoji;
+}
+
+interface ToggleReactionContext {
+  readonly previousQueries: readonly [readonly unknown[], unknown][];
+}
+
+/**
+ * Toggle one reaction on one entry, with **scoped** optimistic updates
+ * + rollback on the React Query cache.
+ *
+ * Wire: `POST {basePath}/entries/{entryId}/reactions/{emoji}` (idempotent
+ * — toggling the same emoji twice removes the reaction; backend keys on
+ * `(entryId, emoji, callerUserId)`). See
+ * granit-fx/granit-dotnet#1811.
+ *
+ * Cache strategy:
+ * - `onMutate` cancels in-flight queries on the surrounding stream's
+ *   prefix and patches every cached `TimelineEntryPage` (and
+ *   single-entry cache) so the matching entry's `reactions[]` reflects
+ *   the toggle immediately.
+ * - `onError` restores the snapshot taken in `onMutate`.
+ * - `onSuccess` writes server truth (the refreshed `TimelineEntry`)
+ *   over any matching entries, then invalidates the prefix so any
+ *   in-flight subscribers refetch from authority.
+ * - The prefix is `[...queryKeyPrefix, entityType, entityId]` — a
+ *   100-toggle session on `Quote/q-1` never invalidates the cache
+ *   for `Quote/q-2` or `Party/p-3`.
+ *
+ * Note: the standalone `useTimeline` hook in this package keeps its
+ * own internal state (not React Query) and is not affected by this
+ * cache layer. Apps using both wire `mutation.onSuccess` to call
+ * `useTimeline.refresh()` themselves; apps that maintain a React
+ * Query stream cache benefit from the scoped patching out of the box.
+ */
+export function useToggleReaction(): UseMutationResult<
+  TimelineEntry,
+  Error,
+  ToggleReactionVariables,
+  ToggleReactionContext
+> {
+  const config = useTimelineConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation<TimelineEntry, Error, ToggleReactionVariables, ToggleReactionContext>({
+    mutationFn: ({ entryId, emoji }) =>
+      toggleReaction(config.client, config.basePath, entryId, emoji),
+
+    onMutate: async (vars) => {
+      const prefix = streamPrefix(config, vars);
+      await queryClient.cancelQueries({ queryKey: prefix });
+
+      const previousQueries = queryClient.getQueriesData({ queryKey: prefix });
+
+      queryClient.setQueriesData<unknown>({ queryKey: prefix }, (old: unknown) =>
+        patchOptimistic(old, vars.entryId, vars.emoji)
+      );
+
+      return { previousQueries };
+    },
+
+    onError: (_error, _vars, context) => {
+      if (!context) return;
+      for (const [key, snapshot] of context.previousQueries) {
+        queryClient.setQueryData(key, snapshot);
+      }
+    },
+
+    onSuccess: (refreshed, vars) => {
+      const prefix = streamPrefix(config, vars);
+      queryClient.setQueriesData<unknown>({ queryKey: prefix }, (old: unknown) =>
+        replaceServerTruth(old, refreshed)
+      );
+      queryClient.invalidateQueries({ queryKey: prefix });
+    },
+  });
+}
+
+function streamPrefix(
+  config: ReturnType<typeof useTimelineConfig>,
+  vars: ToggleReactionVariables
+): readonly unknown[] {
+  return buildTimelineQueryKey(config, vars.entityType, vars.entityId);
+}
+
+/**
+ * Patch every cached entry matching `entryId` with the optimistic
+ * reaction toggle. Walks the two known cache shapes:
+ *   - `TimelineEntryPage` (paginated stream slot)
+ *   - single `TimelineEntry` (per-entry cache)
+ * Other shapes pass through unchanged so apps with custom caches
+ * aren't affected.
+ */
+function patchOptimistic(old: unknown, entryId: TimelineEntryId, emoji: ReactionEmoji): unknown {
+  if (isTimelineEntryPage(old)) {
+    return {
+      ...old,
+      items: old.items.map((entry) =>
+        entry.id === entryId ? toggleEntryReaction(entry, emoji) : entry
+      ),
+    };
+  }
+  if (isTimelineEntry(old) && old.id === entryId) {
+    return toggleEntryReaction(old, emoji);
+  }
+  return old;
+}
+
+function replaceServerTruth(old: unknown, refreshed: TimelineEntry): unknown {
+  if (isTimelineEntryPage(old)) {
+    return {
+      ...old,
+      items: old.items.map((entry) => (entry.id === refreshed.id ? refreshed : entry)),
+    };
+  }
+  if (isTimelineEntry(old) && old.id === refreshed.id) {
+    return refreshed;
+  }
+  return old;
+}
+
+function toggleEntryReaction(entry: TimelineEntry, emoji: ReactionEmoji): TimelineEntry {
+  return { ...entry, reactions: toggleReactionList(entry.reactions, emoji) };
+}
+
+/**
+ * Pure toggle of one emoji on a reactions list — exported so apps
+ * doing optimistic UI outside the React Query cache (e.g. against
+ * `useTimeline`'s internal state) can reuse the same logic.
+ */
+export function toggleReactionList(
+  reactions: readonly Reaction[] | undefined,
+  emoji: ReactionEmoji
+): readonly Reaction[] {
+  const list = reactions ?? [];
+  const existing = list.find((r) => r.emoji === emoji);
+  if (!existing) {
+    return [...list, { emoji, count: 1, hasReacted: true }];
+  }
+  if (existing.hasReacted) {
+    const next: Reaction = { emoji, count: existing.count - 1, hasReacted: false };
+    return next.count <= 0
+      ? list.filter((r) => r.emoji !== emoji)
+      : list.map((r) => (r.emoji === emoji ? next : r));
+  }
+  return list.map((r) => (r.emoji === emoji ? { emoji, count: r.count + 1, hasReacted: true } : r));
+}
+
+function isTimelineEntryPage(value: unknown): value is TimelineEntryPage {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    Array.isArray((value as { items?: unknown }).items)
+  );
+}
+
+function isTimelineEntry(value: unknown): value is TimelineEntry {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as { id?: unknown }).id === 'string' &&
+    typeof (value as { entryType?: unknown }).entryType === 'number'
+  );
+}

--- a/packages/@granit/react-timeline/src/index.ts
+++ b/packages/@granit/react-timeline/src/index.ts
@@ -24,3 +24,6 @@ export type {
   UseTimelineFollowersOptions,
   UseTimelineFollowersReturn,
 } from './hooks/use-timeline-followers.js';
+
+export { toggleReactionList, useToggleReaction } from './hooks/use-toggle-reaction.js';
+export type { ToggleReactionVariables } from './hooks/use-toggle-reaction.js';


### PR DESCRIPTION
## Summary

React Query mutation hook layered on the C1 SDK `toggleReaction()`. Provides scoped optimistic updates + rollback against any cached `TimelineEntryPage` / single-entry slots in the surrounding stream's prefix.

## Hook

```ts
useToggleReaction(): UseMutationResult<TimelineEntry, Error, ToggleReactionVariables>

interface ToggleReactionVariables {
  entityType: string;
  entityId: string;
  entryId: TimelineEntryId;
  emoji: ReactionEmoji;
}
```

`mutationFn` calls `toggleReaction()` with the ambient `<TimelineProvider>` config (basePath + axios client).

## Cache strategy

- **`onMutate`** cancels in-flight queries on `[...queryKeyPrefix, entityType, entityId]`, snapshots all matching cache slots, then patches every `TimelineEntryPage` (or single-entry cache) whose entry id matches — bumps `count` + flips `hasReacted`, or removes the emoji slot when the last reactor un-reacts.
- **`onError`** restores the snapshot taken in `onMutate`.
- **`onSuccess`** overwrites server truth (the refreshed `TimelineEntry`) on matching cache slots, then `invalidateQueries` on the prefix so subscribers refetch from authority.
- **Prefix isolation**: a 100-toggle session on `Quote/q-1` never touches the cache for `Quote/q-2`, `Party/p-3`, or any foreign cache prefix. Regression test asserts.

## Pure helper

`toggleReactionList(reactions, emoji)` is exported separately for apps doing optimistic UI **outside** React Query (e.g. against `useTimeline`'s internal state). Same logic the React Query layer uses internally.

## Note on `useTimeline` integration

The standalone `useTimeline` hook keeps its own internal state (uses `useInfiniteScroll`, not React Query) and isn't auto-synced by this layer. Apps using both wire `mutation.onSuccess` to call `useTimeline.refresh()`, or use `toggleReactionList` against their own `setEntries`. Apps that maintain a React Query stream cache (`['timeline', entityType, entityId]`-keyed) benefit from the scoped patching out of the box.

## Closes

- #406 — C2 — `useToggleReaction()` mutation hook + scoped cache invalidation
- Parent feature: #397
- Backend: granit-fx/granit-dotnet#1811

## Test plan

- [x] 11 new unit tests, **37/37** across `@granit/react-timeline`
- [x] `toggleReactionList` edge cases: fresh add, increment, decrement, last-reactor removal
- [x] Optimistic patch visible **before** the network resolves (mid-flight assertion)
- [x] Server-truth overwrites optimistic on success (count from `7` survives, not `1`)
- [x] Rollback on rejection — cache returns to pre-mutate state
- [x] Prefix isolation — sibling streams (`Quote/q-2`, `Party/p-7`) and foreign prefixes (`['unrelated']`) survive untouched
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-timeline build` — ESM + dts
