### PR TITLE
feat(react-workflow): lifecycle transition prompt metadata + i18n

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -5455,6 +5455,11 @@
           "name": "useWorkflowHistory",
           "kind": "function",
           "signature": "function useWorkflowHistory("
+        },
+        {
+          "name": "buildLifecycleTransitionPrompt",
+          "kind": "function",
+          "signature": "function buildLifecycleTransitionPrompt( fromStatus: WorkflowLifecycleStatusValue, toStatus: WorkflowLifecycleStatusValue ): LifecycleTransitionPrompt"
         }
       ]
     },

--- a/packages/@granit/react-workflow/src/index.ts
+++ b/packages/@granit/react-workflow/src/index.ts
@@ -29,3 +29,12 @@ export type {
   UseWorkflowHistoryOptions,
   UseWorkflowHistoryReturn,
 } from './hooks/use-workflow-history.js';
+
+// Lifecycle transition prompt metadata + i18n bundles
+export { buildLifecycleTransitionPrompt } from './transitions/lifecycle-transition-prompt.js';
+export type {
+  LifecycleTransitionPrompt,
+  LifecycleTransitionSeverity,
+} from './transitions/lifecycle-transition-prompt.js';
+export { workflowTranslationsEn, workflowTranslationsFr } from './locales/index.js';
+export type { WorkflowTranslations } from './locales/index.js';

--- a/packages/@granit/react-workflow/src/locales/en.ts
+++ b/packages/@granit/react-workflow/src/locales/en.ts
@@ -1,0 +1,73 @@
+// ---------------------------------------------------------------------------
+// @granit/react-workflow — English i18n bundle (namespace: "workflow")
+// ---------------------------------------------------------------------------
+//
+// Register at app bootstrap:
+//   import { workflowTranslationsEn } from '@granit/react-workflow';
+//   i18n.addResourceBundle('en', 'workflow', workflowTranslationsEn);
+//
+// Apps can override any key in their own bundle (i18next merges deeply)
+// to customize wording per domain — e.g. "Publish product" instead of
+// the generic "Publish".
+
+/** Strings for a single lifecycle transition prompt. */
+export interface WorkflowTransitionStrings {
+  readonly Title: string;
+  readonly Description: string;
+  readonly Confirm: string;
+}
+
+/** Shape of the resource bundle registered under the `workflow` namespace. */
+export interface WorkflowTranslations {
+  readonly Transition: {
+    readonly DraftToPublished: WorkflowTransitionStrings;
+    readonly DraftToPendingReview: WorkflowTransitionStrings;
+    readonly PendingReviewToPublished: WorkflowTransitionStrings;
+    readonly PendingReviewToDraft: WorkflowTransitionStrings;
+    readonly PublishedToArchived: WorkflowTransitionStrings;
+    readonly ArchivedToPublished: WorkflowTransitionStrings;
+    readonly UnknownToUnknown: WorkflowTransitionStrings;
+  };
+}
+
+export const workflowTranslationsEn: WorkflowTranslations = {
+  Transition: {
+    DraftToPublished: {
+      Title: 'Publish this item?',
+      Description:
+        'Publishing makes the item available to other modules (Subscriptions, Metering, …). You can archive it later, but you cannot return it to Draft once published.',
+      Confirm: 'Publish',
+    },
+    DraftToPendingReview: {
+      Title: 'Submit for review?',
+      Description: 'The item moves to "Pending review" and waits for an approver.',
+      Confirm: 'Submit',
+    },
+    PendingReviewToPublished: {
+      Title: 'Approve and publish?',
+      Description: 'Approves the item and publishes it. This cannot be reverted to Draft.',
+      Confirm: 'Approve & publish',
+    },
+    PendingReviewToDraft: {
+      Title: 'Send back to Draft?',
+      Description: 'Returns the item to Draft for further edits before another review.',
+      Confirm: 'Send back',
+    },
+    PublishedToArchived: {
+      Title: 'Archive this item?',
+      Description:
+        'Archiving removes the item from active use. Downstream references (subscriptions, line items, …) keep working, but the item can no longer be selected for new operations. This action is final — you will not be able to restore it.',
+      Confirm: 'Archive',
+    },
+    ArchivedToPublished: {
+      Title: 'Restore this item?',
+      Description: 'Restores the item to Published status so it can be selected again.',
+      Confirm: 'Restore',
+    },
+    UnknownToUnknown: {
+      Title: 'Confirm this transition?',
+      Description: 'Apply this lifecycle change?',
+      Confirm: 'Confirm',
+    },
+  },
+};

