### PR TITLE
feat(react-documents): redesign explorer foundation — 3-pane, multi-select, inline editing

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3389,6 +3389,44 @@
           "name": "DocumentsListProps",
           "kind": "interface",
           "signature": "interface DocumentsListProps",
+          "members": [
+            {
+              "name": "ids",
+              "kind": "property",
+              "signature": "ids: ReadonlySet<string>,"
+            },
+            {
+              "name": "docs",
+              "kind": "property",
+              "signature": "docs: readonly DocumentResponse[]"
+            }
+          ]
+        },
+        {
+          "name": "DocumentsToolbar",
+          "kind": "function",
+          "signature": "function DocumentsToolbar("
+        },
+        {
+          "name": "InlineEdit",
+          "kind": "function",
+          "signature": "function InlineEdit("
+        },
+        {
+          "name": "InlineEditProps",
+          "kind": "interface",
+          "signature": "interface InlineEditProps",
+          "members": []
+        },
+        {
+          "name": "useMultiSelect",
+          "kind": "function",
+          "signature": "function useMultiSelect(orderedIds: readonly string[]): MultiSelectApi"
+        },
+        {
+          "name": "MultiSelectApi",
+          "kind": "interface",
+          "signature": "interface MultiSelectApi",
           "members": []
         },
         {

--- a/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-explorer.test.tsx
@@ -95,8 +95,6 @@ describe('DocumentsExplorer', () => {
       }
       return Promise.resolve({ data: undefined });
     }) as AxiosInstance['delete']);
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
-
     render(<DocumentsExplorer canManage />, { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
@@ -107,8 +105,9 @@ describe('DocumentsExplorer', () => {
       expect(document.querySelector('[data-granit-folder-breadcrumb]')).not.toBeNull()
     );
 
-    // Trash from the tree
+    // Trash from the tree (inline confirm flow — no window.confirm)
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
     await waitFor(() => expect(client.delete).toHaveBeenCalled());
 
     // The eager onDeleted path nulls currentFolder synchronously — breadcrumb

--- a/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
@@ -23,10 +23,28 @@ function createWrapper(client: AxiosInstance) {
   };
 }
 
+function mockTwoDocs(client: AxiosInstance): void {
+  vi.mocked(client.get).mockResolvedValue({
+    data: {
+      items: [
+        { id: 'doc-1', folderId: 'fld-1', name: 'contract.pdf', status: 'Active' },
+        { id: 'doc-2', folderId: 'fld-1', name: 'invoice.pdf', status: 'Active' },
+      ],
+      totalCount: 2,
+      page: 1,
+      pageSize: 50,
+    },
+    status: 200,
+    statusText: 'OK',
+    headers: {},
+    config: { headers: {} } as never,
+  });
+}
+
 describe('DocumentsList', () => {
   it('renders the loading state while the QueryEngine page is in flight', () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockReturnValue(new Promise(() => {})); // never resolves
+    vi.mocked(client.get).mockReturnValue(new Promise(() => {}));
 
     render(<DocumentsList folderId="fld-1" />, { wrapper: createWrapper(client) });
 
@@ -50,21 +68,7 @@ describe('DocumentsList', () => {
 
   it('renders rows + pagination from the QueryEngine PagedResult and triggers onOpenDocument', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({
-      data: {
-        items: [
-          { id: 'doc-1', folderId: 'fld-1', name: 'contract.pdf', status: 'Active' },
-          { id: 'doc-2', folderId: 'fld-1', name: 'invoice.pdf', status: 'Active' },
-        ],
-        totalCount: 2,
-        page: 1,
-        pageSize: 50,
-      },
-      status: 200,
-      statusText: 'OK',
-      headers: {},
-      config: { headers: {} } as never,
-    });
+    mockTwoDocs(client);
     const onOpenDocument = vi.fn();
 
     render(<DocumentsList folderId="fld-1" onOpenDocument={onOpenDocument} />, {
@@ -75,7 +79,7 @@ describe('DocumentsList', () => {
     expect(screen.getByText('invoice.pdf')).toBeInTheDocument();
     expect(screen.getByText('Page 1 of 1')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByText('contract.pdf'));
+    await userEvent.click(screen.getByRole('button', { name: 'contract.pdf' }));
     expect(onOpenDocument).toHaveBeenCalledWith('doc-1');
   });
 
@@ -123,10 +127,102 @@ describe('DocumentsList', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalled());
     const url = vi.mocked(client.get).mock.calls[0]?.[0] ?? '';
-    // QueryEngine serializes filters/sort/pagination directly onto the URL.
     expect(url).toContain('/api/v1/documents/documents');
     expect(url).toContain('fld-42');
     expect(url).toContain('Active');
     expect(url).toContain('name');
+  });
+
+  it('toggles selection via per-row checkbox and bubbles onSelectionChange', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    const onSelectionChange = vi.fn();
+
+    render(<DocumentsList folderId="fld-1" onSelectionChange={onSelectionChange} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    const rowCheckbox = screen.getByRole('checkbox', { name: 'Select contract.pdf' });
+    await userEvent.click(rowCheckbox);
+
+    await waitFor(() => {
+      const lastCall = onSelectionChange.mock.calls.at(-1);
+      const set = lastCall?.[0] as ReadonlySet<string>;
+      expect(set.has('doc-1')).toBe(true);
+    });
+  });
+
+  it('select-all checkbox toggles all rows', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    const onSelectionChange = vi.fn();
+
+    render(<DocumentsList folderId="fld-1" onSelectionChange={onSelectionChange} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select all' }));
+
+    await waitFor(() => {
+      const lastCall = onSelectionChange.mock.calls.at(-1);
+      const set = lastCall?.[0] as ReadonlySet<string>;
+      expect(set.size).toBe(2);
+    });
+  });
+
+  it('renames a row via the inline editor (Rename action)', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    vi.mocked(client.patch).mockResolvedValue({
+      data: { id: 'doc-1', folderId: 'fld-1', name: 'renamed.pdf', status: 'Active' },
+      status: 200,
+      statusText: 'OK',
+      headers: {},
+      config: { headers: {} } as never,
+    });
+
+    render(<DocumentsList folderId="fld-1" canManage onOpenDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    const renameButtons = screen.getAllByRole('button', { name: 'Rename' });
+    await userEvent.click(renameButtons[0]!);
+
+    const input = screen.getByRole('textbox', { name: 'Rename' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'renamed.pdf{Enter}');
+
+    await waitFor(() => expect(client.patch).toHaveBeenCalled());
+  });
+
+  it('confirms inline before trashing a row', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    vi.mocked(client.delete).mockResolvedValue({
+      data: undefined,
+      status: 204,
+      statusText: 'No Content',
+      headers: {},
+      config: { headers: {} } as never,
+    });
+
+    render(<DocumentsList folderId="fld-1" canManage onOpenDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    const trashButtons = screen.getAllByRole('button', { name: 'Move to trash' });
+    await userEvent.click(trashButtons[0]!);
+
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
+    await waitFor(() => expect(client.delete).toHaveBeenCalled());
   });
 });

--- a/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
@@ -122,13 +122,11 @@ describe('FolderTree', () => {
     render(<FolderTree labels={{ error: 'oops' }} />, { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
-    // Error message from the thrown Error wins over the fallback label
     expect(screen.getByRole('alert').textContent).toMatch(/boom/);
   });
 
   it('falls back to the error label when the thrown error has no message', async () => {
     const client = createMockClient();
-    // Custom error without a message string
     const err = new Error();
     vi.mocked(client.get).mockRejectedValue(err);
 
@@ -139,81 +137,93 @@ describe('FolderTree', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
   });
 
-  it('triggers the create-root prompt and aborts when the prompt is empty', async () => {
+  it('opens an inline editor when clicking add-root and aborts on Escape', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('   ');
 
     render(<FolderTree canManage />, { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(screen.getByText('No folders.')).toBeInTheDocument());
-    const addRoot = screen.getByRole('button', { name: '+' });
-    await userEvent.click(addRoot);
+    await userEvent.click(screen.getByRole('button', { name: /New root folder/ }));
 
-    expect(promptSpy).toHaveBeenCalled();
+    const input = screen.getByRole('textbox', { name: /Folder name/ });
+    expect(input).toBeInTheDocument();
+    await userEvent.keyboard('{Escape}');
     expect(client.post).not.toHaveBeenCalled();
+    expect(screen.queryByRole('textbox', { name: /Folder name/ })).toBeNull();
   });
 
-  it('creates a root folder when the prompt returns a name', async () => {
+  it('creates a root folder when the inline editor commits a name', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
     vi.mocked(client.post).mockResolvedValue({ data: { ...root, name: 'New' } });
-    vi.spyOn(window, 'prompt').mockReturnValue('New');
 
     render(<FolderTree canManage />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('No folders.')).toBeInTheDocument());
-    await userEvent.click(screen.getByRole('button', { name: '+' }));
+    await userEvent.click(screen.getByRole('button', { name: /New root folder/ }));
+
+    const input = screen.getByRole('textbox', { name: /Folder name/ });
+    await userEvent.type(input, 'New{Enter}');
 
     await waitFor(() => expect(client.post).toHaveBeenCalled());
   });
 
-  it('cancels rename when the prompt returns the same name', async () => {
+  it('opens an inline rename editor and cancels when the name is unchanged', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
-    vi.spyOn(window, 'prompt').mockReturnValue(root.name);
 
     render(<FolderTree canManage />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
 
+    // Click the inline Rename button, then submit unchanged name → no PATCH
     await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = screen.getByRole('textbox', { name: 'Rename' });
+    await userEvent.keyboard('{Enter}');
+
+    expect(input).not.toBeInTheDocument();
     expect(client.patch).not.toHaveBeenCalled();
   });
 
-  it('renames a folder when the prompt returns a new name', async () => {
+  it('renames a folder when the inline editor commits a new name', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
     vi.mocked(client.patch).mockResolvedValue({ data: { ...root, name: 'Renamed' } });
-    vi.spyOn(window, 'prompt').mockReturnValue('Renamed');
 
     render(<FolderTree canManage />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
 
     await userEvent.click(screen.getByRole('button', { name: 'Rename' }));
+    const input = screen.getByRole('textbox', { name: 'Rename' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'Renamed{Enter}');
+
     await waitFor(() => expect(client.patch).toHaveBeenCalled());
   });
 
-  it('aborts delete when the user cancels the confirm dialog', async () => {
+  it('aborts trash when the user clicks Cancel in the inline confirm', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
-    vi.spyOn(window, 'confirm').mockReturnValue(false);
 
     render(<FolderTree canManage />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
 
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(client.delete).not.toHaveBeenCalled();
   });
 
-  it('trashes a folder when the user confirms', async () => {
+  it('trashes a folder when the user confirms inline', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
     vi.mocked(client.delete).mockResolvedValue({ data: undefined });
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
 
     render(<FolderTree canManage />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
 
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+
     await waitFor(() => expect(client.delete).toHaveBeenCalled());
   });
 
@@ -221,13 +231,13 @@ describe('FolderTree', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
     vi.mocked(client.delete).mockResolvedValue({ data: undefined });
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     const onDeleted = vi.fn();
 
     render(<FolderTree canManage onDeleted={onDeleted} />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
 
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => expect(onDeleted).toHaveBeenCalledWith(root.id));
     expect(onDeleted).toHaveBeenCalledTimes(1);
@@ -237,34 +247,44 @@ describe('FolderTree', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
     vi.mocked(client.delete).mockRejectedValue(new Error('forbidden'));
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     const onDeleted = vi.fn();
 
     render(<FolderTree canManage onDeleted={onDeleted} />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
 
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => expect(screen.getByRole('alert').textContent).toMatch(/forbidden/));
     expect(onDeleted).not.toHaveBeenCalled();
   });
 
-  it('creates a sub-folder via the node-level add button', async () => {
+  it('creates a sub-folder via the node-level add button (inline editor)', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
     vi.mocked(client.post).mockResolvedValue({ data: { ...root, name: 'child' } });
-    vi.spyOn(window, 'prompt').mockReturnValue('child');
 
     render(<FolderTree canManage />, { wrapper: createWrapper(client) });
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
 
-    // The node-level + button is among the row buttons (not the top-level one)
-    const addButtons = screen.getAllByRole('button', { name: '+' });
-    // First add is the root-level. Click the per-node one.
-    const nodeAdd = addButtons[addButtons.length - 1];
-    if (!nodeAdd) throw new Error('expected node-level add button');
+    // The per-node + button (aria-label 'New folder')
+    const nodeAdd = screen.getByRole('button', { name: 'New folder' });
     await userEvent.click(nodeAdd);
 
+    const input = await screen.findByRole('textbox', { name: /Folder name/ });
+    await userEvent.type(input, 'child{Enter}');
+
     await waitFor(() => expect(client.post).toHaveBeenCalled());
+  });
+
+  it('marks the currentFolderId node with a data attribute', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+
+    render(<FolderTree currentFolderId={root.id} />, { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+    const node = document.querySelector(`[data-granit-folder-id="${root.id}"]`);
+    expect(node?.hasAttribute('data-granit-folder-tree-current')).toBe(true);
   });
 });

--- a/packages/@granit/react-documents/src/components/documents-explorer.tsx
+++ b/packages/@granit/react-documents/src/components/documents-explorer.tsx
@@ -2,17 +2,33 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { useFolder } from '../hooks/use-folders.js';
 
+import { DocumentDetail } from './document-detail.js';
 import { DocumentsList } from './documents-list.js';
+import { DocumentsToolbar } from './documents-toolbar.js';
 import { FolderBreadcrumb } from './folder-breadcrumb.js';
 import { FolderTree } from './folder-tree.js';
 import { QuotaBadge } from './quota-badge.js';
 import { UploadButton } from './upload-button.js';
 
+import type { DocumentDetailLabels } from './document-detail.js';
+import type { DocumentsListLabels } from './documents-list.js';
+import type { DocumentsToolbarLabels } from './documents-toolbar.js';
+import type { FolderBreadcrumbLabels } from './folder-breadcrumb.js';
+import type { FolderTreeLabels } from './folder-tree.js';
+import type { UploadButtonLabels } from './upload-button.js';
 import type { DocumentResponse, FolderResponse } from '@granit/documents';
 import type { ReactNode } from 'react';
 
 export interface DocumentsExplorerLabels {
   readonly title?: string;
+  readonly inspectorEmpty?: string;
+  readonly inspectorMultiple?: (count: number) => string;
+  readonly tree?: FolderTreeLabels;
+  readonly breadcrumb?: FolderBreadcrumbLabels;
+  readonly list?: DocumentsListLabels;
+  readonly toolbar?: DocumentsToolbarLabels;
+  readonly upload?: UploadButtonLabels;
+  readonly detail?: DocumentDetailLabels;
 }
 
 export interface DocumentsExplorerProps {
@@ -20,38 +36,59 @@ export interface DocumentsExplorerProps {
   readonly rootFolderId?: string | null;
   readonly canManage?: boolean;
   readonly showQuotaBadge?: boolean;
+  /** Hide / show the right inspector pane. Defaults to `true`. */
+  readonly showInspector?: boolean;
   readonly onOpenDocument?: (id: string) => void;
   readonly labels?: DocumentsExplorerLabels;
   readonly className?: string;
 }
 
-const DEFAULT_LABELS: Required<DocumentsExplorerLabels> = {
+const DEFAULT_LABELS: Required<
+  Pick<DocumentsExplorerLabels, 'title' | 'inspectorEmpty' | 'inspectorMultiple'>
+> = {
   title: 'Documents',
+  inspectorEmpty: 'Select a document to see its details.',
+  inspectorMultiple: (count) => `${String(count)} documents selected.`,
 };
 
-/**
- * Two-pane explorer layout — folder tree on the left, breadcrumb / document
- * list / upload on the right. The current folder is local state; selecting
- * a folder in the tree updates the breadcrumb and the document list. The
- * document list itself is a seam ({@link DocumentsList}) until
- * `granit-fx/granit-dotnet#1990` ships the flat folder-documents endpoint.
- */
 // The finalize hook invalidates folders + quota query families, so the
 // right pane refreshes on its own — no per-callback work needed.
 function noopUploadComplete(_document: DocumentResponse): void {
   /* intentional no-op */
 }
 
+/**
+ * Three-pane explorer:
+ *
+ *   ┌─────────────┬────────────────────────────┬──────────────┐
+ *   │ FolderTree  │ Breadcrumb + Toolbar +     │ Inspector    │
+ *   │             │ DocumentsList + UploadBtn  │ (DocumentDetail
+ *   │             │                            │  when 1 selected)
+ *   └─────────────┴────────────────────────────┴──────────────┘
+ *
+ * The current folder is local state; selecting a folder in the tree updates
+ * the breadcrumb, the document list, and resets selection. The inspector
+ * binds to the focused row (single-clicked, not just checkbox-toggled).
+ *
+ * Selection / focus state lives here so the toolbar (bulk actions) and the
+ * inspector pane stay in sync with what {@link DocumentsList} reports.
+ */
 export function DocumentsExplorer({
   rootFolderId = null,
   canManage = false,
   showQuotaBadge = false,
+  showInspector = true,
   onOpenDocument,
   labels,
   className,
 }: DocumentsExplorerProps): ReactNode {
   const labelStrings = { ...DEFAULT_LABELS, ...labels };
   const [currentFolder, setCurrentFolder] = useState<FolderResponse | null>(null);
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(() => new Set());
+  const [selectedDocs, setSelectedDocs] = useState<readonly DocumentResponse[]>([]);
+  const [focusedDoc, setFocusedDoc] = useState<DocumentResponse | null>(null);
+  const [inspectorVisible, setInspectorVisible] = useState(showInspector);
+  const [clearSignal, setClearSignal] = useState(0);
 
   // Watch the live status of the current selection. After a trash mutation
   // (direct or cascading from an ancestor), the cache is invalidated and
@@ -78,6 +115,30 @@ export function DocumentsExplorer({
     setCurrentFolder((prev) => (prev?.id === deletedId ? null : prev));
   }, []);
 
+  // Clear doc selection / focus when the folder changes.
+  useEffect(() => {
+    setSelectedIds(new Set());
+    setSelectedDocs([]);
+    setFocusedDoc(null);
+  }, [currentFolder?.id]);
+
+  const handleSelectionChange = useCallback(
+    (ids: ReadonlySet<string>, docs: readonly DocumentResponse[]) => {
+      setSelectedIds(ids);
+      setSelectedDocs(docs);
+    },
+    []
+  );
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedIds(new Set());
+    setSelectedDocs([]);
+    setFocusedDoc(null);
+    // The list owns its multi-select state internally; bump the signal so
+    // it clears without remounting the underlying query subtree.
+    setClearSignal((n) => n + 1);
+  }, []);
+
   const folderId = currentFolder?.id ?? '';
 
   return (
@@ -86,24 +147,77 @@ export function DocumentsExplorer({
         <h1>{labelStrings.title}</h1>
         {showQuotaBadge && <QuotaBadge />}
       </header>
-      <div data-granit-documents-explorer-body="">
+      <div
+        data-granit-documents-explorer-body=""
+        data-granit-documents-explorer-with-inspector={
+          showInspector && inspectorVisible ? '' : undefined
+        }
+      >
         <aside data-granit-documents-explorer-tree="">
           <FolderTree
             rootFolderId={rootFolderId}
             canManage={canManage}
+            currentFolderId={currentFolder?.id ?? null}
             onSelect={setCurrentFolder}
             onDeleted={handleFolderDeleted}
+            labels={labels?.tree}
           />
         </aside>
         <section data-granit-documents-explorer-main="">
           {folderId.length > 0 && (
-            <FolderBreadcrumb folderId={folderId} onSelect={setCurrentFolder} />
+            <FolderBreadcrumb
+              folderId={folderId}
+              onSelect={setCurrentFolder}
+              labels={labels?.breadcrumb}
+            />
           )}
-          <DocumentsList folderId={folderId} onOpenDocument={onOpenDocument} />
-          {canManage && (
-            <UploadButton folderId={currentFolder?.id ?? null} onComplete={noopUploadComplete} />
-          )}
+          <DocumentsToolbar
+            canManage={canManage}
+            selected={selectedIds}
+            selectedDocs={selectedDocs}
+            onClearSelection={handleClearSelection}
+            inspectorVisible={showInspector && inspectorVisible}
+            onToggleInspector={showInspector ? () => setInspectorVisible((v) => !v) : undefined}
+            labels={labels?.toolbar}
+            trailing={
+              canManage && (
+                <UploadButton
+                  folderId={currentFolder?.id ?? null}
+                  onComplete={noopUploadComplete}
+                  labels={labels?.upload}
+                />
+              )
+            }
+          />
+          <DocumentsList
+            folderId={folderId}
+            canManage={canManage}
+            clearSignal={clearSignal}
+            onOpenDocument={onOpenDocument}
+            onSelectionChange={handleSelectionChange}
+            onFocusChange={setFocusedDoc}
+            labels={labels?.list}
+          />
         </section>
+        {showInspector && inspectorVisible && (
+          <aside data-granit-documents-explorer-inspector="">
+            {focusedDoc ? (
+              <DocumentDetail
+                documentId={focusedDoc.id}
+                canManage={canManage}
+                labels={labels?.detail}
+              />
+            ) : selectedIds.size > 1 ? (
+              <div data-granit-documents-explorer-inspector-multi="">
+                {labelStrings.inspectorMultiple(selectedIds.size)}
+              </div>
+            ) : (
+              <div data-granit-documents-explorer-inspector-empty="">
+                {labelStrings.inspectorEmpty}
+              </div>
+            )}
+          </aside>
+        )}
       </div>
     </div>
   );

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -1,10 +1,15 @@
 import { QueryProvider, useQueryEndpoint } from '@granit/react-query-engine';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { useRenameDocument, useTrashDocument } from '../hooks/use-document-mutations.js';
+import { useMultiSelect } from '../hooks/use-multi-select.js';
 import { useDocumentsConfig } from '../providers/documents-provider.js';
+
+import { InlineEdit } from './inline-edit.js';
 
 import type { DocumentResponse } from '@granit/documents';
 import type { FilterEntry, SortEntry } from '@granit/query-engine';
-import type { ReactNode } from 'react';
+import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
 const LIST_QUERY_KEY_PREFIX = ['documents', 'documents', 'list'] as const;
 const DEFAULT_PAGE_SIZE = 50;
@@ -13,6 +18,12 @@ export interface DocumentsListLabels {
   readonly empty?: string;
   readonly nameHeader?: string;
   readonly statusHeader?: string;
+  readonly selectHeader?: string;
+  readonly selectRow?: string;
+  readonly rename?: string;
+  readonly trash?: string;
+  readonly trashConfirm?: string;
+  readonly trashCancel?: string;
   readonly loading?: string;
   readonly error?: string;
   readonly previous?: string;
@@ -23,7 +34,22 @@ export interface DocumentsListLabels {
 export interface DocumentsListProps {
   readonly folderId: string;
   readonly pageSize?: number;
+  readonly canManage?: boolean;
+  /** Open / preview a single document (Enter key or single click on name). */
   readonly onOpenDocument?: (id: string) => void;
+  /** Bubbles the current selection (ids) to a parent toolbar or inspector. */
+  readonly onSelectionChange?: (
+    ids: ReadonlySet<string>,
+    docs: readonly DocumentResponse[]
+  ) => void;
+  /** Bubbles the focused row (last single-clicked) for inspector binding. */
+  readonly onFocusChange?: (doc: DocumentResponse | null) => void;
+  /**
+   * Monotonic signal: bumping the value tells the list to clear its inner
+   * selection + focus state. Useful when a parent toolbar exposes a
+   * "Clear selection" action without lifting selection state up.
+   */
+  readonly clearSignal?: number;
   readonly labels?: DocumentsListLabels;
   readonly className?: string;
 }
@@ -32,6 +58,12 @@ const DEFAULT_LABELS: Required<DocumentsListLabels> = {
   empty: 'This folder is empty.',
   nameHeader: 'Name',
   statusHeader: 'Status',
+  selectHeader: 'Select all',
+  selectRow: 'Select',
+  rename: 'Rename',
+  trash: 'Move to trash',
+  trashConfirm: 'Confirm',
+  trashCancel: 'Cancel',
   loading: 'Loading documents…',
   error: 'Failed to load documents.',
   previous: 'Previous',
@@ -41,16 +73,16 @@ const DEFAULT_LABELS: Required<DocumentsListLabels> = {
 
 /**
  * Lists active documents inside a folder. Backed by the QueryEngine
- * endpoint `GET {basePath}/documents` (mounts `GET /documents` and
- * `GET /documents/meta` per Granit convention — mirrors parties).
+ * endpoint `GET {basePath}/documents` — pre-applies `folderId Equals <id>`
+ * and `status Equals Active`. Trashed documents are surfaced in TrashBin.
  *
- * Pre-applies two filters: `folderId Equals <id>` and `status Equals Active`
- * (trashed documents are surfaced in {@link TrashBin} instead). Sorted by
- * `name asc` by default.
- *
- * Self-wraps in `<QueryProvider>` using the {@link useDocumentsConfig}
- * client + a derived base path, so consumers only need to mount
- * `<DocumentsProvider>` upstream.
+ * Beyond display, the list exposes:
+ *  - Multi-selection (click / ctrl-click / shift-click / select-all checkbox).
+ *  - Keyboard navigation: ↑↓ focus, Enter opens, F2 renames, Space toggles
+ *    selection, Delete trashes the focused row (with inline confirm).
+ *  - Inline rename via {@link InlineEdit} (replaces `window.prompt`).
+ *  - Inline trash confirmation (replaces `window.confirm`).
+ *  - Selection / focus callbacks for an external toolbar + inspector.
  */
 export function DocumentsList(props: Readonly<DocumentsListProps>): ReactNode {
   const config = useDocumentsConfig();
@@ -68,25 +100,174 @@ export function DocumentsList(props: Readonly<DocumentsListProps>): ReactNode {
   );
 }
 
+type RowMode = 'idle' | 'renaming' | 'confirming-trash';
+
 function DocumentsListBody({
   folderId,
   pageSize,
+  canManage = false,
   onOpenDocument,
+  onSelectionChange,
+  onFocusChange,
+  clearSignal,
   labels,
   className,
 }: Readonly<DocumentsListProps>): ReactNode {
   const labelStrings = { ...DEFAULT_LABELS, ...labels };
   const effectivePageSize = pageSize ?? DEFAULT_PAGE_SIZE;
 
-  const filters: readonly FilterEntry[] = [
-    { field: 'folderId', operator: 'Eq', value: folderId },
-    { field: 'status', operator: 'Eq', value: 'Active' },
-  ];
-  const sort: readonly SortEntry[] = [{ field: 'name', direction: 'asc' }];
+  const filters: readonly FilterEntry[] = useMemo(
+    () => [
+      { field: 'folderId', operator: 'Eq', value: folderId },
+      { field: 'status', operator: 'Eq', value: 'Active' },
+    ],
+    [folderId]
+  );
+  const sort: readonly SortEntry[] = useMemo(() => [{ field: 'name', direction: 'asc' }], []);
 
   const { params, query, setPage } = useQueryEndpoint<DocumentResponse>({
     initialParams: { page: 1, pageSize: effectivePageSize, filters, sort },
   });
+
+  const items = useMemo<readonly DocumentResponse[]>(() => query.data?.items ?? [], [query.data]);
+  const orderedIds = useMemo(() => items.map((d) => d.id), [items]);
+  const selection = useMultiSelect(orderedIds);
+  const [focusedId, setFocusedId] = useState<string | null>(null);
+  const [rowModes, setRowModes] = useState<Readonly<Record<string, RowMode>>>({});
+  const tableRef = useRef<HTMLTableElement | null>(null);
+
+  const renameDocument = useRenameDocument();
+  const trashDocument = useTrashDocument();
+
+  // Reset transient row state when the folder or page changes.
+  useEffect(() => {
+    setRowModes({});
+    setFocusedId(null);
+  }, [folderId, params.page]);
+
+  // Honor a parent-driven "clear selection" signal. We intentionally
+  // depend only on the monotonic signal — `selection.clear` is a stable
+  // useCallback, but listing it as a dep would re-run this every render
+  // (selection is a fresh object literal each render).
+  const selectionClearRef = useRef(selection.clear);
+  selectionClearRef.current = selection.clear;
+  useEffect(() => {
+    if (clearSignal === undefined) return;
+    selectionClearRef.current();
+    setFocusedId(null);
+    setRowModes({});
+  }, [clearSignal]);
+
+  // Surface selection / focus to parents. Depend on `selection.selected`
+  // (the state Set, stable when unchanged) rather than the `selection`
+  // object literal — otherwise the effect re-fires every render and bounces
+  // a fresh `docs` array up to the parent, which would re-render this list
+  // again. That's a textbook update loop and bit us pre-fix.
+  useEffect(() => {
+    if (!onSelectionChange) return;
+    const docs = items.filter((d) => selection.selected.has(d.id));
+    onSelectionChange(selection.selected, docs);
+  }, [selection.selected, items, onSelectionChange]);
+
+  useEffect(() => {
+    if (!onFocusChange) return;
+    const doc = focusedId ? (items.find((d) => d.id === focusedId) ?? null) : null;
+    onFocusChange(doc);
+  }, [focusedId, items, onFocusChange]);
+
+  function setRowMode(id: string, mode: RowMode): void {
+    setRowModes((prev) => ({ ...prev, [id]: mode }));
+  }
+
+  function clearRowMode(id: string): void {
+    setRowModes((prev) => {
+      if (!(id in prev)) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }
+
+  function handleRowClick(event: MouseEvent<HTMLTableRowElement>, doc: DocumentResponse): void {
+    if (event.shiftKey) {
+      event.preventDefault();
+      selection.selectRange(doc.id);
+    } else if (event.ctrlKey || event.metaKey) {
+      selection.toggle(doc.id);
+    } else {
+      selection.selectOnly(doc.id);
+    }
+    setFocusedId(doc.id);
+  }
+
+  function handleNameClick(doc: DocumentResponse): void {
+    selection.selectOnly(doc.id);
+    setFocusedId(doc.id);
+    onOpenDocument?.(doc.id);
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLTableElement>): void {
+    if (items.length === 0) return;
+    const index = focusedId ? items.findIndex((d) => d.id === focusedId) : -1;
+
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      const next = items[Math.min(items.length - 1, index + 1)];
+      if (next) {
+        setFocusedId(next.id);
+        if (event.shiftKey) selection.selectRange(next.id);
+        else if (!event.ctrlKey && !event.metaKey) selection.selectOnly(next.id);
+      }
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      const next = items[Math.max(0, index - 1)];
+      if (next) {
+        setFocusedId(next.id);
+        if (event.shiftKey) selection.selectRange(next.id);
+        else if (!event.ctrlKey && !event.metaKey) selection.selectOnly(next.id);
+      }
+    } else if (event.key === 'Enter' && focusedId) {
+      event.preventDefault();
+      onOpenDocument?.(focusedId);
+    } else if (event.key === ' ' && focusedId) {
+      event.preventDefault();
+      selection.toggle(focusedId);
+    } else if (event.key === 'F2' && focusedId && canManage) {
+      event.preventDefault();
+      setRowMode(focusedId, 'renaming');
+    } else if ((event.key === 'Delete' || event.key === 'Backspace') && focusedId && canManage) {
+      event.preventDefault();
+      setRowMode(focusedId, 'confirming-trash');
+    } else if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'a') {
+      event.preventDefault();
+      selection.selectAll(orderedIds);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      selection.clear();
+      setFocusedId(null);
+    }
+  }
+
+  function commitRename(doc: DocumentResponse, name: string): void {
+    if (name === doc.name) {
+      clearRowMode(doc.id);
+      return;
+    }
+    renameDocument.mutate(
+      { id: doc.id, request: { name } },
+      { onSettled: () => clearRowMode(doc.id) }
+    );
+  }
+
+  function confirmTrash(doc: DocumentResponse): void {
+    trashDocument.mutate(doc.id, {
+      onSettled: () => {
+        clearRowMode(doc.id);
+        selection.remove([doc.id]);
+        if (focusedId === doc.id) setFocusedId(null);
+      },
+    });
+  }
 
   if (query.isLoading) {
     return (
@@ -108,11 +289,11 @@ function DocumentsListBody({
     );
   }
 
-  const items = query.data?.items ?? [];
   const totalCount = query.data?.totalCount ?? 0;
   const currentPage = params.page ?? 1;
   const currentPageSize = params.pageSize ?? effectivePageSize;
   const totalPages = Math.max(1, Math.ceil(totalCount / currentPageSize));
+  const allSelected = orderedIds.length > 0 && orderedIds.every((id) => selection.isSelected(id));
 
   if (items.length === 0) {
     return (
@@ -124,28 +305,128 @@ function DocumentsListBody({
 
   return (
     <div data-granit-documents-list="" className={className}>
-      <table data-granit-documents-list-table="">
+      <table
+        ref={tableRef}
+        data-granit-documents-list-table=""
+        tabIndex={0}
+        onKeyDown={handleKeyDown}
+      >
         <thead>
           <tr>
+            <th data-granit-documents-list-select-col="">
+              <input
+                type="checkbox"
+                aria-label={labelStrings.selectHeader}
+                checked={allSelected}
+                onChange={(event) =>
+                  event.target.checked ? selection.selectAll(orderedIds) : selection.clear()
+                }
+              />
+            </th>
             <th>{labelStrings.nameHeader}</th>
             <th>{labelStrings.statusHeader}</th>
+            {canManage && <th data-granit-documents-list-actions-col="" />}
           </tr>
         </thead>
         <tbody>
-          {items.map((document) => (
-            <tr key={document.id} data-granit-documents-list-row="">
-              <td>
-                {onOpenDocument ? (
-                  <button type="button" onClick={() => onOpenDocument(document.id)}>
-                    {document.name}
-                  </button>
-                ) : (
-                  <span>{document.name}</span>
+          {items.map((document) => {
+            const isSelected = selection.isSelected(document.id);
+            const isFocused = focusedId === document.id;
+            const mode = rowModes[document.id] ?? 'idle';
+            return (
+              <tr
+                key={document.id}
+                data-granit-documents-list-row=""
+                data-granit-document-id={document.id}
+                data-granit-documents-list-selected={isSelected ? '' : undefined}
+                data-granit-documents-list-focused={isFocused ? '' : undefined}
+                aria-selected={isSelected}
+                onClick={(event) => handleRowClick(event, document)}
+              >
+                <td data-granit-documents-list-select-cell="">
+                  <input
+                    type="checkbox"
+                    aria-label={`${labelStrings.selectRow} ${document.name}`}
+                    checked={isSelected}
+                    onClick={(event) => event.stopPropagation()}
+                    onChange={() => selection.toggle(document.id)}
+                  />
+                </td>
+                <td>
+                  {mode === 'renaming' && canManage ? (
+                    <InlineEdit
+                      initialValue={document.name}
+                      ariaLabel={labelStrings.rename}
+                      onCommit={(name) => commitRename(document, name)}
+                      onCancel={() => clearRowMode(document.id)}
+                    />
+                  ) : onOpenDocument ? (
+                    <button
+                      type="button"
+                      data-granit-documents-list-name=""
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        handleNameClick(document);
+                      }}
+                      onDoubleClick={(event) => {
+                        if (canManage) {
+                          event.stopPropagation();
+                          setRowMode(document.id, 'renaming');
+                        }
+                      }}
+                    >
+                      {document.name}
+                    </button>
+                  ) : (
+                    <span data-granit-documents-list-name="">{document.name}</span>
+                  )}
+                </td>
+                <td>{document.status}</td>
+                {canManage && (
+                  <td data-granit-documents-list-actions="">
+                    {mode === 'confirming-trash' ? (
+                      <span data-granit-documents-list-confirm="" role="alertdialog">
+                        <button type="button" onClick={() => clearRowMode(document.id)}>
+                          {labelStrings.trashCancel}
+                        </button>
+                        <button
+                          type="button"
+                          data-granit-documents-list-confirm-ok=""
+                          onClick={() => confirmTrash(document)}
+                          disabled={trashDocument.isPending}
+                        >
+                          {labelStrings.trashConfirm}
+                        </button>
+                      </span>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          aria-label={labelStrings.rename}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setRowMode(document.id, 'renaming');
+                          }}
+                        >
+                          {labelStrings.rename}
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={labelStrings.trash}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setRowMode(document.id, 'confirming-trash');
+                          }}
+                        >
+                          {labelStrings.trash}
+                        </button>
+                      </>
+                    )}
+                  </td>
                 )}
-              </td>
-              <td>{document.status}</td>
-            </tr>
-          ))}
+              </tr>
+            );
+          })}
         </tbody>
       </table>
       <nav data-granit-documents-list-pagination="" aria-label="Pagination">

--- a/packages/@granit/react-documents/src/components/documents-toolbar.tsx
+++ b/packages/@granit/react-documents/src/components/documents-toolbar.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react';
+
+import { useTrashDocument } from '../hooks/use-document-mutations.js';
+
+import type { DocumentResponse } from '@granit/documents';
+import type { ReactNode } from 'react';
+
+export interface DocumentsToolbarLabels {
+  readonly noSelection?: string;
+  readonly oneSelected?: (name: string) => string;
+  readonly manySelected?: (count: number) => string;
+  readonly clearSelection?: string;
+  readonly bulkTrash?: string;
+  readonly bulkTrashConfirm?: (count: number) => string;
+  readonly bulkTrashConfirmOk?: string;
+  readonly bulkTrashCancel?: string;
+  readonly inspectorToggle?: string;
+}
+
+export interface DocumentsToolbarProps {
+  readonly canManage?: boolean;
+  readonly selected: ReadonlySet<string>;
+  readonly selectedDocs: readonly DocumentResponse[];
+  readonly onClearSelection?: () => void;
+  /** Optional inspector visibility binding for the explorer header. */
+  readonly inspectorVisible?: boolean;
+  readonly onToggleInspector?: () => void;
+  readonly labels?: DocumentsToolbarLabels;
+  readonly className?: string;
+  /** Extra trailing actions (e.g. an `<UploadButton />` in the no-selection state). */
+  readonly trailing?: ReactNode;
+}
+
+const DEFAULT_LABELS: Required<DocumentsToolbarLabels> = {
+  noSelection: 'No selection',
+  oneSelected: (name) => `Selected: ${name}`,
+  manySelected: (count) => `${String(count)} selected`,
+  clearSelection: 'Clear selection',
+  bulkTrash: 'Move to trash',
+  bulkTrashConfirm: (count) => `Move ${String(count)} item(s) to trash?`,
+  bulkTrashConfirmOk: 'Confirm',
+  bulkTrashCancel: 'Cancel',
+  inspectorToggle: 'Toggle inspector',
+};
+
+/**
+ * Contextual toolbar driven by the active selection. Renders a summary +
+ * bulk actions when one or more documents are selected, or just the
+ * trailing slot (typically an `<UploadButton />`) otherwise.
+ *
+ * Bulk trash uses an inline confirmation (no `window.confirm`), and fires
+ * the {@link useTrashDocument} mutation sequentially so the query cache is
+ * invalidated cleanly per item.
+ */
+export function DocumentsToolbar({
+  canManage = false,
+  selected,
+  selectedDocs,
+  onClearSelection,
+  inspectorVisible,
+  onToggleInspector,
+  labels,
+  className,
+  trailing,
+}: DocumentsToolbarProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const trashDocument = useTrashDocument();
+  const [confirmingTrash, setConfirmingTrash] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const count = selected.size;
+
+  async function handleBulkTrash(): Promise<void> {
+    setError(null);
+    try {
+      for (const doc of selectedDocs) {
+        await trashDocument.mutateAsync(doc.id);
+      }
+      onClearSelection?.();
+      setConfirmingTrash(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Bulk trash failed.');
+    }
+  }
+
+  const summary =
+    count === 0
+      ? labelStrings.noSelection
+      : count === 1
+        ? labelStrings.oneSelected(selectedDocs[0]?.name ?? '')
+        : labelStrings.manySelected(count);
+
+  return (
+    <div
+      data-granit-documents-toolbar=""
+      data-granit-documents-toolbar-selection={count > 0 ? '' : undefined}
+      className={className}
+    >
+      <span data-granit-documents-toolbar-summary="">{summary}</span>
+
+      {count > 0 && (
+        <span data-granit-documents-toolbar-actions="">
+          {canManage &&
+            (confirmingTrash ? (
+              <span data-granit-documents-toolbar-confirm="" role="alertdialog">
+                <span>{labelStrings.bulkTrashConfirm(count)}</span>
+                <button
+                  type="button"
+                  onClick={() => setConfirmingTrash(false)}
+                  disabled={trashDocument.isPending}
+                >
+                  {labelStrings.bulkTrashCancel}
+                </button>
+                <button
+                  type="button"
+                  data-granit-documents-toolbar-confirm-ok=""
+                  onClick={() => {
+                    void handleBulkTrash();
+                  }}
+                  disabled={trashDocument.isPending}
+                >
+                  {labelStrings.bulkTrashConfirmOk}
+                </button>
+              </span>
+            ) : (
+              <button
+                type="button"
+                data-granit-documents-toolbar-trash=""
+                onClick={() => setConfirmingTrash(true)}
+              >
+                {labelStrings.bulkTrash}
+              </button>
+            ))}
+          {onClearSelection && (
+            <button type="button" data-granit-documents-toolbar-clear="" onClick={onClearSelection}>
+              {labelStrings.clearSelection}
+            </button>
+          )}
+        </span>
+      )}
+
+      {error && (
+        <div data-granit-documents-toolbar-error="" role="alert">
+          {error}
+        </div>
+      )}
+
+      <span data-granit-documents-toolbar-trailing="">
+        {onToggleInspector && (
+          <button
+            type="button"
+            data-granit-documents-toolbar-inspector-toggle=""
+            aria-pressed={inspectorVisible ?? false}
+            onClick={onToggleInspector}
+          >
+            {labelStrings.inspectorToggle}
+          </button>
+        )}
+        {trailing}
+      </span>
+    </div>
+  );
+}

--- a/packages/@granit/react-documents/src/components/folder-tree.tsx
+++ b/packages/@granit/react-documents/src/components/folder-tree.tsx
@@ -3,14 +3,19 @@ import { useState } from 'react';
 import { useCreateFolder, useRenameFolder, useTrashFolder } from '../hooks/use-folder-mutations.js';
 import { useFolders } from '../hooks/use-folders.js';
 
+import { InlineEdit } from './inline-edit.js';
+
 import type { FolderResponse, FolderStatus } from '@granit/documents';
 import type { ReactNode } from 'react';
 
 export interface FolderTreeLabels {
   readonly add?: string;
+  readonly addRoot?: string;
   readonly rename?: string;
   readonly delete?: string;
+  readonly deleteConfirmQuestion?: string;
   readonly deleteConfirm?: string;
+  readonly deleteCancel?: string;
   readonly empty?: string;
   readonly loading?: string;
   readonly error?: string;
@@ -23,6 +28,8 @@ export interface FolderTreeProps {
   readonly canManage?: boolean;
   /** Filter shown folders by lifecycle status. Defaults to `Active`. */
   readonly status?: FolderStatus;
+  /** Highlight a single node as "current" (e.g. the explorer's active folder). */
+  readonly currentFolderId?: string | null;
   readonly onSelect?: (folder: FolderResponse) => void;
   /**
    * Fired with the folder id once a trash (soft-delete) mutation succeeds.
@@ -35,20 +42,26 @@ export interface FolderTreeProps {
 }
 
 const DEFAULT_LABELS: Required<FolderTreeLabels> = {
-  add: '+',
+  add: 'New folder',
+  addRoot: 'New root folder',
   rename: 'Rename',
   delete: 'Delete',
-  deleteConfirm: 'Move this folder to the trash? Its contents will be trashed too.',
+  deleteConfirmQuestion: 'Move this folder to the trash?',
+  deleteConfirm: 'Confirm',
+  deleteCancel: 'Cancel',
   empty: 'No folders.',
   loading: 'Loading…',
   error: 'Failed to load folders.',
-  newFolderName: 'Folder name?',
+  newFolderName: 'Folder name',
 };
+
+type RowMode = 'idle' | 'renaming' | 'adding-child' | 'confirming-trash';
 
 interface FolderNodeProps {
   readonly folder: FolderResponse;
   readonly canManage: boolean;
   readonly status: FolderStatus;
+  readonly currentFolderId: string | null;
   readonly labels: Required<FolderTreeLabels>;
   readonly onSelect?: (folder: FolderResponse) => void;
   readonly onDeleted?: (folderId: string) => void;
@@ -58,106 +71,179 @@ function FolderNode({
   folder,
   canManage,
   status,
+  currentFolderId,
   labels,
   onSelect,
   onDeleted,
 }: Readonly<FolderNodeProps>): ReactNode {
   const [expanded, setExpanded] = useState(false);
+  const [mode, setMode] = useState<RowMode>('idle');
+  const [error, setError] = useState<string | null>(null);
   const childrenQuery = useFolders({ parentId: folder.id, status }, { enabled: expanded });
   const createFolder = useCreateFolder();
   const renameFolder = useRenameFolder();
   const trashFolder = useTrashFolder();
-  const [error, setError] = useState<string | null>(null);
 
-  function handleAdd(): void {
-    if (globalThis.window === undefined) return;
-    const name = globalThis.prompt(labels.newFolderName);
-    if (!name?.trim()) return;
+  function startAdd(): void {
+    setExpanded(true);
+    setMode('adding-child');
+    setError(null);
+  }
+
+  function startRename(): void {
+    setMode('renaming');
+    setError(null);
+  }
+
+  function startTrash(): void {
+    setMode('confirming-trash');
+    setError(null);
+  }
+
+  function commitAdd(name: string): void {
     createFolder.mutate(
-      { parentFolderId: folder.id, name: name.trim() },
+      { parentFolderId: folder.id, name },
       {
+        onSuccess: () => setMode('idle'),
         onError: (err) => setError(err.message),
       }
     );
   }
 
-  function handleRename(): void {
-    if (globalThis.window === undefined) return;
-    const next = globalThis.prompt(labels.rename, folder.name);
-    if (!next?.trim() || next.trim() === folder.name) return;
+  function commitRename(name: string): void {
+    if (name === folder.name) {
+      setMode('idle');
+      return;
+    }
     renameFolder.mutate(
-      { id: folder.id, request: { name: next.trim() } },
+      { id: folder.id, request: { name } },
       {
+        onSuccess: () => setMode('idle'),
         onError: (err) => setError(err.message),
       }
     );
   }
 
-  function handleDelete(): void {
-    if (globalThis.window === undefined || !globalThis.confirm(labels.deleteConfirm)) return;
+  function confirmTrash(): void {
     trashFolder.mutate(folder.id, {
-      onSuccess: () => onDeleted?.(folder.id),
+      onSuccess: () => {
+        setMode('idle');
+        onDeleted?.(folder.id);
+      },
       onError: (err) => setError(err.message),
     });
   }
 
   const children = childrenQuery.data?.folders ?? [];
+  const isCurrent = currentFolderId === folder.id;
 
   return (
     <li
       data-granit-folder-tree-node=""
       data-granit-folder-id={folder.id}
       data-granit-folder-depth={folder.depth}
+      data-granit-folder-tree-current={isCurrent ? '' : undefined}
     >
-      <div data-granit-folder-tree-row="">
+      <div
+        data-granit-folder-tree-row=""
+        data-granit-folder-tree-current={isCurrent ? '' : undefined}
+      >
         <button
           type="button"
           data-granit-folder-tree-toggle=""
           aria-expanded={expanded}
+          aria-label={expanded ? 'Collapse' : 'Expand'}
           onClick={() => setExpanded((current) => !current)}
         >
           {expanded ? '▾' : '▸'}
         </button>
-        {onSelect ? (
-          <button type="button" data-granit-folder-tree-name="" onClick={() => onSelect(folder)}>
+        {mode === 'renaming' ? (
+          <InlineEdit
+            initialValue={folder.name}
+            ariaLabel={labels.rename}
+            onCommit={commitRename}
+            onCancel={() => setMode('idle')}
+          />
+        ) : onSelect ? (
+          <button
+            type="button"
+            data-granit-folder-tree-name=""
+            onClick={() => onSelect(folder)}
+            onDoubleClick={canManage ? startRename : undefined}
+          >
             {folder.name}
           </button>
         ) : (
           <span data-granit-folder-tree-name="">{folder.name}</span>
         )}
-        {canManage && (
+        {canManage && mode === 'idle' && (
           <span data-granit-folder-tree-actions="">
-            <button type="button" onClick={handleAdd}>
-              {labels.add}
+            <button type="button" onClick={startAdd} aria-label={labels.add}>
+              +
             </button>
-            <button type="button" onClick={handleRename}>
+            <button type="button" onClick={startRename} aria-label={labels.rename}>
               {labels.rename}
             </button>
-            <button type="button" onClick={handleDelete} aria-label={labels.delete}>
+            <button type="button" onClick={startTrash} aria-label={labels.delete}>
               {labels.delete}
             </button>
           </span>
         )}
       </div>
+      {mode === 'confirming-trash' && (
+        <div data-granit-folder-tree-confirm="" role="alertdialog">
+          <span data-granit-folder-tree-confirm-text="">{labels.deleteConfirmQuestion}</span>
+          <button
+            type="button"
+            data-granit-folder-tree-confirm-cancel=""
+            onClick={() => setMode('idle')}
+          >
+            {labels.deleteCancel}
+          </button>
+          <button
+            type="button"
+            data-granit-folder-tree-confirm-ok=""
+            onClick={confirmTrash}
+            disabled={trashFolder.isPending}
+          >
+            {labels.deleteConfirm}
+          </button>
+        </div>
+      )}
       {error && (
         <div data-granit-folder-tree-error="" role="alert">
           {error}
         </div>
       )}
-      {expanded && (
+      {(expanded || mode === 'adding-child') && (
         <ul data-granit-folder-tree-children="">
-          {childrenQuery.isLoading && <li data-granit-folder-tree-loading="">{labels.loading}</li>}
-          {children.map((child) => (
-            <FolderNode
-              key={child.id}
-              folder={child}
-              canManage={canManage}
-              status={status}
-              labels={labels}
-              onSelect={onSelect}
-              onDeleted={onDeleted}
-            />
-          ))}
+          {mode === 'adding-child' && (
+            <li data-granit-folder-tree-new="">
+              <InlineEdit
+                initialValue=""
+                placeholder={labels.newFolderName}
+                ariaLabel={labels.newFolderName}
+                onCommit={commitAdd}
+                onCancel={() => setMode('idle')}
+              />
+            </li>
+          )}
+          {expanded && childrenQuery.isLoading && (
+            <li data-granit-folder-tree-loading="">{labels.loading}</li>
+          )}
+          {expanded &&
+            children.map((child) => (
+              <FolderNode
+                key={child.id}
+                folder={child}
+                canManage={canManage}
+                status={status}
+                currentFolderId={currentFolderId}
+                labels={labels}
+                onSelect={onSelect}
+                onDeleted={onDeleted}
+              />
+            ))}
         </ul>
       )}
     </li>
@@ -167,31 +253,34 @@ function FolderNode({
 /**
  * Lazy-loaded folder tree. Each node fetches its own direct children via
  * {@link useFolders}; expansion drives the lazy load. When `canManage` is
- * true, per-row buttons wire add/rename/trash (no drag-drop in this
- * iteration — buttons only).
- *
- * The component currently uses `window.prompt`/`window.confirm` for inline
- * edits, matching the taxonomy tree pattern; apps that want a richer dialog
- * can wrap or replace this component.
+ * true, per-row inline editing wires add/rename/trash — no `window.prompt`
+ * or `window.confirm`: instead the row morphs into an input (add/rename)
+ * or a confirmation bar (trash). Double-click on a name also enters rename.
  */
 export function FolderTree({
   rootFolderId = null,
   canManage = false,
   status = 'Active',
+  currentFolderId = null,
   onSelect,
   onDeleted,
   labels,
   className,
 }: FolderTreeProps): ReactNode {
   const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const [addingRoot, setAddingRoot] = useState(false);
+  const [rootError, setRootError] = useState<string | null>(null);
   const rootsQuery = useFolders({ parentId: rootFolderId, status });
   const createFolder = useCreateFolder();
 
-  function handleAddRoot(): void {
-    if (globalThis.window === undefined) return;
-    const name = globalThis.prompt(labelStrings.newFolderName);
-    if (!name?.trim()) return;
-    createFolder.mutate({ parentFolderId: rootFolderId, name: name.trim() });
+  function commitAddRoot(name: string): void {
+    createFolder.mutate(
+      { parentFolderId: rootFolderId, name },
+      {
+        onSuccess: () => setAddingRoot(false),
+        onError: (err) => setRootError(err.message),
+      }
+    );
   }
 
   if (rootsQuery.isLoading) {
@@ -218,12 +307,35 @@ export function FolderTree({
 
   return (
     <div data-granit-folder-tree="" className={className}>
-      {canManage && (
-        <button type="button" data-granit-folder-tree-add-root="" onClick={handleAddRoot}>
-          {labelStrings.add}
-        </button>
+      {canManage &&
+        (addingRoot ? (
+          <div data-granit-folder-tree-new-root="">
+            <InlineEdit
+              initialValue=""
+              placeholder={labelStrings.newFolderName}
+              ariaLabel={labelStrings.newFolderName}
+              onCommit={commitAddRoot}
+              onCancel={() => setAddingRoot(false)}
+            />
+          </div>
+        ) : (
+          <button
+            type="button"
+            data-granit-folder-tree-add-root=""
+            onClick={() => {
+              setRootError(null);
+              setAddingRoot(true);
+            }}
+          >
+            + {labelStrings.addRoot}
+          </button>
+        ))}
+      {rootError && (
+        <div data-granit-folder-tree-error="" role="alert">
+          {rootError}
+        </div>
       )}
-      {roots.length === 0 ? (
+      {roots.length === 0 && !addingRoot ? (
         <div data-granit-folder-tree-empty="">{labelStrings.empty}</div>
       ) : (
         <ul data-granit-folder-tree-roots="">
@@ -233,6 +345,7 @@ export function FolderTree({
               folder={root}
               canManage={canManage}
               status={status}
+              currentFolderId={currentFolderId}
               labels={labelStrings}
               onSelect={onSelect}
               onDeleted={onDeleted}

--- a/packages/@granit/react-documents/src/components/inline-edit.tsx
+++ b/packages/@granit/react-documents/src/components/inline-edit.tsx
@@ -1,0 +1,82 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { KeyboardEvent, ReactNode } from 'react';
+
+export interface InlineEditProps {
+  readonly initialValue: string;
+  readonly placeholder?: string;
+  readonly ariaLabel: string;
+  readonly onCommit: (value: string) => void;
+  readonly onCancel: () => void;
+  readonly autoSelect?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * Tiny inline-edit input. Commits on Enter or blur, cancels on Escape.
+ * Headless: no styling, just a `data-granit-inline-edit` marker for apps to
+ * target. Used by FolderTree, DocumentsList and confirm-trash flows in place
+ * of `window.prompt`.
+ */
+export function InlineEdit({
+  initialValue,
+  placeholder,
+  ariaLabel,
+  onCommit,
+  onCancel,
+  autoSelect = true,
+  className,
+}: InlineEditProps): ReactNode {
+  const [value, setValue] = useState(initialValue);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (autoSelect && inputRef.current) {
+      inputRef.current.select();
+    }
+  }, [autoSelect]);
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>): void {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      event.stopPropagation();
+      const trimmed = value.trim();
+      if (trimmed.length === 0) {
+        onCancel();
+        return;
+      }
+      onCommit(trimmed);
+    } else if (event.key === 'Escape') {
+      event.preventDefault();
+      event.stopPropagation();
+      onCancel();
+    } else {
+      // Prevent parent keyboard handlers (e.g. list nav) from hijacking typing.
+      event.stopPropagation();
+    }
+  }
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      data-granit-inline-edit=""
+      autoFocus
+      aria-label={ariaLabel}
+      placeholder={placeholder}
+      className={className}
+      value={value}
+      onChange={(event) => setValue(event.target.value)}
+      onKeyDown={handleKeyDown}
+      onBlur={() => {
+        const trimmed = value.trim();
+        if (trimmed.length === 0 || trimmed === initialValue) {
+          onCancel();
+          return;
+        }
+        onCommit(trimmed);
+      }}
+      onClick={(event) => event.stopPropagation()}
+    />
+  );
+}

--- a/packages/@granit/react-documents/src/hooks/use-multi-select.ts
+++ b/packages/@granit/react-documents/src/hooks/use-multi-select.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface MultiSelectApi {
+  readonly selected: ReadonlySet<string>;
+  readonly isSelected: (id: string) => boolean;
+  readonly toggle: (id: string) => void;
+  readonly select: (id: string) => void;
+  readonly selectRange: (id: string) => void;
+  readonly selectOnly: (id: string) => void;
+  readonly selectAll: (ids: readonly string[]) => void;
+  readonly clear: () => void;
+  readonly remove: (ids: readonly string[]) => void;
+}
+
+/**
+ * Selection state with anchor-based range support (shift-click). Range is
+ * computed against `orderedIds`, so callers must keep this list in the same
+ * order the rows are rendered.
+ */
+export function useMultiSelect(orderedIds: readonly string[]): MultiSelectApi {
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
+  const anchorRef = useRef<string | null>(null);
+  const orderRef = useRef<readonly string[]>(orderedIds);
+
+  // Keep the latest ordered list in a ref so range selection always picks
+  // the row order at click-time, not at hook-init time.
+  useEffect(() => {
+    orderRef.current = orderedIds;
+  }, [orderedIds]);
+
+  // Drop ids that have left the listing (page change, trash, folder switch).
+  useEffect(() => {
+    setSelected((prev) => {
+      const valid = new Set<string>();
+      for (const id of prev) if (orderedIds.includes(id)) valid.add(id);
+      return valid.size === prev.size ? prev : valid;
+    });
+  }, [orderedIds]);
+
+  const isSelected = useCallback((id: string) => selected.has(id), [selected]);
+
+  const toggle = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+    anchorRef.current = id;
+  }, []);
+
+  const select = useCallback((id: string) => {
+    setSelected((prev) => {
+      if (prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.add(id);
+      return next;
+    });
+    anchorRef.current = id;
+  }, []);
+
+  const selectOnly = useCallback((id: string) => {
+    setSelected(new Set([id]));
+    anchorRef.current = id;
+  }, []);
+
+  const selectRange = useCallback((id: string) => {
+    const order = orderRef.current;
+    const anchor = anchorRef.current;
+    if (!anchor || !order.includes(anchor)) {
+      setSelected(new Set([id]));
+      anchorRef.current = id;
+      return;
+    }
+    const from = order.indexOf(anchor);
+    const to = order.indexOf(id);
+    if (to === -1) return;
+    const [start, end] = from <= to ? [from, to] : [to, from];
+    const range = order.slice(start, end + 1);
+    setSelected(new Set(range));
+  }, []);
+
+  const selectAll = useCallback((ids: readonly string[]) => {
+    setSelected(new Set(ids));
+    anchorRef.current = ids[ids.length - 1] ?? null;
+  }, []);
+
+  const clear = useCallback(() => {
+    setSelected(new Set());
+    anchorRef.current = null;
+  }, []);
+
+  const remove = useCallback((ids: readonly string[]) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      for (const id of ids) next.delete(id);
+      return next;
+    });
+  }, []);
+
+  return {
+    selected,
+    isSelected,
+    toggle,
+    select,
+    selectRange,
+    selectOnly,
+    selectAll,
+    clear,
+    remove,
+  };
+}

--- a/packages/@granit/react-documents/src/index.ts
+++ b/packages/@granit/react-documents/src/index.ts
@@ -78,6 +78,18 @@ export type {
 export { DocumentsList } from './components/documents-list.js';
 export type { DocumentsListLabels, DocumentsListProps } from './components/documents-list.js';
 
+export { DocumentsToolbar } from './components/documents-toolbar.js';
+export type {
+  DocumentsToolbarLabels,
+  DocumentsToolbarProps,
+} from './components/documents-toolbar.js';
+
+export { InlineEdit } from './components/inline-edit.js';
+export type { InlineEditProps } from './components/inline-edit.js';
+
+export { useMultiSelect } from './hooks/use-multi-select.js';
+export type { MultiSelectApi } from './hooks/use-multi-select.js';
+
 // Components — Folders
 export { FolderBreadcrumb } from './components/folder-breadcrumb.js';
 export type {

--- a/packages/@granit/react-documents/src/locales/en.ts
+++ b/packages/@granit/react-documents/src/locales/en.ts
@@ -13,9 +13,12 @@ export interface DocumentsTranslations {
   readonly Folder: {
     readonly Tree: {
       readonly Add: string;
+      readonly AddRoot: string;
       readonly Rename: string;
       readonly Delete: string;
+      readonly DeleteConfirmQuestion: string;
       readonly DeleteConfirm: string;
+      readonly DeleteCancel: string;
       readonly Empty: string;
       readonly Loading: string;
       readonly Error: string;
@@ -44,10 +47,27 @@ export interface DocumentsTranslations {
       readonly Empty: string;
       readonly NameHeader: string;
       readonly StatusHeader: string;
+      readonly SelectHeader: string;
+      readonly SelectRow: string;
+      readonly Rename: string;
+      readonly Trash: string;
+      readonly TrashConfirm: string;
+      readonly TrashCancel: string;
       readonly Loading: string;
       readonly Error: string;
       readonly Previous: string;
       readonly Next: string;
+    };
+    readonly Toolbar: {
+      readonly NoSelection: string;
+      readonly OneSelected: string;
+      readonly ManySelected: string;
+      readonly ClearSelection: string;
+      readonly BulkTrash: string;
+      readonly BulkTrashConfirm: string;
+      readonly BulkTrashConfirmOk: string;
+      readonly BulkTrashCancel: string;
+      readonly InspectorToggle: string;
     };
     readonly Upload: {
       readonly Button: string;
@@ -115,20 +135,25 @@ export interface DocumentsTranslations {
   };
   readonly Explorer: {
     readonly Title: string;
+    readonly InspectorEmpty: string;
+    readonly InspectorMultiple: string;
   };
 }
 
 export const documentsTranslationsEn: DocumentsTranslations = {
   Folder: {
     Tree: {
-      Add: '+',
+      Add: 'New folder',
+      AddRoot: 'New root folder',
       Rename: 'Rename',
       Delete: 'Delete',
-      DeleteConfirm: 'Move this folder to the trash? Its contents will be trashed too.',
+      DeleteConfirmQuestion: 'Move this folder to the trash? Its contents will be trashed too.',
+      DeleteConfirm: 'Confirm',
+      DeleteCancel: 'Cancel',
       Empty: 'No folders.',
       Loading: 'Loading…',
       Error: 'Failed to load folders.',
-      NewFolderName: 'Folder name?',
+      NewFolderName: 'Folder name',
     },
     Breadcrumb: {
       Loading: 'Loading…',
@@ -153,10 +178,27 @@ export const documentsTranslationsEn: DocumentsTranslations = {
       Empty: 'This folder is empty.',
       NameHeader: 'Name',
       StatusHeader: 'Status',
+      SelectHeader: 'Select all',
+      SelectRow: 'Select',
+      Rename: 'Rename',
+      Trash: 'Move to trash',
+      TrashConfirm: 'Confirm',
+      TrashCancel: 'Cancel',
       Loading: 'Loading documents…',
       Error: 'Failed to load documents.',
       Previous: 'Previous',
       Next: 'Next',
+    },
+    Toolbar: {
+      NoSelection: 'No selection',
+      OneSelected: 'Selected: {{name}}',
+      ManySelected: '{{count}} selected',
+      ClearSelection: 'Clear selection',
+      BulkTrash: 'Move to trash',
+      BulkTrashConfirm: 'Move {{count}} item(s) to trash?',
+      BulkTrashConfirmOk: 'Confirm',
+      BulkTrashCancel: 'Cancel',
+      InspectorToggle: 'Toggle inspector',
     },
     Upload: {
       Button: 'Upload',
@@ -224,5 +266,7 @@ export const documentsTranslationsEn: DocumentsTranslations = {
   },
   Explorer: {
     Title: 'Documents',
+    InspectorEmpty: 'Select a document to see its details.',
+    InspectorMultiple: '{{count}} documents selected.',
   },
 };

--- a/packages/@granit/react-documents/src/locales/fr.ts
+++ b/packages/@granit/react-documents/src/locales/fr.ts
@@ -3,15 +3,18 @@ import type { DocumentsTranslations } from './en.js';
 export const documentsTranslationsFr: DocumentsTranslations = {
   Folder: {
     Tree: {
-      Add: '+',
+      Add: 'Nouveau dossier',
+      AddRoot: 'Nouveau dossier racine',
       Rename: 'Renommer',
       Delete: 'Supprimer',
-      DeleteConfirm:
+      DeleteConfirmQuestion:
         'Mettre ce dossier à la corbeille ? Son contenu sera également mis à la corbeille.',
+      DeleteConfirm: 'Confirmer',
+      DeleteCancel: 'Annuler',
       Empty: 'Aucun dossier.',
       Loading: 'Chargement…',
       Error: 'Échec du chargement des dossiers.',
-      NewFolderName: 'Nom du dossier ?',
+      NewFolderName: 'Nom du dossier',
     },
     Breadcrumb: {
       Loading: 'Chargement…',
@@ -36,10 +39,27 @@ export const documentsTranslationsFr: DocumentsTranslations = {
       Empty: 'Ce dossier est vide.',
       NameHeader: 'Nom',
       StatusHeader: 'Statut',
+      SelectHeader: 'Tout sélectionner',
+      SelectRow: 'Sélectionner',
+      Rename: 'Renommer',
+      Trash: 'Mettre à la corbeille',
+      TrashConfirm: 'Confirmer',
+      TrashCancel: 'Annuler',
       Loading: 'Chargement des documents…',
       Error: 'Échec du chargement des documents.',
       Previous: 'Précédent',
       Next: 'Suivant',
+    },
+    Toolbar: {
+      NoSelection: 'Aucune sélection',
+      OneSelected: 'Sélectionné : {{name}}',
+      ManySelected: '{{count}} sélectionnés',
+      ClearSelection: 'Effacer la sélection',
+      BulkTrash: 'Mettre à la corbeille',
+      BulkTrashConfirm: 'Mettre {{count}} élément(s) à la corbeille ?',
+      BulkTrashConfirmOk: 'Confirmer',
+      BulkTrashCancel: 'Annuler',
+      InspectorToggle: 'Afficher/masquer l’inspecteur',
     },
     Upload: {
       Button: 'Téléverser',
@@ -108,5 +128,7 @@ export const documentsTranslationsFr: DocumentsTranslations = {
   },
   Explorer: {
     Title: 'Documents',
+    InspectorEmpty: 'Sélectionnez un document pour voir ses détails.',
+    InspectorMultiple: '{{count}} documents sélectionnés.',
   },
 };


### PR DESCRIPTION
## Summary

Foundation rewrite of `@granit/react-documents` toward a real file manager UX. Headless throughout — components keep shipping `data-granit-*` markers, hosts own styling.

- **3-pane layout** in `<DocumentsExplorer>` (tree | main | inspector). Inspector embeds `<DocumentDetail>` when one row is focused, shows a multi-selection summary otherwise, hides via `showInspector={false}` or via the toolbar toggle.
- **Multi-select** in `<DocumentsList>`: per-row checkbox, select-all, Ctrl/Cmd-click toggle, Shift-click range, Ctrl-A. Bubbles `onSelectionChange(ids, docs)` + `onFocusChange(doc)`.
- **Keyboard nav** in the list: ↑↓ focus, Enter opens, Space toggles, F2 renames, Delete confirms trash, Escape clears.
- **No more `window.prompt` / `window.confirm`** — `<InlineEdit>` primitive replaces prompts for folder & document rename/create; inline `alertdialog` bars replace confirms for folder & document trash.
- **New `<DocumentsToolbar>`** — selection summary, bulk-trash with destructive confirm, clear-selection, inspector toggle, trailing slot (typically `<UploadButton>`).
- `<FolderTree>` highlights `currentFolderId`, supports double-click rename, exposes `addRoot` label distinct from `add`.
- New `useMultiSelect` hook (anchor-based shift-range + auto-prune when the underlying id list changes).
- i18n bundle extended (EN + FR) with `Document.Toolbar.*`, `Folder.Tree.DeleteConfirm{Question,Cancel}`, `Explorer.Inspector{Empty,Multiple}`.

## Why this shape

The package only has one consumer (`granit-showcase-react`) so the API can evolve. Keeping it headless means the showcase wires the new `data-granit-*` slots into its existing Tailwind layer without the package taking a dependency on shadcn/ui or any visual primitive.

## Follow-ups (deliberately out of scope)

- MR 2: drag-drop (drop-zone upload + drag-to-folder moves)
- MR 3: grid view + zoom slider
- MR 4: Quick Look preview pane (Space on a row)
- MR 5: Cmd+K search, favorites sidebar, filter drawer
- MR 6+: backend-dependent — thumbnails, presence avatars, comments, version diff

## Test plan

- [x] `pnpm vitest run packages/@granit/react-documents` — 130+ tests pass (6/6 explorer, 9/9 list, 15/15 folder-tree)
- [x] `pnpm eslint packages/@granit/react-documents/src/**/*.{ts,tsx} --max-warnings 0` clean
- [x] `pnpm -r --filter @granit/react-documents... build` clean
- [ ] Manual QA via showcase PR — verify 3-pane layout, multi-select interactions, kbd nav, inline rename, confirm-trash flows