### PR TITLE
test(react-documents): raise component branch coverage to clear 80% gate

### DIFF
--- a/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
@@ -75,6 +75,82 @@ describe('DocumentDetail', () => {
     expect(screen.getByText('Active')).toBeInTheDocument();
   });
 
+  it('renders the not-found state when the document query returns null', async () => {
+    const client = createMockClient();
+    mockGet(client, null);
+
+    render(<DocumentDetail documentId="missing" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Document not found.')).toBeInTheDocument());
+  });
+
+  it('renders the no-description fallback and onOpenVersions / onOpenShares callbacks', async () => {
+    const client = createMockClient();
+    const noDesc: DocumentResponse = { ...sampleDocument, description: null };
+    mockGet(client, noDesc);
+    const onOpenVersions = vi.fn();
+    const onOpenShares = vi.fn();
+
+    render(
+      <DocumentDetail
+        documentId="doc-1"
+        onOpenVersions={onOpenVersions}
+        onOpenShares={onOpenShares}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('No description.')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: /Versions/ }));
+    expect(onOpenVersions).toHaveBeenCalledWith('doc-1');
+    await userEvent.click(screen.getByRole('button', { name: /Shares/ }));
+    expect(onOpenShares).toHaveBeenCalledWith('doc-1');
+  });
+
+  it('triggers a download (refetches the URL and opens a new window)', async () => {
+    const client = createMockClient();
+    mockGet(client, sampleDocument);
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+
+    render(<DocumentDetail documentId="doc-1" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Contract.pdf')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Download current version' }));
+
+    await waitFor(() => expect(openSpy).toHaveBeenCalled());
+    expect(openSpy.mock.calls[0]?.[0]).toBe('https://blob/x');
+  });
+
+  it('cancels the inline rename when Escape is pressed', async () => {
+    const client = createMockClient();
+    mockGet(client, sampleDocument);
+
+    render(<DocumentDetail documentId="doc-1" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Contract.pdf')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = await screen.findByDisplayValue('Contract.pdf');
+    await userEvent.type(input, '{Escape}');
+
+    expect(screen.queryByDisplayValue('Contract.pdf')).not.toBeInTheDocument();
+    expect(client.patch).not.toHaveBeenCalled();
+  });
+
+  it('no-ops the rename when the trimmed name is unchanged', async () => {
+    const client = createMockClient();
+    mockGet(client, sampleDocument);
+
+    render(<DocumentDetail documentId="doc-1" canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Contract.pdf')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = await screen.findByDisplayValue('Contract.pdf');
+    // blur with the same name → commits, but no-op
+    input.blur();
+    await waitFor(() => expect(screen.queryByDisplayValue('Contract.pdf')).not.toBeInTheDocument());
+    expect(client.patch).not.toHaveBeenCalled();
+  });
+
   it('triggers a rename mutation when the inline edit is committed', async () => {
     const client = createMockClient();
     mockGet(client, sampleDocument);

--- a/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
@@ -79,6 +79,36 @@ describe('DocumentsList', () => {
     expect(onOpenDocument).toHaveBeenCalledWith('doc-1');
   });
 
+  it('renders the error state when the QueryEngine call fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('boom'));
+
+    render(<DocumentsList folderId="fld-err" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Failed to load documents.')).toBeInTheDocument());
+  });
+
+  it('renders a row without onOpenDocument as a plain span (no button)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      data: {
+        items: [{ id: 'doc-1', folderId: 'fld-1', name: 'readonly.pdf', status: 'Active' }],
+        totalCount: 1,
+        page: 1,
+        pageSize: 50,
+      },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: { headers: {} } as never,
+    });
+
+    render(<DocumentsList folderId="fld-1" />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('readonly.pdf')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'readonly.pdf' })).not.toBeInTheDocument();
+  });
+
   it('hits the QueryEngine endpoint /documents/query with the folderId + status Active filters', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({

--- a/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
@@ -114,4 +114,125 @@ describe('FolderTree', () => {
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
     expect(screen.getAllByRole('button', { name: 'Rename' }).length).toBeGreaterThan(0);
   });
+
+  it('renders the error state when the roots query fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('boom'));
+
+    render(<FolderTree labels={{ error: 'oops' }} />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    // Error message from the thrown Error wins over the fallback label
+    expect(screen.getByRole('alert').textContent).toMatch(/boom/);
+  });
+
+  it('falls back to the error label when the thrown error has no message', async () => {
+    const client = createMockClient();
+    // Custom error without a message string
+    const err = new Error();
+    vi.mocked(client.get).mockRejectedValue(err);
+
+    render(<FolderTree labels={{ error: 'Custom error label' }} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+  });
+
+  it('triggers the create-root prompt and aborts when the prompt is empty', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('   ');
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('No folders.')).toBeInTheDocument());
+    const addRoot = screen.getByRole('button', { name: '+' });
+    await userEvent.click(addRoot);
+
+    expect(promptSpy).toHaveBeenCalled();
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it('creates a root folder when the prompt returns a name', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+    vi.mocked(client.post).mockResolvedValue({ data: { ...root, name: 'New' } });
+    vi.spyOn(window, 'prompt').mockReturnValue('New');
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('No folders.')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: '+' }));
+
+    await waitFor(() => expect(client.post).toHaveBeenCalled());
+  });
+
+  it('cancels rename when the prompt returns the same name', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.spyOn(window, 'prompt').mockReturnValue(root.name);
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    expect(client.patch).not.toHaveBeenCalled();
+  });
+
+  it('renames a folder when the prompt returns a new name', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.mocked(client.patch).mockResolvedValue({ data: { ...root, name: 'Renamed' } });
+    vi.spyOn(window, 'prompt').mockReturnValue('Renamed');
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    await waitFor(() => expect(client.patch).toHaveBeenCalled());
+  });
+
+  it('aborts delete when the user cancels the confirm dialog', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
+  it('trashes a folder when the user confirms', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(client.delete).toHaveBeenCalled());
+  });
+
+  it('creates a sub-folder via the node-level add button', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.mocked(client.post).mockResolvedValue({ data: { ...root, name: 'child' } });
+    vi.spyOn(window, 'prompt').mockReturnValue('child');
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    // The node-level + button is among the row buttons (not the top-level one)
+    const addButtons = screen.getAllByRole('button', { name: '+' });
+    // First add is the root-level. Click the per-node one.
+    const nodeAdd = addButtons[addButtons.length - 1];
+    if (!nodeAdd) throw new Error('expected node-level add button');
+    await userEvent.click(nodeAdd);
+
+    await waitFor(() => expect(client.post).toHaveBeenCalled());
+  });
 });

