### PR TITLE
fix(timeline): align reaction test + drop unused destructuring binding

### DIFF
--- a/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
@@ -83,9 +83,7 @@ export function useToggleReaction(): UseMutationResult<
       const previousQueries = queryClient.getQueriesData({ queryKey: prefix });
 
       queryClient.setQueriesData<unknown>({ queryKey: prefix }, (old: unknown) =>
-        patchEntries(old, vars.entryId, (reactions) =>
-          toggleReactionMap(reactions, vars.emoji)
-        )
+        patchEntries(old, vars.entryId, (reactions) => toggleReactionMap(reactions, vars.emoji))
       );
 
       return { previousQueries };
@@ -101,9 +99,7 @@ export function useToggleReaction(): UseMutationResult<
     onSuccess: (result, vars) => {
       const prefix = streamPrefix(config, vars);
       queryClient.setQueriesData<unknown>({ queryKey: prefix }, (old: unknown) =>
-        patchEntries(old, vars.entryId, (reactions) =>
-          applyToggleResult(reactions, result)
-        )
+        patchEntries(old, vars.entryId, (reactions) => applyToggleResult(reactions, result))
       );
       queryClient.invalidateQueries({ queryKey: prefix });
     },
@@ -160,8 +156,10 @@ export function toggleReactionMap(
   if (current.byCurrentUser) {
     const nextCount = current.count - 1;
     if (nextCount <= 0) {
-      const { [emoji]: _, ...rest } = reactions ?? {};
-      return Object.keys(rest).length === 0 ? undefined : rest;
+      const rest = Object.fromEntries(
+        Object.entries(reactions ?? {}).filter(([key]) => key !== emoji)
+      );
+      return Object.keys(rest).length === 0 ? undefined : (rest as ReactionMap);
     }
     return { ...(reactions ?? {}), [emoji]: { count: nextCount, byCurrentUser: false } };
   }
@@ -183,8 +181,10 @@ export function applyToggleResult(
 ): ReactionMap | undefined {
   if (result.count <= 0) {
     if (!reactions) return undefined;
-    const { [result.emoji]: _, ...rest } = reactions;
-    return Object.keys(rest).length === 0 ? undefined : rest;
+    const rest = Object.fromEntries(
+      Object.entries(reactions).filter(([key]) => key !== result.emoji)
+    );
+    return Object.keys(rest).length === 0 ? undefined : (rest as ReactionMap);
   }
   return {
     ...(reactions ?? {}),

--- a/packages/@granit/timeline/src/__tests__/reaction-api.test.ts
+++ b/packages/@granit/timeline/src/__tests__/reaction-api.test.ts
@@ -4,28 +4,19 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { toggleReaction } from '../api/reaction-api.js';
 import { TimelinePermissions } from '../permissions.js';
-import { REACTION_EMOJIS } from '../types/reaction.js';
+import { REACTION_EMOJIS, type ReactionToggleResult } from '../types/reaction.js';
 
 import type { TimelineEntryId } from '../types/stream.js';
-import type { ISODateString } from '@granit/types';
 import type { AxiosInstance } from 'axios';
 
 const BASE_PATH = '/api/v1/timeline';
 const ENTRY_ID: TimelineEntryId = toEntityId<'TimelineEntry'>('e-42');
 
-const SAMPLE_ENTRY = {
-  id: ENTRY_ID,
-  entryType: 0,
-  body: 'Quote approved',
-  authorId: null,
-  authorName: 'System',
-  parentEntryId: null,
-  occurredAt: '2026-05-09T15:00:00Z' as ISODateString,
-  attachments: [],
-  reactions: [
-    { emoji: 'thumbs_up' as const, count: 3, hasReacted: true },
-    { emoji: 'tada' as const, count: 1, hasReacted: false },
-  ],
+const SAMPLE_RESULT: ReactionToggleResult = {
+  entryId: ENTRY_ID,
+  emoji: 'thumbs_up',
+  count: 3,
+  currentUserHasReacted: true,
 };
 
 describe('toggleReaction', () => {
@@ -36,25 +27,26 @@ describe('toggleReaction', () => {
   });
 
   it('POSTs to /entries/{entryId}/reactions/{emoji} with URI-encoded segments', async () => {
-    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_RESULT));
 
     const result = await toggleReaction(client, BASE_PATH, ENTRY_ID, 'thumbs_up');
 
-    expect(client.post).toHaveBeenCalledWith(
-      '/api/v1/timeline/entries/e-42/reactions/thumbs_up'
-    );
-    expect(result).toEqual(SAMPLE_ENTRY);
+    expect(client.post).toHaveBeenCalledWith('/api/v1/timeline/entries/e-42/reactions/thumbs_up');
+    expect(result).toEqual(SAMPLE_RESULT);
   });
 
-  it('returns the refreshed entry — caller patches its cache from this payload', async () => {
-    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
+  it('returns the post-toggle aggregate — caller patches its cache from this payload', async () => {
+    const heartResult: ReactionToggleResult = {
+      entryId: ENTRY_ID,
+      emoji: 'heart',
+      count: 1,
+      currentUserHasReacted: true,
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(heartResult));
 
     const refreshed = await toggleReaction(client, BASE_PATH, ENTRY_ID, 'heart');
 
-    expect(refreshed.reactions).toEqual([
-      { emoji: 'thumbs_up', count: 3, hasReacted: true },
-      { emoji: 'tada', count: 1, hasReacted: false },
-    ]);
+    expect(refreshed).toEqual(heartResult);
   });
 
   it('propagates 403 when the caller lacks Timeline.Reactions.React', async () => {
@@ -64,7 +56,7 @@ describe('toggleReaction', () => {
   });
 
   it('accepts every code in the closed REACTION_EMOJIS catalog', async () => {
-    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_ENTRY));
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(SAMPLE_RESULT));
 
     for (const emoji of REACTION_EMOJIS) {
       // Type-checks at compile time; verifies the runtime catalog


### PR DESCRIPTION
## Summary
Unblocks CI on `develop` — two pre-existing breakages unrelated to any in-flight feature work.

- `reaction-api.test.ts` still asserted the legacy contract where `toggleReaction` returned a full `TimelineEntry` with a `reactions[]` array. The closed `ReactionToggleResult` (`entryId`, `emoji`, `count`, `currentUserHasReacted`) replaced that on the wire in PR #441 / #442 but the test wasn't migrated → `tsc --noEmit` failed on `refreshed.reactions`. Rewrites fixture + per-test mock payloads to match the actual return type.
- `use-toggle-reaction.ts` removed a key from the optimistic `ReactionMap` via `const { [emoji]: _, ...rest } = …`; the unused `_` binding tripped `@typescript-eslint/no-unused-vars` (no `_`-prefix exception in the repo config). Switched to `Object.fromEntries(Object.entries(…).filter(…))` — equivalent, immutable, and self-explanatory.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [ ] `pnpm --filter @granit/timeline test` passes in CI