### PR TITLE
feat(workspaces): add Feature item kind + host-side route table (ADR-057 phase 4)

### DIFF
--- a/packages/@granit/react-workspaces/README.md
+++ b/packages/@granit/react-workspaces/README.md
@@ -24,6 +24,41 @@ This package is the React layer on top of [`@granit/workspaces`](../workspaces).
   `⌘+⇧+.` to expand to full page, stacked peeks)
 - `<LandingRedirect />` — calls `useLandingRoute()` on login, honours the
   5-tier precedence and URL whitelist
+- `<FeatureRouteTableProvider />` + `useResolvedWorkspaceItem()` —
+  host-supplied route table for `Feature` items (ADR-057 §5)
+
+## Feature route table (ADR-057)
+
+Items of kind `Feature` carry a logical `routeName`; the host's React
+app owns the mapping to SPA paths. Wrap the nav root once at startup:
+
+```tsx
+import { FeatureRouteTableProvider, useResolvedWorkspaceItem } from '@granit/react-workspaces';
+import type { FeatureRouteTable } from '@granit/workspaces';
+
+const ROUTES: FeatureRouteTable = {
+  'identity.users.list': { path: '/users' },
+  'invoicing.invoices.list': { path: '/invoicing' },
+  'parties.parties.list': { path: '/crm/parties' },
+};
+
+export function AppShell({ children }: { children: ReactNode }) {
+  return <FeatureRouteTableProvider table={ROUTES}>{children}</FeatureRouteTableProvider>;
+}
+
+function WorkspaceItemLink({ item }: { item: WorkspaceItemResponse }) {
+  const { href, missingRoute, featureName } = useResolvedWorkspaceItem(item);
+  if (missingRoute) {
+    return <span title={`Route not registered for feature ${featureName}`}>{item.displayKey}</span>;
+  }
+  return href ? <a href={href}>{item.displayKey}</a> : null;
+}
+```
+
+When a feature is missing from the host table, the hook returns
+`missingRoute: true` and `href: null` — render a disabled placeholder
+rather than navigating. `linkUrl` on `Link` items is unaffected and
+remains valid for internal SPA routes and external URLs.
 
 ## Status
 

