### PR TITLE
feat(entities-customization): layer 1 customization editor (B1-B6)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -616,6 +616,27 @@
       "exports": []
     },
     {
+      "name": "@granit/entities-customization",
+      "description": "Layer 1 customization (forms + workspaces) — types, API client, and permissions",
+      "exports": [
+        {
+          "name": "CustomizationPermissions",
+          "kind": "const",
+          "signature": "const CustomizationPermissions"
+        },
+        {
+          "name": "getFormCustomization",
+          "kind": "function",
+          "signature": "async function getFormCustomization( client: AxiosInstance, apiBase: string, entityName: string, variant: FormVariant ): Promise<FormCustomizationResponse>"
+        },
+        {
+          "name": "putFormCustomization",
+          "kind": "function",
+          "signature": "async function putFormCustomization( client: AxiosInstance, apiBase: string, entityName: string, variant: FormVariant, request: FormCustomizationRequest ): Promise<FormCustomizationResponse>"
+        }
+      ]
+    },
+    {
       "name": "@granit/entities-views",
       "description": "Framework-agnostic types and helpers for Granit saved views — EntityView aggregate, visibility (Personal / Shared / Tenant), pin / default / personal-default flags, basedOn delta model (mirrors Granit.Entities.Views.Domain)",
       "exports": []
@@ -3025,6 +3046,86 @@
           "name": "useEntityMetadata",
           "kind": "function",
           "signature": "function useEntityMetadata( name: string, options:"
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-entities-customization",
+      "description": "React bindings + headless editors for @granit/entities-customization (Layer 1)",
+      "exports": [
+        {
+          "name": "API_VERSION",
+          "kind": "const",
+          "signature": "const API_VERSION"
+        },
+        {
+          "name": "DEFAULT_API_BASE",
+          "kind": "const",
+          "signature": "const DEFAULT_API_BASE"
+        },
+        {
+          "name": "DEFAULT_QUERY_KEY_PREFIX",
+          "kind": "const",
+          "signature": "const DEFAULT_QUERY_KEY_PREFIX"
+        },
+        {
+          "name": "useFormCustomization",
+          "kind": "function",
+          "signature": "function useFormCustomization("
+        },
+        {
+          "name": "usePutFormCustomization",
+          "kind": "function",
+          "signature": "function usePutFormCustomization(): UseMutationResult< FormCustomizationResponse, Error, PutFormCustomizationArgs >"
+        },
+        {
+          "name": "EffectiveField",
+          "kind": "interface",
+          "signature": "interface EffectiveField",
+          "members": []
+        },
+        {
+          "name": "SchemaField",
+          "kind": "interface",
+          "signature": "interface SchemaField",
+          "members": []
+        },
+        {
+          "name": "FormLayoutEditor",
+          "kind": "function",
+          "signature": "function FormLayoutEditor("
+        },
+        {
+          "name": "FormLayoutEditorProps",
+          "kind": "interface",
+          "signature": "interface FormLayoutEditorProps",
+          "members": []
+        },
+        {
+          "name": "LayoutEditorLabels",
+          "kind": "interface",
+          "signature": "interface LayoutEditorLabels",
+          "members": []
+        },
+        {
+          "name": "WorkspaceLayoutEditor",
+          "kind": "function",
+          "signature": "function WorkspaceLayoutEditor(props: WorkspaceLayoutEditorProps): ReactNode"
+        },
+        {
+          "name": "WorkspaceLayoutEditorProps",
+          "kind": "type",
+          "signature": "type WorkspaceLayoutEditorProps = FormLayoutEditorProps"
+        },
+        {
+          "name": "FieldInspectorOverlay",
+          "kind": "function",
+          "signature": "function FieldInspectorOverlay("
+        },
+        {
+          "name": "RESOLUTION_LAYERS",
+          "kind": "const",
+          "signature": "const RESOLUTION_LAYERS: readonly ResolutionLayer[]"
         }
       ]
     },

--- a/packages/@granit/entities-customization/package.json
+++ b/packages/@granit/entities-customization/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/entities-customization",
+  "description": "Layer 1 customization (forms + workspaces) — types, API client, and permissions",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/entities-customization/src/__tests__/form-customization-api.test.ts
+++ b/packages/@granit/entities-customization/src/__tests__/form-customization-api.test.ts
@@ -1,0 +1,82 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getFormCustomization, putFormCustomization } from '../api/form-customization-api.js';
+
+import type {
+  FormCustomizationRequest,
+  FormCustomizationResponse,
+} from '../types/customization.js';
+
+const apiBase = '/api/v1';
+
+const sampleResponse: FormCustomizationResponse = {
+  entityName: 'Quote',
+  variant: 'Edit',
+  deltas: [
+    { kind: 'Hide', fieldName: 'internalNotes' },
+    { kind: 'Reorder', fieldName: 'amount', afterFieldName: 'currency' },
+  ],
+  updatedAt: '2026-05-06T10:00:00Z',
+  updatedByUserId: 'user-1',
+};
+
+describe('getFormCustomization', () => {
+  it('GETs /entities/{name}/customization/forms/{variant}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
+
+    const result = await getFormCustomization(client, apiBase, 'Quote', 'Edit');
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/forms/Edit');
+    expect(result).toEqual(sampleResponse);
+  });
+
+  it('URI-encodes the entity name and variant', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
+
+    await getFormCustomization(client, apiBase, 'Custom/Entity', 'Read');
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/entities/Custom%2FEntity/customization/forms/Read'
+    );
+  });
+
+  it('propagates 403 when the caller lacks Forms.Read', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Request failed with status code 403'));
+
+    await expect(getFormCustomization(client, apiBase, 'Quote', 'Edit')).rejects.toThrow(/403/);
+  });
+});
+
+describe('putFormCustomization', () => {
+  it('PUTs the deltas body to /entities/{name}/customization/forms/{variant}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleResponse));
+    const request: FormCustomizationRequest = {
+      deltas: [
+        { kind: 'Regroup', fieldName: 'amount', groupKey: 'pricing' },
+        { kind: 'Hide', fieldName: 'internalNotes' },
+      ],
+    };
+
+    const result = await putFormCustomization(client, apiBase, 'Quote', 'Edit', request);
+
+    expect(client.put).toHaveBeenCalledWith(
+      '/api/v1/entities/Quote/customization/forms/Edit',
+      request
+    );
+    expect(result).toEqual(sampleResponse);
+  });
+
+  it('propagates 422 on unknown delta kinds rejected by the backend', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockRejectedValue(new Error('Request failed with status code 422'));
+
+    await expect(
+      putFormCustomization(client, apiBase, 'Quote', 'Edit', { deltas: [] })
+    ).rejects.toThrow(/422/);
+  });
+});

--- a/packages/@granit/entities-customization/src/__tests__/permissions.test.ts
+++ b/packages/@granit/entities-customization/src/__tests__/permissions.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { CustomizationPermissions } from '../permissions.js';
+
+describe('CustomizationPermissions', () => {
+  it('exposes the four canonical keys in the EntitiesCustomization namespace', () => {
+    expect(CustomizationPermissions.EntitiesCustomization.Forms.Read).toBe(
+      'EntitiesCustomization.Forms.Read'
+    );
+    expect(CustomizationPermissions.EntitiesCustomization.Forms.Manage).toBe(
+      'EntitiesCustomization.Forms.Manage'
+    );
+    expect(CustomizationPermissions.EntitiesCustomization.Workspaces.Read).toBe(
+      'EntitiesCustomization.Workspaces.Read'
+    );
+    expect(CustomizationPermissions.EntitiesCustomization.Workspaces.Manage).toBe(
+      'EntitiesCustomization.Workspaces.Manage'
+    );
+  });
+});

--- a/packages/@granit/entities-customization/src/__tests__/workspace-customization-api.test.ts
+++ b/packages/@granit/entities-customization/src/__tests__/workspace-customization-api.test.ts
@@ -1,0 +1,66 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getWorkspaceCustomization,
+  putWorkspaceCustomization,
+} from '../api/workspace-customization-api.js';
+
+import type {
+  WorkspaceCustomizationRequest,
+  WorkspaceCustomizationResponse,
+} from '../types/customization.js';
+
+const apiBase = '/api/v1';
+
+const sampleResponse: WorkspaceCustomizationResponse = {
+  workspaceName: 'sales',
+  deltas: [{ kind: 'Hide', fieldName: 'pipelineForecast' }],
+  updatedAt: '2026-05-06T10:00:00Z',
+  updatedByUserId: 'user-1',
+};
+
+describe('getWorkspaceCustomization', () => {
+  it('GETs /workspaces/{name}/customization', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
+
+    const result = await getWorkspaceCustomization(client, apiBase, 'sales');
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/workspaces/sales/customization');
+    expect(result).toEqual(sampleResponse);
+  });
+
+  it('URI-encodes the workspace name', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
+
+    await getWorkspaceCustomization(client, apiBase, 'sales/eu');
+
+    expect(client.get).toHaveBeenCalledWith('/api/v1/workspaces/sales%2Feu/customization');
+  });
+});
+
+describe('putWorkspaceCustomization', () => {
+  it('PUTs the deltas body', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleResponse));
+    const request: WorkspaceCustomizationRequest = {
+      deltas: [{ kind: 'Reorder', fieldName: 'tile-pipeline', beforeFieldName: 'tile-quotes' }],
+    };
+
+    const result = await putWorkspaceCustomization(client, apiBase, 'sales', request);
+
+    expect(client.put).toHaveBeenCalledWith('/api/v1/workspaces/sales/customization', request);
+    expect(result).toEqual(sampleResponse);
+  });
+
+  it('propagates 403 when the caller lacks Workspaces.Manage', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockRejectedValue(new Error('Request failed with status code 403'));
+
+    await expect(
+      putWorkspaceCustomization(client, apiBase, 'sales', { deltas: [] })
+    ).rejects.toThrow(/403/);
+  });
+});

