### PR TITLE
feat(react-localization): bridge useTranslation for nested namespaces

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4005,6 +4005,11 @@
           "name": "useTimezone",
           "kind": "function",
           "signature": "function useTimezone(): string"
+        },
+        {
+          "name": "useTranslation",
+          "kind": "function",
+          "signature": "function useTranslation< Ns extends FlatNamespace | readonly [FlatNamespace?, ...FlatNamespace[]] = 'translation', KPrefix extends KeyPrefix<FallbackNs<Ns>> = undefined, >( ns?: Ns, options?: UseTranslationOptions<KPrefix> ): UseTranslationResponse<FallbackNs<Ns>, KPrefix>"
         }
       ]
     },

--- a/packages/@granit/react-localization/src/__tests__/use-translation.test.tsx
+++ b/packages/@granit/react-localization/src/__tests__/use-translation.test.tsx
@@ -1,0 +1,123 @@
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { I18nextProvider } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { createReactLocalization } from '../create-react-localization.js';
+import { useTranslation } from '../use-translation.js';
+
+import type { i18n } from 'i18next';
+
+function createWrapper(i18nInstance: i18n) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return React.createElement(I18nextProvider, { i18n: i18nInstance }, children);
+  };
+}
+
+describe('useTranslation', () => {
+  describe('with global separators enabled (default)', () => {
+    it('resolves nested keys via the default namespace', async () => {
+      const i18n = createReactLocalization();
+      i18n.addResourceBundle('en', 'translation', {
+        Group: { Greeting: 'Hello' },
+      });
+      await i18n.changeLanguage('en');
+
+      const { result } = renderHook(() => useTranslation(), {
+        wrapper: createWrapper(i18n),
+      });
+
+      expect(result.current.t('Group.Greeting')).toBe('Hello');
+    });
+
+    it('resolves nested keys in a custom namespace', async () => {
+      const i18n = createReactLocalization();
+      i18n.addResourceBundle('en', 'workflow', {
+        Transition: { DraftToPublished: { Title: 'Publish?' } },
+      });
+      await i18n.changeLanguage('en');
+
+      const { result } = renderHook(() => useTranslation('workflow'), {
+        wrapper: createWrapper(i18n),
+      });
+
+      expect(result.current.t('Transition.DraftToPublished.Title')).toBe('Publish?');
+    });
+  });
+
+  describe('with global separators disabled (flat backend bundles)', () => {
+    it('keeps flat keys working in the default namespace', async () => {
+      const i18n = createReactLocalization();
+      i18n.options.nsSeparator = false;
+      i18n.options.keySeparator = false;
+      i18n.addResourceBundle('en', 'translation', {
+        'Dashboard:X.Description': 'flat literal key',
+      });
+      await i18n.changeLanguage('en');
+
+      const { result } = renderHook(() => useTranslation(), {
+        wrapper: createWrapper(i18n),
+      });
+
+      expect(result.current.t('Dashboard:X.Description')).toBe('flat literal key');
+    });
+
+    it('resolves nested keys in a custom namespace despite global flat config', async () => {
+      const i18n = createReactLocalization();
+      i18n.options.nsSeparator = false;
+      i18n.options.keySeparator = false;
+      i18n.addResourceBundle('en', 'workflow', {
+        Transition: {
+          DraftToPublished: {
+            Title: 'Publish this item?',
+            Description: 'Publishing makes the item available.',
+            Confirm: 'Publish',
+          },
+        },
+      });
+      await i18n.changeLanguage('en');
+
+      const { result } = renderHook(() => useTranslation('workflow'), {
+        wrapper: createWrapper(i18n),
+      });
+
+      expect(result.current.t('Transition.DraftToPublished.Title')).toBe('Publish this item?');
+      expect(result.current.t('Transition.DraftToPublished.Confirm')).toBe('Publish');
+    });
+
+    it('accepts namespaced keys (`ns:key`) in a custom namespace', async () => {
+      const i18n = createReactLocalization();
+      i18n.options.nsSeparator = false;
+      i18n.options.keySeparator = false;
+      i18n.addResourceBundle('en', 'workflow', {
+        Transition: { DraftToPublished: { Title: 'Publish this item?' } },
+      });
+      await i18n.changeLanguage('en');
+
+      const { result } = renderHook(() => useTranslation('workflow'), {
+        wrapper: createWrapper(i18n),
+      });
+
+      // buildLifecycleTransitionPrompt returns keys prefixed with `workflow:`.
+      expect(result.current.t('workflow:Transition.DraftToPublished.Title')).toBe(
+        'Publish this item?'
+      );
+    });
+
+    it('does not override the default namespace even when explicit', async () => {
+      const i18n = createReactLocalization();
+      i18n.options.nsSeparator = false;
+      i18n.options.keySeparator = false;
+      i18n.addResourceBundle('en', 'translation', {
+        'Dashboard:X.Description': 'flat literal',
+      });
+      await i18n.changeLanguage('en');
+
+      const { result } = renderHook(() => useTranslation('translation'), {
+        wrapper: createWrapper(i18n),
+      });
+
+      expect(result.current.t('Dashboard:X.Description')).toBe('flat literal');
+    });
+  });
+});

