### PR TITLE
fix(security): inject Logger + ban console.* + document trust model (re-merge #461)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -163,6 +163,11 @@
               "name": "refreshCsrfToken",
               "kind": "method",
               "signature": "refreshCsrfToken?: () => Promise<string | null>"
+            },
+            {
+              "name": "logger",
+              "kind": "property",
+              "signature": "logger?: Logger"
             }
           ]
         },

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,57 @@ import js from '@eslint/js';
 import importPlugin from 'eslint-plugin-import-x';
 import tseslint from 'typescript-eslint';
 
+// XSS sink bans — applied everywhere in the framework, including allow-listed
+// files. Kept as a const so the console allow-list block can re-declare
+// `no-restricted-syntax` with these rules only (omitting the console bans).
+const XSS_SINK_BANS = [
+  {
+    selector: "JSXAttribute[name.name='dangerouslySetInnerHTML']",
+    message:
+      'dangerouslySetInnerHTML is banned in framework code. Render text via JSX (auto-escaped) or sanitize with DOMPurify and disable this rule locally with a justification.',
+  },
+  {
+    selector: "AssignmentExpression[left.property.name='innerHTML']",
+    message:
+      'Assigning to .innerHTML is banned (XSS sink). Use textContent, JSX, or sanitize with DOMPurify.',
+  },
+  {
+    selector: "AssignmentExpression[left.property.name='outerHTML']",
+    message: 'Assigning to .outerHTML is banned (XSS sink).',
+  },
+  {
+    selector: "CallExpression[callee.name='eval']",
+    message: 'eval() is banned (CSP-incompatible, RCE risk).',
+  },
+  {
+    selector: "NewExpression[callee.name='Function']",
+    message: 'new Function() is banned (CSP-incompatible, eval-equivalent).',
+  },
+  {
+    selector: "CallExpression[callee.object.name='document'][callee.property.name='write']",
+    message: 'document.write is banned (XSS sink, blocks parser).',
+  },
+];
+
+// Console bans — applied to every package EXCEPT the allow-list (fallback
+// shims that run before any Logger can be wired). `no-console` catches
+// direct `console.foo` calls; these selectors also catch the
+// `globalThis.console.foo` / `window.console.foo` workarounds.
+const CONSOLE_BANS = [
+  {
+    selector:
+      "CallExpression[callee.object.object.name='globalThis'][callee.object.property.name='console']",
+    message:
+      'globalThis.console.* is banned. Inject a Logger from `@granit/logger` instead. If this is a bootstrap-time fallback (no logger wired yet), add the file to the eslint allow-list with a justification.',
+  },
+  {
+    selector:
+      "CallExpression[callee.object.object.name='window'][callee.object.property.name='console'], CallExpression[callee.object.object.name='self'][callee.object.property.name='console']",
+    message:
+      'window.console / self.console is banned. Inject a Logger from `@granit/logger`.',
+  },
+];
+
 export default tseslint.config(
   { ignores: ['**/node_modules/**', '**/coverage/**', 'storybook-static/**'] },
 
@@ -48,40 +99,9 @@ export default tseslint.config(
           ],
         },
       ],