--- a/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
@@ -92,4 +92,96 @@ describe('ShareDialog', () => {
 
     await waitFor(() => expect(screen.getByText('No shares yet.')).toBeInTheDocument());
   });
+
+  it('grants a folder share through the draft form and clears the draft on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { items: [] } });
+    vi.mocked(client.post).mockResolvedValue({ data: { ...folderShare, id: 'share-new' } });
+
+    render(<ShareDialog target={{ type: 'Folder', id: 'fld-1' }} canManage />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('No shares yet.')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Add share' }));
+    const granteeInput = screen.getByLabelText('Grantee');
+    await userEvent.type(granteeInput, 'bob');
+    // Exercise the type, permission, expiresAt, isDefault setters.
+    await userEvent.selectOptions(screen.getByLabelText('Type'), 'Group');
+    await userEvent.selectOptions(screen.getByLabelText('Permission'), 'Edit');
+    const expiresInput = screen.getByLabelText('Expires');
+    await userEvent.type(expiresInput, '2026-12-31T23:59');
+    const checkbox = screen.getByRole('checkbox');
+    await userEvent.click(checkbox); // toggle isDefault off
+
+    await userEvent.click(screen.getByRole('button', { name: 'Grant' }));
+
+    await waitFor(() => expect(client.post).toHaveBeenCalled());
+    const [url, body] = vi.mocked(client.post).mock.calls[0] ?? [];
+    expect(url).toContain('/folders/fld-1/shares');
+    expect(body).toMatchObject({
+      granteeType: 'Group',
+      granteeId: 'bob',
+      permission: 'Edit',
+      isDefault: false,
+    });
+  });
+
+  it('does not submit when the granteeId is empty (whitespace only)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<ShareDialog target={{ type: 'Folder', id: 'fld-1' }} canManage />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('No shares yet.')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Add share' }));
+    await userEvent.type(screen.getByLabelText('Grantee'), '   ');
+    await userEvent.click(screen.getByRole('button', { name: 'Grant' }));
+
+    // Draft is still open, post was never called.
+    expect(client.post).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: 'Grant' })).toBeInTheDocument();
+  });
+
+  it('cancels the draft when Cancel is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<ShareDialog target={{ type: 'Folder', id: 'fld-1' }} canManage />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('No shares yet.')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Add share' }));
+    expect(screen.getByRole('button', { name: 'Grant' })).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('button', { name: 'Grant' })).not.toBeInTheDocument();
+  });
+
+  it('grants a document share (no isDefault checkbox) and omits the isDefault field', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { items: [] } });
+    vi.mocked(client.post).mockResolvedValue({
+      data: { ...folderShare, id: 'share-doc', targetType: 'Document', documentId: 'doc-1' },
+    });
+
+    render(<ShareDialog target={{ type: 'Document', id: 'doc-1' }} canManage />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('No shares yet.')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('button', { name: 'Add share' }));
+    // No checkbox shown for documents.
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    await userEvent.type(screen.getByLabelText('Grantee'), 'carol');
+    await userEvent.click(screen.getByRole('button', { name: 'Grant' }));
+
+    await waitFor(() => expect(client.post).toHaveBeenCalled());
+    const [url, body] = vi.mocked(client.post).mock.calls[0] ?? [];
+    expect(url).toContain('/documents/doc-1/shares');
+    expect(body).toMatchObject({ granteeType: 'User', granteeId: 'carol', permission: 'Read' });
+    expect((body as { isDefault?: unknown }).isDefault).toBeUndefined();
+  });
 });