--- a/packages/@granit/entities-customization/src/api/form-customization-api.ts
+++ b/packages/@granit/entities-customization/src/api/form-customization-api.ts
@@ -1,0 +1,48 @@
+import type {
+  FormCustomizationRequest,
+  FormCustomizationResponse,
+  FormVariant,
+} from '../types/customization.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+/** Builds the form-customization endpoint for a given entity + variant. */
+function formPath(apiBase: string, entityName: string, variant: FormVariant): string {
+  return `${apiBase}/entities/${encodeURIComponent(entityName)}/customization/forms/${encodeURIComponent(variant)}`;
+}
+
+/**
+ * Read the active form layout deltas for `entityName`/`variant`.
+ *
+ * `GET {apiBase}/entities/{name}/customization/forms/{variant}`
+ */
+export async function getFormCustomization(
+  client: AxiosInstance,
+  apiBase: string,
+  entityName: string,
+  variant: FormVariant
+): Promise<FormCustomizationResponse> {
+  const response = await client.get<FormCustomizationResponse>(
+    formPath(apiBase, entityName, variant)
+  );
+  return response.data;
+}
+
+/**
+ * Replace the form layout deltas for `entityName`/`variant`. The backend
+ * audits the change (ADR-053 §7) and rejects unknown delta kinds.
+ *
+ * `PUT {apiBase}/entities/{name}/customization/forms/{variant}`
+ */
+export async function putFormCustomization(
+  client: AxiosInstance,
+  apiBase: string,
+  entityName: string,
+  variant: FormVariant,
+  request: FormCustomizationRequest
+): Promise<FormCustomizationResponse> {
+  const response = await client.put<FormCustomizationResponse>(
+    formPath(apiBase, entityName, variant),
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/entities-customization/src/api/workspace-customization-api.ts
+++ b/packages/@granit/entities-customization/src/api/workspace-customization-api.ts
@@ -1,0 +1,43 @@
+import type {
+  WorkspaceCustomizationRequest,
+  WorkspaceCustomizationResponse,
+} from '../types/customization.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+function workspacePath(apiBase: string, workspaceName: string): string {
+  return `${apiBase}/workspaces/${encodeURIComponent(workspaceName)}/customization`;
+}
+
+/**
+ * Read the active workspace layout deltas for `workspaceName`.
+ *
+ * `GET {apiBase}/workspaces/{name}/customization`
+ */
+export async function getWorkspaceCustomization(
+  client: AxiosInstance,
+  apiBase: string,
+  workspaceName: string
+): Promise<WorkspaceCustomizationResponse> {
+  const response = await client.get<WorkspaceCustomizationResponse>(
+    workspacePath(apiBase, workspaceName)
+  );
+  return response.data;
+}
+
+/**
+ * Replace the workspace layout deltas for `workspaceName`.
+ *
+ * `PUT {apiBase}/workspaces/{name}/customization`
+ */
+export async function putWorkspaceCustomization(
+  client: AxiosInstance,
+  apiBase: string,
+  workspaceName: string,
+  request: WorkspaceCustomizationRequest
+): Promise<WorkspaceCustomizationResponse> {
+  const response = await client.put<WorkspaceCustomizationResponse>(
+    workspacePath(apiBase, workspaceName),
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/entities-customization/src/index.ts
+++ b/packages/@granit/entities-customization/src/index.ts
@@ -1,0 +1,23 @@
+// Types
+export type {
+  FormCustomizationRequest,
+  FormCustomizationResponse,
+  FormVariant,
+  HideDelta,
+  LayoutDelta,
+  LayoutDeltaKind,
+  RegroupDelta,
+  ReorderDelta,
+  WorkspaceCustomizationRequest,
+  WorkspaceCustomizationResponse,
+} from './types/index.js';
+
+// Permissions
+export { CustomizationPermissions } from './permissions.js';
+
+// API
+export { getFormCustomization, putFormCustomization } from './api/form-customization-api.js';
+export {
+  getWorkspaceCustomization,
+  putWorkspaceCustomization,
+} from './api/workspace-customization-api.js';

--- a/packages/@granit/entities-customization/src/permissions.ts
+++ b/packages/@granit/entities-customization/src/permissions.ts
@@ -1,0 +1,20 @@
+/**
+ * Customization permission keys (mirror `Granit.EntitiesCustomization`
+ * permissions on the backend, ADR-053 §6).
+ *
+ *  - `Forms.Read` — observe the active form layout deltas
+ *  - `Forms.Manage` — write/replace the form layout deltas
+ *  - `Workspaces.Read` / `Workspaces.Manage` — same, for workspaces
+ */
+export const CustomizationPermissions = {
+  EntitiesCustomization: {
+    Forms: {
+      Read: 'EntitiesCustomization.Forms.Read',
+      Manage: 'EntitiesCustomization.Forms.Manage',
+    },
+    Workspaces: {
+      Read: 'EntitiesCustomization.Workspaces.Read',
+      Manage: 'EntitiesCustomization.Workspaces.Manage',
+    },
+  },
+} as const;

--- a/packages/@granit/entities-customization/src/types/customization.ts
+++ b/packages/@granit/entities-customization/src/types/customization.ts
@@ -1,0 +1,35 @@
+import type { LayoutDelta } from './delta.js';
+
+/**
+ * Form variant — closed catalog mirroring `Granit.EntitiesCustomization.FormVariant`.
+ * Customization scopes layouts per variant so the same entity can have different
+ * field arrangements on the create form, the edit form, and the read view.
+ */
+export type FormVariant = 'Create' | 'Edit' | 'Read';
+
+/** Body for `PUT /api/entities/{name}/customization/forms/{variant}`. */
+export interface FormCustomizationRequest {
+  readonly deltas: readonly LayoutDelta[];
+}
+
+/** Response from `GET|PUT /api/entities/{name}/customization/forms/{variant}`. */
+export interface FormCustomizationResponse {
+  readonly entityName: string;
+  readonly variant: FormVariant;
+  readonly deltas: readonly LayoutDelta[];
+  readonly updatedAt: string | null;
+  readonly updatedByUserId: string | null;
+}
+
+/** Body for `PUT /api/workspaces/{name}/customization`. */
+export interface WorkspaceCustomizationRequest {
+  readonly deltas: readonly LayoutDelta[];
+}
+
+/** Response from `GET|PUT /api/workspaces/{name}/customization`. */
+export interface WorkspaceCustomizationResponse {
+  readonly workspaceName: string;
+  readonly deltas: readonly LayoutDelta[];
+  readonly updatedAt: string | null;
+  readonly updatedByUserId: string | null;
+}

--- a/packages/@granit/entities-customization/src/types/delta.ts
+++ b/packages/@granit/entities-customization/src/types/delta.ts
@@ -1,0 +1,32 @@
+/**
+ * Closed catalog of layout deltas — mirrors `Granit.EntitiesCustomization.LayoutDelta`
+ * (ADR-053 Layer 1). Adding a new delta kind requires an ADR amendment +
+ * coordinated backend/front change; new shapes never appear "by convention".
+ */
+export type LayoutDeltaKind = 'Reorder' | 'Regroup' | 'Hide';
+
+/**
+ * Move a field relative to a sibling. Exactly one of `beforeFieldName` or
+ * `afterFieldName` must be defined; setting both is a backend 422.
+ */
+export interface ReorderDelta {
+  readonly kind: 'Reorder';
+  readonly fieldName: string;
+  readonly beforeFieldName?: string;
+  readonly afterFieldName?: string;
+}
+
+/** Move a field into a group (created on the fly if it doesn't exist yet). */
+export interface RegroupDelta {
+  readonly kind: 'Regroup';
+  readonly fieldName: string;
+  readonly groupKey: string;
+}
+
+/** Hide a field from the current variant; backend keeps it in the schema. */
+export interface HideDelta {
+  readonly kind: 'Hide';
+  readonly fieldName: string;
+}
+
+export type LayoutDelta = ReorderDelta | RegroupDelta | HideDelta;

--- a/packages/@granit/entities-customization/src/types/index.ts
+++ b/packages/@granit/entities-customization/src/types/index.ts
@@ -1,0 +1,14 @@
+export type {
+  HideDelta,
+  LayoutDelta,
+  LayoutDeltaKind,
+  RegroupDelta,
+  ReorderDelta,
+} from './delta.js';
+export type {
+  FormCustomizationRequest,
+  FormCustomizationResponse,
+  FormVariant,
+  WorkspaceCustomizationRequest,
+  WorkspaceCustomizationResponse,
+} from './customization.js';

--- a/packages/@granit/entities-customization/tsconfig.json
+++ b/packages/@granit/entities-customization/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/entities-customization/tsup.config.ts
+++ b/packages/@granit/entities-customization/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-entities-customization/package.json
+++ b/packages/@granit/react-entities-customization/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@granit/react-entities-customization",
+  "description": "React bindings + headless editors for @granit/entities-customization (Layer 1)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities-customization": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/entities-customization": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-entities-customization/src/__tests__/apply-deltas.test.ts
+++ b/packages/@granit/react-entities-customization/src/__tests__/apply-deltas.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  applyDeltas,
+  moveFieldDown,
+  moveFieldUp,
+  setFieldGroup,
+  toggleFieldHidden,
+  type SchemaField,
+} from '../layout/apply-deltas.js';
+
+import type { LayoutDelta } from '@granit/entities-customization';
+
+const fields: readonly SchemaField[] = [
+  { name: 'name', defaultGroup: 'general' },
+  { name: 'amount', defaultGroup: 'pricing' },
+  { name: 'currency', defaultGroup: 'pricing' },
+  { name: 'internalNotes' },
+];
+
+describe('applyDeltas', () => {
+  it('returns the schema order when no deltas apply', () => {
+    expect(applyDeltas(fields, []).map((f) => f.name)).toEqual([
+      'name',
+      'amount',
+      'currency',
+      'internalNotes',
+    ]);
+  });
+
+  it('hides a field via Hide delta', () => {
+    const result = applyDeltas(fields, [{ kind: 'Hide', fieldName: 'internalNotes' }]);
+    expect(result.find((f) => f.name === 'internalNotes')?.hidden).toBe(true);
+  });
+
+  it('reassigns the group via Regroup delta', () => {
+    const result = applyDeltas(fields, [
+      { kind: 'Regroup', fieldName: 'amount', groupKey: 'finance' },
+    ]);
+    expect(result.find((f) => f.name === 'amount')?.group).toBe('finance');
+  });
+
+  it('moves a field before an anchor via Reorder.beforeFieldName', () => {
+    const result = applyDeltas(fields, [
+      { kind: 'Reorder', fieldName: 'currency', beforeFieldName: 'amount' },
+    ]);
+    expect(result.map((f) => f.name)).toEqual(['name', 'currency', 'amount', 'internalNotes']);
+  });
+
+  it('moves a field after an anchor via Reorder.afterFieldName', () => {
+    const result = applyDeltas(fields, [
+      { kind: 'Reorder', fieldName: 'name', afterFieldName: 'currency' },
+    ]);
+    expect(result.map((f) => f.name)).toEqual(['amount', 'currency', 'name', 'internalNotes']);
+  });
+
+  it('ignores Reorder when the anchor does not exist', () => {
+    const result = applyDeltas(fields, [
+      { kind: 'Reorder', fieldName: 'name', beforeFieldName: 'unknownField' },
+    ]);
+    expect(result.map((f) => f.name)).toEqual(['name', 'amount', 'currency', 'internalNotes']);
+  });
+
+  it('ignores deltas targeting unknown fields', () => {
+    const result = applyDeltas(fields, [{ kind: 'Hide', fieldName: 'mystery' }]);
+    expect(result.every((f) => !f.hidden)).toBe(true);
+  });
+
+  it('applies deltas in order — later wins for the same field/kind', () => {
+    const deltas: readonly LayoutDelta[] = [
+      { kind: 'Regroup', fieldName: 'amount', groupKey: 'finance' },
+      { kind: 'Regroup', fieldName: 'amount', groupKey: 'totals' },
+    ];
+    expect(applyDeltas(fields, deltas).find((f) => f.name === 'amount')?.group).toBe('totals');
+  });
+});
+
+describe('moveFieldUp / moveFieldDown', () => {
+  it('moveFieldUp on the first row is a no-op', () => {
+    expect(moveFieldUp(fields, [], 'name')).toEqual([]);
+  });
+
+  it('moveFieldDown on the last row is a no-op', () => {
+    expect(moveFieldDown(fields, [], 'internalNotes')).toEqual([]);
+  });
+
+  it('moveFieldUp produces a Reorder.beforeFieldName delta', () => {
+    const next = moveFieldUp(fields, [], 'amount');
+    expect(applyDeltas(fields, next).map((f) => f.name)).toEqual([
+      'amount',
+      'name',
+      'currency',
+      'internalNotes',
+    ]);
+  });
+
+  it('moveFieldDown produces a Reorder.afterFieldName delta', () => {
+    const next = moveFieldDown(fields, [], 'amount');
+    expect(applyDeltas(fields, next).map((f) => f.name)).toEqual([
+      'name',
+      'currency',
+      'amount',
+      'internalNotes',
+    ]);
+  });
+});
+
+describe('toggleFieldHidden', () => {
+  it('appends a Hide delta when the field is currently visible', () => {
+    const next = toggleFieldHidden(fields, [], 'amount');
+    expect(next).toEqual([{ kind: 'Hide', fieldName: 'amount' }]);
+  });
+
+  it('strips Hide deltas when the field is currently hidden', () => {
+    const initial: readonly LayoutDelta[] = [{ kind: 'Hide', fieldName: 'amount' }];
+    expect(toggleFieldHidden(fields, initial, 'amount')).toEqual([]);
+  });
+});
+
+describe('setFieldGroup', () => {
+  it('replaces any prior Regroup delta for the field', () => {
+    const initial: readonly LayoutDelta[] = [
+      { kind: 'Regroup', fieldName: 'amount', groupKey: 'old' },
+    ];
+    expect(setFieldGroup(initial, 'amount', 'new')).toEqual([
+      { kind: 'Regroup', fieldName: 'amount', groupKey: 'new' },
+    ]);
+  });
+
+  it('clears the group when groupKey is empty', () => {
+    const initial: readonly LayoutDelta[] = [
+      { kind: 'Regroup', fieldName: 'amount', groupKey: 'old' },
+    ];
+    expect(setFieldGroup(initial, 'amount', '')).toEqual([]);
+  });
+});

--- a/packages/@granit/react-entities-customization/src/__tests__/customization-provider.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/customization-provider.test.tsx
@@ -1,0 +1,74 @@
+import { createMockClient } from '@granit/testing';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  CustomizationProvider,
+  buildCustomizationQueryKey,
+  useCustomizationConfig,
+} from '../providers/customization-provider.js';
+
+import type { ReactNode } from 'react';
+
+describe('CustomizationProvider', () => {
+  it('exposes default apiBase and queryKeyPrefix', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CustomizationProvider config={{ client }}>{children}</CustomizationProvider>
+    );
+
+    const { result } = renderHook(() => useCustomizationConfig(), { wrapper });
+
+    expect(result.current.apiBase).toBe('/api/v1');
+    expect(result.current.queryKeyPrefix).toEqual(['entities-customization']);
+    expect(result.current.client).toBe(client);
+  });
+
+  it('honors apiBase + queryKeyPrefix overrides', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CustomizationProvider config={{ client, apiBase: '/svc', queryKeyPrefix: ['t', 'cust'] }}>
+        {children}
+      </CustomizationProvider>
+    );
+
+    const { result } = renderHook(() => useCustomizationConfig(), { wrapper });
+
+    expect(result.current.apiBase).toBe('/svc');
+    expect(result.current.queryKeyPrefix).toEqual(['t', 'cust']);
+  });
+
+  it('throws when used outside the provider', () => {
+    expect(() => renderHook(() => useCustomizationConfig())).toThrow(/CustomizationProvider/);
+  });
+
+  it('throws when no client is available', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CustomizationProvider config={{}}>{children}</CustomizationProvider>
+    );
+
+    expect(() => renderHook(() => useCustomizationConfig(), { wrapper })).toThrow(
+      /requires an Axios client/
+    );
+  });
+});
+
+describe('buildCustomizationQueryKey', () => {
+  it('prepends the configured prefix', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <CustomizationProvider config={{ client, queryKeyPrefix: ['p'] }}>
+        {children}
+      </CustomizationProvider>
+    );
+
+    const { result } = renderHook(() => useCustomizationConfig(), { wrapper });
+
+    expect(buildCustomizationQueryKey(result.current, 'forms', 'Quote', 'Edit')).toEqual([
+      'p',
+      'forms',
+      'Quote',
+      'Edit',
+    ]);
+  });
+});