-      // Ban DOM-XSS sinks framework-wide. Use `@granit/utils/assertSafeUrl`
-      // for any server-controlled URL, and prefer React text rendering over
-      // raw HTML injection. If a package genuinely needs to render HTML
-      // (markdown viewer, etc.), it must sanitize with DOMPurify and add a
-      // file-local eslint-disable with a justification.
-      'no-restricted-syntax': [
-        'error',
-        {
-          selector: "JSXAttribute[name.name='dangerouslySetInnerHTML']",
-          message:
-            'dangerouslySetInnerHTML is banned in framework code. Render text via JSX (auto-escaped) or sanitize with DOMPurify and disable this rule locally with a justification.',
-        },
-        {
-          selector: "AssignmentExpression[left.property.name='innerHTML']",
-          message:
-            'Assigning to .innerHTML is banned (XSS sink). Use textContent, JSX, or sanitize with DOMPurify.',
-        },
-        {
-          selector: "AssignmentExpression[left.property.name='outerHTML']",
-          message: 'Assigning to .outerHTML is banned (XSS sink).',
-        },
-        {
-          selector: "CallExpression[callee.name='eval']",
-          message: 'eval() is banned (CSP-incompatible, RCE risk).',
-        },
-        {
-          selector: "NewExpression[callee.name='Function']",
-          message: 'new Function() is banned (CSP-incompatible, eval-equivalent).',
-        },
-        {
-          selector: "CallExpression[callee.object.name='document'][callee.property.name='write']",
-          message: 'document.write is banned (XSS sink, blocks parser).',
-        },
-      ],
+      // Ban DOM-XSS sinks + console.* framework-wide. Allow-list for
+      // bootstrap-time fallback shims at the bottom of this file.
+      'no-restricted-syntax': ['error', ...XSS_SINK_BANS, ...CONSOLE_BANS],
     },
   },
 
@@ -113,6 +133,26 @@ export default tseslint.config(
   {
     files: ['**/__tests__/**/*.{ts,tsx}', '**/*.test.{ts,tsx}'],
     rules: { '@typescript-eslint/no-explicit-any': 'off' },
+  },
+
+  // Allow-list for legitimate `globalThis.console.*` fallback shims — these
+  // sites run BEFORE any Logger can be wired (config bootstrap, default
+  // renderer shim) or are explicitly the fallback path when the consumer
+  // omits the optional `logger` config. Every entry here must stay tightly
+  // scoped to a single file. Other migrations are tracked in the /security
+  // audit Tactical roadmap (VULN-302). XSS sink bans remain active.
+  {
+    files: [
+      'packages/@granit/api-client/src/index.ts',
+      'packages/@granit/react-bff/src/providers/bff-provider.tsx',
+      'packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx',
+      // Tactical migration pending (VULN-302):
+      'packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts',
+    ],
+    rules: {
+      'no-restricted-syntax': ['error', ...XSS_SINK_BANS],
+      'no-console': 'off',
+    },
   },
 
 );

