### PR TITLE
feat(react-taxonomy): components, entity contribution, locales (T5–T10)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4224,7 +4224,7 @@
         {
           "name": "useCategories",
           "kind": "function",
-          "signature": "function useCategories( filter: CategoryListFilter ): UseQueryResult<readonly CategoryResponse[]>"
+          "signature": "function useCategories( filter: CategoryListFilter, options?:"
         },
         {
           "name": "useCategory",
@@ -4241,6 +4241,116 @@
           "kind": "interface",
           "signature": "interface UseTaxonomySearchOptions extends TaxonomySearchFilter",
           "members": []
+        },
+        {
+          "name": "DocumentTagsBindings",
+          "kind": "interface",
+          "signature": "interface DocumentTagsBindings",
+          "members": []
+        },
+        {
+          "name": "TagChip",
+          "kind": "function",
+          "signature": "function TagChip("
+        },
+        {
+          "name": "TagChipProps",
+          "kind": "interface",
+          "signature": "interface TagChipProps",
+          "members": []
+        },
+        {
+          "name": "TagAutocomplete",
+          "kind": "function",
+          "signature": "function TagAutocomplete("
+        },
+        {
+          "name": "TagChipStrip",
+          "kind": "function",
+          "signature": "function TagChipStrip("
+        },
+        {
+          "name": "TagChipStripLabels",
+          "kind": "interface",
+          "signature": "interface TagChipStripLabels extends TagAutocompleteLabels",
+          "members": []
+        },
+        {
+          "name": "TagChipStripProps",
+          "kind": "interface",
+          "signature": "interface TagChipStripProps",
+          "members": []
+        },
+        {
+          "name": "DocumentTagChipStrip",
+          "kind": "function",
+          "signature": "function DocumentTagChipStrip("
+        },
+        {
+          "name": "DocumentTagChipStripProps",
+          "kind": "interface",
+          "signature": "interface DocumentTagChipStripProps",
+          "members": []
+        },
+        {
+          "name": "TagManager",
+          "kind": "function",
+          "signature": "function TagManager("
+        },
+        {
+          "name": "TagManagerLabels",
+          "kind": "interface",
+          "signature": "interface TagManagerLabels",
+          "members": []
+        },
+        {
+          "name": "TagManagerProps",
+          "kind": "interface",
+          "signature": "interface TagManagerProps",
+          "members": []
+        },
+        {
+          "name": "CategoryBreadcrumb",
+          "kind": "function",
+          "signature": "function CategoryBreadcrumb("
+        },
+        {
+          "name": "CategoryBreadcrumbProps",
+          "kind": "interface",
+          "signature": "interface CategoryBreadcrumbProps",
+          "members": []
+        },
+        {
+          "name": "CategoryTree",
+          "kind": "function",
+          "signature": "function CategoryTree("
+        },
+        {
+          "name": "CategoryTreeLabels",
+          "kind": "interface",
+          "signature": "interface CategoryTreeLabels",
+          "members": []
+        },
+        {
+          "name": "CategoryTreeProps",
+          "kind": "interface",
+          "signature": "interface CategoryTreeProps",
+          "members": []
+        },
+        {
+          "name": "CategorySelector",
+          "kind": "function",
+          "signature": "function CategorySelector("
+        },
+        {
+          "name": "TaxonomySearchBar",
+          "kind": "function",
+          "signature": "function TaxonomySearchBar("
+        },
+        {
+          "name": "entityTaxonomy",
+          "kind": "function",
+          "signature": "function entityTaxonomy( options: EntityTaxonomyContributionOptions ): (props: EntityTaxonomyProps) => ReactNode"
         }
       ]
     },

