### PR TITLE
refactor(types): align enum types with string wire format

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -742,8 +742,8 @@
       "exports": [
         {
           "name": "BlobStatus",
-          "kind": "const",
-          "signature": "const BlobStatus"
+          "kind": "type",
+          "signature": "type BlobStatus = 'Pending' | 'Uploading' | 'Valid' | 'Rejected' | 'Deleted'"
         },
         {
           "name": "BlobStoragePermissions",
@@ -6034,8 +6034,8 @@
       "exports": [
         {
           "name": "WebhookSubscriptionStatus",
-          "kind": "const",
-          "signature": "const WebhookSubscriptionStatus"
+          "kind": "type",
+          "signature": "type WebhookSubscriptionStatus = 'Active' | 'Suspended' | 'Deactivated'"
         },
         {
           "name": "WebhooksPermissions",

--- a/packages/@granit/blob-storage/src/__tests__/blob-storage-types.test.ts
+++ b/packages/@granit/blob-storage/src/__tests__/blob-storage-types.test.ts
@@ -3,15 +3,15 @@ import { describe, expect, it } from 'vitest';
 import { BlobStatus } from '../types/index.js';
 
 describe('BlobStatus', () => {
-  it('should match .NET enum values', () => {
-    expect(BlobStatus.Pending).toBe(0);
-    expect(BlobStatus.Uploading).toBe(1);
-    expect(BlobStatus.Valid).toBe(2);
-    expect(BlobStatus.Rejected).toBe(3);
-    expect(BlobStatus.Deleted).toBe(4);
+  it('matches the wire format (PascalCase strings from JsonStringEnumConverter)', () => {
+    expect(BlobStatus.Pending).toBe('Pending');
+    expect(BlobStatus.Uploading).toBe('Uploading');
+    expect(BlobStatus.Valid).toBe('Valid');
+    expect(BlobStatus.Rejected).toBe('Rejected');
+    expect(BlobStatus.Deleted).toBe('Deleted');
   });
 
-  it('should have exactly 5 members', () => {
+  it('has exactly 5 members', () => {
     expect(Object.keys(BlobStatus)).toHaveLength(5);
   });
 });

--- a/packages/@granit/blob-storage/src/index.ts
+++ b/packages/@granit/blob-storage/src/index.ts
@@ -9,7 +9,6 @@ export type {
   BlobDescriptorResponse,
   BlobDownloadUrlRequest,
   BlobDownloadUrlResponse,
-  BlobStatusValue,
   BlobUploadInitiateRequest,
   BlobUploadInitiateResponse,
 } from './types/index.js';

--- a/packages/@granit/blob-storage/src/types/index.ts
+++ b/packages/@granit/blob-storage/src/types/index.ts
@@ -6,16 +6,17 @@
  * Blob lifecycle status.
  *
  * Mirrors `Granit.BlobStorage.Domain.BlobStatus` (.NET).
+ * Serialized as PascalCase strings via the framework's global `JsonStringEnumConverter`.
  */
-export const BlobStatus = {
-  Pending: 0,
-  Uploading: 1,
-  Valid: 2,
-  Rejected: 3,
-  Deleted: 4,
-} as const;
+export type BlobStatus = 'Pending' | 'Uploading' | 'Valid' | 'Rejected' | 'Deleted';
 
-export type BlobStatusValue = (typeof BlobStatus)[keyof typeof BlobStatus];
+export const BlobStatus = {
+  Pending: 'Pending',
+  Uploading: 'Uploading',
+  Valid: 'Valid',
+  Rejected: 'Rejected',
+  Deleted: 'Deleted',
+} as const satisfies Record<string, BlobStatus>;
 
 // ── Upload initiation ───────────────────────────────────────────────────────
 
@@ -47,7 +48,7 @@ export interface BlobConfirmUploadRequest {
 export interface BlobConfirmUploadResponse {
   readonly blobId: string;
   readonly isValid: boolean;
-  readonly status: BlobStatusValue;
+  readonly status: BlobStatus;
   readonly verifiedContentType: string | null;
   readonly sizeBytes: number | null;
   readonly rejectionReason: string | null;
@@ -86,7 +87,7 @@ export interface BlobDescriptorResponse {
   readonly verifiedContentType: string | null;
   readonly declaredSizeBytes: number;
   readonly actualSizeBytes: number | null;
-  readonly status: BlobStatusValue;
+  readonly status: BlobStatus;
   readonly rejectionReason: string | null;
   readonly deletionReason: string | null;
   readonly createdAt: string;

--- a/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
@@ -75,9 +75,9 @@ describe('createBlobStorageHandlers — upload flow', () => {
     // Subsequent GET resolves the freshly-uploaded record.
     const getResponse = await fetch(`${BASE}/blobs/${encodeURIComponent(ticket.blobId)}`);
     expect(getResponse.status).toBe(200);
-    const descriptor = (await getResponse.json()) as { id: string; status: number };
+    const descriptor = (await getResponse.json()) as { id: string; status: string };
     expect(descriptor.id).toBe(ticket.blobId);
-    expect(descriptor.status).toBe(2); // Valid
+    expect(descriptor.status).toBe('Valid');
   });
 
   it('confirm fails when the blobId is unknown', async () => {

--- a/packages/@granit/react-blob-storage/src/testing/data.ts
+++ b/packages/@granit/react-blob-storage/src/testing/data.ts
@@ -1,12 +1,9 @@
-import type { BlobDescriptorResponse, BlobStatusValue } from '@granit/blob-storage';
+import { BlobStatus } from '@granit/blob-storage';
 
-export const S = {
-  Pending: 0,
-  Uploading: 1,
-  Valid: 2,
-  Rejected: 3,
-  Deleted: 4,
-} as const satisfies Record<string, BlobStatusValue>;
+import type { BlobDescriptorResponse } from '@granit/blob-storage';
+
+/** Short alias for use inside the mock fixtures. */
+export const S = BlobStatus;
 
 export const mockBlobs: BlobDescriptorResponse[] = [
   {

--- a/packages/@granit/react-blob-storage/src/testing/handlers.ts
+++ b/packages/@granit/react-blob-storage/src/testing/handlers.ts
@@ -17,7 +17,7 @@ import type {
   BlobConfirmUploadRequest,
   BlobConfirmUploadResponse,
   BlobDescriptorResponse,
-  BlobStatusValue,
+  BlobStatus,
   BlobUploadInitiateRequest,
   BlobUploadInitiateResponse,
 } from '@granit/blob-storage';
@@ -65,7 +65,7 @@ export const blobQueryMetadata: QueryMetadata = {
     {
       name: 'status',
       label: 'Status',
-      type: 'Int32',
+      type: 'String',
       order: 5,
       isSortable: true,
       isFilterable: false,
@@ -109,7 +109,7 @@ export const blobQueryMetadata: QueryMetadata = {
   dateFilters: [],
   groupByFields: [
     { name: 'containerName', type: 'String' },
-    { name: 'status', type: 'Int32' },
+    { name: 'status', type: 'String' },
   ],
   pagination: {
     defaultPageSize: 20,
@@ -119,12 +119,12 @@ export const blobQueryMetadata: QueryMetadata = {
   },
 };
 
-const STATUS_LABELS: Record<BlobStatusValue, string> = {
-  0: 'Pending',
-  1: 'Uploading',
-  2: 'Valid',
-  3: 'Rejected',
-  4: 'Deleted',
+const STATUS_LABELS: Record<BlobStatus, string> = {
+  Pending: 'Pending',
+  Uploading: 'Uploading',
+  Valid: 'Valid',
+  Rejected: 'Rejected',
+  Deleted: 'Deleted',
 };
 
 /**
@@ -188,7 +188,7 @@ export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const groupByParam = url.searchParams.get('groupBy');
       if (groupByParam) {
         const labelFn = (key: string): string =>
-          groupByParam === 'status' ? (STATUS_LABELS[Number(key) as BlobStatusValue] ?? key) : key;
+          groupByParam === 'status' ? (STATUS_LABELS[key as BlobStatus] ?? key) : key;
         return HttpResponse.json(
           groupByField(filtered as unknown as Record<string, unknown>[], groupByParam, labelFn)
         );

--- a/packages/@granit/react-scheduling/src/testing/handlers.ts
+++ b/packages/@granit/react-scheduling/src/testing/handlers.ts
@@ -1,9 +1,8 @@
-import { DATE_OPERATORS, NUMBER_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { DATE_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { ScheduledActionStatus } from '@granit/scheduling';
 import {
   applyDateFilter,
-  applyNumberFilter,
   applyStringFilter,
   paginate,
   parseFilters,
@@ -44,7 +43,7 @@ export const scheduledActionQueryMetadata: QueryMetadata = {
     {
       name: 'status',
       label: 'Status',
-      type: 'Int32',
+      type: 'String',
       order: 2,
       isSortable: true,
       isFilterable: true,
@@ -107,7 +106,7 @@ export const scheduledActionQueryMetadata: QueryMetadata = {
   ],
   filterableFields: [
     { name: 'payloadType', type: 'String', operators: STRING_OPERATORS },
-    { name: 'status', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'status', type: 'String', operators: STRING_OPERATORS },
     { name: 'executeAt', type: 'DateTime', operators: DATE_OPERATORS },
     { name: 'executedAt', type: 'DateTime', operators: DATE_OPERATORS },
     { name: 'correlationId', type: 'String', operators: STRING_OPERATORS },
@@ -155,7 +154,7 @@ export const scheduledActionQueryMetadata: QueryMetadata = {
     },
   ],
   groupByFields: [
-    { name: 'status', type: 'Int32' },
+    { name: 'status', type: 'String' },
     { name: 'payloadType', type: 'String' },
   ],
   pagination: {
@@ -212,9 +211,6 @@ export function createSchedulingHandlers(baseUrl = DEFAULT_BASE_PATH) {
       for (const f of filters) {
         filtered = filtered.filter((action) => {
           const fieldValue = action[f.field as keyof ScheduledActionResponse];
-          if (f.field === 'status') {
-            return applyNumberFilter(fieldValue as number, f.operator, f.value);
-          }
           if (f.field === 'executeAt') {
             return applyDateFilter(fieldValue as string, f.operator, f.value);
           }

--- a/packages/@granit/react-timeline/src/__tests__/use-timeline-actions.test.ts
+++ b/packages/@granit/react-timeline/src/__tests__/use-timeline-actions.test.ts
@@ -1,3 +1,4 @@
+import { TimelineEntryType } from '@granit/timeline';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -10,7 +11,7 @@ describe('useTimelineActions', () => {
     const client = createMockClient();
     const createdEntry = {
       id: 'e-1',
-      entryType: 0,
+      entryType: TimelineEntryType.Comment,
       body: 'Hello',
       authorId: 'u-1',
       authorName: 'User',
@@ -37,7 +38,7 @@ describe('useTimelineActions', () => {
     let returnedEntry;
     await act(async () => {
       returnedEntry = await result.current.postEntry({
-        entryType: 0,
+        entryType: TimelineEntryType.Comment,
         body: 'Hello',
       });
     });
@@ -45,7 +46,7 @@ describe('useTimelineActions', () => {
     expect(returnedEntry).toEqual(createdEntry);
     expect(onEntryCreated).toHaveBeenCalledWith(createdEntry);
     expect(client.post).toHaveBeenCalledWith('/api/v1/timeline/Patient/p-1/entries', {
-      entryType: 0,
+      entryType: TimelineEntryType.Comment,
       body: 'Hello',
     });
   });
@@ -87,9 +88,9 @@ describe('useTimelineActions', () => {
       { wrapper: createWrapper(client) }
     );
 
-    await expect(result.current.postEntry({ entryType: 0, body: 'Hello' })).rejects.toThrow(
-      'Server error'
-    );
+    await expect(
+      result.current.postEntry({ entryType: TimelineEntryType.Comment, body: 'Hello' })
+    ).rejects.toThrow('Server error');
 
     await waitFor(() => expect(result.current.error?.message).toBe('Server error'));
   });
@@ -125,9 +126,9 @@ describe('useTimelineActions', () => {
       { wrapper: createWrapper(client) }
     );
 
-    await expect(result.current.postEntry({ entryType: 0, body: 'Hello' })).rejects.toThrow(
-      'string error'
-    );
+    await expect(
+      result.current.postEntry({ entryType: TimelineEntryType.Comment, body: 'Hello' })
+    ).rejects.toThrow('string error');
 
     await waitFor(() => expect(result.current.error?.message).toBe('string error'));
   });

--- a/packages/@granit/react-timeline/src/__tests__/use-timeline.test.ts
+++ b/packages/@granit/react-timeline/src/__tests__/use-timeline.test.ts
@@ -1,3 +1,4 @@
+import { TimelineEntryType } from '@granit/timeline';
 import { toEntityId, toISODateString } from '@granit/types';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
@@ -11,7 +12,7 @@ import type { TimelineEntry, TimelineEntryPage } from '@granit/timeline';
 function makeEntry(overrides: Partial<TimelineEntry> = {}): TimelineEntry {
   return {
     id: toEntityId<'TimelineEntry'>('e-1'),
-    entryType: 0,
+    entryType: TimelineEntryType.Comment,
     body: 'Test comment',
     authorId: toEntityId<'User'>('u-1'),
     authorName: 'Dr. Martin',

--- a/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
@@ -1,5 +1,5 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
-import { toReactionEmoji } from '@granit/timeline';
+import { TimelineEntryType, toReactionEmoji } from '@granit/timeline';
 import { toEntityId } from '@granit/types';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
@@ -31,7 +31,7 @@ const EYES = toReactionEmoji('👀');
 function makeEntry(id: TimelineEntryId, reactions?: ReactionMap): TimelineEntry {
   return {
     id,
-    entryType: 0,
+    entryType: TimelineEntryType.Comment,
     body: `entry ${id}`,
     authorId: null,
     authorName: null,

--- a/packages/@granit/react-timeline/src/testing/data.ts
+++ b/packages/@granit/react-timeline/src/testing/data.ts
@@ -1,3 +1,4 @@
+import { TimelineEntryType } from '@granit/timeline';
 import { toEntityId, toISODateString } from '@granit/types';
 
 import type { TimelineEntry } from '@granit/timeline';
@@ -7,7 +8,7 @@ type Mutable<T> = { -readonly [K in keyof T]: T[K] };
 export const mockTimelineEntries: Mutable<TimelineEntry>[] = [
   {
     id: toEntityId<'TimelineEntry'>('tl-1'),
-    entryType: 0,
+    entryType: TimelineEntryType.Comment,
     body: 'Account created and initial roles assigned.',
     authorId: toEntityId<'User'>('admin-001'),
     authorName: 'System Admin',
@@ -17,7 +18,7 @@ export const mockTimelineEntries: Mutable<TimelineEntry>[] = [
   },
   {
     id: toEntityId<'TimelineEntry'>('tl-2'),
-    entryType: 2,
+    entryType: TimelineEntryType.InternalNote,
     body: 'Reviewed user access — confirmed granit-showcase-admin role required for project onboarding.',
     authorId: toEntityId<'User'>('admin-002'),
     authorName: 'Security Officer',
@@ -27,7 +28,7 @@ export const mockTimelineEntries: Mutable<TimelineEntry>[] = [
   },
   {
     id: toEntityId<'TimelineEntry'>('tl-3'),
-    entryType: 1,
+    entryType: TimelineEntryType.SystemLog,
     body: 'Role granit-showcase-readonly removed by admin.',
     authorId: toEntityId<'User'>('system'),
     authorName: 'System',

--- a/packages/@granit/react-timeline/src/testing/handlers.ts
+++ b/packages/@granit/react-timeline/src/testing/handlers.ts
@@ -36,14 +36,14 @@ export function createTimelineHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // POST /:entityType/:entityId/entries — add a new entry
     http.post(`${baseUrl}/:entityType/:entityId/entries`, async ({ request }) => {
       const body = (await request.json()) as {
-        entryType: number;
+        entryType: TimelineEntry['entryType'];
         body: string;
         parentEntryId?: string;
       };
 
       const entry: TimelineEntry = {
         id: toEntityId<'TimelineEntry'>(`tl-${Date.now()}`),
-        entryType: body.entryType as TimelineEntry['entryType'],
+        entryType: body.entryType,
         body: body.body,
         authorId: toEntityId<'User'>('admin-001'),
         authorName: 'System Admin',

--- a/packages/@granit/react-webhooks/src/testing/handlers.ts
+++ b/packages/@granit/react-webhooks/src/testing/handlers.ts
@@ -22,11 +22,14 @@ import {
 } from './data.js';
 
 import type { QueryMetadata } from '@granit/query-engine';
-import type { WebhookSubscriptionResponse } from '@granit/webhooks';
+import type {
+  WebhookSubscriptionResponse,
+  WebhookSubscriptionStatus as WebhookSubscriptionStatusType,
+} from '@granit/webhooks';
 
 /**
  * Mock /meta payload for the webhook subscriptions resource.
- * NOTE: `status` is a numeric enum on the wire (Int32) — see WebhookSubscriptionStatus.
+ * NOTE: `status` is serialized as a PascalCase string on the wire — see WebhookSubscriptionStatus.
  */
 export const webhookSubscriptionQueryMetadata: QueryMetadata = {
   columns: [
@@ -60,7 +63,7 @@ export const webhookSubscriptionQueryMetadata: QueryMetadata = {
     {
       name: 'status',
       label: 'Status',
-      type: 'Int32',
+      type: 'String',
       order: 3,
       isSortable: true,
       isFilterable: true,
@@ -106,7 +109,7 @@ export const webhookSubscriptionQueryMetadata: QueryMetadata = {
   filterableFields: [
     { name: 'targetUrl', type: 'String', operators: STRING_OPERATORS },
     { name: 'eventType', type: 'String', operators: STRING_OPERATORS },
-    { name: 'status', type: 'Int32', operators: NUMBER_OPERATORS },
+    { name: 'status', type: 'String', operators: STRING_OPERATORS },
     { name: 'consecutiveFailureCount', type: 'Int32', operators: NUMBER_OPERATORS },
     { name: 'lastSuccessAt', type: 'DateTime', operators: DATE_OPERATORS },
     { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
@@ -141,7 +144,7 @@ export const webhookSubscriptionQueryMetadata: QueryMetadata = {
     },
   ],
   groupByFields: [
-    { name: 'status', type: 'Int32' },
+    { name: 'status', type: 'String' },
     { name: 'eventType', type: 'String' },
   ],
   pagination: {
@@ -164,7 +167,7 @@ function applyPresets(
   const statusPresets = url.searchParams.get('presets[status]');
   if (statusPresets) {
     const statuses = statusPresets.split(',').map((s) => s.toLowerCase());
-    const statusMap: Record<string, number> = {
+    const statusMap: Record<string, WebhookSubscriptionStatusType> = {
       active: WebhookSubscriptionStatus.Active,
       suspended: WebhookSubscriptionStatus.Suspended,
       deactivated: WebhookSubscriptionStatus.Deactivated,

--- a/packages/@granit/scheduling/src/constants.ts
+++ b/packages/@granit/scheduling/src/constants.ts
@@ -1,3 +1,5 @@
+import type { ScheduledActionStatus } from './types/index.js';
+
 /** Permission strings for the Scheduling module. */
 export const SCHEDULING_PERMISSIONS = {
   ACTIONS_READ: 'Scheduling.Actions.Read',
@@ -6,18 +8,18 @@ export const SCHEDULING_PERMISSIONS = {
 
 /** Status → badge color mapping for UI rendering. */
 export const SCHEDULING_STATUS_COLORS = {
-  0: 'blue',
-  1: 'green',
-  2: 'gray',
-  3: 'red',
-  4: 'amber',
-} as const;
+  Pending: 'blue',
+  Executed: 'green',
+  Cancelled: 'gray',
+  Failed: 'red',
+  Processing: 'amber',
+} as const satisfies Record<ScheduledActionStatus, string>;
 
 /** Status → human-readable label mapping. */
 export const SCHEDULING_STATUS_LABELS = {
-  0: 'Pending',
-  1: 'Executed',
-  2: 'Cancelled',
-  3: 'Failed',
-  4: 'Processing',
-} as const;
+  Pending: 'Pending',
+  Executed: 'Executed',
+  Cancelled: 'Cancelled',
+  Failed: 'Failed',
+  Processing: 'Processing',
+} as const satisfies Record<ScheduledActionStatus, string>;

--- a/packages/@granit/scheduling/src/types/index.ts
+++ b/packages/@granit/scheduling/src/types/index.ts
@@ -1,16 +1,18 @@
 import type { CorrelationId, EntityId, ISODateString } from '@granit/types';
 
-/** Status of a scheduled action. Mirrors Granit.Scheduling.ScheduledActionStatus .NET enum. */
-export const ScheduledActionStatus = {
-  Pending: 0,
-  Executed: 1,
-  Cancelled: 2,
-  Failed: 3,
-  Processing: 4,
-} as const;
+/**
+ * Status of a scheduled action. Mirrors Granit.Scheduling.ScheduledActionStatus .NET enum.
+ * Serialized as PascalCase strings via the framework's global `JsonStringEnumConverter`.
+ */
+export type ScheduledActionStatus = 'Pending' | 'Executed' | 'Cancelled' | 'Failed' | 'Processing';
 
-export type ScheduledActionStatus =
-  (typeof ScheduledActionStatus)[keyof typeof ScheduledActionStatus];
+export const ScheduledActionStatus = {
+  Pending: 'Pending',
+  Executed: 'Executed',
+  Cancelled: 'Cancelled',
+  Failed: 'Failed',
+  Processing: 'Processing',
+} as const satisfies Record<string, ScheduledActionStatus>;
 
 /** Branded scheduled action identifier. */
 export type ScheduledActionId = EntityId<'ScheduledAction'>;

--- a/packages/@granit/timeline/src/__tests__/api.test.ts
+++ b/packages/@granit/timeline/src/__tests__/api.test.ts
@@ -9,6 +9,7 @@ import {
   followEntity,
   unfollowEntity,
 } from '../api/timeline-api.js';
+import { TimelineEntryType } from '../types/index.js';
 
 import type { CreateTimelineEntryRequest, TimelineEntryPage } from '../types/index.js';
 import type { AxiosInstance } from 'axios';
@@ -42,12 +43,12 @@ describe('timeline API', () => {
   describe('createEntry', () => {
     it('should call POST /{entityType}/{entityId}/entries', async () => {
       const request: CreateTimelineEntryRequest = {
-        entryType: 0,
+        entryType: TimelineEntryType.Comment,
         body: 'Hello',
       };
       const entry = {
         id: 'e-1',
-        entryType: 0,
+        entryType: TimelineEntryType.Comment,
         body: 'Hello',
         authorId: 'u-1',
         authorName: 'User',

--- a/packages/@granit/timeline/src/index.ts
+++ b/packages/@granit/timeline/src/index.ts
@@ -9,7 +9,6 @@ export {
   type TimelineEntry,
   type TimelineEntryId,
   type TimelineEntryPage,
-  type TimelineEntryTypeValue,
   type TimelineStreamPage,
   type CreateTimelineEntryRequest,
   type TimelineQueryParams,

--- a/packages/@granit/timeline/src/types/entry-type.ts
+++ b/packages/@granit/timeline/src/types/entry-type.ts
@@ -1,9 +1,10 @@
 // --- Entry types (mirror Granit.Timeline .NET enum) ---
+// Serialized as PascalCase strings via the framework's global `JsonStringEnumConverter`.
+
+export type TimelineEntryType = 'Comment' | 'SystemLog' | 'InternalNote';
 
 export const TimelineEntryType = {
-  Comment: 0,
-  SystemLog: 1,
-  InternalNote: 2,
-} as const;
-
-export type TimelineEntryTypeValue = (typeof TimelineEntryType)[keyof typeof TimelineEntryType];
+  Comment: 'Comment',
+  SystemLog: 'SystemLog',
+  InternalNote: 'InternalNote',
+} as const satisfies Record<string, TimelineEntryType>;

--- a/packages/@granit/timeline/src/types/index.ts
+++ b/packages/@granit/timeline/src/types/index.ts
@@ -1,4 +1,4 @@
-export { TimelineEntryType, type TimelineEntryTypeValue } from './entry-type.js';
+export { TimelineEntryType } from './entry-type.js';
 export type {
   BlobId,
   TimelineAttachmentId,

--- a/packages/@granit/timeline/src/types/request.ts
+++ b/packages/@granit/timeline/src/types/request.ts
@@ -1,10 +1,10 @@
-import type { TimelineEntryTypeValue } from './entry-type.js';
+import type { TimelineEntryType } from './entry-type.js';
 import type { PaginationParams } from '@granit/query-engine';
 
 // --- API request types ---
 
 export interface CreateTimelineEntryRequest {
-  readonly entryType: TimelineEntryTypeValue;
+  readonly entryType: TimelineEntryType;
   readonly body: string;
   readonly parentEntryId?: string;
   readonly attachmentBlobIds?: readonly string[];

--- a/packages/@granit/timeline/src/types/stream.ts
+++ b/packages/@granit/timeline/src/types/stream.ts
@@ -1,4 +1,4 @@
-import type { TimelineEntryTypeValue } from './entry-type.js';
+import type { TimelineEntryType } from './entry-type.js';
 import type { ReactionMap } from './reaction.js';
 import type { TimelineEntryOriginValue } from './source.js';
 import type { PagedResult } from '@granit/query-engine';
@@ -27,7 +27,7 @@ export interface TimelineAttachmentInfo {
 
 export interface TimelineEntry {
   readonly id: TimelineEntryId;
-  readonly entryType: TimelineEntryTypeValue;
+  readonly entryType: TimelineEntryType;
   readonly body: string;
   readonly authorId: UserId | null;
   readonly authorName: string | null;

--- a/packages/@granit/webhooks/src/index.ts
+++ b/packages/@granit/webhooks/src/index.ts
@@ -13,7 +13,6 @@ export type {
   WebhookSubscriptionResponse,
   WebhookSubscriptionRotateSecretResponse,
   WebhookSubscriptionStatsResponse,
-  WebhookSubscriptionStatusValue,
   WebhookSubscriptionTestPingResponse,
   WebhookSubscriptionUpdateRequest,
 } from './types/index.js';

--- a/packages/@granit/webhooks/src/types/index.ts
+++ b/packages/@granit/webhooks/src/types/index.ts
@@ -14,15 +14,16 @@ export type WebhookDeliveryId = EntityId<'WebhookDelivery'>;
  * Webhook subscription lifecycle status.
  *
  * Mirrors `Granit.Webhooks.Domain.WebhookSubscriptionStatus` (.NET).
+ * Serialized as PascalCase strings via the framework's global
+ * `JsonStringEnumConverter`.
  */
-export const WebhookSubscriptionStatus = {
-  Active: 0,
-  Suspended: 1,
-  Deactivated: 2,
-} as const;
+export type WebhookSubscriptionStatus = 'Active' | 'Suspended' | 'Deactivated';
 
-export type WebhookSubscriptionStatusValue =
-  (typeof WebhookSubscriptionStatus)[keyof typeof WebhookSubscriptionStatus];
+export const WebhookSubscriptionStatus = {
+  Active: 'Active',
+  Suspended: 'Suspended',
+  Deactivated: 'Deactivated',
+} as const satisfies Record<string, WebhookSubscriptionStatus>;
 
 // ── Subscription requests ───────────────────────────────────────────────────
 
@@ -49,7 +50,7 @@ export interface WebhookSubscriptionResponse {
   readonly id: WebhookSubscriptionId;
   readonly targetUrl: string;
   readonly eventType: string;
-  readonly status: WebhookSubscriptionStatusValue;
+  readonly status: WebhookSubscriptionStatus;
   readonly consecutiveFailureCount: number;
   readonly lastSuccessAt: string | null;
   readonly createdAt: string;
@@ -61,7 +62,7 @@ export interface WebhookSubscriptionCreatedResponse {
   readonly id: WebhookSubscriptionId;
   readonly targetUrl: string;
   readonly eventType: string;
-  readonly status: WebhookSubscriptionStatusValue;
+  readonly status: WebhookSubscriptionStatus;
   readonly signingSecret: string;
 }
 


### PR DESCRIPTION
## Summary

Phase 4 of the enum-persistence alignment plan (companion to granit-dotnet#2215, which switched .NET enum **DB persistence** from numeric to string).

The .NET backend has always serialized enums as PascalCase strings on the HTTP wire via the framework's global `JsonStringEnumConverter` — but four front-end enum constants were still declared as numeric \`const\` objects, desynced from the actual wire payload. The mismatch was masked because the showcase mapped status names back to numbers at the rendering edges.

### Changes

- Switch four enums to PascalCase string unions matching the wire:
  - \`WebhookSubscriptionStatus\` (\`@granit/webhooks\`)
  - \`ScheduledActionStatus\` (\`@granit/scheduling\`)
  - \`TimelineEntryType\` (\`@granit/timeline\`)
  - \`BlobStatus\` (\`@granit/blob-storage\`)
- Remove the redundant \`*Value\` type aliases (\`WebhookSubscriptionStatusValue\`, \`BlobStatusValue\`, \`TimelineEntryTypeValue\`) — vestige of the numeric-const pattern. The constant doubles as the type now.
- Flip MSW mock metadata columns: \`status\` advertised as \`String\` (was \`Int32\`).
- Update tests and fixtures that hard-coded numeric values to use the named constants.
- Fix the stale \"numeric enum on the wire (Int32)\" comment in \`react-webhooks/testing/handlers.ts\`.

### Wire format verification (Phase 0)

Confirmed via \`src/Granit/Extensions/GranitHostBuilderExtensions.cs\` that \`JsonStringEnumConverter\` is registered globally on \`options.SerializerOptions\` — every \`Granit.*.Endpoints\` DTO inherits the string serialization. No need to spin up the showcase.

### Coordinated rollout

Wire format **does not change** — this is a pure TypeScript declaration alignment. Showcase-react companion PR aligns consumers (\`STATUS_VARIANT\`, \`STATUS_KEY\`, \`ENTRY_TYPE_LABELS\` retyped to the union; deduplicated \`import type\` lines).

## Test plan

- [x] \`pnpm lint\` clean (was 4 import-order errors after edits, fixed)
- [x] \`pnpm -r exec tsc --noEmit\` clean
- [x] \`pnpm test --run\` passes (5602/5602)
- [ ] Visual smoke test on showcase-react: blob list / webhook list / scheduled-actions list status badges render identically before/after (will validate on companion MR)