### PR TITLE
test(timeline): align getStream test with TimelineStreamPage envelope

### DIFF
--- a/packages/@granit/timeline/src/__tests__/api.test.ts
+++ b/packages/@granit/timeline/src/__tests__/api.test.ts
@@ -35,7 +35,7 @@ describe('timeline API', () => {
       expect(client.get).toHaveBeenCalledWith('/api/v1/timeline/Patient/p-1', {
         params: { page: 1, pageSize: 20 },
       });
-      expect(result).toEqual(page);
+      expect(result).toEqual({ page, degradedSources: [] });
     });
   });
 


### PR DESCRIPTION
## Summary

- `getStream` now returns `{ page, degradedSources }` (degraded sources lifted from the `X-Timeline-Degraded-Sources` response header), but the test still asserted the raw `TimelineEntryPage` shape and failed in CI.
- Update the expectation to match the `TimelineStreamPage` envelope.

## Test plan

- [x] `vitest run packages/@granit/timeline/src/__tests__/api.test.ts` — 6/6 passing