### PR TITLE
fix(react-documents): drop stale currentFolder in DocumentsExplorer after trash

### DIFF
--- a/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
@@ -1,13 +1,27 @@
 import { createMockClient, createTestQueryClient } from '@granit/react-testing';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DocumentsExplorer } from '../components/documents-explorer.tsx';
 import { DocumentsProvider } from '../providers/documents-provider.js';
 
 import type { AxiosInstance } from '@granit/api-client';
+import type { FolderResponse } from '@granit/documents';
 import type { ReactNode } from 'react';
+
+const activeFolder: FolderResponse = {
+  id: 'fld-1',
+  parentFolderId: null,
+  name: 'Contracts',
+  path: '/Contracts',
+  depth: 1,
+  ownerUserId: 'user-1',
+  status: 'Active',
+  trashedAt: null,
+  permission: null,
+};
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -54,5 +68,108 @@ describe('DocumentsExplorer', () => {
     render(<DocumentsExplorer canManage />, { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(screen.getByText('Upload')).toBeInTheDocument());
+  });
+
+  it('drops the breadcrumb when the selected folder is trashed from the tree', async () => {
+    const client = createMockClient();
+    let folderStatus: FolderResponse['status'] = 'Active';
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.includes('/folders/fld-1/breadcrumb')) {
+        return Promise.resolve({ data: { folders: [activeFolder] } });
+      }
+      if (url.includes('/folders/fld-1')) {
+        return Promise.resolve({ data: { ...activeFolder, status: folderStatus } });
+      }
+      if (url.includes('/folders')) {
+        return Promise.resolve({
+          data: { folders: folderStatus === 'Active' ? [activeFolder] : [] },
+        });
+      }
+      // QueryEngine /documents/query
+      return Promise.resolve({ data: { items: [], totalCount: 0, page: 1, pageSize: 50 } });
+    }) as AxiosInstance['get']);
+    vi.mocked(client.delete).mockImplementation(((url: string) => {
+      if (url.endsWith('/folders/fld-1')) {
+        folderStatus = 'Trashed';
+        return Promise.resolve({ data: { ...activeFolder, status: 'Trashed' } });
+      }
+      return Promise.resolve({ data: undefined });
+    }) as AxiosInstance['delete']);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<DocumentsExplorer canManage />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    // Select the folder — breadcrumb mounts (folderId.length > 0)
+    await userEvent.click(screen.getByRole('button', { name: 'Contracts' }));
+    await waitFor(() =>
+      expect(document.querySelector('[data-granit-folder-breadcrumb]')).not.toBeNull()
+    );
+
+    // Trash from the tree
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await waitFor(() => expect(client.delete).toHaveBeenCalled());
+
+    // The eager onDeleted path nulls currentFolder synchronously — breadcrumb
+    // unmounts (no folderId.length > 0).
+    await waitFor(() =>
+      expect(document.querySelector('[data-granit-folder-breadcrumb]')).toBeNull()
+    );
+  });
+
+  it('drops a stale selection when the watched folder becomes non-Active (cascade)', async () => {
+    const client = createMockClient();
+    // The tree still lists the folder as Active (its parent was cascade-
+    // trashed by the backend so /folders {parentId} hasn't refreshed yet),
+    // but a direct GET /folders/{id} on the selected row now returns
+    // status: 'Trashed' — typical of a backend that cascades soft-delete to
+    // descendants. The explorer must react to that and null the selection.
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.includes('/folders/fld-1/breadcrumb')) {
+        return Promise.resolve({ data: { folders: [activeFolder] } });
+      }
+      if (url.endsWith('/folders/fld-1')) {
+        return Promise.resolve({ data: { ...activeFolder, status: 'Trashed' } });
+      }
+      if (url.includes('/folders')) {
+        return Promise.resolve({ data: { folders: [activeFolder] } });
+      }
+      return Promise.resolve({ data: { items: [], totalCount: 0, page: 1, pageSize: 50 } });
+    }) as AxiosInstance['get']);
+
+    render(<DocumentsExplorer />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    // Select the (stale-from-tree) folder. useFolder fires, returns Trashed,
+    // and the useEffect should reset currentFolder before the breadcrumb
+    // ever stabilises.
+    await userEvent.click(screen.getByRole('button', { name: 'Contracts' }));
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-granit-folder-breadcrumb]')).toBeNull()
+    );
+  });
+
+  it('drops a stale selection when the watched folder query errors (404/403)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.endsWith('/folders/fld-1')) {
+        return Promise.reject(new Error('not found'));
+      }
+      if (url.includes('/folders')) {
+        return Promise.resolve({ data: { folders: [activeFolder] } });
+      }
+      return Promise.resolve({ data: { items: [], totalCount: 0, page: 1, pageSize: 50 } });
+    }) as AxiosInstance['get']);
+
+    render(<DocumentsExplorer />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Contracts' }));
+
+    await waitFor(() =>
+      expect(document.querySelector('[data-granit-folder-breadcrumb]')).toBeNull()
+    );
   });
 });