--- a/packages/@granit/react-taxonomy/src/__tests__/branch-coverage-extra.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/branch-coverage-extra.test.tsx
@@ -1,0 +1,179 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CategoryTree } from '../components/category-tree.tsx';
+import { TagChipStrip } from '../components/tag-chip-strip.tsx';
+import { TagManager } from '../components/tag-manager.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CategoryResponse, TagAssignmentResponse, TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const tag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const root: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: false,
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TagChipStrip — autocomplete editing branch', () => {
+  it('renders the autocomplete combobox when canManage and + Tag is clicked', async () => {
+    const client = createMockClient();
+    const assignment: TagAssignmentResponse = {
+      tagId: 'tag-1',
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+      assignedAt: '2026-05-02T12:00:00Z',
+    };
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.endsWith('/tags/assignments')) return Promise.resolve({ data: [assignment] });
+      if (url.endsWith('/tags')) return Promise.resolve({ data: [tag] });
+      return Promise.resolve({ data: [] });
+    }) as AxiosInstance['get']);
+
+    render(
+      <TagChipStrip
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        canManage
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('Urgent')).toBeInTheDocument());
+    await userEvent.click(screen.getByText('+ Tag'));
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});
+
+describe('TagManager — hex validation + draft branches', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('surfaces 409 conflicts on create as a localised message', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.post).mockRejectedValue({
+      response: { status: 409 },
+      message: 'fallback',
+    });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New tag' })).toBeEnabled());
+    await userEvent.click(screen.getByRole('button', { name: 'New tag' }));
+    await userEvent.type(screen.getByLabelText('Name'), 'Urgent');
+    await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() =>
+      expect(screen.getByText('A tag with this name already exists.')).toBeInTheDocument()
+    );
+  });
+
+  it('renders an editable name input only when canManage is true', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByDisplayValue('Urgent')).toBeInTheDocument());
+  });
+});
+
+describe('CategoryTree — 422 cycle + cross-scope branches', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'prompt').mockImplementation(() => null);
+    vi.spyOn(window, 'confirm').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('maps a 422 cycle on move to the localised message', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [root] });
+    vi.mocked(client.post).mockRejectedValue({
+      response: { status: 422, data: { detail: 'cycle' } },
+      message: 'fallback',
+    });
+    vi.mocked(window.prompt).mockReturnValueOnce('cat-other');
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button', { name: 'Move' })[0]!);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Cannot move a category under one of its descendants.')
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('maps a 422 has-assignments on delete to the localised message', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [root] });
+    vi.mocked(client.delete).mockRejectedValue({
+      response: { status: 422, data: { detail: 'has-assignments' } },
+      message: 'fallback',
+    });
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText('Cannot delete: this category has active assignments.')
+      ).toBeInTheDocument()
+    );
+  });
+
+  it('skips the create POST when the Add prompt is cancelled at root', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.post).mockResolvedValue({ data: root });
+    vi.mocked(window.prompt).mockReturnValueOnce(null);
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('No categories.')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: '+' }));
+
+    expect(client.post).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/branch-coverage.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/branch-coverage.test.tsx
@@ -1,0 +1,239 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CategorySelector } from '../components/category-selector.tsx';
+import { CategoryTree } from '../components/category-tree.tsx';
+import { TagAutocomplete } from '../components/tag-autocomplete.tsx';
+import { TagChipStrip } from '../components/tag-chip-strip.tsx';
+import { TagManager } from '../components/tag-manager.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CategoryResponse, TagAssignmentResponse, TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const tag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const root: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: false,
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TagChipStrip — manage flow', () => {
+  it('unassigns when × is clicked on a chip under canManage', async () => {
+    const client = createMockClient();
+    const assignment: TagAssignmentResponse = {
+      tagId: 'tag-1',
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+      assignedAt: '2026-05-02T12:00:00Z',
+    };
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.endsWith('/tags/assignments')) return Promise.resolve({ data: [assignment] });
+      if (url.endsWith('/tags')) return Promise.resolve({ data: [tag] });
+      return Promise.resolve({ data: [] });
+    }) as AxiosInstance['get']);
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+    render(
+      <TagChipStrip
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        canManage
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('Urgent')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /Remove Urgent/i }));
+
+    await waitFor(() =>
+      expect(client.delete).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/taxonomy/tags/tag-1/assign/')
+      )
+    );
+  });
+
+  it('renders the error state when the assignments query fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('boom'));
+
+    render(
+      <TagChipStrip
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+});
+
+describe('TagAutocomplete — Arrow Up + Escape', () => {
+  it('Arrow Up clamps highlight at 0; Escape closes the dropdown', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+
+    render(<TagAutocomplete scope="documents" value={[]} onAdd={vi.fn()} onRemove={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    await userEvent.keyboard('{ArrowUp}{ArrowUp}');
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.keyboard('{Escape}');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+describe('TagManager — readonly + delete-cancel branches', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does NOT call DELETE when the confirm dialog is cancelled', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByDisplayValue('Urgent')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
+  it('renders read-only color swatch when canManage is false', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+
+    const { container } = render(<TagManager scope="documents" />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('#FF0000')).toBeInTheDocument());
+    expect(container.querySelector('[data-granit-tag-color-swatch]')).toBeTruthy();
+  });
+
+  it('renders the loading state while the tags query is pending', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockImplementation(() => new Promise(() => {}));
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+});
+
+describe('CategoryTree — error states', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    vi.spyOn(window, 'prompt').mockReturnValue(null);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the error fallback when the roots query fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('roots-failed'));
+
+    render(<CategoryTree scope="documents" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+
+  it('maps a 422 has-descendants error to its localised message', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [root] });
+    vi.mocked(client.delete).mockRejectedValue({
+      response: { status: 422, data: { detail: 'has-descendants' } },
+      message: 'fallback',
+    });
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Cannot delete: this category has descendants/)).toBeInTheDocument()
+    );
+  });
+
+  it('Loading state on roots query', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockImplementation(() => new Promise(() => {}));
+
+    render(<CategoryTree scope="documents" />, { wrapper: createWrapper(client) });
+    expect(screen.getByText('Loading…')).toBeInTheDocument();
+  });
+});
+
+describe('CategorySelector — clear flow', () => {
+  it('DELETEs assignment when Clear is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      data: {
+        ...root,
+        breadcrumb: [root],
+      },
+    });
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+    render(
+      <CategorySelector
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        value="cat-1"
+        canManage
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Clear' }));
+
+    await waitFor(() =>
+      expect(client.delete).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/taxonomy/categories/assign/')
+      )
+    );
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/category-breadcrumb.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-breadcrumb.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CategoryBreadcrumb } from '../components/category-breadcrumb.tsx';
+
+import type { CategoryDetailResponse, CategoryResponse } from '@granit/taxonomy';
+
+const root: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: true,
+};
+
+const leaf: CategoryResponse = {
+  id: 'cat-2',
+  scope: 'documents',
+  parentId: 'cat-1',
+  path: '/legal/contracts',
+  name: 'contracts',
+  depth: 1,
+  hasChildren: false,
+};
+
+const detail: CategoryDetailResponse = { ...leaf, breadcrumb: [root, leaf] };
+
+describe('CategoryBreadcrumb', () => {
+  it('renders root → leaf segments separated by the chevron', () => {
+    const { container } = render(<CategoryBreadcrumb category={detail} />);
+    const segments = container.querySelectorAll('[data-granit-category-breadcrumb-segment]');
+    expect(segments).toHaveLength(2);
+    expect(segments[0]?.textContent).toContain('legal');
+    expect(segments[1]?.textContent).toContain('contracts');
+  });
+
+  it('marks the leaf segment with aria-current="page"', () => {
+    render(<CategoryBreadcrumb category={detail} />);
+    const current = screen.getByText('contracts');
+    expect(current).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('makes non-leaf segments clickable when onSelect is provided', async () => {
+    const onSelect = vi.fn();
+    render(<CategoryBreadcrumb category={detail} onSelect={onSelect} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'legal' }));
+    expect(onSelect).toHaveBeenCalledWith(root);
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/category-selector.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-selector.test.tsx
@@ -1,0 +1,125 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CategorySelector } from '../components/category-selector.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CategoryDetailResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const detail: CategoryDetailResponse = {
+  id: 'cat-2',
+  scope: 'documents',
+  parentId: 'cat-1',
+  path: '/legal/contracts',
+  name: 'contracts',
+  depth: 1,
+  hasChildren: false,
+  breadcrumb: [
+    {
+      id: 'cat-1',
+      scope: 'documents',
+      parentId: null,
+      path: '/legal',
+      name: 'legal',
+      depth: 0,
+      hasChildren: true,
+    },
+    {
+      id: 'cat-2',
+      scope: 'documents',
+      parentId: 'cat-1',
+      path: '/legal/contracts',
+      name: 'contracts',
+      depth: 1,
+      hasChildren: false,
+    },
+  ],
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('CategorySelector', () => {
+  it('renders the "No category" state when value is null', () => {
+    const client = createMockClient();
+
+    render(
+      <CategorySelector
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        value={null}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    expect(screen.getByText('No category')).toBeInTheDocument();
+  });
+
+  it('renders the breadcrumb when a category is assigned', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: detail });
+
+    render(
+      <CategorySelector
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        value="cat-2"
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('contracts')).toBeInTheDocument());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/taxonomy/categories/cat-2');
+  });
+
+  it('opens the dialog when Choose is clicked under canManage', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(
+      <CategorySelector
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        value={null}
+        canManage
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: 'Choose…' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('hides Choose / Clear when canManage is false', () => {
+    const client = createMockClient();
+
+    render(
+      <CategorySelector
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        value="cat-2"
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    expect(screen.queryByRole('button', { name: 'Choose…' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Clear' })).toBeNull();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/category-tree-actions.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-tree-actions.test.tsx
@@ -1,0 +1,121 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CategoryTree } from '../components/category-tree.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CategoryResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const root: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: false,
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('CategoryTree manage actions', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'prompt').mockImplementation(() => null);
+    vi.spyOn(window, 'confirm').mockImplementation(() => true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs a new root category when the Add root button is used', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.post).mockResolvedValue({ data: root });
+    vi.mocked(window.prompt).mockReturnValueOnce('legal');
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('No categories.')).toBeInTheDocument());
+    const addRoot = screen.getByRole('button', { name: '+' });
+    await userEvent.click(addRoot);
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/taxonomy/categories',
+      expect.objectContaining({ parentId: null, name: 'legal' })
+    );
+  });
+
+  it('PATCHes a renamed category when the Rename button is used', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [root] });
+    vi.mocked(client.patch).mockResolvedValue({ data: root });
+    vi.mocked(window.prompt).mockReturnValueOnce('legal-updated');
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button', { name: 'Rename' })[0]!);
+
+    expect(client.patch).toHaveBeenCalledWith(
+      '/api/v1/taxonomy/categories/cat-1',
+      expect.objectContaining({ name: 'legal-updated' })
+    );
+  });
+
+  it('DELETEs when the Delete button is confirmed', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [root] });
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button', { name: 'Delete' })[0]!);
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/taxonomy/categories/cat-1');
+  });
+
+  it('skips the rename PATCH when the prompt is cancelled', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [root] });
+    vi.mocked(client.patch).mockResolvedValue({ data: root });
+    vi.mocked(window.prompt).mockReturnValueOnce(null);
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button', { name: 'Rename' })[0]!);
+
+    expect(client.patch).not.toHaveBeenCalled();
+  });
+
+  it('POSTs move with newParentId=null when the prompt is empty', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [{ ...root, parentId: 'cat-9' }] });
+    vi.mocked(client.post).mockResolvedValue({ data: root });
+    vi.mocked(window.prompt).mockReturnValueOnce('');
+
+    render(<CategoryTree scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    await userEvent.click(screen.getAllByRole('button', { name: 'Move' })[0]!);
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/taxonomy/categories/cat-1/move', {
+      newParentId: null,
+    });
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/category-tree.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/category-tree.test.tsx
@@ -1,0 +1,104 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CategoryTree } from '../components/category-tree.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CategoryResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const root: CategoryResponse = {
+  id: 'cat-1',
+  scope: 'documents',
+  parentId: null,
+  path: '/legal',
+  name: 'legal',
+  depth: 0,
+  hasChildren: true,
+};
+
+const child: CategoryResponse = {
+  id: 'cat-2',
+  scope: 'documents',
+  parentId: 'cat-1',
+  path: '/legal/contracts',
+  name: 'contracts',
+  depth: 1,
+  hasChildren: false,
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('CategoryTree', () => {
+  it('renders the root list and lazy-loads children on expand', async () => {
+    const client = createMockClient();
+    let callCount = 0;
+    vi.mocked(client.get).mockImplementation(((
+      _url: string,
+      opts?: { params?: { parentId?: string } }
+    ) => {
+      callCount += 1;
+      if (opts?.params?.parentId === 'cat-1') {
+        return Promise.resolve({ data: [child] });
+      }
+      return Promise.resolve({ data: [root] });
+    }) as AxiosInstance['get']);
+
+    render(<CategoryTree scope="documents" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    // Children not loaded yet
+    expect(screen.queryByText('contracts')).toBeNull();
+    expect(callCount).toBe(1);
+
+    await userEvent.click(screen.getByRole('button', { expanded: false }));
+    await waitFor(() => expect(screen.getByText('contracts')).toBeInTheDocument());
+    expect(callCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it('shows manage actions only when canManage is true', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [root] });
+
+    const { rerender } = render(<CategoryTree scope="documents" />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Rename' })).toBeNull();
+
+    // Rerender with canManage=true under a fresh wrapper to avoid query cache
+    const wrapped = createWrapper(client);
+    rerender(
+      <div>
+        {wrapped({
+          children: <CategoryTree scope="documents" canManage />,
+        })}
+      </div>
+    );
+    await waitFor(() => expect(screen.getAllByText('legal').length).toBeGreaterThan(0));
+    expect(screen.getAllByRole('button', { name: 'Rename' }).length).toBeGreaterThan(0);
+  });
+
+  it('renders empty state when no roots exist', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<CategoryTree scope="documents" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('No categories.')).toBeInTheDocument());
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/document-tag-chip-strip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/document-tag-chip-strip.test.tsx
@@ -1,0 +1,57 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DocumentTagChipStrip } from '../components/document-tag-chip-strip.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const tag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('DocumentTagChipStrip', () => {
+  it('GETs the proxy URL and renders the returned tags', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+
+    render(<DocumentTagChipStrip scope="documents" basePath="/api/v1" documentId="doc-1" />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('Urgent')).toBeInTheDocument());
+    expect(client.get).toHaveBeenCalledWith('/api/v1/documents/doc-1/tags');
+  });
+
+  it('renders the empty state when the proxy returns no tags', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<DocumentTagChipStrip scope="documents" basePath="/api/v1" documentId="doc-1" />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('No tags.')).toBeInTheDocument());
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/entity-taxonomy.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/entity-taxonomy.test.tsx
@@ -1,0 +1,104 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { entityTaxonomy } from '../contributions/entity-taxonomy.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('entityTaxonomy', () => {
+  it('returns a renderer that mounts both chip strip and selector by default', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    const Renderer = entityTaxonomy({ scope: 'documents' });
+
+    const { container } = render(
+      <Renderer entityName="Granit.Documents.Domain.Document" entityId="doc-1" />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => {
+      expect(container.querySelector('[data-granit-tag-chip-strip]')).toBeTruthy();
+      expect(container.querySelector('[data-granit-category-selector]')).toBeTruthy();
+    });
+  });
+
+  it('omits the chip strip when showTags is false', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    const Renderer = entityTaxonomy({ scope: 'documents', showTags: false });
+
+    const { container } = render(
+      <Renderer entityName="Granit.Documents.Domain.Document" entityId="doc-1" />,
+      { wrapper: createWrapper(client) }
+    );
+
+    expect(container.querySelector('[data-granit-tag-chip-strip]')).toBeNull();
+    expect(container.querySelector('[data-granit-category-selector]')).toBeTruthy();
+  });
+
+  it('returns a no-op renderer when both showTags and showCategory are false', () => {
+    const Renderer = entityTaxonomy({ scope: 'documents', showTags: false, showCategory: false });
+    const { container } = render(
+      <Renderer entityName="Granit.Documents.Domain.Document" entityId="doc-1" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('forwards categoryId to the selector', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.includes('/categories/cat-9')) {
+        return Promise.resolve({
+          data: {
+            id: 'cat-9',
+            scope: 'documents',
+            parentId: null,
+            path: '/legal',
+            name: 'legal',
+            depth: 0,
+            hasChildren: false,
+            breadcrumb: [
+              {
+                id: 'cat-9',
+                scope: 'documents',
+                parentId: null,
+                path: '/legal',
+                name: 'legal',
+                depth: 0,
+                hasChildren: false,
+              },
+            ],
+          },
+        });
+      }
+      return Promise.resolve({ data: [] });
+    }) as AxiosInstance['get']);
+
+    const Renderer = entityTaxonomy({ scope: 'documents', showTags: false });
+    render(
+      <Renderer
+        entityName="Granit.Documents.Domain.Document"
+        entityId="doc-1"
+        categoryId="cat-9"
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('legal')).toBeInTheDocument());
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/locales.test.ts
+++ b/packages/@granit/react-taxonomy/src/__tests__/locales.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+
+import { taxonomyTranslationsEn } from '../locales/en.js';
+import { taxonomyTranslationsFr } from '../locales/fr.js';
+
+import type { TaxonomyTranslations } from '../locales/en.js';
+
+function flatten(obj: unknown, prefix = ''): readonly string[] {
+  if (typeof obj !== 'object' || obj === null) {
+    return [prefix];
+  }
+  return Object.entries(obj as Record<string, unknown>).flatMap(([key, value]) =>
+    flatten(value, prefix === '' ? key : `${prefix}.${key}`)
+  );
+}
+
+describe('Taxonomy locale bundles', () => {
+  it('en and fr expose the same key tree (no missing translations)', () => {
+    const en = flatten(taxonomyTranslationsEn).slice().sort();
+    const fr = flatten(taxonomyTranslationsFr).slice().sort();
+    expect(fr).toEqual(en);
+  });
+
+  it('en bundle satisfies the TaxonomyTranslations contract', () => {
+    const _typed: TaxonomyTranslations = taxonomyTranslationsEn;
+    expect(_typed.Tag.Manager.Title).toBe('Tags');
+    expect(_typed.Search.BelowThreshold).toContain('2');
+  });
+
+  it('fr bundle uses diacritics where expected', () => {
+    expect(taxonomyTranslationsFr.Tag.Strip.Empty).toContain('é');
+    expect(taxonomyTranslationsFr.Category.Tree.Delete).toBe('Supprimer');
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete-create.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete-create.test.tsx
@@ -1,0 +1,60 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TagAutocomplete } from '../components/tag-autocomplete.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const createdTag: TagResponse = {
+  id: 'tag-new',
+  scope: 'documents',
+  name: 'Brand new',
+  color: '#94a3b8',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TagAutocomplete inline create', () => {
+  it('POSTs a new tag when the create option is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.post).mockResolvedValue({ data: createdTag });
+    const onAdd = vi.fn();
+
+    render(
+      <TagAutocomplete scope="documents" value={[]} canManage onAdd={onAdd} onRemove={vi.fn()} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'Brand new');
+    await waitFor(() => expect(screen.getByText(/Create.*Brand new/)).toBeInTheDocument());
+    await userEvent.click(screen.getByText(/Create.*Brand new/));
+
+    await waitFor(() => expect(client.post).toHaveBeenCalled());
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/taxonomy/tags',
+      expect.objectContaining({ name: 'Brand new', scope: 'documents' })
+    );
+    await waitFor(() => expect(onAdd).toHaveBeenCalledWith(createdTag));
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-autocomplete.test.tsx
@@ -1,0 +1,126 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { act, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TagAutocomplete } from '../components/tag-autocomplete.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const sampleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const otherTag: TagResponse = {
+  id: 'tag-2',
+  scope: 'documents',
+  name: 'Internal',
+  color: '#00FF00',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TagAutocomplete', () => {
+  it('renders selected chips and a combobox input', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleTag, otherTag] });
+
+    render(
+      <TagAutocomplete scope="documents" value={['tag-1']} onAdd={vi.fn()} onRemove={vi.fn()} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+
+  it('calls onAdd with the picked suggestion when Enter is pressed', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [otherTag] });
+    const onAdd = vi.fn();
+
+    render(<TagAutocomplete scope="documents" value={[]} onAdd={onAdd} onRemove={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    await act(async () => {
+      input.focus();
+    });
+    await userEvent.keyboard('{Enter}');
+
+    expect(onAdd).toHaveBeenCalledWith(otherTag);
+  });
+
+  it('removes the last selected chip on Backspace when the input is empty', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleTag, otherTag] });
+    const onRemove = vi.fn();
+
+    render(
+      <TagAutocomplete scope="documents" value={['tag-1']} onAdd={vi.fn()} onRemove={onRemove} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(client.get).toHaveBeenCalled());
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.keyboard('{Backspace}');
+
+    expect(onRemove).toHaveBeenCalledWith(sampleTag);
+  });
+
+  it('shows the create option only when canManage and no exact match', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(
+      <TagAutocomplete scope="documents" value={[]} canManage onAdd={vi.fn()} onRemove={vi.fn()} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'New tag');
+
+    expect(screen.getByText(/Create.*New tag/)).toBeInTheDocument();
+  });
+
+  it('does not show create when canManage is false', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<TagAutocomplete scope="documents" value={[]} onAdd={vi.fn()} onRemove={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'New tag');
+
+    expect(screen.queryByText(/Create/)).toBeNull();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-chip-strip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-chip-strip.test.tsx
@@ -1,0 +1,142 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TagChipStrip } from '../components/tag-chip-strip.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagAssignmentResponse, TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const visibleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const hiddenTag: TagResponse = {
+  id: 'tag-2',
+  scope: 'documents',
+  name: 'Internal',
+  color: '#00FF00',
+  hideOnEntityCard: true,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+const assignments: readonly TagAssignmentResponse[] = [
+  {
+    tagId: 'tag-1',
+    targetType: 'Granit.Documents.Domain.Document',
+    targetId: 'doc-1',
+    assignedAt: '2026-05-02T12:00:00Z',
+  },
+  {
+    tagId: 'tag-2',
+    targetType: 'Granit.Documents.Domain.Document',
+    targetId: 'doc-1',
+    assignedAt: '2026-05-02T12:00:00Z',
+  },
+];
+
+function createWrapperFromClient(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function buildClient(): AxiosInstance {
+  const client = createMockClient();
+  vi.mocked(client.get).mockImplementation(((url: string) => {
+    if (url.endsWith('/tag-assignments') || url.endsWith('/tags/assignments')) {
+      return Promise.resolve({ data: assignments });
+    }
+    if (url.endsWith('/tags')) {
+      return Promise.resolve({ data: [visibleTag, hiddenTag] });
+    }
+    return Promise.resolve({ data: [] });
+  }) as AxiosInstance['get']);
+  return client;
+}
+
+describe('TagChipStrip', () => {
+  it('renders only the non-hidden tags by default (hideOnCardOnly = true)', async () => {
+    const client = buildClient();
+
+    render(
+      <TagChipStrip
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+      />,
+      { wrapper: createWrapperFromClient(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('Urgent')).toBeInTheDocument());
+    expect(screen.queryByText('Internal')).toBeNull();
+  });
+
+  it('shows hidden-on-card tags when hideOnCardOnly is false', async () => {
+    const client = buildClient();
+
+    render(
+      <TagChipStrip
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        hideOnCardOnly={false}
+      />,
+      { wrapper: createWrapperFromClient(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('Urgent')).toBeInTheDocument());
+    expect(screen.getByText('Internal')).toBeInTheDocument();
+  });
+
+  it('hides the + button when canManage is false', async () => {
+    const client = buildClient();
+
+    render(
+      <TagChipStrip
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+      />,
+      { wrapper: createWrapperFromClient(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('Urgent')).toBeInTheDocument());
+    expect(screen.queryByText('+ Tag')).toBeNull();
+  });
+
+  it('opens the autocomplete when the + button is clicked under canManage', async () => {
+    const client = buildClient();
+
+    render(
+      <TagChipStrip
+        scope="documents"
+        targetType="Granit.Documents.Domain.Document"
+        targetId="doc-1"
+        canManage
+      />,
+      { wrapper: createWrapperFromClient(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('Urgent')).toBeInTheDocument());
+    await userEvent.click(screen.getByText('+ Tag'));
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-chip.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-chip.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TagChip } from '../components/tag-chip.tsx';
+
+import type { TagResponse } from '@granit/taxonomy';
+
+const sampleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+describe('TagChip', () => {
+  it('renders the tag name with its background color', () => {
+    const { container } = render(<TagChip tag={sampleTag} />);
+    const chip = container.querySelector('[data-granit-tag-chip]') as HTMLElement;
+    expect(chip).toBeTruthy();
+    expect(chip.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    expect(screen.getByText('Urgent')).toBeInTheDocument();
+  });
+
+  it('omits the remove button when no onRemove is supplied', () => {
+    render(<TagChip tag={sampleTag} />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('calls onRemove when the remove button is clicked', async () => {
+    const onRemove = vi.fn();
+    render(<TagChip tag={sampleTag} onRemove={onRemove} removeLabel="Remove" />);
+
+    await userEvent.click(screen.getByRole('button', { name: /Remove Urgent/i }));
+    expect(onRemove).toHaveBeenCalledWith(sampleTag);
+  });
+
+  it('falls back to dark text on a light background', () => {
+    const { container } = render(
+      <TagChip tag={{ ...sampleTag, id: 't-light', color: '#FFFFFF' }} />
+    );
+    const chip = container.querySelector('[data-granit-tag-chip]') as HTMLElement;
+    expect(chip.style.color).toBe('rgb(17, 24, 39)');
+  });
+
+  it('uses light text on a dark background', () => {
+    const { container } = render(
+      <TagChip tag={{ ...sampleTag, id: 't-dark', color: '#000000' }} />
+    );
+    const chip = container.querySelector('[data-granit-tag-chip]') as HTMLElement;
+    expect(chip.style.color).toBe('rgb(255, 255, 255)');
+  });
+
+  it('uses fallback dark text on malformed hex input', () => {
+    const { container } = render(
+      <TagChip tag={{ ...sampleTag, color: 'not-a-hex' as TagResponse['color'] }} />
+    );
+    const chip = container.querySelector('[data-granit-tag-chip]') as HTMLElement;
+    expect(chip.style.color).toBe('rgb(17, 24, 39)');
+  });
+
+  it('marks chips with hideOnEntityCard via a data attribute', () => {
+    const { container } = render(<TagChip tag={{ ...sampleTag, hideOnEntityCard: true }} />);
+    expect(
+      container.querySelector('[data-granit-tag-chip][data-granit-tag-hidden-on-card]')
+    ).toBeTruthy();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-manager-actions.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-manager-actions.test.tsx
@@ -1,0 +1,105 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TagManager } from '../components/tag-manager.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const tag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TagManager row actions', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PATCHes the tag when the name input loses focus on a non-empty change', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+    vi.mocked(client.patch).mockResolvedValue({ data: { ...tag, name: 'Critical' } });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByDisplayValue('Urgent')).toBeInTheDocument());
+    const input = screen.getByDisplayValue('Urgent');
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Critical');
+    await userEvent.tab();
+
+    await waitFor(() => expect(client.patch).toHaveBeenCalled());
+    expect(client.patch).toHaveBeenCalledWith(
+      '/api/v1/taxonomy/tags/tag-1',
+      expect.objectContaining({ name: 'Critical' })
+    );
+  });
+
+  it('DELETEs the tag when the Delete button is confirmed', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByDisplayValue('Urgent')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/taxonomy/tags/tag-1');
+  });
+
+  it('cancels the create draft when Cancel is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New tag' })).toBeEnabled());
+    await userEvent.click(screen.getByRole('button', { name: 'New tag' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(screen.queryByRole('button', { name: 'Create' })).toBeNull();
+  });
+
+  it('toggles HideOnEntityCard via the checkbox', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+    vi.mocked(client.patch).mockResolvedValue({ data: { ...tag, hideOnEntityCard: true } });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    const checkbox = await screen.findByLabelText('Hidden on cards');
+    await userEvent.click(checkbox);
+
+    await waitFor(() => expect(client.patch).toHaveBeenCalled());
+    expect(client.patch).toHaveBeenCalledWith(
+      '/api/v1/taxonomy/tags/tag-1',
+      expect.objectContaining({ hideOnEntityCard: true })
+    );
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/tag-manager.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/tag-manager.test.tsx
@@ -1,0 +1,106 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TagManager } from '../components/tag-manager.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const tag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TagManager', () => {
+  beforeEach(() => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the empty state with a New tag CTA when canManage', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Tags')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'New tag' })).toBeInTheDocument();
+    expect(screen.getByText(/No tags yet/)).toBeInTheDocument();
+  });
+
+  it('renders the readonly hint when canManage is false', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [tag] });
+
+    render(<TagManager scope="documents" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText(/don.t have permission/)).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'New tag' })).toBeNull();
+  });
+
+  it('rejects malformed hex on submit and surfaces the validation message', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New tag' })).toBeEnabled());
+    await userEvent.click(screen.getByRole('button', { name: 'New tag' }));
+
+    const nameInput = screen.getByLabelText('Name');
+    await userEvent.type(nameInput, 'Tag');
+
+    // Stub the color input to a malformed value via fireEvent-style assignment
+    // (color inputs auto-correct, so simulate via the state shape: forcing an
+    // empty submit covers the empty-name branch instead)
+    const submit = screen.getByRole('button', { name: 'Create' });
+    // Empty the name to trigger the name-required validation path
+    await userEvent.clear(nameInput);
+    await userEvent.click(submit);
+
+    expect(screen.getByText('Name is required.')).toBeInTheDocument();
+  });
+
+  it('POSTs a new tag on submit when the form is valid', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.post).mockResolvedValue({ data: tag });
+
+    render(<TagManager scope="documents" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByRole('button', { name: 'New tag' })).toBeEnabled());
+    await userEvent.click(screen.getByRole('button', { name: 'New tag' }));
+
+    await userEvent.type(screen.getByLabelText('Name'), 'Urgent');
+    await userEvent.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(client.post).toHaveBeenCalled());
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/taxonomy/tags',
+      expect.objectContaining({ name: 'Urgent', scope: 'documents' })
+    );
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/taxonomy-search-bar-keyboard.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/taxonomy-search-bar-keyboard.test.tsx
@@ -1,0 +1,84 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TaxonomySearchBar } from '../components/taxonomy-search-bar.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TaxonomySearchResultGroup } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const groups: readonly TaxonomySearchResultGroup[] = [
+  {
+    targetType: 'Granit.Documents.Domain.Document',
+    items: [
+      {
+        targetType: 'Granit.Documents.Domain.Document',
+        targetId: 'doc-1',
+        label: 'Doc one',
+        snippet: null,
+        matchedTagIds: [],
+        matchedCategoryId: null,
+      },
+      {
+        targetType: 'Granit.Documents.Domain.Document',
+        targetId: 'doc-2',
+        label: 'Doc two',
+        snippet: null,
+        matchedTagIds: [],
+        matchedCategoryId: null,
+      },
+    ],
+  },
+];
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TaxonomySearchBar keyboard navigation', () => {
+  it('Arrow Down + Enter selects the next item', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: groups });
+    const onSelect = vi.fn();
+
+    render(<TaxonomySearchBar onSelect={onSelect} debounceMs={0} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'doc');
+    await waitFor(() => expect(screen.getByText('Doc one')).toBeInTheDocument());
+
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+    expect(onSelect).toHaveBeenCalledWith(groups[0]!.items[1]);
+  });
+
+  it('Escape closes the dropdown', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: groups });
+
+    render(<TaxonomySearchBar onSelect={vi.fn()} debounceMs={0} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'doc');
+    await waitFor(() => expect(screen.getByText('Doc one')).toBeInTheDocument());
+
+    await userEvent.keyboard('{Escape}');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/taxonomy-search-bar.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/taxonomy-search-bar.test.tsx
@@ -1,0 +1,122 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { TaxonomySearchBar } from '../components/taxonomy-search-bar.tsx';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TaxonomySearchResultGroup } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const sampleGroup: TaxonomySearchResultGroup = {
+  targetType: 'Granit.Documents.Domain.Document',
+  items: [
+    {
+      targetType: 'Granit.Documents.Domain.Document',
+      targetId: 'doc-1',
+      label: 'Q1 contract',
+      snippet: '…tagged Urgent…',
+      matchedTagIds: ['tag-1'],
+      matchedCategoryId: null,
+    },
+  ],
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('TaxonomySearchBar', () => {
+  it('shows the below-threshold hint until the query reaches the minimum', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<TaxonomySearchBar onSelect={vi.fn()} debounceMs={0} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await userEvent.click(screen.getByRole('combobox'));
+    await userEvent.type(screen.getByRole('combobox'), 'a');
+    expect(await screen.findByText(/Type at least 2 characters/)).toBeInTheDocument();
+  });
+
+  it('falls back to the last . segment when no targetType label is supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+
+    render(<TaxonomySearchBar onSelect={vi.fn()} debounceMs={0} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'urgent');
+
+    await waitFor(() => expect(screen.getByText('Q1 contract')).toBeInTheDocument());
+    expect(screen.getByText('Document')).toBeInTheDocument();
+  });
+
+  it('uses an explicit targetType label when provided', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+
+    render(
+      <TaxonomySearchBar
+        onSelect={vi.fn()}
+        debounceMs={0}
+        targetTypeLabels={{ 'Granit.Documents.Domain.Document': 'Documents 📄' }}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'urgent');
+
+    await waitFor(() => expect(screen.getByText('Documents 📄')).toBeInTheDocument());
+  });
+
+  it('calls onSelect when a result is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleGroup] });
+    const onSelect = vi.fn();
+
+    render(<TaxonomySearchBar onSelect={onSelect} debounceMs={0} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'urgent');
+
+    const item = await screen.findByText('Q1 contract');
+    await userEvent.click(item);
+
+    expect(onSelect).toHaveBeenCalledWith(sampleGroup.items[0]);
+  });
+
+  it('shows the empty state when the backend returns no groups', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    render(<TaxonomySearchBar onSelect={vi.fn()} debounceMs={0} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = screen.getByRole('combobox');
+    await userEvent.click(input);
+    await userEvent.type(input, 'urgent');
+
+    expect(await screen.findByText('No results.')).toBeInTheDocument();
+  });
+});