--- a/packages/@granit/react-entities-customization/src/__tests__/field-inspector-overlay.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/field-inspector-overlay.test.tsx
@@ -1,0 +1,52 @@
+import { fireEvent, render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FieldInspectorOverlay, RESOLUTION_LAYERS } from '../components/field-inspector-overlay.js';
+
+import type { FieldResolutionEntry } from '../components/field-inspector-overlay.js';
+
+describe('FieldInspectorOverlay', () => {
+  it('always renders the full 5-layer chain even when entries are sparse', () => {
+    render(
+      <FieldInspectorOverlay
+        fieldName="amount"
+        entries={[{ layer: 'Layer1Admin', winning: true, summary: 'Hidden' }]}
+      />
+    );
+    const layers = document.querySelectorAll<HTMLElement>('[data-granit-field-inspector-layer]');
+    expect(layers.length).toBe(RESOLUTION_LAYERS.length);
+    expect([...layers].map((l) => l.dataset.layer)).toEqual([
+      'Layer1Admin',
+      'Layer2Workspace',
+      'Layer3Role',
+      'Layer4User',
+      'Layer5Schema',
+    ]);
+  });
+
+  it('marks the winning layer with data-winning and the badge', () => {
+    const entries: readonly FieldResolutionEntry[] = [
+      { layer: 'Layer1Admin', winning: true, summary: 'Hidden' },
+      { layer: 'Layer5Schema', winning: false, summary: 'Default visible' },
+    ];
+    render(<FieldInspectorOverlay fieldName="amount" entries={entries} />);
+
+    const winningRow = document.querySelector<HTMLElement>(
+      '[data-granit-field-inspector-layer][data-winning]'
+    );
+    expect(winningRow?.dataset.layer).toBe('Layer1Admin');
+    expect(document.querySelector('[data-granit-field-inspector-winning]')).not.toBeNull();
+  });
+
+  it('fires onClose when the close button is clicked', () => {
+    const onClose = vi.fn();
+    render(<FieldInspectorOverlay fieldName="amount" entries={[]} onClose={onClose} />);
+    fireEvent.click(document.querySelector('[data-granit-field-inspector-close]')!);
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('omits the close button when onClose is not provided', () => {
+    render(<FieldInspectorOverlay fieldName="amount" entries={[]} />);
+    expect(document.querySelector('[data-granit-field-inspector-close]')).toBeNull();
+  });
+});

--- a/packages/@granit/react-entities-customization/src/__tests__/form-layout-editor.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/form-layout-editor.test.tsx
@@ -1,0 +1,114 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { FormLayoutEditor } from '../components/form-layout-editor.js';
+
+import type { SchemaField } from '../layout/apply-deltas.js';
+import type { LayoutDelta } from '@granit/entities-customization';
+
+const fields: readonly SchemaField[] = [
+  { name: 'name', label: 'Name', defaultGroup: 'general' },
+  { name: 'amount', label: 'Amount', defaultGroup: 'pricing' },
+  { name: 'currency', label: 'Currency', defaultGroup: 'pricing' },
+];
+
+interface HarnessProps {
+  readonly onChange: (next: readonly LayoutDelta[]) => void;
+  readonly initial?: readonly LayoutDelta[];
+  readonly readOnly?: boolean;
+}
+
+function Harness({ onChange, initial = [], readOnly }: HarnessProps) {
+  const [deltas, setDeltas] = useState<readonly LayoutDelta[]>(initial);
+  return (
+    <FormLayoutEditor
+      fields={fields}
+      deltas={deltas}
+      onChange={(next) => {
+        setDeltas(next);
+        onChange(next);
+      }}
+      availableGroups={[
+        { key: 'general', label: 'General' },
+        { key: 'pricing', label: 'Pricing' },
+      ]}
+      readOnly={readOnly}
+    />
+  );
+}
+
+describe('FormLayoutEditor', () => {
+  it('renders one row per field with field-name markers', () => {
+    render(<Harness onChange={() => {}} />);
+    expect(document.querySelectorAll('[data-granit-form-layout-editor-row]').length).toBe(3);
+    expect(document.querySelector('[data-field-name="amount"]')).not.toBeNull();
+  });
+
+  it('disables Move up on the first row and Move down on the last', () => {
+    render(<Harness onChange={() => {}} />);
+    const rows = document.querySelectorAll<HTMLElement>('[data-granit-form-layout-editor-row]');
+    const firstUp = rows[0]?.querySelector<HTMLButtonElement>(
+      '[data-granit-form-layout-editor-move-up]'
+    );
+    const lastDown = rows[2]?.querySelector<HTMLButtonElement>(
+      '[data-granit-form-layout-editor-move-down]'
+    );
+    expect(firstUp?.disabled).toBe(true);
+    expect(lastDown?.disabled).toBe(true);
+  });
+
+  it('moves a field down via Move down and reflects the new order', () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    const amountRow = document.querySelector<HTMLElement>('[data-field-name="amount"]')!;
+    const down = amountRow.querySelector<HTMLButtonElement>(
+      '[data-granit-form-layout-editor-move-down]'
+    )!;
+    fireEvent.click(down);
+
+    expect(onChange).toHaveBeenCalledWith([
+      { kind: 'Reorder', fieldName: 'amount', afterFieldName: 'currency' },
+    ]);
+    const rows = document.querySelectorAll<HTMLElement>('[data-granit-form-layout-editor-row]');
+    expect([...rows].map((r) => r.dataset.fieldName)).toEqual(['name', 'currency', 'amount']);
+  });
+
+  it('toggles hidden state via the Hide button', () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    const row = document.querySelector<HTMLElement>('[data-field-name="amount"]')!;
+    const toggle = row.querySelector<HTMLButtonElement>(
+      '[data-granit-form-layout-editor-toggle-hidden]'
+    )!;
+    fireEvent.click(toggle);
+
+    expect(onChange).toHaveBeenCalledWith([{ kind: 'Hide', fieldName: 'amount' }]);
+    expect(row.dataset.hidden).toBe('');
+  });
+
+  it('emits Regroup deltas when the group select changes', () => {
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    const row = document.querySelector<HTMLElement>('[data-field-name="amount"]')!;
+    const select = row.querySelector<HTMLSelectElement>('[data-granit-form-layout-editor-group]')!;
+    fireEvent.change(select, { target: { value: 'general' } });
+
+    expect(onChange).toHaveBeenCalledWith([
+      { kind: 'Regroup', fieldName: 'amount', groupKey: 'general' },
+    ]);
+  });
+
+  it('disables every control in readOnly mode', () => {
+    render(<Harness onChange={() => {}} readOnly />);
+    const buttons = screen.getAllByRole('button');
+    expect(buttons.every((b) => (b as HTMLButtonElement).disabled)).toBe(true);
+    const select = document.querySelector<HTMLSelectElement>(
+      '[data-granit-form-layout-editor-group]'
+    );
+    expect(select?.disabled).toBe(true);
+  });
+});

