### PR TITLE
feat(react): add React Query hooks for new conformity APIs

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2513,6 +2513,11 @@
       ]
     },
     {
+      "name": "@granit/react-catalog",
+      "description": "React bindings for @granit/catalog — CatalogProvider + React Query hooks for products CRUD, lifecycle (publish/archive) and external mappings",
+      "exports": []
+    },
+    {
       "name": "@granit/react-charts",
       "description": "React chart primitives for Granit — typed <LineChart>, <BarChart>, <PieChart>, <SparklineChart> built on Apache ECharts (modular tree-shaken imports), plus <Chart> escape hatch for raw ECharts options",
       "exports": [
@@ -3893,6 +3898,17 @@
           ]
         },
         {
+          "name": "useApplicationLocalization",
+          "kind": "function",
+          "signature": "function useApplicationLocalization( options: UseApplicationLocalizationOptions ): UseQueryResult<ApplicationLocalizationDto>"
+        },
+        {
+          "name": "UseApplicationLocalizationOptions",
+          "kind": "interface",
+          "signature": "interface UseApplicationLocalizationOptions",
+          "members": []
+        },
+        {
           "name": "useDateLocale",
           "kind": "function",
           "signature": "function useDateLocale(locale: string): Locale"
@@ -4236,6 +4252,12 @@
               "signature": "refresh: () => void"
             }
           ]
+        },
+        {
+          "name": "EntityFollowVariables",
+          "kind": "interface",
+          "signature": "interface EntityFollowVariables",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
+++ b/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
@@ -1,11 +1,16 @@
-import { listAuditLogEntries, getAuditLogEntry, listEntityAuditTrail } from '@granit/auditing';
-import { useQuery } from '@tanstack/react-query';
+import {
+  getAuditLogEntry,
+  listAuditLogEntries,
+  listEntityAuditTrail,
+  pseudonymizeUserAuditLogs,
+} from '@granit/auditing';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { buildAuditLogQueryKey, useAuditLogConfig } from '../providers/audit-log-provider.js';
 
 import type { AuditEntryDetail, AuditListParams, AuditPage } from '@granit/auditing';
 import type { PaginationParams } from '@granit/query-engine';
-import type { UseQueryResult } from '@tanstack/react-query';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /**
  * List paginated audit log entries with optional filters.
@@ -65,7 +70,36 @@ export function useEntityAuditTrail(
 
   return useQuery({
     queryKey: buildAuditLogQueryKey(config, 'entity', entityType, entityId, params),
-    queryFn: () => listEntityAuditTrail(config.client, auditEntriesPath, entityType, entityId, params),
+    queryFn: () =>
+      listEntityAuditTrail(config.client, auditEntriesPath, entityType, entityId, params),
     enabled: entityType.length > 0 && entityId.length > 0,
+  });
+}
+
+/**
+ * Pseudonymize all audit entries for a specific user (GDPR Art. 17).
+ *
+ * Replaces personal data with a SHA-256 hash to preserve audit trail
+ * correlation without re-identification. Invalidates the cached audit log
+ * list on success.
+ *
+ * @example
+ * ```tsx
+ * const pseudonymize = usePseudonymizeUserAuditLogs();
+ * await pseudonymize.mutateAsync(userId);
+ * ```
+ */
+export function usePseudonymizeUserAuditLogs(): UseMutationResult<void, Error, string> {
+  const config = useAuditLogConfig();
+  const basePath = config.basePath;
+  const auditEntriesPath = `${basePath}/audit-entries`;
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (userId: string) =>
+      pseudonymizeUserAuditLogs(config.client, auditEntriesPath, userId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildAuditLogQueryKey(config) });
+    },
   });
 }

--- a/packages/@granit/react-auditing/src/index.ts
+++ b/packages/@granit/react-auditing/src/index.ts
@@ -11,4 +11,5 @@ export {
   useAuditLogEntries,
   useAuditLogEntry,
   useEntityAuditTrail,
+  usePseudonymizeUserAuditLogs,
 } from './hooks/use-audit-log.js';

