### PR TITLE
feat(react-documents): grid view — tile renderer + zoom slider + persistent view prefs

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3410,6 +3410,21 @@
           "members": []
         },
         {
+          "name": "classifyDocumentName",
+          "kind": "function",
+          "signature": "function classifyDocumentName(name: string): DocumentKind"
+        },
+        {
+          "name": "documentBadge",
+          "kind": "function",
+          "signature": "function documentBadge(name: string): string"
+        },
+        {
+          "name": "DocumentKind",
+          "kind": "type",
+          "signature": "type DocumentKind ="
+        },
+        {
           "name": "FolderBreadcrumb",
           "kind": "function",
           "signature": "function FolderBreadcrumb("

--- a/packages/@granit/react-documents/src/__tests__/document-kind.test.ts
+++ b/packages/@granit/react-documents/src/__tests__/document-kind.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyDocumentName, documentBadge } from '../components/document-kind.ts';
+
+describe('classifyDocumentName', () => {
+  it.each([
+    ['photo.jpg', 'image'],
+    ['scan.PNG', 'image'],
+    ['clip.mp4', 'video'],
+    ['song.mp3', 'audio'],
+    ['contract.pdf', 'pdf'],
+    ['notes.docx', 'doc'],
+    ['budget.XLSX', 'spreadsheet'],
+    ['deck.pptx', 'presentation'],
+    ['bundle.tar.gz', 'archive'],
+    ['index.ts', 'code'],
+    ['readme.md', 'text'],
+    ['unknown.xyz', 'other'],
+    ['no-extension', 'other'],
+    ['.dotfile', 'other'],
+    ['trailing.', 'other'],
+  ])('classifies %s as %s', (name, expected) => {
+    expect(classifyDocumentName(name)).toBe(expected);
+  });
+});
+
+describe('documentBadge', () => {
+  it('returns the uppercased extension capped to 4 chars', () => {
+    expect(documentBadge('contract.pdf')).toBe('PDF');
+    expect(documentBadge('archive.tar.gz')).toBe('GZ');
+    expect(documentBadge('bigext.WEBP')).toBe('WEBP');
+    expect(documentBadge('massive.something')).toBe('SOME');
+  });
+
+  it('falls back to a placeholder for files without an extension', () => {
+    expect(documentBadge('readme')).toBe('·');
+    expect(documentBadge('trailing.')).toBe('·');
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
@@ -293,4 +293,53 @@ describe('DocumentsList', () => {
     const row = document.querySelector<HTMLElement>('[data-granit-document-id="doc-1"]');
     expect(row!.getAttribute('draggable')).toBe('false');
   });
+
+  it('renders the table in list mode (default)', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    render(<DocumentsList folderId="fld-1" onOpenDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+    expect(document.querySelector('[data-granit-documents-list-table]')).not.toBeNull();
+    expect(document.querySelector('[data-granit-documents-list-grid]')).toBeNull();
+  });
+
+  it('renders tiles + kind data attributes in grid mode', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    render(
+      <DocumentsList folderId="fld-1" viewMode="grid" tileSize={200} onOpenDocument={vi.fn()} />,
+      { wrapper: createWrapper(client) }
+    );
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    const grid = document.querySelector<HTMLElement>('[data-granit-documents-list-grid]');
+    expect(grid).not.toBeNull();
+    expect(document.querySelector('[data-granit-documents-list-table]')).toBeNull();
+    // CSS var carries the tile size to the host stylesheet.
+    expect(grid!.style.getPropertyValue('--granit-documents-tile-size')).toBe('200px');
+
+    const tiles = document.querySelectorAll('[data-granit-documents-list-tile]');
+    expect(tiles.length).toBe(2);
+    // contract.pdf → 'pdf'; invoice.pdf → 'pdf'
+    expect(tiles[0]!.getAttribute('data-granit-document-kind')).toBe('pdf');
+    expect(tiles[1]!.getAttribute('data-granit-document-kind')).toBe('pdf');
+  });
+
+  it('opens a document on tile double-click', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    const onOpenDocument = vi.fn();
+    render(<DocumentsList folderId="fld-1" viewMode="grid" onOpenDocument={onOpenDocument} />, {
+      wrapper: createWrapper(client),
+    });
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    const tile = document.querySelector<HTMLElement>(
+      '[data-granit-document-id="doc-1"][data-granit-documents-list-tile]'
+    );
+    await userEvent.dblClick(tile!);
+    expect(onOpenDocument).toHaveBeenCalledWith('doc-1');
+  });
 });