--- a/packages/@granit/react-workflow/src/locales/fr.ts
+++ b/packages/@granit/react-workflow/src/locales/fr.ts
@@ -1,0 +1,50 @@
+import type { WorkflowTranslations } from './en.js';
+
+/**
+ * French translation bundle for `@granit/react-workflow`. Register via:
+ *
+ *   i18n.addResourceBundle('fr', 'workflow', workflowTranslationsFr);
+ */
+export const workflowTranslationsFr: WorkflowTranslations = {
+  Transition: {
+    DraftToPublished: {
+      Title: 'Publier cet élément ?',
+      Description:
+        "La publication rend l'élément disponible pour les autres modules (Abonnements, Mesure, …). Vous pourrez l'archiver ensuite, mais pas revenir au statut Brouillon une fois publié.",
+      Confirm: 'Publier',
+    },
+    DraftToPendingReview: {
+      Title: 'Soumettre pour relecture ?',
+      Description: 'L\'élément passe en "En relecture" et attend un approbateur.',
+      Confirm: 'Soumettre',
+    },
+    PendingReviewToPublished: {
+      Title: 'Approuver et publier ?',
+      Description:
+        "Approuve l'élément et le publie. Cette action ne peut pas être annulée vers le statut Brouillon.",
+      Confirm: 'Approuver et publier',
+    },
+    PendingReviewToDraft: {
+      Title: 'Renvoyer en Brouillon ?',
+      Description: "Renvoie l'élément en Brouillon pour modification avant une nouvelle relecture.",
+      Confirm: 'Renvoyer',
+    },
+    PublishedToArchived: {
+      Title: 'Archiver cet élément ?',
+      Description:
+        "L'archivage retire l'élément de l'usage actif. Les références en aval (abonnements, lignes de facture, …) continuent de fonctionner, mais l'élément ne pourra plus être sélectionné pour de nouvelles opérations. Cette action est définitive — vous ne pourrez pas le restaurer.",
+      Confirm: 'Archiver',
+    },
+    ArchivedToPublished: {
+      Title: 'Restaurer cet élément ?',
+      Description:
+        "Restaure l'élément en statut Publié pour qu'il puisse être à nouveau sélectionné.",
+      Confirm: 'Restaurer',
+    },
+    UnknownToUnknown: {
+      Title: 'Confirmer cette transition ?',
+      Description: 'Appliquer ce changement de cycle de vie ?',
+      Confirm: 'Confirmer',
+    },
+  },
+};

--- a/packages/@granit/react-workflow/src/locales/index.ts
+++ b/packages/@granit/react-workflow/src/locales/index.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// @granit/react-workflow — i18next resource bundles (namespace: "workflow")
+// ---------------------------------------------------------------------------
+//
+// Consumers register the bundles with their i18n instance:
+//
+//   import { workflowTranslationsEn, workflowTranslationsFr } from '@granit/react-workflow';
+//   i18n.addResourceBundle('en', 'workflow', workflowTranslationsEn);
+//   i18n.addResourceBundle('fr', 'workflow', workflowTranslationsFr);
+//
+// `buildLifecycleTransitionPrompt` returns translation keys namespaced
+// under `workflow:Transition.{From}To{To}.*` that resolve once the
+// bundle is registered.
+
+export { workflowTranslationsEn } from './en.js';
+export type { WorkflowTransitionStrings, WorkflowTranslations } from './en.js';
+export { workflowTranslationsFr } from './fr.js';

