### PR TITLE
fix(parties): unwrap MapGranitQuery paged envelope in listParties

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3946,6 +3946,12 @@
           "kind": "interface",
           "signature": "interface InvoicingProviderProps",
           "members": []
+        },
+        {
+          "name": "InvoiceTransitionVariables",
+          "kind": "interface",
+          "signature": "interface InvoiceTransitionVariables<TRequest>",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/parties/src/__tests__/parties-api.test.ts
+++ b/packages/@granit/parties/src/__tests__/parties-api.test.ts
@@ -95,7 +95,18 @@ describe('parties-api', () => {
 
       const result = await listParties(client, basePath);
 
-      expect(client.get).toHaveBeenCalledWith(basePath, { params: undefined });
+      expect(client.get).toHaveBeenCalledWith(basePath, { params: { pageSize: 100 } });
+      expect(result).toEqual([sampleListItem]);
+    });
+
+    it('unwraps the paged envelope returned by MapGranitQuery', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({
+        data: { items: [sampleListItem], totalCount: 1, hasMore: false },
+      });
+
+      const result = await listParties(client, basePath);
+
       expect(result).toEqual([sampleListItem]);
     });
 
@@ -105,7 +116,9 @@ describe('parties-api', () => {
 
       await listParties(client, basePath, { role: 'Customer' });
 
-      expect(client.get).toHaveBeenCalledWith(basePath, { params: { role: 'Customer' } });
+      expect(client.get).toHaveBeenCalledWith(basePath, {
+        params: { pageSize: 100, role: 'Customer' },
+      });
     });
   });
 

--- a/packages/@granit/parties/src/api/parties-api.ts
+++ b/packages/@granit/parties/src/api/parties-api.ts
@@ -26,16 +26,23 @@ import type { AxiosInstance } from '@granit/api-client';
  * List parties in the active scope, optionally filtered by role flag.
  *
  * `GET {basePath}`
+ *
+ * The .NET endpoint was migrated to `MapGranitQuery<Party>()`, which returns a
+ * paged envelope (`{ items, totalCount, hasMore }`). Older mocks still return
+ * a flat array — unwrap either shape so consumers keep getting a plain list.
  */
 export async function listParties(
   client: AxiosInstance,
   basePath: string,
   options?: { readonly role?: string }
 ): Promise<readonly PartyListItemResponse[]> {
-  const response = await client.get<readonly PartyListItemResponse[]>(basePath, {
-    params: options?.role ? { role: options.role } : undefined,
-  });
-  return response.data;
+  const params: Record<string, string | number> = { pageSize: 100 };
+  if (options?.role) params.role = options.role;
+  const response = await client.get<
+    readonly PartyListItemResponse[] | { readonly items: readonly PartyListItemResponse[] }
+  >(basePath, { params });
+  const { data } = response;
+  return 'items' in data ? data.items : data;
 }
 
 /**

--- a/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
@@ -116,7 +116,9 @@ describe('use-parties', () => {
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/v1/parties', { params: undefined });
+      expect(client.get).toHaveBeenCalledWith('/api/v1/parties', {
+        params: { pageSize: 100 },
+      });
       expect(result.current.data).toEqual([sampleListItem]);
     });
 
@@ -130,7 +132,7 @@ describe('use-parties', () => {
 
       await waitFor(() => expect(result.current.isFetched).toBe(true));
       expect(client.get).toHaveBeenCalledWith('/api/v1/parties', {
-        params: { role: 'Customer' },
+        params: { pageSize: 100, role: 'Customer' },
       });
     });
 
@@ -143,7 +145,9 @@ describe('use-parties', () => {
       });
 
       await waitFor(() => expect(result.current.isFetched).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/custom/parties', { params: undefined });
+      expect(client.get).toHaveBeenCalledWith('/custom/parties', {
+        params: { pageSize: 100 },
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

- The .NET parties endpoint was migrated to `MapGranitQuery<Party>()`, which returns `{ items, totalCount, hasMore }` instead of a flat array
- `listParties` now detects the envelope shape and unwraps it while staying backward-compat with existing mocks that return a plain array
- Always sends `pageSize=100` so the server-side query plan is deterministic

## Test plan

- [ ] `pnpm --filter @granit/parties test`
- [ ] `pnpm --filter @granit/react-parties test`
- [ ] `pnpm lint`
- [ ] `pnpm tsc`
- [ ] Verify showcase-admin-react still lists parties correctly against the updated backend