### PR TITLE
feat(invoicing): add invoice workflow transitions (finalize/cancel/mark-uncollectible)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3946,6 +3946,12 @@
           "kind": "interface",
           "signature": "interface InvoicingProviderProps",
           "members": []
+        },
+        {
+          "name": "InvoiceTransitionVariables",
+          "kind": "interface",
+          "signature": "interface InvoiceTransitionVariables<TRequest>",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
+++ b/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
@@ -2,13 +2,20 @@ import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  cancelInvoice,
   createInvoice,
   downloadInvoicePdf,
+  finalizeInvoice,
   getInvoiceById,
   listInvoices,
+  markInvoiceUncollectible,
 } from '../api/invoicing-api.js';
 
-import type { InvoiceCreateRequest, InvoiceResponse } from '../types/index.js';
+import type {
+  FinalizeInvoiceRequest,
+  InvoiceCreateRequest,
+  InvoiceResponse,
+} from '../types/index.js';
 
 const sampleLineItem = {
   id: 'li-1',
@@ -170,6 +177,87 @@ describe('invoicing-api', () => {
 
       expect(result.documentType).toBe('CreditNote');
       expect(result.parentInvoiceId).toBe('inv-1');
+    });
+  });
+
+  describe('finalizeInvoice', () => {
+    it('should POST {basePath}/invoices/{id}/finalize with body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+      const request: FinalizeInvoiceRequest = {
+        issuedAt: '2026-03-01T00:00:00Z',
+        dueAt: '2026-03-15T00:00:00Z',
+        comment: 'Issued by ops',
+      };
+
+      const result = await finalizeInvoice(client, '/invoicing', 'inv-1', request);
+
+      expect(client.post).toHaveBeenCalledWith('/invoicing/invoices/inv-1/finalize', request);
+      expect(result).toEqual(sampleInvoice);
+    });
+
+    it('should encode special characters in id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+      await finalizeInvoice(client, '/invoicing', 'inv/special&id', {
+        issuedAt: '2026-03-01T00:00:00Z',
+        dueAt: null,
+      });
+
+      expect(client.post).toHaveBeenCalledWith(
+        `/invoicing/invoices/${encodeURIComponent('inv/special&id')}/finalize`,
+        expect.objectContaining({ issuedAt: '2026-03-01T00:00:00Z', dueAt: null })
+      );
+    });
+  });
+
+  describe('cancelInvoice', () => {
+    it('should POST {basePath}/invoices/{id}/cancel with reason', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+      const result = await cancelInvoice(client, '/invoicing', 'inv-1', { reason: 'Duplicate' });
+
+      expect(client.post).toHaveBeenCalledWith('/invoicing/invoices/inv-1/cancel', {
+        reason: 'Duplicate',
+      });
+      expect(result).toEqual(sampleInvoice);
+    });
+
+    it('should POST with an empty body when no request is provided', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+      await cancelInvoice(client, '/invoicing', 'inv-1');
+
+      expect(client.post).toHaveBeenCalledWith('/invoicing/invoices/inv-1/cancel', {});
+    });
+  });
+
+  describe('markInvoiceUncollectible', () => {
+    it('should POST {basePath}/invoices/{id}/mark-uncollectible with reason', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+      const result = await markInvoiceUncollectible(client, '/invoicing', 'inv-1', {
+        reason: 'Bankruptcy',
+      });
+
+      expect(client.post).toHaveBeenCalledWith('/invoicing/invoices/inv-1/mark-uncollectible', {
+        reason: 'Bankruptcy',
+      });
+      expect(result).toEqual(sampleInvoice);
+    });
+
+    it('should POST with an empty body when no request is provided', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+      await markInvoiceUncollectible(client, '/invoicing', 'inv-1');
+
+      expect(client.post).toHaveBeenCalledWith('/invoicing/invoices/inv-1/mark-uncollectible', {});
     });
   });
 });

