### PR TITLE
feat(taxonomy): @granit/taxonomy API client (T2)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4794,6 +4794,11 @@
           "name": "TaxonomyPermissions",
           "kind": "const",
           "signature": "const TaxonomyPermissions"
+        },
+        {
+          "name": "searchTaxonomy",
+          "kind": "function",
+          "signature": "async function searchTaxonomy( client: AxiosInstance, basePath: string, filter: TaxonomySearchFilter ): Promise<readonly TaxonomySearchResultGroup[]>"
         }
       ]
     },

--- a/packages/@granit/taxonomy/src/__tests__/categories-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/categories-api.test.ts
@@ -1,0 +1,200 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assignCategory,
+  createCategory,
+  deleteCategory,
+  getCategory,
+  listCategories,
+  moveCategory,
+  unassignCategory,
+  updateCategory,
+} from '../api/categories-api.js';
+
+import type {
+  CategoryAssignmentRequest,
+  CategoryAssignmentResponse,
+  CategoryDetailResponse,
+  CategoryResponse,
+  CreateCategoryRequest,
+  MoveCategoryRequest,
+} from '../types.js';
+
+const basePath = '/api/v1/taxonomy';
+
+const sampleRoot: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: true,
+};
+
+const sampleChild: CategoryResponse = {
+  id: 'cat-2',
+  scope: 'documents',
+  parentId: 'cat-1',
+  path: '/legal/contracts',
+  name: 'contracts',
+  depth: 1,
+  hasChildren: false,
+};
+
+const sampleDetail: CategoryDetailResponse = {
+  ...sampleChild,
+  breadcrumb: [sampleRoot, sampleChild],
+};
+
+const sampleAssignment: CategoryAssignmentResponse = {
+  categoryId: 'cat-2',
+  targetType: 'Granit.Documents.Domain.Document',
+  targetId: 'doc-1',
+  assignedAt: '2026-05-02T12:00:00Z',
+};
+
+describe('listCategories', () => {
+  it('GETs /categories with only scope when parentId is omitted', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleRoot]));
+
+    const result = await listCategories(client, basePath, { scope: 'documents' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/categories`, {
+      params: { scope: 'documents' },
+    });
+    expect(result).toEqual([sampleRoot]);
+  });
+
+  it('omits parentId from params when explicitly null (root list)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleRoot]));
+
+    await listCategories(client, basePath, { scope: 'documents', parentId: null });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/categories`, {
+      params: { scope: 'documents' },
+    });
+  });
+
+  it('appends parentId when a non-null id is supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleChild]));
+
+    await listCategories(client, basePath, { scope: 'documents', parentId: 'cat-1' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/categories`, {
+      params: { scope: 'documents', parentId: 'cat-1' },
+    });
+  });
+});
+
+describe('getCategory', () => {
+  it('GETs /categories/{id} and returns the detail with breadcrumb', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleDetail));
+
+    const result = await getCategory(client, basePath, 'cat-2');
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/categories/cat-2`);
+    expect(result.breadcrumb).toEqual([sampleRoot, sampleChild]);
+  });
+});
+
+describe('createCategory', () => {
+  it('POSTs the request body to /categories', async () => {
+    const client = createMockClient();
+    const request: CreateCategoryRequest = {
+      scope: 'documents',
+      parentId: null,
+      name: 'legal',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleRoot));
+
+    const result = await createCategory(client, basePath, request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/categories`, request);
+    expect(result).toEqual(sampleRoot);
+  });
+});
+
+describe('updateCategory', () => {
+  it('PATCHes /categories/{id} with the partial payload', async () => {
+    const client = createMockClient();
+    vi.mocked(client.patch).mockResolvedValue(
+      axiosResponse({ ...sampleChild, name: 'agreements' })
+    );
+
+    const result = await updateCategory(client, basePath, 'cat-2', { name: 'agreements' });
+
+    expect(client.patch).toHaveBeenCalledWith(`${basePath}/categories/cat-2`, {
+      name: 'agreements',
+    });
+    expect(result.name).toBe('agreements');
+  });
+});
+
+describe('moveCategory', () => {
+  it('POSTs newParentId to /categories/{id}/move', async () => {
+    const client = createMockClient();
+    const request: MoveCategoryRequest = { newParentId: 'cat-3' };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleChild));
+
+    await moveCategory(client, basePath, 'cat-2', request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/categories/cat-2/move`, request);
+  });
+
+  it('forwards null newParentId to promote a node to a scope root', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse({ ...sampleChild, parentId: null }));
+
+    await moveCategory(client, basePath, 'cat-2', { newParentId: null });
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/categories/cat-2/move`, {
+      newParentId: null,
+    });
+  });
+});
+
+describe('deleteCategory', () => {
+  it('DELETEs /categories/{id}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    await deleteCategory(client, basePath, 'cat-2');
+
+    expect(client.delete).toHaveBeenCalledWith(`${basePath}/categories/cat-2`);
+  });
+});
+
+describe('assignCategory', () => {
+  it('POSTs the target ref to /categories/{id}/assign', async () => {
+    const client = createMockClient();
+    const request: CategoryAssignmentRequest = {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleAssignment));
+
+    const result = await assignCategory(client, basePath, 'cat-2', request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/categories/cat-2/assign`, request);
+    expect(result).toEqual(sampleAssignment);
+  });
+});
+
+describe('unassignCategory', () => {
+  it('DELETEs /categories/assign/{targetType}/{targetId} with segments encoded', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    await unassignCategory(client, basePath, 'Granit.Documents.Domain.Document', 'doc-1');
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `${basePath}/categories/assign/${encodeURIComponent('Granit.Documents.Domain.Document')}/doc-1`
+    );
+  });
+});