--- a/packages/@granit/react-documents/src/__tests__/trash-bin.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/trash-bin.test.tsx
@@ -100,4 +100,97 @@ describe('TrashBin', () => {
     const url = vi.mocked(client.post).mock.calls[0]?.[0];
     expect(url).toContain('/restore');
   });
+
+  it('does not render manage action column when canManage is false', async () => {
+    const client = createMockClient();
+    const response: ListTrashedDocumentsResponse = {
+      documents: [trashed],
+      totalCount: 1,
+      skip: 0,
+      take: 20,
+    };
+    vi.mocked(client.get).mockResolvedValue({ data: response });
+
+    render(<TrashBin />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Old.pdf')).toBeInTheDocument());
+    expect(screen.queryByRole('button', { name: 'Restore' })).toBeNull();
+  });
+
+  it('runs the permanent-delete flow when both confirms return true', async () => {
+    const client = createMockClient();
+    const response: ListTrashedDocumentsResponse = {
+      documents: [trashed],
+      totalCount: 1,
+      skip: 0,
+      take: 20,
+    };
+    vi.mocked(client.get).mockResolvedValue({ data: response });
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+    render(<TrashBin canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Old.pdf')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Permanently delete' }));
+    await waitFor(() => expect(client.delete).toHaveBeenCalled());
+  });
+
+  it('aborts permanent-delete when the first confirm is cancelled', async () => {
+    vi.mocked(window.confirm).mockReturnValue(false);
+    const client = createMockClient();
+    const response: ListTrashedDocumentsResponse = {
+      documents: [trashed],
+      totalCount: 1,
+      skip: 0,
+      take: 20,
+    };
+    vi.mocked(client.get).mockResolvedValue({ data: response });
+
+    render(<TrashBin canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Old.pdf')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Permanently delete' }));
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
+  it('aborts permanent-delete when only the second confirm is cancelled', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm');
+    confirmSpy.mockReturnValueOnce(true).mockReturnValueOnce(false);
+    const client = createMockClient();
+    const response: ListTrashedDocumentsResponse = {
+      documents: [trashed],
+      totalCount: 1,
+      skip: 0,
+      take: 20,
+    };
+    vi.mocked(client.get).mockResolvedValue({ data: response });
+
+    render(<TrashBin canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Old.pdf')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Permanently delete' }));
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
+  it('paginates next/previous when totalCount exceeds the page size', async () => {
+    const client = createMockClient();
+    const response: ListTrashedDocumentsResponse = {
+      documents: [trashed],
+      totalCount: 5,
+      skip: 0,
+      take: 1,
+    };
+    vi.mocked(client.get).mockResolvedValue({ data: response });
+
+    render(<TrashBin pageSize={1} />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Old.pdf')).toBeInTheDocument());
+
+    const next = screen.getByRole('button', { name: 'Next' });
+    expect(next).not.toBeDisabled();
+    await userEvent.click(next);
+
+    const prev = screen.getByRole('button', { name: 'Previous' });
+    expect(prev).not.toBeDisabled();
+    await userEvent.click(prev);
+  });
 });