--- a/packages/@granit/invoicing/src/api/invoicing-api.ts
+++ b/packages/@granit/invoicing/src/api/invoicing-api.ts
@@ -1,4 +1,10 @@
-import type { InvoiceCreateRequest, InvoiceResponse } from '../types/index.js';
+import type {
+  CancelInvoiceRequest,
+  FinalizeInvoiceRequest,
+  InvoiceCreateRequest,
+  InvoiceResponse,
+  MarkInvoiceUncollectibleRequest,
+} from '../types/index.js';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
@@ -59,5 +65,62 @@ export async function createInvoice(
   request: InvoiceCreateRequest
 ): Promise<InvoiceResponse> {
   const response = await client.post<InvoiceResponse>(`${basePath}/invoices`, request);
+  return response.data;
+}
+
+/**
+ * Finalize a Draft invoice (Draft → Open).
+ *
+ * Delegates the transition to the backend `IWorkflowManager<InvoiceStatus>`;
+ * the next document number is generated server-side.
+ *
+ * `POST {basePath}/invoices/{id}/finalize`
+ */
+export async function finalizeInvoice(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: FinalizeInvoiceRequest
+): Promise<InvoiceResponse> {
+  const response = await client.post<InvoiceResponse>(
+    `${basePath}/invoices/${encodeURIComponent(id)}/finalize`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Cancel an invoice (Open / Uncollectible → Cancelled).
+ *
+ * `POST {basePath}/invoices/{id}/cancel`
+ */
+export async function cancelInvoice(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: CancelInvoiceRequest = {}
+): Promise<InvoiceResponse> {
+  const response = await client.post<InvoiceResponse>(
+    `${basePath}/invoices/${encodeURIComponent(id)}/cancel`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Mark an Open invoice as Uncollectible (bad debt).
+ *
+ * `POST {basePath}/invoices/{id}/mark-uncollectible`
+ */
+export async function markInvoiceUncollectible(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: MarkInvoiceUncollectibleRequest = {}
+): Promise<InvoiceResponse> {
+  const response = await client.post<InvoiceResponse>(
+    `${basePath}/invoices/${encodeURIComponent(id)}/mark-uncollectible`,
+    request
+  );
   return response.data;
 }

--- a/packages/@granit/invoicing/src/index.ts
+++ b/packages/@granit/invoicing/src/index.ts
@@ -1,12 +1,15 @@
 // Types
 export type {
   BillingReason,
+  CancelInvoiceRequest,
   CollectionMethod,
+  FinalizeInvoiceRequest,
   InvoiceCreateRequest,
   InvoiceDocumentType,
   InvoiceId,
   InvoiceLineItemResponse,
   InvoiceResponse,
+  MarkInvoiceUncollectibleRequest,
 } from './types/index.js';
 
 // Permissions
@@ -14,8 +17,11 @@ export { InvoicingPermissions } from './permissions.js';
 
 // API
 export {
+  cancelInvoice,
   createInvoice,
   downloadInvoicePdf,
+  finalizeInvoice,
   getInvoiceById,
   listInvoices,
+  markInvoiceUncollectible,
 } from './api/invoicing-api.js';

--- a/packages/@granit/invoicing/src/permissions.ts
+++ b/packages/@granit/invoicing/src/permissions.ts
@@ -5,6 +5,10 @@ export const InvoicingPermissions = {
     Create: 'Invoicing.Invoices.Create',
     Manage: 'Invoicing.Invoices.Manage',
     Download: 'Invoicing.Invoices.Download',
+    Finalize: 'Invoicing.Invoices.Finalize',
+    RecordPayment: 'Invoicing.Invoices.RecordPayment',
+    Cancel: 'Invoicing.Invoices.Cancel',
+    MarkUncollectible: 'Invoicing.Invoices.MarkUncollectible',
   },
   CreditNotes: {
     Read: 'Invoicing.CreditNotes.Read',

--- a/packages/@granit/invoicing/src/types/index.ts
+++ b/packages/@granit/invoicing/src/types/index.ts
@@ -18,6 +18,28 @@ export type BillingReason =
   | 'Manual'
   | 'Upcoming';
 
+/** Payload for finalizing a Draft invoice (Draft → Open). */
+export interface FinalizeInvoiceRequest {
+  /** Timestamp at which the document is issued (ISO 8601). */
+  readonly issuedAt: string;
+  /** Payment deadline — ignored for credit notes (ISO 8601). */
+  readonly dueAt: string | null;
+  /** Optional comment persisted on the workflow transition record (ISO 27001). */
+  readonly comment?: string | null;
+}
+
+/** Payload for cancelling an invoice (Open / Uncollectible → Cancelled). */
+export interface CancelInvoiceRequest {
+  /** Optional motive persisted on the workflow transition record (ISO 27001 audit trail). */
+  readonly reason?: string | null;
+}
+
+/** Payload for marking an Open invoice as Uncollectible (bad debt). */
+export interface MarkInvoiceUncollectibleRequest {
+  /** Optional motive persisted on the workflow transition record (ISO 27001 audit trail). */
+  readonly reason?: string | null;
+}
+
 /** Payload for creating a new invoice. */
 export interface InvoiceCreateRequest {
   readonly documentType: InvoiceDocumentType;

--- a/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
+++ b/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
@@ -6,15 +6,22 @@ import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  useCancelInvoice,
   useCreateInvoice,
   useDownloadInvoicePdf,
+  useFinalizeInvoice,
   useInvoice,
   useInvoices,
+  useMarkInvoiceUncollectible,
 } from '../hooks/use-invoicing.js';
 import { InvoicingProvider } from '../providers/invoicing-provider.js';
 
 import type { InvoicingConfig } from '../providers/invoicing-provider.js';
-import type { InvoiceCreateRequest, InvoiceResponse } from '@granit/invoicing';
+import type {
+  FinalizeInvoiceRequest,
+  InvoiceCreateRequest,
+  InvoiceResponse,
+} from '@granit/invoicing';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -226,5 +233,89 @@ describe('useCreateInvoice', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error?.message).toBe('Validation failed');
+  });
+});
+
+describe('useFinalizeInvoice', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('finalizes an invoice via POST', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+    const { result } = renderHook(() => useFinalizeInvoice(), {
+      wrapper: createWrapper(client),
+    });
+
+    const request: FinalizeInvoiceRequest = {
+      issuedAt: '2026-03-01T00:00:00Z',
+      dueAt: '2026-03-15T00:00:00Z',
+    };
+
+    result.current.mutate({ id: 'inv-1', request });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.post).toHaveBeenCalledWith('/api/v1/invoicing/invoices/inv-1/finalize', request);
+  });
+});
+
+describe('useCancelInvoice', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('cancels an invoice via POST with a reason', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+    const { result } = renderHook(() => useCancelInvoice(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ id: 'inv-1', request: { reason: 'Duplicate' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.post).toHaveBeenCalledWith('/api/v1/invoicing/invoices/inv-1/cancel', {
+      reason: 'Duplicate',
+    });
+  });
+
+  it('cancels an invoice via POST without a body', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+    const { result } = renderHook(() => useCancelInvoice(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ id: 'inv-1' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.post).toHaveBeenCalledWith('/api/v1/invoicing/invoices/inv-1/cancel', {});
+  });
+});
+
+describe('useMarkInvoiceUncollectible', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('marks an invoice as uncollectible via POST', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
+
+    const { result } = renderHook(() => useMarkInvoiceUncollectible(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ id: 'inv-1', request: { reason: 'Bankruptcy' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/invoicing/invoices/inv-1/mark-uncollectible',
+      { reason: 'Bankruptcy' }
+    );
   });
 });

