### PR TITLE
feat(react-taxonomy): provider + read hooks (T3)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4188,6 +4188,63 @@
       ]
     },
     {
+      "name": "@granit/react-taxonomy",
+      "description": "React bindings for @granit/taxonomy — TaxonomyProvider, hooks, components",
+      "exports": [
+        {
+          "name": "API_VERSION",
+          "kind": "const",
+          "signature": "const API_VERSION"
+        },
+        {
+          "name": "DEFAULT_BASE_PATH",
+          "kind": "const",
+          "signature": "const DEFAULT_BASE_PATH"
+        },
+        {
+          "name": "DEFAULT_QUERY_KEY_PREFIX",
+          "kind": "const",
+          "signature": "const DEFAULT_QUERY_KEY_PREFIX"
+        },
+        {
+          "name": "MODULE",
+          "kind": "const",
+          "signature": "const MODULE"
+        },
+        {
+          "name": "useTagAssignments",
+          "kind": "function",
+          "signature": "function useTagAssignments( target: TaxonomyTargetRef ): UseQueryResult<readonly TagAssignmentResponse[]>"
+        },
+        {
+          "name": "useTags",
+          "kind": "function",
+          "signature": "function useTags(filter: TagListFilter): UseQueryResult<readonly TagResponse[]>"
+        },
+        {
+          "name": "useCategories",
+          "kind": "function",
+          "signature": "function useCategories( filter: CategoryListFilter ): UseQueryResult<readonly CategoryResponse[]>"
+        },
+        {
+          "name": "useCategory",
+          "kind": "function",
+          "signature": "function useCategory(id: string): UseQueryResult<CategoryDetailResponse>"
+        },
+        {
+          "name": "useTaxonomySearch",
+          "kind": "function",
+          "signature": "function useTaxonomySearch( options: UseTaxonomySearchOptions ): UseQueryResult<readonly TaxonomySearchResultGroup[]>"
+        },
+        {
+          "name": "UseTaxonomySearchOptions",
+          "kind": "interface",
+          "signature": "interface UseTaxonomySearchOptions extends TaxonomySearchFilter",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-templating",
       "description": "React bindings for @granit/templating — TemplatingProvider, hooks",
       "exports": [

--- a/packages/@granit/react-taxonomy/package.json
+++ b/packages/@granit/react-taxonomy/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@granit/react-taxonomy",
+  "description": "React bindings for @granit/taxonomy — TaxonomyProvider, hooks, components",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/taxonomy": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/taxonomy": "workspace:*",
+    "@granit/testing": "workspace:*"
+  }
+}

--- a/packages/@granit/react-taxonomy/src/__tests__/taxonomy-provider.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/taxonomy-provider.test.tsx
@@ -1,0 +1,80 @@
+import { createMockClient } from '@granit/testing';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildTaxonomyQueryKey,
+  TaxonomyProvider,
+  useTaxonomyConfig,
+} from '../providers/taxonomy-provider.js';
+
+import type { TaxonomyConfig } from '../providers/taxonomy-provider.js';
+import type { ReactNode } from 'react';
+
+describe('TaxonomyProvider', () => {
+  it('exposes the resolved config (default basePath + queryKeyPrefix)', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+    );
+
+    const { result } = renderHook(() => useTaxonomyConfig(), { wrapper });
+
+    expect(result.current.basePath).toBe('/api/v1/taxonomy');
+    expect(result.current.queryKeyPrefix).toEqual(['taxonomy']);
+    expect(result.current.client).toBe(client);
+  });
+
+  it('honors custom basePath and queryKeyPrefix overrides', () => {
+    const client = createMockClient();
+    const config: TaxonomyConfig = {
+      client,
+      basePath: '/custom/taxonomy',
+      queryKeyPrefix: ['tenant-a', 'taxonomy'],
+    };
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TaxonomyProvider config={config}>{children}</TaxonomyProvider>
+    );
+
+    const { result } = renderHook(() => useTaxonomyConfig(), { wrapper });
+
+    expect(result.current.basePath).toBe('/custom/taxonomy');
+    expect(result.current.queryKeyPrefix).toEqual(['tenant-a', 'taxonomy']);
+  });
+
+  it('throws when used outside the provider', () => {
+    expect(() => renderHook(() => useTaxonomyConfig())).toThrow(/TaxonomyProvider/);
+  });
+
+  it('throws when no client is available (no config.client and no GranitClientProvider)', () => {
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TaxonomyProvider config={{}}>{children}</TaxonomyProvider>
+    );
+
+    expect(() => renderHook(() => useTaxonomyConfig(), { wrapper })).toThrow(
+      /requires an Axios client/
+    );
+  });
+});
+
+describe('buildTaxonomyQueryKey', () => {
+  it('prepends the configured prefix to extra segments', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: ReactNode }) => (
+      <TaxonomyProvider config={{ client, queryKeyPrefix: ['p'] }}>{children}</TaxonomyProvider>
+    );
+
+    const { result } = renderHook(() => useTaxonomyConfig(), { wrapper });
+
+    expect(buildTaxonomyQueryKey(result.current, 'tags', { scope: 'documents' })).toEqual([
+      'p',
+      'tags',
+      { scope: 'documents' },
+    ]);
+    expect(buildTaxonomyQueryKey(result.current, 'category', 'cat-1')).toEqual([
+      'p',
+      'category',
+      'cat-1',
+    ]);
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/use-categories.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-categories.test.tsx
@@ -1,0 +1,112 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useCategories, useCategory } from '../hooks/use-categories.js';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CategoryDetailResponse, CategoryResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const sampleRoot: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: true,
+};
+
+const sampleChild: CategoryResponse = {
+  id: 'cat-2',
+  scope: 'documents',
+  parentId: 'cat-1',
+  path: '/legal/contracts',
+  name: 'contracts',
+  depth: 1,
+  hasChildren: false,
+};
+
+const sampleDetail: CategoryDetailResponse = {
+  ...sampleChild,
+  breadcrumb: [sampleRoot, sampleChild],
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useCategories', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /categories with only scope when no parentId is supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleRoot] });
+
+    const { result } = renderHook(() => useCategories({ scope: 'documents' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/categories', {
+      params: { scope: 'documents' },
+    });
+  });
+
+  it('appends parentId to the query when supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleChild] });
+
+    const { result } = renderHook(() => useCategories({ scope: 'documents', parentId: 'cat-1' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/categories', {
+      params: { scope: 'documents', parentId: 'cat-1' },
+    });
+  });
+});
+
+describe('useCategory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /categories/{id} and returns the detail with breadcrumb', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleDetail });
+
+    const { result } = renderHook(() => useCategory('cat-2'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/categories/cat-2');
+    expect(result.current.data?.breadcrumb).toEqual([sampleRoot, sampleChild]);
+  });
+
+  it('does not fire the query when id is empty', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleDetail });
+
+    const { result } = renderHook(() => useCategory(''), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/use-tags.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-tags.test.tsx
@@ -1,0 +1,129 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useTagAssignments, useTags } from '../hooks/use-tags.js';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagAssignmentResponse, TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const sampleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const sampleAssignment: TagAssignmentResponse = {
+  tagId: 'tag-1',
+  targetType: 'Granit.Documents.Domain.Document',
+  targetId: 'doc-1',
+  assignedAt: '2026-05-02T12:00:00Z',
+};
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <TaxonomyProvider config={{ client, basePath }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useTags', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /tags with the scope and returns the array', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleTag] });
+
+    const { result } = renderHook(() => useTags({ scope: 'documents' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/tags', {
+      params: { scope: 'documents' },
+    });
+    expect(result.current.data).toEqual([sampleTag]);
+  });
+
+  it('forwards the autocomplete query when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleTag] });
+
+    const { result } = renderHook(() => useTags({ scope: 'documents', q: 'urg' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/tags', {
+      params: { scope: 'documents', q: 'urg' },
+    });
+  });
+
+  it('honors a basePath override on the provider', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    const { result } = renderHook(() => useTags({ scope: 'parties' }), {
+      wrapper: createWrapper(client, '/custom/taxonomy'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/custom/taxonomy/tags', {
+      params: { scope: 'parties' },
+    });
+  });
+});
+
+describe('useTagAssignments', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /tags/assignments with the target ref', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleAssignment] });
+
+    const { result } = renderHook(
+      () =>
+        useTagAssignments({
+          targetType: 'Granit.Documents.Domain.Document',
+          targetId: 'doc-1',
+        }),
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/tags/assignments', {
+      params: {
+        targetType: 'Granit.Documents.Domain.Document',
+        targetId: 'doc-1',
+      },
+    });
+    expect(result.current.data).toEqual([sampleAssignment]);
+  });
+
+  it('does not fire the query when the target is incomplete', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    const { result } = renderHook(() => useTagAssignments({ targetType: '', targetId: '' }), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/use-taxonomy-search.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-taxonomy-search.test.tsx
@@ -1,0 +1,83 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useTaxonomySearch } from '../hooks/use-taxonomy-search.js';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TaxonomySearchResultGroup } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const sampleGroup: TaxonomySearchResultGroup = {
+  targetType: 'Granit.Documents.Domain.Document',
+  items: [
+    {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+      label: 'Q1 contract',
+      snippet: '…tagged Urgent…',
+      matchedTagIds: ['tag-1'],
+      matchedCategoryId: null,
+    },
+  ],
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useTaxonomySearch', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs /search and returns the grouped results', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+
+    const { result } = renderHook(() => useTaxonomySearch({ q: 'urgent' }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/search', {
+      params: { q: 'urgent' },
+    });
+    expect(result.current.data).toEqual([sampleGroup]);
+  });
+
+  it('respects enabled=false (no fetch fired)', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    const { result } = renderHook(() => useTaxonomySearch({ q: 'a', enabled: false }), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('strips the enabled flag from the query key (only filter persists)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+
+    const { result } = renderHook(() => useTaxonomySearch({ q: 'urgent', enabled: true }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/search', {
+      params: { q: 'urgent' },
+    });
+  });
+});

