### PR TITLE
fix(presence): align query keys, brand UserId, rename poll API

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -4624,7 +4624,7 @@
         {
           "name": "useUserPresence",
           "kind": "function",
-          "signature": "function useUserPresence( userId: string, options: UseUserPresenceOptions ="
+          "signature": "function useUserPresence( userId: UserId, options: UseUserPresenceOptions ="
         },
         {
           "name": "UseUserPresenceOptions",
@@ -4635,7 +4635,7 @@
         {
           "name": "useBatchPresence",
           "kind": "function",
-          "signature": "function useBatchPresence( userIds: readonly string[], options: UseBatchPresenceOptions ="
+          "signature": "function useBatchPresence( userIds: readonly UserId[], options: UseBatchPresenceOptions ="
         },
         {
           "name": "UseBatchPresenceOptions",

--- a/packages/@granit/presence/README.md
+++ b/packages/@granit/presence/README.md
@@ -9,7 +9,7 @@ Exposes:
   `SetPresenceRequest`, `HeartbeatRequest`, `BatchPresenceRequest`,
   `BatchPresenceResponse`.
 - API functions — `getMyPresence`, `setMyPresence`,
-  `clearMyPresenceOverride`, `sendHeartbeat`, `getUserPresence`,
+  `clearMyPresenceOverride`, `pollMyPresence`, `getUserPresence`,
   `getBatchPresence`.
 - Permission constants — `PresencePermissions.Self.Manage`,
   `PresencePermissions.Users.Read`.

--- a/packages/@granit/presence/src/__tests__/presence-api.test.ts
+++ b/packages/@granit/presence/src/__tests__/presence-api.test.ts
@@ -7,7 +7,7 @@ import {
   getBatchPresence,
   getMyPresence,
   getUserPresence,
-  sendHeartbeat,
+  pollMyPresence,
   setMyPresence,
 } from '../api/presence-api.js';
 
@@ -75,29 +75,14 @@ describe('presence-api', () => {
     });
   });
 
