### PR TITLE
refactor(dashboards): extract Axios layer into core dashboards/api

### DIFF
--- a/packages/@granit/dashboards/package.json
+++ b/packages/@granit/dashboards/package.json
@@ -13,6 +13,12 @@
   "scripts": {
     "build": "tsup"
   },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
   "publishConfig": {
     "exports": {
       ".": {

--- a/packages/@granit/dashboards/src/api/dashboards-api.ts
+++ b/packages/@granit/dashboards/src/api/dashboards-api.ts
@@ -1,0 +1,327 @@
+import type {
+  DashboardRenderedWidget,
+  DashboardRenderRequest,
+  DashboardRenderResponse,
+} from '../rendering/index.js';
+import type {
+  AddWidgetRequest,
+  DashboardCatalogEntryResponse,
+  DashboardDetailResponse,
+  DashboardImportResponse,
+  DashboardMetadataUpdateRequest,
+  DashboardResyncResponse,
+  DashboardStatus,
+  DashboardSummaryResponse,
+  PagedResponse,
+  UpdateWidgetRequest,
+  WidgetDefinitionBase,
+  WidgetInstanceResponse,
+} from '../types/index.js';
+import type { AxiosInstance, AxiosRequestConfig } from '@granit/api-client';
+
+/**
+ * Optional per-call request options forwarded to axios. Restricted to the
+ * fields the dashboards hooks need (notably `signal` for React Query
+ * cancellation). Avoids importing the full `AxiosRequestConfig` surface at
+ * each call site.
+ */
+export type DashboardsRequestOptions = Pick<AxiosRequestConfig, 'signal'>;
+
+/**
+ * Query params accepted by `GET {basePath}/`.
+ */
+export interface DashboardListParams {
+  /** Filter by lifecycle state. `undefined` = all statuses. */
+  readonly status?: DashboardStatus;
+  /** Zero-based page index. Backend default: 0. */
+  readonly page?: number;
+  /** Page size. Backend default: 50, capped at 200. */
+  readonly pageSize?: number;
+}
+
+/**
+ * Body for `POST {widgetsBasePath}/{kind}/render` — the per-widget render
+ * endpoints (P3, symmetric with the bundle path).
+ */
+export interface WidgetRenderBody<TDefinition extends WidgetDefinitionBase> {
+  readonly definition: TDefinition;
+  readonly context: WidgetRenderContextPayload;
+}
+
+/**
+ * Context passed alongside the widget definition to the per-widget render
+ * endpoints. Same shape as the dashboard-level
+ * {@link DashboardRenderRequest} minus the dashboard-scoped fields.
+ */
+export interface WidgetRenderContextPayload {
+  readonly periodFrom?: string;
+  readonly periodTo?: string;
+  readonly periodToken?: string;
+  readonly locale?: string;
+  readonly filters?: Readonly<Record<string, string>> | null;
+}
+
+/**
+ * Wire-format kinds accepted by the per-widget render endpoints.
+ */
+export type WidgetRenderKind = 'kpi' | 'chart' | 'table' | 'pivot' | 'map';
+
+/**
+ * `GET {basePath}/catalog` — returns the catalog of available
+ * `DashboardDefinition` descriptors. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardCatalogEndpoints`.
+ */
+export async function getDashboardCatalog(
+  client: AxiosInstance,
+  basePath: string,
+  options?: DashboardsRequestOptions
+): Promise<readonly DashboardCatalogEntryResponse[]> {
+  const response = await client.get<readonly DashboardCatalogEntryResponse[]>(
+    `${basePath}/catalog`,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `GET {basePath}/?status=&page=&pageSize=` — returns a paged list of the
+ * tenant's persisted dashboards. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardInstanceEndpoints.ListAsync`.
+ */
+export async function listDashboards(
+  client: AxiosInstance,
+  basePath: string,
+  params: DashboardListParams = {},
+  options?: DashboardsRequestOptions
+): Promise<PagedResponse<DashboardSummaryResponse>> {
+  const response = await client.get<PagedResponse<DashboardSummaryResponse>>(basePath, {
+    ...options,
+    params: {
+      status: params.status,
+      page: params.page,
+      pageSize: params.pageSize,
+    },
+  });
+  return response.data;
+}
+
+/**
+ * `GET {basePath}/{id}` — returns the full payload for one persisted
+ * dashboard (summary fields + ordered widget pool). Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardInstanceEndpoints.ReadByIdAsync`.
+ */
+export async function getDashboard(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  options?: DashboardsRequestOptions
+): Promise<DashboardDetailResponse> {
+  const response = await client.get<DashboardDetailResponse>(
+    `${basePath}/${encodeURIComponent(id)}`,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `POST {basePath}/{id}/render` — returns the rendered bundle for a
+ * persisted dashboard.
+ */
+export async function renderDashboard(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: DashboardRenderRequest,
+  options?: DashboardsRequestOptions
+): Promise<DashboardRenderResponse> {
+  const response = await client.post<DashboardRenderResponse>(
+    `${basePath}/${encodeURIComponent(id)}/render`,
+    request,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `POST {basePath}/{id}/publish` — promotes a Draft dashboard to Published.
+ * Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardStateTransitionEndpoints.PublishAsync`.
+ */
+export async function publishDashboard(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  options?: DashboardsRequestOptions
+): Promise<void> {
+  await client.post(`${basePath}/${encodeURIComponent(id)}/publish`, undefined, options);
+}
+
+/**
+ * `POST {basePath}/{id}/archive` — hides a dashboard from the catalog but
+ * keeps the row for audit / restore. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardStateTransitionEndpoints.ArchiveAsync`.
+ */
+export async function archiveDashboard(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  options?: DashboardsRequestOptions
+): Promise<void> {
+  await client.post(`${basePath}/${encodeURIComponent(id)}/archive`, undefined, options);
+}
+
+/**
+ * `POST {basePath}/{id}/restore` — moves an Archived dashboard back to
+ * Draft. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardStateTransitionEndpoints.RestoreAsync`.
+ */
+export async function restoreDashboard(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  options?: DashboardsRequestOptions
+): Promise<void> {
+  await client.post(`${basePath}/${encodeURIComponent(id)}/restore`, undefined, options);
+}
+
+/**
+ * `POST {basePath}/from-definition/{name}` — imports a dashboard definition
+ * from the catalog into the tenant's persisted-instance pool. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardImportEndpoints`.
+ */
+export async function importDashboard(
+  client: AxiosInstance,
+  basePath: string,
+  definitionName: string,
+  options?: DashboardsRequestOptions
+): Promise<DashboardImportResponse> {
+  const response = await client.post<DashboardImportResponse>(
+    `${basePath}/from-definition/${encodeURIComponent(definitionName)}`,
+    undefined,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `POST {basePath}/{id}/resync` — replays the registered
+ * `DashboardDefinition` behind a persisted dashboard's
+ * `sourceDefinitionName`. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardResyncEndpoints.ResyncAsync`.
+ */
+export async function resyncDashboard(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  options?: DashboardsRequestOptions
+): Promise<DashboardResyncResponse> {
+  const response = await client.post<DashboardResyncResponse>(
+    `${basePath}/${encodeURIComponent(id)}/resync`,
+    undefined,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `PUT {basePath}/{id}` — updates the editable metadata (name + grid
+ * layout) of a persisted dashboard. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardMetadataEditEndpoints`.
+ */
+export async function updateDashboardMetadata(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: DashboardMetadataUpdateRequest,
+  options?: DashboardsRequestOptions
+): Promise<DashboardSummaryResponse> {
+  const response = await client.put<DashboardSummaryResponse>(
+    `${basePath}/${encodeURIComponent(id)}`,
+    request,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `POST {basePath}/{dashboardId}/widgets` — pins a new widget to a
+ * persisted dashboard's widget pool. The server allocates the widget id.
+ * Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardWidgetEndpoints.AddWidgetAsync`.
+ */
+export async function createWidget(
+  client: AxiosInstance,
+  basePath: string,
+  dashboardId: string,
+  request: AddWidgetRequest,
+  options?: DashboardsRequestOptions
+): Promise<WidgetInstanceResponse> {
+  const response = await client.post<WidgetInstanceResponse>(
+    `${basePath}/${encodeURIComponent(dashboardId)}/widgets`,
+    request,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `PUT {basePath}/{dashboardId}/widgets/{widgetId}` — full replacement of a
+ * widget's editable fields (layout + title + config). Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardWidgetEndpoints.UpdateWidgetAsync`.
+ */
+export async function updateWidget(
+  client: AxiosInstance,
+  basePath: string,
+  dashboardId: string,
+  widgetId: string,
+  request: UpdateWidgetRequest,
+  options?: DashboardsRequestOptions
+): Promise<WidgetInstanceResponse> {
+  const response = await client.put<WidgetInstanceResponse>(
+    `${basePath}/${encodeURIComponent(dashboardId)}/widgets/${encodeURIComponent(widgetId)}`,
+    request,
+    options
+  );
+  return response.data;
+}
+
+/**
+ * `DELETE {basePath}/{dashboardId}/widgets/{widgetId}` — removes a widget
+ * from the pool and re-ranks remaining widgets. Mirrors
+ * `Granit.Dashboards.Endpoints.DashboardWidgetEndpoints.RemoveWidgetAsync`.
+ */
+export async function deleteWidget(
+  client: AxiosInstance,
+  basePath: string,
+  dashboardId: string,
+  widgetId: string,
+  options?: DashboardsRequestOptions
+): Promise<void> {
+  await client.delete(
+    `${basePath}/${encodeURIComponent(dashboardId)}/widgets/${encodeURIComponent(widgetId)}`,
+    options
+  );
+}
+
+/**
+ * `POST {widgetsBasePath}/{kind}/render` — calls the per-widget render
+ * endpoint (P3 backend, symmetric with the bundle path). Returns a single
+ * {@link DashboardRenderedWidget} envelope.
+ *
+ * Note: `widgetsBasePath` is independent of the dashboards `basePath` — it
+ * targets the per-widget API (default `/api/v1/widgets`).
+ */
+export async function renderWidget<TDefinition extends WidgetDefinitionBase>(
+  client: AxiosInstance,
+  widgetsBasePath: string,
+  kind: WidgetRenderKind,
+  body: WidgetRenderBody<TDefinition>,
+  options?: DashboardsRequestOptions
+): Promise<DashboardRenderedWidget> {
+  const response = await client.post<DashboardRenderedWidget>(
+    `${widgetsBasePath}/${kind}/render`,
+    body,
+    options
+  );
+  return response.data;
+}

--- a/packages/@granit/dashboards/src/api/index.ts
+++ b/packages/@granit/dashboards/src/api/index.ts
@@ -1,0 +1,23 @@
+export {
+  archiveDashboard,
+  createWidget,
+  deleteWidget,
+  getDashboard,
+  getDashboardCatalog,
+  importDashboard,
+  listDashboards,
+  publishDashboard,
+  renderDashboard,
+  renderWidget,
+  restoreDashboard,
+  resyncDashboard,
+  updateDashboardMetadata,
+  updateWidget,
+} from './dashboards-api.js';
+export type {
+  DashboardListParams,
+  DashboardsRequestOptions,
+  WidgetRenderBody,
+  WidgetRenderContextPayload,
+  WidgetRenderKind,
+} from './dashboards-api.js';

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -104,6 +104,32 @@ export {
   isMarkdownSnapshotEnvelope,
   isTextSnapshotEnvelope,
 } from './rendering/index.js';
+// HTTP API — Axios-based, framework-agnostic. React Query hooks live in
+// @granit/react-dashboards and delegate to these functions.
+export {
+  archiveDashboard,
+  createWidget,
+  deleteWidget,
+  getDashboard,
+  getDashboardCatalog,
+  importDashboard,
+  listDashboards,
+  publishDashboard,
+  renderDashboard,
+  renderWidget,
+  restoreDashboard,
+  resyncDashboard,
+  updateDashboardMetadata,
+  updateWidget,
+} from './api/index.js';
+export type {
+  DashboardListParams,
+  DashboardsRequestOptions,
+  WidgetRenderBody,
+  WidgetRenderContextPayload,
+  WidgetRenderKind,
+} from './api/index.js';
+
 export type {
   DashboardDriftStatus,
   DashboardRenderedWidget,

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
@@ -1,3 +1,4 @@
+import { getDashboardCatalog } from '@granit/dashboards';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -30,13 +31,7 @@ export function useDashboardCatalog(
   const { client, basePath } = useDashboardsConfig();
   return useQuery({
     queryKey: dashboardCatalogQueryKey(),
-    queryFn: async ({ signal }) => {
-      const { data } = await client.get<readonly DashboardCatalogEntryResponse[]>(
-        `${basePath}/catalog`,
-        { signal }
-      );
-      return data;
-    },
+    queryFn: ({ signal }) => getDashboardCatalog(client, basePath, { signal }),
     enabled: options.enabled ?? true,
     staleTime: 5 * 60_000,
   });

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-detail.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-detail.ts
@@ -1,3 +1,4 @@
+import { getDashboard } from '@granit/dashboards';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -27,13 +28,7 @@ export function useDashboardDetail(
   const { client, basePath } = useDashboardsConfig();
   return useQuery({
     queryKey: dashboardDetailQueryKey(id),
-    queryFn: async ({ signal }) => {
-      const { data } = await client.get<DashboardDetailResponse>(
-        `${basePath}/${encodeURIComponent(id)}`,
-        { signal }
-      );
-      return data;
-    },
+    queryFn: ({ signal }) => getDashboard(client, basePath, id, { signal }),
     enabled: (options.enabled ?? true) && id.length > 0,
     staleTime: 60_000,
   });

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-list.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-list.ts
@@ -1,3 +1,4 @@
+import { listDashboards } from '@granit/dashboards';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -36,17 +37,7 @@ export function useDashboardList(
   const { client, basePath } = useDashboardsConfig();
   return useQuery({
     queryKey: dashboardListQueryKey(params),
-    queryFn: async ({ signal }) => {
-      const { data } = await client.get<PagedResponse<DashboardSummaryResponse>>(basePath, {
-        signal,
-        params: {
-          status: params.status,
-          page: params.page,
-          pageSize: params.pageSize,
-        },
-      });
-      return data;
-    },
+    queryFn: ({ signal }) => listDashboards(client, basePath, params, { signal }),
     enabled: options.enabled ?? true,
     staleTime: 60_000,
   });

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-render.ts
@@ -1,4 +1,5 @@
 import { HttpError } from '@granit/api-client';
+import { renderDashboard } from '@granit/dashboards';
 import {
   useQuery,
   useQueryClient,
@@ -97,14 +98,8 @@ export function useDashboardRender(
 
   const result = useQuery({
     queryKey,
-    queryFn: async ({ signal }) => {
-      const { data } = await client.post<DashboardRenderResponse>(
-        `${basePath}/${encodeURIComponent(dashboardId)}/render`,
-        normalizedRequest,
-        { signal }
-      );
-      return data;
-    },
+    queryFn: ({ signal }) =>
+      renderDashboard(client, basePath, dashboardId, normalizedRequest, { signal }),
     enabled: options.enabled ?? true,
     retry: shouldRetry,
     staleTime: 60_000,

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-state-transitions.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-state-transitions.ts
@@ -1,3 +1,4 @@
+import { archiveDashboard, publishDashboard, restoreDashboard } from '@granit/dashboards';
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -31,9 +32,7 @@ export function usePublishDashboard(): UseMutationResult<void, Error, string> {
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      await client.post(`${basePath}/${encodeURIComponent(id)}/publish`);
-    },
+    mutationFn: (id: string) => publishDashboard(client, basePath, id),
     onSuccess: (_void, id) => invalidateAfterTransition(queryClient, id),
   });
 }
@@ -50,9 +49,7 @@ export function useArchiveDashboard(): UseMutationResult<void, Error, string> {
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      await client.post(`${basePath}/${encodeURIComponent(id)}/archive`);
-    },
+    mutationFn: (id: string) => archiveDashboard(client, basePath, id),
     onSuccess: (_void, id) => invalidateAfterTransition(queryClient, id),
   });
 }
@@ -66,9 +63,7 @@ export function useRestoreDashboard(): UseMutationResult<void, Error, string> {
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      await client.post(`${basePath}/${encodeURIComponent(id)}/restore`);
-    },
+    mutationFn: (id: string) => restoreDashboard(client, basePath, id),
     onSuccess: (_void, id) => invalidateAfterTransition(queryClient, id),
   });
 }

--- a/packages/@granit/react-dashboards/src/hooks/use-import-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-import-dashboard.ts
@@ -1,3 +1,4 @@
+import { importDashboard } from '@granit/dashboards';
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -25,12 +26,7 @@ export function useImportDashboard(): UseMutationResult<DashboardImportResponse,
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (definitionName: string) => {
-      const { data } = await client.post<DashboardImportResponse>(
-        `${basePath}/from-definition/${encodeURIComponent(definitionName)}`
-      );
-      return data;
-    },
+    mutationFn: (definitionName: string) => importDashboard(client, basePath, definitionName),
     onSuccess: async (imported) => {
       // Drop any stale detail cache for the freshly imported id (most
       // likely none, but cheap to clear).

--- a/packages/@granit/react-dashboards/src/hooks/use-resync-dashboard.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-resync-dashboard.ts
@@ -1,3 +1,4 @@
+import { resyncDashboard } from '@granit/dashboards';
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -33,12 +34,7 @@ export function useResyncDashboard(): UseMutationResult<DashboardResyncResponse,
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (id: string) => {
-      const response = await client.post<DashboardResyncResponse>(
-        `${basePath}/${encodeURIComponent(id)}/resync`
-      );
-      return response.data;
-    },
+    mutationFn: (id: string) => resyncDashboard(client, basePath, id),
     onSuccess: async (_response, id) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['dashboards', 'list'] }),

--- a/packages/@granit/react-dashboards/src/hooks/use-update-dashboard-metadata.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-update-dashboard-metadata.ts
@@ -1,3 +1,4 @@
+import { updateDashboardMetadata } from '@granit/dashboards';
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -36,13 +37,8 @@ export function useUpdateDashboardMetadata(): UseMutationResult<
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ id, request }: UpdateDashboardMetadataVariables) => {
-      const { data } = await client.put<DashboardSummaryResponse>(
-        `${basePath}/${encodeURIComponent(id)}`,
-        request
-      );
-      return data;
-    },
+    mutationFn: ({ id, request }: UpdateDashboardMetadataVariables) =>
+      updateDashboardMetadata(client, basePath, id, request),
     onSuccess: async (_summary, { id }) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ['dashboards', 'list'] }),

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-crud.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-crud.ts
@@ -1,3 +1,4 @@
+import { createWidget, deleteWidget, updateWidget } from '@granit/dashboards';
 import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider.js';
@@ -52,13 +53,8 @@ export function useAddWidget(): UseMutationResult<
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ dashboardId, request }: AddWidgetVariables) => {
-      const { data } = await client.post<WidgetInstanceResponse>(
-        `${basePath}/${encodeURIComponent(dashboardId)}/widgets`,
-        request
-      );
-      return data;
-    },
+    mutationFn: ({ dashboardId, request }: AddWidgetVariables) =>
+      createWidget(client, basePath, dashboardId, request),
     onSuccess: (_widget, { dashboardId }) =>
       queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(dashboardId) }),
   });
@@ -80,13 +76,8 @@ export function useUpdateWidget(): UseMutationResult<
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ dashboardId, widgetId, request }: UpdateWidgetVariables) => {
-      const { data } = await client.put<WidgetInstanceResponse>(
-        `${basePath}/${encodeURIComponent(dashboardId)}/widgets/${encodeURIComponent(widgetId)}`,
-        request
-      );
-      return data;
-    },
+    mutationFn: ({ dashboardId, widgetId, request }: UpdateWidgetVariables) =>
+      updateWidget(client, basePath, dashboardId, widgetId, request),
     onSuccess: (_widget, { dashboardId }) =>
       queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(dashboardId) }),
   });
