### PR TITLE
feat(react-timeline): reactions i18n bundles + dod close (C4)

### DIFF
--- a/packages/@granit/react-timeline/src/__tests__/locales.test.ts
+++ b/packages/@granit/react-timeline/src/__tests__/locales.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { timelineTranslationsEn } from '../locales/en.js';
+import { timelineTranslationsFr } from '../locales/fr.js';
+
+/** Walk an object tree and collect all leaf paths (`'A.B.C'`). */
+function leafPaths(obj: unknown, prefix = ''): readonly string[] {
+  if (typeof obj !== 'object' || obj === null) {
+    return [prefix];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, value]) =>
+    leafPaths(value, prefix ? `${prefix}.${key}` : key)
+  );
+}
+
+describe('timeline locale bundles', () => {
+  it('en exposes the Reaction surface (AriaLabel + Tooltip plurals)', () => {
+    expect(Object.keys(timelineTranslationsEn)).toEqual(['Reaction']);
+    expect(timelineTranslationsEn.Reaction.AriaLabel).toContain('{{emoji}}');
+    expect(timelineTranslationsEn.Reaction.Tooltip.Count_one).toBeTruthy();
+    expect(timelineTranslationsEn.Reaction.Tooltip.Count_other).toBeTruthy();
+  });
+
+  it('fr provides every key declared in en (no missing translations)', () => {
+    const enPaths = new Set(leafPaths(timelineTranslationsEn));
+    const frPaths = new Set(leafPaths(timelineTranslationsFr));
+
+    expect([...enPaths].filter((p) => !frPaths.has(p))).toEqual([]);
+    expect([...frPaths].filter((p) => !enPaths.has(p))).toEqual([]);
+  });
+
+  it('preserves interpolation placeholders across locales', () => {
+    expect(timelineTranslationsFr.Reaction.AriaLabel).toContain('{{emoji}}');
+    expect(timelineTranslationsEn.Reaction.Tooltip.Count_other).toContain('{{count}}');
+    expect(timelineTranslationsFr.Reaction.Tooltip.Count_other).toContain('{{count}}');
+  });
+});

--- a/packages/@granit/react-timeline/src/index.ts
+++ b/packages/@granit/react-timeline/src/index.ts
@@ -30,3 +30,7 @@ export type { ToggleReactionVariables } from './hooks/use-toggle-reaction.js';
 
 export { ReactionBar } from './components/reaction-bar.js';
 export type { ReactionBarLabels, ReactionBarProps } from './components/reaction-bar.js';
+
+// i18n resource bundles (namespace: 'timeline')
+export { timelineTranslationsEn, timelineTranslationsFr } from './locales/index.js';
+export type { TimelineTranslations } from './locales/index.js';

--- a/packages/@granit/react-timeline/src/locales/en.ts
+++ b/packages/@granit/react-timeline/src/locales/en.ts
@@ -1,0 +1,35 @@
+/**
+ * English translation bundle for `@granit/react-timeline`. Consumers
+ * register it via:
+ *
+ *   i18n.addResourceBundle('en', 'timeline', timelineTranslationsEn);
+ *
+ * Components in this package don't call `useTranslation` directly —
+ * they expose `labels` props that apps populate from `t()` results.
+ * This keeps components testable without an i18next bootstrap and
+ * consistent with the headless conventions across the framework.
+ *
+ * Scope of the v1 catalog: surfaces shipped through the C-stream
+ * (Reactions on Timeline). Future stories extend in place.
+ */
+export const timelineTranslationsEn: TimelineTranslations = {
+  Reaction: {
+    AriaLabel: 'React with {{emoji}}',
+    Tooltip: {
+      Count: '{{count}} reactions',
+      Count_one: '1 reaction',
+      Count_other: '{{count}} reactions',
+    },
+  },
+};
+
+export interface TimelineTranslations {
+  readonly Reaction: {
+    readonly AriaLabel: string;
+    readonly Tooltip: {
+      readonly Count: string;
+      readonly Count_one: string;
+      readonly Count_other: string;
+    };
+  };
+}

