### PR TITLE
feat(react-taxonomy): mutation hooks + cache invalidation (T4)

### DIFF
--- a/packages/@granit/react-taxonomy/src/__tests__/use-category-mutations.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-category-mutations.test.tsx
@@ -1,0 +1,233 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAssignCategory,
+  useCreateCategory,
+  useDeleteCategory,
+  useMoveCategory,
+  useUnassignCategory,
+  useUpdateCategory,
+} from '../hooks/use-category-mutations.js';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CategoryAssignmentResponse, CategoryResponse } from '@granit/taxonomy';
+import type { QueryClient } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const sampleCategory: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: true,
+};
+
+const sampleAssignment: CategoryAssignmentResponse = {
+  categoryId: 'cat-1',
+  targetType: 'Granit.Documents.Domain.Document',
+  targetId: 'doc-1',
+  assignedAt: '2026-05-02T12:00:00Z',
+};
+
+interface Harness {
+  readonly client: AxiosInstance;
+  readonly queryClient: QueryClient;
+  readonly wrapper: (props: { children: ReactNode }) => React.ReactElement;
+}
+
+function createHarness(): Harness {
+  const client = createMockClient();
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+    </QueryClientProvider>
+  );
+  return { client, queryClient, wrapper };
+}
+
+describe('useCreateCategory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs and invalidates the per-scope tree', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleCategory });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateCategory('documents'), { wrapper });
+    await result.current.mutateAsync({ scope: 'documents', parentId: null, name: 'legal' });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/taxonomy/categories', expect.any(Object));
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([['taxonomy', 'categories', { scope: 'documents' }]]);
+  });
+});
+
+describe('useUpdateCategory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PATCHes and invalidates the scope tree + the renamed node detail', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.patch).mockResolvedValue({ data: sampleCategory });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateCategory('documents'), { wrapper });
+    await result.current.mutateAsync({ id: 'cat-1', request: { name: 'agreements' } });
+
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['taxonomy', 'categories', { scope: 'documents' }],
+      ['taxonomy', 'category', 'cat-1'],
+    ]);
+  });
+});
+
+describe('useMoveCategory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs and invalidates scope tree + ALL category details (subtree breadcrumbs change)', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleCategory });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useMoveCategory('documents'), { wrapper });
+    await result.current.mutateAsync({ id: 'cat-1', request: { newParentId: 'cat-9' } });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/taxonomy/categories/cat-1/move', {
+      newParentId: 'cat-9',
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['taxonomy', 'categories', { scope: 'documents' }],
+      ['taxonomy', 'category'],
+    ]);
+  });
+
+  it('propagates 422 errors (cross-scope / cycle) without invalidating', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    const error = Object.assign(new Error('cycle'), {
+      response: { status: 422, data: { detail: 'cycle' } },
+    });
+    vi.mocked(client.post).mockRejectedValue(error);
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useMoveCategory('documents'), { wrapper });
+    await expect(
+      result.current.mutateAsync({ id: 'cat-1', request: { newParentId: 'cat-1' } })
+    ).rejects.toMatchObject({ response: { status: 422 } });
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDeleteCategory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('DELETEs and invalidates scope tree + the deleted detail', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteCategory('documents'), { wrapper });
+    await result.current.mutateAsync('cat-1');
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/taxonomy/categories/cat-1');
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['taxonomy', 'categories', { scope: 'documents' }],
+      ['taxonomy', 'category', 'cat-1'],
+    ]);
+  });
+
+  it('propagates 422 errors (descendants / active assignments) without invalidating', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    const error = Object.assign(new Error('has-descendants'), {
+      response: { status: 422, data: { detail: 'has-descendants' } },
+    });
+    vi.mocked(client.delete).mockRejectedValue(error);
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteCategory('documents'), { wrapper });
+    await expect(result.current.mutateAsync('cat-1')).rejects.toMatchObject({
+      response: { status: 422 },
+    });
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAssignCategory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs and invalidates only the impacted target', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleAssignment });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAssignCategory(), { wrapper });
+    await result.current.mutateAsync({
+      categoryId: 'cat-1',
+      target: { targetType: 'Granit.Documents.Domain.Document', targetId: 'doc-1' },
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/taxonomy/categories/cat-1/assign', {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      [
+        'taxonomy',
+        'category-assignments',
+        { targetType: 'Granit.Documents.Domain.Document', targetId: 'doc-1' },
+      ],
+    ]);
+  });
+});
+
+describe('useUnassignCategory', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('DELETEs and invalidates only the impacted target', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUnassignCategory(), { wrapper });
+    await result.current.mutateAsync({
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+    });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `/api/v1/taxonomy/categories/assign/${encodeURIComponent('Granit.Documents.Domain.Document')}/doc-1`
+    );
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      [
+        'taxonomy',
+        'category-assignments',
+        { targetType: 'Granit.Documents.Domain.Document', targetId: 'doc-1' },
+      ],
+    ]);
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/use-tag-mutations.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-tag-mutations.test.tsx
@@ -1,0 +1,202 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAssignTag,
+  useCreateTag,
+  useDeleteTag,
+  useUnassignTag,
+  useUpdateTag,
+} from '../hooks/use-tag-mutations.js';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagAssignmentResponse, TagResponse } from '@granit/taxonomy';
+import type { QueryClient } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const sampleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const sampleAssignment: TagAssignmentResponse = {
+  tagId: 'tag-1',
+  targetType: 'Granit.Documents.Domain.Document',
+  targetId: 'doc-1',
+  assignedAt: '2026-05-02T12:00:00Z',
+};
+
+interface Harness {
+  readonly client: AxiosInstance;
+  readonly queryClient: QueryClient;
+  readonly wrapper: (props: { children: ReactNode }) => React.ReactElement;
+}
+
+function createHarness(): Harness {
+  const client = createMockClient();
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+    </QueryClientProvider>
+  );
+  return { client, queryClient, wrapper };
+}
+
+describe('useCreateTag', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs and invalidates the per-scope tags cache', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleTag });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateTag('documents'), { wrapper });
+    await result.current.mutateAsync({
+      scope: 'documents',
+      name: 'Urgent',
+      color: '#FF0000',
+      hideOnEntityCard: false,
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/taxonomy/tags', expect.any(Object));
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([['taxonomy', 'tags', { scope: 'documents' }]]);
+  });
+});
+
+describe('useUpdateTag', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PATCHes and invalidates per-scope tags + every tag-assignments cache', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.patch).mockResolvedValue({ data: { ...sampleTag, color: '#0000FF' } });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateTag('documents'), { wrapper });
+    await result.current.mutateAsync({ id: 'tag-1', request: { color: '#0000FF' } });
+
+    expect(client.patch).toHaveBeenCalledWith('/api/v1/taxonomy/tags/tag-1', expect.any(Object));
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['taxonomy', 'tags', { scope: 'documents' }],
+      ['taxonomy', 'tag-assignments'],
+    ]);
+  });
+});
+
+describe('useDeleteTag', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('DELETEs and invalidates per-scope tags + every tag-assignments cache', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDeleteTag('documents'), { wrapper });
+    await result.current.mutateAsync('tag-1');
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/taxonomy/tags/tag-1');
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['taxonomy', 'tags', { scope: 'documents' }],
+      ['taxonomy', 'tag-assignments'],
+    ]);
+  });
+});
+
+describe('useAssignTag', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs and invalidates only the impacted target chip strip', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleAssignment });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAssignTag(), { wrapper });
+    await result.current.mutateAsync({
+      tagId: 'tag-1',
+      target: { targetType: 'Granit.Documents.Domain.Document', targetId: 'doc-1' },
+    });
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/taxonomy/tags/tag-1/assign', {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+    });
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      [
+        'taxonomy',
+        'tag-assignments',
+        { targetType: 'Granit.Documents.Domain.Document', targetId: 'doc-1' },
+      ],
+    ]);
+  });
+});
+
+describe('useUnassignTag', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('DELETEs and invalidates only the impacted target chip strip', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUnassignTag(), { wrapper });
+    await result.current.mutateAsync({
+      tagId: 'tag-1',
+      target: { targetType: 'Granit.Documents.Domain.Document', targetId: 'doc-1' },
+    });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      `/api/v1/taxonomy/tags/tag-1/assign/${encodeURIComponent('Granit.Documents.Domain.Document')}/doc-1`
+    );
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      [
+        'taxonomy',
+        'tag-assignments',
+        { targetType: 'Granit.Documents.Domain.Document', targetId: 'doc-1' },
+      ],
+    ]);
+  });
+});
+
+describe('error propagation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('useUpdateTag surfaces 409 conflicts to callers without invalidating', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    const error = Object.assign(new Error('conflict'), { response: { status: 409 } });
+    vi.mocked(client.patch).mockRejectedValue(error);
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateTag('documents'), { wrapper });
+    await expect(
+      result.current.mutateAsync({ id: 'tag-1', request: { name: 'Urgent' } })
+    ).rejects.toMatchObject({ response: { status: 409 } });
+
+    expect(invalidate).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/hooks/use-category-mutations.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-category-mutations.ts
@@ -1,0 +1,205 @@
+import {
+  assignCategory,
+  createCategory,
+  deleteCategory,
+  moveCategory,
+  unassignCategory,
+  updateCategory,
+} from '@granit/taxonomy';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider.js';
+
+import type { ResolvedTaxonomyConfig } from '../providers/taxonomy-provider.js';
+import type {
+  CategoryAssignmentRequest,
+  CategoryAssignmentResponse,
+  CategoryResponse,
+  CreateCategoryRequest,
+  MoveCategoryRequest,
+  TaxonomyTargetRef,
+  UpdateCategoryRequest,
+} from '@granit/taxonomy';
+import type { QueryClient, UseMutationResult } from '@tanstack/react-query';
+
+interface CategoryIdMutationArgs<TRequest> {
+  readonly id: string;
+  readonly request: TRequest;
+}
+
+interface CategoryAssignmentMutationArgs {
+  readonly categoryId: string;
+  readonly target: TaxonomyTargetRef;
+}
+
+/**
+ * Invalidate the per-scope `categories` query family. Tree nodes at every
+ * depth share the prefix, so a single key invalidates the full sub-forest
+ * for the scope (any `parentId`).
+ */
+function invalidateCategoriesForScope(
+  queryClient: QueryClient,
+  config: ResolvedTaxonomyConfig,
+  scope: string
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildTaxonomyQueryKey(config, 'categories', { scope }),
+  });
+}
+
+/**
+ * Invalidate a single category-detail cache (with its breadcrumb).
+ */
+function invalidateCategoryDetail(
+  queryClient: QueryClient,
+  config: ResolvedTaxonomyConfig,
+  id: string
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildTaxonomyQueryKey(config, 'category', id),
+  });
+}
+
+/**
+ * Invalidate all category-detail caches. Used by `move` since the
+ * breadcrumb of every descendant of the moved node changes; without
+ * pre-walking the tree we cannot enumerate them.
+ */
+function invalidateAllCategoryDetails(
+  queryClient: QueryClient,
+  config: ResolvedTaxonomyConfig
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildTaxonomyQueryKey(config, 'category'),
+  });
+}
+
+/**
+ * Invalidate the assignment cache for a specific target. Symmetric with the
+ * tag-assignments key; T7's CategorySelector reads from this namespace.
+ */
+function invalidateCategoryAssignmentsForTarget(
+  queryClient: QueryClient,
+  config: ResolvedTaxonomyConfig,
+  target: TaxonomyTargetRef
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildTaxonomyQueryKey(config, 'category-assignments', target),
+  });
+}
+
+/**
+ * Create a category. Invalidates the impacted scope's tree.
+ */
+export function useCreateCategory(
+  scope: string
+): UseMutationResult<CategoryResponse, Error, CreateCategoryRequest> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateCategoryRequest) =>
+      createCategory(config.client, config.basePath, request),
+    onSuccess: () => {
+      invalidateCategoriesForScope(queryClient, config, scope);
+    },
+  });
+}
+
+/**
+ * Patch a category (rename). Invalidates the scope tree + the renamed node's
+ * detail cache.
+ */
+export function useUpdateCategory(
+  scope: string
+): UseMutationResult<CategoryResponse, Error, CategoryIdMutationArgs<UpdateCategoryRequest>> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: CategoryIdMutationArgs<UpdateCategoryRequest>) =>
+      updateCategory(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      invalidateCategoriesForScope(queryClient, config, scope);
+      invalidateCategoryDetail(queryClient, config, id);
+    },
+  });
+}
+
+/**
+ * Move a category. Old and new parent both need refresh, and every descendant
+ * of the moved subtree has a new breadcrumb — we invalidate broadly. Backend
+ * 422s on cross-scope moves and cycles; surface the problem-detail upstream.
+ */
+export function useMoveCategory(
+  scope: string
+): UseMutationResult<CategoryResponse, Error, CategoryIdMutationArgs<MoveCategoryRequest>> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: CategoryIdMutationArgs<MoveCategoryRequest>) =>
+      moveCategory(config.client, config.basePath, id, request),
+    onSuccess: () => {
+      invalidateCategoriesForScope(queryClient, config, scope);
+      invalidateAllCategoryDetails(queryClient, config);
+    },
+  });
+}
+
+/**
+ * Delete a category. Backend 422s if descendants or active assignments exist;
+ * surface the problem-detail upstream. Invalidates the scope tree.
+ */
+export function useDeleteCategory(scope: string): UseMutationResult<void, Error, string> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteCategory(config.client, config.basePath, id),
+    onSuccess: (_data, id) => {
+      invalidateCategoriesForScope(queryClient, config, scope);
+      invalidateCategoryDetail(queryClient, config, id);
+    },
+  });
+}
+
+/**
+ * Assign (or re-assign — single-assignment, idempotent server-side) a
+ * category to a target. Invalidates the target's category-assignment cache.
+ */
+export function useAssignCategory(): UseMutationResult<
+  CategoryAssignmentResponse,
+  Error,
+  CategoryAssignmentMutationArgs
+> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ categoryId, target }: CategoryAssignmentMutationArgs) => {
+      const request: CategoryAssignmentRequest = target;
+      return assignCategory(config.client, config.basePath, categoryId, request);
+    },
+    onSuccess: (_data, { target }) => {
+      invalidateCategoryAssignmentsForTarget(queryClient, config, target);
+    },
+  });
+}
+
+/**
+ * Remove the category assignment from a target. Invalidates the target's
+ * category-assignment cache.
+ */
+export function useUnassignCategory(): UseMutationResult<void, Error, TaxonomyTargetRef> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (target: TaxonomyTargetRef) =>
+      unassignCategory(config.client, config.basePath, target.targetType, target.targetId),
+    onSuccess: (_data, target) => {
+      invalidateCategoryAssignmentsForTarget(queryClient, config, target);
+    },
+  });
+}