--- a/packages/@granit/react-taxonomy/src/constants.ts
+++ b/packages/@granit/react-taxonomy/src/constants.ts
@@ -1,0 +1,4 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'taxonomy';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+export const DEFAULT_QUERY_KEY_PREFIX = ['taxonomy'] as const;

--- a/packages/@granit/react-taxonomy/src/hooks/use-categories.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-categories.ts
@@ -1,0 +1,52 @@
+import { getCategory, listCategories } from '@granit/taxonomy';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider.js';
+
+import type {
+  CategoryDetailResponse,
+  CategoryListFilter,
+  CategoryResponse,
+} from '@granit/taxonomy';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List the children of a category. Pass `parentId: null` (or omit it) to list
+ * scope roots. Each level is cached independently — the tree UI in T7 calls
+ * this hook once per expanded node.
+ *
+ * @example
+ * ```tsx
+ * const { data: roots } = useCategories({ scope: 'documents' });
+ * const { data: children } = useCategories({ scope: 'documents', parentId });
+ * ```
+ */
+export function useCategories(
+  filter: CategoryListFilter
+): UseQueryResult<readonly CategoryResponse[]> {
+  const config = useTaxonomyConfig();
+
+  return useQuery({
+    queryKey: buildTaxonomyQueryKey(config, 'categories', filter),
+    queryFn: () => listCategories(config.client, config.basePath, filter),
+  });
+}
+
+/**
+ * Get a single category, including its full root→leaf breadcrumb. Disabled
+ * when `id` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: category } = useCategory(selectedId);
+ * ```
+ */
+export function useCategory(id: string): UseQueryResult<CategoryDetailResponse> {
+  const config = useTaxonomyConfig();
+
+  return useQuery({
+    queryKey: buildTaxonomyQueryKey(config, 'category', id),
+    queryFn: () => getCategory(config.client, config.basePath, id),
+    enabled: id.length > 0,
+  });
+}