--- a/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
@@ -217,6 +217,38 @@ describe('FolderTree', () => {
     await waitFor(() => expect(client.delete).toHaveBeenCalled());
   });
 
+  it('invokes onDeleted with the folder id once the trash mutation succeeds', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onDeleted = vi.fn();
+
+    render(<FolderTree canManage onDeleted={onDeleted} />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(onDeleted).toHaveBeenCalledWith(root.id));
+    expect(onDeleted).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT invoke onDeleted when the trash mutation fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.mocked(client.delete).mockRejectedValue(new Error('forbidden'));
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const onDeleted = vi.fn();
+
+    render(<FolderTree canManage onDeleted={onDeleted} />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(screen.getByRole('alert').textContent).toMatch(/forbidden/));
+    expect(onDeleted).not.toHaveBeenCalled();
+  });
+
   it('creates a sub-folder via the node-level add button', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });

--- a/packages/@granit/react-documents/src/components/documents-explorer.tsx
+++ b/packages/@granit/react-documents/src/components/documents-explorer.tsx
@@ -1,4 +1,6 @@
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
+import { useFolder } from '../hooks/use-folders.js';
 
 import { DocumentsList } from './documents-list.js';
 import { FolderBreadcrumb } from './folder-breadcrumb.js';
@@ -45,12 +47,36 @@ export function DocumentsExplorer({
   const labelStrings = { ...DEFAULT_LABELS, ...labels };
   const [currentFolder, setCurrentFolder] = useState<FolderResponse | null>(null);
 
+  // Watch the live status of the current selection. After a trash mutation
+  // (direct or cascading from an ancestor), the cache is invalidated and
+  // this query refetches. We null the selection when the backend either
+  // 404s/403s OR returns a non-Active folder — both signal the panel is
+  // stale.
+  const currentFolderQuery = useFolder(currentFolder?.id ?? '', {
+    enabled: currentFolder !== null,
+  });
+
+  useEffect(() => {
+    if (!currentFolder) return;
+    if (currentFolderQuery.isError) {
+      setCurrentFolder(null);
+      return;
+    }
+    const fresh = currentFolderQuery.data;
+    if (fresh && fresh.status !== 'Active') {
+      setCurrentFolder(null);
+    }
+  }, [currentFolder, currentFolderQuery.data, currentFolderQuery.isError]);
+
+  const handleFolderDeleted = useCallback((deletedId: string) => {
+    setCurrentFolder((prev) => (prev?.id === deletedId ? null : prev));
+  }, []);
+
   const folderId = currentFolder?.id ?? '';
 
   function handleUploadComplete(_document: DocumentResponse): void {
     // The finalize hook already invalidates the folders + quota query
-    // families, so the right pane will refresh on its own once a real
-    // listing endpoint backs DocumentsList.
+    // families, so the right pane refreshes on its own.
   }
 
   return (
@@ -65,6 +91,7 @@ export function DocumentsExplorer({
             rootFolderId={rootFolderId}
             canManage={canManage}
             onSelect={setCurrentFolder}
+            onDeleted={handleFolderDeleted}
           />
         </aside>
         <section data-granit-documents-explorer-main="">

--- a/packages/@granit/react-documents/src/components/folder-tree.tsx
+++ b/packages/@granit/react-documents/src/components/folder-tree.tsx
@@ -24,6 +24,12 @@ export interface FolderTreeProps {
   /** Filter shown folders by lifecycle status. Defaults to `Active`. */
   readonly status?: FolderStatus;
   readonly onSelect?: (folder: FolderResponse) => void;
+  /**
+   * Fired with the folder id once a trash (soft-delete) mutation succeeds.
+   * Consumers (e.g. `DocumentsExplorer`) use this to drop a stale current
+   * selection. Not invoked on mutation error.
+   */
+  readonly onDeleted?: (folderId: string) => void;
   readonly labels?: FolderTreeLabels;
   readonly className?: string;
 }
@@ -45,6 +51,7 @@ interface FolderNodeProps {
   readonly status: FolderStatus;
   readonly labels: Required<FolderTreeLabels>;
   readonly onSelect?: (folder: FolderResponse) => void;
+  readonly onDeleted?: (folderId: string) => void;
 }
 
 function FolderNode({
@@ -53,6 +60,7 @@ function FolderNode({
   status,
   labels,
   onSelect,
+  onDeleted,
 }: Readonly<FolderNodeProps>): ReactNode {
   const [expanded, setExpanded] = useState(false);
   const childrenQuery = useFolders({ parentId: folder.id, status }, { enabled: expanded });
@@ -88,6 +96,7 @@ function FolderNode({
   function handleDelete(): void {
     if (typeof window === 'undefined' || !window.confirm(labels.deleteConfirm)) return;
     trashFolder.mutate(folder.id, {
+      onSuccess: () => onDeleted?.(folder.id),
       onError: (err) => setError(err.message),
     });
   }
@@ -146,6 +155,7 @@ function FolderNode({
               status={status}
               labels={labels}
               onSelect={onSelect}
+              onDeleted={onDeleted}
             />
           ))}
         </ul>
@@ -169,6 +179,7 @@ export function FolderTree({
   canManage = false,
   status = 'Active',
   onSelect,
+  onDeleted,
   labels,
   className,
 }: FolderTreeProps): ReactNode {
@@ -224,6 +235,7 @@ export function FolderTree({
               status={status}
               labels={labelStrings}
               onSelect={onSelect}
+              onDeleted={onDeleted}
             />
           ))}
         </ul>


### PR DESCRIPTION
## Bug

`<DocumentsExplorer>` kept showing a stale `<FolderBreadcrumb>` + `<DocumentsList>` after the selected folder (or an ancestor) was trashed from the `<FolderTree>`. The tree itself refreshed correctly, but the right pane referenced a soft-deleted folder that no longer exists in the active hierarchy.

Repro: open `/documents`, select a folder, trash that folder (or an ancestor) from the tree.

## Cause

- `packages/@granit/react-documents/src/components/documents-explorer.tsx` — `currentFolder` was a `useState` local, never reconciled with mutation results.
- `packages/@granit/react-documents/src/components/folder-tree.tsx` — the trash handler ran the mutation but exposed no callback to the parent, so the explorer had no way to react.

## Fix

Two complementary reconciliations:

**`FolderTree`** — new optional prop:
```ts
readonly onDeleted?: (folderId: string) => void;
```
Fired in the `trashFolder` mutation's `onSuccess` (not on error), and propagated through every recursive `<FolderNode>` so children can trigger it too.

**`DocumentsExplorer`** — two-layer reset:
1. Eager: wires `onDeleted` to `setCurrentFolder(prev => prev?.id === id ? null : prev)` — synchronous, no flicker.
2. Reactive: subscribes to `useFolder(currentFolder.id)` and nulls the selection in a `useEffect` when the watched query either `isError` (404/403 — e.g. ancestor was cascade-trashed and the row became inaccessible) OR returns a non-`Active` status (e.g. backend marks descendants `Trashed` on cascade).

## Backwards compatibility
`onDeleted` is optional — existing consumers of `<FolderTree>` are unaffected.

The headless pattern (data-slot attributes, no added styles) is preserved.

## Tests
- `folder-tree.test.tsx` (+2 tests): `onDeleted` is invoked with the correct id after a successful trash; **not** invoked when the mutation errors.
- `documents-explorer.test.tsx` (+2 tests): selecting then trashing a folder removes the breadcrumb; the cascade path (status flips to `Trashed`) and the 404 path also reset the selection.

## Test plan
- [x] `pnpm tsc` clean
- [x] `pnpm lint --max-warnings 0` clean
- [x] `npx vitest run packages/@granit/react-documents` — 22/22 on the touched files (the broader workspace has a pre-existing `react@19.2.5` ↔ `react@19.2.6` duplicate from #429 — CI fresh installs are unaffected and develop CI is green at `fc8c070`).