--- a/packages/@granit/react-documents/src/__tests__/use-view-preferences.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-view-preferences.test.tsx
@@ -1,0 +1,71 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_TILE_SIZE,
+  DEFAULT_VIEW_MODE,
+  TILE_SIZE_STEPS,
+  useViewPreferences,
+} from '../hooks/use-view-preferences.ts';
+
+const KEY = 'test:view-prefs';
+
+describe('useViewPreferences', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+  });
+  afterEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it('starts with defaults when nothing is persisted', () => {
+    const { result } = renderHook(() => useViewPreferences(KEY));
+    expect(result.current.viewMode).toBe(DEFAULT_VIEW_MODE);
+    expect(result.current.tileSize).toBe(DEFAULT_TILE_SIZE);
+  });
+
+  it('hydrates from localStorage on mount', () => {
+    globalThis.localStorage.setItem(
+      KEY,
+      JSON.stringify({ viewMode: 'grid', tileSize: TILE_SIZE_STEPS[3] })
+    );
+    const { result } = renderHook(() => useViewPreferences(KEY));
+    expect(result.current.viewMode).toBe('grid');
+    expect(result.current.tileSize).toBe(TILE_SIZE_STEPS[3]);
+  });
+
+  it('persists updates back to localStorage', () => {
+    const { result } = renderHook(() => useViewPreferences(KEY));
+    act(() => result.current.setViewMode('grid'));
+    act(() => result.current.setTileSize(TILE_SIZE_STEPS[4]!));
+
+    const stored = JSON.parse(globalThis.localStorage.getItem(KEY) ?? '{}') as {
+      viewMode?: string;
+      tileSize?: number;
+    };
+    expect(stored.viewMode).toBe('grid');
+    expect(stored.tileSize).toBe(TILE_SIZE_STEPS[4]);
+  });
+
+  it('ignores corrupt JSON and falls back to defaults', () => {
+    globalThis.localStorage.setItem(KEY, '{not json');
+    const { result } = renderHook(() => useViewPreferences(KEY));
+    expect(result.current.viewMode).toBe(DEFAULT_VIEW_MODE);
+    expect(result.current.tileSize).toBe(DEFAULT_TILE_SIZE);
+  });
+
+  it('ignores unknown viewMode / out-of-range tileSize from storage', () => {
+    globalThis.localStorage.setItem(KEY, JSON.stringify({ viewMode: 'weird', tileSize: 9999 }));
+    const { result } = renderHook(() => useViewPreferences(KEY));
+    expect(result.current.viewMode).toBe(DEFAULT_VIEW_MODE);
+    expect(result.current.tileSize).toBe(DEFAULT_TILE_SIZE);
+  });
+
+  it('does not touch localStorage when storageKey is null', () => {
+    const { result } = renderHook(() => useViewPreferences(null));
+    act(() => result.current.setViewMode('grid'));
+    expect(globalThis.localStorage.length).toBe(0);
+    // In-memory state still updates.
+    expect(result.current.viewMode).toBe('grid');
+  });
+});

--- a/packages/@granit/react-documents/src/components/document-kind.ts
+++ b/packages/@granit/react-documents/src/components/document-kind.ts
@@ -1,0 +1,142 @@
+/**
+ * Coarse-grained classification of a document based on its filename
+ * extension. Used by `<DocumentsList>` grid mode and tile renderers to
+ * pick an icon / accent color (the package emits `data-granit-document-kind`,
+ * apps own the visual layer).
+ *
+ * Extension-driven on purpose — `DocumentResponse` doesn't carry a MIME
+ * type today; mapping by extension keeps tile rendering local and avoids
+ * a round-trip per row. Update the table when new file types start
+ * showing up in real tenants.
+ */
+export type DocumentKind =
+  | 'image'
+  | 'video'
+  | 'audio'
+  | 'pdf'
+  | 'doc'
+  | 'spreadsheet'
+  | 'presentation'
+  | 'archive'
+  | 'code'
+  | 'text'
+  | 'other';
+
+const KIND_BY_EXTENSION: ReadonlyMap<string, DocumentKind> = new Map<string, DocumentKind>([
+  // images
+  ['jpg', 'image'],
+  ['jpeg', 'image'],
+  ['png', 'image'],
+  ['gif', 'image'],
+  ['webp', 'image'],
+  ['avif', 'image'],
+  ['bmp', 'image'],
+  ['tif', 'image'],
+  ['tiff', 'image'],
+  ['svg', 'image'],
+  ['heic', 'image'],
+  // video
+  ['mp4', 'video'],
+  ['mov', 'video'],
+  ['webm', 'video'],
+  ['mkv', 'video'],
+  ['avi', 'video'],
+  // audio
+  ['mp3', 'audio'],
+  ['wav', 'audio'],
+  ['ogg', 'audio'],
+  ['flac', 'audio'],
+  ['m4a', 'audio'],
+  // pdf
+  ['pdf', 'pdf'],
+  // word-likes
+  ['doc', 'doc'],
+  ['docx', 'doc'],
+  ['odt', 'doc'],
+  ['rtf', 'doc'],
+  // spreadsheets
+  ['xls', 'spreadsheet'],
+  ['xlsx', 'spreadsheet'],
+  ['ods', 'spreadsheet'],
+  ['csv', 'spreadsheet'],
+  ['tsv', 'spreadsheet'],
+  // presentations
+  ['ppt', 'presentation'],
+  ['pptx', 'presentation'],
+  ['odp', 'presentation'],
+  // archives
+  ['zip', 'archive'],
+  ['rar', 'archive'],
+  ['tar', 'archive'],
+  ['gz', 'archive'],
+  ['tgz', 'archive'],
+  ['7z', 'archive'],
+  ['bz2', 'archive'],
+  // code
+  ['js', 'code'],
+  ['mjs', 'code'],
+  ['cjs', 'code'],
+  ['ts', 'code'],
+  ['tsx', 'code'],
+  ['jsx', 'code'],
+  ['py', 'code'],
+  ['rb', 'code'],
+  ['go', 'code'],
+  ['rs', 'code'],
+  ['cs', 'code'],
+  ['java', 'code'],
+  ['kt', 'code'],
+  ['swift', 'code'],
+  ['cpp', 'code'],
+  ['cc', 'code'],
+  ['cxx', 'code'],
+  ['c', 'code'],
+  ['h', 'code'],
+  ['hpp', 'code'],
+  ['sh', 'code'],
+  ['bash', 'code'],
+  ['zsh', 'code'],
+  ['ps1', 'code'],
+  ['sql', 'code'],
+  ['html', 'code'],
+  ['htm', 'code'],
+  ['css', 'code'],
+  ['scss', 'code'],
+  ['less', 'code'],
+  ['json', 'code'],
+  ['xml', 'code'],
+  ['yaml', 'code'],
+  ['yml', 'code'],
+  ['toml', 'code'],
+  // text
+  ['md', 'text'],
+  ['mdx', 'text'],
+  ['txt', 'text'],
+  ['log', 'text'],
+]);
+
+/**
+ * Returns the document kind for a filename. Case-insensitive; everything
+ * after the last `.` is the extension. Files without an extension and
+ * unknown extensions both fall back to `'other'`.
+ */
+export function classifyDocumentName(name: string): DocumentKind {
+  const dot = name.lastIndexOf('.');
+  if (dot <= 0 || dot === name.length - 1) return 'other';
+  const ext = name.slice(dot + 1).toLowerCase();
+  return KIND_BY_EXTENSION.get(ext) ?? 'other';
+}
+
+/**
+ * Short uppercase token suitable for displaying inside a tile when no
+ * thumbnail is available — typically the extension itself, capped to 4
+ * chars. Files without an extension fall back to a generic placeholder.
+ */
+export function documentBadge(name: string): string {
+  const dot = name.lastIndexOf('.');
+  if (dot <= 0 || dot === name.length - 1) return '·';
+  return name
+    .slice(dot + 1)
+    .slice(0, 4)
+    .toUpperCase();
+}

