### PR TITLE
feat(react-documents): drag-and-drop — drop-zone upload + drag rows between folders

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3303,26 +3303,6 @@
       "description": "React bindings for @granit/documents — DocumentsProvider, hooks, components",
       "exports": [
         {
-          "name": "API_VERSION",
-          "kind": "const",
-          "signature": "const API_VERSION"
-        },
-        {
-          "name": "DEFAULT_BASE_PATH",
-          "kind": "const",
-          "signature": "const DEFAULT_BASE_PATH"
-        },
-        {
-          "name": "DEFAULT_QUERY_KEY_PREFIX",
-          "kind": "const",
-          "signature": "const DEFAULT_QUERY_KEY_PREFIX"
-        },
-        {
-          "name": "MODULE",
-          "kind": "const",
-          "signature": "const MODULE"
-        },
-        {
           "name": "useFolder",
           "kind": "function",
           "signature": "function useFolder( id: string, options?:"
@@ -3523,6 +3503,28 @@
           "kind": "interface",
           "signature": "interface UploadButtonProps",
           "members": []
+        },
+        {
+          "name": "UploadDropZone",
+          "kind": "function",
+          "signature": "function UploadDropZone("
+        },
+        {
+          "name": "UploadDropZoneLabels",
+          "kind": "interface",
+          "signature": "interface UploadDropZoneLabels",
+          "members": []
+        },
+        {
+          "name": "UploadDropZoneProps",
+          "kind": "interface",
+          "signature": "interface UploadDropZoneProps",
+          "members": []
+        },
+        {
+          "name": "useFileUpload",
+          "kind": "function",
+          "signature": "function useFileUpload(options: UseFileUploadOptions ="
         },
         {
           "name": "VersionsTimeline",

--- a/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { DocumentsList } from '../components/documents-list.tsx';
+import { DOCUMENT_DRAG_MIME } from '../constants.js';
 import { DocumentsProvider } from '../providers/documents-provider.js';
 
 import type { AxiosInstance } from '@granit/api-client';
@@ -224,5 +225,72 @@ describe('DocumentsList', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
 
     await waitFor(() => expect(client.delete).toHaveBeenCalled());
+  });
+
+  it('sets the granit-documents DataTransfer payload on row drag start (single row)', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+
+    render(<DocumentsList folderId="fld-1" canManage onOpenDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    const row = document.querySelector<HTMLElement>('[data-granit-document-id="doc-1"]');
+    expect(row).not.toBeNull();
+    expect(row!.getAttribute('draggable')).toBe('true');
+
+    const setData = vi.fn();
+    const dragStart = new Event('dragstart', { bubbles: true, cancelable: true });
+    Object.defineProperty(dragStart, 'dataTransfer', {
+      value: { setData, types: [], effectAllowed: 'none' },
+    });
+    row!.dispatchEvent(dragStart);
+
+    const granitCall = setData.mock.calls.find(([type]) => type === DOCUMENT_DRAG_MIME);
+    expect(granitCall).toBeDefined();
+    const payload = JSON.parse(granitCall![1] as string) as { ids: string[] };
+    expect(payload.ids).toEqual(['doc-1']);
+  });
+
+  it('drags the whole selection when the dragged row is part of it', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+
+    render(<DocumentsList folderId="fld-1" canManage onOpenDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    // Select both rows via the select-all checkbox.
+    await userEvent.click(screen.getByRole('checkbox', { name: 'Select all' }));
+
+    const row = document.querySelector<HTMLElement>('[data-granit-document-id="doc-1"]');
+    const setData = vi.fn();
+    const dragStart = new Event('dragstart', { bubbles: true, cancelable: true });
+    Object.defineProperty(dragStart, 'dataTransfer', {
+      value: { setData, types: [], effectAllowed: 'none' },
+    });
+    row!.dispatchEvent(dragStart);
+
+    const granitCall = setData.mock.calls.find(([type]) => type === DOCUMENT_DRAG_MIME);
+    expect(granitCall).toBeDefined();
+    const payload = JSON.parse(granitCall![1] as string) as { ids: string[] };
+    expect(payload.ids.toSorted()).toEqual(['doc-1', 'doc-2']);
+  });
+
+  it('does not start a drag when canManage is false', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+
+    render(<DocumentsList folderId="fld-1" onOpenDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+    const row = document.querySelector<HTMLElement>('[data-granit-document-id="doc-1"]');
+    expect(row!.getAttribute('draggable')).toBe('false');
   });
 });

--- a/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/folder-tree.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { FolderTree } from '../components/folder-tree.tsx';
+import { DOCUMENT_DRAG_MIME } from '../constants.js';
 import { DocumentsProvider } from '../providers/documents-provider.js';
 
 import type { AxiosInstance } from '@granit/api-client';
@@ -286,5 +287,75 @@ describe('FolderTree', () => {
     await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
     const node = document.querySelector(`[data-granit-folder-id="${root.id}"]`);
     expect(node?.hasAttribute('data-granit-folder-tree-current')).toBe(true);
+  });
+
+  it('moves dropped documents into the target folder via useMoveDocument', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+    vi.mocked(client.post).mockResolvedValue({
+      data: {
+        id: 'doc-1',
+        folderId: root.id,
+        name: 'a.pdf',
+        status: 'Active',
+        ownerUserId: 'u',
+        currentVersionId: 'v',
+        description: null,
+        trashedAt: null,
+        permission: null,
+      },
+    });
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    await waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument());
+
+    const row = document.querySelector<HTMLElement>('[data-granit-folder-tree-row]');
+    expect(row).not.toBeNull();
+
+    // Simulate dragenter / dragover / drop with the granit MIME payload.
+    const ids = ['doc-1', 'doc-2'];
+    const types = [DOCUMENT_DRAG_MIME];
+    const store = new Map<string, string>([[DOCUMENT_DRAG_MIME, JSON.stringify({ ids })]]);
+    const dataTransfer = {
+      types,
+      effectAllowed: 'move',
+      dropEffect: 'none',
+      getData: (type: string) => store.get(type) ?? '',
+      setData: vi.fn(),
+    };
+
+    const enter = new Event('dragenter', { bubbles: true });
+    Object.defineProperty(enter, 'dataTransfer', { value: dataTransfer });
+    row!.dispatchEvent(enter);
+    await waitFor(() => expect(row!.hasAttribute('data-granit-folder-tree-drop-over')).toBe(true));
+
+    const drop = new Event('drop', { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, 'dataTransfer', { value: dataTransfer });
+    row!.dispatchEvent(drop);
+
+    await waitFor(() => {
+      const moveCalls = vi.mocked(client.post).mock.calls.filter(([url]) => url.includes('/move'));
+      expect(moveCalls.length).toBe(2);
+    });
+  });
+
+  it('ignores drops that do not carry the granit MIME payload', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [root] } });
+
+    render(<FolderTree canManage />, { wrapper: createWrapper(client) });
+    return waitFor(() => expect(screen.getByText('Contracts')).toBeInTheDocument()).then(() => {
+      const row = document.querySelector<HTMLElement>('[data-granit-folder-tree-row]');
+      const dataTransfer = {
+        types: ['Files'], // a file drag, not an internal document drag
+        getData: () => '',
+      };
+      const drop = new Event('drop', { bubbles: true, cancelable: true });
+      Object.defineProperty(drop, 'dataTransfer', { value: dataTransfer });
+      row!.dispatchEvent(drop);
+
+      const moveCalls = vi.mocked(client.post).mock.calls.filter(([url]) => url.includes('/move'));
+      expect(moveCalls.length).toBe(0);
+    });
   });
 });

