### PR TITLE
chore(sonar): batch fix open code smells across packages

### DIFF
--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -72,7 +72,7 @@ export class CsrfManager {
  * Relative URLs (`/bff/...`) and same-origin absolute URLs are accepted.
  */
 function assertSameOrigin(input: RequestInfo | URL): void {
-  if (typeof globalThis.location === 'undefined') return; // SSR / Node tests
+  if (globalThis.location === undefined) return; // SSR / Node tests
   const rawUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
   let resolved: URL;
   try {

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -168,7 +168,7 @@ export function widgetInstanceToDefinition(
       ? undefined
       : { requiredPermission: instance.requiredPermission }),
   };
-  return widget as WidgetDefinition;
+  return widget;
 }
 
 /**

--- a/packages/@granit/logger-otlp/src/pii-redactor.ts
+++ b/packages/@granit/logger-otlp/src/pii-redactor.ts
@@ -41,8 +41,8 @@ function passesLuhn(digits: string): boolean {
   let sum = 0;
   let alt = false;
   for (let i = digits.length - 1; i >= 0; i--) {
-    const c = digits.charCodeAt(i);
-    if (c < 48 || c > 57) return false;
+    const c = digits.codePointAt(i);
+    if (c === undefined || c < 48 || c > 57) return false;
     let n = c - 48;
     if (alt) {
       n *= 2;

--- a/packages/@granit/query-engine/src/validation/validate-query-request.ts
+++ b/packages/@granit/query-engine/src/validation/validate-query-request.ts
@@ -78,5 +78,5 @@ export function validateQueryRequest(params: QueryRequest): QueryRequest {
     result.sort = clampSort(params.sort);
   }
 
-  return result as QueryRequest;
+  return result;
 }

--- a/packages/@granit/react-activities/src/components/activity-calendar.tsx
+++ b/packages/@granit/react-activities/src/components/activity-calendar.tsx
@@ -118,7 +118,7 @@ export function ActivityCalendar({
         <div data-granit-activity-calendar-error="" role="alert">
           {query.error?.message ?? 'Failed to load calendar.'}
         </div>
-      ) : days.length === 0 || days.every((d) => d.items.length === 0) ? (
+      ) : days.every((d) => d.items.length === 0) ? (
         <div data-granit-activity-calendar-empty="">No activities in this window.</div>
       ) : (
         <ol data-granit-activity-calendar-grid="">
@@ -183,7 +183,7 @@ function computeWindow(anchor: Date, view: ActivityCalendarView): CalendarWindow
 }
 
 function addDays(d: Date, days: number): Date {
-  const next = new Date(d.getTime());
+  const next = new Date(d);
   next.setUTCDate(next.getUTCDate() + days);
   return next;
 }

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -75,7 +75,7 @@ export function BffProvider({ config, children }: BffProviderProps) {
           typeof data === 'object' &&
           data !== null &&
           'authenticated' in data &&
-          (data as { authenticated: unknown }).authenticated === true
+          data.authenticated === true
         ) {
           setUser(data as BffUser);
           await csrfManager.fetchToken();

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -97,8 +97,15 @@ export function BffProvider({ config, children }: BffProviderProps) {
     const interval = configRef.current.sessionCheckInterval ?? 60_000;
     if (interval > 0) {
       // ±10% jitter prevents a synchronised request herd across tabs/users,
-      // and visibilitychange gating avoids polling background tabs.
-      const jitter = () => interval * (0.9 + Math.random() * 0.2);
+      // and visibilitychange gating avoids polling background tabs. Uses
+      // crypto.getRandomValues() rather than Math.random() — not for
+      // security but to keep Sonar's S2245 rule clean across the codebase.
+      const jitter = () => {
+        const buf = new Uint32Array(1);
+        crypto.getRandomValues(buf);
+        const r = buf[0]! / 0x1_0000_0000;
+        return interval * (0.9 + r * 0.2);
+      };
       let timer: ReturnType<typeof setTimeout> | undefined;
 
       const schedule = () => {

--- a/packages/@granit/react-documents/src/components/document-detail.tsx
+++ b/packages/@granit/react-documents/src/components/document-detail.tsx
@@ -114,8 +114,8 @@ export function DocumentDetail({
 
   async function handleDownload(): Promise<void> {
     const result = await downloadUrl.refetch();
-    if (result.data && typeof window !== 'undefined') {
-      window.open(result.data.url, '_blank', 'noopener,noreferrer');
+    if (result.data && typeof globalThis.window !== 'undefined') {
+      globalThis.open(result.data.url, '_blank', 'noopener,noreferrer');
     }
   }
 

--- a/packages/@granit/react-documents/src/components/folder-tree.tsx
+++ b/packages/@granit/react-documents/src/components/folder-tree.tsx
@@ -70,8 +70,8 @@ function FolderNode({
   const [error, setError] = useState<string | null>(null);
 
   function handleAdd(): void {
-    if (typeof window === 'undefined') return;
-    const name = window.prompt(labels.newFolderName);
+    if (typeof globalThis.window === 'undefined') return;
+    const name = globalThis.prompt(labels.newFolderName);
     if (!name?.trim()) return;
     createFolder.mutate(
       { parentFolderId: folder.id, name: name.trim() },
@@ -82,8 +82,8 @@ function FolderNode({
   }
 
   function handleRename(): void {
-    if (typeof window === 'undefined') return;
-    const next = window.prompt(labels.rename, folder.name);
+    if (typeof globalThis.window === 'undefined') return;
+    const next = globalThis.prompt(labels.rename, folder.name);
     if (!next?.trim() || next.trim() === folder.name) return;
     renameFolder.mutate(
       { id: folder.id, request: { name: next.trim() } },
@@ -94,7 +94,8 @@ function FolderNode({
   }
 
   function handleDelete(): void {
-    if (typeof window === 'undefined' || !window.confirm(labels.deleteConfirm)) return;
+    if (typeof globalThis.window === 'undefined' || !globalThis.confirm(labels.deleteConfirm))
+      return;
     trashFolder.mutate(folder.id, {
       onSuccess: () => onDeleted?.(folder.id),
       onError: (err) => setError(err.message),
@@ -188,8 +189,8 @@ export function FolderTree({
   const createFolder = useCreateFolder();
 
   function handleAddRoot(): void {
-    if (typeof window === 'undefined') return;
-    const name = window.prompt(labelStrings.newFolderName);
+    if (typeof globalThis.window === 'undefined') return;
+    const name = globalThis.prompt(labelStrings.newFolderName);
     if (!name?.trim()) return;
     createFolder.mutate({ parentFolderId: rootFolderId, name: name.trim() });
   }

--- a/packages/@granit/react-documents/src/components/trash-bin.tsx
+++ b/packages/@granit/react-documents/src/components/trash-bin.tsx
@@ -67,9 +67,9 @@ export function TrashBin({
   const permanentlyDeleteDocument = usePermanentlyDeleteDocument();
 
   function handlePermanentDelete(id: string): void {
-    if (typeof window === 'undefined') return;
-    if (!window.confirm(labelStrings.permanentlyDeleteConfirm)) return;
-    if (!window.confirm(labelStrings.permanentlyDeleteConfirm)) return;
+    if (typeof globalThis.window === 'undefined') return;
+    if (!globalThis.confirm(labelStrings.permanentlyDeleteConfirm)) return;
+    if (!globalThis.confirm(labelStrings.permanentlyDeleteConfirm)) return;
     permanentlyDeleteDocument.mutate(id);
   }
 

--- a/packages/@granit/react-documents/src/components/versions-timeline.tsx
+++ b/packages/@granit/react-documents/src/components/versions-timeline.tsx
@@ -55,8 +55,8 @@ function VersionRow({ documentId, version, labels }: Readonly<VersionRowProps>):
 
   async function handleDownload(): Promise<void> {
     const result = await downloadUrl.refetch();
-    if (result.data && typeof window !== 'undefined') {
-      window.open(result.data.url, '_blank', 'noopener,noreferrer');
+    if (result.data && typeof globalThis.window !== 'undefined') {
+      globalThis.open(result.data.url, '_blank', 'noopener,noreferrer');
     }
   }
 

--- a/packages/@granit/react-entities-customization/src/components/field-inspector-overlay.tsx
+++ b/packages/@granit/react-entities-customization/src/components/field-inspector-overlay.tsx
@@ -89,7 +89,7 @@ export function FieldInspectorOverlay({
     >
       <header data-granit-field-inspector-header="">
         <h2 data-granit-field-inspector-title="">{merged.title(fieldName)}</h2>
-        {onClose !== undefined ? (
+        {onClose === undefined ? null : (
           <button
             type="button"
             data-granit-field-inspector-close=""
@@ -98,7 +98,7 @@ export function FieldInspectorOverlay({
           >
             {merged.close}
           </button>
-        ) : null}
+        )}
       </header>
       <ol data-granit-field-inspector-layers="">
         {RESOLUTION_LAYERS.map((layer) => {

--- a/packages/@granit/react-entities-customization/src/components/form-layout-editor.tsx
+++ b/packages/@granit/react-entities-customization/src/components/form-layout-editor.tsx
@@ -111,7 +111,7 @@ export function FormLayoutEditor({
           >
             {field.hidden ? merged.show : merged.hide}
           </button>
-          {availableGroups !== undefined ? (
+          {availableGroups === undefined ? null : (
             <select
               data-granit-form-layout-editor-group=""
               aria-label={merged.groupSelectAriaLabel(field.name)}
@@ -126,7 +126,7 @@ export function FormLayoutEditor({
                 </option>
               ))}
             </select>
-          ) : null}
+          )}
         </li>
       ))}
     </ol>

--- a/packages/@granit/react-entities-customization/src/layout/apply-deltas.ts
+++ b/packages/@granit/react-entities-customization/src/layout/apply-deltas.ts
@@ -61,7 +61,7 @@ export function applyDeltas(
       if (anchorIdx === -1 || anchor === delta.fieldName) continue;
       order.splice(fromIdx, 1);
       const reAnchor = order.indexOf(anchor);
-      const targetIdx = delta.beforeFieldName !== undefined ? reAnchor : reAnchor + 1;
+      const targetIdx = delta.beforeFieldName === undefined ? reAnchor + 1 : reAnchor;
       order.splice(targetIdx, 0, delta.fieldName);
     }
   }

--- a/packages/@granit/react-entities/src/components/entity-detail.tsx
+++ b/packages/@granit/react-entities/src/components/entity-detail.tsx
@@ -422,7 +422,8 @@ function formatValue(value: unknown): string {
   if (value === null || value === undefined) return '—';
   if (typeof value === 'boolean') return value ? '✓' : '✗';
   if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
+  // After the guards above, value is a primitive with well-defined String() coercion.
+  return String(value as string | number | bigint);
 }
 
 interface RelationGroupProps {

--- a/packages/@granit/react-taxonomy/src/components/category-tree.tsx
+++ b/packages/@granit/react-taxonomy/src/components/category-tree.tsx
@@ -79,22 +79,22 @@ function CategoryNode({
   const [error, setError] = useState<string | null>(null);
 
   function handleAdd(): void {
-    if (typeof window === 'undefined') return;
-    const name = window.prompt('Category name?');
+    if (typeof globalThis.window === 'undefined') return;
+    const name = globalThis.prompt('Category name?');
     if (!name?.trim()) return;
     createCategory.mutate({ scope, parentId: category.id, name: name.trim() });
   }
 
   function handleRename(): void {
-    if (typeof window === 'undefined') return;
-    const next = window.prompt('Rename category', category.name);
+    if (typeof globalThis.window === 'undefined') return;
+    const next = globalThis.prompt('Rename category', category.name);
     if (!next?.trim() || next.trim() === category.name) return;
     updateCategory.mutate({ id: category.id, request: { name: next.trim() } });
   }
 
   function handleMove(): void {
-    if (typeof window === 'undefined') return;
-    const next = window.prompt(labels.movePrompt, '');
+    if (typeof globalThis.window === 'undefined') return;
+    const next = globalThis.prompt(labels.movePrompt, '');
     if (next === null) return;
     if (next === category.id) {
       setError(labels.error422Cycle);
@@ -121,7 +121,8 @@ function CategoryNode({
   }
 
   function handleDelete(): void {
-    if (typeof window === 'undefined' || !window.confirm(labels.deleteConfirm)) return;
+    if (typeof globalThis.window === 'undefined' || !globalThis.confirm(labels.deleteConfirm))
+      return;
     deleteCategory.mutate(category.id, {
       onError: (err) => {
         const status = (err as { response?: { status?: number; data?: { detail?: string } } })
@@ -236,8 +237,8 @@ export function CategoryTree({
   const createCategory = useCreateCategory(scope);
 
   function handleAddRoot(): void {
-    if (typeof window === 'undefined') return;
-    const name = window.prompt('Root category name?');
+    if (typeof globalThis.window === 'undefined') return;
+    const name = globalThis.prompt('Root category name?');
     if (!name?.trim()) return;
     createCategory.mutate({ scope, parentId: null, name: name.trim() });
   }

--- a/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
@@ -136,7 +136,8 @@ export function TagManager({
   }
 
   function confirmDelete(tag: TagResponse): void {
-    if (typeof window !== 'undefined' && !window.confirm(labelStrings.deleteConfirm)) return;
+    if (typeof globalThis.window !== 'undefined' && !globalThis.confirm(labelStrings.deleteConfirm))
+      return;
     deleteTag.mutate(tag.id);
   }
 

--- a/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
@@ -129,7 +129,7 @@ export function TagManager({
       id: tag.id,
       request: {
         name: patch.name,
-        color: patch.color as HexColor | undefined,
+        color: patch.color,
         hideOnEntityCard: patch.hideOnEntityCard,
       },
     });

--- a/packages/@granit/react-timeline/src/components/reaction-bar.tsx
+++ b/packages/@granit/react-timeline/src/components/reaction-bar.tsx
@@ -1,7 +1,10 @@
-import { REACTION_EMOJIS, type ReactionEmoji, type ReactionMap } from '@granit/timeline';
+import {
+  REACTION_EMOJIS,
+  type ReactionEmoji,
+  type ReactionMap,
+  type TimelineEntryId,
+} from '@granit/timeline';
 import { type ReactNode } from 'react';
-
-import type { TimelineEntryId } from '@granit/timeline';
 
 export interface ReactionBarLabels {
   /**

--- a/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
@@ -151,20 +151,20 @@ export function toggleReactionMap(
 ): ReactionMap | undefined {
   const current = reactions?.[emoji];
   if (!current) {
-    return { ...(reactions ?? {}), [emoji]: { count: 1, byCurrentUser: true } };
+    return { ...reactions, [emoji]: { count: 1, byCurrentUser: true } };
   }
   if (current.byCurrentUser) {
     const nextCount = current.count - 1;
     if (nextCount <= 0) {
-      const rest = Object.fromEntries(
+      const rest: ReactionMap = Object.fromEntries(
         Object.entries(reactions ?? {}).filter(([key]) => key !== emoji)
       );
-      return Object.keys(rest).length === 0 ? undefined : (rest as ReactionMap);
+      return Object.keys(rest).length === 0 ? undefined : rest;
     }
-    return { ...(reactions ?? {}), [emoji]: { count: nextCount, byCurrentUser: false } };
+    return { ...reactions, [emoji]: { count: nextCount, byCurrentUser: false } };
   }
   return {
-    ...(reactions ?? {}),
+    ...reactions,
     [emoji]: { count: current.count + 1, byCurrentUser: true },
   };
 }
@@ -181,13 +181,13 @@ export function applyToggleResult(
 ): ReactionMap | undefined {
   if (result.count <= 0) {
     if (!reactions) return undefined;
-    const rest = Object.fromEntries(
+    const rest: ReactionMap = Object.fromEntries(
       Object.entries(reactions).filter(([key]) => key !== result.emoji)
     );
-    return Object.keys(rest).length === 0 ? undefined : (rest as ReactionMap);
+    return Object.keys(rest).length === 0 ? undefined : rest;
   }
   return {
-    ...(reactions ?? {}),
+    ...reactions,
     [result.emoji]: { count: result.count, byCurrentUser: result.currentUserHasReacted },
   };
 }

--- a/packages/@granit/validation/src/extract-constraints.ts
+++ b/packages/@granit/validation/src/extract-constraints.ts
@@ -104,7 +104,7 @@ function buildFieldConstraint(prop: OpenApiSchemaProperty, isRequired: boolean):
   if (prop['x-granit-pattern-hint'] !== undefined)
     constraint['patternHint'] = prop['x-granit-pattern-hint'];
 
-  return constraint as FieldConstraint;
+  return constraint;
 }
 
 function filterSchemaNames(names: string[], options?: ExtractOptions): string[] {

--- a/packages/@granit/validation/src/get-input-props.ts
+++ b/packages/@granit/validation/src/get-input-props.ts
@@ -40,5 +40,5 @@ export function getInputProps(constraint: FieldConstraint): InputConstraintProps
     props['max'] = constraint.exclusiveMaximum - 1;
   }
 
-  return props as InputConstraintProps;
+  return props;
 }


### PR DESCRIPTION
## Summary

Batch fix for ~45 Sonar code smells (Minor severity) flagged across multiple packages, grouped by pattern.

### Commits (one per pattern)

| Commit | Pattern | Files |
|--------|---------|-------|
| `2ee7ea7` | `charCodeAt` → `codePointAt` (Luhn check) | logger-otlp |
| `6fb14b4` | `Math.random` → `crypto.getRandomValues` (S2245) | react-bff |
| `68072e5` | `window` → `globalThis.window` / `globalThis` | react-documents (4 files), react-taxonomy (2 files) |
| `dcbe177` | `typeof X === 'undefined'` → `X === undefined` | bff/csrf-manager |
| `d15d34f` | Negated ternaries → positive form | react-entities-customization (apply-deltas, field-inspector-overlay, form-layout-editor) |
| `d464bb8` | Duplicate `@granit/timeline` imports merged | react-timeline/reaction-bar |
| `09eb494` | Redundant empty-object spreads `{ ...(x ?? {}) }` → `{ ...x }`; redundant `as ReactionMap` | react-timeline/use-toggle-reaction |
| `10d0a4e` | Drop unnecessary type assertions (`as T` on already-typed values); tighten formatValue narrowing | dashboards, query-engine, react-bff, react-entities, react-taxonomy, validation (×2) |
| `2437c8b` | Redundant empty-array guard before `.every()`; redundant `Date#getTime()` in clone | react-activities/activity-calendar |

### Notes

- `2ee7ea7` re-applies a fix that was lost from the #456 squash-merge (the second commit on that branch was not included).
- Two Sonar findings turned out to be **false positives** after testing and were kept:
  - `react-bff/bff-provider.tsx:80` — `setUser(data as BffUser)`. Removing the assertion makes tsc fail (TS narrows to `object & { authenticated: unknown }`, not `BffUser`).
  - `react-entities/entity-calendar.tsx:215` — `event as unknown as Readonly<Record<string, unknown>>`. Removing makes tsc fail (`CalendarItemResponse` lacks string index signature).

### Test plan

- [x] `pnpm exec eslint <14 modified files>` — clean
- [x] `pnpm -r exec -- tsc --noEmit` — clean (full monorepo)
- [x] `pnpm exec vitest run <11 impacted packages>` — 744/744 passing