--- a/packages/@granit/react-localization/src/index.ts
+++ b/packages/@granit/react-localization/src/index.ts
@@ -28,4 +28,8 @@ export { useDateFormatter } from './use-date-formatter.js';
 export { TimezoneProvider, useTimezone } from './use-timezone.js';
 
 // Re-export from react-i18next so apps import everything from @granit/react-localization.
-export { I18nextProvider, Trans, useTranslation } from 'react-i18next';
+export { I18nextProvider, Trans } from 'react-i18next';
+
+// Custom useTranslation wrapper that auto-applies standard separators for
+// custom namespaces when the app disables them globally. See use-translation.ts.
+export { useTranslation } from './use-translation.js';

--- a/packages/@granit/react-localization/src/use-translation.ts
+++ b/packages/@granit/react-localization/src/use-translation.ts
@@ -1,0 +1,79 @@
+import {
+  type UseTranslationOptions,
+  type UseTranslationResponse,
+  useTranslation as useReactI18NextTranslation,
+} from 'react-i18next';
+
+import type { FlatNamespace, KeyPrefix, Namespace } from 'i18next';
+import type { FallbackNs } from 'react-i18next';
+
+/**
+ * Re-exports `react-i18next`'s `useTranslation` with one bridge:
+ * when the consumer passes an explicit non-default namespace, the
+ * returned `t` function applies the standard separators (`:` for
+ * namespace, `.` for nested keys) per call.
+ *
+ * Why: Granit framework packages (e.g. `@granit/react-workflow`,
+ * `@granit/react-parties`) ship NESTED resource bundles meant to be
+ * traversed via the `.` key separator. Consumer apps that also load
+ * flat backend-shipped bundles (Granit Localization API, with literal
+ * `:` and `.` characters inside keys like `Dashboard:X.Description`)
+ * typically disable both separators globally via
+ * `i18n.options.nsSeparator = false` and `i18n.options.keySeparator = false`.
+ *
+ * With separators disabled globally, framework lookups against nested
+ * bundles fail — the key string is returned verbatim because i18next
+ * cannot find a literal flat key matching the nested path. This hook
+ * detects the situation (custom ns + global separators disabled) and
+ * passes `keySeparator: '.'` / `nsSeparator: ':'` overrides at call
+ * time, so the framework bundle resolves correctly without forcing the
+ * app to re-enable separators globally.
+ *
+ * Default-namespace calls (`useTranslation()`) keep the app's global
+ * configuration untouched — backend flat bundles continue to resolve
+ * against literal keys.
+ */
+export function useTranslation<
+  Ns extends FlatNamespace | readonly [FlatNamespace?, ...FlatNamespace[]] = 'translation',
+  KPrefix extends KeyPrefix<FallbackNs<Ns>> = undefined,
+>(
+  ns?: Ns,
+  options?: UseTranslationOptions<KPrefix>
+): UseTranslationResponse<FallbackNs<Ns>, KPrefix> {
+  const result = useReactI18NextTranslation(ns as Namespace, options);
+  const { t, i18n } = result;
+
+  const defaultNs = i18n.options?.defaultNS;
+  const usesCustomNs =
+    ns !== undefined &&
+    (Array.isArray(ns)
+      ? !ns.every((entry) => entry === undefined || entry === defaultNs)
+      : ns !== defaultNs);
+
+  const separatorsDisabled =
+    i18n.options?.nsSeparator === false || i18n.options?.keySeparator === false;
+
+  if (!usesCustomNs || !separatorsDisabled) {
+    return result;
+  }
+
+  // i18next's `t` has many overloads (key+options, key+defaultValue+options, …).
+  // Forward all args verbatim and inject the separator overrides into the
+  // options object on whichever position holds it. The `t` function carries
+  // a unique brand (`$TFunctionBrand`) that direct casts can't reproduce, so
+  // we route through `unknown` both for the underlying call and the result.
+  const separators = { keySeparator: '.' as const, nsSeparator: ':' as const };
+  const rawT = t as unknown as (...a: unknown[]) => unknown;
+  const wrappedT = function wrappedT(...args: unknown[]) {
+    const lastIndex = args.length - 1;
+    const last = args[lastIndex];
+    if (typeof last === 'object' && last !== null) {
+      args[lastIndex] = { ...separators, ...last };
+    } else {
+      args.push(separators);
+    }
+    return rawT(...args);
+  } as unknown as typeof t;
+
+  return { ...result, t: wrappedT };
+}