--- a/packages/@granit/react-documents/src/__tests__/upload-drop-zone.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/upload-drop-zone.test.tsx
@@ -1,0 +1,231 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UploadDropZone } from '../components/upload-drop-zone.tsx';
+import { DocumentsProvider } from '../providers/documents-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <DocumentsProvider config={{ client }}>{children}</DocumentsProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+interface MockXhr {
+  open: (method: string, url: string) => void;
+  setRequestHeader: (key: string, value: string) => void;
+  send: (body: unknown) => void;
+  upload: { onprogress: ((event: ProgressEvent) => void) | null };
+  onload: (() => void) | null;
+  onerror: (() => void) | null;
+  status: number;
+}
+
+function makeDataTransfer(files: File[], extraTypes: readonly string[] = []): DataTransfer {
+  // jsdom doesn't ship a real DataTransfer; the bits the component touches
+  // are `types`, `files`, and the per-MIME `getData`/`setData` pair.
+  const store = new Map<string, string>();
+  const types: string[] = [
+    ...(files.length > 0 ? ['Files'] : []),
+    ...extraTypes.filter((t) => !(files.length > 0 && t === 'Files')),
+  ];
+  return {
+    types,
+    files: files as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    effectAllowed: 'all',
+    dropEffect: 'none',
+    setData: (type: string, data: string) => {
+      store.set(type, data);
+      if (!types.includes(type)) types.push(type);
+    },
+    getData: (type: string) => store.get(type) ?? '',
+    clearData: () => store.clear(),
+    setDragImage: vi.fn(),
+  } as unknown as DataTransfer;
+}
+
+function dispatchDragEvent(target: Element, kind: string, dataTransfer: DataTransfer): void {
+  const event = new Event(kind, { bubbles: true, cancelable: true });
+  Object.defineProperty(event, 'dataTransfer', { value: dataTransfer });
+  target.dispatchEvent(event);
+}
+
+describe('UploadDropZone', () => {
+  let xhrInstances: MockXhr[];
+  let OriginalXhr: typeof XMLHttpRequest;
+
+  beforeEach(() => {
+    xhrInstances = [];
+    OriginalXhr = globalThis.XMLHttpRequest;
+    class FakeXhr implements MockXhr {
+      open = vi.fn();
+      setRequestHeader = vi.fn();
+      upload: MockXhr['upload'] = { onprogress: null };
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      status = 0;
+      send = vi.fn(() => {
+        queueMicrotask(() => {
+          this.status = 200;
+          this.onload?.();
+        });
+      });
+      constructor() {
+        xhrInstances.push(this);
+      }
+    }
+    (globalThis as { XMLHttpRequest: typeof XMLHttpRequest }).XMLHttpRequest =
+      FakeXhr as unknown as typeof XMLHttpRequest;
+  });
+
+  afterEach(() => {
+    globalThis.XMLHttpRequest = OriginalXhr;
+    vi.restoreAllMocks();
+  });
+
+  it('shows the overlay while files are dragged over and clears it on leave', async () => {
+    const client = createMockClient();
+    render(
+      <UploadDropZone folderId="fld-1">
+        <div>main pane</div>
+      </UploadDropZone>,
+      { wrapper: createWrapper(client) }
+    );
+
+    const zone = document.querySelector<HTMLElement>('[data-granit-upload-drop-zone]');
+    expect(zone).not.toBeNull();
+    // Synthesize the `Files` type — dragenter fires before the OS reveals
+    // the file list, but the type is visible from the start.
+    const dt = makeDataTransfer([], ['Files']);
+    dispatchDragEvent(zone!, 'dragenter', dt);
+
+    await waitFor(() => expect(zone!.hasAttribute('data-granit-upload-drop-zone-over')).toBe(true));
+    expect(screen.getByText('Drop files to upload')).toBeInTheDocument();
+
+    dispatchDragEvent(zone!, 'dragleave', dt);
+
+    await waitFor(() =>
+      expect(zone!.hasAttribute('data-granit-upload-drop-zone-over')).toBe(false)
+    );
+  });
+
+  it('ignores drags that do not carry the Files type', () => {
+    const client = createMockClient();
+    render(
+      <UploadDropZone folderId="fld-1">
+        <div>main pane</div>
+      </UploadDropZone>,
+      { wrapper: createWrapper(client) }
+    );
+
+    const zone = document.querySelector<HTMLElement>('[data-granit-upload-drop-zone]');
+    // No 'Files' type → ignored.
+    dispatchDragEvent(zone!, 'dragenter', makeDataTransfer([]));
+
+    expect(zone!.hasAttribute('data-granit-upload-drop-zone-over')).toBe(false);
+    expect(screen.queryByText('Drop files to upload')).toBeNull();
+  });
+
+  it('does nothing when disabled', () => {
+    const client = createMockClient();
+    render(
+      <UploadDropZone folderId="fld-1" disabled>
+        <div>main pane</div>
+      </UploadDropZone>,
+      { wrapper: createWrapper(client) }
+    );
+
+    const zone = document.querySelector<HTMLElement>('[data-granit-upload-drop-zone]');
+    dispatchDragEvent(zone!, 'dragenter', makeDataTransfer([], ['Files']));
+
+    expect(zone!.hasAttribute('data-granit-upload-drop-zone-over')).toBe(false);
+  });
+
+  it('runs the upload flow for each dropped file and fires onComplete + onBatchDone', async () => {
+    const client = createMockClient();
+    const ticket = {
+      blobId: 'blob-1',
+      uploadUrl: 'https://blob.example/put',
+      httpMethod: 'PUT',
+      expiresAt: '2026-05-12T00:00:00Z',
+      requiredHeaders: {},
+    };
+    const finalized = {
+      id: 'doc-1',
+      folderId: 'fld-1',
+      name: 'a.pdf',
+      status: 'Active',
+      ownerUserId: 'u',
+      currentVersionId: 'v',
+      description: null,
+      trashedAt: null,
+      permission: null,
+    };
+    vi.mocked(client.post).mockImplementation(((url: string) => {
+      if (url.includes('upload-ticket')) {
+        return Promise.resolve({ data: ticket });
+      }
+      if (url.includes('finalize')) {
+        return Promise.resolve({ data: finalized });
+      }
+      return Promise.resolve({ data: undefined });
+    }) as AxiosInstance['post']);
+
+    const onComplete = vi.fn();
+    const onBatchDone = vi.fn();
+    render(
+      <UploadDropZone folderId="fld-1" onComplete={onComplete} onBatchDone={onBatchDone}>
+        <div>main pane</div>
+      </UploadDropZone>,
+      { wrapper: createWrapper(client) }
+    );
+
+    const zone = document.querySelector<HTMLElement>('[data-granit-upload-drop-zone]');
+    const files = [
+      new File(['1'], 'a.pdf', { type: 'application/pdf' }),
+      new File(['2'], 'b.pdf', { type: 'application/pdf' }),
+    ];
+    dispatchDragEvent(zone!, 'drop', makeDataTransfer(files));
+
+    await waitFor(() => expect(onBatchDone).toHaveBeenCalled());
+    expect(onComplete).toHaveBeenCalledTimes(2);
+    expect(onBatchDone).toHaveBeenCalledWith({ succeeded: 2, failed: 0 });
+    // upload-ticket + finalize per file → 4 POSTs
+    expect(vi.mocked(client.post).mock.calls.length).toBe(4);
+  });
+
+  it('reports per-file failure but still counts succeeded uploads', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockImplementation(((url: string) => {
+      if (url.includes('upload-ticket')) {
+        return Promise.reject(new Error('boom'));
+      }
+      return Promise.resolve({ data: undefined });
+    }) as AxiosInstance['post']);
+
+    const onBatchDone = vi.fn();
+    render(
+      <UploadDropZone folderId="fld-1" onBatchDone={onBatchDone}>
+        <div>main pane</div>
+      </UploadDropZone>,
+      { wrapper: createWrapper(client) }
+    );
+
+    const zone = document.querySelector<HTMLElement>('[data-granit-upload-drop-zone]');
+    const files = [new File(['x'], 'a.pdf', { type: 'application/pdf' })];
+    dispatchDragEvent(zone!, 'drop', makeDataTransfer(files));
+
+    await waitFor(() => expect(onBatchDone).toHaveBeenCalledWith({ succeeded: 0, failed: 1 }));
+    expect(screen.getByRole('alert').textContent).toMatch(/boom/i);
+  });
+});

