### PR TITLE
feat(logger): add PII redaction helpers and OTLP transport scrubber

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -944,6 +944,11 @@
               "name": "getTraceContext",
               "kind": "method",
               "signature": "getTraceContext?: () => TraceContext | undefined"
+            },
+            {
+              "name": "redact",
+              "kind": "method",
+              "signature": "redact?: (text: string) => string"
             }
           ]
         },
@@ -963,6 +968,11 @@
               "signature": "spanId: string"
             }
           ]
+        },
+        {
+          "name": "defaultPiiRedactor",
+          "kind": "function",
+          "signature": "function defaultPiiRedactor(input: string): string"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
       "smol-toml": ">=1.6.1",
       "brace-expansion": ">=5.0.5",
       "protobufjs": "^7.5.6",
-      "msw": "^2.14.5",
+      "msw": "^2.14.6",
       "react": "19.2.6",
       "react-dom": "19.2.6"
     }

--- a/packages/@granit/logger-otlp/src/__tests__/pii-redactor.test.ts
+++ b/packages/@granit/logger-otlp/src/__tests__/pii-redactor.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { defaultPiiRedactor } from '../pii-redactor.js';
+
+describe('defaultPiiRedactor', () => {
+  it('redacts emails', () => {
+    expect(defaultPiiRedactor('user john.doe@example.com signed up')).toBe(
+      'user joh***@example.com signed up'
+    );
+  });
+
+  it('redacts Bearer tokens', () => {
+    expect(defaultPiiRedactor('Authorization: Bearer abcdef1234567890')).toBe(
+      'Authorization: Bearer abcd...890'
+    );
+  });
+
+  it('redacts raw JWTs', () => {
+    const jwt = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature1234';
+    expect(defaultPiiRedactor(`token=${jwt}`)).toBe('token=eyJh...234');
+  });
+
+  it('redacts IBANs', () => {
+    expect(defaultPiiRedactor('IBAN BE68539007547034 transfer')).toBe('IBAN BE68*** transfer');
+  });
+
+  it('redacts E.164 phones', () => {
+    expect(defaultPiiRedactor('Call +33612345678 now')).toBe('Call +336*****78 now');
+  });
+
+  it('redacts Luhn-valid credit cards', () => {
+    // 4532015112830366 — valid Luhn
+    expect(defaultPiiRedactor('Card 4532015112830366 used')).toBe('Card ***0366 used');
+  });
+
+  it('does NOT redact long numeric IDs that fail Luhn', () => {
+    // 1234567890123456 — fails Luhn → must not be masked
+    expect(defaultPiiRedactor('Order 1234567890123456')).toBe('Order 1234567890123456');
+  });
+
+  it('returns input unchanged when nothing matches', () => {
+    expect(defaultPiiRedactor('Just a plain message')).toBe('Just a plain message');
+  });
+
+  it('handles empty string', () => {
+    expect(defaultPiiRedactor('')).toBe('');
+  });
+});

--- a/packages/@granit/logger-otlp/src/index.ts
+++ b/packages/@granit/logger-otlp/src/index.ts
@@ -1,3 +1,5 @@
 export { createOtlpTransport } from './otlp-transport.js';
 
 export type { OtlpTransportOptions, TraceContext } from './otlp-transport.js';
+
+export { defaultPiiRedactor } from './pii-redactor.js';

--- a/packages/@granit/logger-otlp/src/otlp-transport.ts
+++ b/packages/@granit/logger-otlp/src/otlp-transport.ts
@@ -41,6 +41,12 @@ export interface OtlpTransportOptions {
   flushInterval?: number;
   /** Optional callback to retrieve trace context for log-to-trace correlation */
   getTraceContext?: () => TraceContext | undefined;
+  /**
+   * Optional PII scrubber applied to the log body and every attribute
+   * value before serialization. Use `defaultPiiRedactor` for a built-in
+   * baseline (email, JWT, Bearer tokens, IBAN, credit card, E.164 phone).
+   */
+  redact?: (text: string) => string;
 }
 
 // ---------------------------------------------------------------------------