--- a/packages/@granit/react-taxonomy/src/hooks/use-tag-mutations.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-tag-mutations.ts
@@ -1,0 +1,195 @@
+import { assignTag, createTag, deleteTag, unassignTag, updateTag } from '@granit/taxonomy';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider.js';
+
+import type { ResolvedTaxonomyConfig } from '../providers/taxonomy-provider.js';
+import type {
+  CreateTagRequest,
+  TagAssignmentRequest,
+  TagAssignmentResponse,
+  TagResponse,
+  TaxonomyTargetRef,
+  UpdateTagRequest,
+} from '@granit/taxonomy';
+import type { QueryClient, UseMutationResult } from '@tanstack/react-query';
+
+interface TagIdMutationArgs<TRequest> {
+  readonly id: string;
+  readonly request: TRequest;
+}
+
+interface TagAssignmentMutationArgs {
+  readonly tagId: string;
+  readonly target: TaxonomyTargetRef;
+}
+
+/**
+ * Invalidate the per-scope `['tags', { scope }]` query family. The object
+ * literal is matched structurally by React Query, so this picks up every
+ * autocomplete variant (any `q`) within the scope without disturbing other
+ * scopes' caches.
+ */
+function invalidateTagsForScope(
+  queryClient: QueryClient,
+  config: ResolvedTaxonomyConfig,
+  scope: string
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildTaxonomyQueryKey(config, 'tags', { scope }),
+  });
+}
+
+/**
+ * Invalidate the assignment cache for a specific target.
+ */
+function invalidateTagAssignmentsForTarget(
+  queryClient: QueryClient,
+  config: ResolvedTaxonomyConfig,
+  target: TaxonomyTargetRef
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildTaxonomyQueryKey(config, 'tag-assignments', target),
+  });
+}
+
+/**
+ * Invalidate every assignment cache, regardless of target. Used by destructive
+ * mutations (delete/update tag) where we cannot enumerate the impacted entity
+ * cards: a renamed or deleted tag may show up in any target's chip strip.
+ */
+function invalidateAllTagAssignments(
+  queryClient: QueryClient,
+  config: ResolvedTaxonomyConfig
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildTaxonomyQueryKey(config, 'tag-assignments'),
+  });
+}
+
+/**
+ * Create a tag in the given scope. Invalidates the `tags` autocomplete cache
+ * for that scope.
+ *
+ * @example
+ * ```tsx
+ * const create = useCreateTag('documents');
+ * await create.mutateAsync({ scope: 'documents', name: 'Urgent', color: '#FF0000', hideOnEntityCard: false });
+ * ```
+ */
+export function useCreateTag(
+  scope: string
+): UseMutationResult<TagResponse, Error, CreateTagRequest> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateTagRequest) => createTag(config.client, config.basePath, request),
+    onSuccess: () => {
+      invalidateTagsForScope(queryClient, config, scope);
+    },
+  });
+}
+
+/**
+ * Patch a tag (rename / recolor / hide). Renames and recolors propagate to
+ * every chip strip displaying the tag, so all `tag-assignments` caches are
+ * invalidated alongside the per-scope tags list.
+ *
+ * @example
+ * ```tsx
+ * const update = useUpdateTag('documents');
+ * await update.mutateAsync({ id: 'tag-1', request: { color: '#0000FF' } });
+ * ```
+ */
+export function useUpdateTag(
+  scope: string
+): UseMutationResult<TagResponse, Error, TagIdMutationArgs<UpdateTagRequest>> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: TagIdMutationArgs<UpdateTagRequest>) =>
+      updateTag(config.client, config.basePath, id, request),
+    onSuccess: () => {
+      invalidateTagsForScope(queryClient, config, scope);
+      invalidateAllTagAssignments(queryClient, config);
+    },
+  });
+}
+
+/**
+ * Delete a tag. Backend cascades all assignments — every chip strip needs to
+ * refresh, so we invalidate the per-scope tags list and the entire
+ * `tag-assignments` namespace.
+ *
+ * @example
+ * ```tsx
+ * const remove = useDeleteTag('documents');
+ * await remove.mutateAsync('tag-1');
+ * ```
+ */
+export function useDeleteTag(scope: string): UseMutationResult<void, Error, string> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteTag(config.client, config.basePath, id),
+    onSuccess: () => {
+      invalidateTagsForScope(queryClient, config, scope);
+      invalidateAllTagAssignments(queryClient, config);
+    },
+  });
+}
+
+/**
+ * Assign a tag to a polymorphic target. Invalidates only the impacted
+ * target's chip strip — other entity cards keep their cached state.
+ *
+ * @example
+ * ```tsx
+ * const assign = useAssignTag();
+ * await assign.mutateAsync({ tagId: 'tag-1', target: { targetType: 'Granit.Documents.Domain.Document', targetId: docId } });
+ * ```
+ */
+export function useAssignTag(): UseMutationResult<
+  TagAssignmentResponse,
+  Error,
+  TagAssignmentMutationArgs
+> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ tagId, target }: TagAssignmentMutationArgs) => {
+      const request: TagAssignmentRequest = target;
+      return assignTag(config.client, config.basePath, tagId, request);
+    },
+    onSuccess: (_data, { target }) => {
+      invalidateTagAssignmentsForTarget(queryClient, config, target);
+    },
+  });
+}
+
+/**
+ * Remove a tag from a polymorphic target. Invalidates only the impacted
+ * target's chip strip.
+ *
+ * @example
+ * ```tsx
+ * const unassign = useUnassignTag();
+ * await unassign.mutateAsync({ tagId: 'tag-1', target: { targetType: '...', targetId: docId } });
+ * ```
+ */
+export function useUnassignTag(): UseMutationResult<void, Error, TagAssignmentMutationArgs> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ tagId, target }: TagAssignmentMutationArgs) =>
+      unassignTag(config.client, config.basePath, tagId, target.targetType, target.targetId),
+    onSuccess: (_data, { target }) => {
+      invalidateTagAssignmentsForTarget(queryClient, config, target);
+    },
+  });
+}