--- a/packages/@granit/react-documents/src/components/documents-explorer.tsx
+++ b/packages/@granit/react-documents/src/components/documents-explorer.tsx
@@ -9,6 +9,7 @@ import { FolderBreadcrumb } from './folder-breadcrumb.js';
 import { FolderTree } from './folder-tree.js';
 import { QuotaBadge } from './quota-badge.js';
 import { UploadButton } from './upload-button.js';
+import { UploadDropZone } from './upload-drop-zone.js';
 
 import type { DocumentDetailLabels } from './document-detail.js';
 import type { DocumentsListLabels } from './documents-list.js';
@@ -16,6 +17,7 @@ import type { DocumentsToolbarLabels } from './documents-toolbar.js';
 import type { FolderBreadcrumbLabels } from './folder-breadcrumb.js';
 import type { FolderTreeLabels } from './folder-tree.js';
 import type { UploadButtonLabels } from './upload-button.js';
+import type { UploadDropZoneLabels } from './upload-drop-zone.js';
 import type { DocumentResponse, FolderResponse } from '@granit/documents';
 import type { ReactNode } from 'react';
 
@@ -28,6 +30,7 @@ export interface DocumentsExplorerLabels {
   readonly list?: DocumentsListLabels;
   readonly toolbar?: DocumentsToolbarLabels;
   readonly upload?: UploadButtonLabels;
+  readonly dropZone?: UploadDropZoneLabels;
   readonly detail?: DocumentDetailLabels;
 }
 