--- a/packages/@granit/react-catalog/package.json
+++ b/packages/@granit/react-catalog/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@granit/react-catalog",
+  "description": "React bindings for @granit/catalog — CatalogProvider + React Query hooks for products CRUD, lifecycle (publish/archive) and external mappings",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/catalog": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "react": "^19.0.0"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-catalog/src/constants.ts
+++ b/packages/@granit/react-catalog/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'catalog';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-catalog/src/hooks/use-products.ts
+++ b/packages/@granit/react-catalog/src/hooks/use-products.ts
@@ -1,0 +1,206 @@
+import {
+  addProductExternalMapping,
+  archiveProduct,
+  createProduct,
+  getProductById,
+  getProductBySku,
+  listPublishedProducts,
+  publishProduct,
+  removeProductExternalMapping,
+  updateProduct,
+  updateProductMetadata,
+} from '@granit/catalog';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildCatalogQueryKey, useCatalogConfig } from '../providers/catalog-provider.js';
+
+import type {
+  AddProductExternalMappingRequest,
+  ProductCreateRequest,
+  ProductExternalMappingId,
+  ProductExternalMappingResponse,
+  ProductId,
+  ProductResponse,
+  ProductUpdateRequest,
+  UpdateProductMetadataRequest,
+} from '@granit/catalog';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/** Lists all Published products in the catalog. */
+export function usePublishedProducts(): UseQueryResult<readonly ProductResponse[]> {
+  const config = useCatalogConfig();
+  return useQuery({
+    queryKey: buildCatalogQueryKey(config, 'products', 'published'),
+    queryFn: () => listPublishedProducts(config.client, config.basePath),
+  });
+}
+
+/** Fetches a product by id (any lifecycle status). */
+export function useProduct(id: ProductId | null | undefined): UseQueryResult<ProductResponse> {
+  const config = useCatalogConfig();
+  return useQuery({
+    queryKey: buildCatalogQueryKey(config, 'products', 'detail', id),
+    queryFn: () => getProductById(config.client, config.basePath, id as ProductId),
+    enabled: Boolean(id),
+  });
+}
+
+/** Fetches a product by SKU (any lifecycle status). */
+export function useProductBySku(sku: string | null | undefined): UseQueryResult<ProductResponse> {
+  const config = useCatalogConfig();
+  return useQuery({
+    queryKey: buildCatalogQueryKey(config, 'products', 'by-sku', sku),
+    queryFn: () => getProductBySku(config.client, config.basePath, sku as string),
+    enabled: Boolean(sku),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations — cache invalidation helper
+// ---------------------------------------------------------------------------
+
+function useInvalidateProducts() {
+  const config = useCatalogConfig();
+  const queryClient = useQueryClient();
+  return (id?: ProductId) => {
+    queryClient.invalidateQueries({ queryKey: buildCatalogQueryKey(config, 'products') });
+    if (id) {
+      queryClient.invalidateQueries({
+        queryKey: buildCatalogQueryKey(config, 'products', 'detail', id),
+      });
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mutations — CRUD
+// ---------------------------------------------------------------------------
+
+/** Creates a new product in Draft status. */
+export function useCreateProduct(): UseMutationResult<
+  ProductResponse,
+  Error,
+  ProductCreateRequest
+> {
+  const config = useCatalogConfig();
+  const invalidate = useInvalidateProducts();
+  return useMutation({
+    mutationFn: (request) => createProduct(config.client, config.basePath, request),
+    onSuccess: () => invalidate(),
+  });
+}
+
+/** Variables for {@link useUpdateProduct}. */
+export interface UpdateProductVariables {
+  readonly id: ProductId;
+  readonly request: ProductUpdateRequest;
+}
+
+/** Updates the editable fields of a Draft product. */
+export function useUpdateProduct(): UseMutationResult<
+  ProductResponse,
+  Error,
+  UpdateProductVariables
+> {
+  const config = useCatalogConfig();
+  const invalidate = useInvalidateProducts();
+  return useMutation({
+    mutationFn: ({ id, request }) => updateProduct(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => invalidate(id),
+  });
+}
+
+/** Variables for {@link useUpdateProductMetadata}. */
+export interface UpdateProductMetadataVariables {
+  readonly id: ProductId;
+  readonly request: UpdateProductMetadataRequest;
+}
+
+/** Replaces all metadata of a product (any lifecycle status). */
+export function useUpdateProductMetadata(): UseMutationResult<
+  ProductResponse,
+  Error,
+  UpdateProductMetadataVariables
+> {
+  const config = useCatalogConfig();
+  const invalidate = useInvalidateProducts();
+  return useMutation({
+    mutationFn: ({ id, request }) =>
+      updateProductMetadata(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => invalidate(id),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations — lifecycle
+// ---------------------------------------------------------------------------
+
+/** Transitions a Draft product to Published. */
+export function usePublishProduct(): UseMutationResult<ProductResponse, Error, ProductId> {
+  const config = useCatalogConfig();
+  const invalidate = useInvalidateProducts();
+  return useMutation({
+    mutationFn: (id) => publishProduct(config.client, config.basePath, id),
+    onSuccess: (_data, id) => invalidate(id),
+  });
+}
+
+/** Archives a Published product. */
+export function useArchiveProduct(): UseMutationResult<ProductResponse, Error, ProductId> {
+  const config = useCatalogConfig();
+  const invalidate = useInvalidateProducts();
+  return useMutation({
+    mutationFn: (id) => archiveProduct(config.client, config.basePath, id),
+    onSuccess: (_data, id) => invalidate(id),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations — external mappings
+// ---------------------------------------------------------------------------
+
+/** Variables for {@link useAddProductExternalMapping}. */
+export interface AddProductExternalMappingVariables {
+  readonly id: ProductId;
+  readonly request: AddProductExternalMappingRequest;
+}
+
+/** Adds an external provider mapping (Stripe, Avalara, Odoo, ...) to a product. */
+export function useAddProductExternalMapping(): UseMutationResult<
+  ProductExternalMappingResponse,
+  Error,
+  AddProductExternalMappingVariables
+> {
+  const config = useCatalogConfig();
+  const invalidate = useInvalidateProducts();
+  return useMutation({
+    mutationFn: ({ id, request }) =>
+      addProductExternalMapping(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => invalidate(id),
+  });
+}
+
+/** Variables for {@link useRemoveProductExternalMapping}. */
+export interface RemoveProductExternalMappingVariables {
+  readonly id: ProductId;
+  readonly mappingId: ProductExternalMappingId;
+}
+
+/** Removes an external provider mapping from a product. */
+export function useRemoveProductExternalMapping(): UseMutationResult<
+  void,
+  Error,
+  RemoveProductExternalMappingVariables
+> {
+  const config = useCatalogConfig();
+  const invalidate = useInvalidateProducts();
+  return useMutation({
+    mutationFn: ({ id, mappingId }) =>
+      removeProductExternalMapping(config.client, config.basePath, id, mappingId),
+    onSuccess: (_data, { id }) => invalidate(id),
+  });
+}

--- a/packages/@granit/react-catalog/src/index.ts
+++ b/packages/@granit/react-catalog/src/index.ts
@@ -1,0 +1,35 @@
+// ---------------------------------------------------------------------------
+// @granit/react-catalog — public API
+// ---------------------------------------------------------------------------
+
+// Provider
+export {
+  CatalogProvider,
+  buildCatalogQueryKey,
+  useCatalogConfig,
+} from './providers/catalog-provider.js';
+export type {
+  CatalogConfig,
+  CatalogProviderProps,
+  ResolvedCatalogConfig,
+} from './providers/catalog-provider.js';
+
+// Hooks
+export {
+  useAddProductExternalMapping,
+  useArchiveProduct,
+  useCreateProduct,
+  useProduct,
+  useProductBySku,
+  usePublishProduct,
+  usePublishedProducts,
+  useRemoveProductExternalMapping,
+  useUpdateProduct,
+  useUpdateProductMetadata,
+} from './hooks/use-products.js';
+export type {
+  AddProductExternalMappingVariables,
+  RemoveProductExternalMappingVariables,
+  UpdateProductMetadataVariables,
+  UpdateProductVariables,
+} from './hooks/use-products.js';

--- a/packages/@granit/react-catalog/src/providers/catalog-provider.tsx
+++ b/packages/@granit/react-catalog/src/providers/catalog-provider.tsx
@@ -1,0 +1,72 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for the catalog provider. */
+export interface CatalogConfig {
+  readonly client?: AxiosInstance;
+  /** Base path prefix (default: `/api/v1/catalog`). */
+  readonly basePath: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * CatalogConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>`.
+ */
+export interface ResolvedCatalogConfig extends CatalogConfig {
+  readonly client: AxiosInstance;
+}
+
+/** Props accepted by {@link CatalogProvider}. `basePath` is optional — the default is applied by the provider. */
+export interface CatalogProviderProps {
+  readonly config: Omit<CatalogConfig, 'basePath'> & Partial<Pick<CatalogConfig, 'basePath'>>;
+  readonly children: ReactNode;
+}
+
+const CatalogConfigContext = createContext<ResolvedCatalogConfig | null>(null);
+
+const DEFAULT_QUERY_KEY_PREFIX = ['catalog'] as const;
+
+/** Provides catalog configuration to child components and hooks. */
+export function CatalogProvider({ config, children }: Readonly<CatalogProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'CatalogProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
+  return <CatalogConfigContext value={value}>{children}</CatalogConfigContext>;
+}
+
+/** Returns the catalog configuration from the nearest `CatalogProvider`. */
+export function useCatalogConfig(): ResolvedCatalogConfig {
+  const ctx = useContext(CatalogConfigContext);
+  if (!ctx) {
+    throw new Error('useCatalogConfig must be used within a CatalogProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for catalog operations. */
+export function buildCatalogQueryKey(
+  config: CatalogConfig,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX;
+  return [...prefix, ...segments];
+}
+
+export { DEFAULT_QUERY_KEY_PREFIX };

--- a/packages/@granit/react-catalog/tsconfig.json
+++ b/packages/@granit/react-catalog/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-catalog/tsup.config.ts
+++ b/packages/@granit/react-catalog/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-localization/src/hooks/use-application-localization.ts
+++ b/packages/@granit/react-localization/src/hooks/use-application-localization.ts
@@ -1,0 +1,43 @@
+import { getApplicationLocalization } from '@granit/localization';
+import { useQuery } from '@tanstack/react-query';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ApplicationLocalizationDto } from '@granit/localization';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/** Options accepted by {@link useApplicationLocalization}. */
+export interface UseApplicationLocalizationOptions {
+  readonly client: AxiosInstance;
+  /** Base path for the localization endpoint. Default: `/api/v1/localization`. */
+  readonly basePath?: string;
+  /** BCP-47 culture name. Omit to let the backend resolve from `Accept-Language`. */
+  readonly cultureName?: string;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetches all localization resources for the requested culture, plus the
+ * list of available languages. Wraps the anonymous, browser-cached
+ * `GET {basePath}` endpoint (cached 1h on the server side).
+ *
+ * Apps typically call this once at bootstrap and feed the result to
+ * `applyTranslations` from `@granit/localization`.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useApplicationLocalization({ client: api, cultureName: 'fr-BE' });
+ * ```
+ */
+export function useApplicationLocalization(
+  options: UseApplicationLocalizationOptions
+): UseQueryResult<ApplicationLocalizationDto> {
+  const { client, basePath = DEFAULT_BASE_PATH, cultureName, enabled } = options;
+  return useQuery({
+    queryKey: ['localization', 'application', cultureName ?? null],
+    queryFn: () => getApplicationLocalization(client, basePath, cultureName),
+    enabled: enabled ?? true,
+    staleTime: 60 * 60_000,
+  });
+}

--- a/packages/@granit/react-localization/src/index.ts
+++ b/packages/@granit/react-localization/src/index.ts
@@ -2,6 +2,10 @@ export { createReactLocalization } from './create-react-localization.js';
 export { useLocale } from './use-locale.js';
 export type { UseLocaleOptions } from './use-locale.js';
 
+// Hooks — Consumer
+export { useApplicationLocalization } from './hooks/use-application-localization.js';
+export type { UseApplicationLocalizationOptions } from './hooks/use-application-localization.js';
+
 // Hooks — Admin
 export {
   useDeleteLocalizationOverride,

--- a/packages/@granit/react-notifications/src/hooks/use-notification-subscriptions.ts
+++ b/packages/@granit/react-notifications/src/hooks/use-notification-subscriptions.ts
@@ -1,0 +1,166 @@
+import {
+  followEntity,
+  listEntityFollowers,
+  listNotificationTypes,
+  listSubscriptions,
+  subscribeToNotificationType,
+  unfollowEntity,
+  unsubscribeFromNotificationType,
+} from '@granit/notifications';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { API_BASE_PATH } from '../constants.js';
+import { useNotificationConfig } from '../providers/notification-provider.js';
+
+import type {
+  NotificationDefinition,
+  NotificationSubscriptionResponse,
+} from '@granit/notifications';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Query keys
+// ---------------------------------------------------------------------------
+
+const NOTIFICATION_TYPES_KEY = ['notifications', 'types'] as const;
+const SUBSCRIPTIONS_KEY = ['notifications', 'subscriptions'] as const;
+const ENTITY_FOLLOWERS_KEY = (entityType: string, entityId: string) =>
+  ['notifications', 'entity', entityType, entityId, 'followers'] as const;
+
+// ---------------------------------------------------------------------------
+// Notification types — the registry of available notifications
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all notification types registered in the system. Use this to build
+ * the preferences UI (which types exist, their default channels, group, etc.).
+ *
+ * `GET /api/v1/notifications/types`
+ */
+export function useNotificationTypes(): UseQueryResult<readonly NotificationDefinition[]> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  return useQuery({
+    queryKey: NOTIFICATION_TYPES_KEY,
+    queryFn: () => listNotificationTypes(config.apiClient, basePath),
+    staleTime: 5 * 60_000,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Subscriptions (per notification type)
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns all notification subscriptions for the current user.
+ *
+ * `GET /api/v1/notifications/subscriptions`
+ */
+export function useNotificationSubscriptions(): UseQueryResult<
+  readonly NotificationSubscriptionResponse[]
+> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  return useQuery({
+    queryKey: SUBSCRIPTIONS_KEY,
+    queryFn: () => listSubscriptions(config.apiClient, basePath),
+  });
+}
+
+/**
+ * Subscribes the current user to a notification type. Idempotent.
+ *
+ * `POST /api/v1/notifications/subscriptions/{typeName}`
+ */
+export function useSubscribeToNotificationType(): UseMutationResult<void, Error, string> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (typeName) => subscribeToNotificationType(config.apiClient, basePath, typeName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY });
+    },
+  });
+}
+
+/**
+ * Unsubscribes the current user from a notification type. Idempotent.
+ *
+ * `DELETE /api/v1/notifications/subscriptions/{typeName}`
+ */
+export function useUnsubscribeFromNotificationType(): UseMutationResult<void, Error, string> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (typeName) => unsubscribeFromNotificationType(config.apiClient, basePath, typeName),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: SUBSCRIPTIONS_KEY });
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Entity followers
+// ---------------------------------------------------------------------------
+
+/** Variables for {@link useFollowEntity} / {@link useUnfollowEntity}. */
+export interface EntityFollowVariables {
+  readonly entityType: string;
+  readonly entityId: string;
+}
+
+/**
+ * Subscribes the current user as a follower of an entity. Idempotent.
+ *
+ * `POST /api/v1/notifications/entity/{entityType}/{entityId}/follow`
+ */
+export function useFollowEntity(): UseMutationResult<void, Error, EntityFollowVariables> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ entityType, entityId }) =>
+      followEntity(config.apiClient, basePath, entityType, entityId),
+    onSuccess: (_data, { entityType, entityId }) => {
+      queryClient.invalidateQueries({ queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId) });
+    },
+  });
+}
+
+/**
+ * Removes the current user from the follower list of an entity. Idempotent.
+ *
+ * `DELETE /api/v1/notifications/entity/{entityType}/{entityId}/follow`
+ */
+export function useUnfollowEntity(): UseMutationResult<void, Error, EntityFollowVariables> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ entityType, entityId }) =>
+      unfollowEntity(config.apiClient, basePath, entityType, entityId),
+    onSuccess: (_data, { entityType, entityId }) => {
+      queryClient.invalidateQueries({ queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId) });
+    },
+  });
+}
+
+/**
+ * Returns all followers of a specific entity.
+ *
+ * `GET /api/v1/notifications/entity/{entityType}/{entityId}/followers`
+ */
+export function useEntityFollowers(
+  entityType: string,
+  entityId: string
+): UseQueryResult<readonly NotificationSubscriptionResponse[]> {
+  const { config } = useNotificationConfig();
+  const basePath = config.basePath ?? API_BASE_PATH;
+  return useQuery({
+    queryKey: ENTITY_FOLLOWERS_KEY(entityType, entityId),
+    queryFn: () => listEntityFollowers(config.apiClient, basePath, entityType, entityId),
+    enabled: Boolean(entityType) && Boolean(entityId),
+  });
+}