--- a/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
+++ b/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
@@ -1,9 +1,23 @@
-import { createInvoice, downloadInvoicePdf, getInvoiceById, listInvoices } from '@granit/invoicing';
+import {
+  cancelInvoice,
+  createInvoice,
+  downloadInvoicePdf,
+  finalizeInvoice,
+  getInvoiceById,
+  listInvoices,
+  markInvoiceUncollectible,
+} from '@granit/invoicing';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { buildInvoicingQueryKey, useInvoicingConfig } from '../providers/invoicing-provider.js';
 
-import type { InvoiceCreateRequest, InvoiceResponse } from '@granit/invoicing';
+import type {
+  CancelInvoiceRequest,
+  FinalizeInvoiceRequest,
+  InvoiceCreateRequest,
+  InvoiceResponse,
+  MarkInvoiceUncollectibleRequest,
+} from '@granit/invoicing';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -86,6 +100,99 @@ export function useCreateInvoice(): UseMutationResult<
 
   return useMutation({
     mutationFn: (request: InvoiceCreateRequest) => createInvoice(config.client, basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildInvoicingQueryKey(config, 'invoices'),
+      });
+    },
+  });
+}
+
+/** Variables for the semantic transition mutations: invoice id + optional request body. */
+export interface InvoiceTransitionVariables<TRequest> {
+  readonly id: string;
+  readonly request?: TRequest;
+}
+
+/**
+ * Finalize a Draft invoice (Draft → Open).
+ * Invalidates invoice queries on success.
+ *
+ * @example
+ * ```tsx
+ * const finalize = useFinalizeInvoice();
+ * await finalize.mutateAsync({ id: 'inv-1', request: { issuedAt, dueAt } });
+ * ```
+ */
+export function useFinalizeInvoice(): UseMutationResult<
+  InvoiceResponse,
+  Error,
+  { readonly id: string; readonly request: FinalizeInvoiceRequest }
+> {
+  const config = useInvoicingConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }) => finalizeInvoice(config.client, basePath, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildInvoicingQueryKey(config, 'invoices'),
+      });
+    },
+  });
+}
+
+/**
+ * Cancel an invoice (Open / Uncollectible → Cancelled).
+ * Invalidates invoice queries on success.
+ *
+ * @example
+ * ```tsx
+ * const cancel = useCancelInvoice();
+ * await cancel.mutateAsync({ id: 'inv-1', request: { reason: 'Duplicate' } });
+ * ```
+ */
+export function useCancelInvoice(): UseMutationResult<
+  InvoiceResponse,
+  Error,
+  InvoiceTransitionVariables<CancelInvoiceRequest>
+> {
+  const config = useInvoicingConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }) => cancelInvoice(config.client, basePath, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildInvoicingQueryKey(config, 'invoices'),
+      });
+    },
+  });
+}
+
+/**
+ * Mark an Open invoice as Uncollectible (bad debt).
+ * Invalidates invoice queries on success.
+ *
+ * @example
+ * ```tsx
+ * const markUncollectible = useMarkInvoiceUncollectible();
+ * await markUncollectible.mutateAsync({ id: 'inv-1', request: { reason: 'Bankruptcy' } });
+ * ```
+ */
+export function useMarkInvoiceUncollectible(): UseMutationResult<
+  InvoiceResponse,
+  Error,
+  InvoiceTransitionVariables<MarkInvoiceUncollectibleRequest>
+> {
+  const config = useInvoicingConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: ({ id, request }) => markInvoiceUncollectible(config.client, basePath, id, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildInvoicingQueryKey(config, 'invoices'),

--- a/packages/@granit/react-invoicing/src/index.ts
+++ b/packages/@granit/react-invoicing/src/index.ts
@@ -8,8 +8,12 @@ export type { InvoicingConfig, InvoicingProviderProps } from './providers/invoic
 
 // Hooks
 export {
+  useCancelInvoice,
   useCreateInvoice,
   useDownloadInvoicePdf,
+  useFinalizeInvoice,
   useInvoice,
   useInvoices,
+  useMarkInvoiceUncollectible,
 } from './hooks/use-invoicing.js';
+export type { InvoiceTransitionVariables } from './hooks/use-invoicing.js';

--- a/packages/@granit/react-invoicing/src/testing/data.ts
+++ b/packages/@granit/react-invoicing/src/testing/data.ts
@@ -106,7 +106,7 @@ export const sampleInvoices: Mutable<InvoiceResponse>[] = [
   {
     id: toEntityId<'Invoice'>('inv_004'),
     invoiceNumber: 'CN-2026-0001',
-    status: 'Void',
+    status: 'Cancelled',
     documentType: 'CreditNote',
     currency: 'EUR',
     subtotal: -2000,

--- a/packages/@granit/react-invoicing/src/testing/handlers.ts
+++ b/packages/@granit/react-invoicing/src/testing/handlers.ts
@@ -13,11 +13,17 @@ import { DEFAULT_BASE_PATH } from '../constants.js';
 
 import { sampleInvoices } from './data.js';
 
-import type { InvoiceCreateRequest } from '@granit/invoicing';
+import type {
+  CancelInvoiceRequest,
+  FinalizeInvoiceRequest,
+  InvoiceCreateRequest,
+  InvoiceResponse,
+  MarkInvoiceUncollectibleRequest,
+} from '@granit/invoicing';
 import type { QueryMetadata } from '@granit/query-engine';
 
 const INVOICE_DOCUMENT_TYPES = ['Invoice', 'CreditNote'];
-const INVOICE_STATUSES = ['Draft', 'Open', 'Paid', 'Void', 'Uncollectible'];
+const INVOICE_STATUSES = ['Draft', 'Open', 'Paid', 'Cancelled', 'Uncollectible'];
 const COLLECTION_METHODS = ['ChargeAutomatically', 'SendInvoice'];
 const BILLING_REASONS = [
   'Subscription',
@@ -277,5 +283,77 @@ export function createInvoicingHandlers(baseUrl = DEFAULT_BASE_PATH) {
         },
       });
     }),
+
+    // POST finalize invoice (Draft → Open)
+    http.post(`${baseUrl}/invoices/:id/finalize`, async ({ params, request }) => {
+      const invoice = sampleInvoices.find((inv) => inv.id === params.id);
+      if (!invoice) return notFound();
+      if (invoice.status !== 'Draft') {
+        return HttpResponse.json(
+          { detail: `Cannot finalize invoice in status '${invoice.status}'.` },
+          { status: 409 }
+        );
+      }
+
+      const body = (await request.json()) as FinalizeInvoiceRequest;
+      const updated: InvoiceResponse = {
+        ...invoice,
+        status: 'Open',
+        issuedAt: body.issuedAt,
+        dueAt: body.dueAt,
+      };
+      replaceInvoice(updated);
+      return HttpResponse.json(updated);
+    }),
+
+    // POST cancel invoice
+    http.post(`${baseUrl}/invoices/:id/cancel`, async ({ params, request }) => {
+      const invoice = sampleInvoices.find((inv) => inv.id === params.id);
+      if (!invoice) return notFound();
+      if (invoice.status !== 'Open' && invoice.status !== 'Uncollectible') {
+        return HttpResponse.json(
+          { detail: `Cannot cancel invoice in status '${invoice.status}'.` },
+          { status: 409 }
+        );
+      }
+
+      // Body is optional; consume if present so the mock surface matches the real endpoint.
+      await readOptionalJson<CancelInvoiceRequest>(request);
+
+      const updated: InvoiceResponse = { ...invoice, status: 'Cancelled' };
+      replaceInvoice(updated);
+      return HttpResponse.json(updated);
+    }),
+
+    // POST mark invoice uncollectible
+    http.post(`${baseUrl}/invoices/:id/mark-uncollectible`, async ({ params, request }) => {
+      const invoice = sampleInvoices.find((inv) => inv.id === params.id);
+      if (!invoice) return notFound();
+      if (invoice.status !== 'Open') {
+        return HttpResponse.json(
+          { detail: `Cannot mark invoice in status '${invoice.status}' as uncollectible.` },
+          { status: 409 }
+        );
+      }
+
+      await readOptionalJson<MarkInvoiceUncollectibleRequest>(request);
+
+      const updated: InvoiceResponse = { ...invoice, status: 'Uncollectible' };
+      replaceInvoice(updated);
+      return HttpResponse.json(updated);
+    }),
   ];
