### PR TITLE
feat(taxonomy): @granit/taxonomy skeleton + types + permissions (T1)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4782,6 +4782,22 @@
       ]
     },
     {
+      "name": "@granit/taxonomy",
+      "description": "Cross-entity Tags and Categories module — types, API client, and permissions",
+      "exports": [
+        {
+          "name": "isHexColor",
+          "kind": "function",
+          "signature": "function isHexColor(value: string): value is HexColor"
+        },
+        {
+          "name": "TaxonomyPermissions",
+          "kind": "const",
+          "signature": "const TaxonomyPermissions"
+        }
+      ]
+    },
+    {
       "name": "@granit/templating",
       "description": "Template management types and API functions — mirrors Granit.Templating .NET",
       "exports": [

--- a/packages/@granit/taxonomy/package.json
+++ b/packages/@granit/taxonomy/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/taxonomy",
+  "description": "Cross-entity Tags and Categories module — types, API client, and permissions",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/taxonomy/src/__tests__/permissions.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/permissions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { TaxonomyPermissions } from '../permissions.js';
+
+describe('TaxonomyPermissions', () => {
+  it('exposes the Tags Read/Manage keys matching the backend', () => {
+    expect(TaxonomyPermissions.Tags.Read).toBe('Taxonomy.Tags.Read');
+    expect(TaxonomyPermissions.Tags.Manage).toBe('Taxonomy.Tags.Manage');
+  });
+
+  it('exposes the Categories Read/Manage keys matching the backend', () => {
+    expect(TaxonomyPermissions.Categories.Read).toBe('Taxonomy.Categories.Read');
+    expect(TaxonomyPermissions.Categories.Manage).toBe('Taxonomy.Categories.Manage');
+  });
+
+  it('exposes the Search.Read key matching the backend', () => {
+    expect(TaxonomyPermissions.Search.Read).toBe('Taxonomy.Search.Read');
+  });
+});

--- a/packages/@granit/taxonomy/src/__tests__/types.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/types.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { isHexColor } from '../types.js';
+
+import type {
+  CategoryAssignmentRequest,
+  CategoryDetailResponse,
+  CategoryResponse,
+  HexColor,
+  TagAssignmentRequest,
+  TagResponse,
+  TaxonomySearchResultGroup,
+  TaxonomySearchResultItem,
+  TaxonomyTargetRef,
+} from '../types.js';
+
+describe('Taxonomy types', () => {
+  it('TagResponse carries the readonly hex color contract + audit timestamps', () => {
+    expectTypeOf<TagResponse>().toMatchTypeOf<{
+      readonly id: string;
+      readonly scope: string;
+      readonly name: string;
+      readonly color: HexColor;
+      readonly hideOnEntityCard: boolean;
+      readonly createdAt: string;
+      readonly updatedAt: string;
+    }>();
+  });
+
+  it('TagAssignmentRequest is structurally a TaxonomyTargetRef', () => {
+    expectTypeOf<TagAssignmentRequest>().toEqualTypeOf<TaxonomyTargetRef>();
+  });
+
+  it('CategoryAssignmentRequest is structurally a TaxonomyTargetRef', () => {
+    expectTypeOf<CategoryAssignmentRequest>().toEqualTypeOf<TaxonomyTargetRef>();
+  });
+
+  it('CategoryResponse parentId is nullable for scope roots', () => {
+    expectTypeOf<CategoryResponse>().toMatchTypeOf<{
+      readonly parentId: string | null;
+      readonly path: string;
+      readonly depth: number;
+      readonly hasChildren: boolean;
+    }>();
+  });
+
+  it('CategoryDetailResponse augments CategoryResponse with a root→leaf breadcrumb', () => {
+    expectTypeOf<CategoryDetailResponse>().toMatchTypeOf<
+      CategoryResponse & { readonly breadcrumb: readonly CategoryResponse[] }
+    >();
+  });
+
+  it('TaxonomySearchResultGroup groups items by targetType', () => {
+    expectTypeOf<TaxonomySearchResultGroup>().toMatchTypeOf<{
+      readonly targetType: string;
+      readonly items: readonly TaxonomySearchResultItem[];
+    }>();
+  });
+});
+
+describe('isHexColor', () => {
+  it('accepts canonical 7-character hex values (upper- and lower-case)', () => {
+    expect(isHexColor('#1a2b3c')).toBe(true);
+    expect(isHexColor('#AABBCC')).toBe(true);
+    expect(isHexColor('#000000')).toBe(true);
+    expect(isHexColor('#ffffff')).toBe(true);
+  });
+
+  it('rejects shorthand, missing-hash, non-hex, and over-long inputs', () => {
+    expect(isHexColor('#abc')).toBe(false);
+    expect(isHexColor('aabbcc')).toBe(false);
+    expect(isHexColor('#12345')).toBe(false);
+    expect(isHexColor('#1234567')).toBe(false);
+    expect(isHexColor('#GGHHII')).toBe(false);
+    expect(isHexColor('red')).toBe(false);
+    expect(isHexColor('')).toBe(false);
+  });
+
+  it('narrows the type to HexColor on success', () => {
+    const candidate: string = '#abcdef';
+    if (isHexColor(candidate)) {
+      expectTypeOf(candidate).toEqualTypeOf<HexColor>();
+    }
+  });
+});

--- a/packages/@granit/taxonomy/src/index.ts
+++ b/packages/@granit/taxonomy/src/index.ts
@@ -1,0 +1,28 @@
+// Types
+export type {
+  CategoryAssignmentRequest,
+  CategoryAssignmentResponse,
+  CategoryDetailResponse,
+  CategoryListFilter,
+  CategoryResponse,
+  CreateCategoryRequest,
+  CreateTagRequest,
+  HexColor,
+  MoveCategoryRequest,
+  TagAssignmentRequest,
+  TagAssignmentResponse,
+  TagListFilter,
+  TagResponse,
+  TaxonomySearchFilter,
+  TaxonomySearchResultGroup,
+  TaxonomySearchResultItem,
+  TaxonomyTargetRef,
+  UpdateCategoryRequest,
+  UpdateTagRequest,
+} from './types.js';
+
+// Type guards
+export { isHexColor } from './types.js';
+
+// Permissions
+export { TaxonomyPermissions } from './permissions.js';

--- a/packages/@granit/taxonomy/src/permissions.ts
+++ b/packages/@granit/taxonomy/src/permissions.ts
@@ -1,0 +1,13 @@
+export const TaxonomyPermissions = {
+  Tags: {
+    Read: 'Taxonomy.Tags.Read',
+    Manage: 'Taxonomy.Tags.Manage',
+  },
+  Categories: {
+    Read: 'Taxonomy.Categories.Read',
+    Manage: 'Taxonomy.Categories.Manage',
+  },
+  Search: {
+    Read: 'Taxonomy.Search.Read',
+  },
+} as const;

--- a/packages/@granit/taxonomy/src/types.ts
+++ b/packages/@granit/taxonomy/src/types.ts
@@ -1,0 +1,139 @@
+/**
+ * 7-character hexadecimal color in `#RRGGBB` form. The backend rejects any
+ * other shape, so the front carries the same constraint at the type level.
+ * Use {@link isHexColor} to validate untrusted strings before casting.
+ */
+export type HexColor = `#${string}`;
+
+const HEX_COLOR_PATTERN = /^#[0-9a-fA-F]{6}$/;
+
+export function isHexColor(value: string): value is HexColor {
+  return HEX_COLOR_PATTERN.test(value);
+}
+
+/**
+ * Polymorphic target reference. `targetType` is the assembly-qualified type
+ * name shipped by the backend (e.g. `"Granit.Documents.Domain.Document"`);
+ * `targetId` is a Guid string.
+ */
+export interface TaxonomyTargetRef {
+  readonly targetType: string;
+  readonly targetId: string;
+}
+
+// ─── Tags ───────────────────────────────────────────────────────────────────
+
+export interface TagResponse {
+  readonly id: string;
+  readonly scope: string;
+  readonly name: string;
+  readonly color: HexColor;
+  readonly hideOnEntityCard: boolean;
+  readonly createdAt: string;
+  readonly updatedAt: string;
+}
+
+export interface TagListFilter {
+  readonly scope: string;
+  readonly q?: string;
+}
+
+export interface CreateTagRequest {
+  readonly scope: string;
+  readonly name: string;
+  readonly color: HexColor;
+  readonly hideOnEntityCard: boolean;
+}
+
+/**
+ * PATCH payload for {@link TagResponse}. Every field is optional — only
+ * supplied fields are mutated server-side.
+ */
+export interface UpdateTagRequest {
+  readonly name?: string;
+  readonly color?: HexColor;
+  readonly hideOnEntityCard?: boolean;
+}
+
+export type TagAssignmentRequest = TaxonomyTargetRef;
+
+export interface TagAssignmentResponse {
+  readonly tagId: string;
+  readonly targetType: string;
+  readonly targetId: string;
+  readonly assignedAt: string;
+}
+
+// ─── Categories ─────────────────────────────────────────────────────────────
+
+export interface CategoryResponse {
+  readonly id: string;
+  readonly scope: string;
+  /** `null` when the node is a scope root. */
+  readonly parentId: string | null;
+  /** Materialised path, root-anchored, e.g. `"/legal/contracts/2026"`. */
+  readonly path: string;
+  readonly name: string;
+  /** 0 for scope roots; one greater than the parent's depth otherwise. */
+  readonly depth: number;
+  readonly hasChildren: boolean;
+}
+
+/**
+ * Single-category detail, augmented with the full breadcrumb (root → leaf,
+ * inclusive of the queried node) for UI rendering without extra round-trips.
+ */
+export interface CategoryDetailResponse extends CategoryResponse {
+  readonly breadcrumb: readonly CategoryResponse[];
+}
+
+export interface CategoryListFilter {
+  readonly scope: string;
+  /** Omit / pass `null` to list scope roots. */
+  readonly parentId?: string | null;
+}
+
+export interface CreateCategoryRequest {
+  readonly scope: string;
+  /** `null` to create a scope root. */
+  readonly parentId: string | null;
+  readonly name: string;
+}
+
+export interface UpdateCategoryRequest {
+  readonly name?: string;
+}
+
+export interface MoveCategoryRequest {
+  /** `null` promotes the node to a scope root. */
+  readonly newParentId: string | null;
+}
+
+export type CategoryAssignmentRequest = TaxonomyTargetRef;
+
+export interface CategoryAssignmentResponse {
+  readonly categoryId: string;
+  readonly targetType: string;
+  readonly targetId: string;
+  readonly assignedAt: string;
+}
+
+// ─── Search ─────────────────────────────────────────────────────────────────
+
+export interface TaxonomySearchFilter {
+  readonly q: string;
+}
+
+export interface TaxonomySearchResultItem {
+  readonly targetType: string;
+  readonly targetId: string;
+  readonly label: string;
+  readonly snippet: string | null;
+  readonly matchedTagIds: readonly string[];
+  readonly matchedCategoryId: string | null;
+}
+
+export interface TaxonomySearchResultGroup {
+  readonly targetType: string;
+  readonly items: readonly TaxonomySearchResultItem[];
+}

--- a/packages/@granit/taxonomy/tsconfig.json
+++ b/packages/@granit/taxonomy/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/taxonomy/tsup.config.ts
+++ b/packages/@granit/taxonomy/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2405,6 +2405,15 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/taxonomy:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/templating:
     dependencies:
       '@granit/query-engine':


### PR DESCRIPTION
## Summary

- Bootstraps `@granit/taxonomy` (SDK core) mirroring the `@granit/activities` skeleton — `package.json`, `tsconfig`, `tsup`, single `src/index.ts` re-export surface.
- `TaxonomyPermissions` exposes the backend permission keys: `Tags.Read|Manage`, `Categories.Read|Manage`, `Search.Read`.
- `HexColor` branded type + `isHexColor` runtime guard enforce the `#RRGGBB` contract.
- `TaxonomyTargetRef` polymorphic target shape reused by `TagAssignmentRequest` / `CategoryAssignmentRequest`.
- Tag types — `TagResponse`, `TagListFilter`, `Create/Update`, `TagAssignmentRequest/Response`.
- Category types — `CategoryResponse` (+ `parentId: string | null` for scope roots), `CategoryDetailResponse` with root→leaf breadcrumb, `Create/Update/Move`, `CategoryAssignmentRequest/Response`.
- Search types — `TaxonomySearchFilter`, `TaxonomySearchResultGroup`, `TaxonomySearchResultItem`.

No API client yet (T2), no React layer yet (T3+).

Refs #385 — closes T1 of #384.

## Test plan

- [x] `pnpm exec eslint 'packages/@granit/taxonomy/src/**/*.ts' --max-warnings 0` clean
- [x] `pnpm --filter @granit/taxonomy exec tsc --noEmit` clean
- [x] `pnpm exec vitest run packages/@granit/taxonomy` — 12 tests passing across 2 files
- [x] Workspace-wide `pnpm tsc` clean (no consumer broken)
- [x] `.mcp-front-index.json` regenerated by pre-commit hook (2 exports detected)