### PR TITLE
test: lift coverage above the 80% gate

### DIFF
--- a/packages/@granit/react-diagnostics/src/__tests__/constants.test.ts
+++ b/packages/@granit/react-diagnostics/src/__tests__/constants.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { API_VERSION, DEFAULT_BASE_PATH, MODULE } from '../constants.js';
+
+describe('react-diagnostics constants', () => {
+  it('exposes the v1 API path under /api/v1/diagnostics', () => {
+    expect(API_VERSION).toBe('v1');
+    expect(MODULE).toBe('diagnostics');
+    expect(DEFAULT_BASE_PATH).toBe('/api/v1/diagnostics');
+  });
+});

--- a/packages/@granit/react-localization/src/__tests__/use-application-localization.test.tsx
+++ b/packages/@granit/react-localization/src/__tests__/use-application-localization.test.tsx
@@ -1,0 +1,80 @@
+import { getApplicationLocalization } from '@granit/localization';
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useApplicationLocalization } from '../hooks/use-application-localization.js';
+
+import type { ApplicationLocalizationDto } from '@granit/localization';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/localization', () => ({
+  getApplicationLocalization: vi.fn(),
+}));
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return ({ children }: { children: ReactNode }) =>
+    React.createElement(QueryClientProvider, { client: queryClient }, children);
+}
+
+beforeEach(() => {
+  vi.mocked(getApplicationLocalization).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const EMPTY_DTO: ApplicationLocalizationDto = {
+  cultureName: 'fr-BE',
+  resources: {},
+  languages: [],
+};
+
+describe('useApplicationLocalization', () => {
+  it('fetches with default basePath and provided culture', async () => {
+    const client = createMockClient();
+    vi.mocked(getApplicationLocalization).mockResolvedValue(EMPTY_DTO);
+
+    const { result } = renderHook(
+      () => useApplicationLocalization({ client, cultureName: 'fr-BE' }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getApplicationLocalization).toHaveBeenCalledWith(
+      client,
+      '/api/v1/localization',
+      'fr-BE'
+    );
+  });
+
+  it('honors custom basePath and undefined culture', async () => {
+    const client = createMockClient();
+    vi.mocked(getApplicationLocalization).mockResolvedValue(EMPTY_DTO);
+
+    renderHook(
+      () => useApplicationLocalization({ client, basePath: '/custom', cultureName: undefined }),
+      { wrapper: createWrapper() }
+    );
+
+    await waitFor(() =>
+      expect(getApplicationLocalization).toHaveBeenCalledWith(client, '/custom', undefined)
+    );
+  });
+
+  it('does not fire the query when enabled is false', () => {
+    const client = createMockClient();
+    vi.mocked(getApplicationLocalization).mockResolvedValue(EMPTY_DTO);
+
+    renderHook(() => useApplicationLocalization({ client, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(getApplicationLocalization).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-map/src/__tests__/map-tile.test.tsx
+++ b/packages/@granit/react-map/src/__tests__/map-tile.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MapTile } from '../components/map-tile.js';
+
+import type { MapWidgetDefinition } from '@granit/analytics';
+
+const useWidgetRenderMock = vi.fn();
+
+vi.mock('@granit/react-dashboards', () => ({
+  useWidgetRender: (...args: unknown[]) => useWidgetRenderMock(...args),
+  RenderedWidget: ({ widget }: { widget: unknown }) => (
+    <div data-slot="rendered-widget">{JSON.stringify(widget)}</div>
+  ),
+}));
+
+const WIDGET = {
+  type: 'map',
+  id: 'w-1',
+} as unknown as MapWidgetDefinition;
+
+describe('MapTile', () => {
+  it('renders a skeleton while loading', () => {
+    useWidgetRenderMock.mockReturnValue({ isLoading: true, isError: false, data: undefined });
+
+    const { container } = render(<MapTile widget={WIDGET} />);
+    expect(container.querySelector('[data-slot="map-tile-skeleton"]')).not.toBeNull();
+  });
+
+  it('renders an error placeholder when the render query fails', () => {
+    useWidgetRenderMock.mockReturnValue({ isLoading: false, isError: true, data: undefined });
+
+    const { container } = render(<MapTile widget={WIDGET} />);
+    expect(container.querySelector('[data-slot="map-tile-error"]')).not.toBeNull();
+  });
+
+  it('returns null when the query has neither data nor an error', () => {
+    useWidgetRenderMock.mockReturnValue({ isLoading: false, isError: false, data: undefined });
+
+    const { container } = render(<MapTile widget={WIDGET} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('dispatches through RenderedWidget on success', () => {
+    useWidgetRenderMock.mockReturnValue({
+      isLoading: false,
+      isError: false,
+      data: { kind: 'Map', payload: {} },
+    });
+
+    render(<MapTile widget={WIDGET} />);
+    expect(screen.getByText(/"kind":"Map"/)).not.toBeNull();
+  });
+});

--- a/packages/@granit/react-map/src/__tests__/registries.test.ts
+++ b/packages/@granit/react-map/src/__tests__/registries.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { MapTile } from '../components/map-tile.js';
+import { mapWidgetConfigFormRegistry } from '../editor/index.js';
+import { defaultMapWidgetRegistry } from '../registry/default-map-widget-registry.js';
+import { defaultMapSnapshotWidgetRegistry } from '../snapshot/default-map-snapshot-widget-registry.js';
+import { MapSnapshotWidget } from '../snapshot/map-snapshot-widget.js';
+
+describe('defaultMapWidgetRegistry', () => {
+  it('registers MapTile under the "map" key', () => {
+    expect(defaultMapWidgetRegistry.map).toBe(MapTile);
+  });
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(defaultMapWidgetRegistry)).toBe(true);
+  });
+});
+
+describe('defaultMapSnapshotWidgetRegistry', () => {
+  it('registers MapSnapshotWidget under the "Map" key', () => {
+    expect(defaultMapSnapshotWidgetRegistry.Map).toBe(MapSnapshotWidget);
+  });
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(defaultMapSnapshotWidgetRegistry)).toBe(true);
+  });
+});
+
+describe('mapWidgetConfigFormRegistry', () => {
+  it('registers a MapConfigForm under the "map" key', () => {
+    expect(mapWidgetConfigFormRegistry.map).toBeTypeOf('function');
+  });
+
+  it('is frozen', () => {
+    expect(Object.isFrozen(mapWidgetConfigFormRegistry)).toBe(true);
+  });
+});

--- a/packages/@granit/react-multi-tenancy/src/__tests__/use-clear-queries-on-tenant-change.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/use-clear-queries-on-tenant-change.test.tsx
@@ -1,0 +1,72 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useClearQueriesOnTenantChange } from '../hooks/use-clear-queries-on-tenant-change.js';
+import { TenantProvider } from '../providers/tenant-provider.js';
+
+import type { TenantResolver } from '@granit/multi-tenancy';
+
+function staticResolver(id: string | undefined): TenantResolver {
+  return {
+    name: 'static',
+    order: 0,
+    resolve: () => (id ? { id, name: id } : null),
+  };
+}
+
+function HookProbe(): null {
+  useClearQueriesOnTenantChange();
+  return null;
+}
+
+describe('useClearQueriesOnTenantChange', () => {
+  it('does not clear on mount when tenant is stable', () => {
+    const qc = new QueryClient();
+    const clear = vi.spyOn(qc, 'clear');
+
+    render(
+      <QueryClientProvider client={qc}>
+        <TenantProvider resolvers={[staticResolver('tenant-1')]}>
+          <HookProbe />
+        </TenantProvider>
+      </QueryClientProvider>
+    );
+
+    expect(clear).not.toHaveBeenCalled();
+  });
+
+  it('clears the cache when the resolved tenant id changes', () => {
+    const qc = new QueryClient();
+    const clear = vi.spyOn(qc, 'clear');
+
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <TenantProvider resolvers={[staticResolver('tenant-1')]}>
+          <HookProbe />
+        </TenantProvider>
+      </QueryClientProvider>
+    );
+
+    rerender(
+      <QueryClientProvider client={qc}>
+        <TenantProvider resolvers={[staticResolver('tenant-2')]}>
+          <HookProbe />
+        </TenantProvider>
+      </QueryClientProvider>
+    );
+
+    expect(clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when used outside a TenantProvider', () => {
+    const qc = new QueryClient();
+    expect(() =>
+      render(
+        <QueryClientProvider client={qc}>
+          <HookProbe />
+        </QueryClientProvider>
+      )
+    ).toThrow(/useTenant must be used within a TenantProvider/);
+  });
+});

--- a/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
@@ -1,0 +1,168 @@
+import {
+  activateTenant,
+  createTenant,
+  deactivateTenant,
+  getTenant,
+  listTenants,
+  updateTenant,
+} from '@granit/multi-tenancy';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useActivateTenant,
+  useCreateTenant,
+  useDeactivateTenant,
+  useTenantDetail,
+  useTenants,
+  useUpdateTenant,
+} from '../hooks/use-tenant-admin.js';
+import { TenantAdminProvider } from '../providers/tenant-admin-provider.js';
+
+import type { AdminTenant, CreateTenantRequest, UpdateTenantRequest } from '@granit/multi-tenancy';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/multi-tenancy', async () => {
+  const actual = await vi.importActual('@granit/multi-tenancy');
+  return {
+    ...actual,
+    listTenants: vi.fn(),
+    getTenant: vi.fn(),
+    createTenant: vi.fn(),
+    updateTenant: vi.fn(),
+    activateTenant: vi.fn(),
+    deactivateTenant: vi.fn(),
+  };
+});
+
+const mockClient = {} as AxiosInstance;
+
+function wrap(client: QueryClient, basePath?: string) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>
+      <TenantAdminProvider config={{ client: mockClient, basePath }}>
+        {children}
+      </TenantAdminProvider>
+    </QueryClientProvider>
+  );
+}
+
+const SAMPLE_TENANT: AdminTenant = {
+  id: 'tenant-1',
+  name: 'Tenant 1',
+  identifier: 'tenant-1',
+  contactEmail: 'admin@tenant-1.test',
+  activated: true,
+  jurisdiction: 'BE',
+  createdAt: '2026-01-01T00:00:00.000Z',
+} as unknown as AdminTenant;
+
+beforeEach(() => {
+  vi.mocked(listTenants).mockReset();
+  vi.mocked(getTenant).mockReset();
+  vi.mocked(createTenant).mockReset();
+  vi.mocked(updateTenant).mockReset();
+  vi.mocked(activateTenant).mockReset();
+  vi.mocked(deactivateTenant).mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useTenants', () => {
+  it('calls listTenants with the configured basePath', async () => {
+    vi.mocked(listTenants).mockResolvedValue([SAMPLE_TENANT]);
+
+    const { result } = renderHook(() => useTenants(), {
+      wrapper: wrap(new QueryClient(), '/api/v1/multi-tenancy'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(listTenants).toHaveBeenCalledWith(mockClient, '/api/v1/multi-tenancy');
+    expect(result.current.data).toEqual([SAMPLE_TENANT]);
+  });
+});
+
+describe('useTenantDetail', () => {
+  it('is disabled when id is empty', () => {
+    renderHook(() => useTenantDetail(''), {
+      wrapper: wrap(new QueryClient()),
+    });
+
+    expect(getTenant).not.toHaveBeenCalled();
+  });
+
+  it('calls getTenant when id is provided', async () => {
+    vi.mocked(getTenant).mockResolvedValue(SAMPLE_TENANT);
+
+    const { result } = renderHook(() => useTenantDetail('tenant-1'), {
+      wrapper: wrap(new QueryClient(), '/admin'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getTenant).toHaveBeenCalledWith(mockClient, '/admin', 'tenant-1');
+  });
+});
+
+describe('mutations invalidate the tenant list', () => {
+  it('useCreateTenant calls createTenant', async () => {
+    vi.mocked(createTenant).mockResolvedValue(SAMPLE_TENANT);
+
+    const { result } = renderHook(() => useCreateTenant(), {
+      wrapper: wrap(new QueryClient(), '/admin'),
+    });
+
+    const req: CreateTenantRequest = { name: 'X' } as CreateTenantRequest;
+    await act(async () => {
+      await result.current.mutateAsync(req);
+    });
+
+    expect(createTenant).toHaveBeenCalledWith(mockClient, '/admin', req);
+  });
+
+  it('useUpdateTenant calls updateTenant', async () => {
+    vi.mocked(updateTenant).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useUpdateTenant(), {
+      wrapper: wrap(new QueryClient(), '/admin'),
+    });
+
+    const req: UpdateTenantRequest = { name: 'X' } as UpdateTenantRequest;
+    await act(async () => {
+      await result.current.mutateAsync({ id: 'tenant-1', request: req });
+    });
+
+    expect(updateTenant).toHaveBeenCalledWith(mockClient, '/admin', 'tenant-1', req);
+  });
+
+  it('useActivateTenant calls activateTenant', async () => {
+    vi.mocked(activateTenant).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useActivateTenant(), {
+      wrapper: wrap(new QueryClient(), '/admin'),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('tenant-1');
+    });
+
+    expect(activateTenant).toHaveBeenCalledWith(mockClient, '/admin', 'tenant-1');
+  });
+
+  it('useDeactivateTenant calls deactivateTenant', async () => {
+    vi.mocked(deactivateTenant).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeactivateTenant(), {
+      wrapper: wrap(new QueryClient(), '/admin'),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('tenant-1');
+    });
+
+    expect(deactivateTenant).toHaveBeenCalledWith(mockClient, '/admin', 'tenant-1');
+  });
+});

--- a/packages/@granit/react-notifications/src/__tests__/use-notification-subscriptions.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/use-notification-subscriptions.test.tsx
@@ -1,0 +1,189 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  useEntityFollowers,
+  useFollowEntity,
+  useNotificationSubscriptions,
+  useNotificationTypes,
+  useSubscribeToNotificationType,
+  useUnfollowEntity,
+  useUnsubscribeFromNotificationType,
+} from '../hooks/use-notification-subscriptions.js';
+import { NotificationProvider } from '../providers/notification-provider.js';
+
+import { axiosResponse, createMockClient } from './test-utils.js';
+
+import type {
+  NotificationConfig,
+  NotificationDefinition,
+  NotificationSubscriptionResponse,
+} from '@granit/notifications';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance, basePath = '/api/v1') {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => {
+    const config: NotificationConfig = { apiClient: client, basePath };
+    return (
+      <QueryClientProvider client={queryClient}>
+        <NotificationProvider config={config}>{children}</NotificationProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+const MOCK_TYPES: NotificationDefinition[] = [
+  {
+    typeName: 'NewMessage',
+    severity: 'Info',
+    group: 'inbox',
+    defaultChannels: ['inApp'],
+  } as unknown as NotificationDefinition,
+];
+
+const MOCK_SUBS: NotificationSubscriptionResponse[] = [
+  {
+    typeName: 'NewMessage',
+    channels: ['inApp'],
+  } as unknown as NotificationSubscriptionResponse,
+];
+
+describe('useNotificationTypes', () => {
+  it('fetches notification definitions', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(MOCK_TYPES));
+
+    const { result } = renderHook(() => useNotificationTypes(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(MOCK_TYPES);
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('/notifications/types'));
+  });
+});
+
+describe('useNotificationSubscriptions', () => {
+  it('lists current-user subscriptions', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(MOCK_SUBS));
+
+    const { result } = renderHook(() => useNotificationSubscriptions(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(MOCK_SUBS);
+  });
+});
+
+describe('useSubscribeToNotificationType', () => {
+  it('POSTs to the subscriptions endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useSubscribeToNotificationType(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('NewMessage');
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      expect.stringContaining('/notifications/subscriptions/NewMessage')
+    );
+  });
+});
+
+describe('useUnsubscribeFromNotificationType', () => {
+  it('DELETEs the subscription endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useUnsubscribeFromNotificationType(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync('NewMessage');
+    });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      expect.stringContaining('/notifications/subscriptions/NewMessage')
+    );
+  });
+});
+
+describe('useFollowEntity', () => {
+  it('POSTs to the follow endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useFollowEntity(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ entityType: 'Invoice', entityId: 'inv-1' });
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      expect.stringContaining('/notifications/entity/Invoice/inv-1/follow')
+    );
+  });
+});
+
+describe('useUnfollowEntity', () => {
+  it('DELETEs the follow endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useUnfollowEntity(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({ entityType: 'Invoice', entityId: 'inv-1' });
+    });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      expect.stringContaining('/notifications/entity/Invoice/inv-1/follow')
+    );
+  });
+});
+
+describe('useEntityFollowers', () => {
+  it('is disabled when entityType or entityId is empty', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    renderHook(() => useEntityFollowers('', 'inv-1'), {
+      wrapper: createWrapper(client),
+    });
+    renderHook(() => useEntityFollowers('Invoice', ''), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('GETs the followers endpoint when both ids are present', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(MOCK_SUBS));
+
+    const { result } = renderHook(() => useEntityFollowers('Invoice', 'inv-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      expect.stringContaining('/notifications/entity/Invoice/inv-1/followers')
+    );
+  });
+});

--- a/packages/@granit/react-timeline/src/__tests__/use-entry-mutations.test.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/use-entry-mutations.test.tsx
@@ -1,0 +1,79 @@
+import { toEntityId } from '@granit/types';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+import { useAnchorEntry, useUpdateEntryBody } from '../hooks/use-entry-mutations.js';
+import { TimelineProvider } from '../providers/timeline-provider.js';
+
+import { axiosResponse, createMockClient } from './test-utils.js';
+
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <TimelineProvider config={{ client, basePath: DEFAULT_BASE_PATH }}>
+        {children}
+      </TimelineProvider>
+    </QueryClientProvider>
+  );
+}
+
+describe('useAnchorEntry', () => {
+  it('POSTs to the anchor endpoint and returns the entryId', async () => {
+    const entryId = toEntityId<'TimelineEntry'>('entry-42');
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse({ entryId }));
+
+    const { result } = renderHook(() => useAnchorEntry(), {
+      wrapper: createWrapper(client),
+    });
+
+    let returned: unknown;
+    await act(async () => {
+      returned = await result.current.mutateAsync({
+        entityType: 'Invoice',
+        entityId: 'inv-1',
+        sourceKey: 'email',
+        sourceId: 'msg-7',
+      });
+    });
+
+    expect(returned).toBe(entryId);
+    expect(client.post).toHaveBeenCalledWith(expect.stringContaining('/Invoice/inv-1/anchor'), {
+      sourceKey: 'email',
+      sourceId: 'msg-7',
+    });
+  });
+});
+
+describe('useUpdateEntryBody', () => {
+  it('PATCHes the entry body endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useUpdateEntryBody(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        entityType: 'Invoice',
+        entityId: 'inv-1',
+        entryId: toEntityId<'TimelineEntry'>('entry-3'),
+        body: 'updated body',
+      });
+    });
+
+    expect(client.patch).toHaveBeenCalledWith(
+      expect.stringContaining('/Invoice/inv-1/entries/entry-3'),
+      { body: 'updated body' }
+    );
+  });
+});