-  describe('sendHeartbeat', () => {
-    it('POSTs /presence/my/poll with clamped idleSeconds', async () => {
+  describe('pollMyPresence', () => {
+    it('POSTs /presence/my/poll with the heartbeat body', async () => {
       const client = createMockClient();
       vi.mocked(client.post).mockResolvedValue(axiosResponse(onlineSnapshot));
 
-      await sendHeartbeat(client, '/api/v1', { idleSeconds: 1_000 });
+      await pollMyPresence(client, '/api/v1', { idleSeconds: 42 });
 
-      expect(client.post).toHaveBeenCalledWith('/api/v1/presence/my/poll', { idleSeconds: 180 });
-    });
-
-    it('floors fractional idleSeconds and rejects negatives', async () => {
-      const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue(axiosResponse(onlineSnapshot));
-
-      await sendHeartbeat(client, '/api/v1', { idleSeconds: 5.9 });
-      expect(client.post).toHaveBeenNthCalledWith(1, '/api/v1/presence/my/poll', {
-        idleSeconds: 5,
-      });
-
-      await sendHeartbeat(client, '/api/v1', { idleSeconds: -42 });
-      expect(client.post).toHaveBeenNthCalledWith(2, '/api/v1/presence/my/poll', {
-        idleSeconds: 0,
-      });
+      expect(client.post).toHaveBeenCalledWith('/api/v1/presence/my/poll', { idleSeconds: 42 });
     });
   });
 
@@ -106,7 +91,7 @@ describe('presence-api', () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue(axiosResponse(onlineSnapshot));
 
-      await getUserPresence(client, '/api/v1', 'user/with/slashes');
+      await getUserPresence(client, '/api/v1', toEntityId<'User'>('user/with/slashes') as UserId);
 
       expect(client.get).toHaveBeenCalledWith('/api/v1/presence/users/user%2Fwith%2Fslashes');
     });

--- a/packages/@granit/presence/src/api/presence-api.ts
+++ b/packages/@granit/presence/src/api/presence-api.ts
@@ -1,7 +1,5 @@
 import { buildApiUrl } from '@granit/api-client';
 
-import { PRESENCE_DEFAULTS } from '../constants.js';
-
 import type {
   BatchPresenceRequest,
   BatchPresenceResponse,
@@ -10,6 +8,7 @@ import type {
   SetPresenceRequest,
 } from '../types/index.js';
 import type { AxiosInstance } from '@granit/api-client';
+import type { UserId } from '@granit/types';
 
 // ---------------------------------------------------------------------------
 // Self endpoints
@@ -68,28 +67,22 @@ export async function clearMyPresenceOverride(
 }
 
 /**
- * Sends a heartbeat for the current user. Should be called periodically
+ * Records a heartbeat for the current user. Should be called periodically
  * while the tab is visible (recommended cadence: 30–45 s).
  *
  * `POST {basePath}/presence/my/poll`
  *
- * Requires `Presence.Self.Manage`.
- *
- * `idleSeconds` is clamped client-side to `[0, MaxIdleSeconds]` (the server
- * applies the same clamp, but we save the validation roundtrip).
+ * Requires `Presence.Self.Manage`. The server clamps `idleSeconds` to
+ * `[0, 2 × OfflineThreshold]`; clients can send any non-negative value.
  */
-export async function sendHeartbeat(
+export async function pollMyPresence(
   client: AxiosInstance,
   basePath: string,
   request: HeartbeatRequest
 ): Promise<PresenceResponse> {
-  const idleSeconds = Math.min(
-    Math.max(0, Math.floor(request.idleSeconds)),
-    PRESENCE_DEFAULTS.MaxIdleSeconds
-  );
   const { data } = await client.post<PresenceResponse>(
     buildApiUrl(basePath, 'presence', 'my', 'poll'),
-    { idleSeconds } satisfies HeartbeatRequest
+    request
   );
   return data;
 }
@@ -109,7 +102,7 @@ export async function sendHeartbeat(
 export async function getUserPresence(
   client: AxiosInstance,
   basePath: string,
-  userId: string
+  userId: UserId
 ): Promise<PresenceResponse> {
   const { data } = await client.get<PresenceResponse>(
     buildApiUrl(basePath, 'presence', 'users', encodeURIComponent(userId))

--- a/packages/@granit/presence/src/index.ts
+++ b/packages/@granit/presence/src/index.ts
@@ -15,7 +15,7 @@ export {
   getBatchPresence,
   getMyPresence,
   getUserPresence,
-  sendHeartbeat,
+  pollMyPresence,
   setMyPresence,
 } from './api/presence-api.js';
 

--- a/packages/@granit/presence/src/types/index.ts
+++ b/packages/@granit/presence/src/types/index.ts
@@ -67,7 +67,7 @@ export interface HeartbeatRequest {
  * and have no duplicates.
  */
 export interface BatchPresenceRequest {
-  readonly userIds: readonly string[];
+  readonly userIds: readonly UserId[];
 }
 
 /**
@@ -76,5 +76,5 @@ export interface BatchPresenceRequest {
  * with `lastSeenUtc = null` — they are present in the dictionary.
  */
 export interface BatchPresenceResponse {
-  readonly presences: Readonly<Record<string, PresenceResponse>>;
+  readonly presences: Readonly<Record<UserId, PresenceResponse>>;
 }

--- a/packages/@granit/react-presence/src/__tests__/presence-provider.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/presence-provider.test.tsx
@@ -1,7 +1,9 @@
 import { createMockClient } from '@granit/react-testing';
+import { toEntityId } from '@granit/types';
 import { renderHook } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
+import { presenceKeys } from '../hooks/query-keys.js';
 import {
   PresenceProvider,
   buildPresenceQueryKey,
@@ -9,11 +11,14 @@ import {
 } from '../providers/presence-provider.js';
 
 import type { AxiosInstance } from '@granit/api-client';
+import type { UserId } from '@granit/types';
 import type { ReactNode } from 'react';
 
-function wrap(client: AxiosInstance) {
+function wrap(client: AxiosInstance, prefix?: readonly string[]) {
   return ({ children }: Readonly<{ children: ReactNode }>) => (
-    <PresenceProvider config={{ client }}>{children}</PresenceProvider>
+    <PresenceProvider config={prefix ? { client, queryKeyPrefix: prefix } : { client }}>
+      {children}
+    </PresenceProvider>
   );
 }
 
@@ -30,6 +35,31 @@ describe('PresenceProvider', () => {
     const client = createMockClient();
     const { result } = renderHook(() => usePresenceConfig(), { wrapper: wrap(client) });
     expect(buildPresenceQueryKey(result.current, 'my')).toEqual(['presence', 'my']);
+  });
+
+  it('composes the provider prefix with the key factory without duplication', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => usePresenceConfig(), { wrapper: wrap(client) });
+    const myKey = buildPresenceQueryKey(result.current, ...presenceKeys.my());
+    expect(myKey).toEqual(['presence', 'my']);
+
+    const userKey = buildPresenceQueryKey(
+      result.current,
+      ...presenceKeys.user(toEntityId<'User'>('user-1') as UserId)
+    );
+    expect(userKey).toEqual(['presence', 'user', 'user-1']);
+  });
+
+  it('honours a custom queryKeyPrefix', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => usePresenceConfig(), {
+      wrapper: wrap(client, ['tenant-a', 'presence']),
+    });
+    expect(buildPresenceQueryKey(result.current, ...presenceKeys.my())).toEqual([
+      'tenant-a',
+      'presence',
+      'my',
+    ]);
   });
 
   it('throws if used outside a provider', () => {

--- a/packages/@granit/react-presence/src/__tests__/use-batch-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-batch-presence.test.tsx
@@ -34,7 +34,10 @@ afterEach(() => {
 describe('useBatchPresence', () => {
   it('chunks at MaxBatchSize (200) and merges the dictionaries', async () => {
     const client = createMockClient();
-    const ids = Array.from({ length: 250 }, (_, i) => `user-${String(i).padStart(3, '0')}`);
+    const ids: UserId[] = Array.from(
+      { length: 250 },
+      (_, i) => toEntityId<'User'>(`user-${String(i).padStart(3, '0')}`) as UserId
+    );
 
     vi.mocked(getBatchPresence).mockImplementation(async (_c, _b, request) => {
       const presences: Record<string, PresenceResponse> = {};
@@ -53,18 +56,20 @@ describe('useBatchPresence', () => {
 
   it('deduplicates and sorts the userIds before calling', async () => {
     const client = createMockClient();
+    const userA = toEntityId<'User'>('user-a') as UserId;
+    const userB = toEntityId<'User'>('user-b') as UserId;
     vi.mocked(getBatchPresence).mockResolvedValue({
-      presences: { 'user-a': makeSnapshot('user-a'), 'user-b': makeSnapshot('user-b') },
+      presences: { [userA]: makeSnapshot(userA), [userB]: makeSnapshot(userB) },
     });
     const { wrapper } = createPresenceTestHarness(client);
 
-    const { result } = renderHook(() => useBatchPresence(['user-b', 'user-a', 'user-a']), {
+    const { result } = renderHook(() => useBatchPresence([userB, userA, userA]), {
       wrapper,
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(getBatchPresence).toHaveBeenCalledTimes(1);
     const sent = vi.mocked(getBatchPresence).mock.calls[0]![2].userIds;
-    expect(sent).toEqual(['user-a', 'user-b']);
+    expect(sent).toEqual([userA, userB]);
   });
 });

--- a/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
@@ -12,10 +12,10 @@ import type { UserId } from '@granit/types';
 
 vi.mock('@granit/presence', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, sendHeartbeat: vi.fn() };
+  return { ...actual, pollMyPresence: vi.fn() };
 });
 
-const { sendHeartbeat } = await import('@granit/presence');
+const { pollMyPresence } = await import('@granit/presence');
 
 const snapshot: PresenceResponse = {
   userId: toEntityId<'User'>('user-1') as UserId,
@@ -36,7 +36,7 @@ function setVisibility(state: DocumentVisibilityState) {
 beforeEach(() => {
   vi.useFakeTimers();
   setVisibility('visible');
-  vi.mocked(sendHeartbeat).mockResolvedValue(snapshot);
+  vi.mocked(pollMyPresence).mockResolvedValue(snapshot);
 });
 
 afterEach(() => {
@@ -54,12 +54,12 @@ describe('useHeartbeat', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(sendHeartbeat).toHaveBeenCalledTimes(1);
+    expect(pollMyPresence).toHaveBeenCalledTimes(1);
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(1_000);
     });
-    expect(sendHeartbeat).toHaveBeenCalledTimes(2);
+    expect(pollMyPresence).toHaveBeenCalledTimes(2);
   });
 
   it('suspends when hidden and resumes when visible', async () => {
@@ -70,19 +70,19 @@ describe('useHeartbeat', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(sendHeartbeat).toHaveBeenCalledTimes(1);
+    expect(pollMyPresence).toHaveBeenCalledTimes(1);
 
     act(() => setVisibility('hidden'));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5_000);
     });
-    expect(sendHeartbeat).toHaveBeenCalledTimes(1);
+    expect(pollMyPresence).toHaveBeenCalledTimes(1);
 
     act(() => setVisibility('visible'));
     await act(async () => {
       await vi.advanceTimersByTimeAsync(0);
     });
-    expect(sendHeartbeat).toHaveBeenCalledTimes(2);
+    expect(pollMyPresence).toHaveBeenCalledTimes(2);
   });
 
   it('does nothing when disabled', async () => {
@@ -93,6 +93,6 @@ describe('useHeartbeat', () => {
     await act(async () => {
       await vi.advanceTimersByTimeAsync(5_000);
     });
-    expect(sendHeartbeat).not.toHaveBeenCalled();
+    expect(pollMyPresence).not.toHaveBeenCalled();
   });
 });

--- a/packages/@granit/react-presence/src/components/presence-picker.tsx
+++ b/packages/@granit/react-presence/src/components/presence-picker.tsx
@@ -1,5 +1,5 @@
 import { PRESENCE_DEFAULTS } from '@granit/presence';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useClearMyPresenceOverride } from '../hooks/use-clear-my-presence-override.js';
 import { useMyPresence } from '../hooks/use-my-presence.js';
@@ -23,6 +23,7 @@ export interface PresencePickerLabels {
   readonly clear?: string;
   readonly save?: string;
   readonly noOverride?: string;
+  readonly invalidUntil?: string;
   readonly overrideUntil?: (untilLocal: string) => string;
   readonly presets?: {
     readonly thirtyMinutes: string;
@@ -47,6 +48,7 @@ const DEFAULT_LABELS: Required<PresencePickerLabels> = {
   clear: 'Clear status',
   save: 'Set status',
   noOverride: 'No active override',
+  invalidUntil: 'The expiry must be in the future and at most 7 days away.',
   overrideUntil: (untilLocal) => `Until ${untilLocal}`,
   presets: {
     thirtyMinutes: '30 minutes',
@@ -185,7 +187,15 @@ export function PresencePicker({
   const [preset, setPreset] = useState<Preset>('1h');
   const [customLocal, setCustomLocal] = useState<string>('');
 
-  const now = useMemo(() => new Date(), [setMutation.isPending, clearMutation.isPending]);
+  // Refresh the reference instant once a minute so preset windows (30 m, 1 h, …)
+  // stay anchored to "now" while the picker is open without re-rendering on
+  // every keystroke.
+  const [nowTick, setNowTick] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowTick(Date.now()), 60_000);
+    return () => clearInterval(id);
+  }, []);
+  const now = useMemo(() => new Date(nowTick), [nowTick]);
 
   const customDate = useMemo(() => {
     if (preset !== 'custom') return null;
@@ -347,8 +357,7 @@ export function PresencePicker({
 
       {!untilValid && (
         <div data-granit-presence-picker-error="" role="alert" style={{ color: '#b91c1c' }}>
-          {/* Plain message — apps that want a localized error can wrap this picker. */}
-          The expiry must be in the future and at most 7 days away.
+          {merged.invalidUntil}
         </div>
       )}
 

--- a/packages/@granit/react-presence/src/hooks/query-keys.ts
+++ b/packages/@granit/react-presence/src/hooks/query-keys.ts
@@ -1,8 +1,14 @@
-/** Query key factory for presence queries. Concatenated after the provider prefix. */
+import type { UserId } from '@granit/types';
+
+/**
+ * Query key factory for presence queries. Returns module-relative segments
+ * — the `PresenceProvider`'s `queryKeyPrefix` (default `['presence']`) is
+ * the single owner of the module namespace and is prepended via
+ * `buildPresenceQueryKey`.
+ */
 export const presenceKeys = {
-  all: ['presence'] as const,
-  my: () => [...presenceKeys.all, 'my'] as const,
-  user: (userId: string) => [...presenceKeys.all, 'user', userId] as const,
-  batch: (userIds: readonly string[]) =>
-    [...presenceKeys.all, 'batch', [...userIds].sort()] as const,
+  all: [] as const,
+  my: () => ['my'] as const,
+  user: (userId: UserId) => ['user', userId] as const,
+  batch: (userIds: readonly UserId[]) => ['batch', [...userIds].sort()] as const,
 };

--- a/packages/@granit/react-presence/src/hooks/use-batch-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-batch-presence.ts
@@ -2,16 +2,13 @@ import { PRESENCE_DEFAULTS, getBatchPresence } from '@granit/presence';
 import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_STALE_TIME_MS } from '../constants.js';
-import {
-  buildPresenceQueryKey,
-  usePresenceConfig,
-  type ResolvedPresenceConfig,
-} from '../providers/presence-provider.js';
+import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-provider.js';
 
 import { presenceKeys } from './query-keys.js';
 
 import type { AxiosInstance } from '@granit/api-client';
 import type { BatchPresenceResponse, PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 export interface UseBatchPresenceOptions {
@@ -25,25 +22,30 @@ const MAX_BATCH = PRESENCE_DEFAULTS.MaxBatchSize;
  * Returns the deduplicated, sorted list — caller doesn't have to worry
  * about ordering or duplicates when picking IDs from several sources.
  */
-function normalize(userIds: readonly string[]): string[] {
+export function normalizeUserIds(userIds: readonly UserId[]): UserId[] {
   return Array.from(new Set(userIds))
     .filter((id) => id.length > 0)
     .sort();
 }
 
-async function fetchBatch(
+export async function fetchBatchPresence(
   client: AxiosInstance,
   basePath: string,
-  userIds: readonly string[]
+  userIds: readonly UserId[]
 ): Promise<BatchPresenceResponse> {
   if (userIds.length <= MAX_BATCH) {
     return getBatchPresence(client, basePath, { userIds });
   }
-  // Server cap is 200 — chunk above that and merge dictionaries.
-  const merged: Record<string, PresenceResponse> = {};
+  // Server cap is 200 — chunk above that and fan out in parallel.
+  const chunks: UserId[][] = [];
   for (let i = 0; i < userIds.length; i += MAX_BATCH) {
-    const chunk = userIds.slice(i, i + MAX_BATCH);
-    const { presences } = await getBatchPresence(client, basePath, { userIds: chunk });
+    chunks.push(userIds.slice(i, i + MAX_BATCH));
+  }
+  const responses = await Promise.all(
+    chunks.map((chunk) => getBatchPresence(client, basePath, { userIds: chunk }))
+  );
+  const merged: Record<UserId, PresenceResponse> = {} as Record<UserId, PresenceResponse>;
+  for (const { presences } of responses) {
     Object.assign(merged, presences);
   }
   return { presences: merged };
@@ -55,31 +57,24 @@ async function fetchBatch(
  * Inputs are deduplicated and sorted before hitting the network and
  * before forming the query key, so two components that ask for the
  * same set of users share a single cache entry. Lists larger than the
- * server cap (200) are chunked transparently.
+ * server cap (200) are chunked transparently and resolved in parallel.
  *
  * Requires `Presence.Users.Read`. Callers without that permission should
  * pass `enabled: false`.
  */
 export function useBatchPresence(
-  userIds: readonly string[],
+  userIds: readonly UserId[],
   options: UseBatchPresenceOptions = {}
 ): UseQueryResult<BatchPresenceResponse> {
   const { enabled = true } = options;
   const config = usePresenceConfig();
-  const ids = normalize(userIds);
+  const ids = normalizeUserIds(userIds);
 
   return useQuery({
     queryKey: buildPresenceQueryKey(config, ...presenceKeys.batch(ids)),
-    queryFn: () => fetchBatch(config.client, config.basePath, ids),
+    queryFn: () => fetchBatchPresence(config.client, config.basePath, ids),
     staleTime: DEFAULT_STALE_TIME_MS,
     refetchOnWindowFocus: true,
     enabled: enabled && ids.length > 0,
   });
 }
-
-// Exposed for tests that want to drive the chunker without spinning React.
-export const __internals = {
-  normalize,
-  fetchBatch: (config: ResolvedPresenceConfig, userIds: readonly string[]) =>
-    fetchBatch(config.client, config.basePath, userIds),
-};

--- a/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
+++ b/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
@@ -1,4 +1,4 @@
-import { sendHeartbeat } from '@granit/presence';
+import { pollMyPresence } from '@granit/presence';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
@@ -70,7 +70,7 @@ export function useHeartbeat(options: UseHeartbeatOptions = {}): void {
       inFlightRef.current = true;
       try {
         const idleSeconds = Math.max(0, Math.floor((Date.now() - lastActivityRef.current) / 1000));
-        const data = await sendHeartbeat(config.client, config.basePath, { idleSeconds });
+        const data = await pollMyPresence(config.client, config.basePath, { idleSeconds });
         if (!cancelled) {
           queryClient.setQueryData<PresenceResponse>(queryKey, data);
         }

--- a/packages/@granit/react-presence/src/hooks/use-set-my-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-set-my-presence.ts
@@ -31,16 +31,16 @@ export function useSetMyPresence(): UseMutationResult<
       await queryClient.cancelQueries({ queryKey });
       const previous = queryClient.getQueryData<PresenceResponse>(queryKey);
       if (previous) {
+        const isAvailable = request.manualStatus === 'Available';
         const optimistic: PresenceResponse = {
           ...previous,
-          manualOverride: request.manualStatus === 'Available' ? null : request.manualStatus,
-          overrideUntilUtc: request.untilUtc,
-          effectiveStatus:
-            request.manualStatus === 'Available'
-              ? previous.effectiveStatus
-              : request.manualStatus === 'AppearOffline'
-                ? 'Offline'
-                : request.manualStatus,
+          manualOverride: isAvailable ? null : request.manualStatus,
+          overrideUntilUtc: isAvailable ? null : request.untilUtc,
+          effectiveStatus: isAvailable
+            ? previous.effectiveStatus
+            : request.manualStatus === 'AppearOffline'
+              ? 'Offline'
+              : request.manualStatus,
         };
         queryClient.setQueryData(queryKey, optimistic);
       }

--- a/packages/@granit/react-presence/src/hooks/use-user-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-user-presence.ts
@@ -7,6 +7,7 @@ import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-
 import { presenceKeys } from './query-keys.js';
 
 import type { PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 export interface UseUserPresenceOptions {
@@ -22,7 +23,7 @@ export interface UseUserPresenceOptions {
  * instead of letting the request 403.
  */
 export function useUserPresence(
-  userId: string,
+  userId: UserId,
   options: UseUserPresenceOptions = {}
 ): UseQueryResult<PresenceResponse> {
   const { enabled = true } = options;


### PR DESCRIPTION
## Summary

Audit follow-up on [#481](https://github.com/granit-fx/granit-front/pull/481). Fixes one breaking bug and a handful of inconsistencies / improvements across `@granit/presence` and `@granit/react-presence`.

### Bug fix (1)

- **Query-key duplication.** `presenceKeys.all` was `['presence']` AND the `PresenceProvider`'s default `queryKeyPrefix` was also `['presence']`, so hooks ended up with keys like `['presence', 'presence', 'my']`. External `invalidateQueries({ queryKey: presenceKeys.all })` calls were silently no-ops, and a custom `queryKeyPrefix` was hidden between the two `'presence'` segments. The factory now returns module-relative segments (`all: []`, `my: () => ['my']`, …) so the provider is the single owner of the namespace. Added a regression test composing `buildPresenceQueryKey(config, ...presenceKeys.my())`.

### Inconsistencies

- Rename `sendHeartbeat` → `pollMyPresence` to mirror the .NET `PollMyPresenceAsync` handler. Updates barrel, tests, README, and `useHeartbeat`.
- Brand `userId` parameters with `@granit/types` `UserId` across `getUserPresence`, `useUserPresence`, `BatchPresenceRequest.userIds`, `BatchPresenceResponse.presences`, and `useBatchPresence` — prevents accidentally passing a non-user `EntityId`.
- Wire `invalidUntil` into `PresencePickerLabels` (was a hardcoded English string while every other copy was overridable).

### Improvements

- `useSetMyPresence` optimistic update: force `overrideUntilUtc: null` when `manualStatus === 'Available'` (was leaving a stale date in the cache for one tick).
- `PresencePicker`: replace the mutation-toggle `useMemo` for `now` with a 60 s `setInterval` ticker so preset windows stay anchored to "now" while the picker is open.
- `useBatchPresence`: parallelize the chunker with `Promise.all` (was sequential).
- Drop client-side `idleSeconds` clamp in `pollMyPresence` — the server already clamps.
- Drop `__internals`; export `normalizeUserIds` / `fetchBatchPresence` by name.

## Test plan

- [x] `pnpm --filter @granit/presence exec tsc --noEmit`
- [x] `pnpm --filter @granit/react-presence exec tsc --noEmit`
- [x] `npx vitest run packages/@granit/presence packages/@granit/react-presence` — 31/31 passed (+1 new regression test)
- [x] ESLint on changed source files — clean
- [ ] Manual smoke: showcase `presence-demo-page` still renders + heartbeat + override picker