### PR TITLE
fix(taxonomy,react-presence): align with backend wire shape + polish

### DIFF
--- a/packages/@granit/react-presence/src/testing/data.ts
+++ b/packages/@granit/react-presence/src/testing/data.ts
@@ -5,12 +5,30 @@ import type { UserId } from '@granit/types';
 
 const baseLastSeen = toISODateString('2026-05-22T10:00:00Z');
 
+// Stable GUIDs — the backend deserializes UserId as System.Guid, so the
+// mocks must use Guid-formatted strings to round-trip through both MSW
+// and the real .NET stack.
+//
+// `self` aligns with the first user in @granit/react-identity/testing
+// (marie.dupont) so demos that mount both providers stay coherent.
 export const mockUsers = [
-  { id: toEntityId<'User'>('user-self') as UserId, name: 'Your Account' },
-  { id: toEntityId<'User'>('user-alice') as UserId, name: 'Alice Martin' },
-  { id: toEntityId<'User'>('user-bob') as UserId, name: 'Bob Lefebvre' },
-  { id: toEntityId<'User'>('user-charlie') as UserId, name: 'Charlie Wood' },
-  { id: toEntityId<'User'>('user-diana') as UserId, name: 'Diana Brown' },
+  {
+    id: toEntityId<'User'>('d2c47314-4d08-4952-98b1-a1b8a6e22ef1') as UserId,
+    name: 'Your Account',
+  },
+  {
+    id: toEntityId<'User'>('0a1b2c3d-1111-4111-8111-aaaaaaaaaaaa') as UserId,
+    name: 'Alice Martin',
+  },
+  {
+    id: toEntityId<'User'>('0a1b2c3d-2222-4222-8222-bbbbbbbbbbbb') as UserId,
+    name: 'Bob Lefebvre',
+  },
+  {
+    id: toEntityId<'User'>('0a1b2c3d-3333-4333-8333-cccccccccccc') as UserId,
+    name: 'Charlie Wood',
+  },
+  { id: toEntityId<'User'>('0a1b2c3d-4444-4444-8444-dddddddddddd') as UserId, name: 'Diana Brown' },
 ];
 
 export const mockMyPresence: PresenceResponse = {

--- a/packages/@granit/react-taxonomy/src/components/category-tree.tsx
+++ b/packages/@granit/react-taxonomy/src/components/category-tree.tsx
@@ -78,18 +78,36 @@ function CategoryNode({
   const deleteCategory = useDeleteCategory(scope);
   const [error, setError] = useState<string | null>(null);
 
+  function extractProblemDetail(err: unknown): string {
+    const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+    if (detail) return detail;
+    return err instanceof Error ? err.message : 'Request failed.';
+  }
+
   function handleAdd(): void {
     if (globalThis.window === undefined) return;
     const name = globalThis.prompt('Category name?');
     if (!name?.trim()) return;
-    createCategory.mutate({ scope, parentId: category.id, name: name.trim() });
+    createCategory.mutate(
+      { scope, parentId: category.id, name: name.trim() },
+      {
+        // Auto-expand the parent so the freshly invalidated children query
+        // actually fires (`enabled: expanded`) and the new node becomes
+        // visible without a second click.
+        onSuccess: () => setExpanded(true),
+        onError: (err) => setError(extractProblemDetail(err)),
+      }
+    );
   }
 
   function handleRename(): void {
     if (globalThis.window === undefined) return;
     const next = globalThis.prompt('Rename category', category.name);
     if (!next?.trim() || next.trim() === category.name) return;
-    updateCategory.mutate({ id: category.id, request: { name: next.trim() } });
+    updateCategory.mutate(
+      { id: category.id, request: { name: next.trim() } },
+      { onError: (err) => setError(extractProblemDetail(err)) }
+    );
   }
 
   function handleMove(): void {
@@ -146,7 +164,13 @@ function CategoryNode({
       data-granit-category-depth={category.depth}
     >
       <div data-granit-category-tree-row="">
-        {category.hasChildren ? (
+        {/* Show the toggle whenever the backend doesn't explicitly say the node
+            is a leaf. The real `CategoryResponse` from the .NET backend has no
+            `hasChildren` field; without this fallback, every row renders as a
+            leaf and the lazy children query (`enabled: expanded`) never fires,
+            so newly created sub-categories are invisible. Only treat the row
+            as a definitive leaf when `hasChildren === false`. */}
+        {category.hasChildren !== false ? (
           <button
             type="button"
             data-granit-category-tree-toggle=""
@@ -234,12 +258,22 @@ export function CategoryTree({
   const labelStrings = { ...DEFAULT_LABELS, ...labels };
   const rootsQuery = useCategories({ scope });
   const createCategory = useCreateCategory(scope);
+  const [rootError, setRootError] = useState<string | null>(null);
 
   function handleAddRoot(): void {
     if (globalThis.window === undefined) return;
     const name = globalThis.prompt('Root category name?');
     if (!name?.trim()) return;
-    createCategory.mutate({ scope, parentId: null, name: name.trim() });
+    createCategory.mutate(
+      { scope, parentId: null, name: name.trim() },
+      {
+        onError: (err) => {
+          const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data
+            ?.detail;
+          setRootError(detail ?? (err instanceof Error ? err.message : 'Request failed.'));
+        },
+      }
+    );
   }
 
   if (rootsQuery.isLoading) {
@@ -270,6 +304,11 @@ export function CategoryTree({
         <button type="button" data-granit-category-tree-add-root="" onClick={handleAddRoot}>
           {labelStrings.add}
         </button>
+      )}
+      {rootError && (
+        <div data-granit-category-tree-error="" role="alert">
+          {rootError}
+        </div>
       )}
       {roots.length === 0 ? (
         <div data-granit-category-tree-empty="">{labelStrings.empty}</div>

--- a/packages/@granit/taxonomy/src/__tests__/search-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/search-api.test.ts
@@ -22,7 +22,7 @@ const sampleGroup: TaxonomySearchResultGroup = {
 };
 
 describe('searchTaxonomy', () => {
-  it('GETs /search with the q query param', async () => {
+  it('GETs /search with the q query param and passes through a bare-array response', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleGroup]));
 
@@ -41,5 +41,49 @@ describe('searchTaxonomy', () => {
     await searchTaxonomy(client, basePath, { q: '' });
 
     expect(client.get).toHaveBeenCalledWith(`${basePath}/search`, { params: { q: '' } });
+  });
+
+  it('adapts the backend SearchResponse envelope into TaxonomySearchResultGroup[]', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({
+        tags: [{ id: 'tag-1', name: 'Urgent' }],
+        hits: {
+          'Granit.Documents.Domain.Document': [{ targetId: 'doc-1', tagIds: ['tag-1'] }],
+        },
+        totalCount: 1,
+        skip: 0,
+        take: 50,
+      })
+    );
+
+    const result = await searchTaxonomy(client, basePath, { q: 'urgent' });
+
+    expect(result).toEqual([
+      {
+        targetType: 'Granit.Documents.Domain.Document',
+        items: [
+          {
+            targetType: 'Granit.Documents.Domain.Document',
+            targetId: 'doc-1',
+            label: '',
+            snippet: null,
+            matchedTagIds: ['tag-1'],
+            matchedCategoryId: null,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('returns [] when the backend envelope has no hits', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ tags: [], hits: {}, totalCount: 0, skip: 0, take: 50 })
+    );
+
+    const result = await searchTaxonomy(client, basePath, { q: 'nothing' });
+
+    expect(result).toEqual([]);
   });
 });

--- a/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
+++ b/packages/@granit/taxonomy/src/__tests__/tags-api.test.ts
@@ -39,9 +39,9 @@ const sampleAssignment: TagAssignmentResponse = {
 };
 
 describe('listTags', () => {
-  it('GETs /tags with the scope query param', async () => {
+  it('GETs /tags with the scope query param and unwraps the ListTagsResponse envelope', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [sampleTag] }));
 
     const result = await listTags(client, basePath, { scope: 'documents' });
 
@@ -53,7 +53,7 @@ describe('listTags', () => {
 
   it('appends q when supplied', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [sampleTag] }));
 
     await listTags(client, basePath, { scope: 'documents', q: 'urg' });
 
@@ -64,13 +64,22 @@ describe('listTags', () => {
 
   it('omits q when undefined', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [sampleTag] }));
 
     await listTags(client, basePath, { scope: 'documents', q: undefined });
 
     expect(client.get).toHaveBeenCalledWith(`${basePath}/tags`, {
       params: { scope: 'documents' },
     });
+  });
+
+  it('tolerates a bare-array response (legacy mocks)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleTag]));
+
+    const result = await listTags(client, basePath, { scope: 'documents' });
+
+    expect(result).toEqual([sampleTag]);
   });
 });
 

--- a/packages/@granit/taxonomy/src/api/search-api.ts
+++ b/packages/@granit/taxonomy/src/api/search-api.ts
@@ -1,9 +1,52 @@
-import type { TaxonomySearchFilter, TaxonomySearchResultGroup } from '../types/index.js';
+import type {
+  TaxonomySearchFilter,
+  TaxonomySearchResultGroup,
+  TaxonomySearchResultItem,
+} from '../types/index.js';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
- * Cross-entity taxonomy search. The backend groups matches by `targetType`
- * and returns at most one group per registered taxonomy host.
+ * Backend wire-shape for `GET /api/v1/taxonomy/search` — keyed dictionary of
+ * per-target-type hits plus a flat list of matching tags. The frontend
+ * collapses this into the legacy `TaxonomySearchResultGroup[]` shape; label
+ * and snippet are left empty because the taxonomy backend doesn't fan out
+ * to entity stores (apps that surface richer results wire their own
+ * cross-entity search on top of this).
+ */
+interface BackendSearchResponse {
+  readonly tags?: ReadonlyArray<{ readonly id: string; readonly name: string }>;
+  readonly hits?: Readonly<
+    Record<string, ReadonlyArray<{ readonly targetId: string; readonly tagIds: readonly string[] }>>
+  >;
+}
+
+function isBackendEnvelope(
+  data: BackendSearchResponse | readonly TaxonomySearchResultGroup[] | null | undefined
+): data is BackendSearchResponse {
+  return data !== null && data !== undefined && !Array.isArray(data);
+}
+
+function adaptBackendResponse(data: BackendSearchResponse): readonly TaxonomySearchResultGroup[] {
+  const hits = data.hits ?? {};
+  return Object.entries(hits).map(([targetType, rows]) => ({
+    targetType,
+    items: rows.map<TaxonomySearchResultItem>((hit) => ({
+      targetType,
+      targetId: hit.targetId,
+      label: '',
+      snippet: null,
+      matchedTagIds: hit.tagIds,
+      matchedCategoryId: null,
+    })),
+  }));
+}
+
+/**
+ * Cross-entity taxonomy search. The backend returns a `SearchResponse`
+ * envelope (`{ tags, hits, totalCount, skip, take }`) keyed by target type;
+ * we collapse it into the legacy group-array shape consumed by the search
+ * bar. Bare-array responses (older mocks / Storybook fixtures) pass
+ * through unchanged.
  *
  * `GET {basePath}/search`
  */
@@ -12,8 +55,11 @@ export async function searchTaxonomy(
   basePath: string,
   filter: TaxonomySearchFilter
 ): Promise<readonly TaxonomySearchResultGroup[]> {
-  const response = await client.get<readonly TaxonomySearchResultGroup[]>(`${basePath}/search`, {
-    params: { q: filter.q },
-  });
-  return response.data;
+  const response = await client.get<BackendSearchResponse | readonly TaxonomySearchResultGroup[]>(
+    `${basePath}/search`,
+    { params: { q: filter.q } }
+  );
+  const data = response.data;
+  if (isBackendEnvelope(data)) return adaptBackendResponse(data);
+  return data ?? [];
 }

--- a/packages/@granit/taxonomy/src/api/tags-api.ts
+++ b/packages/@granit/taxonomy/src/api/tags-api.ts
@@ -21,8 +21,14 @@ export async function listTags(
 ): Promise<readonly TagResponse[]> {
   const params: Record<string, string> = { scope: filter.scope };
   if (filter.q !== undefined) params.q = filter.q;
-  const response = await client.get<readonly TagResponse[]>(`${basePath}/tags`, { params });
-  return response.data;
+  // Backend wraps the listing in `ListTagsResponse { items }`; tolerate the
+  // bare-array shape so older mocks and Storybook fixtures keep working.
+  const response = await client.get<
+    { readonly items: readonly TagResponse[] } | readonly TagResponse[]
+  >(`${basePath}/tags`, { params });
+  const data = response.data;
+  if (Array.isArray(data)) return data;
+  return (data as { readonly items: readonly TagResponse[] } | null | undefined)?.items ?? [];
 }
 
 /**


### PR DESCRIPTION
## Summary

Three related issues surfaced while wiring taxonomy + presence into the showcase together. Shipped as one branch since they were debugged in the same session and touch overlapping smoke-test flows.

### 1. Taxonomy API wire-shape adapters (\`@granit/taxonomy\`)

\`listTags\` and \`searchTaxonomy\` were typed against the legacy bare-array shape, but the .NET backend returns wrapped envelopes:

- \`ListTagsResponse { items }\`
- \`SearchResponse { tags, hits, totalCount, skip, take }\`

The mismatch broke both endpoints against the real backend. Adapted at the API edge so bare-array responses (older mocks / Storybook fixtures) still pass through unchanged. The search adapter collapses the keyed \`hits\` dict into the existing \`TaxonomySearchResultGroup[]\` shape consumers already expect — \`label\` and \`snippet\` are left empty because the taxonomy backend doesn't fan out to entity stores (apps that surface richer results wire their own cross-entity search on top of this).

### 2. \`<CategoryTree>\` UX polish (\`@granit/react-taxonomy\`)

- **Auto-expand on add**: after a successful \`createCategory\`, expand the parent so the lazy children query (\`enabled: expanded\`) actually fires and the new node becomes visible without a second click.
- **\`hasChildren !== false\` fallback**: the real \`CategoryResponse\` from the backend has no \`hasChildren\` field. Without the fallback every row rendered as a leaf and newly created sub-categories stayed invisible. Only treat a row as a definitive leaf when the backend explicitly says so.
- **Surface RFC 7807 \`problem.detail\` errors** inline at the row and root level — replaces the silent failure on validation rejections.

### 3. Presence mock Guids (\`@granit/react-presence\`)

\`UserId\` round-trips through \`System.Guid\` on the backend, so the previous \`user-self\` / \`user-alice\` placeholder ids broke any flow that mixed real BFF + mock presence. Replaced with proper Guid-formatted strings. The new \`self\` Guid aligns with the first user (\`marie.dupont\`) in \`@granit/react-identity/testing\` so demos mounting both providers stay coherent.

## Test plan

- [x] \`pnpm -r exec tsc --noEmit\` — clean
- [x] \`pnpm exec eslint packages/@granit/{taxonomy,react-taxonomy,react-presence}/src --max-warnings 0\` — clean
- [x] \`pnpm exec vitest --run packages/@granit/{taxonomy,react-taxonomy,react-presence}\` — 174/174
- [x] \`pnpm exec vitest --run packages/@granit/arch-tests\` — 1853/1853
- [x] \`pnpm check:csp\` — OK
- [ ] Showcase smoke test: create root category → add child → verify it appears without manual refresh; force a 400 on \`POST /categories\` → verify \`problem.detail\` surfaces inline
- [ ] Showcase smoke test: tag autocomplete + cross-entity search both return non-empty results against the real backend