--- a/packages/@granit/react-workspaces/src/__tests__/feature-route-context.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/feature-route-context.test.tsx
@@ -1,0 +1,150 @@
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  FeatureRouteTableProvider,
+  resolveWorkspaceItem,
+  useFeatureRouteTable,
+  useResolvedWorkspaceItem,
+} from '../routes/feature-route-context.js';
+
+import type { FeatureRouteTable, WorkspaceItemResponse } from '@granit/workspaces';
+import type { ReactNode } from 'react';
+
+const ROUTES: FeatureRouteTable = {
+  'identity.users.list': { path: '/users' },
+  'invoicing.invoices.list': { path: '/invoicing' },
+};
+
+function makeItem(partial: Partial<WorkspaceItemResponse>): WorkspaceItemResponse {
+  return {
+    kind: 'Feature',
+    order: 0,
+    displayKey: null,
+    icon: null,
+    entityName: null,
+    entityViewName: null,
+    entityPresetOverlay: null,
+    dashboardName: null,
+    linkUrl: null,
+    subWorkspaceName: null,
+    featureName: null,
+    routeName: null,
+    ...partial,
+  };
+}
+
+function withProvider(table: FeatureRouteTable | null) {
+  return ({ children }: { children: ReactNode }) =>
+    table === null ? (
+      <>{children}</>
+    ) : (
+      <FeatureRouteTableProvider table={table}>{children}</FeatureRouteTableProvider>
+    );
+}
+
+describe('resolveWorkspaceItem', () => {
+  it('resolves a Feature item via routeName', () => {
+    const item = makeItem({
+      kind: 'Feature',
+      featureName: 'invoicing.invoices.list',
+      routeName: 'invoicing.invoices.list',
+    });
+    expect(resolveWorkspaceItem(item, ROUTES)).toEqual({
+      href: '/invoicing',
+      missingRoute: false,
+      featureName: 'invoicing.invoices.list',
+      spec: { path: '/invoicing' },
+    });
+  });
+
+  it('falls back to featureName when routeName is null', () => {
+    const item = makeItem({
+      kind: 'Feature',
+      featureName: 'identity.users.list',
+      routeName: null,
+    });
+    expect(resolveWorkspaceItem(item, ROUTES).href).toBe('/users');
+  });
+
+  it('flags missingRoute when the host table has no entry', () => {
+    const item = makeItem({
+      kind: 'Feature',
+      featureName: 'unknown.x.list',
+      routeName: 'unknown.x.list',
+    });
+    const resolved = resolveWorkspaceItem(item, ROUTES);
+    expect(resolved.href).toBeNull();
+    expect(resolved.missingRoute).toBe(true);
+    expect(resolved.featureName).toBe('unknown.x.list');
+  });
+
+  it('flags missingRoute when both routeName and featureName are null', () => {
+    const item = makeItem({ kind: 'Feature' });
+    const resolved = resolveWorkspaceItem(item, ROUTES);
+    expect(resolved.href).toBeNull();
+    expect(resolved.missingRoute).toBe(true);
+  });
+
+  it('passes Link items through unchanged', () => {
+    const item = makeItem({ kind: 'Link', linkUrl: 'https://example.com/docs' });
+    expect(resolveWorkspaceItem(item, ROUTES)).toEqual({
+      href: 'https://example.com/docs',
+      missingRoute: false,
+      featureName: null,
+      spec: null,
+    });
+  });
+
+  it('returns null href for non-Feature, non-Link kinds (URL computed elsewhere)', () => {
+    const entity = makeItem({ kind: 'Entity', entityName: 'Party' });
+    expect(resolveWorkspaceItem(entity, ROUTES).href).toBeNull();
+
+    const dashboard = makeItem({ kind: 'Dashboard', dashboardName: 'Sales' });
+    expect(resolveWorkspaceItem(dashboard, ROUTES).href).toBeNull();
+  });
+});
+
+describe('useFeatureRouteTable', () => {
+  it('returns the provided table inside a provider', () => {
+    const { result } = renderHook(() => useFeatureRouteTable(), {
+      wrapper: withProvider(ROUTES),
+    });
+    expect(result.current).toBe(ROUTES);
+  });
+
+  it('returns an empty table when no provider is mounted', () => {
+    const { result } = renderHook(() => useFeatureRouteTable(), {
+      wrapper: withProvider(null),
+    });
+    expect(result.current).toEqual({});
+  });
+});
+
+describe('useResolvedWorkspaceItem', () => {
+  it('resolves a Feature item against the context table', () => {
+    const item = makeItem({
+      kind: 'Feature',
+      featureName: 'invoicing.invoices.list',
+      routeName: 'invoicing.invoices.list',
+    });
+    const { result } = renderHook(() => useResolvedWorkspaceItem(item), {
+      wrapper: withProvider(ROUTES),
+    });
+    expect(result.current.href).toBe('/invoicing');
+    expect(result.current.missingRoute).toBe(false);
+  });
+
+  it('flags missingRoute without a provider', () => {
+    const item = makeItem({
+      kind: 'Feature',
+      featureName: 'invoicing.invoices.list',
+      routeName: 'invoicing.invoices.list',
+    });
+    const { result } = renderHook(() => useResolvedWorkspaceItem(item), {
+      wrapper: withProvider(null),
+    });
+    expect(result.current.href).toBeNull();
+    expect(result.current.missingRoute).toBe(true);
+  });
+});

--- a/packages/@granit/react-workspaces/src/index.ts
+++ b/packages/@granit/react-workspaces/src/index.ts
@@ -15,6 +15,13 @@ export {
 } from './api/use-landing-route.js';
 export { useWorkspaces, workspaceTreeQueryKey } from './api/use-workspaces.js';
 export { useLandingRedirect, useSidePeek } from './hooks/index.js';
