### PR TITLE
feat(timeline): federated stream + edit contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4759,6 +4759,16 @@
               "name": "removeOptimisticEntry",
               "kind": "method",
               "signature": "removeOptimisticEntry: (entryId: string) => void"
+            },
+            {
+              "name": "patchEntry",
+              "kind": "method",
+              "signature": "patchEntry: (entryId: string, updater: (entry: TimelineEntry) => TimelineEntry) => void"
+            },
+            {
+              "name": "degradedSources",
+              "kind": "property",
+              "signature": "degradedSources: readonly string[]"
             }
           ]
         },
@@ -4773,14 +4783,14 @@
           "signature": "function useTimelineFollowers("
         },
         {
-          "name": "toggleReactionList",
+          "name": "useAnchorEntry",
           "kind": "function",
-          "signature": "function toggleReactionList( reactions: readonly Reaction[] | undefined, emoji: ReactionEmoji ): readonly Reaction[]"
+          "signature": "function useAnchorEntry(): UseMutationResult< TimelineEntryId, Error, AnchorEntryVariables >"
         },
         {
-          "name": "useToggleReaction",
+          "name": "useUpdateEntryBody",
           "kind": "function",
-          "signature": "function useToggleReaction(): UseMutationResult< TimelineEntry, Error, ToggleReactionVariables, ToggleReactionContext >"
+          "signature": "function useUpdateEntryBody(): UseMutationResult< void, Error, UpdateEntryBodyVariables >"
         },
         {
           "name": "ToggleReactionVariables",
@@ -5281,7 +5291,7 @@
         {
           "name": "toggleReaction",
           "kind": "function",
-          "signature": "async function toggleReaction( client: AxiosInstance, basePath: string, entryId: TimelineEntryId, emoji: ReactionEmoji ): Promise<TimelineEntry>"
+          "signature": "async function toggleReaction( client: AxiosInstance, basePath: string, entryId: TimelineEntryId, emoji: ReactionEmoji ): Promise<ReactionToggleResult>"
         }
       ]
     },

--- a/packages/@granit/react-timeline/src/__tests__/reaction-bar.test.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/reaction-bar.test.tsx
@@ -5,14 +5,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { ReactionBar } from '../components/reaction-bar.js';
 