### PR DESCRIPTION
## Summary

- Wraps `react-i18next`'s `useTranslation` with separator-bridging logic in `@granit/react-localization`
- When a consumer app disables `nsSeparator` / `keySeparator` globally (typical when loading flat backend-shipped bundles like \`Dashboard:X.Description\`) and a non-default namespace is requested, the wrapper applies per-call overrides (\`:\` for ns, \`.\` for nested keys) so framework bundles still resolve
- Default-namespace calls untouched; apps that keep separators enabled untouched

## Why

Framework packages (`@granit/react-workflow`, `@granit/react-parties`, `@granit/react-documents`, `@granit/react-entities-customization`, `@granit/react-taxonomy`, `@granit/react-timeline`, `@granit/react-activities`, `@granit/react-entities`) ship NESTED resource bundles:

```ts
workflowTranslationsEn = {
  Transition: {
    DraftToPublished: { Title: 'Publish this item?', ... }
  }
}
```

Helpers like `buildLifecycleTransitionPrompt` (PR #473) return namespaced keys (`workflow:Transition.DraftToPublished.Title`) that consumer apps feed back to `t()`.

But the showcase admin app — and any app following the same pattern — disables both separators in i18next to support flat backend keys like `Dashboard:Granit.Showcase.InvoicingOverview` (where `:` and `.` are LITERAL parts of the key). With separators disabled, the framework's nested bundles cannot resolve: `t('workflow:Transition.DraftToPublished.Title')` returns the key string verbatim because i18next looks for a flat literal match.

Before this PR, consumers had to either:
- Manually pass `{ keySeparator: '.', nsSeparator: ':' }` on every `t()` call against a framework namespace, OR
- Pre-flatten the bundles before `addResourceBundle`, OR
- Live with a broken UI showing raw keys (silent bug — see the latent `MergeWizard` issue in `@granit/react-parties` consumed by the showcase parties feature).

## How

`useTranslation(ns, opts)` from `@granit/react-localization` now:

1. Delegates to `react-i18next`'s `useTranslation(ns, opts)` for hook semantics (locale state, namespace binding, suspense).
2. Inspects the i18next instance config + the requested namespace.
3. If `ns` is explicitly passed AND differs from the default namespace AND the instance has either separator disabled → wraps `t` to inject `{ keySeparator: '.', nsSeparator: ':' }` into the options of every call.
4. Otherwise returns the underlying hook result untouched.

The wrapper preserves call-site type inference (response type is still `UseTranslationResponse<…>`).

## Test plan

- [x] 6 new unit tests in [packages/@granit/react-localization/src/__tests__/use-translation.test.tsx](packages/@granit/react-localization/src/__tests__/use-translation.test.tsx) covering:
  - Default-namespace + nested keys (separators enabled) → resolves
  - Custom-namespace + nested keys (separators enabled) → resolves
  - Default-namespace + flat keys (separators disabled) → resolves literally
  - Custom-namespace + nested keys (separators disabled) → resolves via the bridge
  - Custom-namespace + namespaced key `ns:key` form → resolves via the bridge
  - Explicit `useTranslation('translation')` on disabled separators → keeps flat behavior
- [x] \`pnpm tsc --noEmit\` clean on the package
- [x] \`pnpm exec eslint\` clean (--max-warnings 0)
- [x] All 37 react-localization tests pass (31 existing + 6 new)