+export {
+  FeatureRouteTableProvider,
+  resolveWorkspaceItem,
+  useFeatureRouteTable,
+  useResolvedWorkspaceItem,
+} from './routes/index.js';
+export type { FeatureRouteTableProviderProps, ResolvedWorkspaceItem } from './routes/index.js';
 export type {
   SidePeekEntry,
   UseLandingRedirectOptions,

--- a/packages/@granit/react-workspaces/src/routes/feature-route-context.tsx
+++ b/packages/@granit/react-workspaces/src/routes/feature-route-context.tsx
@@ -1,0 +1,128 @@
+import {
+  resolveFeatureRoute,
+  type FeatureRouteSpec,
+  type FeatureRouteTable,
+  type WorkspaceItemResponse,
+} from '@granit/workspaces';
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+
+/**
+ * React context that carries the host-supplied `FeatureRouteTable`
+ * (ADR-057 §5) down to the workspace renderer. Hosts wrap the navigation
+ * tree once at startup; nested renderers consume the table without
+ * threading it through props.
+ */
+const FeatureRouteTableContext = createContext<FeatureRouteTable | null>(null);
+
+export interface FeatureRouteTableProviderProps {
+  readonly table: FeatureRouteTable;
+  readonly children: ReactNode;
+}
+
+/**
+ * Host-side provider. Place once near the navigation root.
+ *
+ * @example
+ * ```tsx
+ * const ROUTES: FeatureRouteTable = {
+ *   'identity.users.list': { path: '/users' },
+ *   'invoicing.invoices.list': { path: '/invoicing' },
+ * };
+ *
+ * <FeatureRouteTableProvider table={ROUTES}>
+ *   <WorkspaceNav />
+ * </FeatureRouteTableProvider>
+ * ```
+ */
+export function FeatureRouteTableProvider({
+  table,
+  children,
+}: FeatureRouteTableProviderProps): ReactNode {
+  return (
+    <FeatureRouteTableContext.Provider value={table}>{children}</FeatureRouteTableContext.Provider>
+  );
+}
+
+/**
+ * Hook variant: read the route table from context. Returns an empty
+ * table if no provider was mounted — the renderer then renders all
+ * `Feature` items as placeholders, which matches the spec for "feature
+ * without a frontend route" (ADR-057 §5, bullet 3).
+ */
+export function useFeatureRouteTable(): FeatureRouteTable {
+  return useContext(FeatureRouteTableContext) ?? EMPTY_TABLE;
+}
+
+const EMPTY_TABLE: FeatureRouteTable = Object.freeze({});
+
+/**
+ * Resolved descriptor for a workspace item, ready for a `<NavLink>` or
+ * `<a>` to consume. `href` is `null` for items the renderer should NOT
+ * link out — typically a `Feature` whose route name is missing from the
+ * host's table.
+ */
+export interface ResolvedWorkspaceItem {
+  /** Final SPA path / absolute URL for this item, or `null` if unresolvable. */
+  readonly href: string | null;
+  /**
+   * `true` when the item references a `Feature` whose route is not
+   * registered in the host table — the renderer should display it as a
+   * disabled placeholder (greyed-out label + tooltip).
+   */
+  readonly missingRoute: boolean;
+  /** Pass-through, useful for tooltip copy on missing routes. */
+  readonly featureName: string | null;
+  /** Resolved spec when the lookup hit (mostly for future expansion). */
+  readonly spec: FeatureRouteSpec | null;
+}
+
+/**
+ * Resolve one `WorkspaceItemResponse` against the host's route table.
+ *
+ * - `Feature` items: lookup by `routeName` (falling back to `featureName`),
+ *   return the SPA path or signal `missingRoute`.
+ * - `Link` items: pass `linkUrl` through unchanged (internal SPA route or
+ *   external URL — see ADR-057 §6, `linkUrl` is not deprecated).
+ * - `Entity` / `Dashboard` / `SubWorkspace`: out of scope for this hook —
+ *   `href` is `null` because their URL is computed elsewhere (entity URL
+ *   helpers, dashboard routes, sub-workspace recursion).
+ *
+ * Pure function — no React state. Exported so non-React consumers
+ * (testing, server-side rendering) can reuse the same logic.
+ */
+export function resolveWorkspaceItem(
+  item: WorkspaceItemResponse,
+  table: FeatureRouteTable
+): ResolvedWorkspaceItem {
+  if (item.kind === 'Feature') {
+    const lookupKey = item.routeName ?? item.featureName;
+    if (lookupKey === null || lookupKey.length === 0) {
+      return {
+        href: null,
+        missingRoute: true,
+        featureName: item.featureName,
+        spec: null,
+      };
+    }
+    const spec = resolveFeatureRoute(table, lookupKey);
+    return {
+      href: spec?.path ?? null,
+      missingRoute: spec === null,
+      featureName: item.featureName,
+      spec,
+    };
+  }
+  if (item.kind === 'Link') {
+    return { href: item.linkUrl, missingRoute: false, featureName: null, spec: null };
+  }
+  return { href: null, missingRoute: false, featureName: null, spec: null };
+}
+
+/**
+ * React hook variant of {@link resolveWorkspaceItem} that pulls the
+ * route table from context. Memoised on the item identity + table.
+ */
+export function useResolvedWorkspaceItem(item: WorkspaceItemResponse): ResolvedWorkspaceItem {
+  const table = useFeatureRouteTable();
+  return useMemo(() => resolveWorkspaceItem(item, table), [item, table]);
+}

--- a/packages/@granit/react-workspaces/src/routes/index.ts
+++ b/packages/@granit/react-workspaces/src/routes/index.ts
@@ -1,0 +1,10 @@
+export {
+  FeatureRouteTableProvider,
+  resolveWorkspaceItem,
+  useFeatureRouteTable,
+  useResolvedWorkspaceItem,
+} from './feature-route-context.js';
+export type {
+  FeatureRouteTableProviderProps,
+  ResolvedWorkspaceItem,
+} from './feature-route-context.js';

--- a/packages/@granit/workspaces/README.md
+++ b/packages/@granit/workspaces/README.md
@@ -21,9 +21,32 @@ Party in Accounting = overdue-balance preset).
 - `WorkspaceTreeResponse` + `WorkspaceResponse` / `WorkspaceSectionResponse`
   / `WorkspaceItemResponse` types
 - `WorkspaceItemKind` discriminated union (Entity / Dashboard / Link /
-  SubWorkspace)
+  SubWorkspace / Feature)
 - `LandingRouteResponse` + `LandingRouteSource`
 - Typed preset overlay schema + `composeWorkspacePresetOverlay(manifest, overlay)` helper