--- a/packages/@granit/api-client/package.json
+++ b/packages/@granit/api-client/package.json
@@ -15,10 +15,17 @@
     "build": "tsup"
   },
   "devDependencies": {
+    "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
+    "@granit/logger": "workspace:*",
     "axios": "*"
+  },
+  "peerDependenciesMeta": {
+    "@granit/logger": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -5,6 +5,8 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from 'axios';
 
+import type { Logger } from '@granit/logger';
+
 /** Authentication mode for the API client. */
 export type ApiClientMode = 'bearer' | 'bff';
 
@@ -36,6 +38,14 @@ export interface ApiClientConfig {
    * request without `X-CSRF-Token`, eliminating defense-in-depth gaps.
    */
   refreshCsrfToken?: () => Promise<string | null>;
+  /**
+   * Optional logger from `@granit/logger`. Used to report interceptor-level
+   * warnings (e.g. missing CSRF token on a BFF mutation). When omitted, the
+   * client falls back to `console.warn` so framework-level diagnostics are
+   * never lost — but production apps should always wire a redacting logger
+   * to keep PII out of `console` and route diagnostics to OTLP.
+   */
+  logger?: Logger;
 }
 
 // ---------------------------------------------------------------------------
@@ -158,9 +168,13 @@ export function createApiClient(config: ApiClientConfig): AxiosInstance {
           if (csrfToken) {
             req.headers['X-CSRF-Token'] = csrfToken;
           } else if (config.csrfTokenGetter || config.refreshCsrfToken) {
-            globalThis.console.warn(
-              '[@granit/api-client] BFF mutation sent without X-CSRF-Token — token unavailable. Request will likely be rejected by the BFF.'
-            );
+            const message =
+              '[@granit/api-client] BFF mutation sent without X-CSRF-Token — token unavailable. Request will likely be rejected by the BFF.';
+            if (config.logger) {
+              config.logger.warn(message, { method: req.method, url: req.url });
+            } else {
+              globalThis.console.warn(message);
+            }
           }
         }
       } else if (_tokenGetter) {

--- a/packages/@granit/bff/package.json
+++ b/packages/@granit/bff/package.json
@@ -14,7 +14,16 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/logger": "workspace:*",
     "@granit/types": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@granit/logger": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@granit/logger": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/bff/src/types/index.ts
+++ b/packages/@granit/bff/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { Logger } from '@granit/logger';
 import type { EntityId, ISODateString, TenantId } from '@granit/types';
 
 // ---------------------------------------------------------------------------
@@ -71,4 +72,11 @@ export interface BffConfig {
   readonly onUnauthenticated?: () => void;
   /** Polling interval for session check in ms. Default: 60000 (1 minute). 0 = disabled. */
   readonly sessionCheckInterval?: number;
+  /**
+   * Optional logger from `@granit/logger`. Receives session-check failures
+   * (network errors, malformed responses). Production apps should wire a
+   * redacting logger so transient auth errors don't leak PII into `console`.
+   * Defaults to a `console.warn` fallback when omitted.
+   */
+  readonly logger?: Logger;
 }

--- a/packages/@granit/react-authorization/README.md
+++ b/packages/@granit/react-authorization/README.md
@@ -41,6 +41,96 @@ function ProtectedButton() {
 }
 ```
 
+## Security model
+
+> **Client-side permission checks are a UX hint, not a security boundary.**
+> Every endpoint that returns or mutates protected data **MUST** re-check
+> authorization on the .NET backend. The hooks in this package help apps
+> hide controls the current user cannot use; they do not — and cannot —
+> stop a user from issuing the underlying API call.
+
+The browser is hostile territory. An attacker can:
+
+- pause the JS engine and flip `permissions.isGranted(...)` to `true`,
+- replay an authenticated XHR with a different payload from DevTools,
+- run a custom userscript or browser extension that mounts the gated
+  component without ever invoking `usePermissions()`.
+
+For that reason the framework draws a hard line between **UX gating** and
+**enforcement**:
+
+| Layer       | Job                                                              | Where it lives                                        |
+| ----------- | ---------------------------------------------------------------- | ----------------------------------------------------- |
+| UX gating   | Hide / disable controls the user cannot use, avoiding noisy 403. | `react-authorization` hooks in this package           |
+| Enforcement | Reject the request (403) when the caller lacks the permission.   | `Granit.Authorization` (.NET backend, every endpoint) |
+
+### Do
+
+- Use `usePermissions().isGranted('Module.Resource.Action')` to **hide**
+  buttons, menu items, dashboard tiles, and form fields the user cannot
+  use.
+- Use the same call to **skip** a fetch that the user is not allowed to
+  trigger (avoids a noisy 403 in the console and the network panel).
+- Treat the result of `isGranted` as a UX optimization: when you do not
+  hide something, the worst case is a server-returned 403.
+
+### Do NOT
+
+- **Do NOT fetch sensitive data and then hide it via CSS / conditional
+  rendering.** Anything the browser receives is reachable from DevTools.
+  If the user is not authorized to see it, the server must not send it.
+
+  ```tsx
+  // ❌ WRONG — payload is already in memory
+  const { data } = useSensitiveData();
+  if (!can('Sensitive.Read')) return null;
+  return <Display data={data} />;
+
+  // ✅ RIGHT — query skipped client-side, AND server rejects unauthorized calls
+  const can = usePermissions().data?.isGranted('Sensitive.Read');
+  const { data } = useSensitiveData({ enabled: can });
+  return <Display data={data} />;
+  ```
+
+- **Do NOT rely on `disabled` / `hidden` attributes for security.** A
+  user can re-enable them in DevTools and submit the form. The server
+  must validate every field, every transition, every command.
+- **Do NOT skip the server-side check because "the UI already prevents
+  it".** Defense in depth — the server is the only authoritative answer
+  to "is this caller allowed to do this".
+- **Do NOT log or display the full permissions catalog of the current
+  user beyond what the UI needs.** Permissions are PII-adjacent in
+  multi-tenant contexts.
+
+### Cross-tenant guarantees
+
+In multi-tenant apps, the tenant header (`X-Tenant-Id`) is injected by
+`@granit/api-client` from the active `TenantProvider`. Switching tenant
+must:
+
+1. update the React Query cache (use `useClearQueriesOnTenantChange`
+   from `@granit/react-multi-tenancy`),
+2. let `usePermissions()` refetch — its query key includes the current
+   user / token so it invalidates implicitly on auth changes; if you
+   resolve tenant from URL only, double-check the refetch fires on
+   tenant change.
+
+A stale `permissions` object served briefly under the wrong tenant is a
+**confidentiality issue**, not just a UX bug.
+
+### Threat model — what this package defends against
+
+| Threat                                                    | Defense                                          |
+| --------------------------------------------------------- | ------------------------------------------------ |
+| User sees a button they cannot use, clicks, gets 403      | ✅ UX gating via `isGranted`                     |
+| User crafts XHR for a forbidden endpoint                  | ❌ Out of scope — server enforces                |
+| Compromised browser extension reads in-memory permissions | ❌ Out of scope — assume server enforcement      |
+| Stale permissions after tenant switch                     | ✅ when `useClearQueriesOnTenantChange` is wired |
+| Stale permissions after back-channel logout               | ✅ via 401 interceptor in `@granit/api-client`   |
+
+For the full client-side security posture, see
+`granit-docs/security/client-authorization.md`.
+
 ## License
 
 Apache-2.0

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -89,7 +89,12 @@ export function BffProvider({ config, children }: BffProviderProps) {
         }
       } catch (error) {
         if (cancelled) return;
-        globalThis.console.warn('[@granit/react-bff] BFF session check failed', error);
+        const message = '[@granit/react-bff] BFF session check failed';
+        if (configRef.current.logger) {
+          configRef.current.logger.warn(message, { error: String(error) });
+        } else {
+          globalThis.console.warn(message, error);
+        }
         setUser(null);
       } finally {
         if (!cancelled) setIsLoading(false);

--- a/packages/@granit/react-entities/package.json
+++ b/packages/@granit/react-entities/package.json
@@ -16,6 +16,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/entities": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
@@ -37,6 +38,7 @@
   "devDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/entities": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",

--- a/packages/@granit/react-entities/src/actions/entity-action-button.tsx
+++ b/packages/@granit/react-entities/src/actions/entity-action-button.tsx
@@ -1,5 +1,7 @@
 import { useCallback, type KeyboardEvent, type ReactNode } from 'react';
 
+import { useEntityRendererLogger } from '../providers/entity-renderer-provider.js';
+
 import type { EntityActionDispatch } from './use-entity-action-dispatcher.js';
 import type { EntityActionManifest } from '@granit/entities';
 
@@ -43,11 +45,14 @@ export function EntityActionButton({
   row,
   dispatch,
 }: EntityActionButtonProps): ReactNode {
+  const logger = useEntityRendererLogger();
   const handleClick = useCallback(() => {
     dispatch(action, rowId, row).catch((error: unknown) => {
-      globalThis.console.error(`EntityAction "${action.name}" failed:`, error);
+      logger.error(`EntityAction "${action.name}" failed`, error, {
+        actionName: action.name,
+      });
     });
-  }, [dispatch, action, rowId, row]);
+  }, [dispatch, action, rowId, row, logger]);
 
   const handleKeyDown = useCallback((event: KeyboardEvent<HTMLButtonElement>) => {
     // Native <button> handles Enter / Space already, but we stop

--- a/packages/@granit/react-entities/src/actions/use-entity-action-dispatcher.ts
+++ b/packages/@granit/react-entities/src/actions/use-entity-action-dispatcher.ts
@@ -1,6 +1,8 @@
 import { useGranitClient } from '@granit/react-api-client';
 import { assertSafeUrl } from '@granit/utils';
-import { useCallback, useContext } from 'react';
+import { useCallback, useContext, useMemo } from 'react';
+
+import { useEntityRendererLogger } from '../providers/entity-renderer-provider.js';
 
 import {
   EntityActionDrawerContext,
@@ -9,6 +11,7 @@ import {
 
 import type { AxiosInstance } from '@granit/api-client';
 import type { EntityActionManifest } from '@granit/entities';
+import type { Logger } from '@granit/logger';
 
 /**
  * Per-kind override hooks for {@link useEntityActionDispatcher}. Apps
@@ -111,10 +114,14 @@ export function useEntityActionDispatcher(
   const client = useGranitClient();
   const drawerCtx = useContext(EntityActionDrawerContext);
   const modalCtx = useContext(EntityActionModalContext);
+  const logger = useEntityRendererLogger();
   const apiCall = handlers.apiCall ?? defaultApiCall;
   const download = handlers.download ?? defaultDownload;
   const navigate = handlers.navigate ?? defaultNavigate;
-  const workflowTransition = handlers.workflowTransition ?? defaultWorkflowTransition;
+  const workflowTransition = useMemo(
+    () => handlers.workflowTransition ?? makeDefaultWorkflowTransition(logger),
+    [handlers.workflowTransition, logger]
+  );
   const openDrawer = handlers.openDrawer;
   const openModal = handlers.openModal;
 
@@ -139,8 +146,9 @@ export function useEntityActionDispatcher(
           } else if (drawerCtx) {
             drawerCtx.open({ action, rowId, row });
           } else {
-            globalThis.console.warn(
-              `EntityAction "${action.name}" is OpenDrawer but no <EntityActionDrawerHost> is mounted in the tree and no \`openDrawer\` handler override was supplied.`
+            logger.warn(
+              `EntityAction "${action.name}" is OpenDrawer but no <EntityActionDrawerHost> is mounted in the tree and no \`openDrawer\` handler override was supplied.`,
+              { actionName: action.name, kind: 'OpenDrawer' }
             );
           }
           return;