--- a/packages/@granit/react-notifications/src/index.ts
+++ b/packages/@granit/react-notifications/src/index.ts
@@ -23,3 +23,14 @@ export type {
 
 export { useNotificationPreferences } from './hooks/use-notification-preferences.js';
 export type { UseNotificationPreferencesReturn } from './hooks/use-notification-preferences.js';
+
+export {
+  useEntityFollowers,
+  useFollowEntity,
+  useNotificationSubscriptions,
+  useNotificationTypes,
+  useSubscribeToNotificationType,
+  useUnfollowEntity,
+  useUnsubscribeFromNotificationType,
+} from './hooks/use-notification-subscriptions.js';
+export type { EntityFollowVariables } from './hooks/use-notification-subscriptions.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1129,6 +1129,28 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/react-catalog:
+    dependencies:
+      '@granit/catalog':
+        specifier: workspace:*
+        version: link:../catalog
+      '@tanstack/react-query':
+        specifier: 5.100.10
+        version: 5.100.10(react@19.2.6)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
   packages/@granit/react-charts:
     dependencies:
       echarts:


### PR DESCRIPTION
## Summary

Follow-up to PR #462 — wraps the API functions added in that PR with idiomatic React Query hooks so consumer apps (showcase, guava-front, guava-admin) can use the new functionality without re-implementing `useQuery`/`useMutation` wrappers.

### New package

**`@granit/react-catalog`** — `CatalogProvider` + 10 hooks:

| Hook | Wraps |
|---|---|
| `usePublishedProducts`, `useProduct`, `useProductBySku` | reads |
| `useCreateProduct`, `useUpdateProduct`, `useUpdateProductMetadata` | CRUD |
| `usePublishProduct`, `useArchiveProduct` | lifecycle |
| `useAddProductExternalMapping`, `useRemoveProductExternalMapping` | external mappings |

### New hooks in existing packages

| Package | Hook(s) |
|---|---|
| `@granit/react-notifications` | `useNotificationTypes`, `useNotificationSubscriptions`, `useSubscribeToNotificationType`, `useUnsubscribeFromNotificationType`, `useFollowEntity`, `useUnfollowEntity`, `useEntityFollowers` |
| `@granit/react-auditing` | `usePseudonymizeUserAuditLogs` (GDPR Art. 17 mutation) |
| `@granit/react-localization` | `useApplicationLocalization` (anonymous consumer endpoint, 1h staleTime) |

All hooks invalidate the relevant query caches on mutation success per the convention used elsewhere in the framework.

## Test plan

- [x] `pnpm tsc` clean
- [x] `pnpm lint` clean
- [x] `pnpm vitest run` on touched packages — 127/127 pass
- [ ] Smoke: showcase / guava-front can import the new hooks and they tree-shake correctly