### PR TITLE
fix(timeline): accept Regional Indicator pairs and tag sequences in parseReactionEmoji

### DIFF
--- a/packages/@granit/timeline/src/__tests__/reaction.test.ts
+++ b/packages/@granit/timeline/src/__tests__/reaction.test.ts
@@ -17,6 +17,12 @@ describe('parseReactionEmoji', () => {
     ['keycap sequence', '1️⃣'],
     ['rocket', '🚀'],
     ['fire', '🔥'],
+    ['country flag — Belgium (RI pair)', '🇧🇪'],
+    ['country flag — France (RI pair)', '🇫🇷'],
+    ['country flag — United States (RI pair)', '🇺🇸'],
+    ['subdivision flag — England (tag sequence)', '🏴󠁧󠁢󠁥󠁮󠁧󠁿'],
+    ['subdivision flag — Scotland (tag sequence)', '🏴󠁧󠁢󠁳󠁣󠁴󠁿'],
+    ['subdivision flag — Wales (tag sequence)', '🏴󠁧󠁢󠁷󠁬󠁳󠁿'],
   ])('accepts a well-formed %s', (_label, value) => {
     expect(parseReactionEmoji(value)).toBe(value);
   });
@@ -27,6 +33,9 @@ describe('parseReactionEmoji', () => {
     ['plain digit (no keycap combiner)', '1'],
     ['short name fallback (legacy wire)', 'thumbs_up'],
     ['multiple emojis concatenated without ZWJ', '👍👎'],
+    ['single Regional Indicator without partner', '🇧'],
+    ['tag sequence missing cancel-tag terminator', '🏴󠁧󠁢󠁥󠁮󠁧'],
+    ['tag chars without a pictographic base', '󠁧󠁢󠁥󠁮󠁧󠁿'],
     ['contains a control char', ''],
   ])('rejects malformed input — %s', (_label, value) => {
     expect(parseReactionEmoji(value)).toBeNull();

--- a/packages/@granit/timeline/src/types/reaction.ts
+++ b/packages/@granit/timeline/src/types/reaction.ts
@@ -19,24 +19,35 @@
 export type ReactionEmoji = string & { readonly __reactionEmoji: unique symbol };
 
 /**
- * Matches one well-formed emoji sequence — two shapes:
+ * Matches one well-formed emoji sequence — four shapes:
  *
- * 1. Keycap: `[0-9#*]` + optional VS-16 + mandatory keycap combiner
- *    (`⃣`). `'1'` alone is not a valid emoji; `'1️⃣'` is.
- * 2. Pictographic: one `\p{Extended_Pictographic}` codepoint, optional
- *    VS-16, optional Fitzpatrick skin-tone modifier, optionally followed
- *    by ZWJ-joined `\p{Extended_Pictographic}` continuations (families,
- *    flag-of-…, professions).
+ * 1. Keycap: `[0-9#*]` + optional VS-16 + mandatory U+20E3 combiner.
+ *    `'1'` alone is not a valid emoji; `'1️⃣'` is.
+ * 2. Regional Indicator pair: two consecutive
+ *    `\p{Regional_Indicator}` codepoints (no ZWJ). Country flags like
+ *    `🇧🇪`, `🇫🇷`, `🇺🇸`. The pair is matched as a unit so a single
+ *    stray RI never validates.
+ * 3. Pictographic: one `\p{Extended_Pictographic}` codepoint, optional
+ *    VS-16, optional Fitzpatrick skin-tone modifier, optionally
+ *    chained via ZWJ (families, professions, flag-of-… ZWJ forms).
+ * 4. Tag sequence: the pictographic shape above, followed by one or
+ *    more tag chars (U+E0020–U+E007E) terminated by U+E007F. Used by
+ *    subdivision flags `🏴󠁧󠁢󠁥󠁮󠁧󠁿` (England), `🏴󠁧󠁢󠁳󠁣󠁴󠁿` (Scotland),
+ *    `🏴󠁧󠁢󠁷󠁬󠁳󠁿` (Wales).
  */
 const EMOJI_SEQUENCE = new RegExp(
   '^' +
     '(?:' +
-    // keycap: digit / # / * + optional VS-16 + mandatory combiner
+    // Keycap
     '[0-9#*]\\uFE0F?\\u20E3' +
     '|' +
-    // pictographic sequence
+    // Regional Indicator pair (flag)
+    '\\p{Regional_Indicator}\\p{Regional_Indicator}' +
+    '|' +
+    // Pictographic + optional tag sequence
     '\\p{Extended_Pictographic}\\uFE0F?[\\u{1F3FB}-\\u{1F3FF}]?' +
     '(?:\\u200D\\p{Extended_Pictographic}\\uFE0F?[\\u{1F3FB}-\\u{1F3FF}]?)*' +
+    '(?:[\\u{E0020}-\\u{E007E}]+\\u{E007F})?' +
     ')' +
     '$',
   'u'


### PR DESCRIPTION
## Summary

Follow-up to #475: the v2 catalog regex shipped there only matched keycap / pictographic / ZWJ chains. Country flags (🇧🇪 = RI pair) and subdivision flags (🏴󠁧󠁢󠁥󠁮󠁧󠁿 = tag sequence) silently fell through and `parseReactionEmoji` returned `null`, breaking emoji-mart picker integrations on the showcase side.

Add explicit alternations for both shapes:

- `\p{Regional_Indicator}\p{Regional_Indicator}` for flag pairs — kept as its own branch so a single stray RI cannot validate.
- `[\u{E0020}-\u{E007E}]+\u{E007F}` suffix on the pictographic branch for tag sequences, anchored by the cancel-tag so partial sequences are rejected.

Backend `EmojiValidator` already accepts RI pairs via its `0x1F000..0x1FAFF` range; tag-sequence support on the backend is tracked in a sibling fix in `granit-dotnet`.

## Test plan

- [x] `pnpm exec vitest run packages/@granit/timeline` — 35/35 passing (6 new accept cases — BE/FR/US flags + ENG/SCT/WLS subdivisions; 3 new reject cases — lone RI, tag sequence missing cancel-tag, tag chars without pictographic base)
- [x] `pnpm tsc` / `pnpm lint` — clean
- [x] `pnpm --filter @granit/timeline --filter @granit/react-timeline build` — clean