--- a/packages/@granit/react-entities-customization/src/__tests__/locales.test.ts
+++ b/packages/@granit/react-entities-customization/src/__tests__/locales.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { customizationTranslationsEn } from '../locales/en.js';
+import { customizationTranslationsFr } from '../locales/fr.js';
+
+function leafPaths(obj: unknown, prefix = ''): readonly string[] {
+  if (typeof obj !== 'object' || obj === null) {
+    return [prefix];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, value]) =>
+    leafPaths(value, prefix ? `${prefix}.${key}` : key)
+  );
+}
+
+describe('customization locale bundles', () => {
+  it('en exposes Editor and Inspector surfaces with the 5 layer labels', () => {
+    expect(Object.keys(customizationTranslationsEn).sort()).toEqual(['Editor', 'Inspector']);
+    expect(Object.keys(customizationTranslationsEn.Inspector.Layers).sort()).toEqual([
+      'Layer1Admin',
+      'Layer2Workspace',
+      'Layer3Role',
+      'Layer4User',
+      'Layer5Schema',
+    ]);
+  });
+
+  it('fr provides every key declared in en (no missing translations)', () => {
+    const enPaths = new Set(leafPaths(customizationTranslationsEn));
+    const frPaths = new Set(leafPaths(customizationTranslationsFr));
+    expect([...enPaths].filter((p) => !frPaths.has(p))).toEqual([]);
+    expect([...frPaths].filter((p) => !enPaths.has(p))).toEqual([]);
+  });
+
+  it('preserves interpolation placeholders across locales', () => {
+    expect(customizationTranslationsEn.Editor.GroupSelectAriaLabel).toContain('{{fieldName}}');
+    expect(customizationTranslationsFr.Editor.GroupSelectAriaLabel).toContain('{{fieldName}}');
+    expect(customizationTranslationsEn.Inspector.Title).toContain('{{fieldName}}');
+    expect(customizationTranslationsFr.Inspector.Title).toContain('{{fieldName}}');
+  });
+});

