### PR TITLE
feat(presence): add @granit/presence and @granit/react-presence

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -5858,7 +5858,7 @@
     },
     {
       "name": "@granit/validation",
-      "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors Granit.Validation .NET contract",
+      "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors the .NET Validation: error-code convention",
       "exports": [
         {
           "name": "VALIDATION_ERROR_CODES",

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1503,6 +1503,22 @@
       ]
     },
     {
+      "name": "@granit/presence",
+      "description": "User presence types and API — mirrors Granit.Presence .NET contract",
+      "exports": [
+        {
+          "name": "PresencePermissions",
+          "kind": "const",
+          "signature": "const PresencePermissions"
+        },
+        {
+          "name": "PRESENCE_DEFAULTS",
+          "kind": "const",
+          "signature": "const PRESENCE_DEFAULTS"
+        }
+      ]
+    },
+    {
       "name": "@granit/privacy",
       "description": "GDPR privacy types and API — data export, deletion, legal agreements — mirrors Granit.Privacy .NET contract",
       "exports": [
@@ -4572,6 +4588,131 @@
           "kind": "interface",
           "signature": "interface PaymentsProviderProps",
           "members": []
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-presence",
+      "description": "React hooks and components for @granit/presence — useMyPresence, useHeartbeat, PresenceDot, PresencePicker",
+      "exports": [
+        {
+          "name": "useMyPresence",
+          "kind": "function",
+          "signature": "function useMyPresence(): UseQueryResult<PresenceResponse>"
+        },
+        {
+          "name": "useSetMyPresence",
+          "kind": "function",
+          "signature": "function useSetMyPresence(): UseMutationResult< PresenceResponse, Error, SetPresenceRequest,"
+        },
+        {
+          "name": "useClearMyPresenceOverride",
+          "kind": "function",
+          "signature": "function useClearMyPresenceOverride(): UseMutationResult<PresenceResponse, Error, void>"
+        },
+        {
+          "name": "useHeartbeat",
+          "kind": "function",
+          "signature": "function useHeartbeat(options: UseHeartbeatOptions ="
+        },
+        {
+          "name": "UseHeartbeatOptions",
+          "kind": "interface",
+          "signature": "interface UseHeartbeatOptions",
+          "members": []
+        },
+        {
+          "name": "useUserPresence",
+          "kind": "function",
+          "signature": "function useUserPresence( userId: string, options: UseUserPresenceOptions ="
+        },
+        {
+          "name": "UseUserPresenceOptions",
+          "kind": "interface",
+          "signature": "interface UseUserPresenceOptions",
+          "members": []
+        },
+        {
+          "name": "useBatchPresence",
+          "kind": "function",
+          "signature": "function useBatchPresence( userIds: readonly string[], options: UseBatchPresenceOptions ="
+        },
+        {
+          "name": "UseBatchPresenceOptions",
+          "kind": "interface",
+          "signature": "interface UseBatchPresenceOptions",
+          "members": []
+        },
+        {
+          "name": "presenceKeys",
+          "kind": "const",
+          "signature": "const presenceKeys"
+        },
+        {
+          "name": "PresenceDot",
+          "kind": "function",
+          "signature": "function PresenceDot("
+        },
+        {
+          "name": "DEFAULT_PRESENCE_COLORS",
+          "kind": "const",
+          "signature": "const DEFAULT_PRESENCE_COLORS: Readonly<Record<PresenceStatus, string>>"
+        },
+        {
+          "name": "PresenceDotLabels",
+          "kind": "interface",
+          "signature": "interface PresenceDotLabels",
+          "members": []
+        },
+        {
+          "name": "PresenceDotProps",
+          "kind": "interface",
+          "signature": "interface PresenceDotProps",
+          "members": []
+        },
+        {
+          "name": "PresencePicker",
+          "kind": "function",
+          "signature": "function PresencePicker("
+        },
+        {
+          "name": "PresencePickerLabels",
+          "kind": "interface",
+          "signature": "interface PresencePickerLabels",
+          "members": []
+        },
+        {
+          "name": "PresencePickerProps",
+          "kind": "interface",
+          "signature": "interface PresencePickerProps",
+          "members": []
+        },
+        {
+          "name": "DndBanner",
+          "kind": "function",
+          "signature": "function DndBanner("
+        },
+        {
+          "name": "DndBannerLabels",
+          "kind": "interface",
+          "signature": "interface DndBannerLabels",
+          "members": []
+        },
+        {
+          "name": "DndBannerProps",
+          "kind": "interface",
+          "signature": "interface DndBannerProps",
+          "members": []
+        },
+        {
+          "name": "PresenceHeartbeat",
+          "kind": "function",
+          "signature": "function PresenceHeartbeat(props: Readonly<PresenceHeartbeatProps>)"
+        },
+        {
+          "name": "PresenceHeartbeatProps",
+          "kind": "type",
+          "signature": "type PresenceHeartbeatProps = UseHeartbeatOptions"
         }
       ]
     },

--- a/packages/@granit/presence/README.md
+++ b/packages/@granit/presence/README.md
@@ -1,0 +1,19 @@
+# @granit/presence
+
+User presence types and API client for the [Granit](https://granit-fx.dev)
+framework. Mirrors the `Granit.Presence` .NET contract.
+
+Exposes:
+
+- Types — `PresenceStatus`, `ManualPresenceStatus`, `PresenceResponse`,
+  `SetPresenceRequest`, `HeartbeatRequest`, `BatchPresenceRequest`,
+  `BatchPresenceResponse`.
+- API functions — `getMyPresence`, `setMyPresence`,
+  `clearMyPresenceOverride`, `sendHeartbeat`, `getUserPresence`,
+  `getBatchPresence`.
+- Permission constants — `PresencePermissions.Self.Manage`,
+  `PresencePermissions.Users.Read`.
+- Defaults — `PRESENCE_DEFAULTS`.
+
+For React hooks, components, and a heartbeat scheduler, install
+[`@granit/react-presence`](../react-presence/README.md).

--- a/packages/@granit/presence/package.json
+++ b/packages/@granit/presence/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/presence",
+  "description": "User presence types and API — mirrors Granit.Presence .NET contract",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/presence/src/__tests__/presence-api.test.ts
+++ b/packages/@granit/presence/src/__tests__/presence-api.test.ts
@@ -1,0 +1,129 @@
+import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
+import { toEntityId, toISODateString } from '@granit/types';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  clearMyPresenceOverride,
+  getBatchPresence,
+  getMyPresence,
+  getUserPresence,
+  sendHeartbeat,
+  setMyPresence,
+} from '../api/presence-api.js';
+
+import type {
+  BatchPresenceResponse,
+  PresenceResponse,
+  SetPresenceRequest,
+} from '../types/index.js';
+import type { UserId } from '@granit/types';
+
+const userId = toEntityId<'User'>('user-1') as UserId;
+
+const onlineSnapshot: PresenceResponse = {
+  userId,
+  effectiveStatus: 'Online',
+  manualOverride: null,
+  overrideUntilUtc: null,
+  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
+};
+
+describe('presence-api', () => {
+  describe('getMyPresence', () => {
+    it('GETs /presence/my', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(onlineSnapshot));
+
+      const result = await getMyPresence(client, '/api/v1');
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/presence/my');
+      expect(result).toEqual(onlineSnapshot);
+    });
+  });
+
+  describe('setMyPresence', () => {
+    it('PUTs /presence/my with the body', async () => {
+      const client = createMockClient();
+      const dnd: PresenceResponse = {
+        ...onlineSnapshot,
+        effectiveStatus: 'DoNotDisturb',
+        manualOverride: 'DoNotDisturb',
+        overrideUntilUtc: toISODateString('2026-05-22T11:00:00Z'),
+      };
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(dnd));
+
+      const body: SetPresenceRequest = {
+        manualStatus: 'DoNotDisturb',
+        untilUtc: toISODateString('2026-05-22T11:00:00Z'),
+      };
+      const result = await setMyPresence(client, '/api/v1', body);
+
+      expect(client.put).toHaveBeenCalledWith('/api/v1/presence/my', body);
+      expect(result).toEqual(dnd);
+    });
+  });
+
+  describe('clearMyPresenceOverride', () => {
+    it('DELETEs /presence/my/override', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue(axiosResponse(onlineSnapshot));
+
+      const result = await clearMyPresenceOverride(client, '/api/v1');
+
+      expect(client.delete).toHaveBeenCalledWith('/api/v1/presence/my/override');
+      expect(result).toEqual(onlineSnapshot);
+    });
+  });
+
+  describe('sendHeartbeat', () => {
+    it('POSTs /presence/my/poll with clamped idleSeconds', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(onlineSnapshot));
+
+      await sendHeartbeat(client, '/api/v1', { idleSeconds: 1_000 });
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/presence/my/poll', { idleSeconds: 180 });
+    });
+
+    it('floors fractional idleSeconds and rejects negatives', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(onlineSnapshot));
+
+      await sendHeartbeat(client, '/api/v1', { idleSeconds: 5.9 });
+      expect(client.post).toHaveBeenNthCalledWith(1, '/api/v1/presence/my/poll', {
+        idleSeconds: 5,
+      });
+
+      await sendHeartbeat(client, '/api/v1', { idleSeconds: -42 });
+      expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/presence/my/poll', {
+        idleSeconds: 0,
+      });
+    });
+  });
+
+  describe('getUserPresence', () => {
+    it('GETs /presence/users/{id} with encoded id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(onlineSnapshot));
+
+      await getUserPresence(client, '/api/v1', 'user/with/slashes');
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/presence/users/user%2Fwith%2Fslashes');
+    });
+  });
+
+  describe('getBatchPresence', () => {
+    it('POSTs /presence/users/batch with the userIds list', async () => {
+      const client = createMockClient();
+      const response: BatchPresenceResponse = { presences: { [userId]: onlineSnapshot } };
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(response));
+
+      const result = await getBatchPresence(client, '/api/v1', { userIds: [userId] });
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/presence/users/batch', {
+        userIds: [userId],
+      });
+      expect(result).toEqual(response);
+    });
+  });
+});

