### PR TITLE
docs(validation): align @granit/validation docs with new Validation: prefix

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -5858,7 +5858,7 @@
     },
     {
       "name": "@granit/validation",
-      "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors Granit.Validation .NET contract",
+      "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors the .NET Validation: error-code convention",
       "exports": [
         {
           "name": "VALIDATION_ERROR_CODES",

--- a/packages/@granit/validation/README.md
+++ b/packages/@granit/validation/README.md
@@ -1,6 +1,6 @@
 # @granit/validation
 
-OpenAPI constraint extraction, field validation, input prop generation, and server-side validation API. Mirrors `Granit.Validation` .NET contract.
+OpenAPI constraint extraction, field validation, input prop generation, and server-side validation API. Mirrors the .NET `Validation:` error-code convention.
 
 ## Installation
 

--- a/packages/@granit/validation/package.json
+++ b/packages/@granit/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@granit/validation",
-  "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors Granit.Validation .NET contract",
+  "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors the .NET Validation: error-code convention",
   "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/@granit/validation/src/constants/error-codes.ts
+++ b/packages/@granit/validation/src/constants/error-codes.ts
@@ -1,6 +1,6 @@
 /**
  * Maps constraint types to i18next-compatible localization keys.
- * These keys mirror the .NET Granit.Validation error code convention.
+ * These keys mirror the .NET Validation: error-code convention.
  */
 export const VALIDATION_ERROR_CODES = {
   required: 'Validation:NotEmptyValidator',


### PR DESCRIPTION
## Summary

Follow-up to #479. Drops the stale `Granit.Validation` .NET-namespace
reference from `@granit/validation` now that the backend has shortened the
error-code prefix and dispersed keys to module-owner resources (companion
to granit-fx/granit-dotnet#2205).

- README tagline
- `package.json` `description`
- `error-codes.ts` JSDoc

The pre-commit hook regenerated `.mcp-front-index.json` from the new
description; no other code changes.

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm tsc` — clean
- [x] `pnpm vitest run` for `@granit/validation` + `@granit/react-validation` — 88/88 green
- [x] Markdownlint on the modified README — clean
- [x] No remaining `Granit.Validation` / `Granit:Validation` matches in the repo

No runtime behaviour change — the breaking prefix change shipped in #479.