@@ -101,11 +92,8 @@ export function useRemoveWidget(): UseMutationResult<void, Error, RemoveWidgetVa
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ dashboardId, widgetId }: RemoveWidgetVariables) => {
-      await client.delete(
-        `${basePath}/${encodeURIComponent(dashboardId)}/widgets/${encodeURIComponent(widgetId)}`
-      );
-    },
+    mutationFn: ({ dashboardId, widgetId }: RemoveWidgetVariables) =>
+      deleteWidget(client, basePath, dashboardId, widgetId),
     onSuccess: (_void, { dashboardId }) =>
       queryClient.invalidateQueries({ queryKey: dashboardDetailQueryKey(dashboardId) }),
   });

--- a/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-widget-render.ts
@@ -1,4 +1,5 @@
 import { HttpError } from '@granit/api-client';
+import { renderWidget } from '@granit/dashboards';
 import { useQuery, type Query, type UseQueryResult } from '@tanstack/react-query';
 import { useMemo } from 'react';
 
@@ -121,14 +122,14 @@ export function useWidgetRender<TDefinition extends WidgetDefinitionBase>(
 
   return useQuery({
     queryKey,
-    queryFn: async ({ signal }) => {
-      const { data } = await client.post<DashboardRenderedWidget>(
-        `${WIDGET_RENDER_PATH}/${kind}/render`,
+    queryFn: ({ signal }) =>
+      renderWidget(
+        client,
+        WIDGET_RENDER_PATH,
+        kind,
         { definition, context: effectiveContext },
         { signal }
-      );
-      return data;
-    },
+      ),
     enabled: options.enabled ?? true,
     retry: shouldRetry,
     staleTime: 60_000,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -132,7 +132,7 @@ importers:
         specifier: ^0.22.1
         version: 0.22.1
       msw:
-        specifier: ^2.14.6
+        specifier: ^2.14.5
         version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       prettier:
         specifier: ^3.8.3
@@ -347,7 +347,11 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
-  packages/@granit/dashboards: {}
+  packages/@granit/dashboards:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
 
   packages/@granit/data-exchange:
     dependencies:
@@ -8267,7 +8271,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1)(msw@2.14.5(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0))
     optional: true
 
   '@vitest/coverage-v8@4.1.6(vitest@4.1.6)':


### PR DESCRIPTION
## Summary

INC3 bis from the recent module homogeneity audit. Make `@granit/dashboards` (core) framework-agnostic by extracting all Axios HTTP calls from `react-dashboards/hooks/*` into `dashboards/src/api/dashboards-api.ts`, mirroring the canonical pattern (activities, parties, etc.).

## Changes

- New `packages/@granit/dashboards/src/api/dashboards-api.ts` with 14 plain async functions covering every backend endpoint touched by the React hooks
- 10 hooks rewired to delegate to the api layer; public signatures unchanged
- `@granit/api-client` added to `dashboards` peerDependencies
- Core `dashboards` package no longer requires React or react-query

| Function | Route |
|---|---|
| `getDashboardCatalog` | `GET {basePath}/catalog` |
| `listDashboards` | `GET {basePath}/` |
| `getDashboard` | `GET {basePath}/{id}` |
| `renderDashboard` | `POST {basePath}/{id}/render` |
| `publishDashboard` | `POST {basePath}/{id}/publish` |
| `archiveDashboard` | `POST {basePath}/{id}/archive` |
| `restoreDashboard` | `POST {basePath}/{id}/restore` |
| `importDashboard` | `POST {basePath}/from-definition/{name}` |
| `resyncDashboard` | `POST {basePath}/{id}/resync` |
| `updateDashboardMetadata` | `PUT {basePath}/{id}` |
| `createWidget` | `POST {basePath}/{dashboardId}/widgets` |
| `updateWidget` | `PUT {basePath}/{dashboardId}/widgets/{widgetId}` |
| `deleteWidget` | `DELETE {basePath}/{dashboardId}/widgets/{widgetId}` |
| `renderWidget` | `POST {widgetsBasePath}/{kind}/render` |

## Test plan

- [x] `pnpm --filter @granit/dashboards exec tsc --noEmit`
- [x] `pnpm --filter @granit/react-dashboards exec tsc --noEmit`
- [x] `pnpm lint` (0 warnings)
- [x] `npx vitest run packages/@granit/dashboards` — 81/81
- [x] `npx vitest run packages/@granit/react-dashboards` — 167/167