--- a/packages/@granit/presence/src/api/presence-api.ts
+++ b/packages/@granit/presence/src/api/presence-api.ts
@@ -1,0 +1,138 @@
+import { buildApiUrl } from '@granit/api-client';
+
+import { PRESENCE_DEFAULTS } from '../constants.js';
+
+import type {
+  BatchPresenceRequest,
+  BatchPresenceResponse,
+  HeartbeatRequest,
+  PresenceResponse,
+  SetPresenceRequest,
+} from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+// ---------------------------------------------------------------------------
+// Self endpoints
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the current user's presence snapshot.
+ *
+ * `GET {basePath}/presence/my`
+ *
+ * Requires authentication only — no extra permission gate.
+ */
+export async function getMyPresence(
+  client: AxiosInstance,
+  basePath: string
+): Promise<PresenceResponse> {
+  const { data } = await client.get<PresenceResponse>(buildApiUrl(basePath, 'presence', 'my'));
+  return data;
+}
+
+/**
+ * Sets the current user's manual override.
+ *
+ * `PUT {basePath}/presence/my`
+ *
+ * Requires `Presence.Self.Manage`.
+ */
+export async function setMyPresence(
+  client: AxiosInstance,
+  basePath: string,
+  request: SetPresenceRequest
+): Promise<PresenceResponse> {
+  const { data } = await client.put<PresenceResponse>(
+    buildApiUrl(basePath, 'presence', 'my'),
+    request
+  );
+  return data;
+}
+
+/**
+ * Clears the current user's manual override — equivalent to setting
+ * `manualStatus = "Available"`.
+ *
+ * `DELETE {basePath}/presence/my/override`
+ *
+ * Requires `Presence.Self.Manage`.
+ */
+export async function clearMyPresenceOverride(
+  client: AxiosInstance,
+  basePath: string
+): Promise<PresenceResponse> {
+  const { data } = await client.delete<PresenceResponse>(
+    buildApiUrl(basePath, 'presence', 'my', 'override')
+  );
+  return data;
+}
+
+/**
+ * Sends a heartbeat for the current user. Should be called periodically
+ * while the tab is visible (recommended cadence: 30–45 s).
+ *
+ * `POST {basePath}/presence/my/poll`
+ *
+ * Requires `Presence.Self.Manage`.
+ *
+ * `idleSeconds` is clamped client-side to `[0, MaxIdleSeconds]` (the server
+ * applies the same clamp, but we save the validation roundtrip).
+ */
+export async function sendHeartbeat(
+  client: AxiosInstance,
+  basePath: string,
+  request: HeartbeatRequest
+): Promise<PresenceResponse> {
+  const idleSeconds = Math.min(
+    Math.max(0, Math.floor(request.idleSeconds)),
+    PRESENCE_DEFAULTS.MaxIdleSeconds
+  );
+  const { data } = await client.post<PresenceResponse>(
+    buildApiUrl(basePath, 'presence', 'my', 'poll'),
+    { idleSeconds } satisfies HeartbeatRequest
+  );
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Other users
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns presence for an arbitrary user.
+ *
+ * `GET {basePath}/presence/users/{userId}`
+ *
+ * Requires `Presence.Users.Read`. Never 404s — unknown users return
+ * `effectiveStatus = "Offline"` with `lastSeenUtc = null`.
+ */
+export async function getUserPresence(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string
+): Promise<PresenceResponse> {
+  const { data } = await client.get<PresenceResponse>(
+    buildApiUrl(basePath, 'presence', 'users', encodeURIComponent(userId))
+  );
+  return data;
+}
+
+/**
+ * Batch presence lookup.
+ *
+ * `POST {basePath}/presence/users/batch`
+ *
+ * Requires `Presence.Users.Read`. The server caps the batch at
+ * `MaxBatchSize` (200). Callers that need more must chunk.
+ */
+export async function getBatchPresence(
+  client: AxiosInstance,
+  basePath: string,
+  request: BatchPresenceRequest
+): Promise<BatchPresenceResponse> {
+  const { data } = await client.post<BatchPresenceResponse>(
+    buildApiUrl(basePath, 'presence', 'users', 'batch'),
+    request
+  );
+  return data;
+}

--- a/packages/@granit/presence/src/constants.ts
+++ b/packages/@granit/presence/src/constants.ts
@@ -1,0 +1,17 @@
+/**
+ * Server defaults for the presence module (mirrors `PresenceOptions` defaults
+ * in `Granit.Presence`). Kept here so React hooks can coordinate poll cadence
+ * with the server-side offline threshold without re-querying configuration.
+ */
+export const PRESENCE_DEFAULTS = {
+  /** Seconds without heartbeat after which a user is considered Offline. */
+  OfflineThresholdSeconds: 90,
+  /** Seconds without user activity after which Online flips to Away. */
+  AwayThresholdSeconds: 180,
+  /** Maximum value the server accepts for `idleSeconds` (= 2 × OfflineThreshold). */
+  MaxIdleSeconds: 180,
+  /** Maximum batch size for `/presence/users/batch`. */
+  MaxBatchSize: 200,
+  /** Maximum duration (seconds) of a manual override `untilUtc`. */
+  MaxOverrideDurationSeconds: 7 * 24 * 60 * 60,
+} as const;

--- a/packages/@granit/presence/src/index.ts
+++ b/packages/@granit/presence/src/index.ts
@@ -1,0 +1,26 @@
+// Types
+export type {
+  BatchPresenceRequest,
+  BatchPresenceResponse,
+  HeartbeatRequest,
+  ManualPresenceStatus,
+  PresenceResponse,
+  PresenceStatus,
+  SetPresenceRequest,
+} from './types/index.js';
+
+// API
+export {
+  clearMyPresenceOverride,
+  getBatchPresence,
+  getMyPresence,
+  getUserPresence,
+  sendHeartbeat,
+  setMyPresence,
+} from './api/presence-api.js';
+
+// Permissions
+export { PresencePermissions } from './permissions.js';
+
+// Defaults
+export { PRESENCE_DEFAULTS } from './constants.js';

--- a/packages/@granit/presence/src/permissions.ts
+++ b/packages/@granit/presence/src/permissions.ts
@@ -1,0 +1,19 @@
+/**
+ * Permission constants for the presence module.
+ * Mirrors `Granit.Presence.Endpoints.Permissions.PresencePermissions`.
+ */
+export const PresencePermissions = {
+  /** Permissions controlling the current user's own presence. */
+  Self: {
+    /**
+     * Grants the right to set/clear manual override and send heartbeats
+     * for the current user's own presence.
+     */
+    Manage: 'Presence.Self.Manage',
+  },
+  /** Permissions controlling read access to other users' presence. */
+  Users: {
+    /** Grants read access to other users' presence (single + batch lookup). */
+    Read: 'Presence.Users.Read',
+  },
+} as const;

--- a/packages/@granit/presence/src/types/index.ts
+++ b/packages/@granit/presence/src/types/index.ts
@@ -1,0 +1,80 @@
+import type { ISODateString, UserId } from '@granit/types';
+
+// ---------------------------------------------------------------------------
+// Presence enums — aligned with Granit.Presence .NET backend
+// ---------------------------------------------------------------------------
+
+/**
+ * Effective presence status computed server-side from heartbeat + manual override.
+ * Mirrors `Granit.Presence.PresenceStatus`.
+ */
+export type PresenceStatus = 'Online' | 'Away' | 'Busy' | 'DoNotDisturb' | 'Offline';
+
+/**
+ * Manual override the user may set on their own presence.
+ * `Available` means "no override" — the effective status falls back to
+ * the activity-derived value.
+ *
+ * Mirrors `Granit.Presence.ManualPresenceStatus`.
+ */
+export type ManualPresenceStatus = 'Available' | 'Busy' | 'DoNotDisturb' | 'AppearOffline';
+
+// ---------------------------------------------------------------------------
+// DTOs
+// ---------------------------------------------------------------------------
+
+/**
+ * Presence snapshot returned by all read endpoints.
+ *
+ * A user that the server has never seen returns `effectiveStatus = "Offline"`
+ * and `lastSeenUtc = null`. There is no 404 case for `/users/{id}` lookups.
+ */
+export interface PresenceResponse {
+  readonly userId: UserId;
+  readonly effectiveStatus: PresenceStatus;
+  readonly manualOverride: ManualPresenceStatus | null;
+  readonly overrideUntilUtc: ISODateString | null;
+  readonly lastSeenUtc: ISODateString | null;
+}
+
+/**
+ * Request body for `PUT /presence/my`.
+ *
+ * Server-side rules (validated as well, but front can short-circuit):
+ *  - When `manualStatus = "Available"`, `untilUtc` must be `null`.
+ *  - When `untilUtc` is set, it must be in the future (>= now + 1s) and
+ *    within `MaxOverrideDuration` (default 7 days).
+ */
+export interface SetPresenceRequest {
+  readonly manualStatus: ManualPresenceStatus;
+  readonly untilUtc: ISODateString | null;
+}
+
+/**
+ * Request body for `POST /presence/my/poll` — single client heartbeat.
+ *
+ * `idleSeconds` is the number of seconds since the last user activity
+ * (keydown/mousemove/scroll). The server clamps the value to
+ * `2 × OfflineThreshold` (default 180s).
+ */
+export interface HeartbeatRequest {
+  readonly idleSeconds: number;
+}
+
+/**
+ * Request body for `POST /presence/users/batch`.
+ * `userIds` must be non-empty, contain at most `MaxBatchSize` (200) entries,
+ * and have no duplicates.
+ */
+export interface BatchPresenceRequest {
+  readonly userIds: readonly string[];
+}
+
+/**
+ * Response body for `POST /presence/users/batch`.
+ * `presences` is keyed by `userId`. Unknown users get an Offline snapshot
+ * with `lastSeenUtc = null` — they are present in the dictionary.
+ */
+export interface BatchPresenceResponse {
+  readonly presences: Readonly<Record<string, PresenceResponse>>;
+}

--- a/packages/@granit/presence/tsconfig.json
+++ b/packages/@granit/presence/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/api-client": ["../api-client/src/index.ts"],
+      "@granit/api-client/test-utils": ["../api-client/src/test-utils.ts"],
+      "@granit/types": ["../types/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/presence/tsup.config.ts
+++ b/packages/@granit/presence/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-presence/README.md
+++ b/packages/@granit/react-presence/README.md
@@ -1,0 +1,31 @@
+# @granit/react-presence
+
+React bindings for [`@granit/presence`](../presence/README.md): provider,
+TanStack Query hooks, heartbeat scheduler, and headless UI components.
+
+## Installation
+
+```bash
+pnpm add @granit/react-presence @granit/presence
+```
+
+## Surface
+
+- `<PresenceProvider>` — wires the Axios client and base path.
+- `<PresenceHeartbeat />` — mount once at the authenticated shell; polls
+  `POST /presence/my/poll` every 30 s while the tab is visible.
+- Hooks — `useMyPresence`, `useSetMyPresence`,
+  `useClearMyPresenceOverride`, `useHeartbeat`, `useUserPresence`,
+  `useBatchPresence`.
+- Components — `<PresenceDot>`, `<PresencePicker>`, `<DndBanner>`.
+- i18n bundles — `presenceTranslationsEn`, `presenceTranslationsFr`
+  (namespace: `presence`).
+- Testing helpers — `createPresenceHandlers` from
+  `@granit/react-presence/testing`.
+
+## Notification gate
+
+When the current user is in `DoNotDisturb` or `AppearOffline`, the backend
+[`Granit.Presence.Notifications`](https://granit-fx.dev) gate suppresses
+push/SignalR/SSE delivery. Surface a passive reminder with `<DndBanner>`
+so users understand why they no longer see toasts.

--- a/packages/@granit/react-presence/package.json
+++ b/packages/@granit/react-presence/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@granit/react-presence",
+  "description": "React hooks and components for @granit/presence — useMyPresence, useHeartbeat, PresenceDot, PresencePicker",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/presence": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/presence": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/react-presence/src/__tests__/dnd-banner.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/dnd-banner.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DndBanner } from '../components/dnd-banner.js';
+import { mockMyPresence } from '../testing/data.js';
+
+describe('DndBanner', () => {
+  it('renders nothing when there is no override', () => {
+    const { container } = render(<DndBanner presence={mockMyPresence} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('shows the DnD copy with a clear button that fires the callback', async () => {
+    const onClear = vi.fn();
+    render(
+      <DndBanner
+        presence={{ ...mockMyPresence, manualOverride: 'DoNotDisturb' }}
+        onClear={onClear}
+      />
+    );
+    expect(screen.getByRole('status')).toBeTruthy();
+    await userEvent.click(screen.getByRole('button', { name: /clear status/i }));
+    expect(onClear).toHaveBeenCalledOnce();
+  });
+
+  it('shows the AppearOffline copy when override = AppearOffline', () => {
+    render(<DndBanner presence={{ ...mockMyPresence, manualOverride: 'AppearOffline' }} />);
+    expect(screen.getByText(/appear offline/i)).toBeTruthy();
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/presence-dot.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/presence-dot.test.tsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_PRESENCE_COLORS, PresenceDot } from '../components/presence-dot.js';
+
+import type { PresenceStatus } from '@granit/presence';
+
+describe('PresenceDot', () => {
+  it.each<PresenceStatus>(['Online', 'Away', 'Busy', 'DoNotDisturb', 'Offline'])(
+    'renders the default colour for %s',
+    (status) => {
+      const { container } = render(<PresenceDot status={status} />);
+      const dot = container.querySelector('[data-granit-presence-dot]')!;
+      expect(dot.getAttribute('data-status')).toBe(status);
+      expect((dot as HTMLElement).style.backgroundColor).toBeTruthy();
+      expect(dot.getAttribute('aria-label')).toBeTruthy();
+      // sanity-check the colour map exposed publicly is the one used.
+      expect(DEFAULT_PRESENCE_COLORS[status]).toBeDefined();
+    }
+  );
+
+  it('honours a custom colour map', () => {
+    const { container } = render(
+      <PresenceDot status="Online" colorMap={{ Online: 'rgb(1, 2, 3)' }} />
+    );
+    const dot = container.querySelector('[data-granit-presence-dot]') as HTMLElement;
+    expect(dot.style.backgroundColor).toBe('rgb(1, 2, 3)');
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/presence-picker.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/presence-picker.test.tsx
@@ -1,0 +1,96 @@
+import { createMockClient } from '@granit/react-testing';
+import { toEntityId, toISODateString } from '@granit/types';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PresencePicker } from '../components/presence-picker.js';
+
+import { createPresenceTestHarness } from './test-utils.js';
+
+import type { PresenceResponse, SetPresenceRequest } from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+vi.mock('@granit/presence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getMyPresence: vi.fn(),
+    setMyPresence: vi.fn(),
+    clearMyPresenceOverride: vi.fn(),
+  };
+});
+
+const { getMyPresence, setMyPresence, clearMyPresenceOverride } = await import('@granit/presence');
+
+const userId = toEntityId<'User'>('user-1') as UserId;
+
+const baseSnapshot: PresenceResponse = {
+  userId,
+  effectiveStatus: 'Online',
+  manualOverride: null,
+  overrideUntilUtc: null,
+  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
+};
+
+beforeEach(() => {
+  vi.mocked(getMyPresence).mockResolvedValue(baseSnapshot);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('PresencePicker', () => {
+  it('submits the selected status with the 1h preset by default', async () => {
+    const client = createMockClient();
+    const dnd: PresenceResponse = {
+      ...baseSnapshot,
+      effectiveStatus: 'DoNotDisturb',
+      manualOverride: 'DoNotDisturb',
+      overrideUntilUtc: toISODateString('2026-05-22T11:00:00Z'),
+    };
+    vi.mocked(setMyPresence).mockResolvedValue(dnd);
+    const { wrapper } = createPresenceTestHarness(client);
+
+    render(<PresencePicker />, { wrapper });
+
+    await userEvent.click(await screen.findByRole('radio', { name: /do not disturb/i }));
+    await userEvent.click(screen.getByRole('button', { name: /set status/i }));
+
+    await waitFor(() => expect(setMyPresence).toHaveBeenCalledOnce());
+    const body = vi.mocked(setMyPresence).mock.calls[0]![2] as SetPresenceRequest;
+    expect(body.manualStatus).toBe('DoNotDisturb');
+    expect(body.untilUtc).not.toBeNull();
+  });
+
+  it('clears the override via the dedicated button', async () => {
+    const client = createMockClient();
+    vi.mocked(getMyPresence).mockResolvedValue({
+      ...baseSnapshot,
+      effectiveStatus: 'Busy',
+      manualOverride: 'Busy',
+      overrideUntilUtc: toISODateString('2026-05-22T11:00:00Z'),
+    });
+    vi.mocked(clearMyPresenceOverride).mockResolvedValue(baseSnapshot);
+    const { wrapper } = createPresenceTestHarness(client);
+
+    render(<PresencePicker />, { wrapper });
+
+    const clearBtn = await screen.findByRole('button', { name: /clear status/i });
+    await userEvent.click(clearBtn);
+    await waitFor(() => expect(clearMyPresenceOverride).toHaveBeenCalledOnce());
+  });
+
+  it('shows the validation message when the custom until is empty', async () => {
+    const client = createMockClient();
+    const { wrapper } = createPresenceTestHarness(client);
+    render(<PresencePicker />, { wrapper });
+
+    await userEvent.click(await screen.findByRole('radio', { name: /^busy$/i }));
+    await userEvent.click(screen.getByRole('radio', { name: /custom/i }));
+
+    expect(screen.getByRole('alert')).toBeTruthy();
+    expect(screen.getByRole('button', { name: /set status/i })).toBeDisabled();
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/presence-provider.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/presence-provider.test.tsx
@@ -1,0 +1,40 @@
+import { createMockClient } from '@granit/react-testing';
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  PresenceProvider,
+  buildPresenceQueryKey,
+  usePresenceConfig,
+} from '../providers/presence-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+function wrap(client: AxiosInstance) {
+  return ({ children }: Readonly<{ children: ReactNode }>) => (
+    <PresenceProvider config={{ client }}>{children}</PresenceProvider>
+  );
+}
+
+describe('PresenceProvider', () => {
+  it('exposes the resolved config with default basePath and prefix', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => usePresenceConfig(), { wrapper: wrap(client) });
+    expect(result.current.client).toBe(client);
+    expect(result.current.basePath).toBe('/api/v1');
+    expect(result.current.queryKeyPrefix).toEqual(['presence']);
+  });
+
+  it('builds query keys under the prefix', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => usePresenceConfig(), { wrapper: wrap(client) });
+    expect(buildPresenceQueryKey(result.current, 'my')).toEqual(['presence', 'my']);
+  });
+
+  it('throws if used outside a provider', () => {
+    expect(() => renderHook(() => usePresenceConfig())).toThrowError(
+      /must be used within a <PresenceProvider>/
+    );
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-presence/src/__tests__/test-utils.tsx
@@ -1,0 +1,22 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+
+import { PresenceProvider } from '../providers/presence-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { QueryClient } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+/**
+ * Builds a wrapper that exposes both a fresh QueryClient and a
+ * PresenceProvider wired to the supplied Axios client.
+ */
+export function createPresenceTestHarness(client: AxiosInstance) {
+  const queryClient: QueryClient = createTestQueryClient();
+  const wrapper = ({ children }: Readonly<{ children: ReactNode }>) => (
+    <QueryClientProvider client={queryClient}>
+      <PresenceProvider config={{ client }}>{children}</PresenceProvider>
+    </QueryClientProvider>
+  );
+  return { queryClient, wrapper };
+}

--- a/packages/@granit/react-presence/src/__tests__/use-batch-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-batch-presence.test.tsx
@@ -1,0 +1,70 @@
+import { createMockClient } from '@granit/react-testing';
+import { toEntityId, toISODateString } from '@granit/types';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useBatchPresence } from '../hooks/use-batch-presence.js';
+
+import { createPresenceTestHarness } from './test-utils.js';
+
+import type { BatchPresenceResponse, PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+vi.mock('@granit/presence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, getBatchPresence: vi.fn() };
+});
+
+const { getBatchPresence } = await import('@granit/presence');
+
+function makeSnapshot(id: string): PresenceResponse {
+  return {
+    userId: toEntityId<'User'>(id) as UserId,
+    effectiveStatus: 'Online',
+    manualOverride: null,
+    overrideUntilUtc: null,
+    lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useBatchPresence', () => {
+  it('chunks at MaxBatchSize (200) and merges the dictionaries', async () => {
+    const client = createMockClient();
+    const ids = Array.from({ length: 250 }, (_, i) => `user-${String(i).padStart(3, '0')}`);
+
+    vi.mocked(getBatchPresence).mockImplementation(async (_c, _b, request) => {
+      const presences: Record<string, PresenceResponse> = {};
+      for (const id of request.userIds) presences[id] = makeSnapshot(id);
+      return { presences } satisfies BatchPresenceResponse;
+    });
+
+    const { wrapper } = createPresenceTestHarness(client);
+    const { result } = renderHook(() => useBatchPresence(ids), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getBatchPresence).toHaveBeenCalledTimes(2);
+    expect(Object.keys(result.current.data!.presences)).toHaveLength(250);
+  });
+
+  it('deduplicates and sorts the userIds before calling', async () => {
+    const client = createMockClient();
+    vi.mocked(getBatchPresence).mockResolvedValue({
+      presences: { 'user-a': makeSnapshot('user-a'), 'user-b': makeSnapshot('user-b') },
+    });
+    const { wrapper } = createPresenceTestHarness(client);
+
+    const { result } = renderHook(() => useBatchPresence(['user-b', 'user-a', 'user-a']), {
+      wrapper,
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getBatchPresence).toHaveBeenCalledTimes(1);
+    const sent = vi.mocked(getBatchPresence).mock.calls[0]![2].userIds;
+    expect(sent).toEqual(['user-a', 'user-b']);
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
@@ -1,0 +1,98 @@
+import { createMockClient } from '@granit/react-testing';
+import { toEntityId, toISODateString } from '@granit/types';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useHeartbeat } from '../hooks/use-heartbeat.js';
+
+import { createPresenceTestHarness } from './test-utils.js';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+vi.mock('@granit/presence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, sendHeartbeat: vi.fn() };
+});
+
+const { sendHeartbeat } = await import('@granit/presence');
+
+const snapshot: PresenceResponse = {
+  userId: toEntityId<'User'>('user-1') as UserId,
+  effectiveStatus: 'Online',
+  manualOverride: null,
+  overrideUntilUtc: null,
+  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
+};
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  setVisibility('visible');
+  vi.mocked(sendHeartbeat).mockResolvedValue(snapshot);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe('useHeartbeat', () => {
+  it('fires an immediate heartbeat and then polls on the interval', async () => {
+    const client = createMockClient();
+    const { wrapper } = createPresenceTestHarness(client);
+
+    renderHook(() => useHeartbeat({ intervalMs: 1_000 }), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(sendHeartbeat).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(sendHeartbeat).toHaveBeenCalledTimes(2);
+  });
+
+  it('suspends when hidden and resumes when visible', async () => {
+    const client = createMockClient();
+    const { wrapper } = createPresenceTestHarness(client);
+
+    renderHook(() => useHeartbeat({ intervalMs: 1_000 }), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(sendHeartbeat).toHaveBeenCalledTimes(1);
+
+    act(() => setVisibility('hidden'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(sendHeartbeat).toHaveBeenCalledTimes(1);
+
+    act(() => setVisibility('visible'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(sendHeartbeat).toHaveBeenCalledTimes(2);
+  });
+
+  it('does nothing when disabled', async () => {
+    const client = createMockClient();
+    const { wrapper } = createPresenceTestHarness(client);
+
+    renderHook(() => useHeartbeat({ disabled: true, intervalMs: 1_000 }), { wrapper });
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(sendHeartbeat).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/use-my-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-my-presence.test.tsx
@@ -1,0 +1,44 @@
+import { createMockClient } from '@granit/react-testing';
+import { toEntityId, toISODateString } from '@granit/types';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useMyPresence } from '../hooks/use-my-presence.js';
+
+import { createPresenceTestHarness } from './test-utils.js';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+vi.mock('@granit/presence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, getMyPresence: vi.fn() };
+});
+
+const { getMyPresence } = await import('@granit/presence');
+
+const snapshot: PresenceResponse = {
+  userId: toEntityId<'User'>('user-1') as UserId,
+  effectiveStatus: 'Online',
+  manualOverride: null,
+  overrideUntilUtc: null,
+  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useMyPresence', () => {
+  it('fetches with the default basePath via the provider', async () => {
+    const client = createMockClient();
+    vi.mocked(getMyPresence).mockResolvedValue(snapshot);
+    const { wrapper } = createPresenceTestHarness(client);
+
+    const { result } = renderHook(() => useMyPresence(), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getMyPresence).toHaveBeenCalledWith(client, '/api/v1');
+    expect(result.current.data).toEqual(snapshot);
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/use-set-my-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-set-my-presence.test.tsx
@@ -1,0 +1,90 @@
+import { createMockClient } from '@granit/react-testing';
+import { toEntityId, toISODateString } from '@granit/types';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useMyPresence } from '../hooks/use-my-presence.js';
+import { useSetMyPresence } from '../hooks/use-set-my-presence.js';
+
+import { createPresenceTestHarness } from './test-utils.js';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+vi.mock('@granit/presence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getMyPresence: vi.fn(),
+    setMyPresence: vi.fn(),
+  };
+});
+
+const { getMyPresence, setMyPresence } = await import('@granit/presence');
+
+const userId = toEntityId<'User'>('user-1') as UserId;
+
+const baseSnapshot: PresenceResponse = {
+  userId,
+  effectiveStatus: 'Online',
+  manualOverride: null,
+  overrideUntilUtc: null,
+  lastSeenUtc: toISODateString('2026-05-22T10:00:00Z'),
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useSetMyPresence', () => {
+  it('optimistically updates the cache and confirms on success', async () => {
+    const client = createMockClient();
+    vi.mocked(getMyPresence).mockResolvedValue(baseSnapshot);
+    const serverDnd: PresenceResponse = {
+      ...baseSnapshot,
+      effectiveStatus: 'DoNotDisturb',
+      manualOverride: 'DoNotDisturb',
+      overrideUntilUtc: toISODateString('2026-05-22T11:00:00Z'),
+    };
+    vi.mocked(setMyPresence).mockResolvedValue(serverDnd);
+
+    const { wrapper } = createPresenceTestHarness(client);
+    const { result } = renderHook(
+      () => ({ query: useMyPresence(), mutation: useSetMyPresence() }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+
+    await result.current.mutation.mutateAsync({
+      manualStatus: 'DoNotDisturb',
+      untilUtc: toISODateString('2026-05-22T11:00:00Z'),
+    });
+
+    await waitFor(() => expect(result.current.query.data).toEqual(serverDnd));
+  });
+
+  it('rolls back when the server returns 400', async () => {
+    const client = createMockClient();
+    vi.mocked(getMyPresence).mockResolvedValue(baseSnapshot);
+    vi.mocked(setMyPresence).mockRejectedValue(new Error('400 Bad Request'));
+
+    const { wrapper } = createPresenceTestHarness(client);
+    const { result } = renderHook(
+      () => ({ query: useMyPresence(), mutation: useSetMyPresence() }),
+      { wrapper }
+    );
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+
+    await expect(
+      result.current.mutation.mutateAsync({
+        manualStatus: 'Busy',
+        untilUtc: toISODateString('1999-01-01T00:00:00Z'),
+      })
+    ).rejects.toThrow();
+
+    await waitFor(() => {
+      expect(result.current.query.data).toEqual(baseSnapshot);
+    });
+  });
+});

--- a/packages/@granit/react-presence/src/components/dnd-banner.tsx
+++ b/packages/@granit/react-presence/src/components/dnd-banner.tsx
@@ -1,0 +1,97 @@
+import type { PresenceResponse } from '@granit/presence';
+import type { CSSProperties, ReactNode } from 'react';
+
+export interface DndBannerLabels {
+  /** Banner copy when the user is in DoNotDisturb. */
+  readonly doNotDisturb?: string;
+  /** Banner copy when the user appears Offline. */
+  readonly appearOffline?: string;
+  /** Label for the "clear override" action button. */
+  readonly clearAction?: string;
+}
+
+const DEFAULT_LABELS: Required<DndBannerLabels> = {
+  doNotDisturb:
+    'You are in Do not disturb — real-time notifications (push, SignalR, SSE) are muted.',
+  appearOffline:
+    'You appear offline — others see you as Offline and real-time notifications are muted.',
+  clearAction: 'Clear status',
+};
+
+export interface DndBannerProps {
+  /** Current presence snapshot. Banner renders nothing when not in DnD/AppearOffline. */
+  readonly presence: PresenceResponse | null | undefined;
+  /** Click handler for the "clear override" CTA. Hidden when omitted. */
+  readonly onClear?: () => void;
+  readonly labels?: DndBannerLabels;
+  readonly className?: string;
+  /** Optional trailing element (e.g. countdown until override expiry). */
+  readonly children?: ReactNode;
+}
+
+const STYLES: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  padding: '0.5rem 0.75rem',
+  borderRadius: 6,
+  background: '#fef3c7', // amber-100
+  color: '#92400e', // amber-800
+  fontSize: 14,
+};
+
+/**
+ * Passive reminder shown when the current user has muted real-time
+ * notifications. The backend Granit.Presence.Notifications gate already
+ * suppresses delivery — this banner just explains *why* the user no
+ * longer sees toasts.
+ *
+ * Headless: a single inline-styled `<div>` so any app can drop it in
+ * without conflicts. Apps that already own a styled banner can ignore
+ * this component and write their own using `useMyPresence`.
+ */
+export function DndBanner({
+  presence,
+  onClear,
+  labels,
+  className,
+  children,
+}: Readonly<DndBannerProps>) {
+  if (!presence) return null;
+  const override = presence.manualOverride;
+  if (override !== 'DoNotDisturb' && override !== 'AppearOffline') return null;
+
+  const merged = { ...DEFAULT_LABELS, ...labels };
+  const message = override === 'DoNotDisturb' ? merged.doNotDisturb : merged.appearOffline;
+
+  return (
+    <div
+      role="status"
+      data-granit-presence-dnd-banner=""
+      data-override={override}
+      className={className}
+      style={STYLES}
+    >
+      <span style={{ flex: 1 }}>{message}</span>
+      {children}
+      {onClear ? (
+        <button
+          type="button"
+          onClick={onClear}
+          data-granit-presence-dnd-clear=""
+          style={{
+            background: 'transparent',
+            border: '1px solid currentColor',
+            borderRadius: 4,
+            padding: '0.125rem 0.5rem',
+            color: 'inherit',
+            cursor: 'pointer',
+            font: 'inherit',
+          }}
+        >
+          {merged.clearAction}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/@granit/react-presence/src/components/presence-dot.tsx
+++ b/packages/@granit/react-presence/src/components/presence-dot.tsx
@@ -1,0 +1,106 @@
+import type { PresenceStatus } from '@granit/presence';
+import type { CSSProperties, ReactNode } from 'react';
+
+/**
+ * Default Tailwind-friendly colour mapping. Apps that theme through
+ * design tokens can override per-status colours via `colorMap` or
+ * `className` (or restyle via the `data-status` attribute).
+ */
+export const DEFAULT_PRESENCE_COLORS: Readonly<Record<PresenceStatus, string>> = {
+  Online: '#22c55e', // emerald-500
+  Away: '#eab308', // yellow-500
+  Busy: '#ef4444', // red-500
+  DoNotDisturb: '#b91c1c', // red-700
+  Offline: '#9ca3af', // gray-400
+};
+
+export interface PresenceDotLabels {
+  /** Tooltip / accessible label per status. */
+  readonly statusLabel?: (status: PresenceStatus) => string;
+}
+
+const DEFAULT_LABELS: Required<PresenceDotLabels> = {
+  statusLabel: (status) => (status === 'DoNotDisturb' ? 'Do not disturb' : status),
+};
+
+export interface PresenceDotProps {
+  /** Effective status to render. */
+  readonly status: PresenceStatus;
+  /** Diameter in px. Default: 10. */
+  readonly size?: number;
+  /**
+   * Whether to render a ring around the dot — useful when overlaid on an
+   * avatar so the dot stays visible against any background. Default: `true`.
+   */
+  readonly bordered?: boolean;
+  /** Custom colour map. Falls back to {@link DEFAULT_PRESENCE_COLORS}. */
+  readonly colorMap?: Partial<Record<PresenceStatus, string>>;
+  /** Render the dot inline (default) or as an overlay positioned on a parent. */
+  readonly variant?: 'inline' | 'overlay';
+  readonly labels?: PresenceDotLabels;
+  readonly className?: string;
+  readonly title?: string;
+  readonly children?: ReactNode;
+  /**
+   * When `true`, the dot is purely decorative — it is hidden from the
+   * accessibility tree (no role, `aria-hidden`). Use when the dot is
+   * already next to a textual label describing the same status.
+   * Default: `false`.
+   */
+  readonly presentational?: boolean;
+}
+
+/**
+ * Single coloured pastille for a presence status. Headless: no chrome,
+ * no animation — apps style via `className` or by selecting on the
+ * `data-status` attribute.
+ */
+export function PresenceDot({
+  status,
+  size = 10,
+  bordered = true,
+  colorMap,
+  variant = 'inline',
+  labels,
+  className,
+  title,
+  children,
+  presentational = false,
+}: Readonly<PresenceDotProps>) {
+  const color = colorMap?.[status] ?? DEFAULT_PRESENCE_COLORS[status];
+  const statusLabel = labels?.statusLabel ?? DEFAULT_LABELS.statusLabel;
+  const accessibleLabel = title ?? statusLabel(status);
+
+  const style: CSSProperties = {
+    display: 'inline-block',
+    width: size,
+    height: size,
+    borderRadius: '50%',
+    backgroundColor: color,
+    boxShadow: bordered ? '0 0 0 2px var(--granit-presence-ring, white)' : undefined,
+    ...(variant === 'overlay'
+      ? {
+          position: 'absolute',
+          right: 0,
+          bottom: 0,
+          pointerEvents: 'none',
+        }
+      : null),
+  };
+
+  return (
+    <span
+      {...(presentational
+        ? { 'aria-hidden': true }
+        : { role: 'status', 'aria-label': accessibleLabel })}
+      data-granit-presence-dot=""
+      data-status={status}
+      data-variant={variant}
+      className={className}
+      style={style}
+      title={presentational ? undefined : accessibleLabel}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/@granit/react-presence/src/components/presence-heartbeat.tsx
+++ b/packages/@granit/react-presence/src/components/presence-heartbeat.tsx
@@ -1,0 +1,20 @@
+import { useHeartbeat, type UseHeartbeatOptions } from '../hooks/use-heartbeat.js';
+
+export type PresenceHeartbeatProps = UseHeartbeatOptions;
+
+/**
+ * Mountable wrapper around {@link useHeartbeat}. Renders nothing.
+ *
+ * Mount this **exactly once** inside the authenticated shell of the app:
+ *
+ * ```tsx
+ * <PresenceProvider>
+ *   <PresenceHeartbeat />
+ *   <App />
+ * </PresenceProvider>
+ * ```
+ */
+export function PresenceHeartbeat(props: Readonly<PresenceHeartbeatProps>) {
+  useHeartbeat(props);
+  return null;
+}

--- a/packages/@granit/react-presence/src/components/presence-picker.tsx
+++ b/packages/@granit/react-presence/src/components/presence-picker.tsx
@@ -1,0 +1,385 @@
+import { PRESENCE_DEFAULTS } from '@granit/presence';
+import { useMemo, useState } from 'react';
+
+import { useClearMyPresenceOverride } from '../hooks/use-clear-my-presence-override.js';
+import { useMyPresence } from '../hooks/use-my-presence.js';
+import { useSetMyPresence } from '../hooks/use-set-my-presence.js';
+
+import { PresenceDot } from './presence-dot.js';
+
+import type { ManualPresenceStatus, PresenceResponse, SetPresenceRequest } from '@granit/presence';
+import type { ISODateString } from '@granit/types';
+import type { CSSProperties, ReactNode } from 'react';
+
+// ---------------------------------------------------------------------------
+// Labels
+// ---------------------------------------------------------------------------
+
+export interface PresencePickerLabels {
+  readonly title?: string;
+  readonly statusLabel?: Record<ManualPresenceStatus, string>;
+  readonly until?: string;
+  readonly customUntil?: string;
+  readonly clear?: string;
+  readonly save?: string;
+  readonly noOverride?: string;
+  readonly overrideUntil?: (untilLocal: string) => string;
+  readonly presets?: {
+    readonly thirtyMinutes: string;
+    readonly oneHour: string;
+    readonly fourHours: string;
+    readonly today: string;
+    readonly custom: string;
+    readonly noExpiry: string;
+  };
+}
+
+const DEFAULT_LABELS: Required<PresencePickerLabels> = {
+  title: 'Set status',
+  statusLabel: {
+    Available: 'Available',
+    Busy: 'Busy',
+    DoNotDisturb: 'Do not disturb',
+    AppearOffline: 'Appear offline',
+  },
+  until: 'Clear after',
+  customUntil: 'Pick a date and time',
+  clear: 'Clear status',
+  save: 'Set status',
+  noOverride: 'No active override',
+  overrideUntil: (untilLocal) => `Until ${untilLocal}`,
+  presets: {
+    thirtyMinutes: '30 minutes',
+    oneHour: '1 hour',
+    fourHours: '4 hours',
+    today: 'Today',
+    custom: 'Custom…',
+    noExpiry: "Don't clear",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+type Preset = 'none' | '30m' | '1h' | '4h' | 'today' | 'custom';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+function endOfTodayLocal(now: Date): Date {
+  const end = new Date(now);
+  end.setHours(23, 59, 0, 0);
+  return end;
+}
+
+function presetToDate(preset: Preset, now: Date): Date | null {
+  switch (preset) {
+    case 'none':
+      return null;
+    case '30m':
+      return new Date(now.getTime() + 30 * 60 * 1000);
+    case '1h':
+      return new Date(now.getTime() + 60 * 60 * 1000);
+    case '4h':
+      return new Date(now.getTime() + 4 * 60 * 60 * 1000);
+    case 'today':
+      return endOfTodayLocal(now);
+    case 'custom':
+      return null;
+  }
+}
+
+const MAX_OVERRIDE_MS = PRESENCE_DEFAULTS.MaxOverrideDurationSeconds * 1000;
+
+function isValidUntil(date: Date | null, now: Date): boolean {
+  if (date == null) return true;
+  const diff = date.getTime() - now.getTime();
+  return diff > 1_000 && diff <= MAX_OVERRIDE_MS;
+}
+
+function toIsoString(date: Date): ISODateString {
+  return date.toISOString() as ISODateString;
+}
+
+function toLocalDateTimeInputValue(date: Date): string {
+  // YYYY-MM-DDTHH:mm in local time, suitable for <input type="datetime-local">.
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return (
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}` +
+    `T${pad(date.getHours())}:${pad(date.getMinutes())}`
+  );
+}
+
+function formatUntilLocal(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString();
+  } catch {
+    return iso;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface PresencePickerProps {
+  /** Override the English defaults — apps usually thread `t()` results in. */
+  readonly labels?: PresencePickerLabels;
+  /**
+   * Called after a successful Set / Clear. Useful for closing a menu.
+   * Receives the fresh server-confirmed presence.
+   */
+  readonly onApplied?: (presence: PresenceResponse) => void;
+  /** Render override around the form. Defaults to an inline-styled div. */
+  readonly className?: string;
+  /** Custom header (e.g. a heading with shared typography). */
+  readonly children?: ReactNode;
+}
+
+const MANUAL_OPTIONS: readonly ManualPresenceStatus[] = [
+  'Available',
+  'Busy',
+  'DoNotDisturb',
+  'AppearOffline',
+];
+
+const FORM_STYLE: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: '0.5rem',
+  padding: '0.75rem',
+  font: 'inherit',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Manual override picker for the current user. Pairs naturally with
+ * {@link useMyPresence} via the same `<PresenceProvider>`.
+ *
+ * The component is headless w.r.t. menu/popover chrome — host it in
+ * whatever container suits the app (`<DropdownMenu>`, dialog, …). All
+ * mutations go through the existing TanStack Query hooks so the cache
+ * stays consistent with other places that render presence.
+ */
+export function PresencePicker({
+  labels,
+  onApplied,
+  className,
+  children,
+}: Readonly<PresencePickerProps>) {
+  const merged: Required<PresencePickerLabels> = {
+    ...DEFAULT_LABELS,
+    ...labels,
+    statusLabel: { ...DEFAULT_LABELS.statusLabel, ...labels?.statusLabel },
+    presets: { ...DEFAULT_LABELS.presets, ...labels?.presets },
+  };
+
+  const { data: presence } = useMyPresence();
+  const setMutation = useSetMyPresence();
+  const clearMutation = useClearMyPresenceOverride();
+
+  const [status, setStatus] = useState<ManualPresenceStatus>('Available');
+  const [preset, setPreset] = useState<Preset>('1h');
+  const [customLocal, setCustomLocal] = useState<string>('');
+
+  const now = useMemo(() => new Date(), [setMutation.isPending, clearMutation.isPending]);
+
+  const customDate = useMemo(() => {
+    if (preset !== 'custom') return null;
+    if (!customLocal) return null;
+    const date = new Date(customLocal);
+    return Number.isNaN(date.getTime()) ? null : date;
+  }, [customLocal, preset]);
+
+  const untilDate = preset === 'custom' ? customDate : presetToDate(preset, now);
+  const isAvailable = status === 'Available';
+  const untilForRequest = isAvailable ? null : untilDate;
+  const customIncomplete = !isAvailable && preset === 'custom' && customDate == null;
+  const untilValid = isAvailable ? true : !customIncomplete && isValidUntil(untilForRequest, now);
+
+  const canSubmit = !setMutation.isPending && untilValid;
+
+  const overrideUntilLocal = presence?.overrideUntilUtc
+    ? formatUntilLocal(presence.overrideUntilUtc)
+    : null;
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canSubmit) return;
+    const request: SetPresenceRequest = {
+      manualStatus: status,
+      untilUtc: untilForRequest ? toIsoString(untilForRequest) : null,
+    };
+    const result = await setMutation.mutateAsync(request);
+    onApplied?.(result);
+  };
+
+  const handleClear = async () => {
+    const result = await clearMutation.mutateAsync();
+    setStatus('Available');
+    setPreset('1h');
+    setCustomLocal('');
+    onApplied?.(result);
+  };
+
+  const minCustomLocal = toLocalDateTimeInputValue(new Date(now.getTime() + 60_000));
+  const maxCustomLocal = toLocalDateTimeInputValue(
+    new Date(now.getTime() + MAX_OVERRIDE_MS - MS_PER_DAY) // leave headroom
+  );
+
+  return (
+    <form
+      data-granit-presence-picker=""
+      className={className}
+      style={FORM_STYLE}
+      onSubmit={handleSubmit}
+    >
+      {children ?? <strong>{merged.title}</strong>}
+
+      <div role="radiogroup" aria-label={merged.title} style={{ display: 'grid', gap: '0.25rem' }}>
+        {MANUAL_OPTIONS.map((option) => (
+          <label
+            key={option}
+            style={{ display: 'flex', alignItems: 'center', gap: '0.5rem', cursor: 'pointer' }}
+          >
+            <input
+              type="radio"
+              name="granit-presence-status"
+              value={option}
+              checked={status === option}
+              onChange={() => setStatus(option)}
+            />
+            <PresenceDot
+              status={
+                option === 'Available' ? 'Online' : option === 'AppearOffline' ? 'Offline' : option
+              }
+              size={8}
+              bordered={false}
+              presentational
+            />
+            <span>{merged.statusLabel[option]}</span>
+          </label>
+        ))}
+      </div>
+
+      {!isAvailable && (
+        <fieldset
+          style={{
+            border: '1px solid #e5e7eb',
+            borderRadius: 4,
+            padding: '0.5rem',
+            display: 'grid',
+            gap: '0.25rem',
+          }}
+        >
+          <legend style={{ padding: '0 0.25rem' }}>{merged.until}</legend>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="radio"
+              name="granit-presence-preset"
+              checked={preset === '30m'}
+              onChange={() => setPreset('30m')}
+            />
+            <span>{merged.presets.thirtyMinutes}</span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="radio"
+              name="granit-presence-preset"
+              checked={preset === '1h'}
+              onChange={() => setPreset('1h')}
+            />
+            <span>{merged.presets.oneHour}</span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="radio"
+              name="granit-presence-preset"
+              checked={preset === '4h'}
+              onChange={() => setPreset('4h')}
+            />
+            <span>{merged.presets.fourHours}</span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="radio"
+              name="granit-presence-preset"
+              checked={preset === 'today'}
+              onChange={() => setPreset('today')}
+            />
+            <span>{merged.presets.today}</span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="radio"
+              name="granit-presence-preset"
+              checked={preset === 'none'}
+              onChange={() => setPreset('none')}
+            />
+            <span>{merged.presets.noExpiry}</span>
+          </label>
+          <label style={{ display: 'flex', alignItems: 'center', gap: '0.5rem' }}>
+            <input
+              type="radio"
+              name="granit-presence-preset"
+              checked={preset === 'custom'}
+              onChange={() => setPreset('custom')}
+            />
+            <span>{merged.presets.custom}</span>
+          </label>
+          {preset === 'custom' && (
+            <input
+              aria-label={merged.customUntil}
+              type="datetime-local"
+              value={customLocal}
+              min={minCustomLocal}
+              max={maxCustomLocal}
+              onChange={(e) => setCustomLocal(e.target.value)}
+              data-granit-presence-custom-until=""
+              style={{ marginLeft: '1.5rem' }}
+            />
+          )}
+        </fieldset>
+      )}
+
+      {!untilValid && (
+        <div data-granit-presence-picker-error="" role="alert" style={{ color: '#b91c1c' }}>
+          {/* Plain message — apps that want a localized error can wrap this picker. */}
+          The expiry must be in the future and at most 7 days away.
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+        {presence?.manualOverride ? (
+          <button
+            type="button"
+            onClick={handleClear}
+            disabled={clearMutation.isPending}
+            data-granit-presence-clear=""
+          >
+            {merged.clear}
+          </button>
+        ) : (
+          <span
+            data-granit-presence-no-override=""
+            style={{ color: '#6b7280', marginRight: 'auto' }}
+          >
+            {merged.noOverride}
+          </span>
+        )}
+        <button type="submit" disabled={!canSubmit} data-granit-presence-save="">
+          {merged.save}
+        </button>
+      </div>
+
+      {overrideUntilLocal && presence?.manualOverride && (
+        <div data-granit-presence-current-override="" style={{ color: '#6b7280', fontSize: 12 }}>
+          {merged.overrideUntil(overrideUntilLocal)}
+        </div>
+      )}
+    </form>
+  );
+}

--- a/packages/@granit/react-presence/src/constants.ts
+++ b/packages/@granit/react-presence/src/constants.ts
@@ -1,0 +1,13 @@
+export const API_VERSION = 'v1';
+/**
+ * API-compatible base path for `@granit/presence` functions.
+ * Those functions append `/presence` internally, so the base they receive
+ * must NOT include the module segment.
+ */
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}`;
+
+/** Default cadence (ms) at which `useHeartbeat` polls the server while visible. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
+
+/** Stale time (ms) applied to `useMyPresence` / `useUserPresence` / `useBatchPresence`. */
+export const DEFAULT_STALE_TIME_MS = 30_000;

--- a/packages/@granit/react-presence/src/hooks/query-keys.ts
+++ b/packages/@granit/react-presence/src/hooks/query-keys.ts
@@ -1,0 +1,8 @@
+/** Query key factory for presence queries. Concatenated after the provider prefix. */
+export const presenceKeys = {
+  all: ['presence'] as const,
+  my: () => [...presenceKeys.all, 'my'] as const,
+  user: (userId: string) => [...presenceKeys.all, 'user', userId] as const,
+  batch: (userIds: readonly string[]) =>
+    [...presenceKeys.all, 'batch', [...userIds].sort()] as const,
+};

--- a/packages/@granit/react-presence/src/hooks/use-batch-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-batch-presence.ts
@@ -1,0 +1,85 @@
+import { PRESENCE_DEFAULTS, getBatchPresence } from '@granit/presence';
+import { useQuery } from '@tanstack/react-query';
+
+import { DEFAULT_STALE_TIME_MS } from '../constants.js';
+import {
+  buildPresenceQueryKey,
+  usePresenceConfig,
+  type ResolvedPresenceConfig,
+} from '../providers/presence-provider.js';
+
+import { presenceKeys } from './query-keys.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { BatchPresenceResponse, PresenceResponse } from '@granit/presence';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+export interface UseBatchPresenceOptions {
+  /** Set to `false` to suppress the request (e.g. when permission is missing). */
+  readonly enabled?: boolean;
+}
+
+const MAX_BATCH = PRESENCE_DEFAULTS.MaxBatchSize;
+
+/**
+ * Returns the deduplicated, sorted list — caller doesn't have to worry
+ * about ordering or duplicates when picking IDs from several sources.
+ */
+function normalize(userIds: readonly string[]): string[] {
+  return Array.from(new Set(userIds))
+    .filter((id) => id.length > 0)
+    .sort();
+}
+
+async function fetchBatch(
+  client: AxiosInstance,
+  basePath: string,
+  userIds: readonly string[]
+): Promise<BatchPresenceResponse> {
+  if (userIds.length <= MAX_BATCH) {
+    return getBatchPresence(client, basePath, { userIds });
+  }
+  // Server cap is 200 — chunk above that and merge dictionaries.
+  const merged: Record<string, PresenceResponse> = {};
+  for (let i = 0; i < userIds.length; i += MAX_BATCH) {
+    const chunk = userIds.slice(i, i + MAX_BATCH);
+    const { presences } = await getBatchPresence(client, basePath, { userIds: chunk });
+    Object.assign(merged, presences);
+  }
+  return { presences: merged };
+}
+
+/**
+ * Fetches presence for a list of users in one (or more) batch calls.
+ *
+ * Inputs are deduplicated and sorted before hitting the network and
+ * before forming the query key, so two components that ask for the
+ * same set of users share a single cache entry. Lists larger than the
+ * server cap (200) are chunked transparently.
+ *
+ * Requires `Presence.Users.Read`. Callers without that permission should
+ * pass `enabled: false`.
+ */
+export function useBatchPresence(
+  userIds: readonly string[],
+  options: UseBatchPresenceOptions = {}
+): UseQueryResult<BatchPresenceResponse> {
+  const { enabled = true } = options;
+  const config = usePresenceConfig();
+  const ids = normalize(userIds);
+
+  return useQuery({
+    queryKey: buildPresenceQueryKey(config, ...presenceKeys.batch(ids)),
+    queryFn: () => fetchBatch(config.client, config.basePath, ids),
+    staleTime: DEFAULT_STALE_TIME_MS,
+    refetchOnWindowFocus: true,
+    enabled: enabled && ids.length > 0,
+  });
+}
+
+// Exposed for tests that want to drive the chunker without spinning React.
+export const __internals = {
+  normalize,
+  fetchBatch: (config: ResolvedPresenceConfig, userIds: readonly string[]) =>
+    fetchBatch(config.client, config.basePath, userIds),
+};

--- a/packages/@granit/react-presence/src/hooks/use-clear-my-presence-override.ts
+++ b/packages/@granit/react-presence/src/hooks/use-clear-my-presence-override.ts
@@ -1,0 +1,23 @@
+import { clearMyPresenceOverride } from '@granit/presence';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-provider.js';
+
+import { presenceKeys } from './query-keys.js';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Mutation that clears the current user's manual override. */
+export function useClearMyPresenceOverride(): UseMutationResult<PresenceResponse, Error, void> {
+  const config = usePresenceConfig();
+  const queryClient = useQueryClient();
+  const queryKey = buildPresenceQueryKey(config, ...presenceKeys.my());
+
+  return useMutation({
+    mutationFn: () => clearMyPresenceOverride(config.client, config.basePath),
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKey, data);
+    },
+  });
+}

--- a/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
+++ b/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
@@ -1,0 +1,120 @@
+import { sendHeartbeat } from '@granit/presence';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+
+import { DEFAULT_HEARTBEAT_INTERVAL_MS } from '../constants.js';
+import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-provider.js';
+
+import { presenceKeys } from './query-keys.js';
+
+import type { PresenceResponse } from '@granit/presence';
+
+export interface UseHeartbeatOptions {
+  /** Polling interval in ms while the tab is visible. Default: 30 000. */
+  readonly intervalMs?: number;
+  /** Disable the hook entirely. Default: false. */
+  readonly disabled?: boolean;
+}
+
+const ACTIVITY_EVENTS: readonly (keyof DocumentEventMap)[] = [
+  'keydown',
+  'mousemove',
+  'scroll',
+] as const;
+
+/**
+ * Sends periodic heartbeats while the tab is visible. Idle seconds are
+ * derived from the last `keydown`/`mousemove`/`scroll` event — we never
+ * read key/mouse values, just the timestamps.
+ *
+ * The hook is meant to be mounted **exactly once** at the authenticated
+ * shell of the app (see `<PresenceHeartbeat />`). Mounting it multiple
+ * times will cause multiple parallel polls.
+ */
+export function useHeartbeat(options: UseHeartbeatOptions = {}): void {
+  const { intervalMs = DEFAULT_HEARTBEAT_INTERVAL_MS, disabled = false } = options;
+  const config = usePresenceConfig();
+  const queryClient = useQueryClient();
+
+  const lastActivityRef = useRef<number>(Date.now());
+  const inFlightRef = useRef(false);
+
+  useEffect(() => {
+    if (disabled) return;
+
+    const bumpActivity = () => {
+      lastActivityRef.current = Date.now();
+    };
+    for (const evt of ACTIVITY_EVENTS) {
+      document.addEventListener(evt, bumpActivity, { passive: true });
+    }
+    return () => {
+      for (const evt of ACTIVITY_EVENTS) {
+        document.removeEventListener(evt, bumpActivity);
+      }
+    };
+  }, [disabled]);
+
+  useEffect(() => {
+    if (disabled) return;
+
+    const queryKey = buildPresenceQueryKey(config, ...presenceKeys.my());
+
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let cancelled = false;
+
+    const tick = async () => {
+      if (cancelled) return;
+      if (document.visibilityState !== 'visible') return;
+      if (inFlightRef.current) return;
+      inFlightRef.current = true;
+      try {
+        const idleSeconds = Math.max(0, Math.floor((Date.now() - lastActivityRef.current) / 1000));
+        const data = await sendHeartbeat(config.client, config.basePath, { idleSeconds });
+        if (!cancelled) {
+          queryClient.setQueryData<PresenceResponse>(queryKey, data);
+        }
+      } catch {
+        // Heartbeat failures are non-critical — keep polling.
+      } finally {
+        inFlightRef.current = false;
+      }
+    };
+
+    const start = () => {
+      if (timer != null) return;
+      // Fire one immediately on (re-)start so the UI reflects state quickly.
+      void tick();
+      timer = setInterval(() => {
+        void tick();
+      }, intervalMs);
+    };
+
+    const stop = () => {
+      if (timer != null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        lastActivityRef.current = Date.now();
+        start();
+      } else {
+        stop();
+      }
+    };
+
+    if (document.visibilityState === 'visible') {
+      start();
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      stop();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+    };
+  }, [config, disabled, intervalMs, queryClient]);
+}

--- a/packages/@granit/react-presence/src/hooks/use-my-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-my-presence.ts
@@ -1,0 +1,26 @@
+import { getMyPresence } from '@granit/presence';
+import { useQuery } from '@tanstack/react-query';
+
+import { DEFAULT_STALE_TIME_MS } from '../constants.js';
+import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-provider.js';
+
+import { presenceKeys } from './query-keys.js';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetches the current user's presence snapshot.
+ *
+ * Refetches on window focus and stays fresh for ~30 s. Combine with
+ * `<PresenceHeartbeat />` to keep the server-side snapshot current.
+ */
+export function useMyPresence(): UseQueryResult<PresenceResponse> {
+  const config = usePresenceConfig();
+  return useQuery({
+    queryKey: buildPresenceQueryKey(config, ...presenceKeys.my()),
+    queryFn: () => getMyPresence(config.client, config.basePath),
+    staleTime: DEFAULT_STALE_TIME_MS,
+    refetchOnWindowFocus: true,
+  });
+}

--- a/packages/@granit/react-presence/src/hooks/use-set-my-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-set-my-presence.ts
@@ -1,0 +1,58 @@
+import { setMyPresence } from '@granit/presence';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-provider.js';
+
+import { presenceKeys } from './query-keys.js';
+
+import type { PresenceResponse, SetPresenceRequest } from '@granit/presence';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Mutation that sets the current user's manual override.
+ *
+ * Performs an optimistic update on `useMyPresence`'s cache and rolls back
+ * if the server returns an error (typically 400 ValidationProblem).
+ */
+export function useSetMyPresence(): UseMutationResult<
+  PresenceResponse,
+  Error,
+  SetPresenceRequest,
+  { previous: PresenceResponse | undefined }
+> {
+  const config = usePresenceConfig();
+  const queryClient = useQueryClient();
+  const queryKey = buildPresenceQueryKey(config, ...presenceKeys.my());
+
+  return useMutation({
+    mutationFn: (request: SetPresenceRequest) =>
+      setMyPresence(config.client, config.basePath, request),
+    onMutate: async (request) => {
+      await queryClient.cancelQueries({ queryKey });
+      const previous = queryClient.getQueryData<PresenceResponse>(queryKey);
+      if (previous) {
+        const optimistic: PresenceResponse = {
+          ...previous,
+          manualOverride: request.manualStatus === 'Available' ? null : request.manualStatus,
+          overrideUntilUtc: request.untilUtc,
+          effectiveStatus:
+            request.manualStatus === 'Available'
+              ? previous.effectiveStatus
+              : request.manualStatus === 'AppearOffline'
+                ? 'Offline'
+                : request.manualStatus,
+        };
+        queryClient.setQueryData(queryKey, optimistic);
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(queryKey, context.previous);
+      }
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(queryKey, data);
+    },
+  });
+}

--- a/packages/@granit/react-presence/src/hooks/use-user-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-user-presence.ts
@@ -1,0 +1,37 @@
+import { getUserPresence } from '@granit/presence';
+import { useQuery } from '@tanstack/react-query';
+
+import { DEFAULT_STALE_TIME_MS } from '../constants.js';
+import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-provider.js';
+
+import { presenceKeys } from './query-keys.js';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+export interface UseUserPresenceOptions {
+  /** Set to `false` to suppress the request (e.g. when permission is missing). */
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetches presence for a single user.
+ *
+ * Requires `Presence.Users.Read`. Callers without that permission should
+ * pass `enabled: false` and fall back to a muted `Offline` indicator
+ * instead of letting the request 403.
+ */
+export function useUserPresence(
+  userId: string,
+  options: UseUserPresenceOptions = {}
+): UseQueryResult<PresenceResponse> {
+  const { enabled = true } = options;
+  const config = usePresenceConfig();
+  return useQuery({
+    queryKey: buildPresenceQueryKey(config, ...presenceKeys.user(userId)),
+    queryFn: () => getUserPresence(config.client, config.basePath, userId),
+    staleTime: DEFAULT_STALE_TIME_MS,
+    refetchOnWindowFocus: true,
+    enabled: enabled && userId.length > 0,
+  });
+}

--- a/packages/@granit/react-presence/src/index.ts
+++ b/packages/@granit/react-presence/src/index.ts
@@ -1,0 +1,40 @@
+// Provider
+export {
+  PresenceProvider,
+  buildPresenceQueryKey,
+  usePresenceConfig,
+} from './providers/presence-provider.js';
+export type {
+  PresenceConfig,
+  PresenceProviderProps,
+  ResolvedPresenceConfig,
+} from './providers/presence-provider.js';
+
+// Hooks
+export { useMyPresence } from './hooks/use-my-presence.js';
+export { useSetMyPresence } from './hooks/use-set-my-presence.js';
+export { useClearMyPresenceOverride } from './hooks/use-clear-my-presence-override.js';
+export { useHeartbeat } from './hooks/use-heartbeat.js';
+export type { UseHeartbeatOptions } from './hooks/use-heartbeat.js';
+export { useUserPresence } from './hooks/use-user-presence.js';
+export type { UseUserPresenceOptions } from './hooks/use-user-presence.js';
+export { useBatchPresence } from './hooks/use-batch-presence.js';
+export type { UseBatchPresenceOptions } from './hooks/use-batch-presence.js';
+export { presenceKeys } from './hooks/query-keys.js';
+
+// Components
+export { PresenceDot, DEFAULT_PRESENCE_COLORS } from './components/presence-dot.js';
+export type { PresenceDotLabels, PresenceDotProps } from './components/presence-dot.js';
+export { PresencePicker } from './components/presence-picker.js';
+export type { PresencePickerLabels, PresencePickerProps } from './components/presence-picker.js';
+export { DndBanner } from './components/dnd-banner.js';
+export type { DndBannerLabels, DndBannerProps } from './components/dnd-banner.js';
+export { PresenceHeartbeat } from './components/presence-heartbeat.js';
+export type { PresenceHeartbeatProps } from './components/presence-heartbeat.js';
+
+// Locales
+export {
+  presenceTranslationsEn,
+  presenceTranslationsFr,
+  type PresenceTranslations,
+} from './locales/index.js';

--- a/packages/@granit/react-presence/src/locales/en.ts
+++ b/packages/@granit/react-presence/src/locales/en.ts
@@ -1,0 +1,83 @@
+/**
+ * English translation bundle for `@granit/react-presence`.
+ *
+ * Consumers register the bundle with their i18n instance:
+ *
+ *   import { presenceTranslationsEn } from '@granit/react-presence';
+ *   i18n.addResourceBundle('en', 'presence', presenceTranslationsEn);
+ *
+ * Components in this package don't call `useTranslation` directly —
+ * they expose `labels` props that apps populate from `t()` results.
+ */
+export interface PresenceTranslations {
+  readonly Status: Readonly<
+    Record<'Online' | 'Away' | 'Busy' | 'DoNotDisturb' | 'Offline', string>
+  >;
+  readonly Manual: Readonly<
+    Record<'Available' | 'Busy' | 'DoNotDisturb' | 'AppearOffline', string>
+  >;
+  readonly Picker: {
+    readonly Title: string;
+    readonly Until: string;
+    readonly Save: string;
+    readonly Clear: string;
+    readonly CustomUntil: string;
+    readonly NoOverride: string;
+    readonly OverrideUntil: string;
+    readonly InvalidUntil: string;
+    readonly Presets: {
+      readonly ThirtyMinutes: string;
+      readonly OneHour: string;
+      readonly FourHours: string;
+      readonly Today: string;
+      readonly Custom: string;
+      readonly NoExpiry: string;
+    };
+  };
+  readonly DndBanner: {
+    readonly DoNotDisturb: string;
+    readonly AppearOffline: string;
+    readonly ClearAction: string;
+  };
+}
+
+export const presenceTranslationsEn: PresenceTranslations = {
+  Status: {
+    Online: 'Online',
+    Away: 'Away',
+    Busy: 'Busy',
+    DoNotDisturb: 'Do not disturb',
+    Offline: 'Offline',
+  },
+  Manual: {
+    Available: 'Available',
+    Busy: 'Busy',
+    DoNotDisturb: 'Do not disturb',
+    AppearOffline: 'Appear offline',
+  },
+  Picker: {
+    Title: 'Set status',
+    Until: 'Clear after',
+    Save: 'Set status',
+    Clear: 'Clear status',
+    CustomUntil: 'Pick a date and time',
+    NoOverride: 'No active override',
+    OverrideUntil: 'Until {{until}}',
+    InvalidUntil: 'The expiry must be in the future and at most 7 days away.',
+    Presets: {
+      ThirtyMinutes: '30 minutes',
+      OneHour: '1 hour',
+      FourHours: '4 hours',
+      Today: 'Today',
+      Custom: 'Custom…',
+      NoExpiry: "Don't clear",
+    },
+  },
+  DndBanner: {
+    DoNotDisturb:
+      'You are in Do not disturb — real-time notifications (push, SignalR, SSE) are muted.',
+    AppearOffline:
+      'You appear offline — others see you as Offline and real-time notifications are muted.',
+    ClearAction: 'Clear status',
+  },
+};

--- a/packages/@granit/react-presence/src/locales/fr.ts
+++ b/packages/@granit/react-presence/src/locales/fr.ts
@@ -1,0 +1,42 @@
+import type { PresenceTranslations } from './en.js';
+
+export const presenceTranslationsFr: PresenceTranslations = {
+  Status: {
+    Online: 'En ligne',
+    Away: 'Absent',
+    Busy: 'Occupé',
+    DoNotDisturb: 'Ne pas déranger',
+    Offline: 'Hors ligne',
+  },
+  Manual: {
+    Available: 'Disponible',
+    Busy: 'Occupé',
+    DoNotDisturb: 'Ne pas déranger',
+    AppearOffline: 'Apparaître hors ligne',
+  },
+  Picker: {
+    Title: 'Définir le statut',
+    Until: 'Effacer après',
+    Save: 'Définir le statut',
+    Clear: 'Effacer le statut',
+    CustomUntil: 'Choisir une date et une heure',
+    NoOverride: 'Aucun statut manuel actif',
+    OverrideUntil: "Jusqu'à {{until}}",
+    InvalidUntil: "L'échéance doit être dans le futur et au plus 7 jours.",
+    Presets: {
+      ThirtyMinutes: '30 minutes',
+      OneHour: '1 heure',
+      FourHours: '4 heures',
+      Today: "Aujourd'hui",
+      Custom: 'Personnalisé…',
+      NoExpiry: 'Ne pas effacer',
+    },
+  },
+  DndBanner: {
+    DoNotDisturb:
+      'Vous êtes en Ne pas déranger — les notifications temps réel (push, SignalR, SSE) sont désactivées.',
+    AppearOffline:
+      'Vous apparaissez hors ligne — les autres vous voient hors ligne et les notifications temps réel sont désactivées.',
+    ClearAction: 'Effacer le statut',
+  },
+};

--- a/packages/@granit/react-presence/src/locales/index.ts
+++ b/packages/@granit/react-presence/src/locales/index.ts
@@ -1,0 +1,14 @@
+// ---------------------------------------------------------------------------
+// @granit/react-presence — i18next resource bundles (namespace: "presence")
+// ---------------------------------------------------------------------------
+//
+//   import { presenceTranslationsEn, presenceTranslationsFr } from '@granit/react-presence';
+//   i18n.addResourceBundle('en', 'presence', presenceTranslationsEn);
+//   i18n.addResourceBundle('fr', 'presence', presenceTranslationsFr);
+//
+// Components expose `labels` props that apps populate from `t()` results.
+// ---------------------------------------------------------------------------
+
+export { presenceTranslationsEn } from './en.js';
+export type { PresenceTranslations } from './en.js';
+export { presenceTranslationsFr } from './fr.js';

--- a/packages/@granit/react-presence/src/providers/presence-provider.tsx
+++ b/packages/@granit/react-presence/src/providers/presence-provider.tsx
@@ -1,0 +1,69 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+export interface PresenceConfig {
+  /** Axios client. Falls back to the nearest `<GranitClientProvider>`. */
+  readonly client?: AxiosInstance;
+  /**
+   * Base path the API functions are called with. Defaults to `/api/v1`.
+   * The module segment (`presence`) is appended internally.
+   */
+  readonly basePath?: string;
+  /** Prefix for query keys — useful to namespace caches in multi-tenant apps. */
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+export interface ResolvedPresenceConfig extends PresenceConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
+}
+
+const DEFAULT_KEY_PREFIX = ['presence'] as const;
+
+const PresenceContext = createContext<ResolvedPresenceConfig | null>(null);
+
+export interface PresenceProviderProps {
+  readonly config?: PresenceConfig;
+  readonly children: ReactNode;
+}
+
+export function usePresenceConfig(): ResolvedPresenceConfig {
+  const config = useContext(PresenceContext);
+  if (!config) {
+    throw new Error('usePresenceConfig must be used within a <PresenceProvider>');
+  }
+  return config;
+}
+
+export function buildPresenceQueryKey(
+  config: ResolvedPresenceConfig,
+  ...segments: readonly unknown[]
+): readonly unknown[] {
+  return [...config.queryKeyPrefix, ...segments];
+}
+
+export function PresenceProvider({ config, children }: Readonly<PresenceProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedPresenceConfig>(() => {
+    const client = config?.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'PresenceProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      client,
+      basePath: config?.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config?.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
+    };
+  }, [config, contextClient]);
+
+  return <PresenceContext value={value}>{children}</PresenceContext>;
+}

--- a/packages/@granit/react-presence/src/testing/data.ts
+++ b/packages/@granit/react-presence/src/testing/data.ts
@@ -1,0 +1,53 @@
+import { toEntityId, toISODateString } from '@granit/types';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+const baseLastSeen = toISODateString('2026-05-22T10:00:00Z');
+
+export const mockUsers = [
+  { id: toEntityId<'User'>('user-self') as UserId, name: 'Your Account' },
+  { id: toEntityId<'User'>('user-alice') as UserId, name: 'Alice Martin' },
+  { id: toEntityId<'User'>('user-bob') as UserId, name: 'Bob Lefebvre' },
+  { id: toEntityId<'User'>('user-charlie') as UserId, name: 'Charlie Wood' },
+  { id: toEntityId<'User'>('user-diana') as UserId, name: 'Diana Brown' },
+];
+
+export const mockMyPresence: PresenceResponse = {
+  userId: mockUsers[0]!.id,
+  effectiveStatus: 'Online',
+  manualOverride: null,
+  overrideUntilUtc: null,
+  lastSeenUtc: baseLastSeen,
+};
+
+export const mockOtherPresences: Record<string, PresenceResponse> = {
+  [mockUsers[1]!.id]: {
+    userId: mockUsers[1]!.id,
+    effectiveStatus: 'Online',
+    manualOverride: null,
+    overrideUntilUtc: null,
+    lastSeenUtc: baseLastSeen,
+  },
+  [mockUsers[2]!.id]: {
+    userId: mockUsers[2]!.id,
+    effectiveStatus: 'Away',
+    manualOverride: null,
+    overrideUntilUtc: null,
+    lastSeenUtc: toISODateString('2026-05-22T09:50:00Z'),
+  },
+  [mockUsers[3]!.id]: {
+    userId: mockUsers[3]!.id,
+    effectiveStatus: 'DoNotDisturb',
+    manualOverride: 'DoNotDisturb',
+    overrideUntilUtc: toISODateString('2026-05-22T18:00:00Z'),
+    lastSeenUtc: toISODateString('2026-05-22T09:55:00Z'),
+  },
+  [mockUsers[4]!.id]: {
+    userId: mockUsers[4]!.id,
+    effectiveStatus: 'Offline',
+    manualOverride: null,
+    overrideUntilUtc: null,
+    lastSeenUtc: toISODateString('2026-05-21T18:00:00Z'),
+  },
+};

--- a/packages/@granit/react-presence/src/testing/handlers.ts
+++ b/packages/@granit/react-presence/src/testing/handlers.ts
@@ -1,0 +1,150 @@
+import { toISODateString } from '@granit/types';
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants.js';
+
+import { mockMyPresence, mockOtherPresences } from './data.js';
+
+import type {
+  BatchPresenceRequest,
+  BatchPresenceResponse,
+  HeartbeatRequest,
+  ManualPresenceStatus,
+  PresenceResponse,
+  PresenceStatus,
+  SetPresenceRequest,
+} from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+type Mutable<T> = { -readonly [P in keyof T]: T[P] };
+
+function recomputeEffective(
+  override: ManualPresenceStatus | null,
+  lastIdleSeconds: number
+): PresenceStatus {
+  if (override === 'AppearOffline') return 'Offline';
+  if (override === 'DoNotDisturb') return 'DoNotDisturb';
+  if (override === 'Busy') return 'Busy';
+  if (lastIdleSeconds >= 180) return 'Away';
+  return 'Online';
+}
+
+function offlineSnapshot(userId: string): PresenceResponse {
+  return {
+    userId: userId as UserId,
+    effectiveStatus: 'Offline',
+    manualOverride: null,
+    overrideUntilUtc: null,
+    lastSeenUtc: null,
+  };
+}
+
+/**
+ * Stateful MSW handlers for the Presence module. Heartbeats, manual
+ * overrides and clears mutate the in-memory record so subsequent GETs
+ * reflect the change.
+ */
+export function createPresenceHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  let my: Mutable<PresenceResponse> = { ...mockMyPresence };
+  let lastIdleSeconds = 0;
+  const others: Record<string, PresenceResponse> = { ...mockOtherPresences };
+
+  return [
+    http.get(`${baseUrl}/presence/my`, () => HttpResponse.json(my)),
+
+    http.put<never, SetPresenceRequest>(`${baseUrl}/presence/my`, async ({ request }) => {
+      const body = (await request.json()) as SetPresenceRequest;
+      // Server-side validation parity.
+      if (body.manualStatus === 'Available' && body.untilUtc !== null) {
+        return HttpResponse.json(
+          {
+            type: 'about:blank',
+            title: 'Bad Request',
+            status: 400,
+            errors: {
+              untilUtc: ['Validation:PresenceUntilWithoutOverride'],
+            },
+          },
+          { status: 400 }
+        );
+      }
+      const override: ManualPresenceStatus | null =
+        body.manualStatus === 'Available' ? null : body.manualStatus;
+      my = {
+        ...my,
+        manualOverride: override,
+        overrideUntilUtc: override ? body.untilUtc : null,
+        effectiveStatus: recomputeEffective(override, lastIdleSeconds),
+        lastSeenUtc: toISODateString(new Date().toISOString()),
+      };
+      return HttpResponse.json(my);
+    }),
+
+    http.delete(`${baseUrl}/presence/my/override`, () => {
+      my = {
+        ...my,
+        manualOverride: null,
+        overrideUntilUtc: null,
+        effectiveStatus: recomputeEffective(null, lastIdleSeconds),
+        lastSeenUtc: toISODateString(new Date().toISOString()),
+      };
+      return HttpResponse.json(my);
+    }),
+
+    http.post<never, HeartbeatRequest>(`${baseUrl}/presence/my/poll`, async ({ request }) => {
+      const body = (await request.json()) as HeartbeatRequest;
+      lastIdleSeconds = Math.min(Math.max(0, body.idleSeconds | 0), 180);
+      my = {
+        ...my,
+        lastSeenUtc: toISODateString(new Date().toISOString()),
+        effectiveStatus: recomputeEffective(my.manualOverride, lastIdleSeconds),
+      };
+      return HttpResponse.json(my);
+    }),
+
+    http.get(`${baseUrl}/presence/users/:userId`, ({ params }) => {
+      const userId = decodeURIComponent(String(params.userId));
+      const snapshot = userId === my.userId ? my : (others[userId] ?? offlineSnapshot(userId));
+      return HttpResponse.json(snapshot);
+    }),
+
+    http.post<never, BatchPresenceRequest>(
+      `${baseUrl}/presence/users/batch`,
+      async ({ request }) => {
+        const body = (await request.json()) as BatchPresenceRequest;
+        if (!body.userIds?.length) {
+          return HttpResponse.json(
+            { title: 'Bad Request', status: 400, errors: { userIds: ['Required'] } },
+            { status: 400 }
+          );
+        }
+        if (body.userIds.length > 200) {
+          return HttpResponse.json(
+            {
+              title: 'Bad Request',
+              status: 400,
+              errors: { userIds: ['Validation:PresenceBatchTooLarge'] },
+            },
+            { status: 400 }
+          );
+        }
+        if (new Set(body.userIds).size !== body.userIds.length) {
+          return HttpResponse.json(
+            {
+              title: 'Bad Request',
+              status: 400,
+              errors: { userIds: ['Validation:PresenceBatchDuplicates'] },
+            },
+            { status: 400 }
+          );
+        }
+        const presences: Record<string, PresenceResponse> = {};
+        for (const id of body.userIds) {
+          presences[id] = id === my.userId ? my : (others[id] ?? offlineSnapshot(id));
+        }
+        const response: BatchPresenceResponse = { presences };
+        return HttpResponse.json(response);
+      }
+    ),
+  ];
+}

--- a/packages/@granit/react-presence/src/testing/index.ts
+++ b/packages/@granit/react-presence/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-presence/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockMyPresence, mockOtherPresences, mockUsers } from './data.js';
+export { createPresenceHandlers } from './handlers.js';

--- a/packages/@granit/react-presence/tsconfig.json
+++ b/packages/@granit/react-presence/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["@testing-library/jest-dom"],
+    "paths": {
+      "@granit/api-client": ["../api-client/src/index.ts"],
+      "@granit/api-client/test-utils": ["../api-client/src/test-utils.ts"],
+      "@granit/presence": ["../presence/src/index.ts"],
+      "@granit/react-api-client": ["../react-api-client/src/index.ts"],
+      "@granit/react-testing": ["../react-testing/src/index.ts"],
+      "@granit/testing": ["../testing/src/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"],
+      "@granit/types": ["../types/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-presence/tsup.config.ts
+++ b/packages/@granit/react-presence/tsup.config.ts
@@ -1,0 +1,6 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  external: [/^@granit\//, 'msw', 'react', '@tanstack/react-query'],
+});

--- a/packages/@granit/taxonomy/src/__tests__/categories-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/categories-api.test.ts
@@ -56,9 +56,9 @@ const sampleAssignment: CategoryAssignmentResponse = {
 };
 
 describe('listCategories', () => {
-  it('GETs /categories with only scope when parentId is omitted', async () => {
+  it('GETs /categories with only scope when parentId is omitted and unwraps the envelope', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleRoot]));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [sampleRoot] }));
 
     const result = await listCategories(client, basePath, { scope: 'documents' });
 
@@ -70,7 +70,7 @@ describe('listCategories', () => {
 
   it('omits parentId from params when explicitly null (root list)', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleRoot]));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [sampleRoot] }));
 
     await listCategories(client, basePath, { scope: 'documents', parentId: null });
 
@@ -81,13 +81,22 @@ describe('listCategories', () => {
 
   it('appends parentId when a non-null id is supplied', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleChild]));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [sampleChild] }));
 
     await listCategories(client, basePath, { scope: 'documents', parentId: 'cat-1' });
 
     expect(client.get).toHaveBeenCalledWith(`${basePath}/categories`, {
       params: { scope: 'documents', parentId: 'cat-1' },
     });
+  });
+
+  it('tolerates a bare-array response (legacy mocks)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleRoot]));
+
+    const result = await listCategories(client, basePath, { scope: 'documents' });
+
+    expect(result).toEqual([sampleRoot]);
   });
 });
 

--- a/packages/@granit/taxonomy/src/api/categories-api.ts
+++ b/packages/@granit/taxonomy/src/api/categories-api.ts
@@ -25,10 +25,16 @@ export async function listCategories(
   if (filter.parentId !== undefined && filter.parentId !== null) {
     params.parentId = filter.parentId;
   }
-  const response = await client.get<readonly CategoryResponse[]>(`${basePath}/categories`, {
-    params,
-  });
-  return response.data;
+  // Backend wraps the listing in `ListCategoriesResponse { items }`. Older
+  // mocks returned a bare array; tolerate both shapes so a stale fixture
+  // doesn't crash the tree.
+  const response = await client.get<
+    { readonly items: readonly CategoryResponse[] } | readonly CategoryResponse[]
+  >(`${basePath}/categories`, { params });
+  const data: { readonly items: readonly CategoryResponse[] } | readonly CategoryResponse[] =
+    response.data;
+  if (Array.isArray(data)) return data;
+  return (data as { readonly items: readonly CategoryResponse[] }).items;
 }
 
 /**

--- a/packages/@granit/validation/README.md
+++ b/packages/@granit/validation/README.md
@@ -1,6 +1,6 @@
 # @granit/validation
 
-OpenAPI constraint extraction, field validation, input prop generation, and server-side validation API. Mirrors `Granit.Validation` .NET contract.
+OpenAPI constraint extraction, field validation, input prop generation, and server-side validation API. Mirrors the .NET `Validation:` error-code convention.
 
 ## Installation
 

--- a/packages/@granit/validation/package.json
+++ b/packages/@granit/validation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@granit/validation",
-  "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors Granit.Validation .NET contract",
+  "description": "OpenAPI constraint extraction, field validation, and input prop generation — mirrors the .NET Validation: error-code convention",
   "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/@granit/validation/src/constants/error-codes.ts
+++ b/packages/@granit/validation/src/constants/error-codes.ts
@@ -1,6 +1,6 @@
 /**
  * Maps constraint types to i18next-compatible localization keys.
- * These keys mirror the .NET Granit.Validation error code convention.
+ * These keys mirror the .NET Validation: error-code convention.
  */
 export const VALIDATION_ERROR_CODES = {
   required: 'Validation:NotEmptyValidator',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -639,6 +639,15 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/presence:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
   packages/@granit/privacy:
     devDependencies:
       '@granit/api-client':
@@ -1974,6 +1983,37 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
+  packages/@granit/react-presence:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.100.11
+        version: 5.100.11(react@19.2.6)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
+      react:
+        specifier: 19.2.6
+        version: 19.2.6
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/presence':
+        specifier: workspace:*
+        version: link:../presence
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -195,6 +195,15 @@ export default defineConfig({
         __dirname,
         'packages/@granit/notifications/src/index.ts'
       ),
+      '@granit/presence': path.resolve(__dirname, 'packages/@granit/presence/src/index.ts'),
+      '@granit/react-presence/testing': path.resolve(
+        __dirname,
+        'packages/@granit/react-presence/src/testing/index.ts'
+      ),
+      '@granit/react-presence': path.resolve(
+        __dirname,
+        'packages/@granit/react-presence/src/index.ts'
+      ),
       '@granit/privacy': path.resolve(__dirname, 'packages/@granit/privacy/src/index.ts'),
       '@granit/query-engine': path.resolve(__dirname, 'packages/@granit/query-engine/src/index.ts'),
       '@granit/validation': path.resolve(__dirname, 'packages/@granit/validation/src/index.ts'),


### PR DESCRIPTION
## Summary

Front-end counterpart of the `Granit.Presence` .NET module (companion to
the backend Presence PR in `granit-fx/granit-dotnet`).

Ships two new packages:

- **`@granit/presence`** — framework-agnostic core: types, 6 API functions
  (`getMyPresence`, `setMyPresence`, `clearMyPresenceOverride`,
  `sendHeartbeat`, `getUserPresence`, `getBatchPresence`), permission
  constants, and server defaults.
- **`@granit/react-presence`** — React bindings:
  - Provider (`<PresenceProvider>`) + TanStack Query hooks
    (`useMyPresence`, `useSetMyPresence`, `useClearMyPresenceOverride`,
    `useHeartbeat`, `useUserPresence`, `useBatchPresence` with automatic
    chunking at the 200-id server cap).
  - Heartbeat (`<PresenceHeartbeat />`): polls `/presence/my/poll` every
    30 s while the tab is visible, derives `idleSeconds` from
    keydown/mousemove/scroll **timestamps only** (no keystroke logging),
    suspends on visibility=hidden.
  - Headless UI: `<PresenceDot>`, `<PresencePicker>` (Available / Busy /
    DoNotDisturb / AppearOffline with 30 min / 1 h / 4 h / today / custom
    until presets, bounded by the 7-day server max), `<DndBanner>` for
    the passive "notifications muted" reminder.
  - i18n bundles (en/fr), MSW handlers under `/testing`.

Server-side validation (idleSeconds clamp, until in future/<=7 days,
Available implies no until, batch dedup/size) is mirrored locally where
useful to save a round-trip.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm tsc`
- [x] `pnpm exec vitest run` — 5599 tests, all green
  (30 new tests across hooks, components, provider, API)
- [x] `pnpm check:csp` — no DOM script sinks introduced
- [x] `pnpm --filter @granit/{presence,react-presence} build` (tsup)
- [ ] Manual UI verification against a live backend — **not run**
      (no Presence-enabled backend running locally yet). Showcase PR
      will exercise the full stack.

Companion to the backend `Granit.Presence` module PR in
`granit-fx/granit-dotnet`.