### PR TITLE
chore(sonar): address open code smells in react-entities and react-taxonomy

### DIFF
--- a/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-gallery.test.tsx
@@ -349,8 +349,10 @@ describe('EntityGallery', () => {
     await waitFor(() =>
       expect(container.querySelector('[data-granit-gallery-card]')).not.toBeNull()
     );
-    const card = container.querySelector('[data-granit-gallery-card]') as HTMLElement;
-    fireEvent.click(card);
+    const cardButton = container.querySelector(
+      '[data-granit-gallery-card] button'
+    ) as HTMLButtonElement;
+    fireEvent.click(cardButton);
     expect(onCardClick).toHaveBeenCalledWith(
       expect.objectContaining({ id: makeParty(1).id, name: 'Party 1' })
     );

--- a/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/entity-kanban.test.tsx
@@ -200,7 +200,9 @@ describe('EntityKanban', () => {
     await waitFor(() =>
       expect(container.querySelector('[data-granit-kanban-card]')).not.toBeNull()
     );
-    fireEvent.click(container.querySelector('[data-granit-kanban-card]') as HTMLLIElement);
+    fireEvent.click(
+      container.querySelector('[data-granit-kanban-card] button') as HTMLButtonElement
+    );
     expect(onCardClick).toHaveBeenCalledWith(PAGE.items[0]);
   });
 

--- a/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
@@ -125,14 +125,14 @@ function makeWrapper() {
 }
 
 describe('EntitySelectionBar — bulk endpoint dispatch', () => {
-  it('routes a click through POST /bulk/{action} with all ids when useBulkEndpoint=true', async () => {
+  it('routes a click through POST /bulk/{action} with all ids when bulkEndpoint=true', async () => {
     const Wrapper = makeWrapper();
     const onComplete = vi.fn();
 
     const { container } = render(
       <Wrapper>
         <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
-          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+          <EntitySelectionBar manifest={makeManifest()} bulkEndpoint onComplete={onComplete} />
         </SelectionProvider>
       </Wrapper>
     );
@@ -152,7 +152,7 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     const { container } = render(
       <Wrapper>
         <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
-          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+          <EntitySelectionBar manifest={makeManifest()} bulkEndpoint onComplete={onComplete} />
         </SelectionProvider>
       </Wrapper>
     );
@@ -175,7 +175,7 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     const { container } = render(
       <Wrapper>
         <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
-          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+          <EntitySelectionBar manifest={makeManifest()} bulkEndpoint onComplete={onComplete} />
         </SelectionProvider>
       </Wrapper>
     );
@@ -204,7 +204,7 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     const { container } = render(
       <Wrapper>
         <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
-          <EntitySelectionBar manifest={makeManifest()} useBulkEndpoint onComplete={onComplete} />
+          <EntitySelectionBar manifest={makeManifest()} bulkEndpoint onComplete={onComplete} />
         </SelectionProvider>
       </Wrapper>
     );
@@ -229,7 +229,7 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
         <SelectionProvider initialSelectedIds={['q1', 'q2']}>
           <EntitySelectionBar
             manifest={makeManifest()}
-            useBulkEndpoint={predicate}
+            bulkEndpoint={predicate}
             handlers={{ apiCall }}
             onComplete={onComplete}
           />
@@ -245,7 +245,7 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     expect(apiCall).not.toHaveBeenCalled(); // per-row dispatcher bypassed
   });
 
-  it('useBulkEndpoint=false keeps the per-row fan-out (regression)', async () => {
+  it('bulkEndpoint=false keeps the per-row fan-out (regression)', async () => {
     const Wrapper = makeWrapper();
     const onComplete = vi.fn();
     const apiCall = vi.fn(async () => {});
@@ -255,7 +255,7 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
         <SelectionProvider initialSelectedIds={['q1', 'q2', 'q3']}>
           <EntitySelectionBar
             manifest={makeManifest()}
-            useBulkEndpoint={false}
+            bulkEndpoint={false}
             handlers={{ apiCall }}
             onComplete={onComplete}
           />

--- a/packages/@granit/react-entities/src/components/entity-gallery.tsx
+++ b/packages/@granit/react-entities/src/components/entity-gallery.tsx
@@ -1,7 +1,7 @@
 import { getPage } from '@granit/query-engine';
 import { useQueryConfig, useQueryEndpointState } from '@granit/react-query-engine';
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useEffect, useMemo, useRef, type KeyboardEvent, type ReactNode } from 'react';
+import { useEffect, useMemo, useRef, type ReactNode } from 'react';
 
 import { EntityActionButton, resolveAction } from '../actions/entity-action-button.js';
 import {
@@ -326,30 +326,27 @@ function GalleryCard({
   const subtitle = subtitleProperty ? readScalar(row[subtitleProperty]) : null;
   const rowId = readScalar(row['id'] ?? row['Id']);
 
-  const handleClick = onCardClick ? () => onCardClick(row) : undefined;
-  const handleKeyDown = onCardClick
-    ? (event: KeyboardEvent<HTMLLIElement>) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          onCardClick(row);
-        }
-      }
-    : undefined;
+  const cardContent = (
+    <>
+      {renderImage ? renderImage(blobId, row) : null}
+      {title === null ? null : <span data-granit-gallery-card-title="">{title}</span>}
+      {subtitle === null ? null : <span data-granit-gallery-card-subtitle="">{subtitle}</span>}
+    </>
+  );
 
   return (
     <li
       data-granit-gallery-card=""
       data-row-id={rowId ?? undefined}
       data-image-blob-id={blobId ?? undefined}
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role={onCardClick ? 'button' : undefined}
-      tabIndex={onCardClick ? 0 : undefined}
-      style={onCardClick ? { cursor: 'pointer' } : undefined}
     >
-      {renderImage ? renderImage(blobId, row) : null}
-      {title === null ? null : <span data-granit-gallery-card-title="">{title}</span>}
-      {subtitle === null ? null : <span data-granit-gallery-card-subtitle="">{subtitle}</span>}
+      {onCardClick ? (
+        <button type="button" onClick={() => onCardClick(row)} style={{ cursor: 'pointer' }}>
+          {cardContent}
+        </button>
+      ) : (
+        cardContent
+      )}
       {actions.length > 0 ? (
         <div data-granit-gallery-card-actions="">
           {actions.map((action) => (

--- a/packages/@granit/react-entities/src/components/entity-kanban.tsx
+++ b/packages/@granit/react-entities/src/components/entity-kanban.tsx
@@ -1,7 +1,7 @@
 import { getPage } from '@granit/query-engine';
 import { useQueryConfig, useQueryEndpointState, useQueryMeta } from '@granit/react-query-engine';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
-import { useMemo, type KeyboardEvent, type ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 
 import type { EntityManifestResponse } from '@granit/entities';
 import type { QueryRequest } from '@granit/query-engine';
@@ -211,25 +211,15 @@ interface KanbanCardProps {
 }
 
 function KanbanCard({ row, titleProperty, fallbackKey, onCardClick }: KanbanCardProps): ReactNode {
-  const handleClick = onCardClick ? () => onCardClick(row) : undefined;
-  const handleKeyDown = onCardClick
-    ? (event: KeyboardEvent<HTMLLIElement>) => {
-        if (event.key === 'Enter' || event.key === ' ') {
-          event.preventDefault();
-          onCardClick(row);
-        }
-      }
-    : undefined;
-  return (
-    <li
-      data-granit-kanban-card=""
-      onClick={handleClick}
-      onKeyDown={handleKeyDown}
-      role={onCardClick ? 'button' : undefined}
-      tabIndex={onCardClick ? 0 : undefined}
-      style={onCardClick ? { cursor: 'pointer' } : undefined}
-    >
-      {formatTitle(row[titleProperty]) ?? fallbackKey}
-    </li>
-  );
+  const label = formatTitle(row[titleProperty]) ?? fallbackKey;
+  if (onCardClick) {
+    return (
+      <li data-granit-kanban-card="">
+        <button type="button" onClick={() => onCardClick(row)} style={{ cursor: 'pointer' }}>
+          {label}
+        </button>
+      </li>
+    );
+  }
+  return <li data-granit-kanban-card="">{label}</li>;
 }

--- a/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
@@ -32,7 +32,7 @@ export interface EntitySelectionBarRecap {
   /**
    * Distinct parent markers (`"{ParentEntityName}:{ParentId}"`) returned
    * by the bulk endpoint. Present only when the click routed through
-   * `executeBulkAction()` (i.e. `useBulkEndpoint` was opt'd in for the
+   * `executeBulkAction()` (i.e. `bulkEndpoint` was opt'd in for the
    * action); `undefined` for the per-row fan-out path. Apps consume
    * this list to invalidate exactly the impacted relation-aggregate
    * caches in one step per parent (D3).
@@ -89,7 +89,7 @@ export interface EntitySelectionBarProps {
    *
    * Default: `false` (per-row fan-out — the pre-D2 behaviour).
    */
-  readonly useBulkEndpoint?: BulkDispatchPredicate;
+  readonly bulkEndpoint?: BulkDispatchPredicate;
   /**
    * Override the English defaults for the visible labels (selection
    * summary + clear button). Apps wire `t('entities:SelectionBar.*')`
@@ -157,7 +157,7 @@ export function EntitySelectionBar({
   handlers,
   onComplete,
   confirm,
-  useBulkEndpoint,
+  bulkEndpoint,
   labels,
   className,
 }: EntitySelectionBarProps): ReactNode {
@@ -186,7 +186,7 @@ export function EntitySelectionBar({
       }
 
       const useBulk =
-        typeof useBulkEndpoint === 'function' ? useBulkEndpoint(ref) : useBulkEndpoint === true;
+        typeof bulkEndpoint === 'function' ? bulkEndpoint(ref) : bulkEndpoint === true;
       const entityName = manifest.identity?.name;
 
       setRunning(ref.name);
@@ -222,7 +222,7 @@ export function EntitySelectionBar({
       dispatch,
       confirm,
       onComplete,
-      useBulkEndpoint,
+      bulkEndpoint,
       client,
       manifest.identity?.name,
     ]

--- a/packages/@granit/react-entities/src/hooks/use-invalidate-entity-relation-aggregates.ts
+++ b/packages/@granit/react-entities/src/hooks/use-invalidate-entity-relation-aggregates.ts
@@ -51,7 +51,7 @@ export function parseRelationAggregateParentMarker(
  * const invalidateParents = useInvalidateEntityRelationAggregates();
  * <EntitySelectionBar
  *   manifest={…}
- *   useBulkEndpoint
+ *   bulkEndpoint
  *   onComplete={(_action, recap) => {
  *     if (recap.parents) invalidateParents(recap.parents);
  *   }}

--- a/packages/@granit/react-taxonomy/src/components/tag-chip.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-chip.tsx
@@ -19,9 +19,9 @@ const FALLBACK_TEXT_DARK = '#111827';
  */
 function pickTextColor(background: string): string {
   if (!/^#[0-9a-fA-F]{6}$/.test(background)) return FALLBACK_TEXT_DARK;
-  const r = parseInt(background.slice(1, 3), 16);
-  const g = parseInt(background.slice(3, 5), 16);
-  const b = parseInt(background.slice(5, 7), 16);
+  const r = Number.parseInt(background.slice(1, 3), 16);
+  const g = Number.parseInt(background.slice(3, 5), 16);
+  const b = Number.parseInt(background.slice(5, 7), 16);
   // Rec. 709 luma — close enough for chip readability.
   const luma = (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
   return luma > 0.6 ? FALLBACK_TEXT_DARK : FALLBACK_TEXT_LIGHT;

--- a/packages/@granit/react-taxonomy/src/components/taxonomy-search-bar.tsx
+++ b/packages/@granit/react-taxonomy/src/components/taxonomy-search-bar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useId, useState } from 'react';
 
 import { useTaxonomySearch } from '../hooks/use-taxonomy-search.js';
 
@@ -61,6 +61,7 @@ export function TaxonomySearchBar({
   className,
 }: TaxonomySearchBarProps): ReactNode {
   const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const listboxId = useId();
   const [input, setInput] = useState('');
   const [debounced, setDebounced] = useState('');
   const [highlight, setHighlight] = useState(0);
@@ -120,7 +121,7 @@ export function TaxonomySearchBar({
   } else {
     let cursor = 0;
     content = (
-      <ul role="listbox" data-granit-taxonomy-search-list="">
+      <ul id={listboxId} role="listbox" data-granit-taxonomy-search-list="">
         {groups.map((group) => {
           const heading =
             targetTypeLabels?.[group.targetType] ?? fallbackTargetTypeLabel(group.targetType);
@@ -165,6 +166,7 @@ export function TaxonomySearchBar({
         type="search"
         role="combobox"
         aria-expanded={open}
+        aria-controls={listboxId}
         aria-autocomplete="list"
         data-granit-taxonomy-search-input=""
         placeholder={labelStrings.placeholder}


### PR DESCRIPTION
## Summary

Closes the open Sonar code smells reported on `react-entities` and `react-taxonomy`.

| # | File | Sonar rule | Fix |
|---|------|-----------|-----|
| 1 | `react-entities/entity-selection-bar.tsx:189` | Bug — `react-hooks/rules-of-hooks` (hook in callback) | Rename misnamed prop `useBulkEndpoint` → `bulkEndpoint`. The prop is not a hook; only its name matched the convention. |
| 2 | `react-entities/entity-kanban.tsx:224,229` | a11y — non-interactive element with mouse/keyboard listener + `tabIndex` | Replace clickable-`<li>` with inner `<button>`. |
| 3 | `react-entities/entity-gallery.tsx:340,347` | Same a11y rules | Same fix; actions div stays outside the button to avoid nested interactives. |
| 4 | `react-taxonomy/tag-chip.tsx:22-24` | ES2015 — `parseInt` → `Number.parseInt` | One-line change. |
| 5 | `react-taxonomy/taxonomy-search-bar.tsx:166` | a11y — combobox missing `aria-controls` | Add `useId()` on the listbox, reference it via `aria-controls`. |

Tests in `entity-kanban.test.tsx` and `entity-gallery.test.tsx` updated to click the inner `<button>` instead of the `<li>`.

## Public API change

`EntitySelectionBar` prop renamed from `useBulkEndpoint` to `bulkEndpoint`. **No external consumer** of this prop in the showcase (verified via `grep`). Internal tests + doc comments updated.

## Test plan

- [x] `pnpm exec eslint packages/@granit/react-entities/src packages/@granit/react-taxonomy/src` — clean
- [x] `pnpm exec tsc --noEmit` on both packages — clean
- [x] `pnpm exec vitest run packages/@granit/react-entities/src packages/@granit/react-taxonomy/src` — 322 passing, including the 2 click tests adjusted for the new DOM structure