+- `FeatureRouteTable` + `resolveFeatureRoute(table, name)` — host-side
+  route name → SPA path lookup (ADR-057 §5)
+
+## Feature route table (ADR-057)
+
+Workspace items of kind `Feature` carry a logical `routeName`
+(`{module}.{entity-plural}.{view}`), not a URL. The host application
+ships a `FeatureRouteTable` mapping each route name to a SPA path; the
+React renderer (or any other consumer) looks the path up at click time.
+
+```ts
+import type { FeatureRouteTable } from '@granit/workspaces';
+
+export const ROUTES: FeatureRouteTable = {
+  'identity.users.list': { path: '/users' },
+  'invoicing.invoices.list': { path: '/invoicing' },
+  'parties.parties.list': { path: '/crm/parties' },
+};
+```
+
+When a feature is not registered in the host's table,
+`resolveFeatureRoute` returns `null` — the renderer should hide the item
+or display a disabled placeholder. The backend never learns about URLs.
 
 The React renderer lives in [`@granit/react-workspaces`](../react-workspaces).
 

--- a/packages/@granit/workspaces/src/__tests__/feature-route-table.test.ts
+++ b/packages/@granit/workspaces/src/__tests__/feature-route-table.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  InvalidFeatureNameError,
+  resolveFeatureRoute,
+  type FeatureRouteTable,
+} from '../routes/feature-route-table.js';
+
+const table: FeatureRouteTable = {
+  'identity.users.list': { path: '/users' },
+  'invoicing.invoices.list': { path: '/invoicing' },
+  'parties.parties.list': { path: '/crm/parties' },
+};
+
+describe('resolveFeatureRoute', () => {
+  it('returns the spec when the feature is registered', () => {
+    expect(resolveFeatureRoute(table, 'invoicing.invoices.list')).toEqual({
+      path: '/invoicing',
+    });
+  });
+
+  it('returns null when the feature is not registered', () => {
+    expect(resolveFeatureRoute(table, 'unknown.feature.name')).toBeNull();
+  });
+
+  it('does not fall back across feature names — exact match only', () => {
+    expect(resolveFeatureRoute(table, 'invoicing.invoices')).toBeNull();
+  });
+
+  it('returns null on an empty registry', () => {
+    expect(resolveFeatureRoute({}, 'invoicing.invoices.list')).toBeNull();
+  });
+
+  it('throws InvalidFeatureNameError on an empty name', () => {
+    expect(() => resolveFeatureRoute(table, '')).toThrow(InvalidFeatureNameError);
+  });
+
+  it('throws InvalidFeatureNameError on a whitespace-only name', () => {
+    expect(() => resolveFeatureRoute(table, '   ')).toThrow(InvalidFeatureNameError);
+  });
+});

