### PR TITLE
feat(arch-tests-kit): enforce README presence + shared-dep version alignment

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -410,6 +410,16 @@
           "name": "scanLocaleParity",
           "kind": "function",
           "signature": "function scanLocaleParity(ctx: ScanContext): Violation[]"
+        },
+        {
+          "name": "scanReadmePresence",
+          "kind": "function",
+          "signature": "function scanReadmePresence(opts: ReadmePresenceOptions): Violation[]"
+        },
+        {
+          "name": "scanSharedDepVersions",
+          "kind": "function",
+          "signature": "function scanSharedDepVersions(opts: SharedDepVersionsOptions): Violation[]"
         }
       ]
     },

--- a/packages/@granit/activities/README.md
+++ b/packages/@granit/activities/README.md
@@ -1,0 +1,3 @@
+# @granit/activities
+
+Cross-entity polymorphic to-do module — types, API client, and permissions

--- a/packages/@granit/analytics/README.md
+++ b/packages/@granit/analytics/README.md
@@ -1,0 +1,3 @@
+# @granit/analytics
+
+Framework-agnostic types for Granit.Analytics — MetricResponse runtime envelopes plus KPI / Chart / Table / Pivot widget definitions consumed by @granit/dashboards

--- a/packages/@granit/arch-tests-kit/src/index.ts
+++ b/packages/@granit/arch-tests-kit/src/index.ts
@@ -29,3 +29,9 @@ export {
   scanWallClockInApi,
   scanUseFormResolver,
 } from './scanners/patterns.js';
+
+export { scanReadmePresence, scanSharedDepVersions } from './scanners/uniformity.js';
+export type {
+  ReadmePresenceOptions,
+  SharedDepVersionsOptions,
+} from './scanners/uniformity.js';