--- a/packages/@granit/react-taxonomy/src/index.ts
+++ b/packages/@granit/react-taxonomy/src/index.ts
@@ -18,3 +18,22 @@ export { useTagAssignments, useTags } from './hooks/use-tags.js';
 export { useCategories, useCategory } from './hooks/use-categories.js';
 export { useTaxonomySearch } from './hooks/use-taxonomy-search.js';
 export type { UseTaxonomySearchOptions } from './hooks/use-taxonomy-search.js';
+
+// Mutation hooks — Tags
+export {
+  useAssignTag,
+  useCreateTag,
+  useDeleteTag,
+  useUnassignTag,
+  useUpdateTag,
+} from './hooks/use-tag-mutations.js';
+
+// Mutation hooks — Categories
+export {
+  useAssignCategory,
+  useCreateCategory,
+  useDeleteCategory,
+  useMoveCategory,
+  useUnassignCategory,
+  useUpdateCategory,
+} from './hooks/use-category-mutations.js';


### PR DESCRIPTION
## Summary

Tag mutations:
- `useCreateTag(scope)` — invalidates `['tags', { scope }]` only.
- `useUpdateTag(scope)` — invalidates per-scope tags AND every chip strip (`tag-assignments` namespace) since rename/recolor propagates.
- `useDeleteTag(scope)` — same broad invalidation: backend cascades the assignments.
- `useAssignTag` / `useUnassignTag` — per-target invalidation, leaves unrelated entity cards' caches intact.