--- a/packages/@granit/workspaces/src/index.ts
+++ b/packages/@granit/workspaces/src/index.ts
@@ -20,6 +20,8 @@ export {
   parseWorkspaceUrl,
 } from './url/index.js';
 export type { ParsedEntityUrl, ParsedWorkspaceUrl } from './url/index.js';
+export { InvalidFeatureNameError, resolveFeatureRoute } from './routes/index.js';
+export type { FeatureRouteSpec, FeatureRouteTable } from './routes/index.js';
 export { WORKSPACE_TREE_SCHEMA_VERSION } from './types/index.js';
 export type {
   LandingRouteResponse,

--- a/packages/@granit/workspaces/src/routes/feature-route-table.ts
+++ b/packages/@granit/workspaces/src/routes/feature-route-table.ts
@@ -1,0 +1,62 @@
+/**
+ * Frontend route table primitive (ADR-057 §5).
+ *
+ * Features carry **route names** (`invoicing.invoices.list`), not URLs.
+ * The host app ships a `FeatureRouteTable` mapping each route name to a
+ * SPA path; the workspace renderer looks the path up at click time.
+ *
+ * Two benefits worth recalling here:
+ *
+ * 1. The frontend owns its URLs — renaming `/invoicing` → `/billing/invoices`
+ *    no longer requires a backend deployment.
+ * 2. Different hosts can map the same feature to different paths.
+ */
+
+/**
+ * One row of the route table.
+ *
+ * Intentionally minimal: we expose the SPA path only. Host-specific
+ * concerns (the React element, route guards, lazy boundaries) stay in
+ * the host's route table and never reach `@granit/workspaces`.
+ */
+export interface FeatureRouteSpec {
+  /** SPA path the React router resolves (e.g. `/invoicing/invoices`). */
+  readonly path: string;
+}
+
+/**
+ * Host-supplied lookup table from feature route name (per ADR-057 §5,
+ * convention `{module}.{entity-plural}.{view}`) to a `FeatureRouteSpec`.
+ *
+ * Hosts construct this once at startup and pass it to the workspace
+ * renderer via context.
+ */
+export type FeatureRouteTable = Readonly<Record<string, FeatureRouteSpec>>;
+
+/**
+ * Thrown when `resolveFeatureRoute` is called with an empty / blank
+ * feature name — a programmer error, never a runtime miss.
+ */
+export class InvalidFeatureNameError extends Error {
+  constructor() {
+    super('Feature name must be a non-empty string.');
+    this.name = 'InvalidFeatureNameError';
+  }
+}
+
+/**
+ * Look up the SPA path for a feature route name. Returns `null` when the
+ * host's route table has no entry — the renderer should hide the item or
+ * render a placeholder rather than navigate (ADR-057 §5).
+ *
+ * @throws {InvalidFeatureNameError} if `featureName` is empty / whitespace.
+ */
+export function resolveFeatureRoute(
+  table: FeatureRouteTable,
+  featureName: string
+): FeatureRouteSpec | null {
+  if (typeof featureName !== 'string' || featureName.trim().length === 0) {
+    throw new InvalidFeatureNameError();
+  }
+  return table[featureName] ?? null;
+}

--- a/packages/@granit/workspaces/src/routes/index.ts
+++ b/packages/@granit/workspaces/src/routes/index.ts
@@ -1,0 +1,2 @@
+export { InvalidFeatureNameError, resolveFeatureRoute } from './feature-route-table.js';
+export type { FeatureRouteSpec, FeatureRouteTable } from './feature-route-table.js';

--- a/packages/@granit/workspaces/src/types/tree.ts
+++ b/packages/@granit/workspaces/src/types/tree.ts
@@ -6,18 +6,21 @@
  * - `Dashboard` — reference to a `DashboardDefinition`
  * - `Link` — internal SPA route or external URL
  * - `SubWorkspace` — recurses into a child workspace
+ * - `Feature` — reference to a feature declared in the host's feature catalog
+ *   (ADR-057). The item carries a logical `routeName` resolved by the host's
+ *   React route table at click time; the backend does not know URLs.
  */
-export type WorkspaceItemKind = 'Entity' | 'Dashboard' | 'Link' | 'SubWorkspace';
+export type WorkspaceItemKind = 'Entity' | 'Dashboard' | 'Link' | 'SubWorkspace' | 'Feature';
 
 /**
  * One item in a workspace section. Mirrors
  * `Granit.Workspaces.Endpoints.Dtos.WorkspaceItemResponse`.
  *
  * Several fields are mutually exclusive depending on `kind` — `entityName`
- * is set for `Entity`, `dashboardName` for `Dashboard`, etc. The wire
- * format models this as a single shape with optional fields rather than a
- * discriminated union; consumers should narrow on `kind` before reading
- * the kind-specific fields.
+ * is set for `Entity`, `dashboardName` for `Dashboard`, `featureName` +
+ * `routeName` for `Feature`, etc. The wire format models this as a single
+ * shape with optional fields rather than a discriminated union; consumers
+ * should narrow on `kind` before reading the kind-specific fields.
  *
  * `entityPresetOverlay` carries the additive preset (filters, sort,
  * columns) layered on top of the entity's compiled defaults. Wire shape
@@ -42,6 +45,10 @@ export interface WorkspaceItemResponse {
   readonly linkUrl: string | null;
   /** Set when `kind` is `SubWorkspace`. */
   readonly subWorkspaceName: string | null;
+  /** Set when `kind` is `Feature` (ADR-057). */
+  readonly featureName: string | null;
+  /** Logical frontend route identifier (Feature items only) — resolved by the React route table at click time. */
+  readonly routeName: string | null;
 }
 
 /**
@@ -60,8 +67,9 @@ export interface WorkspaceSectionResponse {
  * One workspace in the tree. Mirrors
  * `Granit.Workspaces.Endpoints.Dtos.WorkspaceResponse`.
  *
- * `isShell` distinguishes Framework shells (System / Users / Automation /
- * Data / Email / Integrations / Monitoring / Privacy — populated by the
+ * `isShell` distinguishes Framework shells (IdentityAccess / Platform /
+ * Customization / Communication / Storage / Automation / Integrations /
+ * Insights / AI / Observability / Compliance — populated by the
  * `Granit.Workspaces.Framework` contributions) from app-defined
  * workspaces; consumers can use it to render shells under a separate
  * "Framework" header in the sidebar.
@@ -90,5 +98,10 @@ export interface WorkspaceTreeResponse {
  * Schema version this package was compiled against. Consumers can check
  * `tree.schemaVersion === WORKSPACE_TREE_SCHEMA_VERSION` to assert the
  * wire shape matches what they were built for.
+ *
+ * The `Feature` kind + `featureName`/`routeName` fields (ADR-057) are an
+ * additive change: the new fields are nullable, the new kind is a string
+ * literal that older renderers can detect and skip. The schema version
+ * therefore does NOT bump on this change.
  */
 export const WORKSPACE_TREE_SCHEMA_VERSION = 1;