@@ -72,7 +78,11 @@ function errorToAttributes(error: unknown): OtlpAttribute[] {
   return attrs;
 }
 
-function buildLogRecord(entry: LogEntry, traceContext?: TraceContext) {
+function buildLogRecord(
+  entry: LogEntry,
+  traceContext?: TraceContext,
+  redact?: (text: string) => string
+) {
   const attributes: OtlpAttribute[] = [toStringAttribute('logger.prefix', entry.prefix)];
   if (entry.context) {
     attributes.push(...contextToAttributes(entry.context));
@@ -81,11 +91,18 @@ function buildLogRecord(entry: LogEntry, traceContext?: TraceContext) {
     attributes.push(...errorToAttributes(entry.error));
   }
 
+  if (redact) {
+    for (const attr of attributes) {
+      attr.value.stringValue = redact(attr.value.stringValue);
+    }
+  }
+
+  const rawBody = `${entry.prefix} ${entry.message}`;
   return {
     timeUnixNano: String(BigInt(entry.timestamp) * 1_000_000n),
     severityNumber: SEVERITY_NUMBER[entry.level],
     severityText: entry.level,
-    body: { stringValue: `${entry.prefix} ${entry.message}` },
+    body: { stringValue: redact ? redact(rawBody) : rawBody },
     attributes,
     traceId: traceContext?.traceId ?? '',
     spanId: traceContext?.spanId ?? '',
@@ -110,7 +127,9 @@ function buildPayload(entries: LogEntry[], options: OtlpTransportOptions) {
         scopeLogs: [
           {
             scope: { name: '@granit/logger-otlp' },
-            logRecords: entries.map((entry) => buildLogRecord(entry, options.getTraceContext?.())),
+            logRecords: entries.map((entry) =>
+              buildLogRecord(entry, options.getTraceContext?.(), options.redact)
+            ),
           },
         ],
       },

--- a/packages/@granit/logger-otlp/src/pii-redactor.ts
+++ b/packages/@granit/logger-otlp/src/pii-redactor.ts
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------------
+// Default PII scrubber applied on outgoing OTLP log payloads.
+// Defense-in-depth: catches PII that leaks through `err.response.data`,
+// `err.config.url`, Axios stack traces, etc. — payloads that call-site
+// helpers cannot reach.
+// ---------------------------------------------------------------------------
+
+const EMAIL_RE = /(?<local>[A-Za-z0-9._%+-]{1,64})@(?<domain>[A-Za-z0-9.-]+\.[A-Za-z]{2,})/g;
+
+// `Authorization: Bearer xxx` and variants
+const BEARER_RE = /(Bearer\s+)([A-Za-z0-9._-]{8,})/gi;
+
+// Raw JWT (three base64url segments separated by dots, header starts with eyJ)
+const JWT_RE = /\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b/g;
+
+// IBAN (rough): 2 letters + 2 digits + 11-30 alphanumerics
+const IBAN_RE = /\b[A-Z]{2}\d{2}[A-Z0-9]{11,30}\b/g;
+
+// Credit card-ish: 13-19 digits, optionally grouped by spaces or dashes
+const CREDIT_CARD_RE = /\b(?:\d[ -]*?){13,19}\b/g;
+
+// Phone in E.164 (+ followed by 8-15 digits)
+const PHONE_E164_RE = /\+\d{8,15}\b/g;
+
+function maskEmail(_match: string, local: string, domain: string): string {
+  const keep = Math.min(3, local.length);
+  return `${local.slice(0, keep)}***@${domain}`;
+}
+
+function maskBearer(_match: string, prefix: string, token: string): string {
+  if (token.length <= 8) return `${prefix}***`;
+  return `${prefix}${token.slice(0, 4)}...${token.slice(-3)}`;
+}
+
+function maskToken(token: string): string {
+  if (token.length <= 8) return '***';
+  return `${token.slice(0, 4)}...${token.slice(-3)}`;
+}
+
+function passesLuhn(digits: string): boolean {
+  let sum = 0;
+  let alt = false;
+  for (let i = digits.length - 1; i >= 0; i--) {
+    const c = digits.charCodeAt(i);
+    if (c < 48 || c > 57) return false;
+    let n = c - 48;
+    if (alt) {
+      n *= 2;
+      if (n > 9) n -= 9;
+    }
+    sum += n;
+    alt = !alt;
+  }
+  return sum % 10 === 0;
+}
+
+function maskCreditCard(match: string): string {
+  const digits = match.replace(/[^\d]/g, '');
+  if (digits.length < 13 || digits.length > 19) return match;
+  // Only mask when Luhn-valid to limit false positives on long numeric IDs.
+  if (!passesLuhn(digits)) return match;
+  return `***${digits.slice(-4)}`;
+}
+
+/**
+ * Apply built-in PII patterns to a text. Returns the input unchanged when
+ * no pattern matches. Designed to be cheap enough to run on every log
+ * attribute server-side / transport-side.
+ */
+export function defaultPiiRedactor(input: string): string {
+  if (!input) return input;
+  let out = input;
+  // Order matters: redact JWT/Bearer before email (a JWT can contain '@'
+  // inside its base64-decoded payload, but the raw form does not match
+  // EMAIL_RE so this is more about keeping `Bearer eyJ…` clean as a unit).
+  out = out.replace(BEARER_RE, maskBearer);
+  out = out.replace(JWT_RE, (m) => maskToken(m));
+  out = out.replace(EMAIL_RE, maskEmail);
+  out = out.replace(IBAN_RE, (m) => `${m.slice(0, 4)}***`);
+  out = out.replace(CREDIT_CARD_RE, maskCreditCard);
+  out = out.replace(PHONE_E164_RE, (m) =>
+    m.length <= 4 ? '***' : `${m.slice(0, Math.min(4, m.length - 2))}*****${m.slice(-2)}`
+  );
+  return out;
+}

--- a/packages/@granit/logger/src/__tests__/redaction.test.ts
+++ b/packages/@granit/logger/src/__tests__/redaction.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  emailDomain,
+  hashPrefix,
+  redact,
+  redactEmail,
+  redactIpAddress,
+  redactPhone,
+  redactToken,
+  redactUsername,
+} from '../redaction.js';
+
+describe('redactEmail', () => {
+  it('preserves 3-char prefix and domain', () => {
+    expect(redactEmail('john.doe@example.com')).toBe('joh***@example.com');
+  });
+
+  it('masks when no @ is present', () => {
+    expect(redactEmail('not-an-email')).toBe('***');
+  });
+
+  it('masks when local part is empty', () => {
+    expect(redactEmail('@example.com')).toBe('***');
+  });
+});
+
+describe('emailDomain', () => {
+  it('returns the domain', () => {
+    expect(emailDomain('a@example.com')).toBe('example.com');
+  });
+
+  it('returns "unknown" for non-emails', () => {
+    expect(emailDomain('no-at-sign')).toBe('unknown');
+  });
+});
+
+describe('redactPhone', () => {
+  it('keeps country code and last 2 digits', () => {
+    expect(redactPhone('+33612345678')).toBe('+336*****78');
+  });
+
+  it('masks short values', () => {
+    expect(redactPhone('123')).toBe('***');
+  });
+});
+
+describe('redactToken', () => {
+  it('keeps short prefix and suffix', () => {
+    expect(redactToken('dLkj3FDmAbCdEfGh')).toBe('dLkj...fGh');
+  });
+
+  it('masks values shorter than 8 chars', () => {
+    expect(redactToken('short')).toBe('***');
+  });
+});
+
+describe('redactIpAddress', () => {
+  it('masks last IPv4 octet', () => {
+    expect(redactIpAddress('192.168.1.42')).toBe('192.168.1.***');
+  });
+
+  it('truncates IPv6 after the fourth group', () => {
+    expect(redactIpAddress('2001:db8:0:0:0:0:0:1')).toBe('2001:db8:0:0:***');
+  });
+});
+
+describe('redactUsername', () => {
+  it('keeps 3-char prefix', () => {
+    expect(redactUsername('john_admin')).toBe('joh***');
+  });
+
+  it('masks short values', () => {
+    expect(redactUsername('jo')).toBe('***');
+  });
+});
+
+describe('hashPrefix', () => {
+  it('returns an 8-char hex digest', async () => {
+    const out = await hashPrefix('john.doe@example.com');
+    expect(out).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('is deterministic', async () => {
+    expect(await hashPrefix('x')).toBe(await hashPrefix('x'));
+  });
+});
+
+describe('redact aggregate', () => {
+  it('exposes the call-site API', () => {
+    expect(redact.email('john@example.com')).toBe('joh***@example.com');
+    expect(redact.phone('+33612345678')).toBe('+336*****78');
+    expect(redact.token('aaaaaaaaaa')).toBe('aaaa...aaa');
+  });
+});

--- a/packages/@granit/logger/src/index.ts
+++ b/packages/@granit/logger/src/index.ts
@@ -9,3 +9,14 @@ export type {
   LoggerOptions,
   LogTransport,
 } from './logger.js';
+
+export {
+  emailDomain,
+  hashPrefix,
+  redact,
+  redactEmail,
+  redactIpAddress,
+  redactPhone,
+  redactToken,
+  redactUsername,
+} from './redaction.js';

--- a/packages/@granit/logger/src/redaction.ts
+++ b/packages/@granit/logger/src/redaction.ts
@@ -1,0 +1,95 @@
+// ---------------------------------------------------------------------------
+// PII redaction helpers — mirror of Granit.Diagnostics.LogRedaction (.NET).
+// Use these at log call-sites to keep PII out of console/OTLP transports
+// (GDPR Art. 5, ISO 27001 A.5.34).
+// ---------------------------------------------------------------------------
+
+const MASK = '***';
+
+/**
+ * Redacts an email address, preserving up to 3 leading chars and the domain.
+ * `"john.doe@example.com"` → `"joh***@example.com"`.
+ */
+export function redactEmail(email: string): string {
+  const at = email.indexOf('@');
+  if (at <= 0) return MASK;
+  const keep = Math.min(3, at);
+  return `${email.slice(0, keep)}${MASK}${email.slice(at)}`;
+}
+
+/**
+ * Extracts the domain of an email. Returns a bounded, non-PII value
+ * suitable as a span tag. `"john@example.com"` → `"example.com"`.
+ */
+export function emailDomain(email: string): string {
+  const at = email.indexOf('@');
+  return at >= 0 ? email.slice(at + 1) : 'unknown';
+}
+
+/**
+ * Redacts a phone number, preserving the country-code prefix and the last
+ * two digits. `"+33612345678"` → `"+336*****78"`.
+ */
+export function redactPhone(phone: string): string {
+  if (phone.length <= 4) return MASK;
+  const prefix = Math.min(4, phone.length - 2);
+  return `${phone.slice(0, prefix)}*****${phone.slice(-2)}`;
+}
+
+/**
+ * Redacts an opaque token (device token, refresh token, …) preserving a
+ * short prefix and suffix for log correlation. `"dLkj3FDmAbCdEfGh"` →
+ * `"dLkj...fGh"`.
+ */
+export function redactToken(token: string): string {
+  if (token.length <= 8) return MASK;
+  return `${token.slice(0, 4)}...${token.slice(-3)}`;
+}
+
+/**
+ * Masks an IPv4 address to /24. IPv6 is truncated after the fourth group.
+ * `"192.168.1.42"` → `"192.168.1.***"`.
+ */
+export function redactIpAddress(ip: string): string {
+  const lastDot = ip.lastIndexOf('.');
+  if (lastDot > 0) return `${ip.slice(0, lastDot + 1)}${MASK}`;
+  let colons = 0;
+  for (let i = 0; i < ip.length; i++) {
+    if (ip[i] === ':') colons++;
+    if (colons === 4) return `${ip.slice(0, i)}:${MASK}`;
+  }
+  return MASK;
+}
+
+/**
+ * Redacts a username, preserving a 3-char prefix. `"john_admin"` → `"joh***"`.
+ */
+export function redactUsername(username: string): string {
+  if (username.length <= 3) return MASK;
+  return `${username.slice(0, 3)}${MASK}`;
+}
+
+/**
+ * Short, non-reversible hash prefix (SHA-256[:4], 8 hex chars). Useful as
+ * a correlation tag when full content must not be stored. Async because
+ * Web Crypto's `subtle.digest` is the only built-in SHA-256 in the browser.
+ */
+export async function hashPrefix(value: string): Promise<string> {
+  const bytes = new TextEncoder().encode(value);
+  const digest = await crypto.subtle.digest('SHA-256', bytes);
+  const hex = Array.from(new Uint8Array(digest).slice(0, 4))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return hex;
+}
+
+/** Aggregate export mirroring the .NET `LogRedaction` static class shape. */
+export const redact = {
+  email: redactEmail,
+  emailDomain,
+  phone: redactPhone,
+  token: redactToken,
+  ipAddress: redactIpAddress,
+  username: redactUsername,
+  hashPrefix,
+} as const;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,7 +15,7 @@ overrides:
   smol-toml: '>=1.6.1'
   brace-expansion: '>=5.0.5'
   protobufjs: ^7.5.6
-  msw: ^2.14.5
+  msw: ^2.14.6
   react: 19.2.6
   react-dom: 19.2.6
 
@@ -132,7 +132,7 @@ importers:
         specifier: ^0.22.1
         version: 0.22.1
       msw:
-        specifier: ^2.14.5
+        specifier: ^2.14.6
         version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       prettier:
         specifier: ^3.8.3
@@ -633,8 +633,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -701,8 +701,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -797,8 +797,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -825,8 +825,8 @@ importers:
         specifier: workspace:*
         version: link:../authentication
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -853,8 +853,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -969,8 +969,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1000,8 +1000,8 @@ importers:
         specifier: 1.16.1
         version: 1.16.1
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1028,8 +1028,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1071,8 +1071,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1155,8 +1155,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1257,8 +1257,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1307,8 +1307,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1354,7 +1354,7 @@ importers:
         specifier: workspace:*
         version: link:../testing
       msw:
-        specifier: ^2.14.5
+        specifier: ^2.14.6
         version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
 
   packages/@granit/react-entities:
@@ -1468,8 +1468,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1502,8 +1502,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1539,8 +1539,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1588,8 +1588,8 @@ importers:
         specifier: ^25.0.0
         version: 25.8.14(typescript@5.9.3)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@5.9.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@5.9.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1662,8 +1662,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1699,8 +1699,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1727,8 +1727,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1802,8 +1802,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1836,8 +1836,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1879,8 +1879,8 @@ importers:
         specifier: ^1.0.0
         version: 1.8.0(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1916,8 +1916,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -1956,8 +1956,8 @@ importers:
         specifier: 1.16.1
         version: 1.16.1
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2015,8 +2015,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2046,8 +2046,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2089,8 +2089,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2120,8 +2120,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2176,8 +2176,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2235,8 +2235,8 @@ importers:
         specifier: workspace:*
         version: link:../timeline
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2327,8 +2327,8 @@ importers:
         specifier: 5.100.10
         version: 5.100.10(react@19.2.6)
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2361,8 +2361,8 @@ importers:
         specifier: workspace:*
         version: link:../workflow
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -2507,11 +2507,11 @@ importers:
   packages/@granit/testing:
     dependencies:
       msw:
-        specifier: ^2.14.5
-        version: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.8.0)(typescript@6.0.3)
       vitest:
         specifier: ^4.0.0
-        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1)(msw@2.14.5(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0))
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0))
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -3381,10 +3381,6 @@ packages:
   '@microsoft/signalr@10.0.0':
     resolution: {integrity: sha512-0BRqz/uCx3JdrOqiqgFhih/+hfTERaUfCZXFB52uMaZJrKaPRzHzMuqVsJC/V3pt7NozcNXGspjKiQEK+X7P2w==}
 
-  '@mswjs/interceptors@0.41.8':
-    resolution: {integrity: sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==}
-    engines: {node: '>=18'}
-
   '@mswjs/interceptors@0.41.9':
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
@@ -3702,36 +3698,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -3820,36 +3822,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.1':
     resolution: {integrity: sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.1':
     resolution: {integrity: sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.1':
     resolution: {integrity: sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.1':
     resolution: {integrity: sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.1':
     resolution: {integrity: sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.1':
     resolution: {integrity: sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==}
@@ -3911,66 +3919,79 @@ packages:
     resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.4':
     resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.4':
     resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.4':
     resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.4':
     resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.4':
     resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.4':
     resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.4':
     resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.4':
     resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.4':
     resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.4':
     resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.4':
     resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.4':
     resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.4':
     resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
@@ -4225,41 +4246,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4321,7 +4350,7 @@ packages:
   '@vitest/mocker@4.1.4':
     resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
     peerDependencies:
-      msw: ^2.14.5
+      msw: ^2.14.6
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
@@ -4332,7 +4361,7 @@ packages:
   '@vitest/mocker@4.1.6':
     resolution: {integrity: sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==}
     peerDependencies:
-      msw: ^2.14.5
+      msw: ^2.14.6
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
@@ -5337,24 +5366,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5583,16 +5616,6 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-
-  msw@2.14.5:
-    resolution: {integrity: sha512-X6G05oX4x0e+CNI55KMdhMmwHCBKf2iwazGr+iwsdoJ94JA1ED7wSXb6V+lLPdqFkmIlPiGYvayqnaNcOzobDA==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      typescript: '>= 4.8.x'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
 
   msw@2.14.6:
     resolution: {integrity: sha512-ALe+N10S72cyx94cMcy3Zs4HhXCj35sgeAL4c+WTvKi0zWnbd8/h0lcFqv0mb2P+aSgAdD7p9HzvA0DiUPxsyg==}
@@ -7366,15 +7389,6 @@ snapshots:
       - encoding
       - utf-8-validate
 
-  '@mswjs/interceptors@0.41.8':
-    dependencies:
-      '@open-draft/deferred-promise': 2.2.0
-      '@open-draft/logger': 0.3.0
-      '@open-draft/until': 2.1.0
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      strict-event-emitter: 0.5.1
-
   '@mswjs/interceptors@0.41.9':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -8255,15 +8269,6 @@ snapshots:
       '@vitest/utils': 4.1.6
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.4(msw@2.14.5(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.14.5(@types/node@25.8.0)(typescript@6.0.3)
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.4(msw@2.14.6(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0))':
     dependencies:
@@ -9653,10 +9658,10 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.5(@types/node@25.8.0)(typescript@5.9.3):
+  msw@2.14.6(@types/node@25.8.0)(typescript@5.9.3):
     dependencies:
       '@inquirer/confirm': 6.0.13(@types/node@25.8.0)
-      '@mswjs/interceptors': 0.41.8
+      '@mswjs/interceptors': 0.41.9
       '@open-draft/deferred-promise': 3.0.0
       '@types/statuses': 2.0.6
       cookie: 1.1.1
@@ -9675,31 +9680,6 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-
-  msw@2.14.5(@types/node@25.8.0)(typescript@6.0.3):
-    dependencies:
-      '@inquirer/confirm': 6.0.13(@types/node@25.8.0)
-      '@mswjs/interceptors': 0.41.8
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.0
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.6.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 6.0.3
     transitivePeerDependencies:
       - '@types/node'
 
@@ -10352,36 +10332,6 @@ snapshots:
       jiti: 2.6.1
       sass: 1.97.3
       yaml: 2.9.0
-
-  vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1)(msw@2.14.5(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(msw@2.14.5(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.4
-      '@vitest/runner': 4.1.4
-      '@vitest/snapshot': 4.1.4
-      '@vitest/spy': 4.1.4
-      '@vitest/utils': 4.1.4
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.0.0
-      tinybench: 2.9.0
-      tinyexec: 1.1.1
-      tinyglobby: 0.2.16
-      tinyrainbow: 3.1.0
-      vite: 8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-      '@types/node': 25.8.0
-      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
-      jsdom: 29.1.1
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.8.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.1.1)(msw@2.14.6(@types/node@25.8.0)(typescript@6.0.3))(vite@8.0.13(@types/node@25.8.0)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.97.3)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## Summary

Two-layer PII redaction for the logger stack, mirroring `Granit.Diagnostics.LogRedaction` (.NET).

### Layer A — call-site helpers (`@granit/logger`)

New `redact.*` module symmetric to the backend:

- `redact.email("john.doe@example.com")` → `"joh***@example.com"`
- `redact.emailDomain(email)` → `"example.com"` (safe span tag)
- `redact.phone("+33612345678")` → `"+336*****78"`
- `redact.token("dLkj3FDmAbCdEfGh")` → `"dLkj...fGh"`
- `redact.ipAddress("192.168.1.42")` → `"192.168.1.***"` (IPv4 /24, IPv6 truncated after the 4th group)
- `redact.username("john_admin")` → `"joh***"`
- `redact.hashPrefix(value)` → 8-char SHA-256 hex prefix (correlation tag without PII)

Use at log call-sites for controlled flows (e.g. `logger.info(`[Login] user ${redact.email(form.email)}`)`).

### Layer B — transport scrubber (`@granit/logger-otlp`)

New optional `redact?: (text: string) => string` on `OtlpTransportOptions`, applied to log body and every attribute value before serialization. Exported `defaultPiiRedactor` covers:

- emails
- `Authorization: Bearer …` tokens (preserved prefix/suffix)
- raw JWTs (`eyJ…`)
- IBANs
- Luhn-valid credit cards (false-positive guarded)
- E.164 phone numbers

This is defense in depth — catches PII leaking through `err.response.data`, `err.config.url`, Axios stack traces — payloads that call-site helpers can't reach.

### Tests

- 16 tests in `redaction.test.ts`
- 9 tests in `pii-redactor.test.ts`
- All 25 pass; tsc clean; eslint clean.

### Compliance

GDPR Art. 5 (data minimization), ISO 27001 A.5.34 (privacy of PII).

## Consumer

Wired in `granit-showcase-admin-react` (`fix(logger): enable defaultPiiRedactor on OTLP transport`).

## Test plan

- [x] `pnpm exec vitest run packages/@granit/logger/src/__tests__/redaction.test.ts packages/@granit/logger-otlp/src/__tests__/pii-redactor.test.ts` — 25/25
- [x] `pnpm exec tsc --noEmit` on both packages — clean
- [x] `pnpm exec eslint packages/@granit/logger/src packages/@granit/logger-otlp/src` — clean
- [ ] Optional: add the `LoggerMessagePiiAnalyzer` equivalent for JS (lint rule) — out of scope