--- a/packages/@granit/taxonomy/src/__tests__/documents-proxy-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/documents-proxy-api.test.ts
@@ -1,0 +1,67 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  attachTagToDocument,
+  detachTagFromDocument,
+  listDocumentTags,
+} from '../api/documents-proxy-api.js';
+
+import type { TagResponse } from '../types.js';
+
+const basePath = '/api/v1';
+
+const sampleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+describe('listDocumentTags', () => {
+  it('GETs /documents/{documentId}/tags', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+
+    const result = await listDocumentTags(client, basePath, 'doc-1');
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/documents/doc-1/tags`);
+    expect(result).toEqual([sampleTag]);
+  });
+
+  it('encodes the document id', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    await listDocumentTags(client, basePath, 'doc/with slash');
+
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/documents/${encodeURIComponent('doc/with slash')}/tags`
+    );
+  });
+});
+
+describe('attachTagToDocument', () => {
+  it('POSTs (no body) to /documents/{documentId}/tags/{tagId}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    await attachTagToDocument(client, basePath, 'doc-1', 'tag-1');
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/documents/doc-1/tags/tag-1`);
+  });
+});
+
+describe('detachTagFromDocument', () => {
+  it('DELETEs /documents/{documentId}/tags/{tagId}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    await detachTagFromDocument(client, basePath, 'doc-1', 'tag-1');
+
+    expect(client.delete).toHaveBeenCalledWith(`${basePath}/documents/doc-1/tags/tag-1`);
+  });
+});

--- a/packages/@granit/taxonomy/src/__tests__/search-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/search-api.test.ts
@@ -1,0 +1,45 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { searchTaxonomy } from '../api/search-api.js';
+
+import type { TaxonomySearchResultGroup } from '../types.js';
+
+const basePath = '/api/v1/taxonomy';
+
+const sampleGroup: TaxonomySearchResultGroup = {
+  targetType: 'Granit.Documents.Domain.Document',
+  items: [
+    {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+      label: 'Q1 contract',
+      snippet: '…tagged Urgent…',
+      matchedTagIds: ['tag-1'],
+      matchedCategoryId: null,
+    },
+  ],
+};
+
+describe('searchTaxonomy', () => {
+  it('GETs /search with the q query param', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleGroup]));
+
+    const result = await searchTaxonomy(client, basePath, { q: 'urgent' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/search`, {
+      params: { q: 'urgent' },
+    });
+    expect(result).toEqual([sampleGroup]);
+  });
+
+  it('forwards an empty query string to the backend (does not short-circuit)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    await searchTaxonomy(client, basePath, { q: '' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/search`, { params: { q: '' } });
+  });
+});

