### PR TITLE
fix(security): address audit findings (MSAL cache, tenant isolation, CSRF, BFF session)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -152,6 +152,11 @@
               "name": "csrfTokenGetter",
               "kind": "property",
               "signature": "csrfTokenGetter?: CsrfTokenGetter"
+            },
+            {
+              "name": "refreshCsrfToken",
+              "kind": "method",
+              "signature": "refreshCsrfToken?: () => Promise<string | null>"
             }
           ]
         },
@@ -388,6 +393,11 @@
               "name": "onSessionEnd",
               "kind": "method",
               "signature": "onSessionEnd?: () => void"
+            },
+            {
+              "name": "cacheLocation",
+              "kind": "property",
+              "signature": "cacheLocation?: 'memory' | 'sessionStorage' | 'localStorage'"
             }
           ]
         }
@@ -3774,7 +3784,18 @@
           "name": "TenantProviderProps",
           "kind": "interface",
           "signature": "interface TenantProviderProps",
-          "members": []
+          "members": [
+            {
+              "name": "tenantId",
+              "kind": "property",
+              "signature": "tenantId: string | undefined,"
+            },
+            {
+              "name": "previousTenantId",
+              "kind": "property",
+              "signature": "previousTenantId: string | undefined"
+            }
+          ]
         },
         {
           "name": "useKeycloakTenantResolvers",
@@ -3786,6 +3807,11 @@
           "kind": "interface",
           "signature": "interface UseKeycloakTenantResolversOptions",
           "members": []
+        },
+        {
+          "name": "useClearQueriesOnTenantChange",
+          "kind": "function",
+          "signature": "function useClearQueriesOnTenantChange(): void"
         }
       ]
     },

