### PR TITLE
fix(payments): point list helpers at /transactions/mine and /methods/mine

### DIFF
--- a/packages/@granit/payments/src/__tests__/payments-api.test.ts
+++ b/packages/@granit/payments/src/__tests__/payments-api.test.ts
@@ -135,13 +135,13 @@ const sampleProviderCatalog: PaymentProviderCatalogResponse = {
 
 describe('payments-api', () => {
   describe('listPaymentTransactions', () => {
-    it('should GET {basePath}/transactions', async () => {
+    it('should GET {basePath}/transactions/mine', async () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTransaction]));
 
       const result = await listPaymentTransactions(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith(`${basePath}/transactions`);
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/transactions/mine`);
       expect(result).toEqual([sampleTransaction]);
     });
   });
@@ -227,13 +227,13 @@ describe('payments-api', () => {
   });
 
   describe('listPaymentMethods', () => {
-    it('should GET {basePath}/methods', async () => {
+    it('should GET {basePath}/methods/mine', async () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleMethod]));
 
       const result = await listPaymentMethods(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith(`${basePath}/methods`);
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/methods/mine`);
       expect(result).toEqual([sampleMethod]);
     });
   });

--- a/packages/@granit/payments/src/api/payments-api.ts
+++ b/packages/@granit/payments/src/api/payments-api.ts
@@ -16,16 +16,19 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
- * List all payment transactions.
+ * List payment transactions belonging to the current tenant.
  *
- * `GET {basePath}/transactions`
+ * `GET {basePath}/transactions/mine`
+ *
+ * Tenant-scoped read. For cross-tenant admin grids with filtering, use
+ * the QueryEngine endpoint on `${basePath}/transactions`.
  */
 export async function listPaymentTransactions(
   client: AxiosInstance,
   basePath: string
 ): Promise<readonly PaymentTransactionResponse[]> {
   const response = await client.get<readonly PaymentTransactionResponse[]>(
-    `${basePath}/transactions`
+    `${basePath}/transactions/mine`
   );
   return response.data;
 }
@@ -92,15 +95,18 @@ export async function createCheckoutSession(
 }
 
 /**
- * List attached payment methods.
+ * List payment methods attached to the current tenant.
  *
- * `GET {basePath}/methods`
+ * `GET {basePath}/methods/mine`
+ *
+ * Tenant-scoped read. For cross-tenant admin grids with filtering, use
+ * the QueryEngine endpoint on `${basePath}/methods`.
  */
 export async function listPaymentMethods(
   client: AxiosInstance,
   basePath: string
 ): Promise<readonly PaymentMethodResponse[]> {
-  const response = await client.get<readonly PaymentMethodResponse[]>(`${basePath}/methods`);
+  const response = await client.get<readonly PaymentMethodResponse[]>(`${basePath}/methods/mine`);
   return response.data;
 }
 

--- a/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
@@ -161,7 +161,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/transactions');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/transactions/mine');
       expect(result.current.data).toEqual([sampleTransaction]);
     });
 
@@ -174,7 +174,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/custom/payments/transactions');
+      expect(client.get).toHaveBeenCalledWith('/custom/payments/transactions/mine');
     });
   });
 
@@ -301,7 +301,7 @@ describe('use-payments', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/methods');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/payments/methods/mine');
       expect(result.current.data).toEqual([sampleMethod]);
     });
   });

--- a/packages/@granit/react-payments/src/testing/handlers.ts
+++ b/packages/@granit/react-payments/src/testing/handlers.ts
@@ -197,8 +197,8 @@ export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // GET /transactions/meta — query metadata
     createQueryMetaHandler(`${baseUrl}/transactions`, paymentTransactionQueryMetadata),
 
-    // GET all transactions
-    http.get(`${baseUrl}/transactions`, () => {
+    // GET transactions for the current tenant
+    http.get(`${baseUrl}/transactions/mine`, () => {
       return HttpResponse.json(sampleTransactions);
     }),
 
@@ -262,8 +262,8 @@ export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       );
     }),
 
-    // GET payment methods
-    http.get(`${baseUrl}/methods`, () => {
+    // GET payment methods for the current tenant
+    http.get(`${baseUrl}/methods/mine`, () => {
       return HttpResponse.json(samplePaymentMethods);
     }),
 


### PR DESCRIPTION
## Summary

Companion to **granit-business MR !50**: backend renamed the tenant-scoped list endpoints (\`GET /transactions\`, \`GET /methods\`) to \`/transactions/mine\` and \`/methods/mine\` so the root paths can host the new \`MapGranitQuery<T>\` admin grids.

### Changes

- \`@granit/payments/src/api/payments-api.ts\`
  - \`listPaymentTransactions\` hits \`{basePath}/transactions/mine\`
  - \`listPaymentMethods\` hits \`{basePath}/methods/mine\`
  - JSDoc points to the QueryEngine endpoint on the root path for the admin grid use case
  - \`POST /methods\` (attach) and all other endpoints unchanged
- \`@granit/payments/src/__tests__/payments-api.test.ts\` — URL expectations updated
- \`@granit/react-payments/src/__tests__/use-payments.test.tsx\` — \`usePaymentTransactions\` and \`usePaymentMethods\` expect \`/mine\`
- \`@granit/react-payments/src/testing/handlers.ts\` — msw mocks updated

## Test plan

- [ ] \`pnpm --filter @granit/payments test\`
- [ ] \`pnpm --filter @granit/react-payments test\`