--- a/packages/@granit/react-entities-customization/src/__tests__/use-form-customization.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/use-form-customization.test.tsx
@@ -1,0 +1,90 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useFormCustomization, usePutFormCustomization } from '../hooks/use-form-customization.js';
+import { CustomizationProvider } from '../providers/customization-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { FormCustomizationResponse } from '@granit/entities-customization';
+import type { QueryClient } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const sampleResponse: FormCustomizationResponse = {
+  entityName: 'Quote',
+  variant: 'Edit',
+  deltas: [],
+  updatedAt: null,
+  updatedByUserId: null,
+};
+
+interface Harness {
+  readonly client: AxiosInstance;
+  readonly queryClient: QueryClient;
+  readonly onFormCustomizationChanged: ReturnType<typeof vi.fn>;
+  readonly wrapper: (props: { children: ReactNode }) => React.ReactElement;
+}
+
+function createHarness(): Harness {
+  const client = createMockClient();
+  const queryClient = createTestQueryClient();
+  const onFormCustomizationChanged = vi.fn();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <CustomizationProvider config={{ client, onFormCustomizationChanged }}>
+        {children}
+      </CustomizationProvider>
+    );
+  return { client, queryClient, onFormCustomizationChanged, wrapper };
+}
+
+describe('useFormCustomization', () => {
+  it('GETs the form customization endpoint with the resolved key', async () => {
+    const { client, wrapper } = createHarness();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
+
+    const { result } = renderHook(
+      () => useFormCustomization({ entityName: 'Quote', variant: 'Edit' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/forms/Edit');
+    expect(result.current.data).toEqual(sampleResponse);
+  });
+
+  it('is disabled when entityName is empty', () => {
+    const { client, wrapper } = createHarness();
+
+    renderHook(() => useFormCustomization({ entityName: '', variant: 'Edit' }), { wrapper });
+
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('usePutFormCustomization', () => {
+  it('PUTs the deltas, invalidates the read query, and fires the manifest hook', async () => {
+    const { client, queryClient, onFormCustomizationChanged, wrapper } = createHarness();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleResponse));
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => usePutFormCustomization(), { wrapper });
+    await result.current.mutateAsync({
+      entityName: 'Quote',
+      variant: 'Edit',
+      request: { deltas: [{ kind: 'Hide', fieldName: 'internalNotes' }] },
+    });
+
+    expect(client.put).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/forms/Edit', {
+      deltas: [{ kind: 'Hide', fieldName: 'internalNotes' }],
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toContainEqual(['entities-customization', 'forms', 'Quote', 'Edit']);
+    expect(onFormCustomizationChanged).toHaveBeenCalledWith('Quote');
+  });
+});

--- a/packages/@granit/react-entities-customization/src/__tests__/use-workspace-customization.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/use-workspace-customization.test.tsx
@@ -1,0 +1,72 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  usePutWorkspaceCustomization,
+  useWorkspaceCustomization,
+} from '../hooks/use-workspace-customization.js';
+import { CustomizationProvider } from '../providers/customization-provider.js';
+
+import type { WorkspaceCustomizationResponse } from '@granit/entities-customization';
+import type { ReactNode } from 'react';
+
+const sampleResponse: WorkspaceCustomizationResponse = {
+  workspaceName: 'sales',
+  deltas: [],
+  updatedAt: null,
+  updatedByUserId: null,
+};
+
+function createHarness() {
+  const client = createMockClient();
+  const queryClient = createTestQueryClient();
+  const onWorkspaceCustomizationChanged = vi.fn();
+  const wrapper = ({ children }: { children: ReactNode }) =>
+    React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <CustomizationProvider config={{ client, onWorkspaceCustomizationChanged }}>
+        {children}
+      </CustomizationProvider>
+    );
+  return { client, queryClient, onWorkspaceCustomizationChanged, wrapper };
+}
+
+describe('useWorkspaceCustomization', () => {
+  it('GETs the workspace customization endpoint', async () => {
+    const { client, wrapper } = createHarness();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
+
+    const { result } = renderHook(() => useWorkspaceCustomization({ workspaceName: 'sales' }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/workspaces/sales/customization');
+  });
+});
+
+describe('usePutWorkspaceCustomization', () => {
+  it('PUTs deltas and fires the manifest hook on success', async () => {
+    const { client, queryClient, onWorkspaceCustomizationChanged, wrapper } = createHarness();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleResponse));
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => usePutWorkspaceCustomization(), { wrapper });
+    await result.current.mutateAsync({
+      workspaceName: 'sales',
+      request: { deltas: [{ kind: 'Hide', fieldName: 'tile-pipeline' }] },
+    });
+
+    expect(client.put).toHaveBeenCalledWith('/api/v1/workspaces/sales/customization', {
+      deltas: [{ kind: 'Hide', fieldName: 'tile-pipeline' }],
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toContainEqual(['entities-customization', 'workspaces', 'sales']);
+    expect(onWorkspaceCustomizationChanged).toHaveBeenCalledWith('sales');
+  });
+});

--- a/packages/@granit/react-entities-customization/src/components/field-inspector-overlay.tsx
+++ b/packages/@granit/react-entities-customization/src/components/field-inspector-overlay.tsx
@@ -1,0 +1,124 @@
+import type { ReactNode } from 'react';
+
+/**
+ * The 5-layer resolution hierarchy from ADR-053 §4. The order is fixed —
+ * highest precedence first: a Layer 1 (admin) override beats a Layer 5
+ * (schema default) when both apply.
+ *
+ *  1. Layer1Admin     — tenant admin's customization (this package)
+ *  2. Layer2Workspace — workspace-scoped override
+ *  3. Layer3Role      — role-scoped override
+ *  4. Layer4User      — per-user preference
+ *  5. Layer5Schema    — code-declared default
+ */
+export type ResolutionLayer =
+  | 'Layer1Admin'
+  | 'Layer2Workspace'
+  | 'Layer3Role'
+  | 'Layer4User'
+  | 'Layer5Schema';
+
+export const RESOLUTION_LAYERS: readonly ResolutionLayer[] = Object.freeze([
+  'Layer1Admin',
+  'Layer2Workspace',
+  'Layer3Role',
+  'Layer4User',
+  'Layer5Schema',
+]);
+
+/** A single contributing source for a field's effective layout. */
+export interface FieldResolutionEntry {
+  readonly layer: ResolutionLayer;
+  /** Was this layer the winning source for the effective value? */
+  readonly winning: boolean;
+  /** Free-form description of what this layer contributed (e.g. "Hidden"). */
+  readonly summary: string;
+}
+
+export interface FieldInspectorOverlayLabels {
+  readonly title?: (fieldName: string) => string;
+  readonly winningTag?: string;
+  readonly close?: string;
+  readonly layerLabel?: (layer: ResolutionLayer) => string;
+}
+
+const DEFAULT_LABELS: Required<FieldInspectorOverlayLabels> = {
+  title: (fieldName) => `Resolution chain — ${fieldName}`,
+  winningTag: 'winning',
+  close: 'Close',
+  layerLabel: (layer) => layer,
+};
+
+export interface FieldInspectorOverlayProps {
+  readonly fieldName: string;
+  /**
+   * One entry per layer. Callers that don't have data for a layer should
+   * still pass it (with a `summary` like "—") so the overlay shows the
+   * full 5-row resolution chain — that's the anti-Frappe guarantee.
+   */
+  readonly entries: readonly FieldResolutionEntry[];
+  readonly onClose?: () => void;
+  readonly labels?: FieldInspectorOverlayLabels;
+  readonly className?: string;
+}
+
+/**
+ * Headless 5-layer resolution debug overlay. Presents one row per layer
+ * with its summary and a `winning` badge on the layer that produced the
+ * effective value.
+ *
+ * No design-system chrome: apps style via `data-granit-field-inspector*`
+ * markers and host the overlay in their own modal/popover. The component
+ * itself is a `<dialog open>` so screen readers announce it correctly.
+ */
+export function FieldInspectorOverlay({
+  fieldName,
+  entries,
+  onClose,
+  labels,
+  className,
+}: FieldInspectorOverlayProps): ReactNode {
+  const merged = { ...DEFAULT_LABELS, ...labels };
+  return (
+    <dialog
+      open
+      data-granit-field-inspector=""
+      data-field-name={fieldName}
+      className={className}
+      aria-label={merged.title(fieldName)}
+    >
+      <header data-granit-field-inspector-header="">
+        <h2 data-granit-field-inspector-title="">{merged.title(fieldName)}</h2>
+        {onClose !== undefined ? (
+          <button
+            type="button"
+            data-granit-field-inspector-close=""
+            onClick={onClose}
+            aria-label={merged.close}
+          >
+            {merged.close}
+          </button>
+        ) : null}
+      </header>
+      <ol data-granit-field-inspector-layers="">
+        {RESOLUTION_LAYERS.map((layer) => {
+          const entry = entries.find((e) => e.layer === layer);
+          return (
+            <li
+              key={layer}
+              data-granit-field-inspector-layer=""
+              data-layer={layer}
+              data-winning={entry?.winning ? '' : undefined}
+            >
+              <span data-granit-field-inspector-layer-label="">{merged.layerLabel(layer)}</span>
+              <span data-granit-field-inspector-layer-summary="">{entry?.summary ?? '—'}</span>
+              {entry?.winning ? (
+                <span data-granit-field-inspector-winning="">{merged.winningTag}</span>
+              ) : null}
+            </li>
+          );
+        })}
+      </ol>
+    </dialog>
+  );
+}

--- a/packages/@granit/react-entities-customization/src/components/form-layout-editor.tsx
+++ b/packages/@granit/react-entities-customization/src/components/form-layout-editor.tsx
@@ -1,0 +1,134 @@
+import {
+  applyDeltas,
+  moveFieldDown,
+  moveFieldUp,
+  setFieldGroup,
+  toggleFieldHidden,
+  type SchemaField,
+} from '../layout/apply-deltas.js';
+
+import type { LayoutDelta } from '@granit/entities-customization';
+import type { ReactNode } from 'react';
+
+export interface LayoutEditorLabels {
+  readonly moveUp?: string;
+  readonly moveDown?: string;
+  readonly hide?: string;
+  readonly show?: string;
+  readonly groupSelectAriaLabel?: (fieldName: string) => string;
+  readonly noGroup?: string;
+}
+
+const DEFAULT_LABELS: Required<LayoutEditorLabels> = {
+  moveUp: 'Move up',
+  moveDown: 'Move down',
+  hide: 'Hide',
+  show: 'Show',
+  groupSelectAriaLabel: (fieldName) => `Group for ${fieldName}`,
+  noGroup: '— no group —',
+};
+
+export interface FormLayoutEditorProps {
+  readonly fields: readonly SchemaField[];
+  readonly deltas: readonly LayoutDelta[];
+  readonly onChange: (next: readonly LayoutDelta[]) => void;
+  /** Available group keys to assign — shown as a `<select>` per row. */
+  readonly availableGroups?: readonly { readonly key: string; readonly label?: string }[];
+  readonly labels?: LayoutEditorLabels;
+  readonly className?: string;
+  /**
+   * Read-only mode: pass `onChange` undefined-equivalent by passing
+   * `readOnly`. Buttons render disabled and the select is disabled.
+   * Apps gate edit access by the `EntitiesCustomization.Forms.Manage`
+   * permission via this flag.
+   */
+  readonly readOnly?: boolean;
+}
+
+/**
+ * Headless form-layout editor. Renders one row per field with three
+ * controls — move up, move down, hide/show — plus an optional group
+ * `<select>`. No design-system chrome; apps style via the
+ * `data-granit-form-layout-editor*` markers.
+ *
+ * The editor is fully controlled: the parent owns `deltas` state and
+ * decides when to PUT them via `usePutFormCustomization()`. This keeps
+ * the editor unit-testable without React Query and lets apps add
+ * undo/redo on top of the delta list freely.
+ */
+export function FormLayoutEditor({
+  fields,
+  deltas,
+  onChange,
+  availableGroups,
+  labels,
+  className,
+  readOnly,
+}: FormLayoutEditorProps): ReactNode {
+  const merged = { ...DEFAULT_LABELS, ...labels };
+  const effective = applyDeltas(fields, deltas);
+  const disabled = readOnly === true;
+
+  return (
+    <ol
+      data-granit-form-layout-editor=""
+      data-readonly={disabled ? '' : undefined}
+      className={className}
+    >
+      {effective.map((field, idx) => (
+        <li
+          key={field.name}
+          data-granit-form-layout-editor-row=""
+          data-field-name={field.name}
+          data-hidden={field.hidden ? '' : undefined}
+          data-group={field.group ?? undefined}
+        >
+          <span data-granit-form-layout-editor-label="">{field.label ?? field.name}</span>
+          <button
+            type="button"
+            data-granit-form-layout-editor-move-up=""
+            aria-label={merged.moveUp}
+            disabled={disabled || idx === 0}
+            onClick={() => onChange(moveFieldUp(fields, deltas, field.name))}
+          >
+            {merged.moveUp}
+          </button>
+          <button
+            type="button"
+            data-granit-form-layout-editor-move-down=""
+            aria-label={merged.moveDown}
+            disabled={disabled || idx === effective.length - 1}
+            onClick={() => onChange(moveFieldDown(fields, deltas, field.name))}
+          >
+            {merged.moveDown}
+          </button>
+          <button
+            type="button"
+            data-granit-form-layout-editor-toggle-hidden=""
+            aria-pressed={field.hidden}
+            disabled={disabled}
+            onClick={() => onChange(toggleFieldHidden(fields, deltas, field.name))}
+          >
+            {field.hidden ? merged.show : merged.hide}
+          </button>
+          {availableGroups !== undefined ? (
+            <select
+              data-granit-form-layout-editor-group=""
+              aria-label={merged.groupSelectAriaLabel(field.name)}
+              value={field.group ?? ''}
+              disabled={disabled}
+              onChange={(event) => onChange(setFieldGroup(deltas, field.name, event.target.value))}
+            >
+              <option value="">{merged.noGroup}</option>
+              {availableGroups.map((g) => (
+                <option key={g.key} value={g.key}>
+                  {g.label ?? g.key}
+                </option>
+              ))}
+            </select>
+          ) : null}
+        </li>
+      ))}
+    </ol>
+  );
+}

--- a/packages/@granit/react-entities-customization/src/components/workspace-layout-editor.tsx
+++ b/packages/@granit/react-entities-customization/src/components/workspace-layout-editor.tsx
@@ -1,0 +1,16 @@
+import { FormLayoutEditor, type FormLayoutEditorProps } from './form-layout-editor.js';
+
+import type { ReactNode } from 'react';
+
+/**
+ * Workspace tiles are described with the same shape as form fields
+ * (`name` + optional `defaultGroup`/`label`), and the same three deltas
+ * apply (`Reorder`, `Regroup`, `Hide`). We expose a dedicated component
+ * name so consumers can reason about workspace vs. form customization
+ * separately, but the implementation is shared with `<FormLayoutEditor>`.
+ */
+export type WorkspaceLayoutEditorProps = FormLayoutEditorProps;
+
+export function WorkspaceLayoutEditor(props: WorkspaceLayoutEditorProps): ReactNode {
+  return <FormLayoutEditor {...props} />;
+}

--- a/packages/@granit/react-entities-customization/src/constants.ts
+++ b/packages/@granit/react-entities-customization/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const DEFAULT_API_BASE = `/api/${API_VERSION}`;
+export const DEFAULT_QUERY_KEY_PREFIX = ['entities-customization'] as const;

--- a/packages/@granit/react-entities-customization/src/hooks/use-form-customization.ts
+++ b/packages/@granit/react-entities-customization/src/hooks/use-form-customization.ts
@@ -1,0 +1,69 @@
+import { getFormCustomization, putFormCustomization } from '@granit/entities-customization';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  buildCustomizationQueryKey,
+  useCustomizationConfig,
+} from '../providers/customization-provider.js';
+
+import type {
+  FormCustomizationRequest,
+  FormCustomizationResponse,
+  FormVariant,
+} from '@granit/entities-customization';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+interface UseFormCustomizationArgs {
+  readonly entityName: string;
+  readonly variant: FormVariant;
+}
+
+/**
+ * Read the active form layout deltas for an entity/variant pair. Disabled
+ * when `entityName` is empty.
+ */
+export function useFormCustomization({
+  entityName,
+  variant,
+}: UseFormCustomizationArgs): UseQueryResult<FormCustomizationResponse> {
+  const config = useCustomizationConfig();
+
+  return useQuery({
+    queryKey: buildCustomizationQueryKey(config, 'forms', entityName, variant),
+    queryFn: () => getFormCustomization(config.client, config.apiBase, entityName, variant),
+    enabled: entityName.length > 0,
+  });
+}
+
+interface PutFormCustomizationArgs {
+  readonly entityName: string;
+  readonly variant: FormVariant;
+  readonly request: FormCustomizationRequest;
+}
+
+/**
+ * Replace the form layout deltas for an entity/variant. On success:
+ * - the matching `useFormCustomization` query is invalidated
+ * - the optional `onFormCustomizationChanged(entityName)` provider hook
+ *   fires (apps wire it to invalidate the entity manifest cache, since the
+ *   layout flows through `@granit/react-entities`).
+ */
+export function usePutFormCustomization(): UseMutationResult<
+  FormCustomizationResponse,
+  Error,
+  PutFormCustomizationArgs
+> {
+  const config = useCustomizationConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ entityName, variant, request }: PutFormCustomizationArgs) =>
+      putFormCustomization(config.client, config.apiBase, entityName, variant, request),
+    onSuccess: (_data, { entityName, variant }) => {
+      queryClient.invalidateQueries({
+        queryKey: buildCustomizationQueryKey(config, 'forms', entityName, variant),
+      });
+      config.onFormCustomizationChanged?.(entityName);
+    },
+  });
+}