@@ -163,42 +166,49 @@ export function DocumentsExplorer({
             labels={labels?.tree}
           />
         </aside>
-        <section data-granit-documents-explorer-main="">
-          {folderId.length > 0 && (
-            <FolderBreadcrumb
-              folderId={folderId}
-              onSelect={setCurrentFolder}
-              labels={labels?.breadcrumb}
+        <UploadDropZone
+          folderId={currentFolder?.id ?? null}
+          disabled={!canManage}
+          onComplete={noopUploadComplete}
+          labels={labels?.dropZone}
+        >
+          <section data-granit-documents-explorer-main="">
+            {folderId.length > 0 && (
+              <FolderBreadcrumb
+                folderId={folderId}
+                onSelect={setCurrentFolder}
+                labels={labels?.breadcrumb}
+              />
+            )}
+            <DocumentsToolbar
+              canManage={canManage}
+              selected={selectedIds}
+              selectedDocs={selectedDocs}
+              onClearSelection={handleClearSelection}
+              inspectorVisible={showInspector && inspectorVisible}
+              onToggleInspector={showInspector ? () => setInspectorVisible((v) => !v) : undefined}
+              labels={labels?.toolbar}
+              trailing={
+                canManage && (
+                  <UploadButton
+                    folderId={currentFolder?.id ?? null}
+                    onComplete={noopUploadComplete}
+                    labels={labels?.upload}
+                  />
+                )
+              }
             />
-          )}
-          <DocumentsToolbar
-            canManage={canManage}
-            selected={selectedIds}
-            selectedDocs={selectedDocs}
-            onClearSelection={handleClearSelection}
-            inspectorVisible={showInspector && inspectorVisible}
-            onToggleInspector={showInspector ? () => setInspectorVisible((v) => !v) : undefined}
-            labels={labels?.toolbar}
-            trailing={
-              canManage && (
-                <UploadButton
-                  folderId={currentFolder?.id ?? null}
-                  onComplete={noopUploadComplete}
-                  labels={labels?.upload}
-                />
-              )
-            }
-          />
-          <DocumentsList
-            folderId={folderId}
-            canManage={canManage}
-            clearSignal={clearSignal}
-            onOpenDocument={onOpenDocument}
-            onSelectionChange={handleSelectionChange}
-            onFocusChange={setFocusedDoc}
-            labels={labels?.list}
-          />
-        </section>
+            <DocumentsList
+              folderId={folderId}
+              canManage={canManage}
+              clearSignal={clearSignal}
+              onOpenDocument={onOpenDocument}
+              onSelectionChange={handleSelectionChange}
+              onFocusChange={setFocusedDoc}
+              labels={labels?.list}
+            />
+          </section>
+        </UploadDropZone>
         {showInspector && inspectorVisible && (
           <aside data-granit-documents-explorer-inspector="">
             {focusedDoc ? (

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -1,6 +1,7 @@
 import { QueryProvider, useQueryEndpoint } from '@granit/react-query-engine';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import { DOCUMENT_DRAG_MIME } from '../constants.js';
 import { useRenameDocument, useTrashDocument } from '../hooks/use-document-mutations.js';
 import { useMultiSelect } from '../hooks/use-multi-select.js';
 import { useDocumentsConfig } from '../providers/documents-provider.js';
@@ -9,7 +10,7 @@ import { InlineEdit } from './inline-edit.js';
 
 import type { DocumentResponse } from '@granit/documents';
 import type { FilterEntry, SortEntry } from '@granit/query-engine';
-import type { KeyboardEvent, MouseEvent, ReactNode } from 'react';
+import type { DragEvent, KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
 const LIST_QUERY_KEY_PREFIX = ['documents', 'documents', 'list'] as const;
 const DEFAULT_PAGE_SIZE = 50;
@@ -206,6 +207,30 @@ function DocumentsListBody({
     onOpenDocument?.(doc.id);
   }
 
+  function handleRowDragStart(event: DragEvent<HTMLTableRowElement>, doc: DocumentResponse): void {
+    if (!canManage) {
+      event.preventDefault();
+      return;
+    }
+    // If the dragged row is part of the current selection, move the whole
+    // selection. Otherwise, drag this row only (and adopt it as the new
+    // single selection, matching Finder / OneDrive behavior).
+    let ids: string[];
+    if (selection.selected.has(doc.id)) {
+      ids = Array.from(selection.selected);
+    } else {
+      selection.selectOnly(doc.id);
+      ids = [doc.id];
+    }
+    setFocusedId(doc.id);
+    event.dataTransfer.setData(DOCUMENT_DRAG_MIME, JSON.stringify({ ids }));
+    // Plain-text fallback so external apps (e.g. terminal, editor) see at
+    // least the names. Comma-joined keeps it grep-friendly.
+    const names = items.filter((d) => ids.includes(d.id)).map((d) => d.name);
+    event.dataTransfer.setData('text/plain', names.join(', '));
+    event.dataTransfer.effectAllowed = 'move';
+  }
+
   function handleKeyDown(event: KeyboardEvent<HTMLTableElement>): void {
     if (items.length === 0) return;
     const index = focusedId ? items.findIndex((d) => d.id === focusedId) : -1;
@@ -340,8 +365,11 @@ function DocumentsListBody({
                 data-granit-document-id={document.id}
                 data-granit-documents-list-selected={isSelected ? '' : undefined}
                 data-granit-documents-list-focused={isFocused ? '' : undefined}
+                data-granit-documents-list-draggable={canManage ? '' : undefined}
                 aria-selected={isSelected}
+                draggable={canManage}
                 onClick={(event) => handleRowClick(event, document)}
+                onDragStart={(event) => handleRowDragStart(event, document)}
               >
                 <td data-granit-documents-list-select-cell="">
                   <input

--- a/packages/@granit/react-documents/src/components/folder-tree.tsx
+++ b/packages/@granit/react-documents/src/components/folder-tree.tsx
@@ -1,12 +1,14 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
+import { DOCUMENT_DRAG_MIME } from '../constants.js';
+import { useMoveDocument } from '../hooks/use-document-mutations.js';
 import { useCreateFolder, useRenameFolder, useTrashFolder } from '../hooks/use-folder-mutations.js';
 import { useFolders } from '../hooks/use-folders.js';
 
 import { InlineEdit } from './inline-edit.js';
 
 import type { FolderResponse, FolderStatus } from '@granit/documents';
-import type { ReactNode } from 'react';
+import type { DragEvent, ReactNode } from 'react';
 
 export interface FolderTreeLabels {
   readonly add?: string;
@@ -79,10 +81,13 @@ function FolderNode({
   const [expanded, setExpanded] = useState(false);
   const [mode, setMode] = useState<RowMode>('idle');
   const [error, setError] = useState<string | null>(null);
+  const [dropOver, setDropOver] = useState(false);
+  const dropDepthRef = useRef(0);
   const childrenQuery = useFolders({ parentId: folder.id, status }, { enabled: expanded });
   const createFolder = useCreateFolder();
   const renameFolder = useRenameFolder();
   const trashFolder = useTrashFolder();
+  const moveDocument = useMoveDocument();
 
   function startAdd(): void {
     setExpanded(true);
@@ -134,6 +139,64 @@ function FolderNode({
     });
   }
 
+  function carriesDocumentDrag(event: DragEvent<HTMLDivElement>): boolean {
+    if (!canManage) return false;
+    for (const type of event.dataTransfer.types) {
+      if (type === DOCUMENT_DRAG_MIME) return true;
+    }
+    return false;
+  }
+
+  function handleDragEnter(event: DragEvent<HTMLDivElement>): void {
+    if (!carriesDocumentDrag(event)) return;
+    dropDepthRef.current += 1;
+    if (dropDepthRef.current === 1) setDropOver(true);
+  }
+
+  function handleDragLeave(event: DragEvent<HTMLDivElement>): void {
+    if (!carriesDocumentDrag(event)) return;
+    dropDepthRef.current = Math.max(0, dropDepthRef.current - 1);
+    if (dropDepthRef.current === 0) setDropOver(false);
+  }
+
+  function handleDragOver(event: DragEvent<HTMLDivElement>): void {
+    if (!carriesDocumentDrag(event)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'move';
+  }
+
+  async function handleDrop(event: DragEvent<HTMLDivElement>): Promise<void> {
+    if (!carriesDocumentDrag(event)) return;
+    event.preventDefault();
+    event.stopPropagation();
+    dropDepthRef.current = 0;
+    setDropOver(false);
+    const raw = event.dataTransfer.getData(DOCUMENT_DRAG_MIME);
+    if (!raw) return;
+    let payload: { ids?: unknown };
+    try {
+      payload = JSON.parse(raw) as { ids?: unknown };
+    } catch {
+      return;
+    }
+    const ids = Array.isArray(payload.ids)
+      ? payload.ids.filter((x): x is string => typeof x === 'string')
+      : [];
+    if (ids.length === 0) return;
+    setError(null);
+    for (const id of ids) {
+      try {
+        await moveDocument.mutateAsync({
+          id,
+          request: { newFolderId: folder.id },
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Move failed.');
+        break;
+      }
+    }
+  }
+
   const children = childrenQuery.data?.folders ?? [];
   const isCurrent = currentFolderId === folder.id;
 
@@ -147,6 +210,13 @@ function FolderNode({
       <div
         data-granit-folder-tree-row=""
         data-granit-folder-tree-current={isCurrent ? '' : undefined}
+        data-granit-folder-tree-drop-over={dropOver ? '' : undefined}
+        onDragEnter={handleDragEnter}
+        onDragLeave={handleDragLeave}
+        onDragOver={handleDragOver}
+        onDrop={(event) => {
+          void handleDrop(event);
+        }}
       >
         <button
           type="button"

--- a/packages/@granit/react-documents/src/components/upload-button.tsx
+++ b/packages/@granit/react-documents/src/components/upload-button.tsx
@@ -1,8 +1,9 @@
-import { useRef, useState } from 'react';
+import { useRef } from 'react';
 
-import { useFinalizeUpload, useRequestUploadTicket } from '../hooks/use-document-mutations.js';
+import { useFileUpload } from '../hooks/use-file-upload.js';
 
-import type { DocumentResponse, UploadTicketResponse } from '@granit/documents';
+import type { FileUploadError } from '../hooks/use-file-upload.js';
+import type { DocumentResponse } from '@granit/documents';
 import type { ChangeEvent, ReactNode } from 'react';
 
 export interface UploadButtonLabels {
@@ -31,99 +32,50 @@ const DEFAULT_LABELS: Required<UploadButtonLabels> = {
   failed: 'Upload failed.',
 };
 
-const DEFAULT_MAX_ALLOWED_BYTES = 1024 * 1024 * 1024;
+function pickErrorLabel(err: FileUploadError, labels: Required<UploadButtonLabels>): string {
+  if (err.code === 'too-large') return labels.tooLarge;
+  if (err.code === 'quota-exceeded') return labels.quotaExceeded;
+  // Surface the raw message when present (matches the pre-refactor contract
+  // — HTTP statuses, axios validation messages, etc. are usually useful).
+  // Network failures from XHR have a fixed "Network error" placeholder; the
+  // label is preferable there.
+  if (err.code === 'network') return labels.failed;
+  return err.message || labels.failed;
+}
 
 /**
- * Two-phase upload button:
- * 1. {@link useRequestUploadTicket} → presigned PUT URL + required headers.
- * 2. Direct PUT to blob storage via `XMLHttpRequest` to observe upload
- *    progress (the Fetch API has no upload-progress event).
- * 3. {@link useFinalizeUpload} to create the Document row.
- *
- * On HTTP 413 from the finalize step the {@link UploadButtonLabels.quotaExceeded}
- * label is surfaced. Errors set local state and clear the file input.
+ * Single-file upload button. Thin shell over {@link useFileUpload}: the
+ * native `<input type="file">` triggers `uploadFile` with the picked file,
+ * and the hook surfaces progress + a normalized error code. The component
+ * only owns DOM concerns (the hidden input, the visible label, the
+ * progress + error markers).
  */
 export function UploadButton({
   folderId,
   onComplete,
-  maxAllowedBytes = DEFAULT_MAX_ALLOWED_BYTES,
+  maxAllowedBytes,
   labels,
   className,
 }: UploadButtonProps): ReactNode {
   const labelStrings = { ...DEFAULT_LABELS, ...labels };
   const inputRef = useRef<HTMLInputElement | null>(null);
-  const [progress, setProgress] = useState<number | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  const requestTicket = useRequestUploadTicket();
-  const finalize = useFinalizeUpload();
-
-  function uploadToBlobStore(ticket: UploadTicketResponse, file: File): Promise<void> {
-    return new Promise<void>((resolve, reject) => {
-      const xhr = new XMLHttpRequest();
-      xhr.open(ticket.httpMethod, ticket.uploadUrl);
-      for (const [key, value] of Object.entries(ticket.requiredHeaders)) {
-        xhr.setRequestHeader(key, value);
-      }
-      xhr.upload.onprogress = (event) => {
-        if (event.lengthComputable && event.total > 0) {
-          setProgress(Math.round((event.loaded / event.total) * 100));
-        }
-      };
-      xhr.onload = () => {
-        if (xhr.status >= 200 && xhr.status < 300) {
-          resolve();
-          return;
-        }
-        reject(new Error(`Upload failed with HTTP ${xhr.status.toString()}`));
-      };
-      xhr.onerror = () => reject(new Error(labelStrings.failed));
-      xhr.send(file);
-    });
-  }
+  const { uploadFile, progress, lastError } = useFileUpload({ maxAllowedBytes });
 
   async function handleChange(event: ChangeEvent<HTMLInputElement>): Promise<void> {
     const file = event.target.files?.[0];
     if (!file) return;
-    setError(null);
-
-    if (file.size > maxAllowedBytes) {
-      setError(labelStrings.tooLarge);
-      if (inputRef.current) inputRef.current.value = '';
-      return;
-    }
-
     try {
-      setProgress(0);
-      const ticket = await requestTicket.mutateAsync({
-        fileName: file.name,
-        contentType: file.type || 'application/octet-stream',
-        maxAllowedBytes,
-      });
-      await uploadToBlobStore(ticket, file);
-      const document = await finalize.mutateAsync({
-        blobId: ticket.blobId,
-        folderId,
-        name: file.name,
-      });
-      setProgress(null);
-      if (inputRef.current) inputRef.current.value = '';
+      const document = await uploadFile(file, folderId);
       onComplete?.(document);
-    } catch (err) {
-      const status = (err as { response?: { status?: number } } | undefined)?.response?.status;
-      if (status === 413) {
-        setError(labelStrings.quotaExceeded);
-      } else if (err instanceof Error) {
-        setError(err.message || labelStrings.failed);
-      } else {
-        setError(labelStrings.failed);
-      }
-      setProgress(null);
+    } catch {
+      /* normalized into lastError by the hook */
+    } finally {
       if (inputRef.current) inputRef.current.value = '';
     }
   }
 
   const isBusy = progress !== null;
+  const errorMessage = lastError ? pickErrorLabel(lastError, labelStrings) : null;
 
   return (
     <div data-granit-upload-button="" className={className}>
@@ -133,7 +85,9 @@ export function UploadButton({
           type="file"
           data-granit-upload-button-input=""
           disabled={isBusy}
-          onChange={handleChange}
+          onChange={(event) => {
+            void handleChange(event);
+          }}
         />
         <span>{isBusy ? labelStrings.uploading : labelStrings.button}</span>
       </label>
@@ -143,14 +97,14 @@ export function UploadButton({
           role="progressbar"
           aria-valuemin={0}
           aria-valuemax={100}
-          aria-valuenow={progress}
+          aria-valuenow={progress.percent}
         >
-          {progress}%
+          {progress.percent}%
         </div>
       )}
-      {error && (
+      {errorMessage && (
         <div data-granit-upload-button-error="" role="alert">
-          {error}
+          {errorMessage}
         </div>
       )}
     </div>

--- a/packages/@granit/react-documents/src/components/upload-drop-zone.tsx
+++ b/packages/@granit/react-documents/src/components/upload-drop-zone.tsx
@@ -1,0 +1,167 @@
+import { useCallback, useRef, useState } from 'react';
+
+import { useFileUpload } from '../hooks/use-file-upload.js';
+
+import type { FileUploadError } from '../hooks/use-file-upload.js';
+import type { DocumentResponse } from '@granit/documents';
+import type { DragEvent, ReactNode } from 'react';
+
+export interface UploadDropZoneLabels {
+  readonly overlay?: string;
+  readonly uploadingCount?: (done: number, total: number) => string;
+  readonly tooLarge?: string;
+  readonly quotaExceeded?: string;
+  readonly failed?: string;
+}
+
+export interface UploadDropZoneProps {
+  /** Target folder. `null` drops the document directly under the tenant root. */
+  readonly folderId: string | null;
+  /** Disable the drop target entirely (e.g. when the user lacks Manage). */
+  readonly disabled?: boolean;
+  /** Soft cap forwarded to the upload ticket request. Defaults to 1 GiB. */
+  readonly maxAllowedBytes?: number;
+  /** Fired once per successfully finalized document. */
+  readonly onComplete?: (document: DocumentResponse) => void;
+  /** Fired once after the whole batch has settled. */
+  readonly onBatchDone?: (results: { readonly succeeded: number; readonly failed: number }) => void;
+  readonly labels?: UploadDropZoneLabels;
+  readonly className?: string;
+  readonly children?: ReactNode;
+}
+
+const DEFAULT_LABELS: Required<UploadDropZoneLabels> = {
+  overlay: 'Drop files to upload',
+  uploadingCount: (done, total) => `Uploading ${String(done)} / ${String(total)}…`,
+  tooLarge: 'File is too large.',
+  quotaExceeded: 'Tenant storage quota exceeded.',
+  failed: 'Upload failed.',
+};
+
+function pickErrorLabel(err: FileUploadError, labels: Required<UploadDropZoneLabels>): string {
+  if (err.code === 'too-large') return labels.tooLarge;
+  if (err.code === 'quota-exceeded') return labels.quotaExceeded;
+  if (err.code === 'network') return labels.failed;
+  return err.message || labels.failed;
+}
+
+/**
+ * Renders a drop-target wrapper. When the user drags files over the area
+ * (DataTransfer carries the `Files` type), an overlay appears; releasing
+ * sequentially uploads each file via {@link useFileUpload} into
+ * {@link UploadDropZoneProps.folderId | folderId}.
+ *
+ * Drops carrying other DataTransfer types (e.g. internal document drags
+ * for move-to-folder) are ignored — those bubble through to other
+ * handlers (FolderTree drop targets handle moves).
+ *
+ * Drag enter/leave use a counter trick: nested children fire enter/leave
+ * events when the cursor crosses internal boundaries, so we track the
+ * net depth instead of the boolean to keep the overlay stable.
+ */
+export function UploadDropZone({
+  folderId,
+  disabled = false,
+  maxAllowedBytes,
+  onComplete,
+  onBatchDone,
+  labels,
+  className,
+  children,
+}: UploadDropZoneProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const { uploadFile, progress, lastError } = useFileUpload({ maxAllowedBytes });
+  const [batch, setBatch] = useState<{ readonly done: number; readonly total: number } | null>(
+    null
+  );
+  const [over, setOver] = useState(false);
+  const depthRef = useRef(0);
+
+  const carriesFiles = useCallback((event: DragEvent<HTMLDivElement>): boolean => {
+    const types = event.dataTransfer.types;
+    for (const type of types) {
+      if (type === 'Files') return true;
+    }
+    return false;
+  }, []);
+
+  function handleDragEnter(event: DragEvent<HTMLDivElement>): void {
+    if (disabled || !carriesFiles(event)) return;
+    depthRef.current += 1;
+    if (depthRef.current === 1) setOver(true);
+  }
+
+  function handleDragLeave(event: DragEvent<HTMLDivElement>): void {
+    if (disabled || !carriesFiles(event)) return;
+    depthRef.current = Math.max(0, depthRef.current - 1);
+    if (depthRef.current === 0) setOver(false);
+  }
+
+  function handleDragOver(event: DragEvent<HTMLDivElement>): void {
+    if (disabled || !carriesFiles(event)) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = 'copy';
+  }
+
+  async function handleDrop(event: DragEvent<HTMLDivElement>): Promise<void> {
+    if (disabled || !carriesFiles(event)) return;
+    event.preventDefault();
+    depthRef.current = 0;
+    setOver(false);
+    const files = Array.from(event.dataTransfer.files);
+    if (files.length === 0) return;
+    let succeeded = 0;
+    let failed = 0;
+    setBatch({ done: 0, total: files.length });
+    for (const file of files) {
+      try {
+        const doc = await uploadFile(file, folderId);
+        succeeded += 1;
+        onComplete?.(doc);
+      } catch {
+        failed += 1;
+      }
+      setBatch((prev) => (prev ? { done: prev.done + 1, total: prev.total } : null));
+    }
+    setBatch(null);
+    onBatchDone?.({ succeeded, failed });
+  }
+
+  const errorMessage = lastError ? pickErrorLabel(lastError, labelStrings) : null;
+  const showOverlay = over && !disabled;
+  const isBusy = batch !== null;
+
+  return (
+    <div
+      data-granit-upload-drop-zone=""
+      data-granit-upload-drop-zone-over={showOverlay ? '' : undefined}
+      data-granit-upload-drop-zone-busy={isBusy ? '' : undefined}
+      data-granit-upload-drop-zone-disabled={disabled ? '' : undefined}
+      className={className}
+      onDragEnter={handleDragEnter}
+      onDragLeave={handleDragLeave}
+      onDragOver={handleDragOver}
+      onDrop={(event) => {
+        void handleDrop(event);
+      }}
+    >
+      {children}
+      {showOverlay && (
+        <div data-granit-upload-drop-zone-overlay="" aria-hidden>
+          <span>{labelStrings.overlay}</span>
+        </div>
+      )}
+      {batch && (
+        <div data-granit-upload-drop-zone-progress="" role="status" aria-live="polite">
+          {labelStrings.uploadingCount(batch.done, batch.total)}
+          {progress && ` — ${String(progress.percent)}%`}
+        </div>
+      )}
+      {errorMessage && (
+        <div data-granit-upload-drop-zone-error="" role="alert">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-documents/src/constants.ts
+++ b/packages/@granit/react-documents/src/constants.ts
@@ -2,3 +2,11 @@ export const API_VERSION = 'v1';
 export const MODULE = '@granit/documents';
 export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/documents`;
 export const DEFAULT_QUERY_KEY_PREFIX = ['documents'] as const;
+
+/**
+ * Custom DataTransfer MIME type used when dragging documents inside the
+ * explorer. Payload shape: `{ "ids": string[] }`. FolderTree drop targets
+ * recognize this and dispatch move mutations; UploadDropZone ignores it
+ * so internal drags don't trigger an upload flow.
+ */
+export const DOCUMENT_DRAG_MIME = 'application/x-granit-documents';

--- a/packages/@granit/react-documents/src/hooks/use-file-upload.ts
+++ b/packages/@granit/react-documents/src/hooks/use-file-upload.ts
@@ -1,0 +1,138 @@
+import { useCallback, useState } from 'react';
+
+import { useFinalizeUpload, useRequestUploadTicket } from './use-document-mutations.js';
+
+import type { DocumentResponse, UploadTicketResponse } from '@granit/documents';
+
+export interface UseFileUploadOptions {
+  /** Soft cap forwarded to the upload ticket request. Defaults to 1 GiB. */
+  readonly maxAllowedBytes?: number;
+}
+
+export interface FileUploadProgress {
+  readonly file: File;
+  readonly percent: number;
+}
+
+export interface FileUploadError {
+  readonly file: File;
+  readonly code: 'too-large' | 'quota-exceeded' | 'http' | 'network' | 'unknown';
+  readonly message: string;
+}
+
+export interface UseFileUploadResult {
+  readonly uploadFile: (file: File, folderId: string | null) => Promise<DocumentResponse>;
+  readonly progress: FileUploadProgress | null;
+  readonly lastError: FileUploadError | null;
+  readonly resetError: () => void;
+}
+
+const DEFAULT_MAX_ALLOWED_BYTES = 1024 * 1024 * 1024;
+
+class FileUploadFailure extends Error {
+  readonly code: FileUploadError['code'];
+  readonly file: File;
+  constructor(file: File, code: FileUploadError['code'], message: string) {
+    super(message);
+    this.file = file;
+    this.code = code;
+  }
+}
+
+function putToBlobStore(
+  ticket: UploadTicketResponse,
+  file: File,
+  onProgress: (percent: number) => void
+): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open(ticket.httpMethod, ticket.uploadUrl);
+    for (const [key, value] of Object.entries(ticket.requiredHeaders)) {
+      xhr.setRequestHeader(key, value);
+    }
+    xhr.upload.onprogress = (event) => {
+      if (event.lengthComputable && event.total > 0) {
+        onProgress(Math.round((event.loaded / event.total) * 100));
+      }
+    };
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolve();
+        return;
+      }
+      reject(new FileUploadFailure(file, 'http', `Upload failed with HTTP ${String(xhr.status)}`));
+    };
+    xhr.onerror = () => reject(new FileUploadFailure(file, 'network', 'Network error'));
+    xhr.send(file);
+  });
+}
+
+/**
+ * Two-phase upload primitive shared between {@link UploadButton} and
+ * {@link UploadDropZone}:
+ *
+ * 1. `POST /documents/upload-ticket` → presigned PUT URL + headers.
+ * 2. Direct PUT to blob storage via `XMLHttpRequest` (the Fetch API has
+ *    no upload-progress event).
+ * 3. `POST /documents/finalize` to create the Document row.
+ *
+ * Errors are normalized into {@link FileUploadError} with a discriminated
+ * `code`, so callers can map them to labels without re-parsing axios shapes.
+ * The hook is single-flight per call (`uploadFile` returns a promise per
+ * file) — callers that want parallel uploads should call it concurrently;
+ * callers that want serial uploads should `await` between calls.
+ */
+export function useFileUpload(options: UseFileUploadOptions = {}): UseFileUploadResult {
+  const maxAllowedBytes = options.maxAllowedBytes ?? DEFAULT_MAX_ALLOWED_BYTES;
+  const requestTicket = useRequestUploadTicket();
+  const finalize = useFinalizeUpload();
+  const [progress, setProgress] = useState<FileUploadProgress | null>(null);
+  const [lastError, setLastError] = useState<FileUploadError | null>(null);
+
+  const resetError = useCallback(() => setLastError(null), []);
+
+  const uploadFile = useCallback(
+    async (file: File, folderId: string | null): Promise<DocumentResponse> => {
+      setLastError(null);
+      if (file.size > maxAllowedBytes) {
+        const err: FileUploadError = { file, code: 'too-large', message: 'File is too large.' };
+        setLastError(err);
+        throw new FileUploadFailure(file, err.code, err.message);
+      }
+      setProgress({ file, percent: 0 });
+      try {
+        const ticket = await requestTicket.mutateAsync({
+          fileName: file.name,
+          contentType: file.type || 'application/octet-stream',
+          maxAllowedBytes,
+        });
+        await putToBlobStore(ticket, file, (percent) => setProgress({ file, percent }));
+        const document = await finalize.mutateAsync({
+          blobId: ticket.blobId,
+          folderId,
+          name: file.name,
+        });
+        setProgress(null);
+        return document;
+      } catch (err) {
+        const status = (err as { response?: { status?: number } } | undefined)?.response?.status;
+        const code: FileUploadError['code'] =
+          status === 413
+            ? 'quota-exceeded'
+            : err instanceof FileUploadFailure
+              ? err.code
+              : 'unknown';
+        // Keep the raw message verbatim (empty when none) — callers decide
+        // whether to surface it directly or fall back to a localized label.
+        const message = err instanceof Error ? err.message : '';
+        const normalized: FileUploadError = { file, code, message };
+        setLastError(normalized);
+        setProgress(null);
+        throw err instanceof Error ? err : new Error(message || 'Upload failed.');
+      }
+    },
+    [finalize, maxAllowedBytes, requestTicket]
+  );
+
+  return { uploadFile, progress, lastError, resetError };
+}

--- a/packages/@granit/react-documents/src/index.ts
+++ b/packages/@granit/react-documents/src/index.ts
@@ -11,7 +11,13 @@ export type {
 } from './providers/documents-provider.js';
 
 // Constants
-export { API_VERSION, DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX, MODULE } from './constants.js';
+export {
+  API_VERSION,
+  DEFAULT_BASE_PATH,
+  DEFAULT_QUERY_KEY_PREFIX,
+  DOCUMENT_DRAG_MIME,
+  MODULE,
+} from './constants.js';
 
 // Read hooks — Folders
 export { useFolder, useFolderBreadcrumb, useFolders } from './hooks/use-folders.js';
@@ -122,6 +128,17 @@ export type { TrashBinLabels, TrashBinProps } from './components/trash-bin.js';
 // Components — Upload
 export { UploadButton } from './components/upload-button.js';
 export type { UploadButtonLabels, UploadButtonProps } from './components/upload-button.js';
+
+export { UploadDropZone } from './components/upload-drop-zone.js';
+export type { UploadDropZoneLabels, UploadDropZoneProps } from './components/upload-drop-zone.js';
+
+export { useFileUpload } from './hooks/use-file-upload.js';
+export type {
+  FileUploadError,
+  FileUploadProgress,
+  UseFileUploadOptions,
+  UseFileUploadResult,
+} from './hooks/use-file-upload.js';
 
 // Components — Versions
 export { VersionsTimeline } from './components/versions-timeline.js';

--- a/packages/@granit/react-documents/src/locales/en.ts
+++ b/packages/@granit/react-documents/src/locales/en.ts
@@ -76,6 +76,13 @@ export interface DocumentsTranslations {
       readonly TooLarge: string;
       readonly Failed: string;
     };
+    readonly DropZone: {
+      readonly Overlay: string;
+      readonly UploadingCount: string;
+      readonly TooLarge: string;
+      readonly QuotaExceeded: string;
+      readonly Failed: string;
+    };
   };
   readonly Versions: {
     readonly Title: string;
@@ -205,6 +212,13 @@ export const documentsTranslationsEn: DocumentsTranslations = {
       Uploading: 'Uploading…',
       QuotaExceeded: 'Tenant storage quota exceeded.',
       TooLarge: 'File is too large.',
+      Failed: 'Upload failed.',
+    },
+    DropZone: {
+      Overlay: 'Drop files to upload',
+      UploadingCount: 'Uploading {{done}} / {{total}}…',
+      TooLarge: 'File is too large.',
+      QuotaExceeded: 'Tenant storage quota exceeded.',
       Failed: 'Upload failed.',
     },
   },

--- a/packages/@granit/react-documents/src/locales/fr.ts
+++ b/packages/@granit/react-documents/src/locales/fr.ts
@@ -68,6 +68,13 @@ export const documentsTranslationsFr: DocumentsTranslations = {
       TooLarge: 'Le fichier est trop volumineux.',
       Failed: 'Échec du téléversement.',
     },
+    DropZone: {
+      Overlay: 'Déposez les fichiers pour téléverser',
+      UploadingCount: 'Téléversement {{done}} / {{total}}…',
+      TooLarge: 'Le fichier est trop volumineux.',
+      QuotaExceeded: 'Quota de stockage du locataire dépassé.',
+      Failed: 'Échec du téléversement.',
+    },
   },
   Versions: {
     Title: 'Historique des versions',


### PR DESCRIPTION
## Summary

Stacked on top of #490. Adds native HTML5 drag-and-drop on the headless explorer foundation:

- **`useFileUpload` hook** extracted from `UploadButton` — single source of truth for the ticket → PUT → finalize flow, with errors normalized to a discriminated `FileUploadError { code }`. `UploadButton` becomes a thin shell over it.
- **`<UploadDropZone>`** — wraps a target, watches for `Files`-typed drags, shows an overlay, uploads each dropped file sequentially. Fires `onComplete` per file + `onBatchDone({ succeeded, failed })`. Skips internal document drags by MIME so it composes safely with the rest.
- **`<DocumentsList>` rows are now `draggable`** when `canManage`. dragstart sets `application/x-granit-documents` with `{ ids }` — whole selection if the row is in it, otherwise the row alone (which also adopts as the new single selection, Finder/OneDrive style). Plain-text fallback with names for external apps.
- **`<FolderTree>` nodes accept drops** carrying that MIME — sequential `useMoveDocument`. Counter-based dragenter/leave for stable hover feedback (`data-granit-folder-tree-drop-over`).
- **`<DocumentsExplorer>` wires `<UploadDropZone>`** around the main pane so external file drops land in the current folder.
- i18n EN + FR: `Document.DropZone.*` (overlay, batch progress, errors).
- New `DOCUMENT_DRAG_MIME` exported so apps can build custom drop targets that interop with the explorer.

## Why this shape

Headless throughout — no `react-dnd` / `@dnd-kit` dep, just the native HTML5 API. The MIME-based dispatch keeps file-drop and document-move flows orthogonal (drop-zone ignores internal drags, tree nodes ignore file drags).

## Test plan

- [x] `pnpm vitest run packages/@granit/react-documents` — 155/155 (24 files). New: upload-drop-zone overlay show/hide, ignore non-file drags, full upload-per-file flow, per-file error in batch summary; documents-list dragstart payload (single vs selection), draggable=false when canManage off; folder-tree drop dispatches useMoveDocument per id, ignores drops without MIME.
- [x] `pnpm eslint packages/@granit/react-documents/src/**/*.{ts,tsx} --max-warnings 0` clean
- [x] `pnpm -r --filter @granit/react-documents... build` clean
- [ ] Manual QA via showcase MR — drop files into the main pane, drag rows onto folder tree nodes