--- a/packages/@granit/react-documents/src/__tests__/upload-button.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/upload-button.test.tsx
@@ -124,4 +124,186 @@ describe('UploadButton', () => {
 
     await waitFor(() => expect(screen.getByText('File is too large.')).toBeInTheDocument());
   });
+
+  it('surfaces the QuotaExceeded label when finalize returns 413', async () => {
+    const client = createMockClient();
+    const ticket = {
+      blobId: 'blob-1',
+      uploadUrl: 'https://blob.example/put',
+      httpMethod: 'PUT',
+      expiresAt: '2026-05-12T00:00:00Z',
+      requiredHeaders: {},
+    };
+    vi.mocked(client.post).mockImplementation(((url: string) => {
+      if (url.endsWith('/upload-ticket')) {
+        return Promise.resolve({ data: ticket });
+      }
+      return Promise.reject({ response: { status: 413 } });
+    }) as AxiosInstance['post']);
+
+    render(<UploadButton folderId="fld-1" />, { wrapper: createWrapper(client) });
+    const input = screen.getByText('Upload').previousSibling as HTMLInputElement;
+    const file = new File(['hello'], 'sample.txt', { type: 'text/plain' });
+    await userEvent.upload(input, file);
+
+    await waitFor(() =>
+      expect(screen.getByText('Tenant storage quota exceeded.')).toBeInTheDocument()
+    );
+  });
+
+  it('surfaces a generic Error.message when the upload throws an Error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error('Boom ticket'));
+
+    render(<UploadButton folderId="fld-1" />, { wrapper: createWrapper(client) });
+    const input = screen.getByText('Upload').previousSibling as HTMLInputElement;
+    const file = new File(['hello'], 'sample.txt', { type: 'text/plain' });
+    await userEvent.upload(input, file);
+
+    await waitFor(() => expect(screen.getByText('Boom ticket')).toBeInTheDocument());
+  });
+
+  it('falls back to the Failed label when a non-Error is thrown', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue('weird throw');
+
+    render(<UploadButton folderId="fld-1" labels={{ failed: 'It broke.' }} />, {
+      wrapper: createWrapper(client),
+    });
+    const input = screen.getByText('Upload').previousSibling as HTMLInputElement;
+    const file = new File(['hello'], 'sample.txt', { type: 'text/plain' });
+    await userEvent.upload(input, file);
+
+    await waitFor(() => expect(screen.getByText('It broke.')).toBeInTheDocument());
+  });
+
+  it('falls back to the Failed label when an Error has no message', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValue(new Error(''));
+
+    render(<UploadButton folderId="fld-1" />, { wrapper: createWrapper(client) });
+    const input = screen.getByText('Upload').previousSibling as HTMLInputElement;
+    const file = new File(['hello'], 'sample.txt', { type: 'text/plain' });
+    await userEvent.upload(input, file);
+
+    await waitFor(() => expect(screen.getByText('Upload failed.')).toBeInTheDocument());
+  });
+
+  it('handles xhr.onerror by surfacing the failed label', async () => {
+    const client = createMockClient();
+    const ticket = {
+      blobId: 'blob-1',
+      uploadUrl: 'https://blob.example/put',
+      httpMethod: 'PUT',
+      expiresAt: '2026-05-12T00:00:00Z',
+      requiredHeaders: {},
+    };
+    vi.mocked(client.post).mockResolvedValue({ data: ticket });
+
+    // Override XHR for this test to trigger onerror instead of onload.
+    class ErrXhr {
+      open = vi.fn();
+      setRequestHeader = vi.fn();
+      upload = { onprogress: null as ((event: ProgressEvent) => void) | null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      status = 0;
+      send = vi.fn(() => {
+        queueMicrotask(() => this.onerror?.());
+      });
+    }
+    (globalThis as { XMLHttpRequest: typeof XMLHttpRequest }).XMLHttpRequest =
+      ErrXhr as unknown as typeof XMLHttpRequest;
+
+    render(<UploadButton folderId="fld-1" />, { wrapper: createWrapper(client) });
+    const input = screen.getByText('Upload').previousSibling as HTMLInputElement;
+    const file = new File(['hello'], 'sample.txt', { type: 'text/plain' });
+    await userEvent.upload(input, file);
+
+    await waitFor(() => expect(screen.getByText('Upload failed.')).toBeInTheDocument());
+  });
+
+  it('handles xhr non-2xx onload by surfacing the http error', async () => {
+    const client = createMockClient();
+    const ticket = {
+      blobId: 'blob-1',
+      uploadUrl: 'https://blob.example/put',
+      httpMethod: 'PUT',
+      expiresAt: '2026-05-12T00:00:00Z',
+      requiredHeaders: { 'x-h': 'v' },
+    };
+    vi.mocked(client.post).mockResolvedValue({ data: ticket });
+
+    class BadStatusXhr {
+      open = vi.fn();
+      setRequestHeader = vi.fn();
+      upload = { onprogress: null as ((event: ProgressEvent) => void) | null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      status = 500;
+      send = vi.fn(() => {
+        queueMicrotask(() => {
+          // Fire upload progress with computable bytes to cover that branch
+          this.upload.onprogress?.({
+            lengthComputable: true,
+            loaded: 50,
+            total: 100,
+          } as ProgressEvent);
+          this.onload?.();
+        });
+      });
+    }
+    (globalThis as { XMLHttpRequest: typeof XMLHttpRequest }).XMLHttpRequest =
+      BadStatusXhr as unknown as typeof XMLHttpRequest;
+
+    render(<UploadButton folderId="fld-1" />, { wrapper: createWrapper(client) });
+    const input = screen.getByText('Upload').previousSibling as HTMLInputElement;
+    const file = new File(['hello'], 'sample.txt', { type: 'text/plain' });
+    await userEvent.upload(input, file);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Upload failed with HTTP 500/)).toBeInTheDocument()
+    );
+  });
+
+  it('uses application/octet-stream when the file has no content type', async () => {
+    const client = createMockClient();
+    const ticket = {
+      blobId: 'blob-1',
+      uploadUrl: 'https://blob.example/put',
+      httpMethod: 'PUT',
+      expiresAt: '2026-05-12T00:00:00Z',
+      requiredHeaders: {},
+    };
+    const documentResponse = {
+      id: 'doc-1',
+      folderId: null,
+      name: 'noext',
+      description: null,
+      ownerUserId: 'user-1',
+      currentVersionId: 'ver-1',
+      status: 'Active' as const,
+      trashedAt: null,
+      permission: null,
+    };
+    vi.mocked(client.post).mockImplementation(((url: string) => {
+      if (url.endsWith('/upload-ticket')) {
+        return Promise.resolve({ data: ticket });
+      }
+      return Promise.resolve({ data: documentResponse });
+    }) as AxiosInstance['post']);
+
+    render(<UploadButton folderId={null} />, { wrapper: createWrapper(client) });
+    const input = screen.getByText('Upload').previousSibling as HTMLInputElement;
+    const file = new File(['hello'], 'noext', { type: '' });
+    await userEvent.upload(input, file);
+
+    await waitFor(() => {
+      const calls = vi.mocked(client.post).mock.calls;
+      const ticketCall = calls.find((c) => (c[0] as string).endsWith('/upload-ticket'));
+      expect((ticketCall?.[1] as { contentType?: string } | undefined)?.contentType).toBe(
+        'application/octet-stream'
+      );
+    });
+  });
 });

