### PR TITLE
refactor: prefix internal API hook paths with /api/v1

### DIFF
--- a/packages/@granit/metering/src/__tests__/metering-api.test.ts
+++ b/packages/@granit/metering/src/__tests__/metering-api.test.ts
@@ -75,9 +75,11 @@ const sampleQuota: MeteringQuotaStatusResponse = {
 
 describe('metering-api', () => {
   describe('listActiveMeters', () => {
-    it('should GET {basePath}/meters', async () => {
+    it('should GET {basePath}/meters and unwrap the paged envelope', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleMeter] });
+      vi.mocked(client.get).mockResolvedValue({
+        data: { items: [sampleMeter], totalCount: 1 },
+      });
 
       const result = await listActiveMeters(client, basePath);
 
@@ -238,7 +240,9 @@ describe('metering-api', () => {
 
   it('should work with custom basePath', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ data: [sampleMeter] });
+    vi.mocked(client.get).mockResolvedValue({
+      data: { items: [sampleMeter], totalCount: 1 },
+    });
 
     await listActiveMeters(client, '/custom/metering');
 

--- a/packages/@granit/metering/src/api/metering-api.ts
+++ b/packages/@granit/metering/src/api/metering-api.ts
@@ -25,6 +25,7 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 import type {
   CreateSavedViewRequest,
+  PagedResult,
   QueryMetadata,
   SavedViewSummary,
   UpdateSavedViewRequest,
@@ -44,14 +45,15 @@ function usageAggregatesPath(basePath: string): string {
 /**
  * List all active meter definitions.
  *
- * `GET {basePath}/meters`
+ * `GET {basePath}/meters` — QueryEngine-backed, returns a paged envelope which
+ * is unwrapped to a flat array for callers that just want the active set.
  */
 export async function listActiveMeters(
   client: AxiosInstance,
   basePath: string
 ): Promise<readonly MeterDefinitionResponse[]> {
-  const response = await client.get<readonly MeterDefinitionResponse[]>(`${basePath}/meters`);
-  return response.data;
+  const response = await client.get<PagedResult<MeterDefinitionResponse>>(`${basePath}/meters`);
+  return response.data.items;
 }
 
 /**

--- a/packages/@granit/react-analytics/src/api/use-metric.ts
+++ b/packages/@granit/react-analytics/src/api/use-metric.ts
@@ -5,7 +5,7 @@ import { useMemo } from 'react';
 
 import type { MetricRequest, MetricResponse } from '@granit/analytics';
 
-const METRIC_PATH = '/analytics/metrics';
+const METRIC_PATH = '/api/v1/analytics/metrics';
 
 const POLLING_INTERVAL_MS: Readonly<Record<MetricResponse['refreshHint'], number | false>> = {
   Static: false,

--- a/packages/@granit/react-dashboards/src/__tests__/expand-action-params.test.ts
+++ b/packages/@granit/react-dashboards/src/__tests__/expand-action-params.test.ts
@@ -17,10 +17,10 @@ describe('expandActionPlaceholders', () => {
 
   it('substitutes ${aliasName} placeholders from the alias map', () => {
     expect(
-      expandActionPlaceholders('/dashboards/${currentTenant}', {
+      expandActionPlaceholders('/api/v1/dashboards/${currentTenant}', {
         aliases: { currentTenant: 't-7' },
       })
-    ).toBe('/dashboards/t-7');
+    ).toBe('/api/v1/dashboards/t-7');
   });
 
   it('mixes row + alias placeholders in the same value', () => {

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
@@ -90,8 +90,10 @@ let lastBody: unknown = null;
 
 function freshHandlers() {
   return [
-    http.get('http://localhost/dashboards/catalog', () => HttpResponse.json([CATALOG_ENTRY])),
-    http.get('http://localhost/dashboards', ({ request }) => {
+    http.get('http://localhost/api/v1/dashboards/catalog', () =>
+      HttpResponse.json([CATALOG_ENTRY])
+    ),
+    http.get('http://localhost/api/v1/dashboards', ({ request }) => {
       lastQueryParams = new URL(request.url).searchParams;
       const response: PagedResponse<DashboardSummaryResponse> = {
         items: [SUMMARY],
@@ -101,30 +103,33 @@ function freshHandlers() {
       };
       return HttpResponse.json(response);
     }),
-    http.get(`http://localhost/dashboards/${encodeURIComponent(ID)}`, () =>
+    http.get(`http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}`, () =>
       HttpResponse.json(DETAIL)
     ),
     http.post(
-      `http://localhost/dashboards/from-definition/${encodeURIComponent(DEFINITION_NAME)}`,
+      `http://localhost/api/v1/dashboards/from-definition/${encodeURIComponent(DEFINITION_NAME)}`,
       () => HttpResponse.json(IMPORTED, { status: 201 })
     ),
-    http.put(`http://localhost/dashboards/${encodeURIComponent(ID)}`, async ({ request }) => {
-      lastBody = await request.json();
-      return HttpResponse.json(SUMMARY);
-    }),
+    http.put(
+      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}`,
+      async ({ request }) => {
+        lastBody = await request.json();
+        return HttpResponse.json(SUMMARY);
+      }
+    ),
     http.post(
-      `http://localhost/dashboards/${encodeURIComponent(ID)}/publish`,
+      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/publish`,
       () => new HttpResponse(null, { status: 204 })
     ),
     http.post(
-      `http://localhost/dashboards/${encodeURIComponent(ID)}/archive`,
+      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/archive`,
       () => new HttpResponse(null, { status: 204 })
     ),
     http.post(
-      `http://localhost/dashboards/${encodeURIComponent(ID)}/restore`,
+      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/restore`,
       () => new HttpResponse(null, { status: 204 })
     ),
-    http.post(`http://localhost/dashboards/${encodeURIComponent(ID)}/resync`, () =>
+    http.post(`http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/resync`, () =>
       HttpResponse.json({
         id: ID,
         name: 'Invoicing overview',
@@ -138,21 +143,21 @@ function freshHandlers() {
       })
     ),
     http.post(
-      `http://localhost/dashboards/${encodeURIComponent(ID)}/widgets`,
+      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/widgets`,
       async ({ request }) => {
         lastBody = await request.json();
         return HttpResponse.json(WIDGET, { status: 201 });
       }
     ),
     http.put(
-      `http://localhost/dashboards/${encodeURIComponent(ID)}/widgets/${encodeURIComponent(WIDGET_ID)}`,
+      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/widgets/${encodeURIComponent(WIDGET_ID)}`,
       async ({ request }) => {
         lastBody = await request.json();
         return HttpResponse.json(WIDGET);
       }
     ),
     http.delete(
-      `http://localhost/dashboards/${encodeURIComponent(ID)}/widgets/${encodeURIComponent(WIDGET_ID)}`,
+      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/widgets/${encodeURIComponent(WIDGET_ID)}`,
       () => new HttpResponse(null, { status: 204 })
     ),
   ];

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-render.test.tsx
@@ -67,7 +67,7 @@ const BUNDLE: DashboardRenderResponse = {
 };
 
 const server = setupServer(
-  http.post(`http://localhost/dashboards/${DASHBOARD_ID}/render`, async () =>
+  http.post(`http://localhost/api/v1/dashboards/${DASHBOARD_ID}/render`, async () =>
     HttpResponse.json(BUNDLE)
   )
 );

--- a/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-pushed-dashboard.test.tsx
@@ -122,7 +122,7 @@ beforeEach(() => {
 
 let nextBundle: DashboardRenderResponse = PUSH_BUNDLE;
 const server = setupServer(
-  http.post(`http://localhost/dashboards/${DASHBOARD_ID}/render`, async () =>
+  http.post(`http://localhost/api/v1/dashboards/${DASHBOARD_ID}/render`, async () =>
     HttpResponse.json(nextBundle)
   )
 );
@@ -200,7 +200,7 @@ describe('usePushedDashboard', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     await waitFor(() => expect(MockEventSource.instances).toHaveLength(1));
     expect(MockEventSource.instances[0]?.url).toBe(
-      `http://localhost/dashboards/${DASHBOARD_ID}/stream`
+      `http://localhost/api/v1/dashboards/${DASHBOARD_ID}/stream`
     );
   });
 

--- a/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-widget-render.test.tsx
@@ -45,7 +45,7 @@ const ENVELOPE: DashboardRenderedWidget = {
 let lastBody: unknown = null;
 
 const server = setupServer(
-  http.post('http://localhost/widgets/markdown/render', async ({ request }) => {
+  http.post('http://localhost/api/v1/widgets/markdown/render', async ({ request }) => {
     lastBody = await request.json();
     return HttpResponse.json(ENVELOPE);
   })
@@ -54,7 +54,7 @@ const server = setupServer(
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => {
   server.resetHandlers(
-    http.post('http://localhost/widgets/markdown/render', async ({ request }) => {
+    http.post('http://localhost/api/v1/widgets/markdown/render', async ({ request }) => {
       lastBody = await request.json();
       return HttpResponse.json(ENVELOPE);
     })

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-catalog.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-catalog.ts
@@ -3,7 +3,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import type { DashboardCatalogEntryResponse } from '@granit/dashboards';
 
-const CATALOG_PATH = '/dashboards/catalog';
+const CATALOG_PATH = '/api/v1/dashboards/catalog';
 
 /**
  * Cache key for the dashboard catalog. Distinct from the persisted-instance

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-detail.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-detail.ts
@@ -3,7 +3,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import type { DashboardDetailResponse } from '@granit/dashboards';
 
-const DASHBOARDS_PATH = '/dashboards';
+const DASHBOARDS_PATH = '/api/v1/dashboards';
 
 /**
  * Cache key for a single persisted dashboard, keyed by its Guid. Used by

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-list.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-list.ts
@@ -3,7 +3,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import type { DashboardStatus, DashboardSummaryResponse, PagedResponse } from '@granit/dashboards';
 
-const DASHBOARDS_PATH = '/dashboards';
+const DASHBOARDS_PATH = '/api/v1/dashboards';
 
 export interface UseDashboardListParams {
   /** Filter by lifecycle state. `undefined` = all statuses. */

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-render.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-render.ts
@@ -16,7 +16,7 @@ import type {
   RefreshHint,
 } from '@granit/dashboards';
 
-const DASHBOARD_PATH = '/dashboards';
+const DASHBOARD_PATH = '/api/v1/dashboards';
 
 /**
  * Polling cadence per {@link RefreshHint} for the bundle-level refetch. The

--- a/packages/@granit/react-dashboards/src/api/use-dashboard-state-transitions.ts
+++ b/packages/@granit/react-dashboards/src/api/use-dashboard-state-transitions.ts
@@ -3,7 +3,7 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 
 import { dashboardDetailQueryKey } from './use-dashboard-detail.js';
 
-const DASHBOARDS_PATH = '/dashboards';
+const DASHBOARDS_PATH = '/api/v1/dashboards';
 
 /**
  * Shared invalidation routine — all three transitions affect the list

--- a/packages/@granit/react-dashboards/src/api/use-import-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/api/use-import-dashboard.ts
@@ -5,7 +5,7 @@ import { dashboardDetailQueryKey } from './use-dashboard-detail.js';
 
 import type { DashboardImportResponse } from '@granit/dashboards';
 
-const DASHBOARDS_PATH = '/dashboards';
+const DASHBOARDS_PATH = '/api/v1/dashboards';
 
 /**
  * `POST /dashboards/from-definition/{name}` — imports a dashboard

--- a/packages/@granit/react-dashboards/src/api/use-resync-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/api/use-resync-dashboard.ts
@@ -5,7 +5,7 @@ import { dashboardDetailQueryKey } from './use-dashboard-detail.js';
 
 import type { DashboardResyncResponse } from '@granit/dashboards';
 
-const DASHBOARDS_PATH = '/dashboards';
+const DASHBOARDS_PATH = '/api/v1/dashboards';
 
 /**
  * `POST /dashboards/{id}/resync` — replays the registered

--- a/packages/@granit/react-dashboards/src/api/use-update-dashboard-metadata.ts
+++ b/packages/@granit/react-dashboards/src/api/use-update-dashboard-metadata.ts
@@ -5,7 +5,7 @@ import { dashboardDetailQueryKey } from './use-dashboard-detail.js';
 
 import type { DashboardMetadataUpdateRequest, DashboardSummaryResponse } from '@granit/dashboards';
 
-const DASHBOARDS_PATH = '/dashboards';
+const DASHBOARDS_PATH = '/api/v1/dashboards';
 
 /**
  * Variables passed to `useUpdateDashboardMetadata().mutate()` —

--- a/packages/@granit/react-dashboards/src/api/use-widget-crud.ts
+++ b/packages/@granit/react-dashboards/src/api/use-widget-crud.ts
@@ -9,7 +9,7 @@ import type {
   WidgetInstanceResponse,
 } from '@granit/dashboards';
 
-const DASHBOARDS_PATH = '/dashboards';
+const DASHBOARDS_PATH = '/api/v1/dashboards';
 
 /**
  * Variables for `useAddWidget().mutate()`.

--- a/packages/@granit/react-dashboards/src/api/use-widget-render.ts
+++ b/packages/@granit/react-dashboards/src/api/use-widget-render.ts
@@ -12,7 +12,7 @@ import type {
   WidgetDefinitionBase,
 } from '@granit/dashboards';
 
-const WIDGET_RENDER_PATH = '/widgets';
+const WIDGET_RENDER_PATH = '/api/v1/widgets';
 
 /**
  * Polling cadence per {@link RefreshHint} for the per-widget render

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-view-crud.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-view-crud.test.tsx
@@ -45,23 +45,23 @@ let listCalls = 0;
 
 function freshHandlers() {
   return [
-    http.get(`http://localhost/entities/${ENCODED}/views`, () => {
+    http.get(`http://localhost/api/v1/entities/${ENCODED}/views`, () => {
       listCalls += 1;
       return HttpResponse.json([VIEW]);
     }),
-    http.post(`http://localhost/entities/${ENCODED}/views`, async ({ request }) => {
+    http.post(`http://localhost/api/v1/entities/${ENCODED}/views`, async ({ request }) => {
       lastBody = await request.json();
       return HttpResponse.json(VIEW, { status: 201 });
     }),
     http.put(
-      `http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`,
+      `http://localhost/api/v1/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`,
       async ({ request }) => {
         lastBody = await request.json();
         return HttpResponse.json({ ...VIEW, name: 'Renamed' });
       }
     ),
     http.delete(
-      `http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`,
+      `http://localhost/api/v1/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`,
       () => new HttpResponse(null, { status: 204 })
     ),
   ];

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-view-flags.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-view-flags.test.tsx
@@ -22,7 +22,7 @@ import type { ReactNode } from 'react';
 const ENTITY = 'Granit.Parties.Party';
 const ENCODED = encodeURIComponent(ENTITY);
 const VIEW_ID = '8c6b1e10-0000-4000-8000-000000000001';
-const VIEW_PATH = `http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`;
+const VIEW_PATH = `http://localhost/api/v1/entities/${ENCODED}/views/${encodeURIComponent(VIEW_ID)}`;
 
 const VIEW: EntityViewResponse = {
   id: VIEW_ID,

--- a/packages/@granit/react-entities-views/src/__tests__/use-entity-views.test.tsx
+++ b/packages/@granit/react-entities-views/src/__tests__/use-entity-views.test.tsx
@@ -47,13 +47,14 @@ const VIEW_B: EntityViewResponse = {
 
 function freshHandlers() {
   return [
-    http.get(`http://localhost/entities/${ENCODED}/views`, () =>
+    http.get(`http://localhost/api/v1/entities/${ENCODED}/views`, () =>
       HttpResponse.json([VIEW_A, VIEW_B])
     ),
-    http.get(`http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_A.id)}`, () =>
-      HttpResponse.json(VIEW_A)
+    http.get(
+      `http://localhost/api/v1/entities/${ENCODED}/views/${encodeURIComponent(VIEW_A.id)}`,
+      () => HttpResponse.json(VIEW_A)
     ),
-    http.get(`http://localhost/entities/${ENCODED}/views/_default`, () =>
+    http.get(`http://localhost/api/v1/entities/${ENCODED}/views/_default`, () =>
       HttpResponse.json(VIEW_A)
     ),
   ];
@@ -103,8 +104,9 @@ describe('useEntityView', () => {
 
   it('reports 404 as an error', async () => {
     server.use(
-      http.get(`http://localhost/entities/${ENCODED}/views/${encodeURIComponent(VIEW_A.id)}`, () =>
-        HttpResponse.json({ error: 'not found' }, { status: 404 })
+      http.get(
+        `http://localhost/api/v1/entities/${ENCODED}/views/${encodeURIComponent(VIEW_A.id)}`,
+        () => HttpResponse.json({ error: 'not found' }, { status: 404 })
       )
     );
     const { wrapper } = makeWrapper();
@@ -130,7 +132,7 @@ describe('useDefaultEntityView', () => {
 
   it('normalises 204 No Content into null', async () => {
     server.use(
-      http.get(`http://localhost/entities/${ENCODED}/views/_default`, () =>
+      http.get(`http://localhost/api/v1/entities/${ENCODED}/views/_default`, () =>
         HttpResponse.text('', { status: 204 })
       )
     );

--- a/packages/@granit/react-entities-views/src/api/use-default-entity-view.ts
+++ b/packages/@granit/react-entities-views/src/api/use-default-entity-view.ts
@@ -30,7 +30,7 @@ export function useDefaultEntityView(
     queryKey: defaultEntityViewQueryKey(entityName),
     queryFn: async ({ signal }) => {
       const response = await api.get<EntityViewResponse | ''>(
-        `/entities/${encodeURIComponent(entityName)}/views/_default`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/_default`,
         { signal }
       );
       if (response.status === 204) {

--- a/packages/@granit/react-entities-views/src/api/use-entity-view-crud.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-view-crud.ts
@@ -36,7 +36,7 @@ export function useCreateEntityView(
   return useMutation({
     mutationFn: async (request) => {
       const { data } = await api.post<EntityViewResponse>(
-        `/entities/${encodeURIComponent(entityName)}/views`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views`,
         request
       );
       return data;
@@ -65,7 +65,7 @@ export function useUpdateEntityView(
   return useMutation({
     mutationFn: async ({ id, request }) => {
       const { data } = await api.put<EntityViewResponse>(
-        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`,
         request
       );
       return data;
@@ -91,7 +91,7 @@ export function useDeleteEntityView(entityName: string): UseMutationResult<void,
   return useMutation({
     mutationFn: async (id) => {
       await api.delete(
-        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`
       );
     },
     onSuccess: async (_void, id) => {

--- a/packages/@granit/react-entities-views/src/api/use-entity-view-flags.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-view-flags.ts
@@ -34,7 +34,7 @@ export function useSetEntityViewPinned(
   return useMutation({
     mutationFn: async ({ id, value }) => {
       const { data } = await api.post<EntityViewResponse>(
-        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/pin`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/pin`,
         { value }
       );
       return data;
@@ -65,7 +65,7 @@ export function useSetEntityViewTenantDefault(
   return useMutation({
     mutationFn: async ({ id, value }) => {
       const { data } = await api.post<EntityViewResponse>(
-        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/set-default`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/set-default`,
         { value }
       );
       return data;
@@ -95,7 +95,7 @@ export function useSetEntityViewPersonalDefault(
   return useMutation({
     mutationFn: async ({ id, value }) => {
       const { data } = await api.post<EntityViewResponse>(
-        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/star`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/star`,
         { value }
       );
       return data;
@@ -124,7 +124,7 @@ export function useShareEntityView(
   return useMutation({
     mutationFn: async ({ id, request }) => {
       const { data } = await api.post<EntityViewResponse>(
-        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/share`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}/share`,
         request
       );
       return data;

--- a/packages/@granit/react-entities-views/src/api/use-entity-view.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-view.ts
@@ -26,7 +26,7 @@ export function useEntityView(
     queryKey: entityViewQueryKey(entityName, id),
     queryFn: async ({ signal }) => {
       const { data } = await api.get<EntityViewResponse>(
-        `/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views/${encodeURIComponent(id)}`,
         { signal }
       );
       return data;

--- a/packages/@granit/react-entities-views/src/api/use-entity-views.ts
+++ b/packages/@granit/react-entities-views/src/api/use-entity-views.ts
@@ -32,7 +32,7 @@ export function useEntityViews(
     queryKey: entityViewsQueryKey(entityName),
     queryFn: async ({ signal }) => {
       const { data } = await api.get<readonly EntityViewResponse[]>(
-        `/entities/${encodeURIComponent(entityName)}/views`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/views`,
         { signal }
       );
       return data;

--- a/packages/@granit/react-entities/src/__tests__/bulk-action.test.ts
+++ b/packages/@granit/react-entities/src/__tests__/bulk-action.test.ts
@@ -9,7 +9,7 @@ import type { BulkActionResponse } from '@granit/entities';
 
 const ENTITY = 'Granit.Sales.Quote';
 const ACTION = 'Approve';
-const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/bulk/${encodeURIComponent(ACTION)}`;
+const PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY)}/bulk/${encodeURIComponent(ACTION)}`;
 
 const RESPONSE: BulkActionResponse = {
   ok: ['q-1', 'q-2'],
@@ -67,7 +67,7 @@ describe('executeBulkAction', () => {
   it('URI-encodes the entity name and the action segment', async () => {
     const tricky = 'Tenant.Module.Entity Name';
     const trickyAction = 'Mark Done';
-    const url = `http://localhost/entities/${encodeURIComponent(tricky)}/bulk/${encodeURIComponent(trickyAction)}`;
+    const url = `http://localhost/api/v1/entities/${encodeURIComponent(tricky)}/bulk/${encodeURIComponent(trickyAction)}`;
     server.use(http.post(url, () => HttpResponse.json(RESPONSE)));
 
     const response = await executeBulkAction(client, tricky, trickyAction, { ids: ['x-1'] });

--- a/packages/@granit/react-entities/src/__tests__/entity-calendar.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-calendar.test.tsx
@@ -12,7 +12,7 @@ import type { CalendarItemResponse, EntityCalendarLayoutManifest } from '@granit
 import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Invoicing.Invoice';
-const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/calendar`;
+const PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY)}/calendar`;
 const FROM = '2026-05-01T00:00:00Z';
 const TO = '2026-05-31T23:59:59Z';
 

--- a/packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail-relation-modes.test.tsx
@@ -18,7 +18,7 @@ import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Parties.Party';
 const ID = '8c6b1e10-0000-4000-8000-000000000001';
-const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
+const PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
 
 const variant: EntityDetailManifest = {
   name: 'default',

--- a/packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-detail-smart-buttons.test.tsx
@@ -18,7 +18,7 @@ import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Parties.Party';
 const ID = '8c6b1e10-0000-4000-8000-000000000001';
-const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
+const PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
 
 const variant: EntityDetailManifest = {
   name: 'default',

--- a/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
@@ -17,7 +17,7 @@ import type {
 import type { ReactNode } from 'react';
 
 const ENTITY_NAME = 'Granit.Sales.Quote';
-const BULK_PATH = `http://localhost/entities/${encodeURIComponent(ENTITY_NAME)}/bulk/approve`;
+const BULK_PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY_NAME)}/bulk/approve`;
 
 const FULL_SUCCESS: BulkActionResponse = {
   ok: ['q1', 'q2', 'q3'],

--- a/packages/@granit/react-entities/src/__tests__/use-entity-calendar.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-calendar.test.tsx
@@ -12,7 +12,7 @@ import type { CalendarItemResponse } from '@granit/entities';
 import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Invoicing.Invoice';
-const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/calendar`;
+const PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY)}/calendar`;
 const FROM = '2026-05-01T00:00:00Z';
 const TO = '2026-05-31T23:59:59Z';
 

--- a/packages/@granit/react-entities/src/__tests__/use-entity-discovery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-discovery.test.tsx
@@ -36,7 +36,7 @@ let getCalls = 0;
 
 function freshHandlers() {
   return [
-    http.get('http://localhost/entities', () => {
+    http.get('http://localhost/api/v1/entities', () => {
       getCalls += 1;
       return HttpResponse.json(DISCOVERY);
     }),
@@ -93,7 +93,7 @@ describe('useEntityDiscovery', () => {
 
   it('surfaces the error when the endpoint returns 500', async () => {
     server.use(
-      http.get('http://localhost/entities', () =>
+      http.get('http://localhost/api/v1/entities', () =>
         HttpResponse.json({ error: 'boom' }, { status: 500 })
       )
     );

--- a/packages/@granit/react-entities/src/__tests__/use-entity-metadata.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-metadata.test.tsx
@@ -46,7 +46,7 @@ let getCalls = 0;
 
 function freshHandlers() {
   return [
-    http.get(`http://localhost/entities/${ENCODED}`, ({ request }) => {
+    http.get(`http://localhost/api/v1/entities/${ENCODED}`, ({ request }) => {
       getCalls += 1;
       const url = new URL(request.url);
       lastRequest = {
@@ -91,7 +91,7 @@ describe('useEntityMetadata', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(FULL);
-    expect(lastRequest?.url).toBe(`/entities/${ENCODED}`);
+    expect(lastRequest?.url).toBe(`/api/v1/entities/${ENCODED}`);
   });
 
   it('serialises facets as a sorted CSV under ?facets=', async () => {
@@ -100,7 +100,7 @@ describe('useEntityMetadata', () => {
       wrapper,
     });
     await waitFor(() => expect(lastRequest?.url.includes('facets=')).toBe(true));
-    expect(lastRequest?.url).toBe(`/entities/${ENCODED}?facets=forms,identity`);
+    expect(lastRequest?.url).toBe(`/api/v1/entities/${ENCODED}?facets=forms,identity`);
   });
 
   it('shares the cache slot regardless of the facets array order', () => {
@@ -142,7 +142,7 @@ describe('useEntityMetadata', () => {
 
   it('surfaces the error when the endpoint returns 500', async () => {
     server.use(
-      http.get(`http://localhost/entities/${ENCODED}`, () =>
+      http.get(`http://localhost/api/v1/entities/${ENCODED}`, () =>
         HttpResponse.json({ error: 'boom' }, { status: 500 })
       )
     );

--- a/packages/@granit/react-entities/src/__tests__/use-entity-relation-aggregates.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/use-entity-relation-aggregates.test.tsx
@@ -16,7 +16,7 @@ import type { ReactNode } from 'react';
 
 const ENTITY = 'Granit.Parties.Party';
 const ID = '8c6b1e10-0000-4000-8000-000000000001';
-const PATH = `http://localhost/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
+const PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY)}/${encodeURIComponent(ID)}/relations/aggregates`;
 
 const RESPONSE: RelationAggregatesResponse = {
   aggregates: {

--- a/packages/@granit/react-entities/src/api/bulk-action.ts
+++ b/packages/@granit/react-entities/src/api/bulk-action.ts
@@ -26,7 +26,7 @@ export async function executeBulkAction(
   request: BulkActionRequest
 ): Promise<BulkActionResponse> {
   const response = await client.post<BulkActionResponse>(
-    `/entities/${encodeURIComponent(entityName)}/bulk/${encodeURIComponent(action)}`,
+    `/api/v1/entities/${encodeURIComponent(entityName)}/bulk/${encodeURIComponent(action)}`,
     request
   );
   return response.data;

--- a/packages/@granit/react-entities/src/api/use-entity-calendar.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-calendar.ts
@@ -127,7 +127,7 @@ export function useEntityCalendar(
         }
       }
       const { data } = await api.get<readonly CalendarItemResponse[]>(
-        `/entities/${encodeURIComponent(entityName)}/calendar`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/calendar`,
         { params, signal }
       );
       return data;

--- a/packages/@granit/react-entities/src/api/use-entity-discovery.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-discovery.ts
@@ -3,7 +3,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import type { EntityDiscoveryResponse } from '@granit/entities';
 
-const DISCOVERY_PATH = '/entities';
+const DISCOVERY_PATH = '/api/v1/entities';
 
 /**
  * Cache key for the entity discovery tree. Distinct from the per-entity

--- a/packages/@granit/react-entities/src/api/use-entity-metadata.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-metadata.ts
@@ -61,7 +61,7 @@ export function useEntityMetadata(
       }
 
       const response = await api.get<EntityManifestResponse>(
-        `/entities/${encodeURIComponent(name)}`,
+        `/api/v1/entities/${encodeURIComponent(name)}`,
         {
           signal,
           params:

--- a/packages/@granit/react-entities/src/api/use-entity-relation-aggregates.ts
+++ b/packages/@granit/react-entities/src/api/use-entity-relation-aggregates.ts
@@ -59,7 +59,7 @@ export function useEntityRelationAggregates(
           ? { relations: [...relations].sort((a, b) => a.localeCompare(b)) }
           : null;
       const { data } = await api.post<RelationAggregatesResponse>(
-        `/entities/${encodeURIComponent(entityName)}/${encodeURIComponent(entityId)}/relations/aggregates`,
+        `/api/v1/entities/${encodeURIComponent(entityName)}/${encodeURIComponent(entityId)}/relations/aggregates`,
         body,
         { signal }
       );

--- a/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
+++ b/packages/@granit/react-metering/src/__tests__/use-metering.test.tsx
@@ -81,7 +81,9 @@ describe('use-metering', () => {
   describe('useActiveMeters', () => {
     it('fetches active meters with default basePath', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleMeter] });
+      vi.mocked(client.get).mockResolvedValue({
+        data: { items: [sampleMeter], totalCount: 1 },
+      });
 
       const { result } = renderHook(() => useActiveMeters(), {
         wrapper: createWrapper(client),
@@ -94,7 +96,9 @@ describe('use-metering', () => {
 
     it('uses custom basePath', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [] });
+      vi.mocked(client.get).mockResolvedValue({
+        data: { items: [], totalCount: 0 },
+      });
 
       const { result } = renderHook(() => useActiveMeters(), {
         wrapper: createWrapper(client, '/custom/metering'),

--- a/packages/@granit/react-metering/src/testing/handlers.ts
+++ b/packages/@granit/react-metering/src/testing/handlers.ts
@@ -148,9 +148,10 @@ export function createMeteringHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // GET /meters/meta — query metadata
     createQueryMetaHandler(`${baseUrl}/meters`, meterQueryMetadata),
 
-    // GET list active meters
+    // GET list active meters — QueryEngine-backed paged envelope
     http.get(`${baseUrl}/meters`, () => {
-      return HttpResponse.json(meters.filter((m) => m.activated));
+      const items = meters.filter((m) => m.activated);
+      return HttpResponse.json({ items, totalCount: items.length });
     }),
 
     // GET single meter by ID

--- a/packages/@granit/react-workspaces/src/__tests__/use-landing-redirect.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-landing-redirect.test.tsx
@@ -20,7 +20,7 @@ let getCalls = 0;
 
 function freshHandlers() {
   return [
-    http.get('http://localhost/me/landing-route', () => {
+    http.get('http://localhost/api/v1/me/landing-route', () => {
       getCalls += 1;
       return HttpResponse.json(ROUTE);
     }),

--- a/packages/@granit/react-workspaces/src/__tests__/use-landing-route.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-landing-route.test.tsx
@@ -25,11 +25,11 @@ let lastPinBody: unknown = null;
 
 function freshHandlers() {
   return [
-    http.get('http://localhost/me/landing-route', () => {
+    http.get('http://localhost/api/v1/me/landing-route', () => {
       getCalls += 1;
       return HttpResponse.json(ROUTE);
     }),
-    http.put('http://localhost/me/landing-route/pinned', async ({ request }) => {
+    http.put('http://localhost/api/v1/me/landing-route/pinned', async ({ request }) => {
       lastPinBody = await request.json();
       return new HttpResponse(null, { status: 204 });
     }),
@@ -85,7 +85,7 @@ describe('useLandingRoute', () => {
 });
 
 describe('useSetLandingPin', () => {
-  it('PUTs the route to /me/landing-route/pinned', async () => {
+  it('PUTs the route to /api/v1/me/landing-route/pinned', async () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useSetLandingPin(), { wrapper });
 

--- a/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
@@ -50,7 +50,7 @@ let getCalls = 0;
 
 function freshHandlers() {
   return [
-    http.get('http://localhost/workspaces', () => {
+    http.get('http://localhost/api/v1/workspaces', () => {
       getCalls += 1;
       return HttpResponse.json(TREE);
     }),
@@ -106,7 +106,7 @@ describe('useWorkspaces', () => {
 
   it('surfaces the error when the endpoint returns 500', async () => {
     server.use(
-      http.get('http://localhost/workspaces', () =>
+      http.get('http://localhost/api/v1/workspaces', () =>
         HttpResponse.json({ error: 'boom' }, { status: 500 })
       )
     );

--- a/packages/@granit/react-workspaces/src/api/use-landing-route.ts
+++ b/packages/@granit/react-workspaces/src/api/use-landing-route.ts
@@ -9,14 +9,14 @@ import {
 
 import type { LandingRouteResponse, SetPinnedLandingRouteRequest } from '@granit/workspaces';
 
-const LANDING_ROUTE_PATH = '/me/landing-route';
-const LANDING_ROUTE_PINNED_PATH = '/me/landing-route/pinned';
+const LANDING_ROUTE_PATH = '/api/v1/me/landing-route';
+const LANDING_ROUTE_PINNED_PATH = '/api/v1/me/landing-route/pinned';
 
 /** Cache key for the resolved landing route. */
 export const landingRouteQueryKey = () => ['workspaces', 'landing-route'] as const;
 
 /**
- * `GET /me/landing-route` — returns the route the user should be sent to
+ * `GET /api/v1/me/landing-route` — returns the route the user should be sent to
  * after login, plus the tier of the 5-tier resolver that produced it
  * (PersonalSticky / PersonalPinned / Role / Tenant / Framework). Mirrors
  * `Granit.Workspaces.Endpoints.LandingRouteEndpoints.GetAsync`.
@@ -41,7 +41,7 @@ export function useLandingRoute(
 }
 
 /**
- * `PUT /me/landing-route/pinned` — sets (or clears, with `route: null`)
+ * `PUT /api/v1/me/landing-route/pinned` — sets (or clears, with `route: null`)
  * the user's personal pin in the precedence chain. Mirrors
  * `Granit.Workspaces.Endpoints.LandingRouteEndpoints.SetPinnedAsync`.
  *

--- a/packages/@granit/react-workspaces/src/api/use-workspaces.ts
+++ b/packages/@granit/react-workspaces/src/api/use-workspaces.ts
@@ -3,7 +3,7 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import type { WorkspaceTreeResponse } from '@granit/workspaces';
 
-const WORKSPACES_PATH = '/workspaces';
+const WORKSPACES_PATH = '/api/v1/workspaces';
 
 /**
  * Cache key for the workspace tree. Bumped via
@@ -13,7 +13,7 @@ const WORKSPACES_PATH = '/workspaces';
 export const workspaceTreeQueryKey = () => ['workspaces', 'tree'] as const;
 
 /**
- * `GET /workspaces` — returns the workspace tree the requesting user can
+ * `GET /api/v1/workspaces` — returns the workspace tree the requesting user can
  * see, with permission-filtered sections / items, sorted by `order` then
  * `name`. Mirrors `Granit.Workspaces.Endpoints.WorkspacesEndpoints`.
  *


### PR DESCRIPTION
## Summary
- Normalize hook path constants across 7 packages to use `/api/v1/...` instead of bare resource paths, removing reliance on an implicit base URL configured at the Axios / BFF layer.
- `@granit/metering` `listActiveMeters` switches to the `PagedResult` envelope returned by the QueryEngine-backed `GET /meters` endpoint and unwraps `.items` for callers.
- Affected packages: `metering`, `react-analytics`, `react-dashboards`, `react-entities`, `react-entities-views`, `react-metering`, `react-workspaces`.

## Context
These edits were already staged locally at the start of the session; they form a coherent normalization initiative and ship together as one refactor.

## Test plan
- [ ] `pnpm lint`
- [ ] `pnpm tsc`
- [ ] `pnpm test` on the seven touched packages
- [ ] Smoke-check that the consuming app (showcase-admin-react) still resolves the affected endpoints (BFF / Vite proxy may need to be re-confirmed for paths previously prefixed at runtime).