### PR TITLE
feat(arch-tests-kit): add 3 high-ROI scanners (anon default / wall-clock in api / useForm resolver)

### DIFF
--- a/packages/@granit/arch-tests-kit/src/index.ts
+++ b/packages/@granit/arch-tests-kit/src/index.ts
@@ -23,3 +23,9 @@ export { scanBarrelDefaultExports, scanLeakedInternals } from './scanners/barrel
 export type { BarrelScanOptions } from './scanners/barrels.js';
 
 export { scanLocaleParity } from './scanners/i18n.js';
+
+export {
+  scanAnonymousDefaultExports,
+  scanWallClockInApi,
+  scanUseFormResolver,
+} from './scanners/patterns.js';

--- a/packages/@granit/arch-tests-kit/src/scanners/patterns.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/patterns.ts
@@ -1,0 +1,107 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isTestFile, isTestingDir, readFile, rel, stripComments, walkSourceFiles } from '../fs.js';
+
+import type { AllowlistedScanContext, ScanContext, Violation } from '../types.js';
+
+function findSubdirs(root: string, name: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length) {
+    const cur = stack.pop();
+    if (cur === undefined) break;
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      const full = path.join(cur, entry.name);
+      if (entry.name === name) out.push(full);
+      else stack.push(full);
+    }
+  }
+  return out;
+}
+
+// `export default <X>` is OK only when <X> is a named declaration or a bare
+// identifier reference — both give React DevTools / stack traces a useful
+// label. Anonymous values (`() => ...`, `function () {}`, `{}`, `[]`, literals)
+// fail the rule.
+const NAMED_DEFAULT_RE =
+  /\bexport\s+default\s+(?:(?:async\s+)?function\s+\w+|class\s+\w+|[A-Za-z_$][\w$]*\s*(?:;|$|\n))/m;
+const ANY_DEFAULT_RE = /\bexport\s+default\b/;
+
+export function scanAnonymousDefaultExports(ctx: ScanContext): Violation[] {
+  const out: Violation[] = [];
+  for (const m of ctx.modules) {
+    for (const f of walkSourceFiles(m.srcDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
+      const src = stripComments(readFile(f));
+      if (!ANY_DEFAULT_RE.test(src)) continue;
+      if (NAMED_DEFAULT_RE.test(src)) continue;
+      out.push({
+        rule: 'no-anonymous-default-export',
+        module: m.name,
+        file: rel(f, ctx.repoRoot),
+        message:
+          'export default <anonymous> breaks React DevTools labels and stack traces — give the value a name (function Foo() {} / const Foo = ...)',
+      });
+    }
+  }
+  return out;
+}
+
+// Wall-clock reads inside HTTP layers cause timezone drift between server and
+// client, and make API helpers untestable. Pass dates in from the caller.
+const WALLCLOCK_RE = /(^|[^a-zA-Z_.$])(Date\.now\s*\(|new\s+Date\s*\()/;
+
+export function scanWallClockInApi(ctx: ScanContext): Violation[] {
+  const out: Violation[] = [];
+  for (const m of ctx.modules) {
+    for (const apiDir of findSubdirs(m.srcDir, 'api')) {
+      for (const f of walkSourceFiles(apiDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
+        const src = stripComments(readFile(f));
+        if (WALLCLOCK_RE.test(src)) {
+          out.push({
+            rule: 'no-wallclock-in-api',
+            module: m.name,
+            file: rel(f, ctx.repoRoot),
+            message:
+              'api/ must not read the wall clock (Date.now() / new Date()) — accept the value from the caller for testability and timezone consistency',
+          });
+        }
+      }
+    }
+  }
+  return out;
+}
+
+// react-hook-form without a resolver silently skips validation. Every
+// `useForm()` invocation should pair with a `zodResolver(...)` (or any
+// other declared `resolver:` option). Heuristic: if a file calls useForm()
+// and contains no `resolver:` key anywhere, flag it.
+const USE_FORM_CALL_RE = /\buseForm\s*[<(]/;
+const RESOLVER_KEY_RE = /\bresolver\s*:/;
+
+export function scanUseFormResolver(opts: AllowlistedScanContext): Violation[] {
+  const out: Violation[] = [];
+  const allowedModules = new Set(opts.allowedModules ?? []);
+  const allowedFiles = opts.allowedFiles ?? [];
+  for (const m of opts.modules) {
+    if (allowedModules.has(m.name)) continue;
+    for (const f of walkSourceFiles(m.srcDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
+      const relPath = rel(f, opts.repoRoot);
+      if (allowedFiles.some((needle) => relPath.includes(needle))) continue;
+      const src = stripComments(readFile(f));
+      if (!USE_FORM_CALL_RE.test(src)) continue;
+      if (RESOLVER_KEY_RE.test(src)) continue;
+      out.push({
+        rule: 'use-form-needs-resolver',
+        module: m.name,
+        file: relPath,
+        message:
+          'useForm() without resolver silently skips validation — pass resolver: zodResolver(schema) (or another declared resolver)',
+      });
+    }
+  }
+  return out;
+}

--- a/packages/@granit/arch-tests/src/__tests__/patterns.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/patterns.test.ts
@@ -1,0 +1,31 @@
+import {
+  scanAnonymousDefaultExports,
+  scanUseFormResolver,
+  scanWallClockInApi,
+} from '@granit/arch-tests-kit';
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, listPackages, toModules } from './helpers.js';
+
+const ctx = { modules: toModules(listPackages()), repoRoot: REPO_ROOT };
+
+describe('patterns (delegated to kit)', () => {
+  it('no anonymous `export default` (breaks DevTools labels & stack traces)', () => {
+    expect(scanAnonymousDefaultExports(ctx)).toEqual([]);
+  });
+
+  it('api/ helpers do not read the wall clock (Date.now / new Date)', () => {
+    expect(scanWallClockInApi(ctx)).toEqual([]);
+  });
+
+  it('every useForm() call pairs with a resolver (no silent validation skips)', () => {
+    // `react-entities/use-entity-form` is a generic form hook for apps that
+    // bring their own validation contract — see the JSDoc on the export.
+    expect(
+      scanUseFormResolver({
+        ...ctx,
+        allowedFiles: ['react-entities/src/hooks/use-entity-form.ts'],
+      })
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
Extends `@granit/arch-tests-kit` with three scanners targeting recurring
sources of subtle bugs across the framework and downstream apps.

### `scanAnonymousDefaultExports`
Fails when `export default` is not a named declaration or a bare
identifier reference. Anonymous defaults (`export default () => ...`,
`export default {...}`, literals) break React DevTools component labels,
stack traces, and React Refresh.

### `scanWallClockInApi`
Bans `Date.now()` and `new Date()` inside any `api/` directory. Wall-clock
reads at the HTTP boundary cause timezone drift between client and
server (we already pay the cost of `@date-fns/tz`) and make helpers
untestable. Callers must pass the value in.

### `scanUseFormResolver`
Flags files that call `useForm()` but declare no `resolver:` option.
react-hook-form silently skips validation in that configuration;
framework forms should opt in explicitly (typically `zodResolver(schema)`).
Accepts the standard `allowedModules` / `allowedFiles` allowlist;
`react-entities/use-entity-form` is exempted via the allowlist because
its validation contract is delegated to the consuming app (documented
in its JSDoc).

## Rationale
Three rules picked for high ROI / low false-positive ratio:

| Rule | Bug class it catches | Cost to fix violations |
| --- | --- | --- |
| anonymous default | Devtools-blind components, opaque crash reports | ~5 min per occurrence |
| wall-clock in api/ | Timezone drift, untestable HTTP helpers | Move clock to caller, ~10 min |
| useForm without resolver | Silent validation skips in production forms | Plug in `zodResolver` |

All three are file-level checks with simple regex/AST patterns —
runtime is negligible.

## Wiring
The framework's own [`@granit/arch-tests`](packages/@granit/arch-tests/src/__tests__/patterns.test.ts)
suite is now the reference user. The `feat/architecture-tests` PR (#463)
established the kit + framework pattern; this PR extends it.

The kit's README (PR #468) will gain a section on these scanners once
the README PR merges to develop — keeping that change separate avoids
a three-way merge.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] `pnpm vitest run packages/@granit/arch-tests/src` — 7 test files, 1809 assertions green (vs 1806 before; three new top-level assertions added)
- [ ] CI green on PR