--- a/packages/@granit/react-documents/src/components/documents-explorer.tsx
+++ b/packages/@granit/react-documents/src/components/documents-explorer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { useFolder } from '../hooks/use-folders.js';
+import { useViewPreferences } from '../hooks/use-view-preferences.js';
 
 import { DocumentDetail } from './document-detail.js';
 import { DocumentsList } from './documents-list.js';
@@ -41,6 +42,13 @@ export interface DocumentsExplorerProps {
   readonly showQuotaBadge?: boolean;
   /** Hide / show the right inspector pane. Defaults to `true`. */
   readonly showInspector?: boolean;
+  /**
+   * `localStorage` key used to persist list/grid view mode + tile size. Pass
+   * `null` to disable persistence (state still works in-memory). Defaults to
+   * `granit-documents-view`. Tenants that want per-tenant preferences should
+   * pass a tenant-scoped key.
+   */
+  readonly viewPreferencesStorageKey?: string | null;
   readonly onOpenDocument?: (id: string) => void;
   readonly labels?: DocumentsExplorerLabels;
   readonly className?: string;
@@ -81,6 +89,7 @@ export function DocumentsExplorer({
   canManage = false,
   showQuotaBadge = false,
   showInspector = true,
+  viewPreferencesStorageKey = 'granit-documents-view',
   onOpenDocument,
   labels,
   className,
@@ -92,6 +101,8 @@ export function DocumentsExplorer({
   const [focusedDoc, setFocusedDoc] = useState<DocumentResponse | null>(null);
   const [inspectorVisible, setInspectorVisible] = useState(showInspector);
   const [clearSignal, setClearSignal] = useState(0);
+  const { viewMode, tileSize, setViewMode, setTileSize } =
+    useViewPreferences(viewPreferencesStorageKey);
 
   // Watch the live status of the current selection. After a trash mutation
   // (direct or cascading from an ancestor), the cache is invalidated and
@@ -187,6 +198,10 @@ export function DocumentsExplorer({
               onClearSelection={handleClearSelection}
               inspectorVisible={showInspector && inspectorVisible}
               onToggleInspector={showInspector ? () => setInspectorVisible((v) => !v) : undefined}
+              viewMode={viewMode}
+              onViewModeChange={setViewMode}
+              tileSize={tileSize}
+              onTileSizeChange={setTileSize}
               labels={labels?.toolbar}
               trailing={
                 canManage && (
@@ -201,6 +216,8 @@ export function DocumentsExplorer({
             <DocumentsList
               folderId={folderId}
               canManage={canManage}
+              viewMode={viewMode}
+              tileSize={tileSize}
               clearSignal={clearSignal}
               onOpenDocument={onOpenDocument}
               onSelectionChange={handleSelectionChange}

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -6,14 +6,17 @@ import { useRenameDocument, useTrashDocument } from '../hooks/use-document-mutat
 import { useMultiSelect } from '../hooks/use-multi-select.js';
 import { useDocumentsConfig } from '../providers/documents-provider.js';
 
+import { classifyDocumentName, documentBadge } from './document-kind.js';
 import { InlineEdit } from './inline-edit.js';
 
+import type { DocumentsViewMode, TileSizeStep } from '../hooks/use-view-preferences.js';
 import type { DocumentResponse } from '@granit/documents';
 import type { FilterEntry, SortEntry } from '@granit/query-engine';
 import type { DragEvent, KeyboardEvent, MouseEvent, ReactNode } from 'react';
 
 const LIST_QUERY_KEY_PREFIX = ['documents', 'documents', 'list'] as const;
 const DEFAULT_PAGE_SIZE = 50;
+const DEFAULT_TILE_SIZE: TileSizeStep = 160;
 
 export interface DocumentsListLabels {
   readonly empty?: string;
@@ -36,6 +39,10 @@ export interface DocumentsListProps {
   readonly folderId: string;
   readonly pageSize?: number;
   readonly canManage?: boolean;
+  /** `'list'` (default) renders a table, `'grid'` renders a tile grid. */
+  readonly viewMode?: DocumentsViewMode;
+  /** Side of each tile in pixels (grid mode only). Defaults to 160. */
+  readonly tileSize?: TileSizeStep;
   /** Open / preview a single document (Enter key or single click on name). */
   readonly onOpenDocument?: (id: string) => void;
   /** Bubbles the current selection (ids) to a parent toolbar or inspector. */
@@ -77,13 +84,14 @@ const DEFAULT_LABELS: Required<DocumentsListLabels> = {
  * endpoint `GET {basePath}/documents` — pre-applies `folderId Equals <id>`
  * and `status Equals Active`. Trashed documents are surfaced in TrashBin.
  *
- * Beyond display, the list exposes:
- *  - Multi-selection (click / ctrl-click / shift-click / select-all checkbox).
- *  - Keyboard navigation: ↑↓ focus, Enter opens, F2 renames, Space toggles
- *    selection, Delete trashes the focused row (with inline confirm).
- *  - Inline rename via {@link InlineEdit} (replaces `window.prompt`).
- *  - Inline trash confirmation (replaces `window.confirm`).
- *  - Selection / focus callbacks for an external toolbar + inspector.
+ * Two view modes:
+ *  - `'list'` (default): a table with name / status / actions columns.
+ *  - `'grid'`: a tile grid sized by `tileSize`, with a kind badge per
+ *    extension (image / pdf / code / …) emitted as `data-granit-document-kind`
+ *    so hosts can color-code without a thumbnail backend.
+ *
+ * Both modes share the same selection / focus / drag / rename / trash
+ * machinery — switching the view does not lose state.
  */
 export function DocumentsList(props: Readonly<DocumentsListProps>): ReactNode {
   const config = useDocumentsConfig();
@@ -107,6 +115,8 @@ function DocumentsListBody({
   folderId,
   pageSize,
   canManage = false,
+  viewMode = 'list',
+  tileSize = DEFAULT_TILE_SIZE,
   onOpenDocument,
   onSelectionChange,
   onFocusChange,
@@ -135,7 +145,6 @@ function DocumentsListBody({
   const selection = useMultiSelect(orderedIds);
   const [focusedId, setFocusedId] = useState<string | null>(null);
   const [rowModes, setRowModes] = useState<Readonly<Record<string, RowMode>>>({});
-  const tableRef = useRef<HTMLTableElement | null>(null);
 
   const renameDocument = useRenameDocument();
   const trashDocument = useTrashDocument();
@@ -189,7 +198,7 @@ function DocumentsListBody({
     });
   }
 
-  function handleRowClick(event: MouseEvent<HTMLTableRowElement>, doc: DocumentResponse): void {
+  function handleItemClick(event: MouseEvent, doc: DocumentResponse): void {
     if (event.shiftKey) {
       event.preventDefault();
       selection.selectRange(doc.id);
@@ -207,13 +216,13 @@ function DocumentsListBody({
     onOpenDocument?.(doc.id);
   }
 
-  function handleRowDragStart(event: DragEvent<HTMLTableRowElement>, doc: DocumentResponse): void {
+  function handleItemDragStart(event: DragEvent, doc: DocumentResponse): void {
     if (!canManage) {
       event.preventDefault();
       return;
     }
-    // If the dragged row is part of the current selection, move the whole
-    // selection. Otherwise, drag this row only (and adopt it as the new
+    // If the dragged item is part of the current selection, move the whole
+    // selection. Otherwise, drag this item only (and adopt it as the new
     // single selection, matching Finder / OneDrive behavior).
     let ids: string[];
     if (selection.selected.has(doc.id)) {
@@ -231,11 +240,16 @@ function DocumentsListBody({
     event.dataTransfer.effectAllowed = 'move';
   }
 
-  function handleKeyDown(event: KeyboardEvent<HTMLTableElement>): void {
+  function handleKeyDown(event: KeyboardEvent<HTMLElement>): void {
     if (items.length === 0) return;
     const index = focusedId ? items.findIndex((d) => d.id === focusedId) : -1;
 
-    if (event.key === 'ArrowDown') {
+    // Both list and grid use the same linear nav model. In grid mode the
+    // visual rows are CSS-driven (auto-fill); without a JS-tracked column
+    // count we can't do Finder-style up/down between rows, so left/right
+    // (and up/down) all walk the flat ordering. Good enough for v1, and
+    // matches what shadcn / radix do for command palettes.
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
       event.preventDefault();
       const next = items[Math.min(items.length - 1, index + 1)];
       if (next) {
@@ -243,7 +257,7 @@ function DocumentsListBody({
         if (event.shiftKey) selection.selectRange(next.id);
         else if (!event.ctrlKey && !event.metaKey) selection.selectOnly(next.id);
       }
-    } else if (event.key === 'ArrowUp') {
+    } else if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
       event.preventDefault();
       const next = items[Math.max(0, index - 1)];
       if (next) {
@@ -299,6 +313,7 @@ function DocumentsListBody({
       <div
         data-granit-documents-list=""
         data-granit-documents-list-loading=""
+        data-granit-documents-list-view={viewMode}
         className={className}
       >
         {labelStrings.loading}
@@ -308,7 +323,12 @@ function DocumentsListBody({
 
   if (query.isError) {
     return (
-      <div data-granit-documents-list="" data-granit-documents-list-error="" className={className}>
+      <div
+        data-granit-documents-list=""
+        data-granit-documents-list-error=""
+        data-granit-documents-list-view={viewMode}
+        className={className}
+      >
         {labelStrings.error}
       </div>
     );
@@ -322,54 +342,64 @@ function DocumentsListBody({
 
   if (items.length === 0) {
     return (
-      <div data-granit-documents-list="" className={className}>
+      <div
+        data-granit-documents-list=""
+        data-granit-documents-list-view={viewMode}
+        className={className}
+      >
         <div data-granit-documents-list-empty="">{labelStrings.empty}</div>
       </div>
     );
   }
 
+  const itemRenderState = items.map((document) => ({
+    document,
+    isSelected: selection.isSelected(document.id),
+    isFocused: focusedId === document.id,
+    mode: rowModes[document.id] ?? 'idle',
+    kind: classifyDocumentName(document.name),
+    badge: documentBadge(document.name),
+  }));
+
   return (
-    <div data-granit-documents-list="" className={className}>
-      <table
-        ref={tableRef}
-        data-granit-documents-list-table=""
-        tabIndex={0}
-        onKeyDown={handleKeyDown}
-      >
-        <thead>
-          <tr>
-            <th data-granit-documents-list-select-col="">
-              <input
-                type="checkbox"
-                aria-label={labelStrings.selectHeader}
-                checked={allSelected}
-                onChange={(event) =>
-                  event.target.checked ? selection.selectAll(orderedIds) : selection.clear()
-                }
-              />
-            </th>
-            <th>{labelStrings.nameHeader}</th>
-            <th>{labelStrings.statusHeader}</th>
-            {canManage && <th data-granit-documents-list-actions-col="" />}
-          </tr>
-        </thead>
-        <tbody>
-          {items.map((document) => {
-            const isSelected = selection.isSelected(document.id);
-            const isFocused = focusedId === document.id;
-            const mode = rowModes[document.id] ?? 'idle';
-            return (
+    <div
+      data-granit-documents-list=""
+      data-granit-documents-list-view={viewMode}
+      className={className}
+    >
+      {viewMode === 'list' ? (
+        <table data-granit-documents-list-table="" tabIndex={0} onKeyDown={handleKeyDown}>
+          <thead>
+            <tr>
+              <th data-granit-documents-list-select-col="">
+                <input
+                  type="checkbox"
+                  aria-label={labelStrings.selectHeader}
+                  checked={allSelected}
+                  onChange={(event) =>
+                    event.target.checked ? selection.selectAll(orderedIds) : selection.clear()
+                  }
+                />
+              </th>
+              <th>{labelStrings.nameHeader}</th>
+              <th>{labelStrings.statusHeader}</th>
+              {canManage && <th data-granit-documents-list-actions-col="" />}
+            </tr>
+          </thead>
+          <tbody>
+            {itemRenderState.map(({ document, isSelected, isFocused, mode, kind }) => (
               <tr
                 key={document.id}
                 data-granit-documents-list-row=""
                 data-granit-document-id={document.id}
+                data-granit-document-kind={kind}
                 data-granit-documents-list-selected={isSelected ? '' : undefined}
                 data-granit-documents-list-focused={isFocused ? '' : undefined}
                 data-granit-documents-list-draggable={canManage ? '' : undefined}
                 aria-selected={isSelected}
                 draggable={canManage}
-                onClick={(event) => handleRowClick(event, document)}
-                onDragStart={(event) => handleRowDragStart(event, document)}
+                onClick={(event) => handleItemClick(event, document)}
+                onDragStart={(event) => handleItemDragStart(event, document)}
               >
                 <td data-granit-documents-list-select-cell="">
                   <input
@@ -453,10 +483,114 @@ function DocumentsListBody({
                   </td>
                 )}
               </tr>
-            );
-          })}
-        </tbody>
-      </table>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <ul
+          data-granit-documents-list-grid=""
+          // tile size becomes a CSS custom property the host stylesheet picks
+          // up to drive the grid column track + tile dimensions.
+          style={{ ['--granit-documents-tile-size' as string]: `${String(tileSize)}px` }}
+          tabIndex={0}
+          aria-multiselectable
+          onKeyDown={handleKeyDown}
+        >
+          {itemRenderState.map(({ document, isSelected, isFocused, mode, kind, badge }) => (
+            <li
+              key={document.id}
+              data-granit-documents-list-tile=""
+              data-granit-document-id={document.id}
+              data-granit-document-kind={kind}
+              data-granit-documents-list-selected={isSelected ? '' : undefined}
+              data-granit-documents-list-focused={isFocused ? '' : undefined}
+              data-granit-documents-list-draggable={canManage ? '' : undefined}
+              aria-selected={isSelected}
+              draggable={canManage}
+              onClick={(event) => handleItemClick(event, document)}
+              onDoubleClick={() => onOpenDocument?.(document.id)}
+              onDragStart={(event) => handleItemDragStart(event, document)}
+            >
+              <input
+                type="checkbox"
+                data-granit-documents-list-tile-checkbox=""
+                aria-label={`${labelStrings.selectRow} ${document.name}`}
+                checked={isSelected}
+                onClick={(event) => event.stopPropagation()}
+                onChange={() => selection.toggle(document.id)}
+              />
+              <div data-granit-documents-list-tile-thumb="" aria-hidden>
+                <span data-granit-documents-list-tile-badge="">{badge}</span>
+              </div>
+              <div data-granit-documents-list-tile-name="">
+                {mode === 'renaming' && canManage ? (
+                  <InlineEdit
+                    initialValue={document.name}
+                    ariaLabel={labelStrings.rename}
+                    onCommit={(name) => commitRename(document, name)}
+                    onCancel={() => clearRowMode(document.id)}
+                  />
+                ) : onOpenDocument ? (
+                  <button
+                    type="button"
+                    data-granit-documents-list-name=""
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      handleNameClick(document);
+                    }}
+                  >
+                    {document.name}
+                  </button>
+                ) : (
+                  <span data-granit-documents-list-name="">{document.name}</span>
+                )}
+              </div>
+              {canManage && (
+                <div data-granit-documents-list-tile-actions="">
+                  {mode === 'confirming-trash' ? (
+                    <span data-granit-documents-list-confirm="" role="alertdialog">
+                      <button type="button" onClick={() => clearRowMode(document.id)}>
+                        {labelStrings.trashCancel}
+                      </button>
+                      <button
+                        type="button"
+                        data-granit-documents-list-confirm-ok=""
+                        onClick={() => confirmTrash(document)}
+                        disabled={trashDocument.isPending}
+                      >
+                        {labelStrings.trashConfirm}
+                      </button>
+                    </span>
+                  ) : (
+                    <>
+                      <button
+                        type="button"
+                        aria-label={labelStrings.rename}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setRowMode(document.id, 'renaming');
+                        }}
+                      >
+                        {labelStrings.rename}
+                      </button>
+                      <button
+                        type="button"
+                        aria-label={labelStrings.trash}
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          setRowMode(document.id, 'confirming-trash');
+                        }}
+                      >
+                        {labelStrings.trash}
+                      </button>
+                    </>
+                  )}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
       <nav data-granit-documents-list-pagination="" aria-label="Pagination">
         <button type="button" onClick={() => setPage(currentPage - 1)} disabled={currentPage <= 1}>
           {labelStrings.previous}

--- a/packages/@granit/react-documents/src/components/documents-toolbar.tsx
+++ b/packages/@granit/react-documents/src/components/documents-toolbar.tsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 
 import { useTrashDocument } from '../hooks/use-document-mutations.js';
+import { TILE_SIZE_STEPS } from '../hooks/use-view-preferences.js';
 
+import type { DocumentsViewMode, TileSizeStep } from '../hooks/use-view-preferences.js';
 import type { DocumentResponse } from '@granit/documents';
 import type { ReactNode } from 'react';
 
@@ -15,6 +17,9 @@ export interface DocumentsToolbarLabels {
   readonly bulkTrashConfirmOk?: string;
   readonly bulkTrashCancel?: string;
   readonly inspectorToggle?: string;
+  readonly viewList?: string;
+  readonly viewGrid?: string;
+  readonly zoom?: string;
 }
 
 export interface DocumentsToolbarProps {
@@ -25,6 +30,12 @@ export interface DocumentsToolbarProps {
   /** Optional inspector visibility binding for the explorer header. */
   readonly inspectorVisible?: boolean;
   readonly onToggleInspector?: () => void;
+  /** Current list/grid view mode. When unset the switcher is hidden. */
+  readonly viewMode?: DocumentsViewMode;
+  readonly onViewModeChange?: (mode: DocumentsViewMode) => void;
+  /** Current tile size (grid mode). When unset the zoom slider is hidden. */
+  readonly tileSize?: TileSizeStep;
+  readonly onTileSizeChange?: (size: TileSizeStep) => void;
   readonly labels?: DocumentsToolbarLabels;
   readonly className?: string;
   /** Extra trailing actions (e.g. an `<UploadButton />` in the no-selection state). */
@@ -41,6 +52,9 @@ const DEFAULT_LABELS: Required<DocumentsToolbarLabels> = {
   bulkTrashConfirmOk: 'Confirm',
   bulkTrashCancel: 'Cancel',
   inspectorToggle: 'Toggle inspector',
+  viewList: 'List view',
+  viewGrid: 'Grid view',
+  zoom: 'Tile size',
 };
 
 /**
@@ -59,6 +73,10 @@ export function DocumentsToolbar({
   onClearSelection,
   inspectorVisible,
   onToggleInspector,
+  viewMode,
+  onViewModeChange,
+  tileSize,
+  onTileSizeChange,
   labels,
   className,
   trailing,
@@ -146,6 +164,51 @@ export function DocumentsToolbar({
       )}
 
       <span data-granit-documents-toolbar-trailing="">
+        {viewMode && onViewModeChange && (
+          <span
+            data-granit-documents-toolbar-view=""
+            role="group"
+            aria-label={labelStrings.viewList}
+          >
+            <button
+              type="button"
+              data-granit-documents-toolbar-view-list=""
+              aria-pressed={viewMode === 'list'}
+              aria-label={labelStrings.viewList}
+              onClick={() => onViewModeChange('list')}
+            >
+              ≡
+            </button>
+            <button
+              type="button"
+              data-granit-documents-toolbar-view-grid=""
+              aria-pressed={viewMode === 'grid'}
+              aria-label={labelStrings.viewGrid}
+              onClick={() => onViewModeChange('grid')}
+            >
+              ▦
+            </button>
+          </span>
+        )}
+        {viewMode === 'grid' && tileSize !== undefined && onTileSizeChange && (
+          <label data-granit-documents-toolbar-zoom="">
+            <span data-granit-documents-toolbar-zoom-label="">{labelStrings.zoom}</span>
+            <input
+              type="range"
+              min={0}
+              max={TILE_SIZE_STEPS.length - 1}
+              step={1}
+              value={Math.max(0, TILE_SIZE_STEPS.indexOf(tileSize))}
+              aria-label={labelStrings.zoom}
+              aria-valuetext={`${String(tileSize)}px`}
+              onChange={(event) => {
+                const idx = Number(event.target.value);
+                const next = TILE_SIZE_STEPS[idx];
+                if (next !== undefined) onTileSizeChange(next);
+              }}
+            />
+          </label>
+        )}
         {onToggleInspector && (
           <button
             type="button"

--- a/packages/@granit/react-documents/src/hooks/use-view-preferences.ts
+++ b/packages/@granit/react-documents/src/hooks/use-view-preferences.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export type DocumentsViewMode = 'list' | 'grid';
+
+/** Discrete tile-size steps (px). Indexed 0..N-1 for the slider. */
+export const TILE_SIZE_STEPS = [96, 128, 160, 200, 240] as const;
+export type TileSizeStep = (typeof TILE_SIZE_STEPS)[number];
+
+export const DEFAULT_VIEW_MODE: DocumentsViewMode = 'list';
+export const DEFAULT_TILE_SIZE: TileSizeStep = 160;
+
+export interface ViewPreferences {
+  readonly viewMode: DocumentsViewMode;
+  readonly tileSize: TileSizeStep;
+  readonly setViewMode: (mode: DocumentsViewMode) => void;
+  readonly setTileSize: (size: TileSizeStep) => void;
+}
+
+interface StorageShape {
+  readonly viewMode?: DocumentsViewMode;
+  readonly tileSize?: TileSizeStep;
+}
+
+function readStorage(key: string): StorageShape | null {
+  if (typeof globalThis.localStorage === 'undefined') return null;
+  try {
+    const raw = globalThis.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StorageShape;
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key: string, value: StorageShape): void {
+  if (typeof globalThis.localStorage === 'undefined') return;
+  try {
+    globalThis.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* quota / disabled — silently ignore */
+  }
+}
+
+/**
+ * Persists list/grid view mode and tile size in `localStorage` so the
+ * choice survives reloads. The `storageKey` is supplied by the caller so
+ * different mount points (tenant-scoped, per-folder, …) can keep
+ * independent preferences. Passing `null` disables persistence — useful
+ * for tests and for callers that hold the state elsewhere.
+ *
+ * Hydration is deferred to a mount-time effect so the SSR / first paint
+ * is deterministic (always the default), then the real value swaps in on
+ * the client. Avoids the classic hydration-mismatch hazard.
+ */
+export function useViewPreferences(storageKey: string | null): ViewPreferences {
+  const [viewMode, setViewModeState] = useState<DocumentsViewMode>(DEFAULT_VIEW_MODE);
+  const [tileSize, setTileSizeState] = useState<TileSizeStep>(DEFAULT_TILE_SIZE);
+
+  useEffect(() => {
+    if (!storageKey) return;
+    const stored = readStorage(storageKey);
+    if (!stored) return;
+    if (stored.viewMode === 'list' || stored.viewMode === 'grid') {
+      setViewModeState(stored.viewMode);
+    }
+    if (
+      typeof stored.tileSize === 'number' &&
+      (TILE_SIZE_STEPS as readonly number[]).includes(stored.tileSize)
+    ) {
+      setTileSizeState(stored.tileSize);
+    }
+  }, [storageKey]);
+
+  const setViewMode = useCallback(
+    (mode: DocumentsViewMode) => {
+      setViewModeState(mode);
+      if (storageKey) writeStorage(storageKey, { viewMode: mode, tileSize });
+    },
+    [storageKey, tileSize]
+  );
+
+  const setTileSize = useCallback(
+    (size: TileSizeStep) => {
+      setTileSizeState(size);
+      if (storageKey) writeStorage(storageKey, { viewMode, tileSize: size });
+    },
+    [storageKey, viewMode]
+  );
+
+  return { viewMode, tileSize, setViewMode, setTileSize };
+}

--- a/packages/@granit/react-documents/src/index.ts
+++ b/packages/@granit/react-documents/src/index.ts
@@ -96,6 +96,21 @@ export type { InlineEditProps } from './components/inline-edit.js';
 export { useMultiSelect } from './hooks/use-multi-select.js';
 export type { MultiSelectApi } from './hooks/use-multi-select.js';
 
+export {
+  DEFAULT_TILE_SIZE,
+  DEFAULT_VIEW_MODE,
+  TILE_SIZE_STEPS,
+  useViewPreferences,
+} from './hooks/use-view-preferences.js';
+export type {
+  DocumentsViewMode,
+  TileSizeStep,
+  ViewPreferences,
+} from './hooks/use-view-preferences.js';
+
+export { classifyDocumentName, documentBadge } from './components/document-kind.js';
+export type { DocumentKind } from './components/document-kind.js';
+
 // Components — Folders
 export { FolderBreadcrumb } from './components/folder-breadcrumb.js';
 export type {

--- a/packages/@granit/react-documents/src/locales/en.ts
+++ b/packages/@granit/react-documents/src/locales/en.ts
@@ -68,6 +68,9 @@ export interface DocumentsTranslations {
       readonly BulkTrashConfirmOk: string;
       readonly BulkTrashCancel: string;
       readonly InspectorToggle: string;
+      readonly ViewList: string;
+      readonly ViewGrid: string;
+      readonly Zoom: string;
     };
     readonly Upload: {
       readonly Button: string;
@@ -206,6 +209,9 @@ export const documentsTranslationsEn: DocumentsTranslations = {
       BulkTrashConfirmOk: 'Confirm',
       BulkTrashCancel: 'Cancel',
       InspectorToggle: 'Toggle inspector',
+      ViewList: 'List view',
+      ViewGrid: 'Grid view',
+      Zoom: 'Tile size',
     },
     Upload: {
       Button: 'Upload',

--- a/packages/@granit/react-documents/src/locales/fr.ts
+++ b/packages/@granit/react-documents/src/locales/fr.ts
@@ -60,6 +60,9 @@ export const documentsTranslationsFr: DocumentsTranslations = {
       BulkTrashConfirmOk: 'Confirmer',
       BulkTrashCancel: 'Annuler',
       InspectorToggle: 'Afficher/masquer l’inspecteur',
+      ViewList: 'Vue liste',
+      ViewGrid: 'Vue grille',
+      Zoom: 'Taille des tuiles',
     },
     Upload: {
       Button: 'Téléverser',


### PR DESCRIPTION
## Summary

Adds a list/grid view toggle to the explorer. All existing selection, keyboard, drag-drop, inline-rename and trash-confirm machinery is preserved across both modes.

- **`<DocumentsList viewMode tileSize>`** — new optional props. `'list'` (default) keeps the existing table; `'grid'` renders a CSS-grid of `<li>` tiles. Switching mode does not lose state.
- **`useViewPreferences(storageKey)`** — persists view mode + tile size in `localStorage`, hydrating on mount so SSR / first paint stay deterministic. Pass `null` to opt out (useful in tests).
- **`classifyDocumentName` + `documentBadge`** — extension-based classifier. Tiles emit `data-granit-document-kind` (`image|video|audio|pdf|doc|spreadsheet|presentation|archive|code|text|other`) so apps can color-code thumbs without a backend round-trip — `DocumentResponse` doesn't carry a MIME today.
- **`<DocumentsToolbar>`** gains a view switcher (list / grid icons) + a zoom slider over the discrete `TILE_SIZE_STEPS` (96 / 128 / 160 / 200 / 240 px). The slider drives a CSS custom property `--granit-documents-tile-size` on the grid container so the host stylesheet sizes tiles + columns via `repeat(auto-fill, minmax(...))`.
- **`<DocumentsExplorer>`** wires the hook + props through with a `viewPreferencesStorageKey` prop (defaults to `granit-documents-view`) for tenant-scoped overrides.
- Grid keyboard nav uses the same linear ordering as list — ArrowLeft / Right are now active aliases for Up / Down. No JS column tracking (CSS auto-fill drives visual rows). Matches radix / shadcn command palettes.
- i18n EN + FR: `Document.Toolbar.{ViewList,ViewGrid,Zoom}`.

## Test plan

- [x] `pnpm vitest run packages/@granit/react-documents` — 181/181 pass (26 files). New: classifier table + edge cases, view-prefs hydration / persistence / corrupt JSON / out-of-range / null opt-out, list-vs-grid rendering, tile kind data attr, tile-size CSS var, double-click opens.
- [x] `pnpm eslint packages/@granit/react-documents/src/**/*.{ts,tsx} --max-warnings 0` clean
- [x] `pnpm -r --filter @granit/react-documents... build` clean
- [ ] Manual QA via showcase PR — toggle list/grid, slide zoom, verify selection / kbd nav / DnD / inline rename all work in grid mode