--- a/packages/@granit/react-entities-customization/src/hooks/use-workspace-customization.ts
+++ b/packages/@granit/react-entities-customization/src/hooks/use-workspace-customization.ts
@@ -1,0 +1,63 @@
+import {
+  getWorkspaceCustomization,
+  putWorkspaceCustomization,
+} from '@granit/entities-customization';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  buildCustomizationQueryKey,
+  useCustomizationConfig,
+} from '../providers/customization-provider.js';
+
+import type {
+  WorkspaceCustomizationRequest,
+  WorkspaceCustomizationResponse,
+} from '@granit/entities-customization';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+interface UseWorkspaceCustomizationArgs {
+  readonly workspaceName: string;
+}
+
+/** Read the active workspace layout deltas. Disabled when `workspaceName` is empty. */
+export function useWorkspaceCustomization({
+  workspaceName,
+}: UseWorkspaceCustomizationArgs): UseQueryResult<WorkspaceCustomizationResponse> {
+  const config = useCustomizationConfig();
+
+  return useQuery({
+    queryKey: buildCustomizationQueryKey(config, 'workspaces', workspaceName),
+    queryFn: () => getWorkspaceCustomization(config.client, config.apiBase, workspaceName),
+    enabled: workspaceName.length > 0,
+  });
+}
+
+interface PutWorkspaceCustomizationArgs {
+  readonly workspaceName: string;
+  readonly request: WorkspaceCustomizationRequest;
+}
+
+/**
+ * Replace the workspace layout deltas. Invalidates the matching read query
+ * and fires the `onWorkspaceCustomizationChanged` hook so apps can refresh
+ * the workspace manifest cache (`@granit/react-workspaces`).
+ */
+export function usePutWorkspaceCustomization(): UseMutationResult<
+  WorkspaceCustomizationResponse,
+  Error,
+  PutWorkspaceCustomizationArgs
+> {
+  const config = useCustomizationConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ workspaceName, request }: PutWorkspaceCustomizationArgs) =>
+      putWorkspaceCustomization(config.client, config.apiBase, workspaceName, request),
+    onSuccess: (_data, { workspaceName }) => {
+      queryClient.invalidateQueries({
+        queryKey: buildCustomizationQueryKey(config, 'workspaces', workspaceName),
+      });
+      config.onWorkspaceCustomizationChanged?.(workspaceName);
+    },
+  });
+}