### PR DESCRIPTION
## Summary

Phase 4 of [ADR-057](https://github.com/granit-fx/granit-docs) — frontend
catch-up for the workspace `Feature` kind and the host-side route table
that decouples backend from frontend routing.

- `@granit/workspaces`: adds `'Feature'` to `WorkspaceItemKind`,
  `featureName` + `routeName` fields to `WorkspaceItemResponse` (both
  nullable). Ships `FeatureRouteTable`, `FeatureRouteSpec`,
  `resolveFeatureRoute`, `InvalidFeatureNameError`. JSDoc updated to the
  11 ADR-057 Framework shells.
- `@granit/react-workspaces`: adds `<FeatureRouteTableProvider />`,
  `useFeatureRouteTable()`, `resolveWorkspaceItem()` (pure) and
  `useResolvedWorkspaceItem()` (hook). Items missing a registered route
  surface `missingRoute: true` so the renderer can render a disabled
  placeholder (per ADR-057 §5, bullet 3).
- Wire format change is **additive** — `WORKSPACE_TREE_SCHEMA_VERSION`
  unchanged. `linkUrl` on `Link` items is not deprecated.

## ADR-057 §5 — Route names decouple backend from frontend routing

> Features carry route names (`invoicing.invoices.list`), not URLs
> (`/invoicing`). The host's React app ships a route table that maps
> names to paths. The workspace tree response carries `routeName`; the
> React workspace renderer looks up the path at click time.

```ts
import type { FeatureRouteTable } from '@granit/workspaces';

export const ROUTES: FeatureRouteTable = {
  'identity.users.list':       { path: '/users' },
  'invoicing.invoices.list':   { path: '/invoicing' },
  'parties.parties.list':      { path: '/crm/parties' },
};
```

## Out of scope

- **No host app wires the table.** No `apps/*` directory exists in this
  repo today; `granit-showcase-admin-react` lives elsewhere. The pattern
  is documented in both package READMEs and ready for the host repo to
  consume. Follow-up to be tracked separately.
- **No `WorkspaceNav` renderer changes.** The renderer in
  `@granit/react-workspaces` is still a scaffold (issue #300); the
  resolver primitives shipped here are the building blocks the renderer
  will consume once it lands.

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint` — clean (`--max-warnings 0`)
- [x] Vitest on new code — `feature-route-table` (6 / 6) + pure
      `resolveWorkspaceItem` cases (8 / 8) pass.
- [ ] React-hook tests (`useFeatureRouteTable`, `useResolvedWorkspaceItem`)
      hit a **pre-existing** React-duplicate issue on `develop` (React
      19.2.5 vs 19.2.6 in the resolved tree) that fails *all* existing
      `@granit/react-workspaces` hook tests with `Cannot read properties
      of null (reading 'useEffect' | 'useContext' | 'useMemo')`. Out of
      scope for this PR; flagging for a separate infra fix.