--- a/packages/@granit/arch-tests-kit/src/scanners/uniformity.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/uniformity.ts
@@ -1,0 +1,172 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { rel } from '../fs.js';
+
+import type { AllowlistedScanContext, ScanContext, Violation } from '../types.js';
+
+const H1_RE = /^#\s+(.+?)\s*$/m;
+
+/**
+ * Every module ships a `README.md` introducing it. The H1 (first `#` heading,
+ * not necessarily the first line — leading `<img>` / badges are allowed)
+ * must read `# <expectedHeading>` so the doc is recognizable without
+ * opening it.
+ *
+ * `expectedHeading` defaults to the module's name, which works for packages
+ * (`@granit/foo` matches the published name). Apps can pass a custom
+ * resolver via {@link ReadmePresenceOptions.expectedHeading}.
+ */
+export interface ReadmePresenceOptions extends AllowlistedScanContext {
+  /** Compute the expected H1 text for a given module. Defaults to `m.name`. */
+  expectedHeading?: (moduleName: string) => string;
+}
+
+export function scanReadmePresence(opts: ReadmePresenceOptions): Violation[] {
+  const out: Violation[] = [];
+  const allowedModules = new Set(opts.allowedModules ?? []);
+  const allowedFiles = opts.allowedFiles ?? [];
+  const heading = opts.expectedHeading ?? ((name) => name);
+
+  for (const m of opts.modules) {
+    if (allowedModules.has(m.name)) continue;
+    const readme = path.join(m.dir, 'README.md');
+    const relPath = rel(readme, opts.repoRoot);
+    if (allowedFiles.some((needle) => relPath.includes(needle))) continue;
+
+    if (!fs.existsSync(readme)) {
+      out.push({
+        rule: 'readme-presence',
+        module: m.name,
+        file: relPath,
+        message: 'missing README.md (every module ships one for onboarding)',
+      });
+      continue;
+    }
+    const src = fs.readFileSync(readme, 'utf8');
+    const match = src.match(H1_RE);
+    if (!match) {
+      out.push({
+        rule: 'readme-h1',
+        module: m.name,
+        file: relPath,
+        message: 'README.md has no `# H1` heading',
+      });
+      continue;
+    }
+    const expected = heading(m.name);
+    if (match[1] !== expected) {
+      out.push({
+        rule: 'readme-h1',
+        module: m.name,
+        file: relPath,
+        message: `README.md H1 is "${match[1]}", expected "${expected}"`,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * For a curated list of dependencies that every package must agree on
+ * (React, TanStack Query, …), ensures every package that lists the dep
+ * uses the same version constraint. Drift is the most common source of
+ * upgrade pain — one package pinning `^5.0.0` while another pins
+ * `^5.95.0` produces two resolved versions and breaks shared singletons.
+ */
+export interface SharedDepVersionsOptions extends ScanContext {
+  /**
+   * Dependency names to scan. Each must use a single shared version
+   * across all packages that declare it.
+   */
+  deps: ReadonlyArray<string>;
+  /**
+   * Where to read the `package.json` for each module. Defaults to
+   * `<dir>/package.json` (works for npm packages).
+   */
+  packageJsonPath?: (m: { dir: string }) => string;
+  /**
+   * Sections to inspect. Defaults to dependencies + peerDependencies +
+   * devDependencies — versions must agree across all three.
+   */
+  sections?: ReadonlyArray<'dependencies' | 'peerDependencies' | 'devDependencies'>;
+}
+
+const DEFAULT_SECTIONS = ['dependencies', 'peerDependencies', 'devDependencies'] as const;
+
+export function scanSharedDepVersions(opts: SharedDepVersionsOptions): Violation[] {
+  const sections = opts.sections ?? DEFAULT_SECTIONS;
+  const resolvePkgJson = opts.packageJsonPath ?? ((m) => path.join(m.dir, 'package.json'));
+  const out: Violation[] = [];
+
+  // dep -> Map<version, modules using it>
+  const byDep = new Map<string, Map<string, string[]>>();
+  for (const dep of opts.deps) byDep.set(dep, new Map());
+
+  for (const m of opts.modules) {
+    const f = resolvePkgJson(m);
+    if (!fs.existsSync(f)) continue;
+    const pkg = JSON.parse(fs.readFileSync(f, 'utf8')) as Record<
+      string,
+      Record<string, string> | undefined
+    >;
+    for (const dep of opts.deps) {
+      const versions = new Set<string>();
+      for (const section of sections) {
+        const v = pkg[section]?.[dep];
+        if (v !== undefined && !v.startsWith('workspace:') && v !== '*') versions.add(v);
+      }
+      const distinct = [...versions];
+      if (distinct.length === 0) continue;
+      if (distinct.length > 1) {
+        out.push({
+          rule: 'shared-dep-version-drift-within-package',
+          module: m.name,
+          file: rel(f, opts.repoRoot),
+          message: `${dep} is declared with multiple versions in this package: ${distinct.join(', ')}`,
+        });
+      }
+      const v = distinct[0];
+      if (v === undefined) continue;
+      const slot = byDep.get(dep);
+      if (!slot) continue;
+      const existing = slot.get(v) ?? [];
+      existing.push(m.name);
+      slot.set(v, existing);
+    }
+  }
+
+  for (const dep of opts.deps) {
+    const slot = byDep.get(dep);
+    if (!slot || slot.size <= 1) continue;
+    // More than one distinct version across the workspace.
+    const summary = [...slot.entries()]
+      .map(([ver, modules]) => `${ver} (${modules.length}× — e.g. ${modules.slice(0, 3).join(', ')})`)
+      .join(' vs ');
+    // Attribute the violation to the minority versions so the report
+    // points at the packages to align.
+    const sorted = [...slot.entries()].sort((a, b) => b[1].length - a[1].length);
+    const majorityModules = sorted[0]?.[1] ?? [];
+    const majority = new Set(majorityModules);
+    for (const m of opts.modules) {
+      if (majority.has(m.name)) continue;
+      // Only flag modules that declared the dep with a non-majority version.
+      let declares = false;
+      for (const [, modules] of sorted.slice(1)) {
+        if (modules.includes(m.name)) {
+          declares = true;
+          break;
+        }
+      }
+      if (!declares) continue;
+      out.push({
+        rule: 'shared-dep-version-drift',
+        module: m.name,
+        file: rel(resolvePkgJson(m), opts.repoRoot),
+        message: `${dep} version differs from the majority — align with the dominant constraint. Workspace state: ${summary}`,
+      });
+    }
+  }
+
+  return out;
+}

--- a/packages/@granit/arch-tests/README.md
+++ b/packages/@granit/arch-tests/README.md
@@ -1,0 +1,3 @@
+# @granit/arch-tests
+
+Architecture tests — enforce framework-wide structural, naming, and dependency conventions.

--- a/packages/@granit/arch-tests/src/__tests__/uniformity.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/uniformity.test.ts
@@ -1,0 +1,32 @@
+import { scanReadmePresence, scanSharedDepVersions } from '@granit/arch-tests-kit';
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, listPackages, toModules } from './helpers.js';
+
+const ctx = { modules: toModules(listPackages()), repoRoot: REPO_ROOT };
+
+describe('uniformity (delegated to kit)', () => {
+  it('every package ships a README.md with `# @granit/<name>` as the H1', () => {
+    expect(scanReadmePresence(ctx)).toEqual([]);
+  });
+
+  it('shared deps use the same version constraint across every package', () => {
+    expect(
+      scanSharedDepVersions({
+        ...ctx,
+        deps: [
+          'react',
+          'react-dom',
+          '@tanstack/react-query',
+          'react-i18next',
+          'react-hook-form',
+          'i18next',
+          'date-fns',
+          'zod',
+          'clsx',
+          'tailwind-merge',
+        ],
+      }),
+    ).toEqual([]);
+  });
+});

--- a/packages/@granit/authentication-cognito/README.md
+++ b/packages/@granit/authentication-cognito/README.md
@@ -1,0 +1,3 @@
+# @granit/authentication-cognito
+
+AWS Cognito User Pools OIDC authentication types — CognitoAuthContextType, config

--- a/packages/@granit/authentication-entraid/README.md
+++ b/packages/@granit/authentication-entraid/README.md
@@ -1,0 +1,3 @@
+# @granit/authentication-entraid
+
+Microsoft Entra ID (Azure AD) OIDC authentication types — EntraIdAuthContextType, config

--- a/packages/@granit/authentication-google-cloud/README.md
+++ b/packages/@granit/authentication-google-cloud/README.md
@@ -1,0 +1,3 @@
+# @granit/authentication-google-cloud
+
+Google Cloud Identity Platform (Firebase Auth) authentication types — GoogleCloudAuthContextType, config

--- a/packages/@granit/authentication-keycloak/README.md
+++ b/packages/@granit/authentication-keycloak/README.md
@@ -1,0 +1,3 @@
+# @granit/authentication-keycloak
+
+Keycloak OIDC authentication types — KeycloakAuthContextType, config, events

--- a/packages/@granit/authentication-local/README.md
+++ b/packages/@granit/authentication-local/README.md
@@ -1,0 +1,3 @@
+# @granit/authentication-local
+
+Local credential authentication types and API — headless login, passkey assertion — mirrors Granit.Identity.Local.Endpoints .NET contract

--- a/packages/@granit/catalog/README.md
+++ b/packages/@granit/catalog/README.md
@@ -1,0 +1,3 @@
+# @granit/catalog
+
+Product catalog types and API functions — mirrors Granit.Catalog .NET (products, lifecycle, external mappings)

--- a/packages/@granit/charts/README.md
+++ b/packages/@granit/charts/README.md
@@ -1,0 +1,3 @@
+# @granit/charts
+
+Framework-agnostic chart primitives for Granit — typed series shapes, ECharts theme builder from Tailwind tokens, locale-aware tick formatters

--- a/packages/@granit/csp/README.md
+++ b/packages/@granit/csp/README.md
@@ -1,0 +1,3 @@
+# @granit/csp
+
+Content Security Policy + Trusted Types helpers for Granit apps. Idempotent installers for the core `granit` policy plus a per-package registry, and helpers to build the `trusted-types` directive from the policies the app actually installs.

--- a/packages/@granit/customer-balance/README.md
+++ b/packages/@granit/customer-balance/README.md
@@ -1,0 +1,3 @@
+# @granit/customer-balance
+
+Customer balance and credits — types and API functions

--- a/packages/@granit/dashboards/README.md
+++ b/packages/@granit/dashboards/README.md
@@ -1,0 +1,3 @@
+# @granit/dashboards
+
+Framework-agnostic types and registry contracts for Granit dashboards — DashboardDefinition, WidgetDefinition discriminated union, layout primitives, and built-in presentation widgets (Markdown / Image / Text)

--- a/packages/@granit/documents/README.md
+++ b/packages/@granit/documents/README.md
@@ -1,0 +1,3 @@
+# @granit/documents
+
+Granit.Documents Phase 1 module — types, API client, and permissions

--- a/packages/@granit/entities-customization/README.md
+++ b/packages/@granit/entities-customization/README.md
@@ -1,0 +1,3 @@
+# @granit/entities-customization
+
+Layer 1 customization (forms + workspaces) — types, API client, and permissions

--- a/packages/@granit/invoicing/README.md
+++ b/packages/@granit/invoicing/README.md
@@ -1,0 +1,3 @@
+# @granit/invoicing
+
+Invoice lifecycle — types and API functions for invoices and credit notes

--- a/packages/@granit/localization/package.json
+++ b/packages/@granit/localization/package.json
@@ -17,7 +17,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/storage": "workspace:*",
     "@granit/types": "workspace:*",
-    "i18next": "^25.0.0"
+    "i18next": "^26.0.0"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",

--- a/packages/@granit/metering/README.md
+++ b/packages/@granit/metering/README.md
@@ -1,0 +1,3 @@
+# @granit/metering
+
+Usage metering — meter definitions, events, and quota types and API functions

--- a/packages/@granit/parties/README.md
+++ b/packages/@granit/parties/README.md
@@ -1,0 +1,3 @@
+# @granit/parties
+
+Parties (Tiers / Business Partners) — types and API functions

--- a/packages/@granit/payments/README.md
+++ b/packages/@granit/payments/README.md
@@ -1,0 +1,3 @@
+# @granit/payments
+
+Payment processing — charges, refunds, checkout, and payment methods types and API functions

--- a/packages/@granit/react-analytics/README.md
+++ b/packages/@granit/react-analytics/README.md
@@ -1,0 +1,3 @@
+# @granit/react-analytics
+
+React hooks and renderers for @granit/analytics — useMetric hook plus KpiTile widget renderer registered into the @granit/dashboards widget registry

--- a/packages/@granit/react-api-client/README.md
+++ b/packages/@granit/react-api-client/README.md
@@ -1,0 +1,3 @@
+# @granit/react-api-client
+
+React context provider for sharing an Axios instance across Granit framework packages

--- a/packages/@granit/react-authentication-cognito/README.md
+++ b/packages/@granit/react-authentication-cognito/README.md
@@ -1,0 +1,3 @@
+# @granit/react-authentication-cognito
+
+React hooks for AWS Cognito OIDC authentication — useCognitoInit

--- a/packages/@granit/react-authentication-entraid/README.md
+++ b/packages/@granit/react-authentication-entraid/README.md
@@ -1,0 +1,3 @@
+# @granit/react-authentication-entraid
+
+React hooks for Microsoft Entra ID OIDC authentication — useEntraIdInit

--- a/packages/@granit/react-authentication-google-cloud/README.md
+++ b/packages/@granit/react-authentication-google-cloud/README.md
@@ -1,0 +1,3 @@
+# @granit/react-authentication-google-cloud
+
+React hooks for Google Cloud Identity Platform (Firebase Auth) — useGoogleCloudInit

--- a/packages/@granit/react-authentication-keycloak/README.md
+++ b/packages/@granit/react-authentication-keycloak/README.md
@@ -1,0 +1,3 @@
+# @granit/react-authentication-keycloak
+
+React hooks for Keycloak OIDC authentication — useKeycloakInit

--- a/packages/@granit/react-authentication-local/README.md
+++ b/packages/@granit/react-authentication-local/README.md
@@ -1,0 +1,3 @@
+# @granit/react-authentication-local
+
+React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion

--- a/packages/@granit/react-catalog/README.md
+++ b/packages/@granit/react-catalog/README.md
@@ -1,0 +1,3 @@
+# @granit/react-catalog
+
+React bindings for @granit/catalog — CatalogProvider + React Query hooks for products CRUD, lifecycle (publish/archive) and external mappings

--- a/packages/@granit/react-charts/README.md
+++ b/packages/@granit/react-charts/README.md
@@ -1,0 +1,3 @@
+# @granit/react-charts
+
+React chart primitives for Granit — typed <LineChart>, <BarChart>, <PieChart>, <SparklineChart> built on Apache ECharts (modular tree-shaken imports), plus <Chart> escape hatch for raw ECharts options

--- a/packages/@granit/react-customer-balance/README.md
+++ b/packages/@granit/react-customer-balance/README.md
@@ -1,0 +1,3 @@
+# @granit/react-customer-balance
+
+React bindings for @granit/customer-balance — CustomerBalanceProvider and hooks

--- a/packages/@granit/react-dashboard-editor/README.md
+++ b/packages/@granit/react-dashboard-editor/README.md
@@ -1,0 +1,3 @@
+# @granit/react-dashboard-editor
+
+React dashboard editor primitives for Granit — drag-and-drop reorderable widget grid built on dnd-kit. Pairs with the read-mode <RenderedDashboard> from @granit/react-dashboards. Frontend half of EPIC #1366 story B5-C (dashboard composer).

--- a/packages/@granit/react-dashboards/README.md
+++ b/packages/@granit/react-dashboards/README.md
@@ -1,0 +1,3 @@
+# @granit/react-dashboards
+
+React renderer for @granit/dashboards — Dashboard layout component, WidgetRegistry provider, and built-in renderers for Markdown / Image / Text widgets

--- a/packages/@granit/react-documents/README.md
+++ b/packages/@granit/react-documents/README.md
@@ -1,0 +1,3 @@
+# @granit/react-documents
+
+React bindings for @granit/documents — DocumentsProvider, hooks, components

--- a/packages/@granit/react-entities-customization/README.md
+++ b/packages/@granit/react-entities-customization/README.md
@@ -1,0 +1,3 @@
+# @granit/react-entities-customization
+
+React bindings + headless editors for @granit/entities-customization (Layer 1)

--- a/packages/@granit/react-invoicing/README.md
+++ b/packages/@granit/react-invoicing/README.md
@@ -1,0 +1,3 @@
+# @granit/react-invoicing
+
+React bindings for @granit/invoicing — InvoicingProvider and hooks

--- a/packages/@granit/react-localization/package.json
+++ b/packages/@granit/react-localization/package.json
@@ -25,7 +25,7 @@
     "i18next": "^25.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0",
-    "react-i18next": "^16.0.0"
+    "react-i18next": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@granit/query-engine": {

--- a/packages/@granit/react-localization/package.json
+++ b/packages/@granit/react-localization/package.json
@@ -22,7 +22,7 @@
     "@granit/storage": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "date-fns": "^4.0.0",
-    "i18next": "^25.0.0",
+    "i18next": "^26.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0",
     "react-i18next": "^17.0.0"

--- a/packages/@granit/react-map/README.md
+++ b/packages/@granit/react-map/README.md
@@ -1,0 +1,3 @@
+# @granit/react-map
+
+React Map primitives for Granit — vanilla Leaflet wrapper with multi-provider tile support (OpenStreetMap default, SPW Walloon geoportal, ArcGIS, custom). Ships <MapSnapshotWidget> registered into the dashboard snapshot widget registry; mandatory tile-provider attribution. No react-leaflet dep (Hippocratic license rejected for compliance).

--- a/packages/@granit/react-metering/README.md
+++ b/packages/@granit/react-metering/README.md
@@ -1,0 +1,3 @@
+# @granit/react-metering
+
+React bindings for @granit/metering — MeteringProvider and hooks

--- a/packages/@granit/react-parties/README.md
+++ b/packages/@granit/react-parties/README.md
@@ -1,0 +1,3 @@
+# @granit/react-parties
+
+React bindings for @granit/parties — PartiesProvider, hooks, MergeWizard and TanStack Query mutations

--- a/packages/@granit/react-parties/package.json
+++ b/packages/@granit/react-parties/package.json
@@ -24,7 +24,7 @@
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0",
-    "react-i18next": "^16.0.0 || ^17.0.0"
+    "react-i18next": "^17.0.0"
   },
   "peerDependenciesMeta": {
     "@granit/query-engine": {

--- a/packages/@granit/react-payments/README.md
+++ b/packages/@granit/react-payments/README.md
@@ -1,0 +1,3 @@
+# @granit/react-payments
+
+React bindings for @granit/payments — PaymentsProvider and hooks

--- a/packages/@granit/react-scheduling/README.md
+++ b/packages/@granit/react-scheduling/README.md
@@ -1,0 +1,3 @@
+# @granit/react-scheduling
+
+React hooks for scheduled action management — useScheduledActions, useCancelScheduledAction, useRescheduleScheduledAction

--- a/packages/@granit/react-subscriptions/README.md
+++ b/packages/@granit/react-subscriptions/README.md
@@ -1,0 +1,3 @@
+# @granit/react-subscriptions
+
+React bindings for @granit/subscriptions — SubscriptionsProvider and hooks

--- a/packages/@granit/react-tax/README.md
+++ b/packages/@granit/react-tax/README.md
@@ -1,0 +1,3 @@
+# @granit/react-tax
+
+React bindings for @granit/tax — TaxProvider and hooks

--- a/packages/@granit/react-taxonomy/README.md
+++ b/packages/@granit/react-taxonomy/README.md
@@ -1,0 +1,3 @@
+# @granit/react-taxonomy
+
+React bindings for @granit/taxonomy — TaxonomyProvider, hooks, components

--- a/packages/@granit/scheduling/README.md
+++ b/packages/@granit/scheduling/README.md
@@ -1,0 +1,3 @@
+# @granit/scheduling
+
+Scheduled action types and API — mirrors Granit.Scheduling .NET contract

--- a/packages/@granit/subscriptions/README.md
+++ b/packages/@granit/subscriptions/README.md
@@ -1,0 +1,3 @@
+# @granit/subscriptions
+
+Plan catalog, subscription lifecycle, price versioning, and seat management — types and API functions

--- a/packages/@granit/tax/README.md
+++ b/packages/@granit/tax/README.md
@@ -1,0 +1,3 @@
+# @granit/tax
+
+Tax validation and rate lookup — types and API functions

--- a/packages/@granit/taxonomy/README.md
+++ b/packages/@granit/taxonomy/README.md
@@ -1,0 +1,3 @@
+# @granit/taxonomy
+
+Cross-entity Tags and Categories module — types, API client, and permissions

--- a/packages/@granit/types/README.md
+++ b/packages/@granit/types/README.md
@@ -1,0 +1,3 @@
+# @granit/types
+
+Cross-cutting branded types for the Granit framework

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,8 +509,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       i18next:
-        specifier: ^25.0.0
-        version: 25.8.14(typescript@5.9.3)
+        specifier: ^26.0.0
+        version: 26.2.0(typescript@6.0.3)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -1664,17 +1664,17 @@ importers:
         specifier: ^4.0.0
         version: 4.1.0
       i18next:
-        specifier: ^25.0.0
-        version: 25.8.14(typescript@5.9.3)
+        specifier: ^26.0.0
+        version: 26.2.0(typescript@6.0.3)
       msw:
         specifier: ^2.14.6
-        version: 2.14.6(@types/node@25.9.0)(typescript@5.9.3)
+        version: 2.14.6(@types/node@25.9.0)(typescript@6.0.3)
       react:
         specifier: 19.2.6
         version: 19.2.6
       react-i18next:
-        specifier: ^16.0.0
-        version: 16.5.4(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3)
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -1933,8 +1933,8 @@ importers:
         specifier: 19.2.6
         version: 19.2.6
       react-i18next:
-        specifier: ^16.0.0 || ^17.0.0
-        version: 17.0.4(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
+        specifier: ^17.0.0
+        version: 17.0.8(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
@@ -5200,14 +5200,6 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
-  i18next@25.8.14:
-    resolution: {integrity: sha512-paMUYkfWJMsWPeE/Hejcw+XLhHrQPehem+4wMo+uELnvIwvCG019L9sAIljwjCmEMtFQQO3YeitJY8Kctei3iA==}
-    peerDependencies:
-      typescript: ^5
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-
   i18next@26.2.0:
     resolution: {integrity: sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==}
     peerDependencies:
@@ -5915,22 +5907,6 @@ packages:
     peerDependencies:
       react: 19.2.6
 
-  react-i18next@16.5.4:
-    resolution: {integrity: sha512-6yj+dcfMncEC21QPhOTsW8mOSO+pzFmT6uvU7XXdvM/Cp38zJkmTeMeKmTrmCMD5ToT79FmiE/mRWiYWcJYW4g==}
-    peerDependencies:
-      i18next: '>= 25.6.2'
-      react: 19.2.6
-      react-dom: '*'
-      react-native: '*'
-      typescript: ^5
-    peerDependenciesMeta:
-      react-dom:
-        optional: true
-      react-native:
-        optional: true
-      typescript:
-        optional: true
-
   react-i18next@17.0.4:
     resolution: {integrity: sha512-hQipmK4EF0y6RO6tt6WuqnmWpWYEXmQUUzecmMBuNsIgYd3smXcG4GtYPWhvgxn0pqMOItKlEO8H24HCs5hc3g==}
     peerDependencies:
@@ -6300,11 +6276,6 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
-
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -9187,12 +9158,6 @@ snapshots:
 
   husky@9.1.7: {}
 
-  i18next@25.8.14(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
-    optionalDependencies:
-      typescript: 5.9.3
-
   i18next@26.2.0(typescript@6.0.3):
     optionalDependencies:
       typescript: 6.0.3
@@ -9771,31 +9736,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msw@2.14.6(@types/node@25.9.0)(typescript@5.9.3):
-    dependencies:
-      '@inquirer/confirm': 6.0.13(@types/node@25.9.0)
-      '@mswjs/interceptors': 0.41.9
-      '@open-draft/deferred-promise': 3.0.0
-      '@types/statuses': 2.0.6
-      cookie: 1.1.1
-      graphql: 16.14.0
-      headers-polyfill: 5.0.1
-      is-node-process: 1.2.0
-      outvariant: 1.4.3
-      path-to-regexp: 6.3.0
-      picocolors: 1.1.1
-      rettime: 0.11.11
-      statuses: 2.0.2
-      strict-event-emitter: 0.5.1
-      tough-cookie: 6.0.1
-      type-fest: 5.6.0
-      until-async: 3.0.2
-      yargs: 17.7.2
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@types/node'
-
   msw@2.14.6(@types/node@25.9.0)(typescript@6.0.3):
     dependencies:
       '@inquirer/confirm': 6.0.13(@types/node@25.9.0)
@@ -9984,17 +9924,6 @@ snapshots:
   react-hook-form@7.76.0(react@19.2.6):
     dependencies:
       react: 19.2.6
-
-  react-i18next@16.5.4(i18next@25.8.14(typescript@5.9.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@5.9.3):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      html-parse-stringify: 3.0.1
-      i18next: 25.8.14(typescript@5.9.3)
-      react: 19.2.6
-      use-sync-external-store: 1.6.0(react@19.2.6)
-    optionalDependencies:
-      react-dom: 19.2.6(react@19.2.6)
-      typescript: 5.9.3
 
   react-i18next@17.0.4(i18next@26.2.0(typescript@6.0.3))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(typescript@6.0.3):
     dependencies:
@@ -10364,9 +10293,6 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  typescript@5.9.3:
-    optional: true
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
## Summary
Adds two scanners targeting cross-package **uniformity** (vs. earlier
rules that targeted correctness / security).

### `scanReadmePresence`
Every module ships a `README.md` whose H1 matches the module name
(`# @granit/<name>`). The H1 doesn't have to be the first line — leading
`<img>` / badge HTML is allowed, matching the existing branded READMEs.

Backfills the 46 packages that were missing a README with a stub seeded
from `package.json`'s `description` field. Stubs are intentionally
minimal — the goal is a uniform entry point, not full docs in this PR.
Maintainers can expand each over time.

### `scanSharedDepVersions`
For a curated list of deps that must agree workspace-wide
(`react`, `react-dom`, `@tanstack/react-query`, `react-i18next`,
`react-hook-form`, `i18next`, `date-fns`, `zod`, `clsx`,
`tailwind-merge`), every package that declares the dep must use the same
version constraint. Drift here is the most common source of upgrade pain
because it produces two resolved versions and breaks shared singletons.

Two flavors:
- `shared-dep-version-drift` — different versions across packages
- `shared-dep-version-drift-within-package` — different versions across
  `dependencies` / `peerDependencies` / `devDependencies` inside a
  single package

### Fixes the one drift in granit-front
- `react-i18next`: `^17.0.0` was the workspace majority (8 packages).
  `@granit/react-localization` declared `^16.0.0`,
  `@granit/react-parties` declared `^16.0.0 || ^17.0.0`. Aligned both
  on `^17.0.0`.

## Why these two together
Both are zero-runtime-cost, both produce uniform onboarding/upgrade
behavior across the framework, and both have a clean fix path
(backfill / re-align). They naturally pair as a single 'uniformity'
sweep before the suite expands further.

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm tsc` clean
- [x] `pnpm vitest run packages/@granit/arch-tests/src` — 8 test files, 1825 assertions green (vs 1809 before — two new top-level assertions + the 46 READMEs flip from violation to pass).
- [x] `npx markdownlint-cli2` clean on the generated stubs.
- [ ] CI green on PR