### PR TITLE
fix(validation): drop Granit prefix from validation error codes

### DIFF
--- a/packages/@granit/react-validation/src/__tests__/create-constraints-resolver.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/create-constraints-resolver.test.ts
@@ -45,8 +45,8 @@ describe('createConstraintsResolver', () => {
       fields: createFields('name', 'email'),
     });
     expect(result.errors['name']).toEqual({
-      type: 'Granit:Validation:NotEmptyValidator',
-      message: 'Granit:Validation:NotEmptyValidator (PropertyName=name)',
+      type: 'Validation:NotEmptyValidator',
+      message: 'Validation:NotEmptyValidator (PropertyName=name)',
     });
   });
 
@@ -55,7 +55,7 @@ describe('createConstraintsResolver', () => {
     const result = await resolver({ name: 'a'.repeat(101), email: 'a@b.com' }, undefined, {
       fields: createFields('name', 'email'),
     });
-    expect(result.errors['name']!.type).toBe('Granit:Validation:MaximumLengthValidator');
+    expect(result.errors['name']!.type).toBe('Validation:MaximumLengthValidator');
   });
 
   it('returns error for pattern violation', async () => {
@@ -66,7 +66,7 @@ describe('createConstraintsResolver', () => {
     const result = await resolver({ code: 'abc' }, undefined, {
       fields: createFields('code'),
     });
-    expect(result.errors['code']!.type).toBe('Granit:Validation:RegularExpressionValidator');
+    expect(result.errors['code']!.type).toBe('Validation:RegularExpressionValidator');
   });
 
   it('calls t() with error code and params for parameterized errors', async () => {
@@ -75,7 +75,7 @@ describe('createConstraintsResolver', () => {
     await resolver({ name: 'a'.repeat(101), email: 'a@b.com' }, undefined, {
       fields: createFields('name', 'email'),
     });
-    expect(t).toHaveBeenCalledWith('Granit:Validation:MaximumLengthValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:MaximumLengthValidator', {
       maxLength: 100,
       PropertyName: 'name',
       nsSeparator: false,
@@ -125,7 +125,7 @@ describe('createConstraintsResolver', () => {
     t.mockClear();
     const resolver = createConstraintsResolver(constraints, t);
     await resolver({ name: '' }, undefined, { fields: createFields('name') });
-    expect(t).toHaveBeenCalledWith('Granit:Validation:NotEmptyValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:NotEmptyValidator', {
       PropertyName: 'name',
       nsSeparator: false,
     });
@@ -137,7 +137,7 @@ describe('createConstraintsResolver', () => {
       labelResolver: (f) => f.toUpperCase(),
     });
     await resolver({ name: '' }, undefined, { fields: createFields('name') });
-    expect(t).toHaveBeenCalledWith('Granit:Validation:NotEmptyValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:NotEmptyValidator', {
       PropertyName: 'NAME',
       nsSeparator: false,
     });
@@ -147,7 +147,7 @@ describe('createConstraintsResolver', () => {
     t.mockClear();
     const resolver = createConstraintsResolver(constraints, t);
     await resolver({ email: '' }, undefined, { fields: createFields('email') });
-    expect(t).toHaveBeenCalledWith('Granit:Validation:NotEmptyValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:NotEmptyValidator', {
       PropertyName: 'email',
       nsSeparator: false,
     });

--- a/packages/@granit/react-validation/src/__tests__/use-field-props.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/use-field-props.test.ts
@@ -12,7 +12,7 @@ describe('useFieldProps', () => {
     name: { required: true, maxLength: 100 },
     iban: {
       required: true,
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     },
   };
 
@@ -28,7 +28,7 @@ describe('useFieldProps', () => {
 
   it('returns serverHint when granitValidator is present', () => {
     const { result } = renderHook(() => useFieldProps(constraints, 'iban', t));
-    expect(result.current.serverHint).toBe('translated:Granit:Validation:InvalidIban');
+    expect(result.current.serverHint).toBe('translated:Validation:InvalidIban');
   });
 
   it('omits serverHint when no granitValidator', () => {

--- a/packages/@granit/react-validation/src/__tests__/use-server-validation.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/use-server-validation.test.ts
@@ -46,7 +46,7 @@ describe('useServerValidation', () => {
 
   it('returns idle when value is empty and field is not required', () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     const { result } = renderHook(() =>
       useServerValidation({
@@ -62,7 +62,7 @@ describe('useServerValidation', () => {
   it('returns idle when value is empty and field is required (let resolver handle)', () => {
     const constraint: FieldConstraint = {
       required: true,
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     const { result } = renderHook(() =>
       useServerValidation({
@@ -79,7 +79,7 @@ describe('useServerValidation', () => {
     const constraint: FieldConstraint = {
       required: true,
       maxLength: 5,
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     const { result } = renderHook(() =>
       useServerValidation({
@@ -94,7 +94,7 @@ describe('useServerValidation', () => {
 
   it('returns idle when enabled is false', () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     const { result } = renderHook(() =>
       useServerValidation({
@@ -110,7 +110,7 @@ describe('useServerValidation', () => {
 
   it('transitions to validating after debounce', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     mockValidateFieldServer.mockReturnValue(new Promise(() => {})); // never resolves
 
@@ -135,7 +135,7 @@ describe('useServerValidation', () => {
 
   it('transitions to valid when server returns Valid', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     mockValidateFieldServer.mockResolvedValue('Valid');
 
@@ -158,7 +158,7 @@ describe('useServerValidation', () => {
 
   it('transitions to invalid with translated message when server returns Invalid', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     mockValidateFieldServer.mockResolvedValue('Invalid');
 
@@ -177,12 +177,12 @@ describe('useServerValidation', () => {
     });
 
     expect(result.current.status).toBe('invalid');
-    expect(result.current.message).toBe('translated:Granit:Validation:InvalidIban');
+    expect(result.current.message).toBe('translated:Validation:InvalidIban');
   });
 
   it('transitions to idle when server returns ValidatorNotFound', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:Unknown',
+      granitValidator: 'Validation:Unknown',
     };
     mockValidateFieldServer.mockResolvedValue('ValidatorNotFound');
 
@@ -205,7 +205,7 @@ describe('useServerValidation', () => {
 
   it('transitions to error on network failure', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     mockValidateFieldServer.mockRejectedValue(new Error('Network error'));
 
@@ -229,7 +229,7 @@ describe('useServerValidation', () => {
 
   it('debounces — does not call server before debounce time', () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
 
     renderHook(() =>
@@ -248,7 +248,7 @@ describe('useServerValidation', () => {
 
   it('resets to idle and restarts debounce when value changes', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     };
     mockValidateFieldServer.mockResolvedValue('Valid');
 

--- a/packages/@granit/validation/src/__tests__/extract-constraints.test.ts
+++ b/packages/@granit/validation/src/__tests__/extract-constraints.test.ts
@@ -124,7 +124,7 @@ describe('extractConstraints', () => {
             properties: {
               iban: {
                 type: 'string',
-                'x-granit-validator': 'Granit:Validation:InvalidIban',
+                'x-granit-validator': 'Validation:InvalidIban',
               },
             },
           },
@@ -134,7 +134,7 @@ describe('extractConstraints', () => {
 
     const result = extractConstraints(spec);
     expect(result['Payment']!['iban']).toEqual({
-      granitValidator: 'Granit:Validation:InvalidIban',
+      granitValidator: 'Validation:InvalidIban',
     });
   });
 

--- a/packages/@granit/validation/src/__tests__/server-validation-api.test.ts
+++ b/packages/@granit/validation/src/__tests__/server-validation-api.test.ts
@@ -16,7 +16,7 @@ function createMockClient() {
 describe('listValidators', () => {
   it('calls GET /validators and returns the list', async () => {
     const client = createMockClient();
-    const validators = ['Granit:Validation:InvalidIban', 'Granit:Validation:InvalidBce'];
+    const validators = ['Validation:InvalidIban', 'Validation:InvalidBce'];
     client.get.mockResolvedValue({ data: validators });
 
     const result = await listValidators(client as never);
@@ -39,18 +39,18 @@ describe('validateFieldServer', () => {
   it('calls POST /validate and returns the status', async () => {
     const client = createMockClient();
     client.post.mockResolvedValue({
-      data: { errorCode: 'Granit:Validation:InvalidIban', status: 'Valid' },
+      data: { errorCode: 'Validation:InvalidIban', status: 'Valid' },
     });
 
     const result = await validateFieldServer(
       client as never,
-      'Granit:Validation:InvalidIban',
+      'Validation:InvalidIban',
       'BE68539007547034'
     );
 
     expect(client.post).toHaveBeenCalledWith(
       '/api/v1/validation/validate',
-      { errorCode: 'Granit:Validation:InvalidIban', value: 'BE68539007547034' },
+      { errorCode: 'Validation:InvalidIban', value: 'BE68539007547034' },
       { signal: undefined }
     );
     expect(result).toBe('Valid');
@@ -59,14 +59,10 @@ describe('validateFieldServer', () => {
   it('returns Invalid for invalid values', async () => {
     const client = createMockClient();
     client.post.mockResolvedValue({
-      data: { errorCode: 'Granit:Validation:InvalidIban', status: 'Invalid' },
+      data: { errorCode: 'Validation:InvalidIban', status: 'Invalid' },
     });
 
-    const result = await validateFieldServer(
-      client as never,
-      'Granit:Validation:InvalidIban',
-      'INVALID'
-    );
+    const result = await validateFieldServer(client as never, 'Validation:InvalidIban', 'INVALID');
 
     expect(result).toBe('Invalid');
   });
@@ -111,14 +107,14 @@ describe('validateFieldsBatch', () => {
   it('calls POST /validate-batch and returns results', async () => {
     const client = createMockClient();
     const results = [
-      { errorCode: 'Granit:Validation:InvalidIban', status: 'Valid' as const },
-      { errorCode: 'Granit:Validation:InvalidBce', status: 'Invalid' as const },
+      { errorCode: 'Validation:InvalidIban', status: 'Valid' as const },
+      { errorCode: 'Validation:InvalidBce', status: 'Invalid' as const },
     ];
     client.post.mockResolvedValue({ data: { results } });
 
     const fields = [
-      { errorCode: 'Granit:Validation:InvalidIban', value: 'BE68539007547034' },
-      { errorCode: 'Granit:Validation:InvalidBce', value: '0000000000' },
+      { errorCode: 'Validation:InvalidIban', value: 'BE68539007547034' },
+      { errorCode: 'Validation:InvalidBce', value: '0000000000' },
     ];
     const result = await validateFieldsBatch(client as never, fields);
 

--- a/packages/@granit/validation/src/constants/error-codes.ts
+++ b/packages/@granit/validation/src/constants/error-codes.ts
@@ -3,15 +3,15 @@
  * These keys mirror the .NET Granit.Validation error code convention.
  */
 export const VALIDATION_ERROR_CODES = {
-  required: 'Granit:Validation:NotEmptyValidator',
-  maxLength: 'Granit:Validation:MaximumLengthValidator',
-  minLength: 'Granit:Validation:MinimumLengthValidator',
-  pattern: 'Granit:Validation:RegularExpressionValidator',
-  formatEmail: 'Granit:Validation:EmailValidator',
-  minimum: 'Granit:Validation:GreaterThanOrEqualValidator',
-  maximum: 'Granit:Validation:LessThanOrEqualValidator',
-  exclusiveMinimum: 'Granit:Validation:GreaterThanValidator',
-  exclusiveMaximum: 'Granit:Validation:LessThanValidator',
+  required: 'Validation:NotEmptyValidator',
+  maxLength: 'Validation:MaximumLengthValidator',
+  minLength: 'Validation:MinimumLengthValidator',
+  pattern: 'Validation:RegularExpressionValidator',
+  formatEmail: 'Validation:EmailValidator',
+  minimum: 'Validation:GreaterThanOrEqualValidator',
+  maximum: 'Validation:LessThanOrEqualValidator',
+  exclusiveMinimum: 'Validation:GreaterThanValidator',
+  exclusiveMaximum: 'Validation:LessThanValidator',
 } as const;
 
 export type ValidationErrorCode =


### PR DESCRIPTION
## Summary
- Align `VALIDATION_ERROR_CODES` values with the backend convention by dropping the redundant `Granit:` prefix (e.g. `Granit:Validation:NotEmptyValidator` → `Validation:NotEmptyValidator`).
- Update affected test fixtures in `@granit/validation` and `@granit/react-validation` to match the new codes.

## Test plan
- [ ] `pnpm --filter @granit/validation test`
- [ ] `pnpm --filter @granit/react-validation test`
- [ ] Confirm backend `Granit.Validation` emits matching `Validation:*` codes (server-side parity)
- [ ] Smoke-check a form in showcase-admin-react to confirm error messages still resolve via i18n