-import type { Reaction, TimelineEntryId } from '@granit/timeline';
+import type { ReactionMap, TimelineEntryId } from '@granit/timeline';
 
 const ENTRY_ID = toEntityId<'TimelineEntry'>('e-42') as TimelineEntryId;
 
 describe('<ReactionBar>', () => {
   it('renders the full closed catalog (5 buttons, regardless of input shape)', () => {
     const { container } = render(
-      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={vi.fn()} />
+      <ReactionBar entryId={ENTRY_ID} reactions={undefined} onToggle={vi.fn()} />
     );
 
     const buttons = container.querySelectorAll('[data-granit-reaction-bar-button]');
@@ -23,32 +23,32 @@ describe('<ReactionBar>', () => {
   });
 
   it('reflects per-emoji count and aria-pressed from the reactions prop', () => {
-    const reactions: Reaction[] = [
-      { emoji: ':thumbs_up:', count: 5, hasReacted: true },
-      { emoji: ':eyes:', count: 2, hasReacted: false },
-    ];
+    const reactions: ReactionMap = {
+      thumbs_up: { count: 5, byCurrentUser: true },
+      eyes: { count: 2, byCurrentUser: false },
+    };
     const { container } = render(
       <ReactionBar entryId={ENTRY_ID} reactions={reactions} onToggle={vi.fn()} />
     );
 
-    const thumbs = container.querySelector('[data-emoji=":thumbs_up:"]') as HTMLElement;
+    const thumbs = container.querySelector('[data-emoji="thumbs_up"]') as HTMLElement;
     expect(thumbs.getAttribute('aria-pressed')).toBe('true');
     expect(thumbs.getAttribute('data-count')).toBe('5');
     expect(thumbs.getAttribute('data-has-reacted')).toBe('');
 
-    const eyes = container.querySelector('[data-emoji=":eyes:"]') as HTMLElement;
+    const eyes = container.querySelector('[data-emoji="eyes"]') as HTMLElement;
     expect(eyes.getAttribute('aria-pressed')).toBe('false');
     expect(eyes.getAttribute('data-count')).toBe('2');
     expect(eyes.getAttribute('data-has-reacted')).toBeNull();
 
-    const unused = container.querySelector('[data-emoji=":heart:"]') as HTMLElement;
+    const unused = container.querySelector('[data-emoji="heart"]') as HTMLElement;
     expect(unused.getAttribute('data-count')).toBe('0');
     expect(unused.getAttribute('aria-pressed')).toBe('false');
   });
 
   it('hides the count badge when count is zero', () => {
     const { container } = render(
-      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={vi.fn()} />
+      <ReactionBar entryId={ENTRY_ID} reactions={undefined} onToggle={vi.fn()} />
     );
 
     expect(container.querySelectorAll('[data-granit-reaction-bar-count]')).toHaveLength(0);
@@ -57,17 +57,17 @@ describe('<ReactionBar>', () => {
   it('fires onToggle with { entryId, emoji } when a button is clicked', () => {
     const onToggle = vi.fn();
     const { container } = render(
-      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={onToggle} />
+      <ReactionBar entryId={ENTRY_ID} reactions={undefined} onToggle={onToggle} />
     );
 
-    fireEvent.click(container.querySelector('[data-emoji=":tada:"]') as HTMLElement);
+    fireEvent.click(container.querySelector('[data-emoji="tada"]') as HTMLElement);
 
     expect(onToggle).toHaveBeenCalledTimes(1);
-    expect(onToggle).toHaveBeenCalledWith({ entryId: ENTRY_ID, emoji: ':tada:' });
+    expect(onToggle).toHaveBeenCalledWith({ entryId: ENTRY_ID, emoji: 'tada' });
   });
 
   it('renders read-only when no onToggle callback is provided (permission gating)', () => {
-    const { container } = render(<ReactionBar entryId={ENTRY_ID} reactions={[]} />);
+    const { container } = render(<ReactionBar entryId={ENTRY_ID} reactions={undefined} />);
 
     const root = container.querySelector('[data-granit-reaction-bar]') as HTMLElement;
     expect(root.getAttribute('data-readonly')).toBe('');
@@ -76,16 +76,14 @@ describe('<ReactionBar>', () => {
       expect(btn.disabled).toBe(true);
     });
 
-    // Counts still render — it's a read-only tally
-    fireEvent.click(container.querySelector('[data-emoji=":heart:"]') as HTMLElement);
-    // No assertion needed — disabled buttons emit no click event by default
+    fireEvent.click(container.querySelector('[data-emoji="heart"]') as HTMLElement);
   });
 
   it('uses the buttonAriaLabel override when supplied', () => {
     render(
       <ReactionBar
         entryId={ENTRY_ID}
-        reactions={[]}
+        reactions={undefined}
         onToggle={vi.fn()}
         labels={{
           buttonAriaLabel: (emoji) => `Réagir avec ${emoji}`,
@@ -93,12 +91,12 @@ describe('<ReactionBar>', () => {
       />
     );
 
-    expect(screen.getByRole('button', { name: 'Réagir avec :thumbs_up:' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Réagir avec thumbs_up' })).toBeDefined();
   });
 
   it('exposes the entry id on the root for app-level styling / instrumentation', () => {
     const { container } = render(
-      <ReactionBar entryId={ENTRY_ID} reactions={[]} onToggle={vi.fn()} />
+      <ReactionBar entryId={ENTRY_ID} reactions={undefined} onToggle={vi.fn()} />
     );
     const root = container.querySelector('[data-granit-reaction-bar]') as HTMLElement;
     expect(root.getAttribute('data-entry-id')).toBe(ENTRY_ID);

--- a/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
@@ -5,10 +5,16 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { toggleReactionList, useToggleReaction } from '../hooks/use-toggle-reaction.js';
+import { toggleReactionMap, useToggleReaction } from '../hooks/use-toggle-reaction.js';
 import { TimelineProvider } from '../providers/timeline-provider.js';
 
-import type { Reaction, TimelineEntry, TimelineEntryId, TimelineEntryPage } from '@granit/timeline';
+import type {
+  ReactionMap,
+  ReactionToggleResult,
+  TimelineEntry,
+  TimelineEntryId,
+  TimelineEntryPage,
+} from '@granit/timeline';
 import type { ISODateString } from '@granit/types';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
@@ -16,7 +22,7 @@ import type { ReactNode } from 'react';
 const ENTRY_ID = toEntityId<'TimelineEntry'>('e-1') as TimelineEntryId;
 const OTHER_ENTRY_ID = toEntityId<'TimelineEntry'>('e-99') as TimelineEntryId;
 
-function makeEntry(id: TimelineEntryId, reactions: readonly Reaction[] = []): TimelineEntry {
+function makeEntry(id: TimelineEntryId, reactions?: ReactionMap): TimelineEntry {
   return {
     id,
     entryType: 0,
@@ -32,6 +38,15 @@ function makeEntry(id: TimelineEntryId, reactions: readonly Reaction[] = []): Ti
 
 function makePage(items: readonly TimelineEntry[]): TimelineEntryPage {
   return { items, totalCount: items.length, nextCursor: null };
+}
+
+function makeToggleResult(
+  entryId: string,
+  emoji: ReactionToggleResult['emoji'],
+  count: number,
+  byCurrentUser: boolean
+): ReactionToggleResult {
+  return { entryId, emoji, count, currentUserHasReacted: byCurrentUser };
 }
 
 interface Harness {
@@ -54,30 +69,30 @@ function createHarness(): Harness {
   return { client, queryClient, wrapper };
 }
 
-describe('toggleReactionList', () => {
-  it('adds a fresh reaction with count=1, hasReacted=true', () => {
-    expect(toggleReactionList(undefined, ':thumbs_up:')).toEqual([
-      { emoji: ':thumbs_up:', count: 1, hasReacted: true },
-    ]);
+describe('toggleReactionMap', () => {
+  it('adds a fresh reaction with count=1, byCurrentUser=true', () => {
+    expect(toggleReactionMap(undefined, 'thumbs_up')).toEqual({
+      thumbs_up: { count: 1, byCurrentUser: true },
+    });
   });
 
-  it('increments count + flips hasReacted when caller had not reacted', () => {
-    const before: Reaction[] = [{ emoji: ':heart:', count: 5, hasReacted: false }];
-    expect(toggleReactionList(before, ':heart:')).toEqual([
-      { emoji: ':heart:', count: 6, hasReacted: true },
-    ]);
+  it('increments count + flips byCurrentUser when caller had not reacted', () => {
+    const before: ReactionMap = { heart: { count: 5, byCurrentUser: false } };
+    expect(toggleReactionMap(before, 'heart')).toEqual({
+      heart: { count: 6, byCurrentUser: true },
+    });
   });
 
-  it('decrements count + flips hasReacted when caller had reacted', () => {
-    const before: Reaction[] = [{ emoji: ':tada:', count: 3, hasReacted: true }];
-    expect(toggleReactionList(before, ':tada:')).toEqual([
-      { emoji: ':tada:', count: 2, hasReacted: false },
-    ]);
+  it('decrements count + flips byCurrentUser when caller had reacted', () => {
+    const before: ReactionMap = { tada: { count: 3, byCurrentUser: true } };
+    expect(toggleReactionMap(before, 'tada')).toEqual({
+      tada: { count: 2, byCurrentUser: false },
+    });
   });
 
   it('removes the entry entirely when toggling off the last reactor', () => {
-    const before: Reaction[] = [{ emoji: ':eyes:', count: 1, hasReacted: true }];
-    expect(toggleReactionList(before, ':eyes:')).toEqual([]);
+    const before: ReactionMap = { eyes: { count: 1, byCurrentUser: true } };
+    expect(toggleReactionMap(before, 'eyes')).toBeUndefined();
   });
 });
 
@@ -89,8 +104,8 @@ describe('useToggleReaction — optimistic update', () => {
     const initial = makePage([makeEntry(ENTRY_ID), makeEntry(OTHER_ENTRY_ID)]);
     queryClient.setQueryData(['timeline', 'Quote', 'q-1'], initial);
 
-    let resolveNetwork: (value: TimelineEntry) => void = () => {};
-    const networkPromise = new Promise<TimelineEntry>((resolve) => {
+    let resolveNetwork: (value: ReactionToggleResult) => void = () => {};
+    const networkPromise = new Promise<ReactionToggleResult>((resolve) => {
       resolveNetwork = resolve;
     });
     vi.mocked(client.post).mockImplementation(
@@ -99,39 +114,35 @@ describe('useToggleReaction — optimistic update', () => {
 
     const { result } = renderHook(() => useToggleReaction(), { wrapper });
 
-    // Fire and forget so we can observe the mid-flight cache state.
     result.current.mutate({
       entityType: 'Quote',
       entityId: 'q-1',
       entryId: ENTRY_ID,
-      emoji: ':thumbs_up:',
+      emoji: 'thumbs_up',
     });
 
-    // Optimistic patch is synchronous after onMutate runs.
     await waitFor(() => {
       const page = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
-      expect(page?.items[0]?.reactions).toEqual([
-        { emoji: ':thumbs_up:', count: 1, hasReacted: true },
-      ]);
+      expect(page?.items[0]?.reactions).toEqual({
+        thumbs_up: { count: 1, byCurrentUser: true },
+      });
     });
-    // The unrelated entry in the same page is untouched.
     const page = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
-    expect(page?.items[1]?.reactions).toEqual([]);
+    expect(page?.items[1]?.reactions).toBeUndefined();
 
-    // Resolve the network with server truth (count overrides optimistic).
-    resolveNetwork(makeEntry(ENTRY_ID, [{ emoji: ':thumbs_up:', count: 7, hasReacted: true }]));
+    resolveNetwork(makeToggleResult(ENTRY_ID, 'thumbs_up', 7, true));
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     const finalPage = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
-    expect(finalPage?.items[0]?.reactions).toEqual([
-      { emoji: ':thumbs_up:', count: 7, hasReacted: true },
-    ]);
+    expect(finalPage?.items[0]?.reactions).toEqual({
+      thumbs_up: { count: 7, byCurrentUser: true },
+    });
   });
 
   it('rolls back to the snapshot when the mutation rejects', async () => {
     const { client, queryClient, wrapper } = createHarness();
     const initial = makePage([
-      makeEntry(ENTRY_ID, [{ emoji: ':heart:', count: 5, hasReacted: false }]),
+      makeEntry(ENTRY_ID, { heart: { count: 5, byCurrentUser: false } }),
     ]);
     queryClient.setQueryData(['timeline', 'Quote', 'q-1'], initial);
 
@@ -142,13 +153,13 @@ describe('useToggleReaction — optimistic update', () => {
       entityType: 'Quote',
       entityId: 'q-1',
       entryId: ENTRY_ID,
-      emoji: ':heart:',
+      emoji: 'heart',
     });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     const page = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
-    expect(page?.items[0]?.reactions).toEqual([{ emoji: ':heart:', count: 5, hasReacted: false }]);
+    expect(page?.items[0]?.reactions).toEqual({ heart: { count: 5, byCurrentUser: false } });
   });
 });
 
@@ -158,23 +169,19 @@ describe('useToggleReaction — scoped invalidation', () => {
   it("does not touch unrelated streams' caches", async () => {
     const { client, queryClient, wrapper } = createHarness();
 
-    // Target stream
     queryClient.setQueryData(['timeline', 'Quote', 'q-1'], makePage([makeEntry(ENTRY_ID)]));
-    // Sibling stream — different entityId
     queryClient.setQueryData(
       ['timeline', 'Quote', 'q-2'],
       makePage([makeEntry(toEntityId<'TimelineEntry'>('e-other-1') as TimelineEntryId)])
     );
-    // Sibling stream — different entityType
     queryClient.setQueryData(
       ['timeline', 'Party', 'p-7'],
       makePage([makeEntry(toEntityId<'TimelineEntry'>('e-other-2') as TimelineEntryId)])
     );
-    // Foreign cache prefix entirely
     queryClient.setQueryData(['unrelated'], 'keep-me');
 
     vi.mocked(client.post).mockResolvedValue(
-      axiosResponse(makeEntry(ENTRY_ID, [{ emoji: ':eyes:', count: 1, hasReacted: true }]))
+      axiosResponse(makeToggleResult(ENTRY_ID, 'eyes', 1, true))
     );
 
     const { result } = renderHook(() => useToggleReaction(), { wrapper });
@@ -182,12 +189,11 @@ describe('useToggleReaction — scoped invalidation', () => {
       entityType: 'Quote',
       entityId: 'q-1',
       entryId: ENTRY_ID,
-      emoji: ':eyes:',
+      emoji: 'eyes',
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    // Sibling caches are not invalidated.
     const sibling1 = queryClient.getQueryCache().find({
       queryKey: ['timeline', 'Quote', 'q-2'],
     });

--- a/packages/@granit/react-timeline/src/components/reaction-bar.tsx
+++ b/packages/@granit/react-timeline/src/components/reaction-bar.tsx
@@ -1,4 +1,4 @@
-import { REACTION_EMOJIS, type Reaction, type ReactionEmoji } from '@granit/timeline';
+import { REACTION_EMOJIS, type ReactionEmoji, type ReactionMap } from '@granit/timeline';
 import { type ReactNode } from 'react';
 
 import type { TimelineEntryId } from '@granit/timeline';
@@ -7,7 +7,7 @@ export interface ReactionBarLabels {
   /**
    * Aria label for one reaction button. Receives the emoji code so apps
    * can localize per emoji via
-   * `t('timeline:Reaction.AriaLabel.' + emoji.replaceAll(':', ''))`.
+   * `t('timeline:Reaction.AriaLabel.' + emoji)`.
    */
   readonly buttonAriaLabel?: (emoji: ReactionEmoji) => string;
 }
@@ -20,15 +20,16 @@ export interface ReactionBarProps {
   /** Id of the entry this bar belongs to — passed to the toggle callback. */
   readonly entryId: TimelineEntryId;
   /**
-   * Current reactions for the entry — typically `entry.reactions ?? []`.
-   * Missing emojis render as `count=0, hasReacted=false` so the bar
-   * always shows the full closed catalog.
+   * Current reactions for the entry — typically `entry.reactions`
+   * straight from the stream payload. Missing emojis render as
+   * `count=0, byCurrentUser=false` so the bar always shows the full
+   * closed catalog.
    */
-  readonly reactions: readonly Reaction[];
+  readonly reactions: ReactionMap | undefined;
   /**
    * Click handler. When `undefined`, the bar renders as a read-only
    * tally — buttons disabled, no toggle. Apps gate by the
-   * `Timeline.React` permission via this callback's presence.
+   * `Timeline.Reactions.React` permission via this callback's presence.
    */
   readonly onToggle?: (args: { entryId: TimelineEntryId; emoji: ReactionEmoji }) => void;
   /** Override the English defaults for aria labels (i18n in C4). */
@@ -59,7 +60,6 @@ export function ReactionBar({
   className,
 }: ReactionBarProps): ReactNode {
   const merged = { ...DEFAULT_LABELS, ...labels };
-  const byEmoji = indexReactions(reactions);
   const isInteractive = onToggle != null;
 
   return (
@@ -71,9 +71,9 @@ export function ReactionBar({
       className={className}
     >
       {REACTION_EMOJIS.map((emoji) => {
-        const reaction = byEmoji.get(emoji);
-        const count = reaction?.count ?? 0;
-        const hasReacted = reaction?.hasReacted ?? false;
+        const aggregate = reactions?.[emoji];
+        const count = aggregate?.count ?? 0;
+        const hasReacted = aggregate?.byCurrentUser ?? false;
         return (
           <button
             key={emoji}
@@ -94,12 +94,4 @@ export function ReactionBar({
       })}
     </div>
   );
-}
-
-function indexReactions(reactions: readonly Reaction[]): Map<ReactionEmoji, Reaction> {
-  const map = new Map<ReactionEmoji, Reaction>();
-  for (const r of reactions) {
-    map.set(r.emoji, r);
-  }
-  return map;
 }

--- a/packages/@granit/react-timeline/src/hooks/use-entry-mutations.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-entry-mutations.ts
@@ -1,0 +1,76 @@
+import { anchorTimelineEntry, updateTimelineEntryBody } from '@granit/timeline';
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+
+import { useTimelineConfig } from '../providers/timeline-provider.js';
+
+import type { TimelineEntryId } from '@granit/timeline';
+
+/**
+ * Arguments accepted by {@link useAnchorEntry}. The
+ * `(entityType, entityId)` pair identifies the surrounding stream;
+ * `(sourceKey, sourceId)` identifies the external entry to anchor.
+ */
+export interface AnchorEntryVariables {
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly sourceKey: string;
+  readonly sourceId: string;
+}
+
+/**
+ * Mutation that materialises (or recovers) the native shadow row for
+ * an external timeline source entry.
+ *
+ * Idempotent server-side: the backend derives a deterministic v5 GUID
+ * from `(tenantId, entityType, entityId, sourceKey, sourceId)`, so
+ * concurrent calls all converge on the same `entryId`. Callers chain
+ * this before any reaction / reply operation that needs a stable
+ * native id.
+ *
+ * Wire: `POST {basePath}/{entityType}/{entityId}/anchor`. See
+ * granit-fx/granit-dotnet — `AnchorExternalAsync` endpoint.
+ */
+export function useAnchorEntry(): UseMutationResult<
+  TimelineEntryId,
+  Error,
+  AnchorEntryVariables
+> {
+  const { client, basePath } = useTimelineConfig();
+
+  return useMutation<TimelineEntryId, Error, AnchorEntryVariables>({
+    mutationFn: ({ entityType, entityId, sourceKey, sourceId }) =>
+      anchorTimelineEntry(client, basePath, entityType, entityId, { sourceKey, sourceId }),
+  });
+}
+
+/** Arguments accepted by {@link useUpdateEntryBody}. */
+export interface UpdateEntryBodyVariables {
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly entryId: TimelineEntryId;
+  readonly body: string;
+}
+
+/**
+ * Mutation that replaces the Markdown body of a Comment or
+ * InternalNote authored by the current user, provided the configured
+ * edit window has not elapsed. The four backend gates (origin, type,
+ * authorship, window) surface as RFC 7807 `403` with `type:
+ * "timeline-entry-not-editable"` and a machine-readable `reason` in
+ * the response extensions when rejected — apps should inspect the
+ * axios error to localise the message.
+ *
+ * Wire: `PATCH {basePath}/{entityType}/{entityId}/entries/{entryId}`.
+ */
+export function useUpdateEntryBody(): UseMutationResult<
+  void,
+  Error,
+  UpdateEntryBodyVariables
+> {
+  const { client, basePath } = useTimelineConfig();
+
+  return useMutation<void, Error, UpdateEntryBodyVariables>({
+    mutationFn: ({ entityType, entityId, entryId, body }) =>
+      updateTimelineEntryBody(client, basePath, entityType, entityId, entryId, { body }),
+  });
+}

--- a/packages/@granit/react-timeline/src/hooks/use-timeline.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-timeline.ts
@@ -1,10 +1,10 @@
 import { useInfiniteScroll } from '@granit/react-query-engine';
 import { getStream } from '@granit/timeline';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useTimelineConfig } from '../providers/timeline-provider.js';
 
-import type { TimelineEntry } from '@granit/timeline';
+import type { TimelineEntry, TimelineEntryPage, TimelineStreamPage } from '@granit/timeline';
 
 const DEFAULT_PAGE_SIZE = 20;
 
@@ -25,6 +25,22 @@ export interface UseTimelineReturn {
   refresh: () => void;
   addOptimisticEntry: (entry: TimelineEntry) => void;
   removeOptimisticEntry: (entryId: string) => void;
+  /**
+   * Patch one entry in place. The `updater` receives the matching
+   * entry and must return its replacement (return the input to skip).
+   * Entries with non-matching ids pass through untouched. Useful for
+   * surgical updates (reaction toggles, edits) that should not trigger
+   * a full stream refresh.
+   */
+  patchEntry: (entryId: string, updater: (entry: TimelineEntry) => TimelineEntry) => void;
+  /**
+   * Source keys reported degraded by the latest stream fetch. Empty
+   * unless one or more registered `ITimelineSource` contributors timed
+   * out or threw under the `DegradeGracefully` policy on the backend.
+   * Hosts typically render a "partial data" banner when this is
+   * non-empty.
+   */
+  degradedSources: readonly string[];
 }
 
 /**
@@ -39,10 +55,20 @@ export function useTimeline({
   pageSize = DEFAULT_PAGE_SIZE,
 }: UseTimelineOptions): UseTimelineReturn {
   const { client, basePath } = useTimelineConfig();
+  const [degradedSources, setDegradedSources] = useState<readonly string[]>([]);
 
   const fetcher = useCallback(
-    (page: number, ps: number) =>
-      getStream(client, basePath, entityType, entityId, { page, pageSize: ps }),
+    async (page: number, ps: number): Promise<TimelineEntryPage> => {
+      const result: TimelineStreamPage = await getStream(client, basePath, entityType, entityId, {
+        page,
+        pageSize: ps,
+      });
+      // Latest call wins — degraded set reflects the most recent stream
+      // response, not the union across pagination. Empty array reset on
+      // a healthy page so the host can clear its banner.
+      setDegradedSources(result.degradedSources);
+      return result.page;
+    },
     [client, basePath, entityType, entityId]
   );
 
@@ -72,6 +98,13 @@ export function useTimeline({
     [setEntries]
   );
 
+  const patchEntry = useCallback(
+    (entryId: string, updater: (entry: TimelineEntry) => TimelineEntry) => {
+      setEntries((prev) => prev.map((e) => (e.id === entryId ? updater(e) : e)));
+    },
+    [setEntries]
+  );
+
   return {
     entries,
     totalCount,
@@ -83,5 +116,7 @@ export function useTimeline({
     refresh,
     addOptimisticEntry,
     removeOptimisticEntry,
+    patchEntry,
+    degradedSources,
   };
 }

--- a/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
@@ -4,8 +4,9 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { buildTimelineQueryKey, useTimelineConfig } from '../providers/timeline-provider.js';
 
 import type {
-  Reaction,
   ReactionEmoji,
+  ReactionMap,
+  ReactionToggleResult,
   TimelineEntry,
   TimelineEntryId,
   TimelineEntryPage,
@@ -16,6 +17,11 @@ import type {
  * surrounding stream's `(entityType, entityId)` so the hook scopes
  * cache patches + invalidation to that stream's query keys —
  * unrelated streams' caches survive untouched.
+ *
+ * For entries with `origin === 'External'` that have no native shadow
+ * row yet, the caller must first call {@link useAnchorEntry} to
+ * materialise the shadow, then pass the returned shadow id as
+ * `entryId` here. The reaction endpoint only operates on native ids.
  */
 export interface ToggleReactionVariables {
   readonly entityType: string;
@@ -43,8 +49,9 @@ interface ToggleReactionContext {
  *   single-entry cache) so the matching entry's `reactions[]` reflects
  *   the toggle immediately.
  * - `onError` restores the snapshot taken in `onMutate`.
- * - `onSuccess` writes server truth (the refreshed `TimelineEntry`)
- *   over any matching entries, then invalidates the prefix so any
+ * - `onSuccess` writes server truth (the authoritative
+ *   `ReactionToggleResult` for the toggled emoji) into the map of
+ *   any matching cached entries, then invalidates the prefix so any
  *   in-flight subscribers refetch from authority.
  * - The prefix is `[...queryKeyPrefix, entityType, entityId]` — a
  *   100-toggle session on `Quote/q-1` never invalidates the cache
@@ -57,7 +64,7 @@ interface ToggleReactionContext {
  * Query stream cache benefit from the scoped patching out of the box.
  */
 export function useToggleReaction(): UseMutationResult<
-  TimelineEntry,
+  ReactionToggleResult,
   Error,
   ToggleReactionVariables,
   ToggleReactionContext
@@ -65,7 +72,7 @@ export function useToggleReaction(): UseMutationResult<
   const config = useTimelineConfig();
   const queryClient = useQueryClient();
 
-  return useMutation<TimelineEntry, Error, ToggleReactionVariables, ToggleReactionContext>({
+  return useMutation<ReactionToggleResult, Error, ToggleReactionVariables, ToggleReactionContext>({
     mutationFn: ({ entryId, emoji }) =>
       toggleReaction(config.client, config.basePath, entryId, emoji),
 
@@ -76,7 +83,9 @@ export function useToggleReaction(): UseMutationResult<
       const previousQueries = queryClient.getQueriesData({ queryKey: prefix });
 
       queryClient.setQueriesData<unknown>({ queryKey: prefix }, (old: unknown) =>
-        patchOptimistic(old, vars.entryId, vars.emoji)
+        patchEntries(old, vars.entryId, (reactions) =>
+          toggleReactionMap(reactions, vars.emoji)
+        )
       );
 
       return { previousQueries };
@@ -89,10 +98,12 @@ export function useToggleReaction(): UseMutationResult<
       }
     },
 
-    onSuccess: (refreshed, vars) => {
+    onSuccess: (result, vars) => {
       const prefix = streamPrefix(config, vars);
       queryClient.setQueriesData<unknown>({ queryKey: prefix }, (old: unknown) =>
-        replaceServerTruth(old, refreshed)
+        patchEntries(old, vars.entryId, (reactions) =>
+          applyToggleResult(reactions, result)
+        )
       );
       queryClient.invalidateQueries({ queryKey: prefix });
     },
@@ -107,66 +118,78 @@ function streamPrefix(
 }
 
 /**
- * Patch every cached entry matching `entryId` with the optimistic
- * reaction toggle. Walks the two known cache shapes:
- *   - `TimelineEntryPage` (paginated stream slot)
- *   - single `TimelineEntry` (per-entry cache)
- * Other shapes pass through unchanged so apps with custom caches
- * aren't affected.
+ * Patch every cached entry matching `entryId` by replacing its
+ * `reactions` map with `mutate(entry.reactions)`. Walks the two known
+ * cache shapes (`TimelineEntryPage` + bare `TimelineEntry`); other
+ * shapes pass through unchanged.
  */
-function patchOptimistic(old: unknown, entryId: TimelineEntryId, emoji: ReactionEmoji): unknown {
+function patchEntries(
+  old: unknown,
+  entryId: TimelineEntryId,
+  mutate: (reactions: ReactionMap | undefined) => ReactionMap | undefined
+): unknown {
   if (isTimelineEntryPage(old)) {
     return {
       ...old,
       items: old.items.map((entry) =>
-        entry.id === entryId ? toggleEntryReaction(entry, emoji) : entry
+        entry.id === entryId ? { ...entry, reactions: mutate(entry.reactions) } : entry
       ),
     };
   }
   if (isTimelineEntry(old) && old.id === entryId) {
-    return toggleEntryReaction(old, emoji);
+    return { ...old, reactions: mutate(old.reactions) };
   }
   return old;
-}
-
-function replaceServerTruth(old: unknown, refreshed: TimelineEntry): unknown {
-  if (isTimelineEntryPage(old)) {
-    return {
-      ...old,
-      items: old.items.map((entry) => (entry.id === refreshed.id ? refreshed : entry)),
-    };
-  }
-  if (isTimelineEntry(old) && old.id === refreshed.id) {
-    return refreshed;
-  }
-  return old;
-}
-
-function toggleEntryReaction(entry: TimelineEntry, emoji: ReactionEmoji): TimelineEntry {
-  return { ...entry, reactions: toggleReactionList(entry.reactions, emoji) };
 }
 
 /**
- * Pure toggle of one emoji on a reactions list — exported so apps
- * doing optimistic UI outside the React Query cache (e.g. against
- * `useTimeline`'s internal state) can reuse the same logic.
+ * Pure optimistic toggle of one emoji on a {@link ReactionMap} —
+ * exported so apps doing optimistic UI outside the React Query cache
+ * (e.g. against `useTimeline`'s internal state) can reuse the same
+ * logic. The server's authoritative count is applied later via
+ * {@link applyToggleResult}.
  */
-export function toggleReactionList(
-  reactions: readonly Reaction[] | undefined,
+export function toggleReactionMap(
+  reactions: ReactionMap | undefined,
   emoji: ReactionEmoji
-): readonly Reaction[] {
-  const list = reactions ?? [];
-  const existing = list.find((r) => r.emoji === emoji);
-  if (!existing) {
-    return [...list, { emoji, count: 1, hasReacted: true }];
+): ReactionMap | undefined {
+  const current = reactions?.[emoji];
+  if (!current) {
+    return { ...(reactions ?? {}), [emoji]: { count: 1, byCurrentUser: true } };
   }
-  if (existing.hasReacted) {
-    const next: Reaction = { emoji, count: existing.count - 1, hasReacted: false };
-    return next.count <= 0
-      ? list.filter((r) => r.emoji !== emoji)
-      : list.map((r) => (r.emoji === emoji ? next : r));
+  if (current.byCurrentUser) {
+    const nextCount = current.count - 1;
+    if (nextCount <= 0) {
+      const { [emoji]: _, ...rest } = reactions ?? {};
+      return Object.keys(rest).length === 0 ? undefined : rest;
+    }
+    return { ...(reactions ?? {}), [emoji]: { count: nextCount, byCurrentUser: false } };
   }
-  return list.map((r) => (r.emoji === emoji ? { emoji, count: r.count + 1, hasReacted: true } : r));
+  return {
+    ...(reactions ?? {}),
+    [emoji]: { count: current.count + 1, byCurrentUser: true },
+  };
+}
+
+/**
+ * Apply the backend's authoritative `(emoji, count, byCurrentUser)` to a
+ * {@link ReactionMap}. Exported so apps using `useTimeline` (or any other
+ * non-React-Query stream state) can merge the {@link ReactionToggleResult}
+ * straight into their entry without a full refetch.
+ */
+export function applyToggleResult(
+  reactions: ReactionMap | undefined,
+  result: ReactionToggleResult
+): ReactionMap | undefined {
+  if (result.count <= 0) {
+    if (!reactions) return undefined;
+    const { [result.emoji]: _, ...rest } = reactions;
+    return Object.keys(rest).length === 0 ? undefined : rest;
+  }
+  return {
+    ...(reactions ?? {}),
+    [result.emoji]: { count: result.count, byCurrentUser: result.currentUserHasReacted },
+  };
 }
 
 function isTimelineEntryPage(value: unknown): value is TimelineEntryPage {

--- a/packages/@granit/react-timeline/src/index.ts
+++ b/packages/@granit/react-timeline/src/index.ts
@@ -25,7 +25,17 @@ export type {
   UseTimelineFollowersReturn,
 } from './hooks/use-timeline-followers.js';
 
-export { toggleReactionList, useToggleReaction } from './hooks/use-toggle-reaction.js';
+export {
+  applyToggleResult,
+  toggleReactionMap,
+  useToggleReaction,
+} from './hooks/use-toggle-reaction.js';
+
+export { useAnchorEntry, useUpdateEntryBody } from './hooks/use-entry-mutations.js';
+export type {
+  AnchorEntryVariables,
+  UpdateEntryBodyVariables,
+} from './hooks/use-entry-mutations.js';
 export type { ToggleReactionVariables } from './hooks/use-toggle-reaction.js';
 
 export { ReactionBar } from './components/reaction-bar.js';

--- a/packages/@granit/timeline/src/__tests__/reaction-api.test.ts
+++ b/packages/@granit/timeline/src/__tests__/reaction-api.test.ts
@@ -23,8 +23,8 @@ const SAMPLE_ENTRY = {
   occurredAt: '2026-05-09T15:00:00Z' as ISODateString,
   attachments: [],
   reactions: [
-    { emoji: ':thumbs_up:' as const, count: 3, hasReacted: true },
-    { emoji: ':tada:' as const, count: 1, hasReacted: false },
+    { emoji: 'thumbs_up' as const, count: 3, hasReacted: true },
+    { emoji: 'tada' as const, count: 1, hasReacted: false },
   ],
 };
 
@@ -38,10 +38,10 @@ describe('toggleReaction', () => {
   it('POSTs to /entries/{entryId}/reactions/{emoji} with URI-encoded segments', async () => {
     vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
 
-    const result = await toggleReaction(client, BASE_PATH, ENTRY_ID, ':thumbs_up:');
+    const result = await toggleReaction(client, BASE_PATH, ENTRY_ID, 'thumbs_up');
 
     expect(client.post).toHaveBeenCalledWith(
-      '/api/v1/timeline/entries/e-42/reactions/%3Athumbs_up%3A'
+      '/api/v1/timeline/entries/e-42/reactions/thumbs_up'
     );
     expect(result).toEqual(SAMPLE_ENTRY);
   });
@@ -49,18 +49,18 @@ describe('toggleReaction', () => {
   it('returns the refreshed entry — caller patches its cache from this payload', async () => {
     vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
 
-    const refreshed = await toggleReaction(client, BASE_PATH, ENTRY_ID, ':heart:');
+    const refreshed = await toggleReaction(client, BASE_PATH, ENTRY_ID, 'heart');
 
     expect(refreshed.reactions).toEqual([
-      { emoji: ':thumbs_up:', count: 3, hasReacted: true },
-      { emoji: ':tada:', count: 1, hasReacted: false },
+      { emoji: 'thumbs_up', count: 3, hasReacted: true },
+      { emoji: 'tada', count: 1, hasReacted: false },
     ]);
   });
 
-  it('propagates 403 when the caller lacks Timeline.React', async () => {
+  it('propagates 403 when the caller lacks Timeline.Reactions.React', async () => {
     vi.mocked(client.post).mockRejectedValue(new Error('Request failed with status code 403'));
 
-    await expect(toggleReaction(client, BASE_PATH, ENTRY_ID, ':eyes:')).rejects.toThrow(/403/);
+    await expect(toggleReaction(client, BASE_PATH, ENTRY_ID, 'eyes')).rejects.toThrow(/403/);
   });
 
   it('accepts every code in the closed REACTION_EMOJIS catalog', async () => {
@@ -78,6 +78,6 @@ describe('toggleReaction', () => {
 
 describe('TimelinePermissions', () => {
   it('exposes the React permission key matching the backend wire string', () => {
-    expect(TimelinePermissions.Timeline.React).toBe('Timeline.React');
+    expect(TimelinePermissions.Timeline.Reactions.React).toBe('Timeline.Reactions.React');
   });
 });

--- a/packages/@granit/timeline/src/api/reaction-api.ts
+++ b/packages/@granit/timeline/src/api/reaction-api.ts
@@ -1,7 +1,7 @@
 import { buildApiUrl } from '@granit/api-client';
 
-import type { ReactionEmoji } from '../types/reaction.js';
-import type { TimelineEntry, TimelineEntryId } from '../types/stream.js';
+import type { ReactionEmoji, ReactionToggleResult } from '../types/reaction.js';
+import type { TimelineEntryId } from '../types/stream.js';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
@@ -12,19 +12,20 @@ import type { AxiosInstance } from '@granit/api-client';
  * The backend treats the call as a toggle keyed on
  * `(entryId, emoji, callerUserId)`: a fresh call adds the reaction;
  * a repeat call from the same caller removes it. The response is the
- * full updated entry (with refreshed `reactions[]`) so the client can
- * patch its cache without a separate stream re-fetch.
+ * post-toggle authoritative state for the `(entryId, emoji)` pair —
+ * apps patch their local cache by merging this aggregate back into
+ * the entry's `reactions` map.
  *
  * Mirror of the dotnet endpoint shipped in
- * granit-fx/granit-dotnet#1811. Permission: {@link TimelinePermissions.Timeline.React}.
+ * granit-fx/granit-dotnet#1811. Permission: `Timeline.Reactions.React`.
  */
 export async function toggleReaction(
   client: AxiosInstance,
   basePath: string,
   entryId: TimelineEntryId,
   emoji: ReactionEmoji
-): Promise<TimelineEntry> {
-  const { data } = await client.post<TimelineEntry>(
+): Promise<ReactionToggleResult> {
+  const { data } = await client.post<ReactionToggleResult>(
     buildApiUrl(
       basePath,
       'entries',

--- a/packages/@granit/timeline/src/api/timeline-api.ts
+++ b/packages/@granit/timeline/src/api/timeline-api.ts
@@ -4,9 +4,18 @@ import type {
   CreateTimelineEntryRequest,
   TimelineQueryParams,
   TimelineEntry,
+  TimelineEntryId,
   TimelineEntryPage,
+  TimelineStreamPage,
 } from '../types/index.js';
 import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Response header surfaced by the stream endpoint when one or more
+ * registered `ITimelineSource` contributors failed (timeout or thrown)
+ * under the `DegradeGracefully` policy. Comma-separated source keys.
+ */
+const DEGRADED_SOURCES_HEADER = 'x-timeline-degraded-sources';
 
 function buildEntityUrl(
   basePath: string,
@@ -22,20 +31,35 @@ function buildEntityUrl(
   );
 }
 
+/**
+ * Fetches one page of the federated timeline stream.
+ *
+ * Returns the merged page **plus** the list of contributors that
+ * degraded for this call (lifted from the `X-Timeline-Degraded-Sources`
+ * response header). Callers should surface a "partial data" indicator
+ * when `degradedSources.length > 0`.
+ */
 export async function getStream(
   client: AxiosInstance,
   basePath: string,
   entityType: string,
   entityId: string,
   params?: TimelineQueryParams
-): Promise<TimelineEntryPage> {
-  const { data } = await client.get<TimelineEntryPage>(
+): Promise<TimelineStreamPage> {
+  const response = await client.get<TimelineEntryPage>(
     buildEntityUrl(basePath, entityType, entityId),
-    {
-      params,
-    }
+    { params }
   );
-  return data;
+  const rawHeader = response.headers?.[DEGRADED_SOURCES_HEADER];
+  const headerValue = Array.isArray(rawHeader) ? rawHeader.join(',') : rawHeader;
+  const degradedSources =
+    typeof headerValue === 'string' && headerValue.length > 0
+      ? headerValue
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+      : [];
+  return { page: response.data, degradedSources };
 }
 
 export async function createEntry(
@@ -60,6 +84,51 @@ export async function deleteEntry(
   entryId: string
 ): Promise<void> {
   await client.delete(buildEntityUrl(basePath, entityType, entityId, 'entries', entryId));
+}
+
+/**
+ * Materialises (or returns the existing) shadow row for an external
+ * source entry so subsequent reactions and replies can target a stable
+ * native id. Idempotent: same `(entityType, entityId, sourceKey, sourceId)`
+ * always resolves to the same deterministic v5 GUID backend-side.
+ *
+ * `POST {basePath}/{entityType}/{entityId}/anchor`
+ */
+export async function anchorTimelineEntry(
+  client: AxiosInstance,
+  basePath: string,
+  entityType: string,
+  entityId: string,
+  request: { readonly sourceKey: string; readonly sourceId: string }
+): Promise<TimelineEntryId> {
+  const { data } = await client.post<{ entryId: TimelineEntryId }>(
+    buildEntityUrl(basePath, entityType, entityId, 'anchor'),
+    request
+  );
+  return data.entryId;
+}
+
+/**
+ * Replaces the Markdown body of a Comment or InternalNote authored by
+ * the current user, provided the configured edit window has not
+ * elapsed. The four backend gates (origin, type, authorship, window)
+ * are enforced server-side and surface as `403 timeline-entry-not-editable`
+ * with `reason` in the RFC 7807 extensions when rejected.
+ *
+ * `PATCH {basePath}/{entityType}/{entityId}/entries/{entryId}`
+ */
+export async function updateTimelineEntryBody(
+  client: AxiosInstance,
+  basePath: string,
+  entityType: string,
+  entityId: string,
+  entryId: string,
+  request: { readonly body: string }
+): Promise<void> {
+  await client.patch(
+    buildEntityUrl(basePath, entityType, entityId, 'entries', entryId),
+    request
+  );
 }
 
 export async function followEntity(

--- a/packages/@granit/timeline/src/index.ts
+++ b/packages/@granit/timeline/src/index.ts
@@ -9,12 +9,21 @@ export {
   type TimelineEntryId,
   type TimelineEntryPage,
   type TimelineEntryTypeValue,
+  type TimelineStreamPage,
   type CreateTimelineEntryRequest,
   type TimelineQueryParams,
   type TimelineConfig,
   type MentionSuggestion,
-  type Reaction,
+  type ReactionAggregate,
   type ReactionEmoji,
+  type ReactionMap,
+  type ReactionToggleResult,
+  TimelineEntryNotEditableReason,
+  TimelineEntryOrigin,
+  TimelineSourceKeys,
+  isValidSourceKey,
+  type TimelineEntryNotEditableReasonValue,
+  type TimelineEntryOriginValue,
 } from './types/index.js';
 
 // Permissions
@@ -22,11 +31,13 @@ export { TimelinePermissions } from './permissions.js';
 
 // API
 export {
+  anchorTimelineEntry,
   createEntry,
   deleteEntry,
   getFollowers,
   getStream,
   followEntity,
   unfollowEntity,
+  updateTimelineEntryBody,
 } from './api/timeline-api.js';
 export { toggleReaction } from './api/reaction-api.js';

--- a/packages/@granit/timeline/src/permissions.ts
+++ b/packages/@granit/timeline/src/permissions.ts
@@ -4,7 +4,9 @@
  */
 export const TimelinePermissions = {
   Timeline: {
-    /** Required to react / un-react on a timeline entry (C-stream). */
-    React: 'Timeline.React',
+    Reactions: {
+      /** Required to react / un-react on a timeline entry (C-stream). */
+      React: 'Timeline.Reactions.React',
+    },
   },
 } as const;

--- a/packages/@granit/timeline/src/types/index.ts
+++ b/packages/@granit/timeline/src/types/index.ts
@@ -6,9 +6,25 @@ export type {
   TimelineEntry,
   TimelineEntryId,
   TimelineEntryPage,
+  TimelineStreamPage,
 } from './stream.js';
 export type { CreateTimelineEntryRequest, TimelineQueryParams } from './request.js';
 export type { TimelineConfig } from './config.js';
 export type { MentionSuggestion } from './mention.js';
 export { REACTION_EMOJIS } from './reaction.js';
-export type { Reaction, ReactionEmoji } from './reaction.js';
+export type {
+  ReactionAggregate,
+  ReactionEmoji,
+  ReactionMap,
+  ReactionToggleResult,
+} from './reaction.js';
+export {
+  TimelineEntryNotEditableReason,
+  TimelineEntryOrigin,
+  TimelineSourceKeys,
+  isValidSourceKey,
+} from './source.js';
+export type {
+  TimelineEntryNotEditableReasonValue,
+  TimelineEntryOriginValue,
+} from './source.js';

--- a/packages/@granit/timeline/src/types/reaction.ts
+++ b/packages/@granit/timeline/src/types/reaction.ts
@@ -4,32 +4,49 @@
  * amendment (same anti-Odoo policy as the rest of Phase 2: closed
  * enums on the wire, never an `eval:` string).
  *
- * Codes follow the `:short_name:` convention, not the literal emoji,
- * so client-side rendering can swap visual style (Twemoji, Apple,
- * native) without re-keying state.
+ * Wire identifier is the snake_case short name (no `:` delimiters) —
+ * matches `Granit.Timeline.Domain.ReactionEmojiCatalog`. The literal
+ * glyph is purely a client-side rendering concern (Twemoji, Apple,
+ * native) and never crosses the wire.
  */
-export type ReactionEmoji = ':thumbs_up:' | ':heart:' | ':tada:' | ':joy:' | ':eyes:';
+export type ReactionEmoji = 'thumbs_up' | 'heart' | 'tada' | 'joy' | 'eyes';
 
 /** Closed catalog as a frozen tuple — useful for picker iteration. */
 export const REACTION_EMOJIS: readonly ReactionEmoji[] = Object.freeze([
-  ':thumbs_up:',
-  ':heart:',
-  ':tada:',
-  ':joy:',
-  ':eyes:',
+  'thumbs_up',
+  'heart',
+  'tada',
+  'joy',
+  'eyes',
 ]);
 
 /**
- * Aggregated reaction count for one entry / emoji pair.
- *
- * `hasReacted` is the **caller's** status — true when the
- * authenticated user has reacted with this emoji on this entry.
- * Toggling the same emoji twice removes the reaction (idempotent).
+ * Aggregated reaction count for one emoji on one entry. Lives inside
+ * the entry's {@link ReactionMap}, keyed by the emoji short name —
+ * the map only carries emojis with at least one reaction, so an
+ * entry with zero reactions has `reactions` either undefined or `{}`.
  */
-export interface Reaction {
-  readonly emoji: ReactionEmoji;
+export interface ReactionAggregate {
   /** Distinct users who reacted with this emoji. */
   readonly count: number;
-  /** True when the authenticated caller has reacted with this emoji. */
-  readonly hasReacted: boolean;
+  /** True when the authenticated caller is among the reactors. */
+  readonly byCurrentUser: boolean;
+}
+
+/**
+ * Per-emoji reaction summary attached to a timeline entry. Mirrors
+ * the backend `IReadOnlyDictionary<string, ReactionAggregateResponse>`
+ * payload — only emojis with at least one reaction are present.
+ */
+export type ReactionMap = Readonly<Partial<Record<ReactionEmoji, ReactionAggregate>>>;
+
+/**
+ * Post-toggle authoritative state for a single (entry, emoji) pair,
+ * returned by `POST /entries/{entryId}/reactions/{emoji}`.
+ */
+export interface ReactionToggleResult {
+  readonly entryId: string;
+  readonly emoji: ReactionEmoji;
+  readonly count: number;
+  readonly currentUserHasReacted: boolean;
 }

--- a/packages/@granit/timeline/src/types/source.ts
+++ b/packages/@granit/timeline/src/types/source.ts
@@ -1,0 +1,54 @@
+/**
+ * Where a {@link TimelineEntry} originates in the federated stream.
+ *
+ * The concrete contributor name (`"auditing"`, `"workflow"`, …) lives
+ * in `TimelineEntry.sourceKey` as a soft string contract, so new
+ * contributors can plug in without bumping this enum. Mirror of
+ * `Granit.Timeline.TimelineEntryOrigin` on the backend.
+ */
+export const TimelineEntryOrigin = {
+  /** Entry stored directly in the timeline table (Comment, InternalNote, or native SystemLog). */
+  Native: 'Native',
+  /** Entry projected from a registered `ITimelineSource`. */
+  External: 'External',
+} as const;
+
+export type TimelineEntryOriginValue =
+  (typeof TimelineEntryOrigin)[keyof typeof TimelineEntryOrigin];
+
+/**
+ * Well-known `sourceKey` values for federated timeline sources.
+ * Contributors declare their own key — the set is pluggable, not an
+ * enum. Mirror of `Granit.Timeline.Abstractions.TimelineSourceKeys`.
+ */
+export const TimelineSourceKeys = {
+  /** Reserved key for entries stored directly in the timeline table. */
+  Native: 'native',
+} as const;
+
+const SOURCE_KEY_PATTERN = /^[a-z][a-z0-9_-]{0,63}$/;
+
+/** Validates a candidate source key against the wire convention `^[a-z][a-z0-9_-]{0,63}$`. */
+export function isValidSourceKey(sourceKey: string): boolean {
+  return SOURCE_KEY_PATTERN.test(sourceKey);
+}
+
+/**
+ * Machine-readable rejection reason returned by `PATCH /entries/{id}`
+ * in the RFC 7807 `extensions.reason` field when one of the four edit
+ * gates rejects the request. Mirror of
+ * `Granit.Timeline.Abstractions.TimelineEntryNotEditableReason`.
+ */
+export const TimelineEntryNotEditableReason = {
+  /** Entry projected from an external `ITimelineSource` (anchor shadow or live projection). */
+  ExternalOrigin: 'ExternalOrigin',
+  /** Entry is a `SystemLog` — immutable by design (ISO 27001). */
+  SystemLog: 'SystemLog',
+  /** Current user is not the author of the entry. */
+  NotAuthor: 'NotAuthor',
+  /** The edit window configured in `TimelineOptions.EditWindow` has elapsed. */
+  WindowExpired: 'WindowExpired',
+} as const;
+
+export type TimelineEntryNotEditableReasonValue =
+  (typeof TimelineEntryNotEditableReason)[keyof typeof TimelineEntryNotEditableReason];

--- a/packages/@granit/timeline/src/types/stream.ts
+++ b/packages/@granit/timeline/src/types/stream.ts
@@ -1,5 +1,6 @@
 import type { TimelineEntryTypeValue } from './entry-type.js';
-import type { Reaction } from './reaction.js';
+import type { ReactionMap } from './reaction.js';
+import type { TimelineEntryOriginValue } from './source.js';
 import type { PagedResult } from '@granit/query-engine';
 import type { EntityId, ISODateString, UserId } from '@granit/types';
 
@@ -34,14 +35,49 @@ export interface TimelineEntry {
   readonly occurredAt: ISODateString;
   readonly attachments: readonly TimelineAttachmentInfo[];
   /**
-   * Aggregated reactions on this entry — one entry per emoji that has
-   * at least one reactor. Optional for backward compatibility while
-   * the backend reaction module rolls out
-   * (granit-fx/granit-dotnet#1811); once C-stream lands end-to-end,
-   * every entry carries the field (empty array when no reactions are
-   * present).
+   * Aggregated reactions on this entry — dict keyed by the emoji
+   * short name, carrying only emojis with at least one reactor.
+   * Omitted (`undefined`) when the entry has zero reactions to keep
+   * the wire payload tight (mirrors the backend `Reactions` field on
+   * `TimelineStreamEntryResponse`, granit-fx/granit-dotnet#1811).
    */
-  readonly reactions?: readonly Reaction[];
+  readonly reactions?: ReactionMap;
+  /**
+   * Where this entry originates. `'Native'` for rows stored directly
+   * in the timeline; `'External'` for entries projected from a
+   * registered `ITimelineSource` (e.g. audit). The native default
+   * matches backend behaviour for legacy streams without contributors.
+   */
+  readonly origin?: TimelineEntryOriginValue;
+  /**
+   * Contributor key when {@link origin} is `'External'`
+   * (e.g. `'auditing'`). Always `'native'` for native rows. Together
+   * with {@link sourceId} it forms the stable identifier the anchor
+   * endpoint uses to materialise a shadow row.
+   */
+  readonly sourceKey?: string;
+  /** External primary key in the contributor's store, `null` for native rows. */
+  readonly sourceId?: string | null;
+  /**
+   * Timestamp of the last body edit, or `null` if the entry has never
+   * been edited. Always `null` for external-origin entries — they
+   * reflect upstream changes through a fresh projection, not this
+   * field.
+   */
+  readonly editedAt?: ISODateString | null;
 }
 
 export type TimelineEntryPage = PagedResult<TimelineEntry>;
+
+/**
+ * Stream fetch result — paged entries plus the list of registered
+ * contributors that were dropped from this response (timeout or thrown)
+ * under the `DegradeGracefully` policy. Mirror of the backend
+ * `TimelineStreamResult`, lifted from the `X-Timeline-Degraded-Sources`
+ * response header on the wire.
+ */
+export interface TimelineStreamPage {
+  readonly page: TimelineEntryPage;
+  /** Source keys that failed for this call. Empty when every contributor answered in time. */
+  readonly degradedSources: readonly string[];
+}


### PR DESCRIPTION
## Summary

- Aligns `@granit/timeline` and `@granit/react-timeline` with the backend's federated stream contract (`ITimelineSource`) and the new in-place edit endpoint.
- Adds `origin` / `sourceKey` / `sourceId` / `editedAt` fields on `TimelineEntry` plus the matching const-as-enums (`TimelineEntryOrigin`, `TimelineSourceKeys`, `TimelineEntryNotEditableReason`).
- Adds `anchorTimelineEntry`, `updateTimelineEntryBody` API funcs and `useAnchorEntry` / `useUpdateEntryBody` hooks.
- `getStream` now returns `{ page, degradedSources }`, lifted from the `X-Timeline-Degraded-Sources` response header for the `DegradeGracefully` policy.
- Permission key corrected from `Timeline.React` to `Timeline.Reactions.React` to match the backend registry.

## Test plan

- [ ] `pnpm build` for both `@granit/timeline` and `@granit/react-timeline` — passes locally
- [ ] Consumer (`granit-showcase-admin-react`) type-checks with the new shapes — see companion PR
- [ ] Backend contract validated against `Granit.Timeline.TimelineStreamEntry`, `AnchorTimelineEntryResponse`, `UpdateTimelineEntryBodyRequest`, RFC 7807 `timeline-entry-not-editable` extensions
- [ ] Unit tests on the package compile against the new shapes (reaction-bar / use-toggle-reaction / reaction-api)