### PR TITLE
fix(documents): drop /query suffix from QueryEngine route

### DIFF
--- a/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
@@ -85,7 +85,7 @@ describe('DocumentsExplorer', () => {
           data: { folders: folderStatus === 'Active' ? [activeFolder] : [] },
         });
       }
-      // QueryEngine /documents/query
+      // QueryEngine /documents
       return Promise.resolve({ data: { items: [], totalCount: 0, page: 1, pageSize: 50 } });
     }) as AxiosInstance['get']);
     vi.mocked(client.delete).mockImplementation(((url: string) => {

--- a/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
@@ -109,7 +109,7 @@ describe('DocumentsList', () => {
     expect(screen.queryByRole('button', { name: 'readonly.pdf' })).not.toBeInTheDocument();
   });
 
-  it('hits the QueryEngine endpoint /documents/query with the folderId + status Active filters', async () => {
+  it('hits the QueryEngine endpoint /documents with the folderId + status Active filters', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({
       data: { items: [], totalCount: 0, page: 1, pageSize: 50 },
@@ -124,7 +124,7 @@ describe('DocumentsList', () => {
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     const url = vi.mocked(client.get).mock.calls[0]?.[0] ?? '';
     // QueryEngine serializes filters/sort/pagination directly onto the URL.
-    expect(url).toContain('/api/v1/documents/documents/query');
+    expect(url).toContain('/api/v1/documents/documents');
     expect(url).toContain('fld-42');
     expect(url).toContain('Active');
     expect(url).toContain('name');

--- a/packages/@granit/react-documents/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-documents/src/__tests__/testing-handlers.test.ts
@@ -21,9 +21,9 @@ describe('createDocumentsHandlers', () => {
     expect(handlers.length).toBeGreaterThanOrEqual(25);
   });
 
-  it('responds with the documentQueryMetadata at /documents/query/meta', async () => {
+  it('responds with the documentQueryMetadata at /documents/meta', async () => {
     server.use(...createDocumentsHandlers({ basePath: BASE }));
-    const response = await fetch(`${BASE}/documents/query/meta`);
+    const response = await fetch(`${BASE}/documents/meta`);
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(documentQueryMetadata);
   });
@@ -35,10 +35,10 @@ describe('createDocumentsHandlers', () => {
     expect(await response.json()).toEqual(mockQuotaData);
   });
 
-  it('filters /documents/query by folderId Eq', async () => {
+  it('filters /documents by folderId Eq', async () => {
     server.use(...createDocumentsHandlers({ basePath: BASE }));
     const response = await fetch(
-      `${BASE}/documents/query?filter[folderId.Eq]=${FOLDER_CONTRACTS_ID}&filter[status.Eq]=Active&page=1&pageSize=50`
+      `${BASE}/documents?filter[folderId.Eq]=${FOLDER_CONTRACTS_ID}&filter[status.Eq]=Active&page=1&pageSize=50`
     );
     expect(response.status).toBe(200);
     const body = (await response.json()) as { items: { folderId: string }[] };

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -41,7 +41,8 @@ const DEFAULT_LABELS: Required<DocumentsListLabels> = {
 
 /**
  * Lists active documents inside a folder. Backed by the QueryEngine
- * endpoint `GET {basePath}/documents/query` (granit-fx/granit-dotnet#1993).
+ * endpoint `GET {basePath}/documents` (mounts `GET /documents` and
+ * `GET /documents/meta` per Granit convention — mirrors parties).
  *
  * Pre-applies two filters: `folderId Equals <id>` and `status Equals Active`
  * (trashed documents are surfaced in {@link TrashBin} instead). Sorted by
@@ -58,7 +59,7 @@ export function DocumentsList(props: Readonly<DocumentsListProps>): ReactNode {
     <QueryProvider
       config={{
         client: config.client,
-        basePath: `${config.basePath}/documents/query`,
+        basePath: `${config.basePath}/documents`,
         queryKeyPrefix: [...LIST_QUERY_KEY_PREFIX, props.folderId],
       }}
     >

--- a/packages/@granit/react-documents/src/testing/handlers.ts
+++ b/packages/@granit/react-documents/src/testing/handlers.ts
@@ -111,9 +111,9 @@ export function createDocumentsHandlers(
 
   return [
     // ── QueryEngine /meta + list ─────────────────────────────────────────────
-    createQueryMetaHandler(`${basePath}/documents/query`, documentQueryMetadata),
+    createQueryMetaHandler(`${basePath}/documents`, documentQueryMetadata),
 
-    http.get(`${basePath}/documents/query`, ({ request }) => {
+    http.get(`${basePath}/documents`, ({ request }) => {
       const url = new URL(request.url);
       const filters = parseFilters(url);
       const sort = parseSort(url);


### PR DESCRIPTION
## Summary

- `DocumentsList` and `createDocumentsHandlers` were still pointing at the old `GET /documents/query` route. The backend renamed it to `GET /documents` ([granit-business@2de70b5d](https://gitlab.digitaldynamics.be/digital-dynamics/granit-fx/granit-business/-/commit/2de70b5d)) to match the parties convention — `MapGranitQuery` mounts the listing at the entity-root group plus the auto-mounted `GET /documents/meta`.
- Without this fix any consumer calling `DocumentsList` hits a 404 against a real backend, and MSW handlers stand up routes that no longer exist.
- Pure URL alignment — no behaviour change, no public API rename.

Backend reality after #1993 + the follow-up cleanup:

- `GET /api/v1/documents/documents` — paged list
- `GET /api/v1/documents/documents/meta` — query metadata
- `GET /api/v1/documents/documents/{id}` — detail (existing `DocumentMutationEndpoints`)

The `/documents/documents` doubling is intentional — module mount (`documents`) + resource (`documents`), same shape as `/parties/duplicates/{id}` in `@granit/parties`.

## Test plan

- [x] `pnpm tsc` (workspace-wide)
- [x] `pnpm lint`
- [x] `npx vitest run packages/@granit/react-documents` — 140/140
- [ ] Showcase integration: companion MR in `granit-showcase-react` registers `createDocumentsHandlers` so the explorer renders mocked documents end-to-end