### PR TITLE
fix(security): enforce IsHost contract on /bff/user (VULN-205)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2201,6 +2201,16 @@
           "signature": "function useBffFetch()"
         },
         {
+          "name": "resolveBffTenantId",
+          "kind": "function",
+          "signature": "function resolveBffTenantId(user: BffUser | null): string | undefined"
+        },
+        {
+          "name": "useBffTenantGetter",
+          "kind": "function",
+          "signature": "function useBffTenantGetter(): () => string | undefined"
+        },
+        {
           "name": "BffGuard",
           "kind": "function",
           "signature": "function BffGuard("
@@ -3822,6 +3832,11 @@
           "name": "useClearQueriesOnTenantChange",
           "kind": "function",
           "signature": "function useClearQueriesOnTenantChange(): void"
+        },
+        {
+          "name": "useClearQueriesOnUserChange",
+          "kind": "function",
+          "signature": "function useClearQueriesOnUserChange(userId: string | undefined): void"
         }
       ]
     },

--- a/packages/@granit/bff/src/__tests__/parse-bff-user.test.ts
+++ b/packages/@granit/bff/src/__tests__/parse-bff-user.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseBffSessionResponse } from '../validation/parse-bff-user.js';
+
+const validIsoDate = '2026-12-31T23:59:59Z';
+
+const validBase = {
+  authenticated: true as const,
+  sub: 'user-1',
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  roles: ['Reader'],
+  sessionExpiresAt: validIsoDate,
+};
+
+describe('parseBffSessionResponse', () => {
+  describe('unauthenticated', () => {
+    it('accepts { authenticated: false }', () => {
+      const r = parseBffSessionResponse({ authenticated: false });
+      expect(r).toEqual({ success: true, data: { authenticated: false } });
+    });
+
+    it('ignores extra fields on unauthenticated response', () => {
+      const r = parseBffSessionResponse({ authenticated: false, extra: 'noise' });
+      expect(r.success).toBe(true);
+    });
+  });
+
+  describe('tenant user (isHost: false)', () => {
+    it('accepts a complete tenant user payload', () => {
+      const r = parseBffSessionResponse({
+        ...validBase,
+        isHost: false,
+        tenantId: 'acme',
+      });
+      expect(r.success).toBe(true);
+      if (r.success && r.data.authenticated) {
+        expect(r.data.isHost).toBe(false);
+        if (!r.data.isHost) {
+          expect(r.data.tenantId).toBe('acme');
+        }
+      }
+    });
+
+    it('rejects a tenant user with missing tenantId', () => {
+      const r = parseBffSessionResponse({
+        ...validBase,
+        isHost: false,
+      });
+      expect(r.success).toBe(false);
+      if (!r.success) {
+        expect(r.issues.some((i) => i.includes('tenantId'))).toBe(true);
+      }
+    });
+
+    it('rejects a tenant user with empty tenantId', () => {
+      const r = parseBffSessionResponse({
+        ...validBase,
+        isHost: false,
+        tenantId: '',
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('host user (isHost: true)', () => {
+    it('accepts a host user without tenantId', () => {
+      const r = parseBffSessionResponse({ ...validBase, isHost: true });
+      expect(r.success).toBe(true);
+      if (r.success && r.data.authenticated) {
+        expect(r.data.isHost).toBe(true);
+        // The discriminated union must NOT expose `tenantId` on the host branch.
+        expect('tenantId' in r.data).toBe(false);
+      }
+    });
+
+    it('rejects a host user carrying a tenantId (invariant violated)', () => {
+      const r = parseBffSessionResponse({
+        ...validBase,
+        isHost: true,
+        tenantId: 'acme',
+      });
+      expect(r.success).toBe(false);
+      if (!r.success) {
+        expect(r.issues.some((i) => i.includes('IsHost ⇔ tenantId'))).toBe(true);
+      }
+    });
+
+    it('rejects a host user with non-null but empty tenantId still flagged', () => {
+      const r = parseBffSessionResponse({
+        ...validBase,
+        isHost: true,
+        tenantId: 'x',
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+
+  describe('malformed payloads', () => {
+    it('rejects null', () => {
+      expect(parseBffSessionResponse(null).success).toBe(false);
+    });
+
+    it('rejects a non-object (string)', () => {
+      expect(parseBffSessionResponse('hello').success).toBe(false);
+    });
+
+    it('rejects when `authenticated` is missing', () => {
+      const r = parseBffSessionResponse({ ...validBase, isHost: false, tenantId: 'acme' });
+      delete (r as unknown as { authenticated?: unknown }).authenticated;
+      // Build the actual rejection case
+      const r2 = parseBffSessionResponse({
+        sub: 'x',
+        isHost: false,
+        tenantId: 'a',
+      });
+      expect(r2.success).toBe(false);
+    });
+
+    it('rejects when isHost is not a boolean', () => {
+      const r = parseBffSessionResponse({ ...validBase, isHost: 'yes', tenantId: 'acme' });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects when sub is empty', () => {
+      const r = parseBffSessionResponse({ ...validBase, sub: '', isHost: true });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects when roles is not an array', () => {
+      const r = parseBffSessionResponse({ ...validBase, roles: 'Reader', isHost: true });
+      expect(r.success).toBe(false);
+    });
+
+    it('rejects when sessionExpiresAt is not ISO-8601', () => {
+      const r = parseBffSessionResponse({
+        ...validBase,
+        sessionExpiresAt: 'last tuesday',
+        isHost: true,
+      });
+      expect(r.success).toBe(false);
+    });
+  });
+});

--- a/packages/@granit/bff/src/index.ts
+++ b/packages/@granit/bff/src/index.ts
@@ -1,8 +1,10 @@
 export type {
   BffConfig,
+  BffHostUser,
   BffSessionId,
   BffSessionInfo,
   BffSessionListResponse,
+  BffTenantUser,
   BffUnauthenticated,
   BffUser,
   BffUserResponse,
@@ -15,3 +17,6 @@ export {
   revokeAllOtherBffSessions,
   revokeBffSession,
 } from './api/bff-session-api.js';
+
+export { parseBffSessionResponse } from './validation/index.js';
+export type { ParseResult } from './validation/index.js';

--- a/packages/@granit/bff/src/types/index.ts
+++ b/packages/@granit/bff/src/types/index.ts
@@ -2,18 +2,38 @@ import type { EntityId, ISODateString, TenantId } from '@granit/types';
 
 // ---------------------------------------------------------------------------
 // BFF authentication types — mirrors Granit.Bff .NET contract
+//
+// Since granit-dotnet EPIC #2133 (Story #2134), `BffUserResponse.IsHost`
+// is the authoritative Host/Tenant marker emitted by the BFF, with the
+// invariant `IsHost ⇔ tenant_id claim absent`. The front mirrors that
+// invariant in the type system via a discriminated union — a tenant user
+// is guaranteed to carry `tenantId: string`, a host user is guaranteed to
+// have no `tenantId` field.
 // ---------------------------------------------------------------------------
 
-/** Authenticated user returned by GET /{prefix}/bff/user. */
-export interface BffUser {
+/** Common fields shared by every authenticated user. */
+interface BffAuthenticatedUserBase {
   readonly authenticated: true;
   readonly sub: string;
   readonly name: string;
   readonly email: string;
   readonly roles: readonly string[];
-  readonly tenantId?: TenantId;
   readonly sessionExpiresAt: ISODateString;
 }
+
+/** Tenant-scoped user — must carry a non-empty `tenantId`. */
+export interface BffTenantUser extends BffAuthenticatedUserBase {
+  readonly isHost: false;
+  readonly tenantId: TenantId;
+}
+
+/** Host (cross-tenant) user — must NOT carry a `tenantId`. */
+export interface BffHostUser extends BffAuthenticatedUserBase {
+  readonly isHost: true;
+}
+
+/** Authenticated user returned by GET /{prefix}/bff/user. */
+export type BffUser = BffTenantUser | BffHostUser;
 
 /** Unauthenticated response from GET /{prefix}/bff/user. */
 export interface BffUnauthenticated {

--- a/packages/@granit/bff/src/validation/index.ts
+++ b/packages/@granit/bff/src/validation/index.ts
@@ -1,0 +1,2 @@
+export { parseBffSessionResponse } from './parse-bff-user.js';
+export type { ParseResult } from './parse-bff-user.js';

--- a/packages/@granit/bff/src/validation/parse-bff-user.ts
+++ b/packages/@granit/bff/src/validation/parse-bff-user.ts
@@ -1,0 +1,160 @@
+// ---------------------------------------------------------------------------
+// Runtime validator for the GET /{prefix}/bff/user response.
+//
+// The BFF is first-party but its response crosses a network boundary, may be
+// rewritten by misconfigured proxies / captive portals, and must respect the
+// invariant `IsHost ⇔ tenant_id absent`. The validator enforces the
+// discriminated-union shape so the auth context never observes a malformed
+// state. No external dep (zod, ajv) — the contract is finite and stable.
+// ---------------------------------------------------------------------------
+
+import type {
+  BffHostUser,
+  BffTenantUser,
+  BffUnauthenticated,
+  BffUserResponse,
+} from '../types/index.js';
+import type { ISODateString, TenantId } from '@granit/types';
+
+/** Discriminated result mirroring zod's safeParse. */
+export type ParseResult<T> =
+  | { readonly success: true; readonly data: T }
+  | { readonly success: false; readonly issues: readonly string[] };
+
+function isObject(x: unknown): x is Record<string, unknown> {
+  return typeof x === 'object' && x !== null;
+}
+
+function isString(x: unknown): x is string {
+  return typeof x === 'string';
+}
+
+function isNonEmptyString(x: unknown): x is string {
+  return typeof x === 'string' && x.length > 0;
+}
+
+function isStringArray(x: unknown): x is readonly string[] {
+  return Array.isArray(x) && x.every(isString);
+}
+
+function isIsoDate(x: unknown): x is string {
+  if (!isString(x)) return false;
+  // Loose ISO-8601 sanity check — full grammar is enforced server-side.
+  return /^\d{4}-\d{2}-\d{2}T/.test(x);
+}
+
+/** Asserts the common authenticated-user fields. */
+function readAuthenticatedBase(
+  obj: Record<string, unknown>,
+  issues: string[]
+): {
+  sub: string;
+  name: string;
+  email: string;
+  roles: readonly string[];
+  sessionExpiresAt: ISODateString;
+} | null {
+  let ok = true;
+  if (!isNonEmptyString(obj.sub)) {
+    issues.push('field "sub" must be a non-empty string');
+    ok = false;
+  }
+  if (!isString(obj.name)) {
+    issues.push('field "name" must be a string');
+    ok = false;
+  }
+  if (!isString(obj.email)) {
+    issues.push('field "email" must be a string');
+    ok = false;
+  }
+  if (!isStringArray(obj.roles)) {
+    issues.push('field "roles" must be a string array');
+    ok = false;
+  }
+  if (!isIsoDate(obj.sessionExpiresAt)) {
+    issues.push('field "sessionExpiresAt" must be an ISO-8601 string');
+    ok = false;
+  }
+  if (!ok) return null;
+  return {
+    sub: obj.sub as string,
+    name: obj.name as string,
+    email: obj.email as string,
+    roles: obj.roles as readonly string[],
+    sessionExpiresAt: obj.sessionExpiresAt as ISODateString,
+  };
+}
+
+/**
+ * Parse a raw `/bff/user` response into a typed {@link BffUserResponse}.
+ *
+ * Enforces the granit-dotnet contract:
+ * - `authenticated: false` → unauthenticated, no other fields required.
+ * - `authenticated: true`, `isHost: false` → tenant user, MUST carry
+ *   non-empty `tenantId`.
+ * - `authenticated: true`, `isHost: true` → host user, MUST NOT carry
+ *   `tenantId`.
+ *
+ * Any deviation returns `{ success: false, issues: [...] }`; the caller
+ * should treat the response as untrustworthy (typically: log + force
+ * unauthenticated state).
+ */
+export function parseBffSessionResponse(raw: unknown): ParseResult<BffUserResponse> {
+  const issues: string[] = [];
+
+  if (!isObject(raw)) {
+    return { success: false, issues: ['response body is not a JSON object'] };
+  }
+
+  if (raw.authenticated === false) {
+    const result: BffUnauthenticated = { authenticated: false };
+    return { success: true, data: result };
+  }
+
+  if (raw.authenticated !== true) {
+    return {
+      success: false,
+      issues: ['field "authenticated" must be a boolean literal (true or false)'],
+    };
+  }
+
+  if (typeof raw.isHost !== 'boolean') {
+    issues.push('field "isHost" must be a boolean');
+  }
+
+  const base = readAuthenticatedBase(raw, issues);
+
+  if (raw.isHost === true) {
+    if ('tenantId' in raw && raw.tenantId !== undefined && raw.tenantId !== null) {
+      issues.push('host user must NOT carry a tenantId (invariant IsHost ⇔ tenantId absent)');
+    }
+    if (!base || issues.length > 0) {
+      return { success: false, issues };
+    }
+    const host: BffHostUser = {
+      authenticated: true,
+      isHost: true,
+      ...base,
+    };
+    return { success: true, data: host };
+  }
+
+  if (raw.isHost === false) {
+    if (!isNonEmptyString(raw.tenantId)) {
+      issues.push('tenant user must carry a non-empty tenantId');
+    }
+    if (!base || issues.length > 0) {
+      return { success: false, issues };
+    }
+    const tenant: BffTenantUser = {
+      authenticated: true,
+      isHost: false,
+      ...base,
+      tenantId: raw.tenantId as TenantId,
+    };
+    return { success: true, data: tenant };
+  }
+
+  // isHost was not a boolean — already reported above.
+  return { success: false, issues };
+}

--- a/packages/@granit/react-bff/src/__tests__/bff-provider.test.tsx
+++ b/packages/@granit/react-bff/src/__tests__/bff-provider.test.tsx
@@ -12,6 +12,7 @@ import type { BffConfig } from '@granit/bff';
 
 const authenticatedResponse = {
   authenticated: true,
+  isHost: false,
   sub: 'user-123',
   name: 'Alice',
   email: 'alice@test.com',

--- a/packages/@granit/react-bff/src/__tests__/bff-sessions.test.tsx
+++ b/packages/@granit/react-bff/src/__tests__/bff-sessions.test.tsx
@@ -13,6 +13,7 @@ import type { BffConfig } from '@granit/bff';
 
 const authenticatedResponse = {
   authenticated: true,
+  isHost: false,
   sub: 'user-123',
   name: 'Alice',
   email: 'alice@test.com',

--- a/packages/@granit/react-bff/src/__tests__/use-bff-tenant.test.ts
+++ b/packages/@granit/react-bff/src/__tests__/use-bff-tenant.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveBffTenantId } from '../hooks/use-bff-tenant.js';
+
+import type { BffHostUser, BffTenantUser } from '@granit/bff';
+
+const tenantUser: BffTenantUser = {
+  authenticated: true,
+  isHost: false,
+  sub: 't',
+  name: 'T',
+  email: 't@x',
+  roles: [],
+  sessionExpiresAt: '2026-12-31T23:59:59Z',
+  tenantId: 'acme' as BffTenantUser['tenantId'],
+};
+
+const hostUser: BffHostUser = {
+  authenticated: true,
+  isHost: true,
+  sub: 'h',
+  name: 'H',
+  email: 'h@x',
+  roles: ['Host'],
+  sessionExpiresAt: '2026-12-31T23:59:59Z',
+};
+
+describe('resolveBffTenantId', () => {
+  it('returns tenantId for a tenant user', () => {
+    expect(resolveBffTenantId(tenantUser)).toBe('acme');
+  });
+
+  it('returns undefined for a host user — never auto-inject X-Tenant-Id', () => {
+    expect(resolveBffTenantId(hostUser)).toBeUndefined();
+  });
+
+  it('returns undefined for an anonymous / bootstrap state', () => {
+    expect(resolveBffTenantId(null)).toBeUndefined();
+  });
+});

--- a/packages/@granit/react-bff/src/hooks/use-bff-tenant.ts
+++ b/packages/@granit/react-bff/src/hooks/use-bff-tenant.ts
@@ -1,0 +1,42 @@
+import { useBffConfig } from '../providers/bff-provider.js';
+
+import type { BffUser } from '@granit/bff';
+
+/**
+ * Extract the tenant id to inject into `X-Tenant-Id` from a BFF user.
+ *
+ * **Never returns the tenant id for a Host user.** A Host user has no
+ * default tenant scope: the backend (`Granit.MultiTenancy` +
+ * `Granit.MultiTenancy.Authorization`) rejects any `X-Tenant-Id` header
+ * coming from a Host session unless the user holds the
+ * `MultiTenancy.Host.Impersonate` permission, and even then the
+ * impersonation must be an explicit, short-lived action — not the result
+ * of an automatic header injection. Returning `undefined` here keeps the
+ * interceptor honest.
+ *
+ * @returns `tenantId` for an authenticated tenant user, `undefined` for
+ *   Host users, anonymous sessions, or while bootstrapping.
+ */
+export function resolveBffTenantId(user: BffUser | null): string | undefined {
+  if (!user) return undefined;
+  if (user.isHost) return undefined;
+  return user.tenantId;
+}
+
+/**
+ * React-side accessor for {@link resolveBffTenantId} reading the active
+ * `<BffProvider>` context. Drop-in for `setTenantGetter`:
+ *
+ * @example
+ * ```tsx
+ * function ApiClientBootstrap() {
+ *   const getTenantId = useBffTenantGetter();
+ *   useEffect(() => setTenantGetter(getTenantId), [getTenantId]);
+ *   return null;
+ * }
+ * ```
+ */
+export function useBffTenantGetter(): () => string | undefined {
+  const { user } = useBffConfig();
+  return () => resolveBffTenantId(user);
+}

--- a/packages/@granit/react-bff/src/index.ts
+++ b/packages/@granit/react-bff/src/index.ts
@@ -4,6 +4,7 @@ export type { BffContextType, BffProviderProps } from './providers/bff-provider.
 export { useBffAuth } from './hooks/use-bff-auth.js';
 export { useBffCsrf } from './hooks/use-bff-csrf.js';
 export { useBffFetch } from './hooks/use-bff-fetch.js';
+export { resolveBffTenantId, useBffTenantGetter } from './hooks/use-bff-tenant.js';
 
 export {
   useBffSessions,

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -1,4 +1,4 @@
-import { CsrfManager } from '@granit/bff';
+import { CsrfManager, parseBffSessionResponse } from '@granit/bff';
 import {
   createContext,
   useCallback,
@@ -63,21 +63,25 @@ export function BffProvider({ config, children }: BffProviderProps) {
           configRef.current.onUnauthenticated?.();
           return;
         }
-        // JSON.parse will throw on HTML captive-portal responses; the shape
-        // check below ensures attacker-controlled fields cannot flow into the
-        // auth context even when the body parses as some other JSON.
-        const data = (await response.json()) as unknown;
+        // JSON.parse will throw on HTML captive-portal responses; the
+        // discriminated-union parser below enforces the granit-dotnet contract
+        // (IsHost ⇔ tenantId absent), so attacker-influenced or malformed
+        // payloads cannot flow into the auth context — see VULN-205.
+        const raw = (await response.json()) as unknown;
         if (cancelled) return;
 
-        // Minimal shape validation — defense in depth, do not trust the
-        // response just because the BFF is first-party.
-        if (
-          typeof data === 'object' &&
-          data !== null &&
-          'authenticated' in data &&
-          data.authenticated === true
-        ) {
-          setUser(data as BffUser);
+        const parsed = parseBffSessionResponse(raw);
+        if (!parsed.success) {
+          globalThis.console.warn(
+            '[@granit/react-bff] Malformed /bff/user response — treating as unauthenticated',
+            { issues: parsed.issues }
+          );
+          setUser(null);
+          configRef.current.onUnauthenticated?.();
+          return;
+        }
+        if (parsed.data.authenticated) {
+          setUser(parsed.data);
           await csrfManager.fetchToken();
         } else {
           setUser(null);

--- a/packages/@granit/react-multi-tenancy/src/__tests__/use-clear-queries-on-user-change.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/use-clear-queries-on-user-change.test.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useClearQueriesOnUserChange } from '../hooks/use-clear-queries-on-user-change.js';
+
+import type { ReactNode } from 'react';
+
+function wrap(client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useClearQueriesOnUserChange', () => {
+  it('does not clear on mount with a stable user id', () => {
+    const client = new QueryClient();
+    const clear = vi.spyOn(client, 'clear');
+
+    renderHook(() => useClearQueriesOnUserChange('user-1'), { wrapper: wrap(client) });
+
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it('clears the cache when the user id changes', () => {
+    const client = new QueryClient();
+    const clear = vi.spyOn(client, 'clear');
+
+    const { rerender } = renderHook(
+      ({ uid }: { uid: string | undefined }) => useClearQueriesOnUserChange(uid),
+      {
+        wrapper: wrap(client),
+        initialProps: { uid: 'user-1' as string | undefined },
+      }
+    );
+
+    rerender({ uid: 'user-2' });
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears on login (undefined -> string)', () => {
+    const client = new QueryClient();
+    const clear = vi.spyOn(client, 'clear');
+
+    const { rerender } = renderHook(
+      ({ uid }: { uid: string | undefined }) => useClearQueriesOnUserChange(uid),
+      {
+        wrapper: wrap(client),
+        initialProps: { uid: undefined as string | undefined },
+      }
+    );
+
+    rerender({ uid: 'user-1' });
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears on logout (string -> undefined)', () => {
+    const client = new QueryClient();
+    const clear = vi.spyOn(client, 'clear');
+
+    const { rerender } = renderHook(
+      ({ uid }: { uid: string | undefined }) => useClearQueriesOnUserChange(uid),
+      {
+        wrapper: wrap(client),
+        initialProps: { uid: 'user-1' as string | undefined },
+      }
+    );
+
+    rerender({ uid: undefined });
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@granit/react-multi-tenancy/src/hooks/use-clear-queries-on-user-change.ts
+++ b/packages/@granit/react-multi-tenancy/src/hooks/use-clear-queries-on-user-change.ts
@@ -1,0 +1,39 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Clears the React Query cache whenever the authenticated user id changes.
+ *
+ * Complements {@link useClearQueriesOnTenantChange}: tenant-scoped cache
+ * clearing handles tenant switches, but **not** user switches inside the
+ * same tenant. A logout from user A followed by a login from user B
+ * (same tenant) would otherwise leave user A's responses cached and
+ * available to user B until they go stale — a confidentiality issue,
+ * especially when query keys do not include the user id explicitly.
+ *
+ * Pass the current user's stable identifier (typically `user.sub` from
+ * `useBffAuth()` or the Keycloak `tokenParsed.sub`). The hook clears the
+ * cache on every transition, including login (`undefined → sub`) and
+ * logout (`sub → undefined`).
+ *
+ * @example
+ * ```tsx
+ * function App() {
+ *   const { user } = useBffAuth();
+ *   useClearQueriesOnUserChange(user?.sub);
+ *   return <Routes />;
+ * }
+ * ```
+ */
+export function useClearQueriesOnUserChange(userId: string | undefined): void {
+  const queryClient = useQueryClient();
+  const previousUserIdRef = useRef<string | undefined>(userId);
+
+  useEffect(() => {
+    const previous = previousUserIdRef.current;
+    if (previous !== userId) {
+      queryClient.clear();
+      previousUserIdRef.current = userId;
+    }
+  }, [userId, queryClient]);
+}

--- a/packages/@granit/react-multi-tenancy/src/index.ts
+++ b/packages/@granit/react-multi-tenancy/src/index.ts
@@ -17,6 +17,7 @@ export type {
 export { useKeycloakTenantResolvers } from './hooks/use-keycloak-tenant-resolvers.js';
 export type { UseKeycloakTenantResolversOptions } from './hooks/use-keycloak-tenant-resolvers.js';
 export { useClearQueriesOnTenantChange } from './hooks/use-clear-queries-on-tenant-change.js';
+export { useClearQueriesOnUserChange } from './hooks/use-clear-queries-on-user-change.js';
 
 // Hooks — Tenant admin
 export {


### PR DESCRIPTION
## Summary

Companion to **granit-dotnet EPIC [#2133](https://github.com/granit-fx/granit-dotnet/issues/2133)** (PRs #2137 / #2138 merged 2026-05-19). The backend now emits an authoritative `IsHost: bool` on `BffUserResponse` with the invariant `IsHost ⇔ tenant_id claim absent`, plus a server-side gate (`MultiTenancy.Host.Impersonate`) on any `X-Tenant-Id` sent by a Host session. This PR mirrors the contract on the front.

Closes **VULN-205** (Medium) from the front-end security audit.

### Changes

- **`@granit/bff`** — `BffUser` becomes a discriminated union (`BffTenantUser` | `BffHostUser`). Host users have no `tenantId` field in the type, tenant users have `tenantId: TenantId` as mandatory. Misuse becomes a compile error.
- **`@granit/bff`** — ships `parseBffSessionResponse(raw)`, a zero-dep runtime validator (no zod) enforcing the discriminated shape + the `IsHost ⇔ tenantId absent` invariant. Replaces the previous `data as BffUser` cast in `BffProvider`. Malformed responses are logged via `console.warn` and treated as unauthenticated — defense in depth against proxy rewrites, captive portals, future BFF bugs.
- **`@granit/react-bff`** — adds `resolveBffTenantId(user)` and `useBffTenantGetter()`. Both return `undefined` for Host users — the front MUST NOT auto-inject `X-Tenant-Id` for a Host session (the backend would 403 anyway, but defense in depth).
- **`@granit/react-multi-tenancy`** — adds `useClearQueriesOnUserChange(userId)`, counterpart to `useClearQueriesOnTenantChange`. Closes the user-A → user-B cache leak path within the same tenant.

### Test plan

- [x] `pnpm lint` — 0 warning
- [x] `pnpm tsc` — exit 0
- [x] `vitest run` on touched packages (`@granit/bff` + `@granit/react-bff` + `@granit/react-multi-tenancy`) — 81/81
- [x] 15 new unit tests : parser (host valid / tenant valid / invariants violated / malformed payloads), tenant resolver (tenant / host / null), user-change hook (mount / change / login / logout).
- [x] Existing BffProvider/BffSessions fixtures updated to include `isHost: false`.

### Breaking change

`BffUser` is now a discriminated union. Code that did `user.tenantId` without checking `isHost` first will need to gate via `if (!user.isHost) …` or use `resolveBffTenantId(user)`. The change surfaces a real correctness gap (Host users were silently typed as having an optional `tenantId`); apps should adopt this PR alongside wiring `useBffTenantGetter()` into their `setTenantGetter` boot.