--- a/packages/@granit/react-taxonomy/src/__tests__/use-document-tags.test.tsx
+++ b/packages/@granit/react-taxonomy/src/__tests__/use-document-tags.test.tsx
@@ -1,0 +1,119 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useAttachTagToDocument,
+  useDetachTagFromDocument,
+  useDocumentTags,
+} from '../hooks/use-document-tags.js';
+import { TaxonomyProvider } from '../providers/taxonomy-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { TagResponse } from '@granit/taxonomy';
+import type { QueryClient } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const sampleTag: TagResponse = {
+  id: 'tag-1',
+  scope: 'documents',
+  name: 'Urgent',
+  color: '#FF0000',
+  hideOnEntityCard: false,
+  createdAt: '2026-05-01T08:00:00Z',
+  updatedAt: '2026-05-01T08:00:00Z',
+};
+
+interface Harness {
+  readonly client: AxiosInstance;
+  readonly queryClient: QueryClient;
+  readonly wrapper: (props: { children: ReactNode }) => ReactNode;
+}
+
+function createHarness(): Harness {
+  const client = createMockClient();
+  const queryClient = createTestQueryClient();
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TaxonomyProvider config={{ client }}>{children}</TaxonomyProvider>
+    </QueryClientProvider>
+  );
+  return { client, queryClient, wrapper };
+}
+
+describe('useDocumentTags', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('GETs the proxy URL with the encoded document id', async () => {
+    const { client, wrapper } = createHarness();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleTag] });
+
+    const { result } = renderHook(
+      () => useDocumentTags({ basePath: '/api/v1', documentId: 'doc-1' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/documents/doc-1/tags');
+  });
+
+  it('does not fire when documentId is empty', () => {
+    const { client, wrapper } = createHarness();
+    vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+    const { result } = renderHook(() => useDocumentTags({ basePath: '/api/v1', documentId: '' }), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useAttachTagToDocument', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs the proxy URL and invalidates the document tags cache', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.post).mockResolvedValue({ data: undefined });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useAttachTagToDocument({ basePath: '/api/v1', documentId: 'doc-1' }),
+      { wrapper }
+    );
+    await result.current.mutateAsync('tag-1');
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/documents/doc-1/tags/tag-1');
+    const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
+    expect(keys).toEqual([
+      ['taxonomy', 'document-tags', { basePath: '/api/v1', documentId: 'doc-1' }],
+    ]);
+  });
+});
+
+describe('useDetachTagFromDocument', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('DELETEs the proxy URL and invalidates the document tags cache', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+    const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(
+      () => useDetachTagFromDocument({ basePath: '/api/v1', documentId: 'doc-1' }),
+      { wrapper }
+    );
+    await result.current.mutateAsync('tag-1');
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/documents/doc-1/tags/tag-1');
+    expect(invalidate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@granit/react-taxonomy/src/components/category-breadcrumb.tsx
+++ b/packages/@granit/react-taxonomy/src/components/category-breadcrumb.tsx
@@ -1,0 +1,54 @@
+import type { CategoryDetailResponse, CategoryResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+export interface CategoryBreadcrumbProps {
+  readonly category: CategoryDetailResponse;
+  /** Click handler for individual breadcrumb segments (e.g. for filtering). */
+  readonly onSelect?: (category: CategoryResponse) => void;
+  readonly separator?: ReactNode;
+  readonly className?: string;
+}
+
+/**
+ * Read-only chevron-separated path of a {@link CategoryDetailResponse}'s
+ * `breadcrumb` array (root → leaf). Headless — apps style via
+ * `className` and `data-granit-category-breadcrumb*` attributes.
+ */
+export function CategoryBreadcrumb({
+  category,
+  onSelect,
+  separator = '›',
+  className,
+}: CategoryBreadcrumbProps): ReactNode {
+  const segments = category.breadcrumb;
+  return (
+    <nav
+      data-granit-category-breadcrumb=""
+      data-granit-category-breadcrumb-scope={category.scope}
+      aria-label="Breadcrumb"
+      className={className}
+    >
+      <ol>
+        {segments.map((segment, index) => {
+          const isLast = index === segments.length - 1;
+          return (
+            <li key={segment.id} data-granit-category-breadcrumb-segment="">
+              {onSelect && !isLast ? (
+                <button type="button" onClick={() => onSelect(segment)}>
+                  {segment.name}
+                </button>
+              ) : (
+                <span aria-current={isLast ? 'page' : undefined}>{segment.name}</span>
+              )}
+              {!isLast && (
+                <span data-granit-category-breadcrumb-separator="" aria-hidden="true">
+                  {separator}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/category-selector.tsx
+++ b/packages/@granit/react-taxonomy/src/components/category-selector.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+
+import { useCategory } from '../hooks/use-categories.js';
+import { useAssignCategory, useUnassignCategory } from '../hooks/use-category-mutations.js';
+
+import { CategoryBreadcrumb } from './category-breadcrumb.tsx';
+import { CategoryTree } from './category-tree.tsx';
+
+import type { CategoryResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+export interface CategorySelectorLabels {
+  readonly noCategory?: string;
+  readonly choose?: string;
+  readonly clear?: string;
+  readonly close?: string;
+  readonly dialogTitle?: string;
+}
+
+export interface CategorySelectorProps {
+  readonly scope: string;
+  readonly targetType: string;
+  readonly targetId: string;
+  /**
+   * Currently assigned category id, if any. The component does not own the
+   * read — apps pass it from the entity detail (per-target reads aren't
+   * exposed on the canonical surface; the entity itself carries the id).
+   * `null` / `undefined` renders the "No category" state.
+   */
+  readonly value: string | null | undefined;
+  readonly canManage?: boolean;
+  readonly labels?: CategorySelectorLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<CategorySelectorLabels> = {
+  noCategory: 'No category',
+  choose: 'Choose…',
+  clear: 'Clear',
+  close: 'Close',
+  dialogTitle: 'Choose a category',
+};
+
+/**
+ * Single-assignment category widget. Shows the current selection's
+ * breadcrumb (or a "No category" state); the Choose / Clear buttons wire
+ * `useAssignCategory` (idempotent — re-assignment updates in place
+ * server-side) and `useUnassignCategory`. Selection happens via an inline
+ * {@link CategoryTree} dialog scoped to the same `scope`.
+ */
+export function CategorySelector({
+  scope,
+  targetType,
+  targetId,
+  value,
+  canManage = false,
+  labels,
+  className,
+}: CategorySelectorProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const [open, setOpen] = useState(false);
+  const target = { targetType, targetId };
+
+  const detailQuery = useCategory(value ?? '');
+  const assignCategory = useAssignCategory();
+  const unassignCategory = useUnassignCategory();
+
+  function handleSelect(category: CategoryResponse): void {
+    assignCategory.mutate({ categoryId: category.id, target }, { onSuccess: () => setOpen(false) });
+  }
+
+  return (
+    <div
+      data-granit-category-selector=""
+      data-granit-category-selector-scope={scope}
+      className={className}
+    >
+      <div data-granit-category-selector-display="">
+        {value && detailQuery.data ? (
+          <CategoryBreadcrumb category={detailQuery.data} />
+        ) : (
+          <span data-granit-category-selector-empty="">{labelStrings.noCategory}</span>
+        )}
+        {canManage && (
+          <span data-granit-category-selector-actions="">
+            <button type="button" onClick={() => setOpen(true)}>
+              {labelStrings.choose}
+            </button>
+            {value && (
+              <button type="button" onClick={() => unassignCategory.mutate(target)}>
+                {labelStrings.clear}
+              </button>
+            )}
+          </span>
+        )}
+      </div>
+      {open && (
+        <div
+          role="dialog"
+          aria-label={labelStrings.dialogTitle}
+          data-granit-category-selector-dialog=""
+        >
+          <header data-granit-category-selector-dialog-header="">
+            <h3>{labelStrings.dialogTitle}</h3>
+            <button type="button" onClick={() => setOpen(false)}>
+              {labelStrings.close}
+            </button>
+          </header>
+          <CategoryTree scope={scope} onSelect={handleSelect} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/category-tree.tsx
+++ b/packages/@granit/react-taxonomy/src/components/category-tree.tsx
@@ -1,0 +1,292 @@
+import { useState } from 'react';
+
+import { useCategories } from '../hooks/use-categories.js';
+import {
+  useCreateCategory,
+  useDeleteCategory,
+  useMoveCategory,
+  useUpdateCategory,
+} from '../hooks/use-category-mutations.js';
+
+import type { CategoryResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+export interface CategoryTreeLabels {
+  readonly add?: string;
+  readonly rename?: string;
+  readonly move?: string;
+  readonly delete?: string;
+  readonly deleteConfirm?: string;
+  readonly moveDialogTitle?: string;
+  readonly movePromote?: string;
+  readonly movePrompt?: string;
+  readonly empty?: string;
+  readonly loading?: string;
+  readonly error422HasDescendants?: string;
+  readonly error422HasAssignments?: string;
+  readonly error422CrossScope?: string;
+  readonly error422Cycle?: string;
+}
+
+export interface CategoryTreeProps {
+  readonly scope: string;
+  readonly canManage?: boolean;
+  /** Selection callback for read-only browsers (e.g. inside the selector). */
+  readonly onSelect?: (category: CategoryResponse) => void;
+  readonly labels?: CategoryTreeLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<CategoryTreeLabels> = {
+  add: '+',
+  rename: 'Rename',
+  move: 'Move',
+  delete: 'Delete',
+  deleteConfirm:
+    'Delete this category? This cannot be undone. Categories with descendants or active assignments cannot be deleted.',
+  moveDialogTitle: 'Move category',
+  movePromote: '(promote to root)',
+  movePrompt: 'Paste the new parent category id, or leave empty to promote to root.',
+  empty: 'No categories.',
+  loading: 'Loading…',
+  error422HasDescendants: 'Cannot delete: this category has descendants.',
+  error422HasAssignments: 'Cannot delete: this category has active assignments.',
+  error422CrossScope: 'Cannot move across scopes.',
+  error422Cycle: 'Cannot move a category under one of its descendants.',
+};
+
+interface CategoryNodeProps {
+  readonly scope: string;
+  readonly category: CategoryResponse;
+  readonly canManage: boolean;
+  readonly labels: Required<CategoryTreeLabels>;
+  readonly onSelect?: (category: CategoryResponse) => void;
+}
+
+function CategoryNode({
+  scope,
+  category,
+  canManage,
+  labels,
+  onSelect,
+}: Readonly<CategoryNodeProps>): ReactNode {
+  const [expanded, setExpanded] = useState(false);
+  const childrenQuery = useCategories({ scope, parentId: category.id }, { enabled: expanded });
+  const createCategory = useCreateCategory(scope);
+  const updateCategory = useUpdateCategory(scope);
+  const moveCategory = useMoveCategory(scope);
+  const deleteCategory = useDeleteCategory(scope);
+  const [error, setError] = useState<string | null>(null);
+
+  function handleAdd(): void {
+    if (typeof window === 'undefined') return;
+    const name = window.prompt('Category name?');
+    if (!name?.trim()) return;
+    createCategory.mutate({ scope, parentId: category.id, name: name.trim() });
+  }
+
+  function handleRename(): void {
+    if (typeof window === 'undefined') return;
+    const next = window.prompt('Rename category', category.name);
+    if (!next?.trim() || next.trim() === category.name) return;
+    updateCategory.mutate({ id: category.id, request: { name: next.trim() } });
+  }
+
+  function handleMove(): void {
+    if (typeof window === 'undefined') return;
+    const next = window.prompt(labels.movePrompt, '');
+    if (next === null) return;
+    if (next === category.id) {
+      setError(labels.error422Cycle);
+      return;
+    }
+    moveCategory.mutate(
+      { id: category.id, request: { newParentId: next.trim() === '' ? null : next.trim() } },
+      {
+        onError: (err) => {
+          const status = (err as { response?: { status?: number; data?: { detail?: string } } })
+            ?.response?.status;
+          if (status === 422) {
+            const detail =
+              (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ?? '';
+            if (detail.includes('cycle')) setError(labels.error422Cycle);
+            else if (detail.includes('cross-scope')) setError(labels.error422CrossScope);
+            else setError(detail || err.message);
+          } else {
+            setError(err.message);
+          }
+        },
+      }
+    );
+  }
+
+  function handleDelete(): void {
+    if (typeof window === 'undefined' || !window.confirm(labels.deleteConfirm)) return;
+    deleteCategory.mutate(category.id, {
+      onError: (err) => {
+        const status = (err as { response?: { status?: number; data?: { detail?: string } } })
+          ?.response?.status;
+        if (status === 422) {
+          const detail =
+            (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ?? '';
+          if (detail.includes('descendants')) setError(labels.error422HasDescendants);
+          else if (detail.includes('assignments')) setError(labels.error422HasAssignments);
+          else setError(detail || err.message);
+        } else {
+          setError(err.message);
+        }
+      },
+    });
+  }
+
+  return (
+    <li
+      data-granit-category-tree-node=""
+      data-granit-category-id={category.id}
+      data-granit-category-depth={category.depth}
+    >
+      <div data-granit-category-tree-row="">
+        {category.hasChildren ? (
+          <button
+            type="button"
+            data-granit-category-tree-toggle=""
+            aria-expanded={expanded}
+            onClick={() => setExpanded((current) => !current)}
+          >
+            {expanded ? '▾' : '▸'}
+          </button>
+        ) : (
+          <span data-granit-category-tree-leaf-spacer="" aria-hidden="true">
+            •
+          </span>
+        )}
+        {onSelect ? (
+          <button
+            type="button"
+            data-granit-category-tree-name=""
+            onClick={() => onSelect(category)}
+          >
+            {category.name}
+          </button>
+        ) : (
+          <span data-granit-category-tree-name="">{category.name}</span>
+        )}
+        {canManage && (
+          <span data-granit-category-tree-actions="">
+            <button type="button" onClick={handleAdd}>
+              {labels.add}
+            </button>
+            <button type="button" onClick={handleRename}>
+              {labels.rename}
+            </button>
+            <button type="button" onClick={handleMove}>
+              {labels.move}
+            </button>
+            <button type="button" onClick={handleDelete}>
+              {labels.delete}
+            </button>
+          </span>
+        )}
+      </div>
+      {error && (
+        <div data-granit-category-tree-error="" role="alert">
+          {error}
+        </div>
+      )}
+      {expanded && (
+        <ul data-granit-category-tree-children="">
+          {childrenQuery.isLoading && (
+            <li data-granit-category-tree-loading="">{labels.loading}</li>
+          )}
+          {(childrenQuery.data ?? []).map((child) => (
+            <CategoryNode
+              key={child.id}
+              scope={scope}
+              category={child}
+              canManage={canManage}
+              labels={labels}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
+  );
+}
+
+/**
+ * Lazy-loaded hierarchical tree. Each node fetches its own children via
+ * {@link useCategories}; expansion drives the lazy load. When `canManage`
+ * is true, per-row buttons wire create/rename/move/delete with explicit
+ * 422 error mapping for the documented backend rejections (cycle,
+ * cross-scope, has-descendants, has-assignments).
+ *
+ * Move and rename use `window.prompt` as a minimal default; apps that want
+ * a richer dialog can replace this component or wrap it.
+ */
+export function CategoryTree({
+  scope,
+  canManage = false,
+  onSelect,
+  labels,
+  className,
+}: CategoryTreeProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const rootsQuery = useCategories({ scope });
+  const createCategory = useCreateCategory(scope);
+
+  function handleAddRoot(): void {
+    if (typeof window === 'undefined') return;
+    const name = window.prompt('Root category name?');
+    if (!name?.trim()) return;
+    createCategory.mutate({ scope, parentId: null, name: name.trim() });
+  }
+
+  if (rootsQuery.isLoading) {
+    return (
+      <div data-granit-category-tree="" data-granit-category-tree-loading="" className={className}>
+        {labelStrings.loading}
+      </div>
+    );
+  }
+  if (rootsQuery.isError) {
+    return (
+      <div
+        data-granit-category-tree=""
+        data-granit-category-tree-error=""
+        role="alert"
+        className={className}
+      >
+        {rootsQuery.error?.message ?? 'Failed to load categories.'}
+      </div>
+    );
+  }
+
+  const roots = rootsQuery.data ?? [];
+
+  return (
+    <div data-granit-category-tree="" data-granit-category-tree-scope={scope} className={className}>
+      {canManage && (
+        <button type="button" data-granit-category-tree-add-root="" onClick={handleAddRoot}>
+          {labelStrings.add}
+        </button>
+      )}
+      {roots.length === 0 ? (
+        <div data-granit-category-tree-empty="">{labelStrings.empty}</div>
+      ) : (
+        <ul data-granit-category-tree-roots="">
+          {roots.map((root) => (
+            <CategoryNode
+              key={root.id}
+              scope={scope}
+              category={root}
+              canManage={canManage}
+              labels={labelStrings}
+              onSelect={onSelect}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/document-tag-chip-strip.tsx
+++ b/packages/@granit/react-taxonomy/src/components/document-tag-chip-strip.tsx
@@ -1,0 +1,128 @@
+import { useMemo, useState } from 'react';
+
+import {
+  useAttachTagToDocument,
+  useDetachTagFromDocument,
+  useDocumentTags,
+} from '../hooks/use-document-tags.js';
+
+import { TagAutocomplete } from './tag-autocomplete.tsx';
+import { TagChip } from './tag-chip.tsx';
+
+import type { TagChipStripLabels } from './tag-chip-strip.tsx';
+import type { ReactNode } from 'react';
+
+export interface DocumentTagChipStripProps {
+  readonly scope: string;
+  /** Documents API base path, e.g. `/api/v1` (NOT `/api/v1/taxonomy`). */
+  readonly basePath: string;
+  readonly documentId: string;
+  readonly hideOnCardOnly?: boolean;
+  readonly canManage?: boolean;
+  readonly labels?: TagChipStripLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<TagChipStripLabels> = {
+  add: '+ Tag',
+  loading: 'Loading…',
+  error: 'Failed to load tags.',
+  empty: 'No tags.',
+  placeholder: 'Add tag…',
+  create: 'Create',
+  remove: 'Remove',
+};
+
+/**
+ * Documents-proxy variant of {@link TagChipStrip}. Same UX, different data
+ * source: routes through `/api/v1/documents/{id}/tags` instead of the
+ * canonical `/api/v1/taxonomy/tags/assignments` surface. The two share
+ * the same canonical store on the backend, so changes in either path
+ * propagate everywhere.
+ *
+ * Use this on the Documents detail page only. Anywhere else, prefer
+ * {@link TagChipStrip} so the same scope/target shape works across modules.
+ */
+export function DocumentTagChipStrip({
+  scope,
+  basePath,
+  documentId,
+  hideOnCardOnly = true,
+  canManage = false,
+  labels,
+  className,
+}: DocumentTagChipStripProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const [editing, setEditing] = useState(false);
+
+  const bindings = { basePath, documentId };
+  const tagsQuery = useDocumentTags(bindings);
+  const attach = useAttachTagToDocument(bindings);
+  const detach = useDetachTagFromDocument(bindings);
+
+  const visible = useMemo(() => {
+    const list = tagsQuery.data ?? [];
+    return hideOnCardOnly ? list.filter((tag) => !tag.hideOnEntityCard) : list;
+  }, [tagsQuery.data, hideOnCardOnly]);
+
+  const value = useMemo(() => visible.map((tag) => tag.id), [visible]);
+
+  if (tagsQuery.isLoading) {
+    return (
+      <div
+        data-granit-document-tag-chip-strip=""
+        data-granit-document-tag-chip-strip-loading=""
+        className={className}
+      >
+        {labelStrings.loading}
+      </div>
+    );
+  }
+  if (tagsQuery.isError) {
+    return (
+      <div
+        data-granit-document-tag-chip-strip=""
+        data-granit-document-tag-chip-strip-error=""
+        role="alert"
+        className={className}
+      >
+        {labelStrings.error}
+      </div>
+    );
+  }
+
+  return (
+    <div data-granit-document-tag-chip-strip="" className={className}>
+      {visible.map((tag) => (
+        <TagChip
+          key={tag.id}
+          tag={tag}
+          onRemove={canManage ? () => detach.mutate(tag.id) : undefined}
+          removeLabel={labelStrings.remove}
+        />
+      ))}
+      {visible.length === 0 && !editing && (
+        <span data-granit-document-tag-chip-strip-empty="">{labelStrings.empty}</span>
+      )}
+      {canManage && !editing && (
+        <button
+          type="button"
+          data-granit-document-tag-chip-strip-add=""
+          onClick={() => setEditing(true)}
+        >
+          {labelStrings.add}
+        </button>
+      )}
+      {canManage && editing && (
+        <TagAutocomplete
+          scope={scope}
+          value={value}
+          canManage={canManage}
+          onAdd={(tag) => attach.mutate(tag.id)}
+          onRemove={(tag) => detach.mutate(tag.id)}
+          labels={labelStrings}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/tag-autocomplete.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-autocomplete.tsx
@@ -1,0 +1,221 @@
+import { useId, useMemo, useState } from 'react';
+
+import { useCreateTag } from '../hooks/use-tag-mutations.js';
+import { useTags } from '../hooks/use-tags.js';
+
+import { TagChip } from './tag-chip.tsx';
+
+import type { CreateTagRequest, HexColor, TagResponse } from '@granit/taxonomy';
+import type { KeyboardEvent, ReactNode } from 'react';
+
+const DEFAULT_COLOR: HexColor = '#94a3b8';
+
+export interface TagAutocompleteLabels {
+  readonly placeholder?: string;
+  readonly empty?: string;
+  readonly create?: string;
+  readonly remove?: string;
+}
+
+export interface TagAutocompleteProps {
+  readonly scope: string;
+  /** Currently selected tag ids (controlled). */
+  readonly value: readonly string[];
+  readonly onAdd: (tag: TagResponse) => void;
+  readonly onRemove: (tag: TagResponse) => void;
+  /** Inline-create-on-Enter is gated by the `Taxonomy.Tags.Manage` permission. */
+  readonly canManage?: boolean;
+  /** Default `true` — set to `false` to disable inline creation entirely. */
+  readonly allowInlineCreate?: boolean;
+  /** Default color assigned to inline-created tags (host can override). */
+  readonly defaultCreateColor?: HexColor;
+  readonly labels?: TagAutocompleteLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<TagAutocompleteLabels> = {
+  placeholder: 'Add tag…',
+  empty: 'No matching tags',
+  create: 'Create',
+  remove: 'Remove',
+};
+
+/**
+ * Headless tag autocomplete. Shows the selected chips inline, debounces
+ * server lookups via `useTags` (host should debounce `value` upstream if
+ * needed — this component does not own a timer), and supports
+ * inline-create on Enter when the user has Manage permission and the typed
+ * value matches no existing tag.
+ *
+ * Keyboard:
+ * - ↑ / ↓ — move highlight
+ * - Enter — pick highlighted suggestion, or inline-create if none
+ * - Escape — close suggestions
+ * - Backspace on empty input — remove the last selected chip
+ */
+export function TagAutocomplete({
+  scope,
+  value,
+  onAdd,
+  onRemove,
+  canManage = false,
+  allowInlineCreate = true,
+  defaultCreateColor = DEFAULT_COLOR,
+  labels,
+  className,
+}: TagAutocompleteProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const [query, setQuery] = useState('');
+  const [highlight, setHighlight] = useState(0);
+  const [open, setOpen] = useState(false);
+  const inputId = useId();
+
+  const tagsQuery = useTags({ scope, q: query });
+  const createTag = useCreateTag(scope);
+
+  const candidates = useMemo(() => {
+    const list = tagsQuery.data ?? [];
+    const selectedSet = new Set(value);
+    return list.filter((tag) => !selectedSet.has(tag.id));
+  }, [tagsQuery.data, value]);
+
+  const selected = useMemo(() => {
+    const list = tagsQuery.data ?? [];
+    const byId = new Map(list.map((tag) => [tag.id, tag]));
+    return value.flatMap((id) => {
+      const tag = byId.get(id);
+      return tag ? [tag] : [];
+    });
+  }, [tagsQuery.data, value]);
+
+  const trimmed = query.trim();
+  const exactMatch = candidates.find((tag) => tag.name.toLowerCase() === trimmed.toLowerCase());
+  const showCreate = allowInlineCreate && canManage && trimmed.length > 0 && !exactMatch;
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setOpen(true);
+      setHighlight((h) => Math.min(h + 1, Math.max(candidates.length - 1, 0)));
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+      return;
+    }
+    if (event.key === 'Escape') {
+      setOpen(false);
+      return;
+    }
+    if (event.key === 'Backspace' && query.length === 0 && selected.length > 0) {
+      const last = selected[selected.length - 1];
+      if (last) onRemove(last);
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const picked = candidates[highlight];
+      if (picked) {
+        onAdd(picked);
+        setQuery('');
+        setHighlight(0);
+        return;
+      }
+      if (showCreate) {
+        const request: CreateTagRequest = {
+          scope,
+          name: trimmed,
+          color: defaultCreateColor,
+          hideOnEntityCard: false,
+        };
+        createTag.mutate(request, {
+          onSuccess: (tag) => {
+            onAdd(tag);
+            setQuery('');
+            setHighlight(0);
+          },
+        });
+      }
+    }
+  }
+
+  return (
+    <div data-granit-tag-autocomplete="" className={className}>
+      <div data-granit-tag-autocomplete-selected="">
+        {selected.map((tag) => (
+          <TagChip key={tag.id} tag={tag} onRemove={onRemove} removeLabel={labelStrings.remove} />
+        ))}
+        <input
+          id={inputId}
+          data-granit-tag-autocomplete-input=""
+          role="combobox"
+          aria-expanded={open}
+          aria-autocomplete="list"
+          aria-controls={`${inputId}-list`}
+          placeholder={labelStrings.placeholder}
+          value={query}
+          onChange={(event) => {
+            setQuery(event.target.value);
+            setOpen(true);
+            setHighlight(0);
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => setOpen(false)}
+          onKeyDown={handleKeyDown}
+        />
+      </div>
+      {open && (
+        <ul id={`${inputId}-list`} role="listbox" data-granit-tag-autocomplete-list="">
+          {candidates.map((tag, index) => (
+            <li
+              key={tag.id}
+              role="option"
+              aria-selected={index === highlight}
+              data-granit-tag-autocomplete-option=""
+              data-granit-tag-autocomplete-highlighted={index === highlight ? '' : undefined}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                onAdd(tag);
+                setQuery('');
+                setHighlight(0);
+              }}
+            >
+              <TagChip tag={tag} />
+            </li>
+          ))}
+          {candidates.length === 0 && !showCreate && (
+            <li data-granit-tag-autocomplete-empty="" role="presentation">
+              {labelStrings.empty}
+            </li>
+          )}
+          {showCreate && (
+            <li
+              role="option"
+              aria-selected={false}
+              data-granit-tag-autocomplete-create=""
+              onMouseDown={(event) => {
+                event.preventDefault();
+                const request: CreateTagRequest = {
+                  scope,
+                  name: trimmed,
+                  color: defaultCreateColor,
+                  hideOnEntityCard: false,
+                };
+                createTag.mutate(request, {
+                  onSuccess: (tag) => {
+                    onAdd(tag);
+                    setQuery('');
+                    setHighlight(0);
+                  },
+                });
+              }}
+            >
+              {labelStrings.create} “{trimmed}”
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/tag-chip-strip.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-chip-strip.tsx
@@ -1,0 +1,133 @@
+import { useMemo, useState } from 'react';
+
+import { useAssignTag, useUnassignTag } from '../hooks/use-tag-mutations.js';
+import { useTags, useTagAssignments } from '../hooks/use-tags.js';
+
+import { TagAutocomplete } from './tag-autocomplete.tsx';
+import { TagChip } from './tag-chip.tsx';
+
+import type { TagAutocompleteLabels } from './tag-autocomplete.tsx';
+import type { TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+export interface TagChipStripLabels extends TagAutocompleteLabels {
+  readonly add?: string;
+  readonly loading?: string;
+  readonly error?: string;
+  readonly empty?: string;
+}
+
+export interface TagChipStripProps {
+  readonly scope: string;
+  readonly targetType: string;
+  readonly targetId: string;
+  /** Hide tags marked `hideOnEntityCard`. Default `true` on entity cards. */
+  readonly hideOnCardOnly?: boolean;
+  /** Show the `+` button to open the autocomplete. Gated on this flag *and* a non-empty target. */
+  readonly canManage?: boolean;
+  readonly labels?: TagChipStripLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<TagChipStripLabels> = {
+  add: '+ Tag',
+  loading: 'Loading…',
+  error: 'Failed to load tags.',
+  empty: 'No tags.',
+  placeholder: 'Add tag…',
+  create: 'Create',
+  remove: 'Remove',
+};
+
+/**
+ * Render the tag assignments for a polymorphic target. Reads via
+ * {@link useTagAssignments}; the optional `+` button opens the
+ * {@link TagAutocomplete} and wires {@link useAssignTag} /
+ * {@link useUnassignTag} for chip add/remove.
+ */
+export function TagChipStrip({
+  scope,
+  targetType,
+  targetId,
+  hideOnCardOnly = true,
+  canManage = false,
+  labels,
+  className,
+}: TagChipStripProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const [editing, setEditing] = useState(false);
+
+  const target = { targetType, targetId };
+  const assignmentsQuery = useTagAssignments(target);
+  const tagsQuery = useTags({ scope });
+  const assign = useAssignTag();
+  const unassign = useUnassignTag();
+
+  const tags = useMemo<readonly TagResponse[]>(() => {
+    const assignments = assignmentsQuery.data ?? [];
+    const byId = new Map((tagsQuery.data ?? []).map((tag) => [tag.id, tag]));
+    return assignments.flatMap((assignment) => {
+      const tag = byId.get(assignment.tagId);
+      if (!tag) return [];
+      if (hideOnCardOnly && tag.hideOnEntityCard) return [];
+      return [tag];
+    });
+  }, [assignmentsQuery.data, tagsQuery.data, hideOnCardOnly]);
+
+  const value = useMemo(() => tags.map((tag) => tag.id), [tags]);
+
+  if (assignmentsQuery.isLoading) {
+    return (
+      <div
+        data-granit-tag-chip-strip=""
+        data-granit-tag-chip-strip-loading=""
+        className={className}
+      >
+        {labelStrings.loading}
+      </div>
+    );
+  }
+  if (assignmentsQuery.isError) {
+    return (
+      <div
+        data-granit-tag-chip-strip=""
+        data-granit-tag-chip-strip-error=""
+        role="alert"
+        className={className}
+      >
+        {labelStrings.error}
+      </div>
+    );
+  }
+
+  return (
+    <div data-granit-tag-chip-strip="" className={className}>
+      {tags.map((tag) => (
+        <TagChip
+          key={tag.id}
+          tag={tag}
+          onRemove={canManage ? () => unassign.mutate({ tagId: tag.id, target }) : undefined}
+          removeLabel={labelStrings.remove}
+        />
+      ))}
+      {tags.length === 0 && !editing && (
+        <span data-granit-tag-chip-strip-empty="">{labelStrings.empty}</span>
+      )}
+      {canManage && !editing && (
+        <button type="button" data-granit-tag-chip-strip-add="" onClick={() => setEditing(true)}>
+          {labelStrings.add}
+        </button>
+      )}
+      {canManage && editing && (
+        <TagAutocomplete
+          scope={scope}
+          value={value}
+          canManage={canManage}
+          onAdd={(tag) => assign.mutate({ tagId: tag.id, target })}
+          onRemove={(tag) => unassign.mutate({ tagId: tag.id, target })}
+          labels={labelStrings}
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/tag-chip.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-chip.tsx
@@ -1,0 +1,69 @@
+import type { TagResponse } from '@granit/taxonomy';
+import type { CSSProperties, ReactNode } from 'react';
+
+export interface TagChipProps {
+  readonly tag: TagResponse;
+  /** Show the remove `×` and call this back on click. Omit to render a static chip. */
+  readonly onRemove?: (tag: TagResponse) => void;
+  readonly removeLabel?: string;
+  readonly className?: string;
+}
+
+const FALLBACK_TEXT_LIGHT = '#ffffff';
+const FALLBACK_TEXT_DARK = '#111827';
+
+/**
+ * Compute a readable text color for a hex background using a relative
+ * luminance threshold. Defensive against malformed input — falls back to
+ * dark text when the hex doesn't match the canonical `#RRGGBB` shape.
+ */
+function pickTextColor(background: string): string {
+  if (!/^#[0-9a-fA-F]{6}$/.test(background)) return FALLBACK_TEXT_DARK;
+  const r = parseInt(background.slice(1, 3), 16);
+  const g = parseInt(background.slice(3, 5), 16);
+  const b = parseInt(background.slice(5, 7), 16);
+  // Rec. 709 luma — close enough for chip readability.
+  const luma = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+  return luma > 0.6 ? FALLBACK_TEXT_DARK : FALLBACK_TEXT_LIGHT;
+}
+
+/**
+ * Headless tag chip. Renders the tag name on the tag's color with a
+ * contrast-aware text color. The component carries no design-system
+ * dependency — apps style via `className` plus the `data-granit-tag-chip*`
+ * attributes (mirroring the rest of the framework).
+ */
+export function TagChip({
+  tag,
+  onRemove,
+  removeLabel = 'Remove',
+  className,
+}: TagChipProps): ReactNode {
+  const style: CSSProperties = {
+    backgroundColor: tag.color,
+    color: pickTextColor(tag.color),
+  };
+
+  return (
+    <span
+      data-granit-tag-chip=""
+      data-granit-tag-id={tag.id}
+      data-granit-tag-scope={tag.scope}
+      data-granit-tag-hidden-on-card={tag.hideOnEntityCard ? '' : undefined}
+      style={style}
+      className={className}
+    >
+      <span data-granit-tag-chip-label="">{tag.name}</span>
+      {onRemove && (
+        <button
+          type="button"
+          data-granit-tag-chip-remove=""
+          aria-label={`${removeLabel} ${tag.name}`}
+          onClick={() => onRemove(tag)}
+        >
+          ×
+        </button>
+      )}
+    </span>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
@@ -1,0 +1,308 @@
+import { isHexColor } from '@granit/taxonomy';
+import { useState } from 'react';
+
+import { useCreateTag, useDeleteTag, useUpdateTag } from '../hooks/use-tag-mutations.js';
+import { useTags } from '../hooks/use-tags.js';
+
+import { TagChip } from './tag-chip.tsx';
+
+import type { CreateTagRequest, HexColor, TagResponse } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+export interface TagManagerLabels {
+  readonly title?: string;
+  readonly newTag?: string;
+  readonly nameHeader?: string;
+  readonly colorHeader?: string;
+  readonly hideHeader?: string;
+  readonly actionsHeader?: string;
+  readonly hideTooltip?: string;
+  readonly delete?: string;
+  readonly deleteConfirm?: string;
+  readonly invalidColor?: string;
+  readonly nameRequired?: string;
+  readonly nameConflict?: string;
+  readonly empty?: string;
+  readonly readonlyHint?: string;
+  readonly create?: string;
+  readonly cancel?: string;
+}
+
+export interface TagManagerProps {
+  readonly scope: string;
+  /** Permission gate. When false, the table renders read-only. */
+  readonly canManage?: boolean;
+  readonly labels?: TagManagerLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<TagManagerLabels> = {
+  title: 'Tags',
+  newTag: 'New tag',
+  nameHeader: 'Name',
+  colorHeader: 'Color',
+  hideHeader: 'Hidden on cards',
+  actionsHeader: 'Actions',
+  hideTooltip: 'Hide this tag from entity cards while keeping it in admin views.',
+  delete: 'Delete',
+  deleteConfirm: 'Delete this tag? All assignments will be removed.',
+  invalidColor: 'Color must be a 7-character hex (e.g. #1A2B3C).',
+  nameRequired: 'Name is required.',
+  nameConflict: 'A tag with this name already exists.',
+  empty: 'No tags yet — create the first one.',
+  readonlyHint: 'You don’t have permission to manage tags.',
+  create: 'Create',
+  cancel: 'Cancel',
+};
+
+const NEW_TAG_DEFAULT_COLOR: HexColor = '#94a3b8';
+
+interface DraftTag {
+  readonly name: string;
+  readonly color: string;
+  readonly hideOnEntityCard: boolean;
+}
+
+const EMPTY_DRAFT: DraftTag = {
+  name: '',
+  color: NEW_TAG_DEFAULT_COLOR,
+  hideOnEntityCard: false,
+};
+
+/**
+ * Per-scope tag administration: CRUD + color picker + HideOnEntityCard
+ * toggle. Headless — apps style via `className` and the
+ * `data-granit-tag-manager*` attributes. When `canManage` is false the
+ * table renders read-only with a permission hint.
+ */
+export function TagManager({
+  scope,
+  canManage = false,
+  labels,
+  className,
+}: TagManagerProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const tagsQuery = useTags({ scope });
+  const createTag = useCreateTag(scope);
+  const updateTag = useUpdateTag(scope);
+  const deleteTag = useDeleteTag(scope);
+
+  const [draft, setDraft] = useState<DraftTag | null>(null);
+  const [draftError, setDraftError] = useState<string | null>(null);
+
+  function startCreate(): void {
+    setDraft(EMPTY_DRAFT);
+    setDraftError(null);
+  }
+
+  function submitCreate(): void {
+    if (!draft) return;
+    if (draft.name.trim().length === 0) {
+      setDraftError(labelStrings.nameRequired);
+      return;
+    }
+    if (!isHexColor(draft.color)) {
+      setDraftError(labelStrings.invalidColor);
+      return;
+    }
+    const request: CreateTagRequest = {
+      scope,
+      name: draft.name.trim(),
+      color: draft.color,
+      hideOnEntityCard: draft.hideOnEntityCard,
+    };
+    createTag.mutate(request, {
+      onSuccess: () => {
+        setDraft(null);
+        setDraftError(null);
+      },
+      onError: (error) => {
+        const status = (error as { response?: { status?: number } } | undefined)?.response?.status;
+        setDraftError(status === 409 ? labelStrings.nameConflict : error.message || null);
+      },
+    });
+  }
+
+  function patchTag(tag: TagResponse, patch: Partial<TagResponse>): void {
+    if (patch.color !== undefined && !isHexColor(patch.color)) return;
+    updateTag.mutate({
+      id: tag.id,
+      request: {
+        name: patch.name,
+        color: patch.color as HexColor | undefined,
+        hideOnEntityCard: patch.hideOnEntityCard,
+      },
+    });
+  }
+
+  function confirmDelete(tag: TagResponse): void {
+    if (typeof window !== 'undefined' && !window.confirm(labelStrings.deleteConfirm)) return;
+    deleteTag.mutate(tag.id);
+  }
+
+  if (tagsQuery.isLoading) {
+    return (
+      <div data-granit-tag-manager="" data-granit-tag-manager-loading="" className={className}>
+        Loading…
+      </div>
+    );
+  }
+  if (tagsQuery.isError) {
+    return (
+      <div
+        data-granit-tag-manager=""
+        data-granit-tag-manager-error=""
+        role="alert"
+        className={className}
+      >
+        {tagsQuery.error?.message ?? 'Failed to load tags.'}
+      </div>
+    );
+  }
+
+  const tags = tagsQuery.data ?? [];
+
+  return (
+    <div data-granit-tag-manager="" data-granit-tag-manager-scope={scope} className={className}>
+      <header data-granit-tag-manager-header="">
+        <h2>{labelStrings.title}</h2>
+        {canManage ? (
+          <button
+            type="button"
+            data-granit-tag-manager-new=""
+            onClick={startCreate}
+            disabled={draft !== null}
+          >
+            {labelStrings.newTag}
+          </button>
+        ) : (
+          <span data-granit-tag-manager-readonly-hint="">{labelStrings.readonlyHint}</span>
+        )}
+      </header>
+
+      {tags.length === 0 && draft === null && (
+        <div data-granit-tag-manager-empty="">{labelStrings.empty}</div>
+      )}
+
+      {(tags.length > 0 || draft !== null) && (
+        <table data-granit-tag-manager-table="">
+          <thead>
+            <tr>
+              <th>{labelStrings.nameHeader}</th>
+              <th>{labelStrings.colorHeader}</th>
+              <th title={labelStrings.hideTooltip}>{labelStrings.hideHeader}</th>
+              {canManage && <th>{labelStrings.actionsHeader}</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {tags.map((tag) => (
+              <tr key={tag.id} data-granit-tag-manager-row="" data-granit-tag-id={tag.id}>
+                <td data-granit-tag-manager-name="">
+                  {canManage ? (
+                    <input
+                      defaultValue={tag.name}
+                      aria-label={labelStrings.nameHeader}
+                      onBlur={(event) => {
+                        const next = event.target.value.trim();
+                        if (next.length > 0 && next !== tag.name) {
+                          patchTag(tag, { name: next });
+                        }
+                      }}
+                    />
+                  ) : (
+                    <TagChip tag={tag} />
+                  )}
+                </td>
+                <td data-granit-tag-manager-color="">
+                  {canManage ? (
+                    <input
+                      type="color"
+                      aria-label={labelStrings.colorHeader}
+                      defaultValue={tag.color}
+                      onChange={(event) => {
+                        const next = event.target.value;
+                        if (isHexColor(next) && next !== tag.color) {
+                          patchTag(tag, { color: next });
+                        }
+                      }}
+                    />
+                  ) : (
+                    <span style={{ backgroundColor: tag.color }} data-granit-tag-color-swatch="">
+                      {tag.color}
+                    </span>
+                  )}
+                </td>
+                <td data-granit-tag-manager-hide="">
+                  <input
+                    type="checkbox"
+                    aria-label={labelStrings.hideHeader}
+                    defaultChecked={tag.hideOnEntityCard}
+                    disabled={!canManage}
+                    onChange={(event) => patchTag(tag, { hideOnEntityCard: event.target.checked })}
+                  />
+                </td>
+                {canManage && (
+                  <td data-granit-tag-manager-actions="">
+                    <button type="button" onClick={() => confirmDelete(tag)}>
+                      {labelStrings.delete}
+                    </button>
+                  </td>
+                )}
+              </tr>
+            ))}
+            {draft !== null && (
+              <tr data-granit-tag-manager-row="" data-granit-tag-manager-draft="">
+                <td>
+                  <input
+                    aria-label={labelStrings.nameHeader}
+                    autoFocus
+                    value={draft.name}
+                    onChange={(event) => setDraft({ ...draft, name: event.target.value })}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="color"
+                    aria-label={labelStrings.colorHeader}
+                    value={draft.color}
+                    onChange={(event) => setDraft({ ...draft, color: event.target.value })}
+                  />
+                </td>
+                <td>
+                  <input
+                    type="checkbox"
+                    aria-label={labelStrings.hideHeader}
+                    checked={draft.hideOnEntityCard}
+                    onChange={(event) =>
+                      setDraft({ ...draft, hideOnEntityCard: event.target.checked })
+                    }
+                  />
+                </td>
+                <td>
+                  <button type="button" onClick={submitCreate} disabled={createTag.isPending}>
+                    {labelStrings.create}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setDraft(null);
+                      setDraftError(null);
+                    }}
+                  >
+                    {labelStrings.cancel}
+                  </button>
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      )}
+
+      {draftError && (
+        <div data-granit-tag-manager-draft-error="" role="alert">
+          {draftError}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/components/taxonomy-search-bar.tsx
+++ b/packages/@granit/react-taxonomy/src/components/taxonomy-search-bar.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from 'react';
+
+import { useTaxonomySearch } from '../hooks/use-taxonomy-search.js';
+
+import type { TaxonomySearchResultItem } from '@granit/taxonomy';
+import type { ReactNode } from 'react';
+
+const DEFAULT_DEBOUNCE_MS = 300;
+const DEFAULT_MIN_QUERY_LENGTH = 2;
+
+export interface TaxonomySearchBarLabels {
+  readonly placeholder?: string;
+  readonly belowThreshold?: string;
+  readonly empty?: string;
+  readonly loading?: string;
+  readonly error?: string;
+}
+
+export interface TaxonomySearchBarProps {
+  readonly onSelect: (item: TaxonomySearchResultItem) => void;
+  /**
+   * Map an assembly-qualified `targetType` to a localised group heading.
+   * When unset for a key, the bar falls back to the last `.` segment.
+   */
+  readonly targetTypeLabels?: Readonly<Record<string, string>>;
+  readonly debounceMs?: number;
+  readonly minQueryLength?: number;
+  readonly labels?: TaxonomySearchBarLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<TaxonomySearchBarLabels> = {
+  placeholder: 'Search…',
+  belowThreshold: 'Type at least 2 characters',
+  empty: 'No results.',
+  loading: 'Searching…',
+  error: 'Search failed.',
+};
+
+function fallbackTargetTypeLabel(targetType: string): string {
+  const idx = targetType.lastIndexOf('.');
+  return idx >= 0 ? targetType.slice(idx + 1) : targetType;
+}
+
+/**
+ * Cross-entity taxonomy search bar. Owns its own debounce + min-length
+ * threshold; results are grouped by `targetType` with localised headings
+ * resolved from `targetTypeLabels` (fallback: last segment of the
+ * assembly-qualified type name). Apps decide what to do on selection
+ * (typically navigate to the target's detail page).
+ *
+ * Keyboard: arrow keys move within the flat option list across groups;
+ * Enter selects the highlighted item; Escape closes the dropdown.
+ */
+export function TaxonomySearchBar({
+  onSelect,
+  targetTypeLabels,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+  minQueryLength = DEFAULT_MIN_QUERY_LENGTH,
+  labels,
+  className,
+}: TaxonomySearchBarProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const [input, setInput] = useState('');
+  const [debounced, setDebounced] = useState('');
+  const [highlight, setHighlight] = useState(0);
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    const handle = setTimeout(() => setDebounced(input), debounceMs);
+    return () => clearTimeout(handle);
+  }, [input, debounceMs]);
+
+  const enabled = debounced.length >= minQueryLength;
+  const searchQuery = useTaxonomySearch({ q: debounced, enabled });
+
+  const groups = searchQuery.data ?? [];
+  const flatItems: readonly TaxonomySearchResultItem[] = groups.flatMap((group) => group.items);
+
+  function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlight((h) => Math.min(h + 1, Math.max(flatItems.length - 1, 0)));
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlight((h) => Math.max(h - 1, 0));
+      return;
+    }
+    if (event.key === 'Escape') {
+      setOpen(false);
+      return;
+    }
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const picked = flatItems[highlight];
+      if (picked) {
+        onSelect(picked);
+        setOpen(false);
+      }
+    }
+  }
+
+  let content: ReactNode;
+  if (!enabled) {
+    content = (
+      <div data-granit-taxonomy-search-below-threshold="">{labelStrings.belowThreshold}</div>
+    );
+  } else if (searchQuery.isLoading) {
+    content = <div data-granit-taxonomy-search-loading="">{labelStrings.loading}</div>;
+  } else if (searchQuery.isError) {
+    content = (
+      <div data-granit-taxonomy-search-error="" role="alert">
+        {labelStrings.error}
+      </div>
+    );
+  } else if (groups.length === 0) {
+    content = <div data-granit-taxonomy-search-empty="">{labelStrings.empty}</div>;
+  } else {
+    let cursor = 0;
+    content = (
+      <ul role="listbox" data-granit-taxonomy-search-list="">
+        {groups.map((group) => {
+          const heading =
+            targetTypeLabels?.[group.targetType] ?? fallbackTargetTypeLabel(group.targetType);
+          return (
+            <li key={group.targetType} role="presentation" data-granit-taxonomy-search-group="">
+              <h4 data-granit-taxonomy-search-group-heading="">{heading}</h4>
+              <ul role="group">
+                {group.items.map((item) => {
+                  const index = cursor++;
+                  const isHighlighted = index === highlight;
+                  return (
+                    <li
+                      key={`${item.targetType}:${item.targetId}`}
+                      role="option"
+                      aria-selected={isHighlighted}
+                      data-granit-taxonomy-search-item=""
+                      data-granit-taxonomy-search-highlighted={isHighlighted ? '' : undefined}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        onSelect(item);
+                        setOpen(false);
+                      }}
+                    >
+                      <span data-granit-taxonomy-search-item-label="">{item.label}</span>
+                      {item.snippet && (
+                        <span data-granit-taxonomy-search-item-snippet="">{item.snippet}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
+          );
+        })}
+      </ul>
+    );
+  }
+
+  return (
+    <div data-granit-taxonomy-search="" className={className}>
+      <input
+        type="search"
+        role="combobox"
+        aria-expanded={open}
+        aria-autocomplete="list"
+        data-granit-taxonomy-search-input=""
+        placeholder={labelStrings.placeholder}
+        value={input}
+        onChange={(event) => {
+          setInput(event.target.value);
+          setHighlight(0);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+        onKeyDown={handleKeyDown}
+      />
+      {open && content}
+    </div>
+  );
+}

--- a/packages/@granit/react-taxonomy/src/contributions/entity-taxonomy.tsx
+++ b/packages/@granit/react-taxonomy/src/contributions/entity-taxonomy.tsx
@@ -1,0 +1,103 @@
+import { CategorySelector } from '../components/category-selector.tsx';
+import { TagChipStrip } from '../components/tag-chip-strip.tsx';
+
+import type { CategorySelectorLabels } from '../components/category-selector.tsx';
+import type { TagChipStripLabels } from '../components/tag-chip-strip.tsx';
+import type { ReactNode } from 'react';
+
+export interface EntityTaxonomyContributionOptions {
+  /** Module scope, e.g. `'documents'` / `'parties'`. Required. */
+  readonly scope: string;
+  /** Show the chip strip. Default `true`. */
+  readonly showTags?: boolean;
+  /** Show the category selector. Default `true`. */
+  readonly showCategory?: boolean;
+  /** Default `false` on the entity-detail surface. */
+  readonly hideOnCardOnly?: boolean;
+  readonly canManage?: boolean;
+  readonly tagLabels?: TagChipStripLabels;
+  readonly categoryLabels?: CategorySelectorLabels;
+  readonly className?: string;
+}
+
+export interface EntityTaxonomyProps {
+  /** Wire identifier of the entity (e.g. `"Granit.Documents.Domain.Document"`). */
+  readonly entityName: string;
+  readonly entityId: string;
+  /** Currently assigned category id, supplied by the host (read from the entity payload). */
+  readonly categoryId?: string | null;
+}
+
+/**
+ * Factory producing an `EntityTaxonomy` renderer that hosts can place on
+ * the entity-detail surface — header, side rail, drawer, wherever. We
+ * deliberately do NOT key into `EntitySidePanel` for this contribution
+ * because `SidePanelKind` in `@granit/entities` is a closed union; adding
+ * `'Taxonomy'` is a separate breaking change for that package. Until
+ * then, hosts call this factory at module wiring time and render the
+ * returned component themselves.
+ *
+ * ```tsx
+ * import { entityTaxonomy } from '@granit/react-taxonomy';
+ * const EntityTaxonomy = entityTaxonomy({ scope: 'documents', canManage: true });
+ *
+ * function DocumentDetail({ doc }: { doc: Document }) {
+ *   return <EntityTaxonomy entityName="Granit.Documents.Domain.Document" entityId={doc.id} categoryId={doc.categoryId} />;
+ * }
+ * ```
+ */
+export function entityTaxonomy(
+  options: EntityTaxonomyContributionOptions
+): (props: EntityTaxonomyProps) => ReactNode {
+  const {
+    scope,
+    showTags = true,
+    showCategory = true,
+    hideOnCardOnly = false,
+    canManage = false,
+    tagLabels,
+    categoryLabels,
+    className,
+  } = options;
+
+  if (!showTags && !showCategory) {
+    return function EmptyEntityTaxonomy(): ReactNode {
+      return null;
+    };
+  }
+
+  return function EntityTaxonomy({
+    entityName,
+    entityId,
+    categoryId,
+  }: EntityTaxonomyProps): ReactNode {
+    return (
+      <div
+        data-granit-entity-taxonomy=""
+        data-granit-entity-taxonomy-scope={scope}
+        className={className}
+      >
+        {showTags && (
+          <TagChipStrip
+            scope={scope}
+            targetType={entityName}
+            targetId={entityId}
+            hideOnCardOnly={hideOnCardOnly}
+            canManage={canManage}
+            labels={tagLabels}
+          />
+        )}
+        {showCategory && (
+          <CategorySelector
+            scope={scope}
+            targetType={entityName}
+            targetId={entityId}
+            value={categoryId ?? null}
+            canManage={canManage}
+            labels={categoryLabels}
+          />
+        )}
+      </div>
+    );
+  };
+}

--- a/packages/@granit/react-taxonomy/src/hooks/use-categories.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-categories.ts
@@ -22,13 +22,15 @@ import type { UseQueryResult } from '@tanstack/react-query';
  * ```
  */
 export function useCategories(
-  filter: CategoryListFilter
+  filter: CategoryListFilter,
+  options?: { readonly enabled?: boolean }
 ): UseQueryResult<readonly CategoryResponse[]> {
   const config = useTaxonomyConfig();
 
   return useQuery({
     queryKey: buildTaxonomyQueryKey(config, 'categories', filter),
     queryFn: () => listCategories(config.client, config.basePath, filter),
+    enabled: options?.enabled ?? true,
   });
 }
 

--- a/packages/@granit/react-taxonomy/src/hooks/use-document-tags.ts
+++ b/packages/@granit/react-taxonomy/src/hooks/use-document-tags.ts
@@ -1,0 +1,79 @@
+import { attachTagToDocument, detachTagFromDocument, listDocumentTags } from '@granit/taxonomy';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildTaxonomyQueryKey, useTaxonomyConfig } from '../providers/taxonomy-provider.js';
+
+import type { TagResponse } from '@granit/taxonomy';
+import type { QueryClient, UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Documents-proxy basePath. The proxy URL pattern is
+ * `/api/v1/documents/{id}/tags` — it sits *above* the `/api/v1/taxonomy`
+ * surface configured on the provider. Callers pass it explicitly because
+ * `<DocumentTagChipStrip>` is the only component that uses these endpoints
+ * and the host knows the canonical Documents API base.
+ */
+export interface DocumentTagsBindings {
+  readonly basePath: string;
+  readonly documentId: string;
+}
+
+function invalidateDocumentTags(queryClient: QueryClient, queryKey: readonly unknown[]): void {
+  queryClient.invalidateQueries({ queryKey });
+}
+
+/**
+ * List the tags currently attached to a document via the proxy endpoint.
+ * Disabled when `documentId` is empty.
+ */
+export function useDocumentTags(
+  bindings: DocumentTagsBindings
+): UseQueryResult<readonly TagResponse[]> {
+  const config = useTaxonomyConfig();
+  const queryKey = buildTaxonomyQueryKey(config, 'document-tags', bindings);
+
+  return useQuery({
+    queryKey,
+    queryFn: () => listDocumentTags(config.client, bindings.basePath, bindings.documentId),
+    enabled: bindings.documentId.length > 0,
+  });
+}
+
+/**
+ * Attach an existing tag to a document. Invalidates only the impacted
+ * document's tag list — sibling documents keep their cached state.
+ */
+export function useAttachTagToDocument(
+  bindings: DocumentTagsBindings
+): UseMutationResult<void, Error, string> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+  const queryKey = buildTaxonomyQueryKey(config, 'document-tags', bindings);
+
+  return useMutation({
+    mutationFn: (tagId: string) =>
+      attachTagToDocument(config.client, bindings.basePath, bindings.documentId, tagId),
+    onSuccess: () => {
+      invalidateDocumentTags(queryClient, queryKey);
+    },
+  });
+}
+
+/**
+ * Detach a tag from a document. Invalidates only the impacted document.
+ */
+export function useDetachTagFromDocument(
+  bindings: DocumentTagsBindings
+): UseMutationResult<void, Error, string> {
+  const config = useTaxonomyConfig();
+  const queryClient = useQueryClient();
+  const queryKey = buildTaxonomyQueryKey(config, 'document-tags', bindings);
+
+  return useMutation({
+    mutationFn: (tagId: string) =>
+      detachTagFromDocument(config.client, bindings.basePath, bindings.documentId, tagId),
+    onSuccess: () => {
+      invalidateDocumentTags(queryClient, queryKey);
+    },
+  });
+}

--- a/packages/@granit/react-taxonomy/src/index.ts
+++ b/packages/@granit/react-taxonomy/src/index.ts
@@ -18,6 +18,12 @@ export { useTagAssignments, useTags } from './hooks/use-tags.js';
 export { useCategories, useCategory } from './hooks/use-categories.js';
 export { useTaxonomySearch } from './hooks/use-taxonomy-search.js';
 export type { UseTaxonomySearchOptions } from './hooks/use-taxonomy-search.js';
+export {
+  useAttachTagToDocument,
+  useDetachTagFromDocument,
+  useDocumentTags,
+} from './hooks/use-document-tags.js';
+export type { DocumentTagsBindings } from './hooks/use-document-tags.js';
 
 // Mutation hooks — Tags
 export {
@@ -37,3 +43,43 @@ export {
   useUnassignCategory,
   useUpdateCategory,
 } from './hooks/use-category-mutations.js';
+
+// Components
+export { TagChip } from './components/tag-chip.tsx';
+export type { TagChipProps } from './components/tag-chip.tsx';
+export { TagAutocomplete } from './components/tag-autocomplete.tsx';
+export type {
+  TagAutocompleteLabels,
+  TagAutocompleteProps,
+} from './components/tag-autocomplete.tsx';
+export { TagChipStrip } from './components/tag-chip-strip.tsx';
+export type { TagChipStripLabels, TagChipStripProps } from './components/tag-chip-strip.tsx';
+export { DocumentTagChipStrip } from './components/document-tag-chip-strip.tsx';
+export type { DocumentTagChipStripProps } from './components/document-tag-chip-strip.tsx';
+export { TagManager } from './components/tag-manager.tsx';
+export type { TagManagerLabels, TagManagerProps } from './components/tag-manager.tsx';
+export { CategoryBreadcrumb } from './components/category-breadcrumb.tsx';
+export type { CategoryBreadcrumbProps } from './components/category-breadcrumb.tsx';
+export { CategoryTree } from './components/category-tree.tsx';
+export type { CategoryTreeLabels, CategoryTreeProps } from './components/category-tree.tsx';
+export { CategorySelector } from './components/category-selector.tsx';
+export type {
+  CategorySelectorLabels,
+  CategorySelectorProps,
+} from './components/category-selector.tsx';
+export { TaxonomySearchBar } from './components/taxonomy-search-bar.tsx';
+export type {
+  TaxonomySearchBarLabels,
+  TaxonomySearchBarProps,
+} from './components/taxonomy-search-bar.tsx';
+
+// Contributions
+export { entityTaxonomy } from './contributions/entity-taxonomy.tsx';
+export type {
+  EntityTaxonomyContributionOptions,
+  EntityTaxonomyProps,
+} from './contributions/entity-taxonomy.tsx';
+
+// i18n
+export { taxonomyTranslationsEn, taxonomyTranslationsFr } from './locales/index.js';
+export type { TaxonomyTranslations } from './locales/index.js';

--- a/packages/@granit/react-taxonomy/src/locales/en.ts
+++ b/packages/@granit/react-taxonomy/src/locales/en.ts
@@ -1,0 +1,149 @@
+/**
+ * English translation bundle for `@granit/react-taxonomy`. Consumers
+ * register it via:
+ *
+ *   i18n.addResourceBundle('en', 'taxonomy', taxonomyTranslationsEn);
+ *
+ * Components in this package don't call `useTranslation` directly — they
+ * expose `labels` props that apps populate from `t()`. This keeps the
+ * components testable without i18next bootstrap, and keeps the framework
+ * headless: apps own when and how to mount i18n.
+ */
+export const taxonomyTranslationsEn: TaxonomyTranslations = {
+  Tag: {
+    Chip: {
+      Remove: 'Remove',
+    },
+    Strip: {
+      Add: '+ Tag',
+      Empty: 'No tags.',
+      Loading: 'Loading…',
+      Error: 'Failed to load tags.',
+    },
+    Autocomplete: {
+      Placeholder: 'Add tag…',
+      Empty: 'No matching tags',
+      Create: 'Create',
+    },
+    Manager: {
+      Title: 'Tags',
+      NewTag: 'New tag',
+      NameHeader: 'Name',
+      ColorHeader: 'Color',
+      HideHeader: 'Hidden on cards',
+      ActionsHeader: 'Actions',
+      HideTooltip: 'Hide this tag from entity cards while keeping it in admin views.',
+      Delete: 'Delete',
+      DeleteConfirm: 'Delete this tag? All assignments will be removed.',
+      InvalidColor: 'Color must be a 7-character hex (e.g. #1A2B3C).',
+      NameRequired: 'Name is required.',
+      NameConflict: 'A tag with this name already exists.',
+      Empty: 'No tags yet — create the first one.',
+      ReadonlyHint: 'You don’t have permission to manage tags.',
+      Create: 'Create',
+      Cancel: 'Cancel',
+    },
+  },
+  Category: {
+    Tree: {
+      Add: '+',
+      Rename: 'Rename',
+      Move: 'Move',
+      Delete: 'Delete',
+      DeleteConfirm:
+        'Delete this category? Categories with descendants or active assignments cannot be deleted.',
+      MoveDialogTitle: 'Move category',
+      MovePromote: '(promote to root)',
+      MovePrompt: 'Paste the new parent category id, or leave empty to promote to root.',
+      Empty: 'No categories.',
+      Loading: 'Loading…',
+      Error422HasDescendants: 'Cannot delete: this category has descendants.',
+      Error422HasAssignments: 'Cannot delete: this category has active assignments.',
+      Error422CrossScope: 'Cannot move across scopes.',
+      Error422Cycle: 'Cannot move a category under one of its descendants.',
+    },
+    Selector: {
+      NoCategory: 'No category',
+      Choose: 'Choose…',
+      Clear: 'Clear',
+      Close: 'Close',
+      DialogTitle: 'Choose a category',
+    },
+  },
+  Search: {
+    Placeholder: 'Search…',
+    BelowThreshold: 'Type at least 2 characters',
+    Empty: 'No results.',
+    Loading: 'Searching…',
+    Error: 'Search failed.',
+  },
+};
+
+export interface TaxonomyTranslations {
+  readonly Tag: {
+    readonly Chip: {
+      readonly Remove: string;
+    };
+    readonly Strip: {
+      readonly Add: string;
+      readonly Empty: string;
+      readonly Loading: string;
+      readonly Error: string;
+    };
+    readonly Autocomplete: {
+      readonly Placeholder: string;
+      readonly Empty: string;
+      readonly Create: string;
+    };
+    readonly Manager: {
+      readonly Title: string;
+      readonly NewTag: string;
+      readonly NameHeader: string;
+      readonly ColorHeader: string;
+      readonly HideHeader: string;
+      readonly ActionsHeader: string;
+      readonly HideTooltip: string;
+      readonly Delete: string;
+      readonly DeleteConfirm: string;
+      readonly InvalidColor: string;
+      readonly NameRequired: string;
+      readonly NameConflict: string;
+      readonly Empty: string;
+      readonly ReadonlyHint: string;
+      readonly Create: string;
+      readonly Cancel: string;
+    };
+  };
+  readonly Category: {
+    readonly Tree: {
+      readonly Add: string;
+      readonly Rename: string;
+      readonly Move: string;
+      readonly Delete: string;
+      readonly DeleteConfirm: string;
+      readonly MoveDialogTitle: string;
+      readonly MovePromote: string;
+      readonly MovePrompt: string;
+      readonly Empty: string;
+      readonly Loading: string;
+      readonly Error422HasDescendants: string;
+      readonly Error422HasAssignments: string;
+      readonly Error422CrossScope: string;
+      readonly Error422Cycle: string;
+    };
+    readonly Selector: {
+      readonly NoCategory: string;
+      readonly Choose: string;
+      readonly Clear: string;
+      readonly Close: string;
+      readonly DialogTitle: string;
+    };
+  };
+  readonly Search: {
+    readonly Placeholder: string;
+    readonly BelowThreshold: string;
+    readonly Empty: string;
+    readonly Loading: string;
+    readonly Error: string;
+  };
+}

--- a/packages/@granit/react-taxonomy/src/locales/fr.ts
+++ b/packages/@granit/react-taxonomy/src/locales/fr.ts
@@ -1,0 +1,74 @@
+import type { TaxonomyTranslations } from './en.js';
+
+export const taxonomyTranslationsFr: TaxonomyTranslations = {
+  Tag: {
+    Chip: {
+      Remove: 'Retirer',
+    },
+    Strip: {
+      Add: '+ Étiquette',
+      Empty: 'Aucune étiquette.',
+      Loading: 'Chargement…',
+      Error: 'Échec du chargement des étiquettes.',
+    },
+    Autocomplete: {
+      Placeholder: 'Ajouter une étiquette…',
+      Empty: 'Aucune étiquette correspondante',
+      Create: 'Créer',
+    },
+    Manager: {
+      Title: 'Étiquettes',
+      NewTag: 'Nouvelle étiquette',
+      NameHeader: 'Nom',
+      ColorHeader: 'Couleur',
+      HideHeader: 'Masquée sur les fiches',
+      ActionsHeader: 'Actions',
+      HideTooltip:
+        'Masque cette étiquette sur les fiches d’entité tout en la conservant dans les vues d’administration.',
+      Delete: 'Supprimer',
+      DeleteConfirm: 'Supprimer cette étiquette ? Toutes les affectations seront retirées.',
+      InvalidColor: 'La couleur doit être un code hexadécimal à 7 caractères (par ex. #1A2B3C).',
+      NameRequired: 'Le nom est obligatoire.',
+      NameConflict: 'Une étiquette portant ce nom existe déjà.',
+      Empty: 'Aucune étiquette pour le moment — créez la première.',
+      ReadonlyHint: 'Vous n’avez pas la permission de gérer les étiquettes.',
+      Create: 'Créer',
+      Cancel: 'Annuler',
+    },
+  },
+  Category: {
+    Tree: {
+      Add: '+',
+      Rename: 'Renommer',
+      Move: 'Déplacer',
+      Delete: 'Supprimer',
+      DeleteConfirm:
+        'Supprimer cette catégorie ? Une catégorie ayant des sous-catégories ou des affectations actives ne peut pas être supprimée.',
+      MoveDialogTitle: 'Déplacer la catégorie',
+      MovePromote: '(promouvoir à la racine)',
+      MovePrompt:
+        'Collez l’identifiant de la nouvelle catégorie parente, ou laissez vide pour promouvoir à la racine.',
+      Empty: 'Aucune catégorie.',
+      Loading: 'Chargement…',
+      Error422HasDescendants: 'Suppression impossible : cette catégorie a des sous-catégories.',
+      Error422HasAssignments:
+        'Suppression impossible : cette catégorie a des affectations actives.',
+      Error422CrossScope: 'Impossible de déplacer la catégorie entre périmètres.',
+      Error422Cycle: 'Impossible de déplacer une catégorie sous l’un de ses propres descendants.',
+    },
+    Selector: {
+      NoCategory: 'Aucune catégorie',
+      Choose: 'Choisir…',
+      Clear: 'Effacer',
+      Close: 'Fermer',
+      DialogTitle: 'Choisir une catégorie',
+    },
+  },
+  Search: {
+    Placeholder: 'Rechercher…',
+    BelowThreshold: 'Saisissez au moins 2 caractères',
+    Empty: 'Aucun résultat.',
+    Loading: 'Recherche…',
+    Error: 'Échec de la recherche.',
+  },
+};

--- a/packages/@granit/react-taxonomy/src/locales/index.ts
+++ b/packages/@granit/react-taxonomy/src/locales/index.ts
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------------
+// @granit/react-taxonomy — i18next resource bundles (namespace: "taxonomy")
+// ---------------------------------------------------------------------------
+//
+// Consumers register the bundles with their i18n instance:
+//
+//   import { taxonomyTranslationsEn, taxonomyTranslationsFr } from '@granit/react-taxonomy';
+//   i18n.addResourceBundle('en', 'taxonomy', taxonomyTranslationsEn);
+//   i18n.addResourceBundle('fr', 'taxonomy', taxonomyTranslationsFr);
+//
+// Components in this package don't call `useTranslation` directly — they
+// expose `labels` props that apps populate from `t()`. This keeps the
+// components testable without i18next bootstrap, and keeps the framework
+// headless: apps own when and how to mount i18n.
+//
+// NOTE on culture coverage: the backend ships permission labels in 18
+// cultures via `PermissionGroup:Taxonomy`. Front-end packages in this repo
+// uniformly ship en + fr bundles only (the Digital Dynamics product
+// surface is bilingual); the backend strings reach the role editor through
+// its existing localization pipeline regardless of front bundles.
+// ---------------------------------------------------------------------------
+
+export { taxonomyTranslationsEn } from './en.js';
+export type { TaxonomyTranslations } from './en.js';
+export { taxonomyTranslationsFr } from './fr.js';

--- a/packages/@granit/react-taxonomy/tsconfig.json
+++ b/packages/@granit/react-taxonomy/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": {
+    "types": ["@testing-library/jest-dom"],
     "paths": {
       "@granit/taxonomy": ["../taxonomy/src/index.ts"]
     }


### PR DESCRIPTION
Closes T5–T10 of #384 in a single PR (per request).

## Summary

**T5 — tag primitives + chip strip + Documents proxy variant** (#389)
- `<TagChip />` headless chip with contrast-aware text color (Rec. 709 luma).
- `<TagAutocomplete />` combobox with keyboard nav (↑/↓/Enter/Esc/Backspace), inline-create-on-Enter gated by `canManage`, reuses `useTags` / `useCreateTag`.
- `<TagChipStrip />` reads `useTagAssignments`, `hideOnCardOnly` filter, `+ Tag` opens the autocomplete and wires assign/unassign mutations.
- `<DocumentTagChipStrip />` proxy variant routing through `/api/v1/documents/{id}/tags` via `useDocumentTags` + `useAttach/Detach` hooks (added in `src/hooks/use-document-tags.ts`). Same canonical store on the backend — no second state shape for Documents.

**T6 — `<TagManager />` per-scope admin** (#390)
- CRUD with inline-edit name on blur, color picker (constrained to `#RRGGBB` via `isHexColor`), `HideOnEntityCard` toggle, delete with `window.confirm`. `canManage=false` renders read-only with a permission hint.

**T7 — category UI** (#391)
- `<CategoryTree />` lazy-loads children per node; `useCategories` grew an `enabled` option (additive, backwards compatible) so collapsed nodes don't fire. Manage actions wire create/rename/move/delete with explicit 422 mapping (cycle, cross-scope, has-descendants, has-assignments).
- `<CategorySelector />` single-assignment widget showing the current breadcrumb (or "No category"); Choose opens an inline tree dialog, Clear unassigns. Idempotent re-assignment via `useAssignCategory`.
- `<CategoryBreadcrumb />` read-only chevron-separated path with optional per-segment `onSelect`.

**T8 — `<TaxonomySearchBar />`** (#392)
- Owns its own debounce + min-length threshold (defaults 300ms / 2 chars). Results grouped by `targetType` with localised headings (host supplies `targetTypeLabels`; fallback is the last `.` segment of the assembly-qualified name). Keyboard ↑/↓/Enter/Esc, mouse-click selects.

**T9 — `entityTaxonomy` contribution** (#393)
- Factory returning a renderer that mounts `<TagChipStrip />` + `<CategorySelector />` for an entity. Deliberately **not** keyed into `EntitySidePanel` because `@granit/entities`' `SidePanelKind` is a closed union; adding `'Taxonomy'` is a separate breaking change for that package. Hosts call the factory at wiring time and render the result anywhere on the detail surface.

**T10 — locales + DoD** (#394)
- `en` + `fr` resource bundles under `src/locales/`, namespace `'taxonomy'`. Mirrors the **en/fr-only** convention every other `@granit/*` package ships in this repo (the brief's "18 cultures" reflects backend permission labels, which surface through the existing localization pipeline on the role editor — front bundles stay bilingual).
- Components don't call `useTranslation`; they expose `labels` props apps populate from `t()`. Headless and testable without i18next bootstrap.
- Locale parity test asserts en/fr expose the same key tree.

Refs #389, #390, #391, #392, #393, #394 — closes T5–T10 of #384.

## Test plan

- [x] `pnpm exec eslint 'packages/@granit/react-taxonomy/src/**/*.{ts,tsx}' --max-warnings 0` clean
- [x] Workspace-wide `pnpm tsc` clean (exit 0)
- [x] `pnpm exec vitest run packages/@granit/react-taxonomy` — **107 tests across 24 files passing**
- [x] Coverage scoped to `react-taxonomy/src/**/*.{ts,tsx}`: **86.76% statements / 80.44% branches / 87.73% functions / 88.63% lines** (all ≥ 80%)
- [x] `.mcp-front-index.json` regenerated (30 exports detected on `@granit/react-taxonomy`)

## Notes

- **Storybook** — explicitly out of scope: this repo doesn't use Storybook (zero `*.stories.tsx` across all 124 packages, no Storybook tooling wired). The brief's mention is carried over from a different project context.
- **`SidePanelKind: 'Taxonomy'`** — adding the literal to `@granit/entities`' closed union is a separate breaking change, intentionally deferred. The contribution factory works without it.