--- a/packages/@granit/react-taxonomy/src/hooks/use-tags.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-tags.ts
@@ -1,0 +1,56 @@
+import { getTagAssignments, listTags } from '@granit/taxonomy';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider.js';
+
+import type {
+  TagAssignmentResponse,
+  TagListFilter,
+  TagResponse,
+  TaxonomyTargetRef,
+} from '@granit/taxonomy';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+const TAGS_AUTOCOMPLETE_STALE_TIME_MS = 30_000;
+
+/**
+ * List tags within a scope, optionally narrowed by an autocomplete query.
+ * Uses `keepPreviousData` so the typeahead doesn't flicker between keystrokes,
+ * with a 30s `staleTime` to amortize repeat queries.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useTags({ scope: 'documents', q: input });
+ * ```
+ */
+export function useTags(filter: TagListFilter): UseQueryResult<readonly TagResponse[]> {
+  const config = useTaxonomyConfig();
+
+  return useQuery({
+    queryKey: buildTaxonomyQueryKey(config, 'tags', filter),
+    queryFn: () => listTags(config.client, config.basePath, filter),
+    staleTime: TAGS_AUTOCOMPLETE_STALE_TIME_MS,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * List the tag assignments for a polymorphic target — used by entity cards
+ * to render their chip strip. Disabled when either segment is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useTagAssignments({ targetType: 'Granit.Documents.Domain.Document', targetId });
+ * ```
+ */
+export function useTagAssignments(
+  target: TaxonomyTargetRef
+): UseQueryResult<readonly TagAssignmentResponse[]> {
+  const config = useTaxonomyConfig();
+
+  return useQuery({
+    queryKey: buildTaxonomyQueryKey(config, 'tag-assignments', target),
+    queryFn: () => getTagAssignments(config.client, config.basePath, target),
+    enabled: target.targetType.length > 0 && target.targetId.length > 0,
+  });
+}

--- a/packages/@granit/react-taxonomy/src/hooks/use-taxonomy-search.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-taxonomy-search.ts
@@ -1,0 +1,39 @@
+import { searchTaxonomy } from '@granit/taxonomy';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider.js';
+
+import type { TaxonomySearchFilter, TaxonomySearchResultGroup } from '@granit/taxonomy';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+export interface UseTaxonomySearchOptions extends TaxonomySearchFilter {
+  /**
+   * Disable the query — useful for below-threshold queries (e.g. `q.length < 2`).
+   * Defaults to `true`.
+   */
+  readonly enabled?: boolean;
+}
+
+/**
+ * Cross-entity taxonomy search. Caller is expected to debounce `q` upstream
+ * (the search bar in T8 does ≥ 300ms). Uses `keepPreviousData` to avoid
+ * flicker between keystrokes.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useTaxonomySearch({ q: debouncedQ, enabled: debouncedQ.length >= 2 });
+ * ```
+ */
+export function useTaxonomySearch(
+  options: UseTaxonomySearchOptions
+): UseQueryResult<readonly TaxonomySearchResultGroup[]> {
+  const config = useTaxonomyConfig();
+  const { enabled, ...filter } = options;
+
+  return useQuery({
+    queryKey: buildTaxonomyQueryKey(config, 'search', filter),
+    queryFn: () => searchTaxonomy(config.client, config.basePath, filter),
+    enabled: enabled ?? true,
+    placeholderData: keepPreviousData,
+  });
+}

--- a/packages/@granit/react-taxonomy/src/index.ts
+++ b/packages/@granit/react-taxonomy/src/index.ts
@@ -1,0 +1,20 @@
+// Provider
+export {
+  buildTaxonomyQueryKey,
+  TaxonomyProvider,
+  useTaxonomyConfig,
+} from './providers/taxonomy-provider.js';
+export type {
+  ResolvedTaxonomyConfig,
+  TaxonomyConfig,
+  TaxonomyProviderProps,
+} from './providers/taxonomy-provider.js';
+
+// Constants
+export { API_VERSION, DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX, MODULE } from './constants.js';
+
+// Read hooks
+export { useTagAssignments, useTags } from './hooks/use-tags.js';
+export { useCategories, useCategory } from './hooks/use-categories.js';
+export { useTaxonomySearch } from './hooks/use-taxonomy-search.js';
+export type { UseTaxonomySearchOptions } from './hooks/use-taxonomy-search.js';

--- a/packages/@granit/react-taxonomy/src/providers/taxonomy-provider.tsx
+++ b/packages/@granit/react-taxonomy/src/providers/taxonomy-provider.tsx
@@ -1,0 +1,69 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for the taxonomy provider. */
+export interface TaxonomyConfig {
+  readonly client?: AxiosInstance;
+  /** Base path for taxonomy endpoints (default: `/api/v1/taxonomy`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * TaxonomyConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedTaxonomyConfig extends TaxonomyConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
+}
+
+export interface TaxonomyProviderProps {
+  readonly config: TaxonomyConfig;
+  readonly children: ReactNode;
+}
+
+const TaxonomyConfigContext = createContext<ResolvedTaxonomyConfig | null>(null);
+
+/** Provides taxonomy configuration to child components and hooks. */
+export function TaxonomyProvider({ config, children }: Readonly<TaxonomyProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedTaxonomyConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'TaxonomyProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      client,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? [...DEFAULT_QUERY_KEY_PREFIX],
+    };
+  }, [config, contextClient]);
+  return <TaxonomyConfigContext value={value}>{children}</TaxonomyConfigContext>;
+}
+
+/** Returns the taxonomy configuration from the nearest `TaxonomyProvider`. */
+export function useTaxonomyConfig(): ResolvedTaxonomyConfig {
+  const ctx = useContext(TaxonomyConfigContext);
+  if (!ctx) {
+    throw new Error('useTaxonomyConfig must be used within a TaxonomyProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for taxonomy operations. */
+export function buildTaxonomyQueryKey(
+  config: ResolvedTaxonomyConfig,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...config.queryKeyPrefix, ...segments];
+}

--- a/packages/@granit/react-taxonomy/tsconfig.json
+++ b/packages/@granit/react-taxonomy/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/taxonomy": ["../taxonomy/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-taxonomy/tsup.config.ts
+++ b/packages/@granit/react-taxonomy/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2093,6 +2093,31 @@ importers:
         specifier: workspace:*
         version: link:../types
 
+  packages/@granit/react-taxonomy:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.9
+        version: 5.100.9(react@19.2.5)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.5
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/taxonomy':
+        specifier: workspace:*
+        version: link:../taxonomy
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/react-templating:
     dependencies:
       '@granit/react-query-engine':


### PR DESCRIPTION
## Summary

- Bootstraps `@granit/react-taxonomy` mirroring `@granit/react-activities`. `TaxonomyProvider` resolves the Axios client from `config.client` or the nearest `<GranitClientProvider>`, with `basePath` (`/api/v1/taxonomy`) and `queryKeyPrefix` (`['taxonomy']`) defaults.
- `useTags({ scope, q? })` — autocomplete-friendly: `keepPreviousData` + 30s `staleTime`.
- `useTagAssignments({ targetType, targetId })` — chip-strip data source; disabled when either segment is empty.
- `useCategories({ scope, parentId? })` — children of a node, root list when `parentId` omitted. Each level cached independently for the lazy-load tree in T7.
- `useCategory(id)` — full detail with root→leaf breadcrumb. Disabled when `id` empty.
- `useTaxonomySearch({ q, enabled? })` — `keepPreviousData` + caller-driven `enabled`. The flag is stripped from the query key so toggling doesn't fragment cache.

Refs #387 — closes T3 of #384.

## Test plan

- [x] `pnpm exec eslint 'packages/@granit/react-taxonomy/src/**/*.{ts,tsx}' --max-warnings 0` clean
- [x] Workspace-wide `pnpm tsc` clean (exit 0 across all packages)
- [x] `pnpm exec vitest run packages/@granit/react-taxonomy` — 17 tests across 4 files
- [x] Coverage scoped to `packages/@granit/react-taxonomy/src/**/*.{ts,tsx}`: **100% statements / 100% branches / 100% functions / 100% lines**
- [x] `.mcp-front-index.json` regenerated (10 exports detected on `@granit/react-taxonomy`)