@@ -150,8 +158,9 @@ export function useEntityActionDispatcher(
           } else if (modalCtx) {
             modalCtx.open({ action, rowId, row });
           } else {
-            globalThis.console.warn(
-              `EntityAction "${action.name}" is OpenModal but no <EntityActionModalHost> is mounted in the tree and no \`openModal\` handler override was supplied.`
+            logger.warn(
+              `EntityAction "${action.name}" is OpenModal but no <EntityActionModalHost> is mounted in the tree and no \`openModal\` handler override was supplied.`,
+              { actionName: action.name, kind: 'OpenModal' }
             );
           }
           return;
@@ -167,6 +176,7 @@ export function useEntityActionDispatcher(
       openModal,
       drawerCtx,
       modalCtx,
+      logger,
     ]
   );
 }
@@ -219,11 +229,14 @@ const defaultNavigate: EntityActionHandler = (action, rowId) => {
   globalThis.location.href = assertSafeUrl(url);
 };
 
-const defaultWorkflowTransition: EntityActionHandler = (action) => {
-  globalThis.console.warn(
-    `EntityAction "${action.name}" is a WorkflowTransition; the framework's default dispatcher does not execute transitions. Pass a \`workflowTransition\` handler to \`useEntityActionDispatcher\` (typically wired through \`useExecuteTransition()\` from \`@granit/react-workflow\`).`
-  );
-};
+function makeDefaultWorkflowTransition(logger: Logger): EntityActionHandler {
+  return (action) => {
+    logger.warn(
+      `EntityAction "${action.name}" is a WorkflowTransition; the framework's default dispatcher does not execute transitions. Pass a \`workflowTransition\` handler to \`useEntityActionDispatcher\` (typically wired through \`useExecuteTransition()\` from \`@granit/react-workflow\`).`,
+      { actionName: action.name, kind: 'WorkflowTransition' }
+    );
+  };
+}
 
 function readFilename(headers: Record<string, string>): string | null {
   const disposition = headers['content-disposition'] ?? headers['Content-Disposition'];

--- a/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
@@ -7,6 +7,7 @@ import {
   useEntityActionDispatcher,
   type EntityActionHandlers,
 } from '../actions/use-entity-action-dispatcher.js';
+import { useEntityRendererLogger } from '../providers/entity-renderer-provider.js';
 import { useSelection } from '../selection/selection-context.js';
 
 import type {
@@ -165,6 +166,7 @@ export function EntitySelectionBar({
   const dispatch = useEntityActionDispatcher(handlers);
   const client = useGranitClient();
   const selection = useSelection();
+  const logger = useEntityRendererLogger();
   const [running, setRunning] = useState<string | null>(null);
 
   const selectionActions = manifest.collections?.selectionActions ?? [];
@@ -257,7 +259,9 @@ export function EntitySelectionBar({
             disabled={isRunning || running !== null}
             onClick={() => {
               handleClick(ref, action).catch((error: unknown) => {
-                globalThis.console.error(`Selection action "${ref.name}" failed:`, error);
+                logger.error(`Selection action "${ref.name}" failed`, error, {
+                  actionName: ref.name,
+                });
               });
             }}
             onKeyDown={swallowEnterSpace}

--- a/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
+++ b/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
@@ -2,6 +2,8 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 import { EMPTY_COMPONENT_CATALOG, type EntityComponentCatalog } from './component-catalog.js';
 
+import type { Logger } from '@granit/logger';
+
 /**
  * Resolves an i18n key (as carried by the manifest) into a localised
  * string. Apps wire react-i18next or their own resolver here so the
@@ -15,7 +17,26 @@ const defaultResolveLabel: ResolveLabel = (key, fallback) => fallback ?? key;
 export interface EntityRendererContextValue {
   readonly components: EntityComponentCatalog;
   readonly resolveLabel: ResolveLabel;
+  /**
+   * Logger used by built-in dispatchers and selection bars to report action
+   * failures. When omitted, falls back to a `console`-backed shim so errors
+   * surface during development; production apps should always wire a
+   * redacting logger from `@granit/logger`.
+   */
+  readonly logger: Logger;
 }
+
+const consoleLogger: Logger = {
+  debug: (message, context) => globalThis.console.debug(message, context),
+  info: (message, context) => globalThis.console.info(message, context),
+  warn: (message, context) => globalThis.console.warn(message, context),
+  error: (message, error, context) => globalThis.console.error(message, error, context),
+  // The shim is a leaf — `child(prefix)` returns the same instance so apps
+  // wiring `useEntityRendererLogger().child('…')` outside a provider don't
+  // crash. Real namespacing kicks in once a `@granit/logger` Logger is
+  // wired via `<EntityRendererProvider logger={…}>`.
+  child: () => consoleLogger,
+};
 
 const EntityRendererContext = createContext<EntityRendererContextValue | null>(null);
 
@@ -24,6 +45,12 @@ export interface EntityRendererProviderProps {
   readonly components?: EntityComponentCatalog;
   /** i18n bridge. Default returns `fallback ?? key` so the UI shows the key while the app wires translations. */
   readonly resolveLabel?: ResolveLabel;
+  /**
+   * Logger from `@granit/logger`. Defaults to a `console`-backed shim — wire
+   * a redacting logger in production to avoid leaking action payloads or
+   * error details into the browser console.
+   */
+  readonly logger?: Logger;
   readonly children: ReactNode;
 }
 
@@ -38,13 +65,20 @@ export interface EntityRendererProviderProps {
 export function EntityRendererProvider({
   components = EMPTY_COMPONENT_CATALOG,
   resolveLabel = defaultResolveLabel,
+  logger = consoleLogger,
   children,
 }: EntityRendererProviderProps): ReactNode {
   const value = useMemo<EntityRendererContextValue>(
-    () => ({ components, resolveLabel }),
-    [components, resolveLabel]
+    () => ({ components, resolveLabel, logger }),
+    [components, resolveLabel, logger]
   );
   return <EntityRendererContext.Provider value={value}>{children}</EntityRendererContext.Provider>;
+}
+
+/** Reads the renderer logger. Falls back to a console shim outside a provider. */
+export function useEntityRendererLogger(): Logger {
+  const ctx = useContext(EntityRendererContext);
+  return ctx?.logger ?? consoleLogger;
 }
 
 /**

--- a/packages/@granit/react-entities/src/providers/index.ts
+++ b/packages/@granit/react-entities/src/providers/index.ts
@@ -1,4 +1,8 @@
-export { EntityRendererProvider, useEntityRenderer } from './entity-renderer-provider.js';
+export {
+  EntityRendererProvider,
+  useEntityRenderer,
+  useEntityRendererLogger,
+} from './entity-renderer-provider.js';
 export { EMPTY_COMPONENT_CATALOG } from './component-catalog.js';
 export type {
   EntityRendererContextValue,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
         specifier: 1.16.1
         version: 1.16.1
     devDependencies:
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -333,6 +336,10 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+    devDependencies:
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
 
   packages/@granit/blob-storage:
     devDependencies:
@@ -1417,6 +1424,9 @@ importers:
       '@granit/entities':
         specifier: workspace:*
         version: link:../entities
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine


### PR DESCRIPTION
## Summary

**Re-merge of PR #461** that was orphaned: it merged into the `chore/security-quick-wins` feature branch _after_ PR #460 had already squash-merged into `develop`, so its commit `65a28a6` never made it to `develop`.

This PR cherry-picks the orphaned commit on top of the current `develop` tip, with one minor conflict resolution (the `executeBulkAction` import in `entity-selection-bar.tsx` moved to `@granit/entities` between then and now — kept the new location, added the new `useEntityRendererLogger` import).

Original PR #461 content (verbatim):

### VULN-302 — Logger injection

- **`@granit/api-client`** — `ApiClientConfig.logger?: Logger`. CSRF-missing-on-mutation warn routes through it; `console.warn` fallback when no logger wired.
- **`@granit/bff`** — `BffConfig.logger?: Logger` (typed in core, consumed in `react-bff`). Session-check errors no longer leak raw axios error objects.
- **`@granit/react-entities`** — `<EntityRendererProvider logger={…}>` plus `useEntityRendererLogger()`. Wired into `EntityActionButton`, `EntitySelectionBar`, `useEntityActionDispatcher` (4 console sites replaced).

### VULN-301 — Client-side authorization trust model

- **`@granit/react-authorization/README.md`** — "Security model" section.
- **`granit-docs/frontend/security/client-authorization.mdx`** — full Starlight page.

### Architecture test — ban `console.*` framework-wide

- ESLint `no-restricted-syntax` extended to ban `globalThis.console.*`, `window.console.*`, `self.console.*`.
- Allow-list scoped to legitimate fallback shims (api-client, react-bff/bff-provider, react-entities/entity-renderer-provider, react-authentication-entraid — last one Tactical-pending).

## Test plan

- [x] `pnpm lint` — 0 warning
- [x] `pnpm tsc` — exit 0
- [x] `vitest run` on touched packages — 388/388

## Notes

The `chore/security-quick-wins` branch on origin still exists and can be deleted post-merge — it's now superseded by this redo. The 3-dot diff vs. `chore/security-quick-wins` would have been ugly because of the squash-merge of #460; cherry-pick is the clean path.