--- a/packages/@granit/react-timeline/src/locales/fr.ts
+++ b/packages/@granit/react-timeline/src/locales/fr.ts
@@ -1,0 +1,18 @@
+import type { TimelineTranslations } from './en.js';
+
+/**
+ * French translation bundle for `@granit/react-timeline`. Consumers
+ * register it via:
+ *
+ *   i18n.addResourceBundle('fr', 'timeline', timelineTranslationsFr);
+ */
+export const timelineTranslationsFr: TimelineTranslations = {
+  Reaction: {
+    AriaLabel: 'Réagir avec {{emoji}}',
+    Tooltip: {
+      Count: '{{count}} réactions',
+      Count_one: '1 réaction',
+      Count_other: '{{count}} réactions',
+    },
+  },
+};

--- a/packages/@granit/react-timeline/src/locales/index.ts
+++ b/packages/@granit/react-timeline/src/locales/index.ts
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------------------
+// @granit/react-timeline — i18next resource bundles (namespace: "timeline")
+// ---------------------------------------------------------------------------
+//
+// Consumers register the bundles with their i18n instance:
+//
+//   import { timelineTranslationsEn, timelineTranslationsFr } from '@granit/react-timeline';
+//   i18n.addResourceBundle('en', 'timeline', timelineTranslationsEn);
+//   i18n.addResourceBundle('fr', 'timeline', timelineTranslationsFr);
+//
+// Components in this package don't call `useTranslation` directly — they
+// expose `labels` props that apps populate from `t()` results. This
+// keeps components testable without an i18next bootstrap and consistent
+// with the headless conventions across the framework.
+// ---------------------------------------------------------------------------
+
+export { timelineTranslationsEn } from './en.js';
+export type { TimelineTranslations } from './en.js';
+export { timelineTranslationsFr } from './fr.js';


### PR DESCRIPTION
## Summary

Closes the **C-stream** of Phase 2 — Reactions on Timeline (C1 → C4).

## What's in this PR

### i18n bundles (en + fr) — `timeline` namespace

`@granit/react-timeline` now ships en + fr resource bundles, scoped to the v1 surfaces touched by the C-stream:

```
Reaction.AriaLabel               'React with {{emoji}}'
Reaction.Tooltip.Count           (with _one / _other plurals)
```

Apps register via:

```ts
import { timelineTranslationsEn, timelineTranslationsFr } from '@granit/react-timeline';
i18n.addResourceBundle('en', 'timeline', timelineTranslationsEn);
i18n.addResourceBundle('fr', 'timeline', timelineTranslationsFr);
```

Both bundles satisfy a shared `TimelineTranslations` interface — adding a locale is one typed file checked at compile time. Future C/D-stream surfaces extend the bundle in place.

### Wiring with `<ReactionBar>` (C3)

The `labels.buttonAriaLabel` prop already accepts a `(emoji) => string` function and interpolation lives in the catalog, so apps wire it in one line:

```tsx
const { t } = useTranslation('timeline');

<ReactionBar
  entryId={entry.id}
  reactions={entry.reactions ?? []}
  onToggle={…}
  labels={{ buttonAriaLabel: (emoji) => t('Reaction.AriaLabel', { emoji }) }}
/>
```

### Naming choice

Story sketched per-emoji aria-label keys (`AriaLabel.thumbs_up`, `AriaLabel.heart`, …); shipped a single `AriaLabel` with `{{emoji}}` interpolation instead — same UX outcome, half the bundle, one localizer task instead of five. The closed catalog is enforced at the type level (`ReactionEmoji`), and the picker passes the emoji code straight through.

## Closes

- #408 — C4 — i18n + DoD
- Parent feature: #397
- Wraps the full C-stream front delivery (C1 → C4)

## Cumulative DoD (C-stream)

- [x] `pnpm tsc` — green workspace-wide
- [x] `pnpm lint --max-warnings 0` — green
- [x] `pnpm vitest run packages/@granit/timeline packages/@granit/react-timeline` — **58/58**, 9 test files
- [x] `pnpm -F @granit/timeline build` + `pnpm -F @granit/react-timeline build` — ESM + dts
- [x] No new third-party deps introduced
- [x] All 4 PRs targeted `develop`, never `main`

## Test plan

- [x] `locales.test.ts` — 3 tests: top-level keys, en/fr leaf-path drift, placeholder preservation across locales
- [x] No regression on prior C-stream tests (SDK + hook + picker)
