### PR TITLE
chore(sonar): batch 2 — additional code smell fixes

### DIFF
--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -71,9 +71,15 @@ export class CsrfManager {
  * Throws if `input` resolves to a different origin than the current document.
  * Relative URLs (`/bff/...`) and same-origin absolute URLs are accepted.
  */
+function extractRawUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
 function assertSameOrigin(input: RequestInfo | URL): void {
   if (globalThis.location === undefined) return; // SSR / Node tests
-  const rawUrl = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+  const rawUrl = extractRawUrl(input);
   let resolved: URL;
   try {
     resolved = new URL(rawUrl, globalThis.location.href);

--- a/packages/@granit/logger-otlp/src/pii-redactor.ts
+++ b/packages/@granit/logger-otlp/src/pii-redactor.ts
@@ -7,8 +7,8 @@
 
 const EMAIL_RE = /(?<local>[A-Za-z0-9._%+-]{1,64})@(?<domain>[A-Za-z0-9.-]+\.[A-Za-z]{2,})/g;
 
-// `Authorization: Bearer xxx` and variants
-const BEARER_RE = /(Bearer\s+)([A-Za-z0-9._-]{8,})/gi;
+// `Authorization: Bearer xxx` and variants (token chars; `i` flag covers a-z).
+const BEARER_RE = /(Bearer\s+)([A-Z0-9._-]{8,})/gi;
 
 // Raw JWT (three base64url segments separated by dots, header starts with eyJ)
 const JWT_RE = /\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b/g;

--- a/packages/@granit/react-activities/src/__tests__/activity-calendar.test.tsx
+++ b/packages/@granit/react-activities/src/__tests__/activity-calendar.test.tsx
@@ -177,7 +177,7 @@ describe('<ActivityCalendar>', () => {
     );
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
-    const switcher = screen.getByRole('group', { name: 'View' });
+    const switcher = screen.getByRole('toolbar', { name: 'View' });
     fireEvent.click(within(switcher).getByRole('button', { name: 'Day' }));
 
     await waitFor(() => {

--- a/packages/@granit/react-activities/src/components/activity-calendar.tsx
+++ b/packages/@granit/react-activities/src/components/activity-calendar.tsx
@@ -97,7 +97,7 @@ export function ActivityCalendar({
         <span data-granit-activity-calendar-range="">
           {window.from.toISOString().slice(0, 10)} → {window.to.toISOString().slice(0, 10)}
         </span>
-        <div data-granit-activity-calendar-view-switcher="" role="group" aria-label="View">
+        <div data-granit-activity-calendar-view-switcher="" role="toolbar" aria-label="View">
           {(['day', 'week', 'month'] as const).map((v) => (
             <button
               key={v}
@@ -112,44 +112,53 @@ export function ActivityCalendar({
         </div>
       </div>
 
-      {query.isLoading ? (
-        <div data-granit-activity-calendar-loading="">Loading…</div>
-      ) : query.isError ? (
-        <div data-granit-activity-calendar-error="" role="alert">
-          {query.error?.message ?? 'Failed to load calendar.'}
-        </div>
-      ) : days.every((d) => d.items.length === 0) ? (
-        <div data-granit-activity-calendar-empty="">No activities in this window.</div>
-      ) : (
-        <ol data-granit-activity-calendar-grid="">
-          {days.map((d) => (
-            <li
-              key={d.iso}
-              data-granit-activity-calendar-day=""
-              data-activity-calendar-date={d.iso}
-            >
-              <header>{d.iso}</header>
-              <ul data-granit-activity-calendar-items="">
-                {d.items.map((item) => (
-                  <li key={item.id}>
-                    <button
-                      type="button"
-                      data-granit-activity-calendar-item=""
-                      data-activity-id={item.id}
-                      data-activity-color={item.color}
-                      data-activity-status={item.status}
-                      onClick={onItemClick ? () => onItemClick(item) : undefined}
-                    >
-                      {item.title}
-                    </button>
-                  </li>
-                ))}
-              </ul>
-            </li>
-          ))}
-        </ol>
-      )}
+      {renderCalendarBody(query, days, onItemClick)}
     </div>
+  );
+}
+
+function renderCalendarBody(
+  query: ReturnType<typeof useActivitiesCalendar>,
+  days: readonly CalendarDay[],
+  onItemClick: ((item: ActivityCalendarItemResponse) => void) | undefined
+): ReactNode {
+  if (query.isLoading) {
+    return <div data-granit-activity-calendar-loading="">Loading…</div>;
+  }
+  if (query.isError) {
+    return (
+      <div data-granit-activity-calendar-error="" role="alert">
+        {query.error?.message ?? 'Failed to load calendar.'}
+      </div>
+    );
+  }
+  if (days.every((d) => d.items.length === 0)) {
+    return <div data-granit-activity-calendar-empty="">No activities in this window.</div>;
+  }
+  return (
+    <ol data-granit-activity-calendar-grid="">
+      {days.map((d) => (
+        <li key={d.iso} data-granit-activity-calendar-day="" data-activity-calendar-date={d.iso}>
+          <header>{d.iso}</header>
+          <ul data-granit-activity-calendar-items="">
+            {d.items.map((item) => (
+              <li key={item.id}>
+                <button
+                  type="button"
+                  data-granit-activity-calendar-item=""
+                  data-activity-id={item.id}
+                  data-activity-color={item.color}
+                  data-activity-status={item.status}
+                  onClick={onItemClick ? () => onItemClick(item) : undefined}
+                >
+                  {item.title}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </li>
+      ))}
+    </ol>
   );
 }
 

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -103,7 +103,7 @@ export function BffProvider({ config, children }: BffProviderProps) {
       const jitter = () => {
         const buf = new Uint32Array(1);
         crypto.getRandomValues(buf);
-        const r = buf[0]! / 0x1_0000_0000;
+        const r = buf[0]! / 2 ** 32;
         return interval * (0.9 + r * 0.2);
       };
       let timer: ReturnType<typeof setTimeout> | undefined;

--- a/packages/@granit/react-blob-storage/src/components/blob-upload-field.tsx
+++ b/packages/@granit/react-blob-storage/src/components/blob-upload-field.tsx
@@ -187,29 +187,9 @@ export function BlobUploadField({
     onChange(null);
   }, [disabled, busy, reset, onChange]);
 
-  const preview =
-    renderPreview === null ? null : renderPreview ? (
-      renderPreview(value, state)
-    ) : value ? (
-      <BlobImage blobId={value} alt="" loading="lazy" />
-    ) : null;
-
+  const preview = computePreview(renderPreview, value, state);
   const showClear = value !== null && !busy;
-  const clearSlot =
-    renderClear === null ? null : showClear ? (
-      renderClear ? (
-        renderClear({ clear: handleClear, disabled: disabled ?? false })
-      ) : (
-        <button
-          type="button"
-          onClick={handleClear}
-          disabled={disabled}
-          data-granit-blob-upload-clear=""
-        >
-          Clear
-        </button>
-      )
-    ) : null;
+  const clearSlot = computeClearSlot(renderClear, showClear, handleClear, disabled ?? false);
 
   return (
     <div
@@ -238,15 +218,56 @@ export function BlobUploadField({
           aria-label="Upload progress"
         />
       ) : null}
-      {validationError ? (
-        <span role="alert" data-granit-blob-upload-error="" data-error-kind="validation">
-          {validationError}
-        </span>
-      ) : state.phase === 'error' && state.error ? (
-        <span role="alert" data-granit-blob-upload-error="" data-error-kind="upload">
-          {state.error.message}
-        </span>
-      ) : null}
+      {renderErrorBanner(validationError, state)}
     </div>
+  );
+}
+
+function renderErrorBanner(validationError: string | null, state: BlobUploadState): ReactNode {
+  if (validationError) {
+    return (
+      <span role="alert" data-granit-blob-upload-error="" data-error-kind="validation">
+        {validationError}
+      </span>
+    );
+  }
+  if (state.phase === 'error' && state.error) {
+    return (
+      <span role="alert" data-granit-blob-upload-error="" data-error-kind="upload">
+        {state.error.message}
+      </span>
+    );
+  }
+  return null;
+}
+
+function computePreview(
+  renderPreview: BlobUploadFieldProps['renderPreview'],
+  value: string | null,
+  state: BlobUploadState
+): ReactNode {
+  if (renderPreview === null) return null;
+  if (renderPreview) return renderPreview(value, state);
+  if (value) return <BlobImage blobId={value} alt="" loading="lazy" />;
+  return null;
+}
+
+function computeClearSlot(
+  renderClear: BlobUploadFieldProps['renderClear'],
+  showClear: boolean,
+  handleClear: () => void,
+  disabled: boolean
+): ReactNode {
+  if (renderClear === null || !showClear) return null;
+  if (renderClear) return renderClear({ clear: handleClear, disabled });
+  return (
+    <button
+      type="button"
+      onClick={handleClear}
+      disabled={disabled}
+      data-granit-blob-upload-clear=""
+    >
+      Clear
+    </button>
   );
 }

--- a/packages/@granit/react-documents/src/components/document-detail.tsx
+++ b/packages/@granit/react-documents/src/components/document-detail.tsx
@@ -114,7 +114,7 @@ export function DocumentDetail({
 
   async function handleDownload(): Promise<void> {
     const result = await downloadUrl.refetch();
-    if (result.data && typeof globalThis.window !== 'undefined') {
+    if (result.data && globalThis.window !== undefined) {
       globalThis.open(result.data.url, '_blank', 'noopener,noreferrer');
     }
   }

--- a/packages/@granit/react-documents/src/components/documents-explorer.tsx
+++ b/packages/@granit/react-documents/src/components/documents-explorer.tsx
@@ -36,6 +36,12 @@ const DEFAULT_LABELS: Required<DocumentsExplorerLabels> = {
  * document list itself is a seam ({@link DocumentsList}) until
  * `granit-fx/granit-dotnet#1990` ships the flat folder-documents endpoint.
  */
+// The finalize hook invalidates folders + quota query families, so the
+// right pane refreshes on its own — no per-callback work needed.
+function noopUploadComplete(_document: DocumentResponse): void {
+  /* intentional no-op */
+}
+
 export function DocumentsExplorer({
   rootFolderId = null,
   canManage = false,
@@ -74,11 +80,6 @@ export function DocumentsExplorer({
 
   const folderId = currentFolder?.id ?? '';
 
-  function handleUploadComplete(_document: DocumentResponse): void {
-    // The finalize hook already invalidates the folders + quota query
-    // families, so the right pane refreshes on its own.
-  }
-
   return (
     <div data-granit-documents-explorer="" className={className}>
       <header data-granit-documents-explorer-header="">
@@ -100,7 +101,7 @@ export function DocumentsExplorer({
           )}
           <DocumentsList folderId={folderId} onOpenDocument={onOpenDocument} />
           {canManage && (
-            <UploadButton folderId={currentFolder?.id ?? null} onComplete={handleUploadComplete} />
+            <UploadButton folderId={currentFolder?.id ?? null} onComplete={noopUploadComplete} />
           )}
         </section>
       </div>

--- a/packages/@granit/react-documents/src/components/folder-tree.tsx
+++ b/packages/@granit/react-documents/src/components/folder-tree.tsx
@@ -70,7 +70,7 @@ function FolderNode({
   const [error, setError] = useState<string | null>(null);
 
   function handleAdd(): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     const name = globalThis.prompt(labels.newFolderName);
     if (!name?.trim()) return;
     createFolder.mutate(
@@ -82,7 +82,7 @@ function FolderNode({
   }
 
   function handleRename(): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     const next = globalThis.prompt(labels.rename, folder.name);
     if (!next?.trim() || next.trim() === folder.name) return;
     renameFolder.mutate(
@@ -94,8 +94,7 @@ function FolderNode({
   }
 
   function handleDelete(): void {
-    if (typeof globalThis.window === 'undefined' || !globalThis.confirm(labels.deleteConfirm))
-      return;
+    if (globalThis.window === undefined || !globalThis.confirm(labels.deleteConfirm)) return;
     trashFolder.mutate(folder.id, {
       onSuccess: () => onDeleted?.(folder.id),
       onError: (err) => setError(err.message),
@@ -189,7 +188,7 @@ export function FolderTree({
   const createFolder = useCreateFolder();
 
   function handleAddRoot(): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     const name = globalThis.prompt(labelStrings.newFolderName);
     if (!name?.trim()) return;
     createFolder.mutate({ parentFolderId: rootFolderId, name: name.trim() });

--- a/packages/@granit/react-documents/src/components/trash-bin.tsx
+++ b/packages/@granit/react-documents/src/components/trash-bin.tsx
@@ -67,7 +67,7 @@ export function TrashBin({
   const permanentlyDeleteDocument = usePermanentlyDeleteDocument();
 
   function handlePermanentDelete(id: string): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     if (!globalThis.confirm(labelStrings.permanentlyDeleteConfirm)) return;
     if (!globalThis.confirm(labelStrings.permanentlyDeleteConfirm)) return;
     permanentlyDeleteDocument.mutate(id);

--- a/packages/@granit/react-documents/src/components/versions-timeline.tsx
+++ b/packages/@granit/react-documents/src/components/versions-timeline.tsx
@@ -55,7 +55,7 @@ function VersionRow({ documentId, version, labels }: Readonly<VersionRowProps>):
 
   async function handleDownload(): Promise<void> {
     const result = await downloadUrl.refetch();
-    if (result.data && typeof globalThis.window !== 'undefined') {
+    if (result.data && globalThis.window !== undefined) {
       globalThis.open(result.data.url, '_blank', 'noopener,noreferrer');
     }
   }

--- a/packages/@granit/react-taxonomy/src/components/category-selector.tsx
+++ b/packages/@granit/react-taxonomy/src/components/category-selector.tsx
@@ -95,11 +95,7 @@ export function CategorySelector({
         )}
       </div>
       {open && (
-        <div
-          role="dialog"
-          aria-label={labelStrings.dialogTitle}
-          data-granit-category-selector-dialog=""
-        >
+        <dialog open aria-label={labelStrings.dialogTitle} data-granit-category-selector-dialog="">
           <header data-granit-category-selector-dialog-header="">
             <h3>{labelStrings.dialogTitle}</h3>
             <button type="button" onClick={() => setOpen(false)}>
@@ -107,7 +103,7 @@ export function CategorySelector({
             </button>
           </header>
           <CategoryTree scope={scope} onSelect={handleSelect} />
-        </div>
+        </dialog>
       )}
     </div>
   );

--- a/packages/@granit/react-taxonomy/src/components/category-tree.tsx
+++ b/packages/@granit/react-taxonomy/src/components/category-tree.tsx
@@ -79,21 +79,21 @@ function CategoryNode({
   const [error, setError] = useState<string | null>(null);
 
   function handleAdd(): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     const name = globalThis.prompt('Category name?');
     if (!name?.trim()) return;
     createCategory.mutate({ scope, parentId: category.id, name: name.trim() });
   }
 
   function handleRename(): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     const next = globalThis.prompt('Rename category', category.name);
     if (!next?.trim() || next.trim() === category.name) return;
     updateCategory.mutate({ id: category.id, request: { name: next.trim() } });
   }
 
   function handleMove(): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     const next = globalThis.prompt(labels.movePrompt, '');
     if (next === null) return;
     if (next === category.id) {
@@ -121,8 +121,7 @@ function CategoryNode({
   }
 
   function handleDelete(): void {
-    if (typeof globalThis.window === 'undefined' || !globalThis.confirm(labels.deleteConfirm))
-      return;
+    if (globalThis.window === undefined || !globalThis.confirm(labels.deleteConfirm)) return;
     deleteCategory.mutate(category.id, {
       onError: (err) => {
         const status = (err as { response?: { status?: number; data?: { detail?: string } } })
@@ -237,7 +236,7 @@ export function CategoryTree({
   const createCategory = useCreateCategory(scope);
 
   function handleAddRoot(): void {
-    if (typeof globalThis.window === 'undefined') return;
+    if (globalThis.window === undefined) return;
     const name = globalThis.prompt('Root category name?');
     if (!name?.trim()) return;
     createCategory.mutate({ scope, parentId: null, name: name.trim() });

--- a/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-manager.tsx
@@ -136,8 +136,7 @@ export function TagManager({
   }
 
   function confirmDelete(tag: TagResponse): void {
-    if (typeof globalThis.window !== 'undefined' && !globalThis.confirm(labelStrings.deleteConfirm))
-      return;
+    if (globalThis.window !== undefined && !globalThis.confirm(labelStrings.deleteConfirm)) return;
     deleteTag.mutate(tag.id);
   }
 

--- a/packages/@granit/react-timeline/src/components/reaction-bar.tsx
+++ b/packages/@granit/react-timeline/src/components/reaction-bar.tsx
@@ -70,7 +70,7 @@ export function ReactionBar({
       data-granit-reaction-bar=""
       data-entry-id={entryId}
       data-readonly={isInteractive ? undefined : ''}
-      role="group"
+      role="toolbar"
       className={className}
     >
       {REACTION_EMOJIS.map((emoji) => {


### PR DESCRIPTION
## Summary

Follow-up batch to #458 — fixes Sonar issues that were either newly introduced by #458's changes (e.g. `typeof globalThis.window` patterns appearing after the `window` → `globalThis` migration) or surfaced on a later scan.

### Commits

| Commit | Pattern | Files |
|--------|---------|-------|
| `d4d254d` | `[A-Za-z]` duplicate range under `/i` flag in `BEARER_RE` | logger-otlp/pii-redactor |
| `1c87ec0` | Triple-nested ternary → `extractRawUrl` helper | bff/csrf-manager |
| `ac40354` | Nested ternaries → helpers (`renderCalendarBody`, `computePreview`, `computeClearSlot`, `renderErrorBanner`) | react-activities/activity-calendar, react-blob-storage/blob-upload-field |
| `2fe8aff` | Hoist `noopUploadComplete` out of `DocumentsExplorer` (perf — avoid recreate on each render) | react-documents/documents-explorer |
| `ce01e56` | `<div role="dialog">` → `<dialog>`; `role="group"` → `role="toolbar"` on button bars | react-taxonomy/category-selector, react-activities/activity-calendar, react-timeline/reaction-bar |
| `6ab2d74` | `typeof globalThis.window === 'undefined'` → `globalThis.window === undefined` | react-documents (4), react-taxonomy (2) |
| `e432bf8` | Invalid hex grouping `0x1_0000_0000` → `2 ** 32` for Uint32 normalisation | react-bff/bff-provider |

### Notes on Sonar findings that were not fixed (confirmed false positives)

- **`role="progressbar"` × 3** (quota-badge, quota-panel, upload-button) — switching to `<progress>` removes the custom child fill-bar (`<span style="width: X%">`). Kept role + aria attributes.
- **`role="listbox"` × 2** (tag-autocomplete, taxonomy-search-bar) — `<select>` cannot render `TagChip` / snippet content per option.
- **`role="presentation"` on `<li>` × 2** — Sonar suggests `<img alt="">` but these are list items, not images.
- **`role="group"` on nested `<ul>` × 1** (taxonomy-search-bar) — official ARIA pattern for grouping options inside a listbox.
- **`setUser(data as BffUser)`** (bff-provider L80) — removing the assertion breaks tsc: TS narrows to `object & { authenticated: unknown }`, not `BffUser`.

### Test plan

- [x] `pnpm -r exec -- tsc --noEmit` — clean (full monorepo)
- [x] `pnpm exec eslint <touched files>` — clean
- [x] Targeted vitest on impacted packages — 426/427 → 1 click-target test updated (`role="toolbar"` instead of `"group"`) → 62/62 in react-activities