--- a/packages/@granit/utils/src/__tests__/safe-url.test.ts
+++ b/packages/@granit/utils/src/__tests__/safe-url.test.ts
@@ -67,4 +67,9 @@ describe('assertSafeUrl', () => {
     const long = `javascript:${'a'.repeat(200)}`;
     expect(() => assertSafeUrl(long)).toThrow(/.{0,80}/);
   });
+
+  it('coerces non-string input via String() in the error message', () => {
+    // @ts-expect-error — exercising defensive branch (non-string sink input)
+    expect(() => assertSafeUrl(null)).toThrow(/Unsafe URL rejected: "null"/);
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -353,10 +353,7 @@ export default defineConfig({
       '@granit/testing': path.resolve(__dirname, 'packages/@granit/testing/src/index.ts'),
       '@granit/timeline': path.resolve(__dirname, 'packages/@granit/timeline/src/index.ts'),
       '@granit/tracing': path.resolve(__dirname, 'packages/@granit/tracing/src/index.ts'),
-      '@granit/csp/testing': path.resolve(
-        __dirname,
-        'packages/@granit/csp/src/testing/index.ts'
-      ),
+      '@granit/csp/testing': path.resolve(__dirname, 'packages/@granit/csp/src/testing/index.ts'),
       '@granit/csp': path.resolve(__dirname, 'packages/@granit/csp/src/index.ts'),
       '@granit/react-map/csp': path.resolve(
         __dirname,
@@ -396,6 +393,10 @@ export default defineConfig({
         '**/__tests__/test-utils.tsx',
         '**/api-client/src/test-utils.ts',
         '**/src/testing/**',
+        // @granit/testing is the framework's test-infra package — its source is
+        // tooling for other packages' tests, not runtime code under coverage.
+        'packages/@granit/testing/**',
+        'packages/@granit/react-testing/**',
       ],
       thresholds: {
         lines: 80,


### PR DESCRIPTION
## Summary

CI was failing on the branch-coverage gate (79.9% < 80%). This PR pushes every
threshold comfortably above 80% by adding tests for the previously-untested
modules and excluding `@granit/testing` / `@granit/react-testing` from the
coverage report (their source IS test infrastructure, not runtime code).

### Coverage

| Metric     | Before  | After   |
|------------|---------|---------|
| Statements | 88.47%  | 90.19%  |
| Branches   | 79.98% \U0001f534 | 81.36% \U0001f7e2 |
| Functions  | 87.11%  | 89.11%  |
| Lines      | 89.82%  | 91.69%  |

### Modules covered

Previously at 0%:
- \`@granit/react-localization\` — \`useApplicationLocalization\`
- \`@granit/react-multi-tenancy\` — \`use-tenant-admin\` (6 hooks), \`useClearQueriesOnTenantChange\`
- \`@granit/react-notifications\` — \`use-notification-subscriptions\` (7 hooks)
- \`@granit/react-timeline\` — \`useAnchorEntry\`, \`useUpdateEntryBody\`
- \`@granit/react-map\` — \`MapTile\` (4 render branches), \`defaultMapWidgetRegistry\`, \`defaultMapSnapshotWidgetRegistry\`, \`mapWidgetConfigFormRegistry\`
- \`@granit/react-diagnostics\` — \`constants\` smoke

Defensive branches:
- \`@granit/utils\` — \`assertSafeUrl\` non-string input path

### Config

\`vitest.config.ts\` — coverage exclude list now contains
\`packages/@granit/testing/**\` and \`packages/@granit/react-testing/**\`,
matching the existing rationale for \`**/src/testing/**\`.

## Test plan

- [x] \`pnpm test:coverage\` — all thresholds pass with margin
- [x] \`pnpm tsc\` — clean
- [x] \`pnpm lint\` — clean (\`--max-warnings 0\`)
- [x] \`pnpm check:csp\` — clean