+}
+
+function replaceInvoice(updated: InvoiceResponse): void {
+  const idx = sampleInvoices.findIndex((inv) => inv.id === updated.id);
+  if (idx >= 0) sampleInvoices[idx] = updated;
+}
+
+async function readOptionalJson<T>(request: Request): Promise<T | null> {
+  try {
+    return (await request.json()) as T;
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
## Summary

- Expose the three semantic invoice workflow transitions backed by the .NET `IWorkflowManager<InvoiceStatus>`:
  - `finalizeInvoice` (`Draft → Open`) + `FinalizeInvoiceRequest`
  - `cancelInvoice` (`Open|Uncollectible → Cancelled`) + `CancelInvoiceRequest`
  - `markInvoiceUncollectible` (`Open → Uncollectible`) + `MarkInvoiceUncollectibleRequest`
- New permissions: `Invoicing.Invoices.{Finalize, RecordPayment, Cancel, MarkUncollectible}`
- React Query mutation hooks (`useFinalizeInvoice`, `useCancelInvoice`, `useMarkInvoiceUncollectible`) that invalidate the invoices query family on success
- MSW handlers enforce the status-precondition contract (`409 Conflict` on illegal transitions)
- Sample data status `'Void'` renamed to `'Cancelled'` to match the backend enum

## Test plan

- [ ] `pnpm --filter @granit/invoicing test`
- [ ] `pnpm --filter @granit/react-invoicing test`
- [ ] `pnpm lint`
- [ ] `pnpm tsc`
- [ ] Smoke test the new hooks in showcase-admin-react against a Draft invoice