--- a/packages/@granit/react-workflow/src/transitions/__tests__/lifecycle-transition-prompt.test.ts
+++ b/packages/@granit/react-workflow/src/transitions/__tests__/lifecycle-transition-prompt.test.ts
@@ -1,0 +1,54 @@
+import { WorkflowLifecycleStatus } from '@granit/workflow';
+import { describe, expect, it } from 'vitest';
+
+import { buildLifecycleTransitionPrompt } from '../lifecycle-transition-prompt.js';
+
+describe('buildLifecycleTransitionPrompt', () => {
+  it('marks Published → Archived as destructive and requiring strong confirm', () => {
+    const prompt = buildLifecycleTransitionPrompt(
+      WorkflowLifecycleStatus.Published,
+      WorkflowLifecycleStatus.Archived
+    );
+
+    expect(prompt.severity).toBe('destructive');
+    expect(prompt.requiresStrongConfirm).toBe(true);
+    expect(prompt.titleKey).toBe('workflow:Transition.PublishedToArchived.Title');
+    expect(prompt.descriptionKey).toBe('workflow:Transition.PublishedToArchived.Description');
+    expect(prompt.confirmLabelKey).toBe('workflow:Transition.PublishedToArchived.Confirm');
+  });
+
+  it('marks Draft → Published as info, no strong confirm', () => {
+    const prompt = buildLifecycleTransitionPrompt(
+      WorkflowLifecycleStatus.Draft,
+      WorkflowLifecycleStatus.Published
+    );
+
+    expect(prompt.severity).toBe('info');
+    expect(prompt.requiresStrongConfirm).toBe(false);
+    expect(prompt.titleKey).toBe('workflow:Transition.DraftToPublished.Title');
+  });
+
+  it('marks transitions into PendingReview as warning', () => {
+    const prompt = buildLifecycleTransitionPrompt(
+      WorkflowLifecycleStatus.Draft,
+      WorkflowLifecycleStatus.PendingReview
+    );
+
+    expect(prompt.severity).toBe('warning');
+    expect(prompt.requiresStrongConfirm).toBe(false);
+    expect(prompt.titleKey).toBe('workflow:Transition.DraftToPendingReview.Title');
+  });
+
+  it('returns a non-throwing generic prompt for unknown pairs', () => {
+    const prompt = buildLifecycleTransitionPrompt(
+      // Unknown status value — guard against future enum additions on the
+      // backend the front doesn't recognize yet.
+      99 as unknown as typeof WorkflowLifecycleStatus.Draft,
+      99 as unknown as typeof WorkflowLifecycleStatus.Published
+    );
+
+    expect(prompt.severity).toBe('info');
+    expect(prompt.requiresStrongConfirm).toBe(false);
+    expect(prompt.titleKey).toBe('workflow:Transition.UnknownToUnknown.Title');
+  });
+});