--- a/packages/@granit/api-client/src/__tests__/api-client.test.ts
+++ b/packages/@granit/api-client/src/__tests__/api-client.test.ts
@@ -451,6 +451,7 @@ describe('BFF mode', () => {
   });
 
   it('should NOT inject X-CSRF-Token when csrfTokenGetter returns null', async () => {
+    const warnSpy = vi.spyOn(globalThis.console, 'warn').mockImplementation(() => undefined);
     const client = mod.createApiClient({
       baseURL: 'https://api.example.com',
       mode: 'bff',
@@ -460,6 +461,40 @@ describe('BFF mode', () => {
 
     const response = await client.post('/test', {});
     expect(response.config.headers['X-CSRF-Token']).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('BFF mutation sent without X-CSRF-Token')
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('should self-heal: await refreshCsrfToken when cached token is null', async () => {
+    const refreshCsrfToken = vi.fn().mockResolvedValue('fresh-csrf');
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => null,
+      refreshCsrfToken,
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.post('/test', {});
+    expect(refreshCsrfToken).toHaveBeenCalledOnce();
+    expect(response.config.headers['X-CSRF-Token']).toBe('fresh-csrf');
+  });
+
+  it('should prefer the cached token over the refresh callback when available', async () => {
+    const refreshCsrfToken = vi.fn().mockResolvedValue('refreshed');
+    const client = mod.createApiClient({
+      baseURL: 'https://api.example.com',
+      mode: 'bff',
+      csrfTokenGetter: () => 'cached',
+      refreshCsrfToken,
+    });
+    client.defaults.adapter = captureAdapter;
+
+    const response = await client.post('/test', {});
+    expect(refreshCsrfToken).not.toHaveBeenCalled();
+    expect(response.config.headers['X-CSRF-Token']).toBe('cached');
   });
 
   it('should NOT inject Authorization header in BFF mode', async () => {

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -28,6 +28,14 @@ export interface ApiClientConfig {
    * Typically obtained from `CsrfManager.getToken` in `@granit/bff`.
    */
   csrfTokenGetter?: CsrfTokenGetter;
+  /**
+   * Optional async fetch-and-cache callback invoked when a BFF mutation is
+   * about to be sent and `csrfTokenGetter()` returns `null` (bootstrap race
+   * window). Typically `csrfManager.fetchToken` from `@granit/bff`. When
+   * provided, the interceptor awaits a fresh token instead of sending the
+   * request without `X-CSRF-Token`, eliminating defense-in-depth gaps.
+   */
+  refreshCsrfToken?: () => Promise<string | null>;
 }
 
 // ---------------------------------------------------------------------------
@@ -120,11 +128,20 @@ export function createApiClient(config: ApiClientConfig): AxiosInstance {
   instance.interceptors.request.use(
     async (req: InternalAxiosRequestConfig) => {
       if (isBff) {
-        // BFF mode: inject CSRF token on mutation methods
-        if (config.csrfTokenGetter && MUTATION_METHODS.has(req.method ?? '')) {
-          const csrfToken = config.csrfTokenGetter();
+        // BFF mode: inject CSRF token on mutation methods. If the cached token
+        // is not yet available (bootstrap race), await the refresh callback
+        // instead of silently sending the request without X-CSRF-Token.
+        if (MUTATION_METHODS.has(req.method ?? '')) {
+          let csrfToken = config.csrfTokenGetter?.() ?? null;
+          if (!csrfToken && config.refreshCsrfToken) {
+            csrfToken = await config.refreshCsrfToken();
+          }
           if (csrfToken) {
             req.headers['X-CSRF-Token'] = csrfToken;
+          } else if (config.csrfTokenGetter || config.refreshCsrfToken) {
+            globalThis.console.warn(
+              '[@granit/api-client] BFF mutation sent without X-CSRF-Token — token unavailable. Request will likely be rejected by the BFF.'
+            );
           }
         }
       } else if (_tokenGetter) {

--- a/packages/@granit/authentication-entraid/src/types/index.ts
+++ b/packages/@granit/authentication-entraid/src/types/index.ts
@@ -29,4 +29,14 @@ export interface EntraIdCoreConfig {
   onAcquireTokenFailure?: () => void;
   /** Called when the user's session is terminated. */
   onSessionEnd?: () => void;
+
+  /**
+   * MSAL token cache location. Defaults to `'memory'` so OIDC tokens are not
+   * readable by same-origin JavaScript (XSS, malicious browser extensions).
+   * Override only when cross-tab persistence is required AND the app ships an
+   * XSS-hardened CSP. Storing tokens in `localStorage`/`sessionStorage` is a
+   * known high-severity risk (CWE-922) — prefer the BFF cookie pattern
+   * (`@granit/bff`) for persistent sessions.
+   */
+  cacheLocation?: 'memory' | 'sessionStorage' | 'localStorage';
 }

--- a/packages/@granit/bff/src/__tests__/csrf-manager.test.ts
+++ b/packages/@granit/bff/src/__tests__/csrf-manager.test.ts
@@ -177,5 +177,26 @@ describe('CsrfManager', () => {
       const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
       expect(init?.credentials).toBe('include');
     });
+
+    it('should reject cross-origin requests to prevent BFF cookie leakage', async () => {
+      const manager = new CsrfManager('/app');
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+      const wrappedFetch = manager.createFetchWithCsrf();
+
+      await expect(wrappedFetch('https://evil.example.com/steal')).rejects.toThrow(
+        /refuses cross-origin request/
+      );
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should accept same-origin absolute URLs', async () => {
+      const manager = new CsrfManager('/app');
+      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+      const wrappedFetch = manager.createFetchWithCsrf();
+
+      const sameOrigin = `${globalThis.location.origin}/app/bff/anything`;
+      await wrappedFetch(sameOrigin);
+      expect(globalThis.fetch).toHaveBeenCalledOnce();
+    });
   });
 });

--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -32,14 +32,30 @@ export class CsrfManager {
     return this.token;
   }
 
-  /** Return the current CSRF token, or null if not yet fetched. */
+  /**
+   * Return the current CSRF token, or null if not yet fetched.
+   *
+   * @internal Intended for the api-client interceptor wiring only. Consumers
+   * should let `@granit/api-client` inject the header automatically rather
+   * than calling this directly; exposing the raw token to UI code expands the
+   * attack surface for malicious same-origin scripts.
+   */
   getToken(): string | null {
     return this.token;
   }
 
-  /** Create a fetch wrapper that auto-injects X-CSRF-Token on mutation requests. */
+  /**
+   * Create a fetch wrapper that auto-injects `X-CSRF-Token` on mutation
+   * requests and sends the BFF session cookie via `credentials: 'include'`.
+   *
+   * The wrapper rejects any URL that is not same-origin as the document — a
+   * cross-origin request would inadvertently send the BFF session cookie to
+   * a third party. Domain API calls must go through `@granit/api-client`
+   * instead of this helper.
+   */
   createFetchWithCsrf(): typeof fetch {
-    return (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      assertSameOrigin(input);
       const method = (init?.method ?? 'GET').toUpperCase();
       if (MUTATION_METHODS.has(method) && this.token) {
         const headers = new Headers(init?.headers);
@@ -48,5 +64,26 @@ export class CsrfManager {
       }
       return fetch(input, { ...init, credentials: 'include' });
     };
+  }
+}
+
+/**
+ * Throws if `input` resolves to a different origin than the current document.
+ * Relative URLs (`/bff/...`) and same-origin absolute URLs are accepted.
+ */
+function assertSameOrigin(input: RequestInfo | URL): void {
+  if (typeof globalThis.location === 'undefined') return; // SSR / Node tests
+  const rawUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  let resolved: URL;
+  try {
+    resolved = new URL(rawUrl, globalThis.location.href);
+  } catch {
+    throw new TypeError(`[@granit/bff] CsrfManager: invalid URL "${String(rawUrl)}"`);
+  }
+  if (resolved.origin !== globalThis.location.origin) {
+    throw new Error(
+      `[@granit/bff] CsrfManager refuses cross-origin request to ${resolved.origin}. ` +
+        `Use @granit/api-client for domain APIs; this helper is reserved for BFF same-origin endpoints.`
+    );
   }
 }

--- a/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
+++ b/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
@@ -63,7 +63,10 @@ export function useEntraIdInit(config: EntraIdCoreConfig): EntraIdCoreResult {
             authority: config.authority,
             redirectUri: config.redirectUri,
           },
-          cache: { cacheLocation: 'sessionStorage' },
+          // Default to in-memory cache — OIDC tokens stored in
+          // localStorage/sessionStorage are readable by any same-origin script
+          // (XSS, malicious extensions). See EntraIdCoreConfig.cacheLocation.
+          cache: { cacheLocation: config.cacheLocation ?? 'memory' },
         });
 
         await msalInstance.initialize();
@@ -98,8 +101,11 @@ export function useEntraIdInit(config: EntraIdCoreConfig): EntraIdCoreResult {
             msalInstance.logoutRedirect();
           });
         }
-      } catch {
-        // MSAL init failed — stay unauthenticated
+      } catch (error) {
+        globalThis.console.warn(
+          '[@granit/react-authentication-entraid] MSAL initialization failed',
+          error
+        );
       } finally {
         setLoading(false);
       }

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -53,17 +53,40 @@ export function BffProvider({ config, children }: BffProviderProps) {
         const response = await fetch(`${configRef.current.pathPrefix}/bff/user`, {
           credentials: 'include',
         });
-        const data = await response.json();
         if (cancelled) return;
-        if (data.authenticated) {
+
+        // Validate transport-level success and content-type before parsing —
+        // captive portals, proxy error pages and HTML redirects can otherwise
+        // flow attacker-influenced fields into the auth context.
+        if (!response.ok) {
+          setUser(null);
+          configRef.current.onUnauthenticated?.();
+          return;
+        }
+        // JSON.parse will throw on HTML captive-portal responses; the shape
+        // check below ensures attacker-controlled fields cannot flow into the
+        // auth context even when the body parses as some other JSON.
+        const data = (await response.json()) as unknown;
+        if (cancelled) return;
+
+        // Minimal shape validation — defense in depth, do not trust the
+        // response just because the BFF is first-party.
+        if (
+          typeof data === 'object' &&
+          data !== null &&
+          'authenticated' in data &&
+          (data as { authenticated: unknown }).authenticated === true
+        ) {
           setUser(data as BffUser);
           await csrfManager.fetchToken();
         } else {
           setUser(null);
           configRef.current.onUnauthenticated?.();
         }
-      } catch {
-        if (!cancelled) setUser(null);
+      } catch (error) {
+        if (cancelled) return;
+        globalThis.console.warn('[@granit/react-bff] BFF session check failed', error);
+        setUser(null);
       } finally {
         if (!cancelled) setIsLoading(false);
       }
@@ -73,10 +96,37 @@ export function BffProvider({ config, children }: BffProviderProps) {
 
     const interval = configRef.current.sessionCheckInterval ?? 60_000;
     if (interval > 0) {
-      const timer = setInterval(() => void checkSession(), interval);
+      // ±10% jitter prevents a synchronised request herd across tabs/users,
+      // and visibilitychange gating avoids polling background tabs.
+      const jitter = () => interval * (0.9 + Math.random() * 0.2);
+      let timer: ReturnType<typeof setTimeout> | undefined;
+
+      const schedule = () => {
+        timer = setTimeout(() => {
+          if (cancelled) return;
+          if (typeof document === 'undefined' || !document.hidden) {
+            void checkSession();
+          }
+          schedule();
+        }, jitter());
+      };
+      schedule();
+
+      const onVisibility = () => {
+        if (typeof document !== 'undefined' && !document.hidden && !cancelled) {
+          void checkSession();
+        }
+      };
+      if (typeof document !== 'undefined') {
+        document.addEventListener('visibilitychange', onVisibility);
+      }
+
       return () => {
         cancelled = true;
-        clearInterval(timer);
+        if (timer) clearTimeout(timer);
+        if (typeof document !== 'undefined') {
+          document.removeEventListener('visibilitychange', onVisibility);
+        }
       };
     }
 

--- a/packages/@granit/react-multi-tenancy/src/__tests__/tenant-provider.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/tenant-provider.test.tsx
@@ -69,6 +69,45 @@ describe('TenantProvider', () => {
 
     expect(setTenantGetter).toHaveBeenCalledWith(expect.any(Function));
   });
+
+  it('does not fire onTenantChange on initial mount', () => {
+    const onTenantChange = vi.fn();
+    const resolvers: TenantResolver[] = [
+      { order: 100, name: 'test', resolve: () => ({ id: 'tenant-1' }) },
+    ];
+
+    renderHook(() => useTenant(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <TenantProvider resolvers={resolvers} onTenantChange={onTenantChange}>
+          {children}
+        </TenantProvider>
+      ),
+    });
+
+    expect(onTenantChange).not.toHaveBeenCalled();
+  });
+
+  it('fires onTenantChange when the resolved tenant id changes', () => {
+    const onTenantChange = vi.fn();
+    let currentTenantId = 'tenant-a';
+    const resolvers: TenantResolver[] = [
+      { order: 100, name: 'dynamic', resolve: () => ({ id: currentTenantId }) },
+    ];
+
+    const { rerender } = renderHook(() => useTenant(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <TenantProvider resolvers={[...resolvers]} onTenantChange={onTenantChange}>
+          {children}
+        </TenantProvider>
+      ),
+    });
+
+    currentTenantId = 'tenant-b';
+    rerender();
+
+    expect(onTenantChange).toHaveBeenCalledTimes(1);
+    expect(onTenantChange).toHaveBeenCalledWith('tenant-b', 'tenant-a');
+  });
 });
 
 describe('useTenant', () => {

--- a/packages/@granit/react-multi-tenancy/src/hooks/use-clear-queries-on-tenant-change.ts
+++ b/packages/@granit/react-multi-tenancy/src/hooks/use-clear-queries-on-tenant-change.ts
@@ -1,0 +1,37 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+import { useTenant } from '../providers/tenant-provider.js';
+
+/**
+ * Clears the React Query cache whenever the active tenant id changes.
+ *
+ * Must be mounted **inside** both a `<QueryClientProvider>` and a
+ * `<TenantProvider>`. Prevents tenant-A responses from being served briefly
+ * under a tenant-B context after the user switches tenants — a confidentiality
+ * issue tracked by the framework's security audit.
+ *
+ * Prefer wiring this hook (or passing `onTenantChange={() => queryClient.clear()}`
+ * to `<TenantProvider>`) in every multi-tenant app.
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   useClearQueriesOnTenantChange();
+ *   return <Routes />;
+ * }
+ * ```
+ */
+export function useClearQueriesOnTenantChange(): void {
+  const queryClient = useQueryClient();
+  const tenant = useTenant();
+  const previousTenantIdRef = useRef<string | undefined>(tenant.tenantId);
+
+  useEffect(() => {
+    const previous = previousTenantIdRef.current;
+    if (previous !== tenant.tenantId) {
+      queryClient.clear();
+      previousTenantIdRef.current = tenant.tenantId;
+    }
+  }, [tenant.tenantId, queryClient]);
+}

--- a/packages/@granit/react-multi-tenancy/src/index.ts
+++ b/packages/@granit/react-multi-tenancy/src/index.ts
@@ -16,6 +16,7 @@ export type {
 // Hooks — Runtime
 export { useKeycloakTenantResolvers } from './hooks/use-keycloak-tenant-resolvers.js';
 export type { UseKeycloakTenantResolversOptions } from './hooks/use-keycloak-tenant-resolvers.js';
+export { useClearQueriesOnTenantChange } from './hooks/use-clear-queries-on-tenant-change.js';
 
 // Hooks — Tenant admin
 export {

--- a/packages/@granit/react-multi-tenancy/src/providers/tenant-provider.tsx
+++ b/packages/@granit/react-multi-tenancy/src/providers/tenant-provider.tsx
@@ -16,6 +16,24 @@ export interface TenantProviderProps {
   readonly resolvers: readonly TenantResolver[];
   /** Multi-tenancy options. */
   readonly options?: MultiTenancyOptions;
+  /**
+   * Fired when the resolved tenant id changes (not on mount). Use to clear
+   * tenant-scoped caches — typically `queryClient.clear()` — to prevent
+   * cross-tenant data leakage via stale React Query entries.
+   *
+   * @example
+   * ```tsx
+   * const queryClient = useQueryClient();
+   * <TenantProvider
+   *   resolvers={resolvers}
+   *   onTenantChange={() => queryClient.clear()}
+   * >...</TenantProvider>
+   * ```
+   */
+  readonly onTenantChange?: (
+    tenantId: string | undefined,
+    previousTenantId: string | undefined
+  ) => void;
   readonly children: ReactNode;
 }
 
@@ -24,6 +42,7 @@ const TenantContext = createContext<CurrentTenant | null>(null);
 export function TenantProvider({
   resolvers,
   options,
+  onTenantChange,
   children,
 }: Readonly<TenantProviderProps>): React.JSX.Element {
   const isEnabled = options?.isEnabled !== false;
@@ -45,6 +64,18 @@ export function TenantProvider({
     if (!isEnabled) return;
     setTenantGetter(() => tenantRef.current.tenantId);
   }, [isEnabled]);
+
+  const previousTenantIdRef = useRef<string | undefined>(tenant.tenantId);
+  const onTenantChangeRef = useRef(onTenantChange);
+  onTenantChangeRef.current = onTenantChange;
+
+  useEffect(() => {
+    const previous = previousTenantIdRef.current;
+    if (previous !== tenant.tenantId) {
+      onTenantChangeRef.current?.(tenant.tenantId, previous);
+      previousTenantIdRef.current = tenant.tenantId;
+    }
+  }, [tenant.tenantId]);
 
   return <TenantContext value={tenant}>{children}</TenantContext>;
 }


### PR DESCRIPTION
Resolves the actionable findings from the 2026-05-17 security audit (`/security` skill, 126 packages reviewed). Telemetry/GDPR consent gating remains tracked in #448 and is intentionally out of scope here.

## Summary

| ID | Severity | Standard | Fix |
|----|---------|----------|-----|
| VULN-101 | HIGH | CWE-922 / ASVS V3.5.3 | MSAL `cacheLocation` defaults to `'memory'`; opt-in field added for cross-tab persistence |
| VULN-102 | HIGH | CWE-524 / API1:2023 | `TenantProvider` accepts `onTenantChange`; new `useClearQueriesOnTenantChange` hook clears React Query cache on tenant switch |
| VULN-201 | MEDIUM | CWE-352 / ASVS V4.2.2 | `@granit/api-client` accepts `refreshCsrfToken`; awaits a fresh token instead of silently sending mutations without `X-CSRF-Token`; warns when unavailable |
| VULN-203 | MEDIUM | CWE-20 / A08:2021 | `BffProvider` checks `response.ok` and enforces `{ authenticated: true }` shape before populating auth context |
| VULN-204 | MEDIUM | CWE-200 | `CsrfManager.createFetchWithCsrf` rejects cross-origin URLs (BFF cookie leakage); `getToken()` marked `@internal` |
| VULN-301 | LOW | ASVS V11.1.6 | BFF session poll jitters ±10 % and pauses on `document.hidden` |
| VULN-403 | INFO | A09:2021 | Replaced silent `catch {}` in MSAL/BFF init with `console.warn` |

## Files

- `packages/@granit/api-client/src/index.ts` — `refreshCsrfToken` option + interceptor self-heal
- `packages/@granit/authentication-entraid/src/types/index.ts` — `cacheLocation` config field
- `packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts` — memory cache default + logging
- `packages/@granit/bff/src/csrf/csrf-manager.ts` — same-origin guard, async wrapper, `@internal` on `getToken`
- `packages/@granit/react-bff/src/providers/bff-provider.tsx` — `response.ok` + shape validation + jitter/visibility polling
- `packages/@granit/react-multi-tenancy/src/providers/tenant-provider.tsx` — `onTenantChange` prop
- `packages/@granit/react-multi-tenancy/src/hooks/use-clear-queries-on-tenant-change.ts` — new hook (peer-dep on `@tanstack/react-query`)

## Compatibility

- All changes are **additive**: new optional props/config fields, no removed exports, no signature breaks.
- `TenantProvider` does **not** require a `QueryClientProvider` (the new hook does; consumers wire it explicitly to keep the provider QueryClient-agnostic).

## Test plan

- [x] `pnpm tsc` — clean
- [x] `pnpm lint --max-warnings 0` — clean
- [x] `pnpm test` — 3549/3550 pass (the single failure is `@granit/timeline/api.test.ts`, pre-existing on `develop`, unrelated)
- [x] New tests cover: CSRF same-origin rejection, `onTenantChange` fire-on-change/no-fire-on-mount, CSRF self-heal via `refreshCsrfToken`, BFF warn on missing token
- [ ] Consumer apps (`showcase-admin-react`) should adopt:
  - `useClearQueriesOnTenantChange()` inside their `QueryClientProvider`
  - Pass `refreshCsrfToken: () => csrfManager.fetchToken()` to `createApiClient` in BFF mode

## Related

- `/security` audit report (2026-05-17)
- #448 — telemetry consent gating (separate scope, opt-in via Klaro)