### PR TITLE
feat(react-timeline): <ReactionBar /> headless picker (C3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4288,6 +4288,23 @@
           "kind": "interface",
           "signature": "interface ToggleReactionVariables",
           "members": []
+        },
+        {
+          "name": "ReactionBar",
+          "kind": "function",
+          "signature": "function ReactionBar("
+        },
+        {
+          "name": "ReactionBarLabels",
+          "kind": "interface",
+          "signature": "interface ReactionBarLabels",
+          "members": []
+        },
+        {
+          "name": "ReactionBarProps",
+          "kind": "interface",
+          "signature": "interface ReactionBarProps",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-timeline/src/__tests__/reaction-bar.test.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/reaction-bar.test.tsx
@@ -1,0 +1,106 @@
+import { REACTION_EMOJIS } from '@granit/timeline';
+import { toEntityId } from '@granit/types';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ReactionBar } from '../components/reaction-bar.js';
+
+import type { Reaction, TimelineEntryId } from '@granit/timeline';
+
+const ENTRY_ID = toEntityId<'TimelineEntry'>('e-42') as TimelineEntryId;
+
+describe('<ReactionBar>', () => {
+  it('renders the full closed catalog (5 buttons, regardless of input shape)', () => {
+    const { container } = render(
+      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={vi.fn()} />
+    );
+
+    const buttons = container.querySelectorAll('[data-granit-reaction-bar-button]');
+    expect(buttons).toHaveLength(REACTION_EMOJIS.length);
+    REACTION_EMOJIS.forEach((emoji, i) => {
+      expect(buttons[i]?.getAttribute('data-emoji')).toBe(emoji);
+    });
+  });
+
+  it('reflects per-emoji count and aria-pressed from the reactions prop', () => {
+    const reactions: Reaction[] = [
+      { emoji: ':thumbs_up:', count: 5, hasReacted: true },
+      { emoji: ':eyes:', count: 2, hasReacted: false },
+    ];
+    const { container } = render(
+      <ReactionBar entryId={ENTRY_ID} reactions={reactions} onToggle={vi.fn()} />
+    );
+
+    const thumbs = container.querySelector('[data-emoji=":thumbs_up:"]') as HTMLElement;
+    expect(thumbs.getAttribute('aria-pressed')).toBe('true');
+    expect(thumbs.getAttribute('data-count')).toBe('5');
+    expect(thumbs.getAttribute('data-has-reacted')).toBe('');
+
+    const eyes = container.querySelector('[data-emoji=":eyes:"]') as HTMLElement;
+    expect(eyes.getAttribute('aria-pressed')).toBe('false');
+    expect(eyes.getAttribute('data-count')).toBe('2');
+    expect(eyes.getAttribute('data-has-reacted')).toBeNull();
+
+    const unused = container.querySelector('[data-emoji=":heart:"]') as HTMLElement;
+    expect(unused.getAttribute('data-count')).toBe('0');
+    expect(unused.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('hides the count badge when count is zero', () => {
+    const { container } = render(
+      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={vi.fn()} />
+    );
+
+    expect(container.querySelectorAll('[data-granit-reaction-bar-count]')).toHaveLength(0);
+  });
+
+  it('fires onToggle with { entryId, emoji } when a button is clicked', () => {
+    const onToggle = vi.fn();
+    const { container } = render(
+      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={onToggle} />
+    );
+
+    fireEvent.click(container.querySelector('[data-emoji=":tada:"]') as HTMLElement);
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(onToggle).toHaveBeenCalledWith({ entryId: ENTRY_ID, emoji: ':tada:' });
+  });
+
+  it('renders read-only when no onToggle callback is provided (permission gating)', () => {
+    const { container } = render(<ReactionBar entryId={ENTRY_ID} reactions={[]} />);
+
+    const root = container.querySelector('[data-granit-reaction-bar]') as HTMLElement;
+    expect(root.getAttribute('data-readonly')).toBe('');
+
+    container.querySelectorAll('button').forEach((btn) => {
+      expect(btn.disabled).toBe(true);
+    });
+
+    // Counts still render — it's a read-only tally
+    fireEvent.click(container.querySelector('[data-emoji=":heart:"]') as HTMLElement);
+    // No assertion needed — disabled buttons emit no click event by default
+  });
+
+  it('uses the buttonAriaLabel override when supplied', () => {
+    render(
+      <ReactionBar
+        entryId={ENTRY_ID}
+        reactions={[]}
+        onToggle={vi.fn()}
+        labels={{
+          buttonAriaLabel: (emoji) => `Réagir avec ${emoji}`,
+        }}
+      />
+    );
+
+    expect(screen.getByRole('button', { name: 'Réagir avec :thumbs_up:' })).toBeDefined();
+  });
+
+  it('exposes the entry id on the root for app-level styling / instrumentation', () => {
+    const { container } = render(
+      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={vi.fn()} />
+    );
+    const root = container.querySelector('[data-granit-reaction-bar]') as HTMLElement;
+    expect(root.getAttribute('data-entry-id')).toBe(ENTRY_ID);
+  });
+});

--- a/packages/@granit/react-timeline/src/components/reaction-bar.tsx
+++ b/packages/@granit/react-timeline/src/components/reaction-bar.tsx
@@ -1,0 +1,105 @@
+import { REACTION_EMOJIS, type Reaction, type ReactionEmoji } from '@granit/timeline';
+import { type ReactNode } from 'react';
+
+import type { TimelineEntryId } from '@granit/timeline';
+
+export interface ReactionBarLabels {
+  /**
+   * Aria label for one reaction button. Receives the emoji code so apps
+   * can localize per emoji via
+   * `t('timeline:Reaction.AriaLabel.' + emoji.replaceAll(':', ''))`.
+   */
+  readonly buttonAriaLabel?: (emoji: ReactionEmoji) => string;
+}
+
+const DEFAULT_LABELS: Required<ReactionBarLabels> = {
+  buttonAriaLabel: (emoji) => `React with ${emoji}`,
+};
+
+export interface ReactionBarProps {
+  /** Id of the entry this bar belongs to — passed to the toggle callback. */
+  readonly entryId: TimelineEntryId;
+  /**
+   * Current reactions for the entry — typically `entry.reactions ?? []`.
+   * Missing emojis render as `count=0, hasReacted=false` so the bar
+   * always shows the full closed catalog.
+   */
+  readonly reactions: readonly Reaction[];
+  /**
+   * Click handler. When `undefined`, the bar renders as a read-only
+   * tally — buttons disabled, no toggle. Apps gate by the
+   * `Timeline.React` permission via this callback's presence.
+   */
+  readonly onToggle?: (args: { entryId: TimelineEntryId; emoji: ReactionEmoji }) => void;
+  /** Override the English defaults for aria labels (i18n in C4). */
+  readonly labels?: ReactionBarLabels;
+  readonly className?: string;
+}
+
+/**
+ * Headless reaction picker — five buttons (the closed v1 catalog from
+ * `@granit/timeline`) with per-button count and `aria-pressed`
+ * reflecting the caller's `hasReacted` state.
+ *
+ * Visual chrome (emoji glyph rendering, theme tokens, hover/focus
+ * styling) is the consuming app's responsibility — the bar exposes
+ * `data-emoji` / `data-granit-reaction-bar-*` markers and renders the
+ * raw `:short_name:` codes by default. Apps can swap to Twemoji or
+ * native via CSS pseudo-elements keyed on `data-emoji`.
+ *
+ * Apps wire `onToggle` to `useToggleReaction()` from this package
+ * (the hook handles optimistic + rollback against the React Query
+ * cache when present).
+ */
+export function ReactionBar({
+  entryId,
+  reactions,
+  onToggle,
+  labels,
+  className,
+}: ReactionBarProps): ReactNode {
+  const merged = { ...DEFAULT_LABELS, ...labels };
+  const byEmoji = indexReactions(reactions);
+  const isInteractive = onToggle != null;
+
+  return (
+    <div
+      data-granit-reaction-bar=""
+      data-entry-id={entryId}
+      data-readonly={isInteractive ? undefined : ''}
+      role="group"
+      className={className}
+    >
+      {REACTION_EMOJIS.map((emoji) => {
+        const reaction = byEmoji.get(emoji);
+        const count = reaction?.count ?? 0;
+        const hasReacted = reaction?.hasReacted ?? false;
+        return (
+          <button
+            key={emoji}
+            type="button"
+            data-granit-reaction-bar-button=""
+            data-emoji={emoji}
+            data-count={count}
+            data-has-reacted={hasReacted ? '' : undefined}
+            aria-pressed={hasReacted}
+            aria-label={merged.buttonAriaLabel(emoji)}
+            disabled={!isInteractive}
+            onClick={isInteractive ? () => onToggle({ entryId, emoji }) : undefined}
+          >
+            <span data-granit-reaction-bar-emoji="">{emoji}</span>
+            {count > 0 ? <span data-granit-reaction-bar-count="">{count}</span> : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function indexReactions(reactions: readonly Reaction[]): Map<ReactionEmoji, Reaction> {
+  const map = new Map<ReactionEmoji, Reaction>();
+  for (const r of reactions) {
+    map.set(r.emoji, r);
+  }
+  return map;
+}

--- a/packages/@granit/react-timeline/src/index.ts
+++ b/packages/@granit/react-timeline/src/index.ts
@@ -27,3 +27,6 @@ export type {
 
 export { toggleReactionList, useToggleReaction } from './hooks/use-toggle-reaction.js';
 export type { ToggleReactionVariables } from './hooks/use-toggle-reaction.js';
+
+export { ReactionBar } from './components/reaction-bar.js';
+export type { ReactionBarLabels, ReactionBarProps } from './components/reaction-bar.js';


### PR DESCRIPTION
## Summary

Five-button reaction picker — closed v1 catalog from `@granit/timeline`. Renders the full set **regardless of input shape**: missing emojis show `count=0` + `aria-pressed=false` so the bar always exposes the same five slots, no catalog-drift reconciliation in app code.

## Behaviour

- Per-button `data-emoji` marker + `data-count` + `data-has-reacted` attribute (set when the caller has reacted with that emoji)
- `aria-pressed` reflects `hasReacted`; `aria-label` defaults to `"React with {emoji}"` — overridable via `labels.buttonAriaLabel` for i18n in C4
- Click fires `onToggle({ entryId, emoji })` — apps wire `useToggleReaction()` from C2, or any other handler. The bar is hook-agnostic.
- **Permission gating via callback presence**: when `onToggle` is `undefined`, buttons render `disabled`, root carries `data-readonly` — apps gate by `Timeline.React` with one conditional

## Headless conventions

- `data-granit-reaction-bar` / `data-granit-reaction-bar-button` / `data-granit-reaction-bar-count` / `data-granit-reaction-bar-emoji`
- Renders the raw `:short_name:` codes by default — apps swap to Twemoji / native via CSS pseudo-elements keyed on `data-emoji`
- `role="group"` on the root, `type="button"` on every button

## Wiring with C2

```tsx
const toggle = useToggleReaction();

<ReactionBar
  entryId={entry.id}
  reactions={entry.reactions ?? []}
  onToggle={({ entryId, emoji }) =>
    toggle.mutate({ entityType: 'Quote', entityId: 'q-1', entryId, emoji })
  }
/>
```

## Closes

- #407 — C3 — `<ReactionBar>` headless picker
- Parent feature: #397
- Backend: granit-fx/granit-dotnet#1811

## Test plan

- [x] 7 new unit tests, **44/44** across `@granit/react-timeline`
- [x] Full catalog renders (5 buttons, ordered, `data-emoji` correct)
- [x] `count` + `aria-pressed` + `data-has-reacted` mapping from input
- [x] `count=0` → no count badge rendered
- [x] Click on `:tada:` → `onToggle({ entryId, emoji: ':tada:' })`
- [x] Read-only mode: `data-readonly`, all buttons `disabled`
- [x] `buttonAriaLabel` override (e.g. localized for FR)
- [x] `data-entry-id` on root for instrumentation
- [x] `pnpm tsc` + `pnpm lint --max-warnings 0` — green
- [x] `pnpm -F @granit/react-timeline build` — ESM + dts