--- a/packages/@granit/react-workflow/src/transitions/lifecycle-transition-prompt.ts
+++ b/packages/@granit/react-workflow/src/transitions/lifecycle-transition-prompt.ts
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------
+// Lifecycle transition prompts — confirmation metadata for workflow transitions
+// ---------------------------------------------------------------------------
+//
+// Centralizes the severity / wording / strong-confirm decision for the
+// common WorkflowLifecycleStatus transitions (Draft → Published, Published →
+// Archived, …). Consumer apps build their own AlertDialog around the
+// metadata returned here, keeping `@granit/react-workflow` free of any
+// concrete UI-library dependency.
+//
+// Translation keys point into the `workflow` i18n namespace (see
+// `./locales/en.ts`) — apps register the bundle once at bootstrap and let
+// `useTranslation` resolve the strings.
+
+import { WorkflowLifecycleStatus } from '@granit/workflow';
+
+import type { WorkflowLifecycleStatusValue } from '@granit/workflow';
+
+/** Severity classification — drives Alert / Button variants in consumer UIs. */
+export type LifecycleTransitionSeverity = 'info' | 'warning' | 'destructive';
+
+/**
+ * Metadata describing how a {@link WorkflowLifecycleStatusValue} transition
+ * should be confirmed in the UI — title / description i18n keys, severity,
+ * and whether the consumer should require strong confirmation (typically
+ * a "type the entity name to confirm" step for destructive actions).
+ */
+export interface LifecycleTransitionPrompt {
+  /** Translation key for the dialog title. Pass to `t()` in the consumer. */
+  readonly titleKey: string;
+  /** Translation key for the dialog description / body. */
+  readonly descriptionKey: string;
+  /** Translation key for the confirm button label. */
+  readonly confirmLabelKey: string;
+  /** Severity hint for Alert / Button variants. */
+  readonly severity: LifecycleTransitionSeverity;
+  /**
+   * Whether the consumer should require strong confirmation (e.g. typing
+   * the entity name) before invoking the mutation. `true` only for
+   * destructive transitions today (Published → Archived).
+   */
+  readonly requiresStrongConfirm: boolean;
+}
+
+const STATUS_NAME: Record<WorkflowLifecycleStatusValue, string> = {
+  [WorkflowLifecycleStatus.Draft]: 'Draft',
+  [WorkflowLifecycleStatus.PendingReview]: 'PendingReview',
+  [WorkflowLifecycleStatus.Published]: 'Published',
+  [WorkflowLifecycleStatus.Archived]: 'Archived',
+};
+
+/**
+ * Returns the {@link LifecycleTransitionPrompt} metadata for a
+ * `(fromStatus → toStatus)` pair. The translation keys are namespaced under
+ * `workflow:Transition.{From}To{To}.*` so consumers may override individual
+ * strings per domain by re-registering the namespace.
+ *
+ * The function always returns metadata — unknown / unusual pairs fall back
+ * to a generic "Confirm transition" prompt rather than throwing, so a
+ * consumer that ships a new workflow doesn't crash at runtime.
+ */
+export function buildLifecycleTransitionPrompt(
+  fromStatus: WorkflowLifecycleStatusValue,
+  toStatus: WorkflowLifecycleStatusValue
+): LifecycleTransitionPrompt {
+  const transitionKey = `${STATUS_NAME[fromStatus] ?? 'Unknown'}To${STATUS_NAME[toStatus] ?? 'Unknown'}`;
+  const namespaced = (suffix: string) => `workflow:Transition.${transitionKey}.${suffix}`;
+
+  const destructive = toStatus === WorkflowLifecycleStatus.Archived;
+  const severity: LifecycleTransitionSeverity = destructive
+    ? 'destructive'
+    : toStatus === WorkflowLifecycleStatus.PendingReview
+      ? 'warning'
+      : 'info';
+
+  return {
+    titleKey: namespaced('Title'),
+    descriptionKey: namespaced('Description'),
+    confirmLabelKey: namespaced('Confirm'),
+    severity,
+    requiresStrongConfirm: destructive,
+  };
+}


### PR DESCRIPTION
## Summary

Adds `buildLifecycleTransitionPrompt(from, to)` to `@granit/react-workflow` so any module with a `WorkflowLifecycleStatus`-driven entity (Catalog, Invoicing, Parties, Documents, …) gets a uniform confirmation-dialog story without duplicating wording or severity logic.

### What the utility returns

\`\`\`ts
const prompt = buildLifecycleTransitionPrompt(
  WorkflowLifecycleStatus.Published,
  WorkflowLifecycleStatus.Archived
);
// {
//   titleKey: 'workflow:Transition.PublishedToArchived.Title',
//   descriptionKey: 'workflow:Transition.PublishedToArchived.Description',
//   confirmLabelKey: 'workflow:Transition.PublishedToArchived.Confirm',
//   severity: 'destructive',
//   requiresStrongConfirm: true,
// }
\`\`\`

Consumers pass the keys through their own `useTranslation` and `severity` through their AlertDialog / Button variants — the framework stays UI-library-agnostic (same convention as `@granit/react-parties`' `MergeWizard`).

### Transitions covered

| From → To | Severity | Strong confirm |
|---|---|---|
| Draft → Published | info | no |
| Draft → PendingReview | warning | no |
| PendingReview → Published | info | no |
| PendingReview → Draft | info | no |
| **Published → Archived** | **destructive** | **yes** |
| Archived → Published | info | no |
| Unknown → Unknown (fallback) | info | no |

### i18n

Ships English + French resource bundles under the `workflow` namespace (`workflowTranslationsEn`, `workflowTranslationsFr`). Apps register once at bootstrap:

\`\`\`ts
i18n.addResourceBundle('en', 'workflow', workflowTranslationsEn);
\`\`\`

Apps can override individual keys for domain-specific wording (e.g. "Publish product" instead of the generic "Publish this item?").

## Test plan

- [x] \`pnpm tsc\` clean
- [x] \`pnpm lint\` clean
- [x] \`pnpm vitest run\` — 28/28 workflow tests pass (4 new for the utility)
- [ ] Showcase MR consuming this surface (catalog \`LifecycleActions\` confirmation): follows in a separate MR.