### PR TITLE
fix(arch-tests-kit): add missing tsup.config.ts

### DIFF
--- a/packages/@granit/arch-tests-kit/tsup.config.ts
+++ b/packages/@granit/arch-tests-kit/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();


### PR DESCRIPTION
## Summary

`@granit/arch-tests-kit` ships with a `"build": "tsup"` script but no `tsup.config.ts`, causing the build to fail with:

```
No input files, try "tsup <your-file>" instead
```

Adds the canonical shared preset config used by every other `@granit/*` package — single line `export default createTsupConfig()`.

## Test plan

- [x] `pnpm --filter @granit/arch-tests-kit build` succeeds (dist/index.js + dist/index.d.ts generated)