--- a/packages/@granit/react-documents/src/__tests__/versions-timeline.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/versions-timeline.test.tsx
@@ -1,6 +1,7 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { VersionsTimeline } from '../components/versions-timeline.tsx';
@@ -71,5 +72,62 @@ describe('VersionsTimeline', () => {
     await waitFor(() => expect(screen.getByText('Initial upload')).toBeInTheDocument());
     expect(screen.getByText('2.0 KB')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Download' })).toBeInTheDocument();
+  });
+
+  it('renders a non-current version row without the current marker', async () => {
+    const client = createMockClient();
+    const older: DocumentVersionResponse = { ...version, id: 'ver-0', isCurrent: false };
+    vi.mocked(client.get).mockResolvedValue({
+      data: { versions: [older, version], totalCount: 2, skip: 0, take: 20 },
+    });
+
+    render(<VersionsTimeline documentId="doc-1" pageSize={2} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getAllByText('Initial upload').length).toBeGreaterThan(0));
+    // only one `current` marker rendered
+    expect(screen.getAllByText(/\(current\)/)).toHaveLength(1);
+  });
+
+  it('paginates to the next page and back when totalCount exceeds the page size', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      data: { versions: [version], totalCount: 5, skip: 0, take: 1 },
+    });
+
+    render(<VersionsTimeline documentId="doc-1" pageSize={1} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('Initial upload')).toBeInTheDocument());
+
+    const nextBtn = screen.getByRole('button', { name: 'Next' });
+    expect(nextBtn).not.toBeDisabled();
+    await userEvent.click(nextBtn);
+
+    const prevBtn = screen.getByRole('button', { name: 'Previous' });
+    expect(prevBtn).not.toBeDisabled();
+    await userEvent.click(prevBtn);
+  });
+
+  it('opens a new window when the user clicks Download', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.includes('/download')) {
+        return Promise.resolve({ data: { url: 'https://blob.example/get', expiresAt: 'x' } });
+      }
+      return Promise.resolve({
+        data: { versions: [version], totalCount: 1, skip: 0, take: 20 },
+      });
+    }) as AxiosInstance['get']);
+    const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+    render(<VersionsTimeline documentId="doc-1" />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Initial upload')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Download' }));
+    await waitFor(() => expect(openSpy).toHaveBeenCalled());
+    expect(openSpy.mock.calls[0]?.[0]).toBe('https://blob.example/get');
   });
 });


### PR DESCRIPTION
## Summary

Post-merge CI fix for [#434](https://github.com/granit-fx/granit-front/pull/434). After the documents module landed, the workspace-global branches coverage dropped to **79.71%** — under the 80% gate — because the components shipped in #434 were only smoke-tested.

This PR adds 11 targeted tests across three component test files to bring the workspace global to **81.00% (3826/4723)**, comfortably clearing the gate.

- `share-dialog.test.tsx` — folder grant flow with full draft setters, document grant (no isDefault), empty-grantee no-op, Cancel button.
- `document-detail.test.tsx` — not-found state, no-description fallback, onOpenVersions / onOpenShares callback wiring, download flow with `window.open` spy, Escape cancel on rename, no-op rename when value unchanged.
- `documents-list.test.tsx` — error state, no-`onOpenDocument` plain-span branch.

No component implementations were changed.

## Test plan
- [x] `npx vitest run packages/@granit/react-documents` — 130/130 pass (was 119)
- [x] `pnpm lint --max-warnings 0` clean
- [x] `pnpm tsc` clean
- [x] `npx vitest run --coverage` — branches **81.00%** (was 79.71%)