Category mutations:
- `useCreateCategory(scope)` — invalidates `['categories', { scope }]`.
- `useUpdateCategory(scope)` — scope tree + the renamed node's detail (breadcrumb).
- `useMoveCategory(scope)` — scope tree + ALL category details: every descendant of the moved subtree has a new breadcrumb.
- `useDeleteCategory(scope)` — scope tree + deleted detail.
- `useAssignCategory` / `useUnassignCategory` — per-target on `category-assignments` (reserves the key for T7's selector).

Server errors — 422 (move cycle / cross-scope, delete with descendants/active assignments) and 409 (tag rename conflict) are propagated to callers without invalidating; nothing changed server-side, so optimistic UI state can be rolled back without a re-fetch.

Cache key strategy — invalidations match by structural object subset (React Query `partialMatchKey`), so e.g. invalidating `['tags', { scope: 'documents' }]` picks up every autocomplete variant (`q`) for that scope without disturbing other scopes.

Refs #388 — closes T4 of #384.

## Test plan

- [x] `pnpm exec eslint` clean
- [x] Workspace-wide `pnpm tsc` clean (exit 0)
- [x] `pnpm exec vitest run packages/@granit/react-taxonomy` — 31 tests across 6 files
- [x] Coverage scoped to `react-taxonomy/src/**/*.{ts,tsx}`: **100% statements / 100% branches / 100% functions / 100% lines**