--- a/packages/@granit/react-entities-customization/src/index.ts
+++ b/packages/@granit/react-entities-customization/src/index.ts
@@ -1,0 +1,48 @@
+// Provider
+export {
+  CustomizationProvider,
+  buildCustomizationQueryKey,
+  useCustomizationConfig,
+} from './providers/customization-provider.js';
+export type {
+  CustomizationConfig,
+  CustomizationProviderProps,
+  ResolvedCustomizationConfig,
+} from './providers/customization-provider.js';
+
+// Constants
+export { API_VERSION, DEFAULT_API_BASE, DEFAULT_QUERY_KEY_PREFIX } from './constants.js';
+
+// Hooks
+export { useFormCustomization, usePutFormCustomization } from './hooks/use-form-customization.js';
+export {
+  usePutWorkspaceCustomization,
+  useWorkspaceCustomization,
+} from './hooks/use-workspace-customization.js';
+
+// Layout helpers (pure)
+export {
+  applyDeltas,
+  moveFieldDown,
+  moveFieldUp,
+  setFieldGroup,
+  toggleFieldHidden,
+} from './layout/apply-deltas.js';
+export type { EffectiveField, SchemaField } from './layout/apply-deltas.js';
+
+// Components
+export { FormLayoutEditor } from './components/form-layout-editor.js';
+export type { FormLayoutEditorProps, LayoutEditorLabels } from './components/form-layout-editor.js';
+export { WorkspaceLayoutEditor } from './components/workspace-layout-editor.js';
+export type { WorkspaceLayoutEditorProps } from './components/workspace-layout-editor.js';
+export { FieldInspectorOverlay, RESOLUTION_LAYERS } from './components/field-inspector-overlay.js';
+export type {
+  FieldInspectorOverlayLabels,
+  FieldInspectorOverlayProps,
+  FieldResolutionEntry,
+  ResolutionLayer,
+} from './components/field-inspector-overlay.js';
+
+// i18n resource bundles (namespace: 'customization')
+export { customizationTranslationsEn, customizationTranslationsFr } from './locales/index.js';
+export type { CustomizationTranslations } from './locales/index.js';

--- a/packages/@granit/react-entities-customization/src/layout/apply-deltas.ts
+++ b/packages/@granit/react-entities-customization/src/layout/apply-deltas.ts
@@ -1,0 +1,138 @@
+import type { LayoutDelta } from '@granit/entities-customization';
+
+/** A field declared by the underlying schema/manifest, before deltas apply. */
+export interface SchemaField {
+  readonly name: string;
+  /** Default group key from the schema (e.g. `'general'`). May be undefined. */
+  readonly defaultGroup?: string;
+  /** Optional human label — passed through unchanged on the effective view. */
+  readonly label?: string;
+}
+
+/** A field after deltas apply: order is significant, and `hidden`/`group` reflect overrides. */
+export interface EffectiveField {
+  readonly name: string;
+  readonly label?: string;
+  readonly group?: string;
+  readonly hidden: boolean;
+}
+
+/**
+ * Apply a list of deltas to the schema fields and return the effective
+ * layout. Pure function — same inputs always yield the same output, which
+ * keeps the editor predictable and testable without React.
+ *
+ * Resolution semantics (mirrors backend, ADR-053 §4):
+ *  - Deltas apply in order; later deltas override earlier ones for the
+ *    same field (e.g. two `Hide` deltas idempotent; `Reorder` then
+ *    `Reorder` keeps the latter).
+ *  - `Reorder.beforeFieldName` and `Reorder.afterFieldName` are honored
+ *    only if the anchor exists in the current order. Unknown anchors
+ *    are silently ignored — backend rejects on PUT, so the editor
+ *    never persists an invalid delta.
+ *  - `Regroup` overrides `defaultGroup`.
+ *  - `Hide` flips `hidden` to true (no `Show` delta — un-hiding means
+ *    removing the Hide delta from the list).
+ */
+export function applyDeltas(
+  fields: readonly SchemaField[],
+  deltas: readonly LayoutDelta[]
+): readonly EffectiveField[] {
+  const order: string[] = fields.map((f) => f.name);
+  const meta = new Map<string, EffectiveField>();
+  for (const f of fields) {
+    meta.set(f.name, { name: f.name, label: f.label, group: f.defaultGroup, hidden: false });
+  }
+
+  for (const delta of deltas) {
+    if (!meta.has(delta.fieldName)) continue;
+    if (delta.kind === 'Hide') {
+      const current = meta.get(delta.fieldName)!;
+      meta.set(delta.fieldName, { ...current, hidden: true });
+    } else if (delta.kind === 'Regroup') {
+      const current = meta.get(delta.fieldName)!;
+      meta.set(delta.fieldName, { ...current, group: delta.groupKey });
+    } else if (delta.kind === 'Reorder') {
+      const fromIdx = order.indexOf(delta.fieldName);
+      if (fromIdx === -1) continue;
+      const anchor = delta.beforeFieldName ?? delta.afterFieldName;
+      if (anchor === undefined) continue;
+      const anchorIdx = order.indexOf(anchor);
+      if (anchorIdx === -1 || anchor === delta.fieldName) continue;
+      order.splice(fromIdx, 1);
+      const reAnchor = order.indexOf(anchor);
+      const targetIdx = delta.beforeFieldName !== undefined ? reAnchor : reAnchor + 1;
+      order.splice(targetIdx, 0, delta.fieldName);
+    }
+  }
+
+  return order.map((name) => meta.get(name)!);
+}
+
+/**
+ * Move a field one slot earlier in the effective order. Returns the next
+ * `deltas` list (or the same reference if already at the top).
+ */
+export function moveFieldUp(
+  fields: readonly SchemaField[],
+  deltas: readonly LayoutDelta[],
+  fieldName: string
+): readonly LayoutDelta[] {
+  const effective = applyDeltas(fields, deltas);
+  const idx = effective.findIndex((f) => f.name === fieldName);
+  if (idx <= 0) return deltas;
+  const previous = effective[idx - 1];
+  if (previous === undefined) return deltas;
+  return [...deltas, { kind: 'Reorder', fieldName, beforeFieldName: previous.name }];
+}
+
+/**
+ * Move a field one slot later in the effective order. Returns the next
+ * `deltas` list (or the same reference if already at the bottom).
+ */
+export function moveFieldDown(
+  fields: readonly SchemaField[],
+  deltas: readonly LayoutDelta[],
+  fieldName: string
+): readonly LayoutDelta[] {
+  const effective = applyDeltas(fields, deltas);
+  const idx = effective.findIndex((f) => f.name === fieldName);
+  if (idx === -1 || idx >= effective.length - 1) return deltas;
+  const next = effective[idx + 1];
+  if (next === undefined) return deltas;
+  return [...deltas, { kind: 'Reorder', fieldName, afterFieldName: next.name }];
+}
+
+/**
+ * Flip a field's visibility. Adding a hide appends a `Hide` delta;
+ * un-hiding strips every `Hide` delta for that field (deltas remain a
+ * historical/append log on the wire, but the editor's view is
+ * declarative).
+ */
+export function toggleFieldHidden(
+  fields: readonly SchemaField[],
+  deltas: readonly LayoutDelta[],
+  fieldName: string
+): readonly LayoutDelta[] {
+  const effective = applyDeltas(fields, deltas);
+  const target = effective.find((f) => f.name === fieldName);
+  if (target === undefined) return deltas;
+  if (target.hidden) {
+    return deltas.filter((d) => !(d.kind === 'Hide' && d.fieldName === fieldName));
+  }
+  return [...deltas, { kind: 'Hide', fieldName }];
+}
+
+/**
+ * Move a field into a group. Empty `groupKey` removes any `Regroup` delta
+ * (the field falls back to its schema default).
+ */
+export function setFieldGroup(
+  deltas: readonly LayoutDelta[],
+  fieldName: string,
+  groupKey: string
+): readonly LayoutDelta[] {
+  const stripped = deltas.filter((d) => !(d.kind === 'Regroup' && d.fieldName === fieldName));
+  if (groupKey.length === 0) return stripped;
+  return [...stripped, { kind: 'Regroup', fieldName, groupKey }];
+}