--- a/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
@@ -1,0 +1,169 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  assignTag,
+  createTag,
+  deleteTag,
+  getTagAssignments,
+  listTags,
+  unassignTag,
+  updateTag,
+} from '../api/tags-api.js';
+
+import type {
+  CreateTagRequest,
+  TagAssignmentRequest,
+  TagAssignmentResponse,
+  TagResponse,
+  UpdateTagRequest,
+} from '../types.js';
+
+const basePath = '/api/v1/taxonomy';
+
+const sampleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const sampleAssignment: TagAssignmentResponse = {
+  tagId: 'tag-1',
+  targetType: 'Granit.Documents.Domain.Document',
+  targetId: 'doc-1',
+  assignedAt: '2026-05-02T12:00:00Z',
+};
+
+describe('listTags', () => {
+  it('GETs /tags with the scope query param', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+
+    const result = await listTags(client, basePath, { scope: 'documents' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/tags`, {
+      params: { scope: 'documents' },
+    });
+    expect(result).toEqual([sampleTag]);
+  });
+
+  it('appends q when supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+
+    await listTags(client, basePath, { scope: 'documents', q: 'urg' });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/tags`, {
+      params: { scope: 'documents', q: 'urg' },
+    });
+  });
+
+  it('omits q when undefined', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+
+    await listTags(client, basePath, { scope: 'documents', q: undefined });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/tags`, {
+      params: { scope: 'documents' },
+    });
+  });
+});
+
+describe('createTag', () => {
+  it('POSTs the request body to /tags', async () => {
+    const client = createMockClient();
+    const request: CreateTagRequest = {
+      scope: 'documents',
+      name: 'Urgent',
+      color: '#FF0000',
+      hideOnEntityCard: false,
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleTag));
+
+    const result = await createTag(client, basePath, request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/tags`, request);
+    expect(result).toEqual(sampleTag);
+  });
+});
+
+describe('updateTag', () => {
+  it('PATCHes /tags/{id} with the partial payload and url-encodes the id', async () => {
+    const client = createMockClient();
+    const request: UpdateTagRequest = { name: 'Critical' };
+    vi.mocked(client.patch).mockResolvedValue(axiosResponse({ ...sampleTag, name: 'Critical' }));
+
+    const result = await updateTag(client, basePath, 'tag/with slash', request);
+
+    expect(client.patch).toHaveBeenCalledWith(
+      `${basePath}/tags/${encodeURIComponent('tag/with slash')}`,
+      request
+    );
+    expect(result.name).toBe('Critical');
+  });
+});
+
+describe('deleteTag', () => {
+  it('DELETEs /tags/{id}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    await deleteTag(client, basePath, 'tag-1');
+
+    expect(client.delete).toHaveBeenCalledWith(`${basePath}/tags/tag-1`);
+  });
+});
+
+describe('assignTag', () => {
+  it('POSTs the target ref to /tags/{id}/assign', async () => {
+    const client = createMockClient();
+    const request: TagAssignmentRequest = {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleAssignment));
+
+    const result = await assignTag(client, basePath, 'tag-1', request);
+
+    expect(client.post).toHaveBeenCalledWith(`${basePath}/tags/tag-1/assign`, request);
+    expect(result).toEqual(sampleAssignment);
+  });
+});
+
+describe('unassignTag', () => {
+  it('DELETEs /tags/{id}/assign/{targetType}/{targetId} with all segments encoded', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    await unassignTag(client, basePath, 'tag-1', 'Granit.Documents.Domain.Document', 'doc-1');
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `${basePath}/tags/tag-1/assign/${encodeURIComponent('Granit.Documents.Domain.Document')}/doc-1`
+    );
+  });
+});
+
+describe('getTagAssignments', () => {
+  it('GETs /tags/assignments with targetType + targetId query params', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleAssignment]));
+
+    const result = await getTagAssignments(client, basePath, {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+    });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/tags/assignments`, {
+      params: {
+        targetType: 'Granit.Documents.Domain.Document',
+        targetId: 'doc-1',
+      },
+    });
+    expect(result).toEqual([sampleAssignment]);
+  });
+});

--- a/packages/@granit/taxonomy/src/api/categories-api.ts
+++ b/packages/@granit/taxonomy/src/api/categories-api.ts
@@ -1,0 +1,149 @@
+import type {
+  CategoryAssignmentRequest,
+  CategoryAssignmentResponse,
+  CategoryDetailResponse,
+  CategoryListFilter,
+  CategoryResponse,
+  CreateCategoryRequest,
+  MoveCategoryRequest,
+  UpdateCategoryRequest,
+} from '../types.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List categories within a scope. Pass `parentId` to fetch children of a
+ * specific node; omit / pass `null` to fetch scope roots.
+ *
+ * `GET {basePath}/categories`
+ */
+export async function listCategories(
+  client: AxiosInstance,
+  basePath: string,
+  filter: CategoryListFilter
+): Promise<readonly CategoryResponse[]> {
+  const params: Record<string, string> = { scope: filter.scope };
+  if (filter.parentId !== undefined && filter.parentId !== null) {
+    params.parentId = filter.parentId;
+  }
+  const response = await client.get<readonly CategoryResponse[]>(`${basePath}/categories`, {
+    params,
+  });
+  return response.data;
+}
+
+/**
+ * Get a single category, including its full root→leaf breadcrumb.
+ *
+ * `GET {basePath}/categories/{id}`
+ */
+export async function getCategory(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<CategoryDetailResponse> {
+  const response = await client.get<CategoryDetailResponse>(
+    `${basePath}/categories/${encodeURIComponent(id)}`
+  );
+  return response.data;
+}
+
+/**
+ * Create a category. Pass `parentId: null` to create a scope root.
+ *
+ * `POST {basePath}/categories`
+ */
+export async function createCategory(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreateCategoryRequest
+): Promise<CategoryResponse> {
+  const response = await client.post<CategoryResponse>(`${basePath}/categories`, request);
+  return response.data;
+}
+
+/**
+ * Patch a category — currently only rename is supported on the backend.
+ *
+ * `PATCH {basePath}/categories/{id}`
+ */
+export async function updateCategory(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: UpdateCategoryRequest
+): Promise<CategoryResponse> {
+  const response = await client.patch<CategoryResponse>(
+    `${basePath}/categories/${encodeURIComponent(id)}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Move a category under a new parent. Backend rejects cross-scope moves and
+ * cycles (returns 422 — surface the problem-detail in the UI).
+ *
+ * `POST {basePath}/categories/{id}/move`
+ */
+export async function moveCategory(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: MoveCategoryRequest
+): Promise<CategoryResponse> {
+  const response = await client.post<CategoryResponse>(
+    `${basePath}/categories/${encodeURIComponent(id)}/move`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Delete a category. Backend returns 422 if the category has descendants or
+ * active assignments.
+ *
+ * `DELETE {basePath}/categories/{id}`
+ */
+export async function deleteCategory(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete<void>(`${basePath}/categories/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Assign a category to a polymorphic target. Categories are single-assignment
+ * per scope: re-posting a different `categoryId` for the same target updates
+ * the assignment in place rather than 409'ing.
+ *
+ * `POST {basePath}/categories/{id}/assign`
+ */
+export async function assignCategory(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: CategoryAssignmentRequest
+): Promise<CategoryAssignmentResponse> {
+  const response = await client.post<CategoryAssignmentResponse>(
+    `${basePath}/categories/${encodeURIComponent(id)}/assign`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Remove the category assignment from a polymorphic target.
+ *
+ * `DELETE {basePath}/categories/assign/{targetType}/{targetId}`
+ */
+export async function unassignCategory(
+  client: AxiosInstance,
+  basePath: string,
+  targetType: string,
+  targetId: string
+): Promise<void> {
+  await client.delete<void>(
+    `${basePath}/categories/assign/${encodeURIComponent(targetType)}/${encodeURIComponent(targetId)}`
+  );
+}

--- a/packages/@granit/taxonomy/src/api/documents-proxy-api.ts
+++ b/packages/@granit/taxonomy/src/api/documents-proxy-api.ts
@@ -1,0 +1,61 @@
+import type { TagResponse } from '../types.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Documents-proxy endpoints (`/api/v1/documents/{id}/tags`) — UX shortcut on
+ * the Documents surface backed by the same canonical taxonomy store. The
+ * `targetType` and `targetId` are implicit in the URL shape, so callers don't
+ * supply them.
+ *
+ * Use these for the Documents detail page only. Anywhere else, prefer the
+ * canonical {@link tags-api} functions so the same scope/target shape works
+ * across modules.
+ */
+
+/**
+ * List the tags currently assigned to a document.
+ *
+ * `GET {basePath}/documents/{documentId}/tags`
+ */
+export async function listDocumentTags(
+  client: AxiosInstance,
+  basePath: string,
+  documentId: string
+): Promise<readonly TagResponse[]> {
+  const response = await client.get<readonly TagResponse[]>(
+    `${basePath}/documents/${encodeURIComponent(documentId)}/tags`
+  );
+  return response.data;
+}
+
+/**
+ * Attach an existing tag to a document.
+ *
+ * `POST {basePath}/documents/{documentId}/tags/{tagId}`
+ */
+export async function attachTagToDocument(
+  client: AxiosInstance,
+  basePath: string,
+  documentId: string,
+  tagId: string
+): Promise<void> {
+  await client.post<void>(
+    `${basePath}/documents/${encodeURIComponent(documentId)}/tags/${encodeURIComponent(tagId)}`
+  );
+}
+
+/**
+ * Detach a tag from a document.
+ *
+ * `DELETE {basePath}/documents/{documentId}/tags/{tagId}`
+ */
+export async function detachTagFromDocument(
+  client: AxiosInstance,
+  basePath: string,
+  documentId: string,
+  tagId: string
+): Promise<void> {
+  await client.delete<void>(
+    `${basePath}/documents/${encodeURIComponent(documentId)}/tags/${encodeURIComponent(tagId)}`
+  );
+}

--- a/packages/@granit/taxonomy/src/api/search-api.ts
+++ b/packages/@granit/taxonomy/src/api/search-api.ts
@@ -1,0 +1,19 @@
+import type { TaxonomySearchFilter, TaxonomySearchResultGroup } from '../types.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Cross-entity taxonomy search. The backend groups matches by `targetType`
+ * and returns at most one group per registered taxonomy host.
+ *
+ * `GET {basePath}/search`
+ */
+export async function searchTaxonomy(
+  client: AxiosInstance,
+  basePath: string,
+  filter: TaxonomySearchFilter
+): Promise<readonly TaxonomySearchResultGroup[]> {
+  const response = await client.get<readonly TaxonomySearchResultGroup[]>(`${basePath}/search`, {
+    params: { q: filter.q },
+  });
+  return response.data;
+}

--- a/packages/@granit/taxonomy/src/api/tags-api.ts
+++ b/packages/@granit/taxonomy/src/api/tags-api.ts
@@ -1,0 +1,125 @@
+import type {
+  CreateTagRequest,
+  TagAssignmentRequest,
+  TagAssignmentResponse,
+  TagListFilter,
+  TagResponse,
+  UpdateTagRequest,
+} from '../types.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List tags scoped to `filter.scope`, optionally narrowed by autocomplete query
+ * `filter.q`. The backend already enforces `scope` as required.
+ *
+ * `GET {basePath}/tags`
+ */
+export async function listTags(
+  client: AxiosInstance,
+  basePath: string,
+  filter: TagListFilter
+): Promise<readonly TagResponse[]> {
+  const params: Record<string, string> = { scope: filter.scope };
+  if (filter.q !== undefined) params.q = filter.q;
+  const response = await client.get<readonly TagResponse[]>(`${basePath}/tags`, { params });
+  return response.data;
+}
+
+/**
+ * Create a tag in the given scope.
+ *
+ * `POST {basePath}/tags`
+ */
+export async function createTag(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreateTagRequest
+): Promise<TagResponse> {
+  const response = await client.post<TagResponse>(`${basePath}/tags`, request);
+  return response.data;
+}
+
+/**
+ * Patch a tag — rename, recolor, or toggle `hideOnEntityCard`. Only supplied
+ * fields are mutated.
+ *
+ * `PATCH {basePath}/tags/{id}`
+ */
+export async function updateTag(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: UpdateTagRequest
+): Promise<TagResponse> {
+  const response = await client.patch<TagResponse>(
+    `${basePath}/tags/${encodeURIComponent(id)}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Delete a tag. The backend cascades all assignments.
+ *
+ * `DELETE {basePath}/tags/{id}`
+ */
+export async function deleteTag(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete<void>(`${basePath}/tags/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Assign a tag to a polymorphic target.
+ *
+ * `POST {basePath}/tags/{id}/assign`
+ */
+export async function assignTag(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: TagAssignmentRequest
+): Promise<TagAssignmentResponse> {
+  const response = await client.post<TagAssignmentResponse>(
+    `${basePath}/tags/${encodeURIComponent(id)}/assign`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Remove a tag from a polymorphic target.
+ *
+ * `DELETE {basePath}/tags/{id}/assign/{targetType}/{targetId}`
+ */
+export async function unassignTag(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  targetType: string,
+  targetId: string
+): Promise<void> {
+  await client.delete<void>(
+    `${basePath}/tags/${encodeURIComponent(id)}/assign/${encodeURIComponent(targetType)}/${encodeURIComponent(targetId)}`
+  );
+}
+
+/**
+ * List all tag assignments for a polymorphic target — used by entity cards
+ * to render their chip strip.
+ *
+ * `GET {basePath}/tags/assignments`
+ */
+export async function getTagAssignments(
+  client: AxiosInstance,
+  basePath: string,
+  target: { readonly targetType: string; readonly targetId: string }
+): Promise<readonly TagAssignmentResponse[]> {
+  const response = await client.get<readonly TagAssignmentResponse[]>(
+    `${basePath}/tags/assignments`,
+    { params: { targetType: target.targetType, targetId: target.targetId } }
+  );
+  return response.data;
+}

--- a/packages/@granit/taxonomy/src/index.ts
+++ b/packages/@granit/taxonomy/src/index.ts
@@ -26,3 +26,36 @@ export { isHexColor } from './types.js';
 
 // Permissions
 export { TaxonomyPermissions } from './permissions.js';
+
+// API — Tags
+export {
+  assignTag,
+  createTag,
+  deleteTag,
+  getTagAssignments,
+  listTags,
+  unassignTag,
+  updateTag,
+} from './api/tags-api.js';
+
+// API — Categories
+export {
+  assignCategory,
+  createCategory,
+  deleteCategory,
+  getCategory,
+  listCategories,
+  moveCategory,
+  unassignCategory,
+  updateCategory,
+} from './api/categories-api.js';
+
+// API — Search
+export { searchTaxonomy } from './api/search-api.js';
+
+// API — Documents proxy (use only on the Documents surface)
+export {
+  attachTagToDocument,
+  detachTagFromDocument,
+  listDocumentTags,
+} from './api/documents-proxy-api.js';


### PR DESCRIPTION
## Summary

- Hand-written Axios wrappers for the Taxonomy backend, mirroring `@granit/activities`. Every function takes `(client, basePath, ...)` so the same code serves the canonical `/api/v1/taxonomy` surface and any host-specific basePath override.
- `tags-api.ts` — `listTags`, `createTag`, `updateTag` (PATCH), `deleteTag`, `assignTag`, `unassignTag`, `getTagAssignments`. Query params omit undefined keys; path segments url-encoded.
- `categories-api.ts` — `listCategories` (parentId omitted ↔ null treated as scope-roots), `getCategory` (with breadcrumb), `create/update/move/delete`, `assignCategory` (single-assignment, idempotent server-side), `unassignCategory`.
- `search-api.ts` — `searchTaxonomy` returning grouped results.
- `documents-proxy-api.ts` — thin adapter for the Documents UX shortcut (`/api/v1/documents/{id}/tags`). `targetType`/`targetId` are implicit in the URL shape so callers pass `documentId` only. Used by `<TagChipStrip>` in T5 when the host opts into the proxy basePath.

Refs #386 — closes T2 of #384.

## Test plan

- [x] `pnpm exec eslint 'packages/@granit/taxonomy/src/**/*.ts' --max-warnings 0` clean
- [x] `pnpm --filter @granit/taxonomy exec tsc --noEmit` clean
- [x] `pnpm exec vitest run packages/@granit/taxonomy` — 38 tests across 6 files
- [x] Coverage scoped to `packages/@granit/taxonomy/src/**/*.ts`: **100% statements / 100% branches / 100% functions / 100% lines**
- [x] `.mcp-front-index.json` regenerated by pre-commit hook (3 exports detected)