--- a/packages/@granit/react-entities-customization/src/locales/en.ts
+++ b/packages/@granit/react-entities-customization/src/locales/en.ts
@@ -1,0 +1,54 @@
+export interface CustomizationTranslations {
+  readonly Editor: {
+    readonly MoveUp: string;
+    readonly MoveDown: string;
+    readonly Hide: string;
+    readonly Show: string;
+    readonly NoGroup: string;
+    readonly GroupSelectAriaLabel: string;
+  };
+  readonly Inspector: {
+    readonly Title: string;
+    readonly Close: string;
+    readonly WinningTag: string;
+    readonly Layers: {
+      readonly Layer1Admin: string;
+      readonly Layer2Workspace: string;
+      readonly Layer3Role: string;
+      readonly Layer4User: string;
+      readonly Layer5Schema: string;
+    };
+  };
+}
+
+/**
+ * English translation bundle for `@granit/react-entities-customization`.
+ *
+ *   i18n.addResourceBundle('en', 'customization', customizationTranslationsEn);
+ *
+ * Components don't call `useTranslation` — apps populate the
+ * `labels` props from `t()` results to keep the package headless and
+ * testable without an i18next bootstrap.
+ */
+export const customizationTranslationsEn: CustomizationTranslations = {
+  Editor: {
+    MoveUp: 'Move up',
+    MoveDown: 'Move down',
+    Hide: 'Hide',
+    Show: 'Show',
+    NoGroup: '— no group —',
+    GroupSelectAriaLabel: 'Group for {{fieldName}}',
+  },
+  Inspector: {
+    Title: 'Resolution chain — {{fieldName}}',
+    Close: 'Close',
+    WinningTag: 'winning',
+    Layers: {
+      Layer1Admin: 'Tenant admin (customization)',
+      Layer2Workspace: 'Workspace',
+      Layer3Role: 'Role',
+      Layer4User: 'User preference',
+      Layer5Schema: 'Schema default',
+    },
+  },
+};

--- a/packages/@granit/react-entities-customization/src/locales/fr.ts
+++ b/packages/@granit/react-entities-customization/src/locales/fr.ts
@@ -1,0 +1,29 @@
+import type { CustomizationTranslations } from './en.js';
+
+/**
+ * French translation bundle for `@granit/react-entities-customization`.
+ *
+ *   i18n.addResourceBundle('fr', 'customization', customizationTranslationsFr);
+ */
+export const customizationTranslationsFr: CustomizationTranslations = {
+  Editor: {
+    MoveUp: 'Monter',
+    MoveDown: 'Descendre',
+    Hide: 'Masquer',
+    Show: 'Afficher',
+    NoGroup: '— aucun groupe —',
+    GroupSelectAriaLabel: 'Groupe pour {{fieldName}}',
+  },
+  Inspector: {
+    Title: 'Chaîne de résolution — {{fieldName}}',
+    Close: 'Fermer',
+    WinningTag: 'gagnant',
+    Layers: {
+      Layer1Admin: 'Admin du tenant (personnalisation)',
+      Layer2Workspace: 'Espace de travail',
+      Layer3Role: 'Rôle',
+      Layer4User: 'Préférence utilisateur',
+      Layer5Schema: 'Valeur par défaut du schéma',
+    },
+  },
+};

--- a/packages/@granit/react-entities-customization/src/locales/index.ts
+++ b/packages/@granit/react-entities-customization/src/locales/index.ts
@@ -1,0 +1,22 @@
+// ---------------------------------------------------------------------------
+// @granit/react-entities-customization — i18next resource bundles
+// (namespace: "customization")
+// ---------------------------------------------------------------------------
+//
+// Consumers register the bundles with their i18n instance:
+//
+//   import {
+//     customizationTranslationsEn,
+//     customizationTranslationsFr,
+//   } from '@granit/react-entities-customization';
+//   i18n.addResourceBundle('en', 'customization', customizationTranslationsEn);
+//   i18n.addResourceBundle('fr', 'customization', customizationTranslationsFr);
+//
+// Components in this package don't call `useTranslation` directly — they
+// expose `labels` props that apps populate from `t()` results. Keeps the
+// package headless and consistent with the rest of the framework.
+// ---------------------------------------------------------------------------
+
+export { customizationTranslationsEn } from './en.js';
+export type { CustomizationTranslations } from './en.js';
+export { customizationTranslationsFr } from './fr.js';

--- a/packages/@granit/react-entities-customization/src/providers/customization-provider.tsx
+++ b/packages/@granit/react-entities-customization/src/providers/customization-provider.tsx
@@ -1,0 +1,76 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_API_BASE, DEFAULT_QUERY_KEY_PREFIX } from '../constants.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/**
+ * Configuration for the customization provider. `apiBase` is the API root
+ * (without trailing slash) — e.g. `/api/v1`. The provider then composes
+ * `${apiBase}/entities/...` and `${apiBase}/workspaces/...` itself, since
+ * Layer 1 customization spans both surfaces.
+ */
+export interface CustomizationConfig {
+  readonly client?: AxiosInstance;
+  readonly apiBase?: string;
+  readonly queryKeyPrefix?: readonly string[];
+  /**
+   * Optional invalidator hooks called after a successful customization PUT.
+   * The customization editor lives "above" the entity manifest cache, so
+   * apps wire these to React Query invalidators in the consuming module
+   * (e.g. invalidate `['entities', 'manifest', name]` when a form layout
+   * changes). Keeping it as a callback avoids a hard peer dependency on
+   * `@granit/react-entities` / `@granit/react-workspaces`.
+   */
+  readonly onFormCustomizationChanged?: (entityName: string) => void;
+  readonly onWorkspaceCustomizationChanged?: (workspaceName: string) => void;
+}
+
+export interface ResolvedCustomizationConfig extends CustomizationConfig {
+  readonly client: AxiosInstance;
+  readonly apiBase: string;
+  readonly queryKeyPrefix: readonly string[];
+}
+
+export interface CustomizationProviderProps {
+  readonly config: CustomizationConfig;
+  readonly children: ReactNode;
+}
+
+const CustomizationConfigContext = createContext<ResolvedCustomizationConfig | null>(null);
+
+export function CustomizationProvider({ config, children }: Readonly<CustomizationProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedCustomizationConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'CustomizationProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      client,
+      apiBase: config.apiBase ?? DEFAULT_API_BASE,
+      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+    };
+  }, [config, contextClient]);
+  return <CustomizationConfigContext value={value}>{children}</CustomizationConfigContext>;
+}
+
+export function useCustomizationConfig(): ResolvedCustomizationConfig {
+  const ctx = useContext(CustomizationConfigContext);
+  if (!ctx) {
+    throw new Error('useCustomizationConfig must be used within a CustomizationProvider');
+  }
+  return ctx;
+}
+
+export function buildCustomizationQueryKey(
+  config: ResolvedCustomizationConfig,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...config.queryKeyPrefix, ...segments];
+}

--- a/packages/@granit/react-entities-customization/tsconfig.json
+++ b/packages/@granit/react-entities-customization/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/entities-customization": ["../entities-customization/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-entities-customization/tsup.config.ts
+++ b/packages/@granit/react-entities-customization/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -383,6 +383,15 @@ importers:
 
   packages/@granit/entities: {}
 
+  packages/@granit/entities-customization:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/entities-views: {}
 
   packages/@granit/error-boundary: {}
@@ -1329,6 +1338,31 @@ importers:
       '@granit/react-query-engine':
         specifier: workspace:*
         version: link:../react-query-engine
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/react-entities-customization:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.9
+        version: 5.100.9(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/entities-customization':
+        specifier: workspace:*
+        version: link:../entities-customization
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Summary

Mirrors the dotnet `Granit.EntitiesCustomization` module (ADR-053) on the front. Closes #399, #400, #401, #402, #403, #404 — feature #396.

Two new packages, headless throughout (no design-system chrome):

- **`@granit/entities-customization`** — typed SDK
  - Closed `LayoutDelta` discriminated union (`Reorder` / `Regroup` / `Hide`)
  - `FormCustomizationRequest/Response` + `WorkspaceCustomizationRequest/Response`
  - 4 endpoints: `PUT|GET /api/v1/entities/{name}/customization/forms/{variant}` and `PUT|GET /api/v1/workspaces/{name}/customization`
  - `CustomizationPermissions.EntitiesCustomization.{Forms,Workspaces}.{Read,Manage}` (4 keys)

- **`@granit/react-entities-customization`** — React bindings + headless editors
  - `<CustomizationProvider>` exposes `onForm/onWorkspaceCustomizationChanged` callbacks so apps can invalidate the entity manifest cache without creating a hard peer on `react-entities`/`react-workspaces`.
  - Hooks: `useFormCustomization`, `usePutFormCustomization`, `useWorkspaceCustomization`, `usePutWorkspaceCustomization`.
  - Pure delta helpers (testable without React): `applyDeltas`, `moveFieldUp/Down`, `toggleFieldHidden`, `setFieldGroup`.
  - `<FormLayoutEditor>` + `<WorkspaceLayoutEditor>` with `data-granit-form-layout-editor*` markers, `aria-pressed`, `readOnly` for permission gating.
  - `<FieldInspectorOverlay>` always renders the full 5-layer chain (Layer1Admin → Layer5Schema) with a `winning` badge — the anti-Frappe transparency guarantee.
  - en + fr i18n bundles (namespace `customization`).

## Test plan

- [x] `pnpm exec vitest run packages/@granit/entities-customization packages/@granit/react-entities-customization` → 49/49 green
- [x] `pnpm --filter @granit/entities-customization exec tsc --noEmit` clean
- [x] `pnpm --filter @granit/react-entities-customization exec tsc --noEmit` clean
- [x] `pnpm lint` clean
- [x] `pnpm --filter @granit/entities-customization build` → ESM 1.62 KB / dts 4.62 KB
- [x] `pnpm --filter @granit/react-entities-customization build` → ESM 13.48 KB / dts 13.01 KB