### PR TITLE
feat(react-documents): quick look preview modal — image / pdf / video / audio / text

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3350,6 +3350,11 @@
           "members": []
         },
         {
+          "name": "DocumentQuickLook",
+          "kind": "function",
+          "signature": "function DocumentQuickLook("
+        },
+        {
           "name": "DocumentsExplorer",
           "kind": "function",
           "signature": "function DocumentsExplorer("

--- a/packages/@granit/react-documents/src/__tests__/document-quick-look.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/document-quick-look.test.tsx
@@ -1,0 +1,246 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DocumentQuickLook } from '../components/document-quick-look.tsx';
+import { DocumentsProvider } from '../providers/documents-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { DocumentResponse } from '@granit/documents';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <DocumentsProvider config={{ client }}>{children}</DocumentsProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function makeDocument(id: string, name: string): DocumentResponse {
+  return {
+    id,
+    folderId: 'fld-1',
+    name,
+    status: 'Active',
+    ownerUserId: 'u',
+    currentVersionId: 'v',
+    description: null,
+    trashedAt: null,
+    permission: null,
+  };
+}
+
+function mockGet(client: AxiosInstance, routes: Record<string, unknown>, fallback?: unknown): void {
+  vi.mocked(client.get).mockImplementation(((url: string) => {
+    for (const [pattern, payload] of Object.entries(routes)) {
+      if (url.includes(pattern)) return Promise.resolve({ data: payload });
+    }
+    if (fallback !== undefined) return Promise.resolve({ data: fallback });
+    return Promise.reject(new Error(`No mock for ${url}`));
+  }) as AxiosInstance['get']);
+}
+
+describe('DocumentQuickLook', () => {
+  // jsdom doesn't implement showModal/close; shim them so the dialog effect
+  // can run without crashing the test.
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = function showModal() {
+      this.setAttribute('open', '');
+    };
+    HTMLDialogElement.prototype.close = function close() {
+      this.removeAttribute('open');
+      this.dispatchEvent(new Event('close'));
+    };
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('does not open when documentId is null', () => {
+    const client = createMockClient();
+    render(<DocumentQuickLook documentId={null} onClose={() => undefined} />, {
+      wrapper: createWrapper(client),
+    });
+    const dialog = document.querySelector<HTMLDialogElement>('[data-granit-document-quick-look]');
+    expect(dialog?.hasAttribute('open')).toBe(false);
+  });
+
+  it('opens and renders an image preview for an image kind', async () => {
+    const client = createMockClient();
+    mockGet(client, {
+      '/documents/doc-1/download': { url: 'https://blob.example/photo.png' },
+      '/documents/doc-1': makeDocument('doc-1', 'photo.png'),
+    });
+
+    render(<DocumentQuickLook documentId="doc-1" onClose={() => undefined} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const dialog = await waitFor(() =>
+      document.querySelector<HTMLDialogElement>('[data-granit-document-quick-look]')
+    );
+    expect(dialog?.hasAttribute('open')).toBe(true);
+    // Kind is computed from the document name once the docQuery resolves.
+    await waitFor(() =>
+      expect(dialog?.getAttribute('data-granit-document-quick-look-kind')).toBe('image')
+    );
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-granit-document-quick-look-image]')).not.toBeNull();
+    });
+  });
+
+  it('renders an iframe for a pdf kind', async () => {
+    const client = createMockClient();
+    mockGet(client, {
+      '/documents/doc-1/download': { url: 'https://blob.example/contract.pdf' },
+      '/documents/doc-1': makeDocument('doc-1', 'contract.pdf'),
+    });
+
+    render(<DocumentQuickLook documentId="doc-1" onClose={() => undefined} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => {
+      const iframe = document.querySelector<HTMLIFrameElement>(
+        '[data-granit-document-quick-look-pdf]'
+      );
+      expect(iframe?.src).toContain('contract.pdf');
+    });
+  });
+
+  it('fetches text content and renders it inline for a text kind', async () => {
+    const client = createMockClient();
+    const fileText = 'hello world';
+    vi.mocked(client.get).mockImplementation(((url: string) => {
+      if (url.includes('/documents/doc-1/download')) {
+        return Promise.resolve({ data: { url: 'https://blob.example/notes.md' } });
+      }
+      if (url === 'https://blob.example/notes.md') {
+        return Promise.resolve({ data: fileText });
+      }
+      if (url.includes('/documents/doc-1')) {
+        return Promise.resolve({ data: makeDocument('doc-1', 'notes.md') });
+      }
+      return Promise.reject(new Error(`No mock for ${url}`));
+    }) as AxiosInstance['get']);
+
+    render(<DocumentQuickLook documentId="doc-1" onClose={() => undefined} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(screen.getByText('hello world')).toBeInTheDocument());
+  });
+
+  it('renders a fallback for unsupported kinds', async () => {
+    const client = createMockClient();
+    mockGet(client, {
+      '/documents/doc-1/download': { url: 'https://blob.example/bundle.zip' },
+      '/documents/doc-1': makeDocument('doc-1', 'bundle.zip'),
+    });
+
+    render(<DocumentQuickLook documentId="doc-1" onClose={() => undefined} />, {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText(/No preview available for archive/i)).toBeInTheDocument()
+    );
+  });
+
+  it('navigates with ← / → through siblings', async () => {
+    const client = createMockClient();
+    mockGet(client, {
+      '/documents/doc-1/download': { url: 'https://blob.example/a.png' },
+      '/documents/doc-1': makeDocument('doc-1', 'a.png'),
+    });
+
+    const onNavigate = vi.fn();
+    const siblings = [
+      makeDocument('doc-0', 'before.png'),
+      makeDocument('doc-1', 'a.png'),
+      makeDocument('doc-2', 'after.png'),
+    ];
+    render(
+      <DocumentQuickLook
+        documentId="doc-1"
+        siblings={siblings}
+        onNavigate={onNavigate}
+        onClose={() => undefined}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const dialog = await waitFor(() =>
+      document.querySelector<HTMLDialogElement>('[data-granit-document-quick-look]')
+    );
+    expect(dialog).not.toBeNull();
+    // Position counter "2 / 3".
+    expect(screen.getByText('2 / 3')).toBeInTheDocument();
+
+    // jsdom doesn't reliably make a <dialog> the activeElement, so we
+    // dispatch keyboard events directly. The component's onKeyDown handler
+    // doesn't care about focus.
+    fireEvent.keyDown(dialog!, { key: 'ArrowRight' });
+    expect(onNavigate).toHaveBeenCalledWith('doc-2');
+
+    fireEvent.keyDown(dialog!, { key: 'ArrowLeft' });
+    fireEvent.keyDown(dialog!, { key: 'ArrowLeft' });
+    // First left → doc-0, second left clamped (already at first).
+    expect(onNavigate).toHaveBeenLastCalledWith('doc-0');
+  });
+
+  it('disables the prev button at the start and next at the end of siblings', async () => {
+    const client = createMockClient();
+    mockGet(client, {
+      '/documents/doc-0/download': { url: 'https://blob.example/start.png' },
+      '/documents/doc-0': makeDocument('doc-0', 'start.png'),
+    });
+
+    const siblings = [makeDocument('doc-0', 'start.png'), makeDocument('doc-1', 'end.png')];
+    render(
+      <DocumentQuickLook
+        documentId="doc-0"
+        siblings={siblings}
+        onNavigate={vi.fn()}
+        onClose={vi.fn()}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => screen.getByText('1 / 2'));
+    const prev = document.querySelector<HTMLButtonElement>(
+      '[data-granit-document-quick-look-prev]'
+    );
+    const next = document.querySelector<HTMLButtonElement>(
+      '[data-granit-document-quick-look-next]'
+    );
+    expect(prev?.disabled).toBe(true);
+    expect(next?.disabled).toBe(false);
+  });
+
+  it('calls onClose when the dialog dispatches a close event', async () => {
+    const client = createMockClient();
+    mockGet(client, {
+      '/documents/doc-1/download': { url: 'https://blob.example/photo.png' },
+      '/documents/doc-1': makeDocument('doc-1', 'photo.png'),
+    });
+
+    const onClose = vi.fn();
+    render(<DocumentQuickLook documentId="doc-1" onClose={onClose} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const dialog = await waitFor(() =>
+      document.querySelector<HTMLDialogElement>('[data-granit-document-quick-look]')
+    );
+    expect(dialog).not.toBeNull();
+    dialog!.close();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-list.test.tsx
@@ -327,6 +327,62 @@ describe('DocumentsList', () => {
     expect(tiles[1]!.getAttribute('data-granit-document-kind')).toBe('pdf');
   });
 
+  it('invokes onPreviewDocument when Space is pressed on the focused row', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    const onPreviewDocument = vi.fn();
+
+    render(
+      <DocumentsList
+        folderId="fld-1"
+        onOpenDocument={vi.fn()}
+        onPreviewDocument={onPreviewDocument}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    // Click the name to focus the row, then press Space.
+    await userEvent.click(screen.getByRole('button', { name: 'contract.pdf' }));
+    const table = document.querySelector<HTMLTableElement>('[data-granit-documents-list-table]');
+    table!.focus();
+    await userEvent.keyboard(' ');
+
+    expect(onPreviewDocument).toHaveBeenCalled();
+    const [doc] = onPreviewDocument.mock.calls[0]!;
+    expect((doc as { id: string }).id).toBe('doc-1');
+  });
+
+  it('falls back to toggling selection on Space when no onPreviewDocument is set', async () => {
+    const client = createMockClient();
+    mockTwoDocs(client);
+    const onSelectionChange = vi.fn();
+
+    render(
+      <DocumentsList
+        folderId="fld-1"
+        onOpenDocument={vi.fn()}
+        onSelectionChange={onSelectionChange}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('contract.pdf')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'contract.pdf' }));
+    // After click → selection has doc-1. Space should toggle it off.
+    const table = document.querySelector<HTMLTableElement>('[data-granit-documents-list-table]');
+    table!.focus();
+    await userEvent.keyboard(' ');
+
+    await waitFor(() => {
+      const lastCall = onSelectionChange.mock.calls.at(-1);
+      const set = lastCall?.[0] as ReadonlySet<string>;
+      expect(set.has('doc-1')).toBe(false);
+    });
+  });
+
   it('opens a document on tile double-click', async () => {
     const client = createMockClient();
     mockTwoDocs(client);

--- a/packages/@granit/react-documents/src/components/document-quick-look.tsx
+++ b/packages/@granit/react-documents/src/components/document-quick-look.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useDocument, useDocumentDownloadUrl } from '../hooks/use-documents.js';
+import { useDocumentsConfig } from '../providers/documents-provider.js';
+
+import { classifyDocumentName } from './document-kind.js';
+
+import type { DocumentKind } from './document-kind.js';
+import type { DocumentResponse } from '@granit/documents';
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+
+export interface DocumentQuickLookLabels {
+  readonly title?: string;
+  readonly close?: string;
+  readonly download?: string;
+  readonly previous?: string;
+  readonly next?: string;
+  readonly loading?: string;
+  readonly loadingPreview?: string;
+  readonly unsupportedKind?: (kind: DocumentKind) => string;
+  readonly downloadToView?: string;
+  readonly previewError?: string;
+  readonly position?: (current: number, total: number) => string;
+}
+
+export interface DocumentQuickLookProps {
+  /** Currently previewed document id. Pass `null` to keep the modal closed. */
+  readonly documentId: string | null;
+  readonly onClose: () => void;
+  /**
+   * Sibling documents (typically the current page of the list). When
+   * supplied, `←` / `→` navigate through them and the header shows
+   * "n / total". When omitted, navigation is disabled.
+   */
+  readonly siblings?: readonly DocumentResponse[];
+  /** Called with a sibling id when the user navigates via `←` / `→`. */
+  readonly onNavigate?: (documentId: string) => void;
+  readonly labels?: DocumentQuickLookLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<DocumentQuickLookLabels> = {
+  title: 'Preview',
+  close: 'Close',
+  download: 'Download',
+  previous: 'Previous',
+  next: 'Next',
+  loading: 'Loading…',
+  loadingPreview: 'Loading preview…',
+  unsupportedKind: (kind) => `No preview available for ${kind} files.`,
+  downloadToView: 'Download to view',
+  previewError: 'Failed to load preview.',
+  position: (current, total) => `${String(current)} / ${String(total)}`,
+};
+
+// Max bytes to inline-fetch + render in <pre>. Bigger files fall back to a
+// "Download to view" message to avoid OOM in jsdom / weak clients.
+const MAX_INLINE_TEXT_BYTES = 512 * 1024;
+
+// Keys that count as a "text-like" preview (fetch URL → render as <pre>).
+const TEXT_KINDS: ReadonlySet<DocumentKind> = new Set<DocumentKind>(['text', 'code']);
+
+interface PreviewContent {
+  readonly status: 'loading' | 'ready' | 'error' | 'too-large';
+  readonly text?: string;
+  readonly message?: string;
+}
+
+/**
+ * Quick Look modal — full-viewport preview triggered by `Space` from the
+ * documents list, mirroring macOS Finder. Renderer is dispatched on the
+ * document's extension-based kind:
+ *
+ * - image     → `<img>`
+ * - video     → `<video controls autoPlay>`
+ * - audio     → `<audio controls autoPlay>`
+ * - pdf       → `<iframe>` (browser-native PDF viewer)
+ * - text/code → fetch the URL + render as `<pre>` (capped at 512 KB so we
+ *               don't OOM on a 300 MB log; bigger files fall back to the
+ *               download placeholder)
+ * - other     → "Download to view" placeholder
+ *
+ * Sibling navigation is opt-in: pass `siblings` + `onNavigate` and `←` / `→`
+ * walk the list (typically the current paged result). The modal uses the
+ * native `<dialog>` element for focus trap + Esc to close, mounted via
+ * portal so it escapes the explorer's grid container.
+ */
+export function DocumentQuickLook({
+  documentId,
+  onClose,
+  siblings,
+  onNavigate,
+  labels,
+  className,
+}: DocumentQuickLookProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const config = useDocumentsConfig();
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+
+  // Open / close the native <dialog> in sync with documentId so backdrop +
+  // focus trap behaviors come for free.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (documentId && !dialog.open) {
+      try {
+        dialog.showModal();
+      } catch {
+        /* dialog already-open in jsdom corner cases */
+      }
+    } else if (!documentId && dialog.open) {
+      dialog.close();
+    }
+  }, [documentId]);
+
+  const docQuery = useDocument(documentId ?? '', { enabled: Boolean(documentId) });
+  const urlQuery = useDocumentDownloadUrl(documentId ?? '', undefined, {
+    enabled: Boolean(documentId),
+  });
+
+  const document = docQuery.data ?? null;
+  const downloadUrl = urlQuery.data?.url ?? null;
+  const kind = useMemo<DocumentKind>(
+    () => (document ? classifyDocumentName(document.name) : 'other'),
+    [document]
+  );
+
+  // For text-like kinds we pull the actual content via the presigned URL so
+  // we can show a real preview (not just a download prompt). One fetch per
+  // (documentId, url) — cancelled on unmount / id change.
+  const [previewContent, setPreviewContent] = useState<PreviewContent | null>(null);
+  useEffect(() => {
+    if (!documentId || !downloadUrl || !TEXT_KINDS.has(kind)) {
+      setPreviewContent(null);
+      return;
+    }
+    setPreviewContent({ status: 'loading' });
+    const controller = new AbortController();
+    void (async () => {
+      try {
+        const response = await config.client.get<string>(downloadUrl, {
+          signal: controller.signal,
+          responseType: 'text',
+          transformResponse: (raw: unknown) => raw,
+        });
+        const text = String(response.data ?? '');
+        if (text.length > MAX_INLINE_TEXT_BYTES) {
+          setPreviewContent({ status: 'too-large' });
+          return;
+        }
+        setPreviewContent({ status: 'ready', text });
+      } catch (err) {
+        if (controller.signal.aborted) return;
+        setPreviewContent({
+          status: 'error',
+          message: err instanceof Error ? err.message : labelStrings.previewError,
+        });
+      }
+    })();
+    return () => controller.abort();
+  }, [documentId, downloadUrl, kind, config.client, labelStrings.previewError]);
+
+  const currentIndex = useMemo(() => {
+    if (!siblings || !documentId) return -1;
+    return siblings.findIndex((s) => s.id === documentId);
+  }, [siblings, documentId]);
+
+  function navigate(direction: -1 | 1): void {
+    if (!siblings || !onNavigate || currentIndex === -1) return;
+    const next = currentIndex + direction;
+    if (next < 0 || next >= siblings.length) return;
+    const sibling = siblings[next];
+    if (sibling) onNavigate(sibling.id);
+  }
+
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLDialogElement>): void {
+    if (event.key === 'ArrowLeft') {
+      event.preventDefault();
+      navigate(-1);
+    } else if (event.key === 'ArrowRight') {
+      event.preventDefault();
+      navigate(1);
+    }
+  }
+
+  function handleDownload(): void {
+    if (!downloadUrl || typeof globalThis.window === 'undefined') return;
+    globalThis.window.open(downloadUrl, '_blank', 'noopener,noreferrer');
+  }
+
+  // Rendered even when documentId is null so the <dialog> ref stays mounted
+  // and the open/close effect can drive it. Native <dialog> + `showModal()`
+  // uses the browser's top-layer, so we don't need a portal to escape
+  // `overflow: hidden` ancestors — the modal floats above all other content.
+  return (
+    <dialog
+      ref={dialogRef}
+      data-granit-document-quick-look=""
+      data-granit-document-quick-look-kind={kind}
+      aria-label={labelStrings.title}
+      className={className}
+      onClose={onClose}
+      onCancel={onClose}
+      onKeyDown={handleKeyDown}
+    >
+      <header data-granit-document-quick-look-header="">
+        <span data-granit-document-quick-look-name="">
+          {document?.name ?? labelStrings.loading}
+        </span>
+        {siblings && currentIndex !== -1 && (
+          <span data-granit-document-quick-look-position="">
+            {labelStrings.position(currentIndex + 1, siblings.length)}
+          </span>
+        )}
+        <div data-granit-document-quick-look-actions="">
+          {siblings && onNavigate && (
+            <>
+              <button
+                type="button"
+                data-granit-document-quick-look-prev=""
+                aria-label={labelStrings.previous}
+                disabled={currentIndex <= 0}
+                onClick={() => navigate(-1)}
+              >
+                ‹
+              </button>
+              <button
+                type="button"
+                data-granit-document-quick-look-next=""
+                aria-label={labelStrings.next}
+                disabled={currentIndex === -1 || currentIndex >= siblings.length - 1}
+                onClick={() => navigate(1)}
+              >
+                ›
+              </button>
+            </>
+          )}
+          <button
+            type="button"
+            data-granit-document-quick-look-download=""
+            disabled={!downloadUrl}
+            onClick={handleDownload}
+          >
+            {labelStrings.download}
+          </button>
+          <button
+            type="button"
+            data-granit-document-quick-look-close=""
+            aria-label={labelStrings.close}
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+      </header>
+      <div data-granit-document-quick-look-body="">
+        {!documentId || !document ? (
+          <div data-granit-document-quick-look-loading="">{labelStrings.loading}</div>
+        ) : urlQuery.isError ? (
+          <div data-granit-document-quick-look-error="" role="alert">
+            {labelStrings.previewError}
+          </div>
+        ) : !downloadUrl ? (
+          <div data-granit-document-quick-look-loading="">{labelStrings.loadingPreview}</div>
+        ) : kind === 'image' ? (
+          <img data-granit-document-quick-look-image="" src={downloadUrl} alt={document.name} />
+        ) : kind === 'video' ? (
+          <video data-granit-document-quick-look-video="" src={downloadUrl} controls autoPlay />
+        ) : kind === 'audio' ? (
+          <audio data-granit-document-quick-look-audio="" src={downloadUrl} controls autoPlay />
+        ) : kind === 'pdf' ? (
+          <iframe data-granit-document-quick-look-pdf="" src={downloadUrl} title={document.name} />
+        ) : TEXT_KINDS.has(kind) ? (
+          previewContent?.status === 'loading' ? (
+            <div data-granit-document-quick-look-loading="">{labelStrings.loadingPreview}</div>
+          ) : previewContent?.status === 'ready' ? (
+            <pre data-granit-document-quick-look-text="">{previewContent.text}</pre>
+          ) : previewContent?.status === 'too-large' ? (
+            <div data-granit-document-quick-look-fallback="">{labelStrings.downloadToView}</div>
+          ) : (
+            <div data-granit-document-quick-look-error="" role="alert">
+              {previewContent?.message ?? labelStrings.previewError}
+            </div>
+          )
+        ) : (
+          <div data-granit-document-quick-look-fallback="">
+            <p>{labelStrings.unsupportedKind(kind)}</p>
+            <p>{labelStrings.downloadToView}</p>
+          </div>
+        )}
+      </div>
+    </dialog>
+  );
+}

--- a/packages/@granit/react-documents/src/components/documents-explorer.tsx
+++ b/packages/@granit/react-documents/src/components/documents-explorer.tsx
@@ -4,6 +4,7 @@ import { useFolder } from '../hooks/use-folders.js';
 import { useViewPreferences } from '../hooks/use-view-preferences.js';
 
 import { DocumentDetail } from './document-detail.js';
+import { DocumentQuickLook } from './document-quick-look.js';
 import { DocumentsList } from './documents-list.js';
 import { DocumentsToolbar } from './documents-toolbar.js';
 import { FolderBreadcrumb } from './folder-breadcrumb.js';
@@ -13,6 +14,7 @@ import { UploadButton } from './upload-button.js';
 import { UploadDropZone } from './upload-drop-zone.js';
 
 import type { DocumentDetailLabels } from './document-detail.js';
+import type { DocumentQuickLookLabels } from './document-quick-look.js';
 import type { DocumentsListLabels } from './documents-list.js';
 import type { DocumentsToolbarLabels } from './documents-toolbar.js';
 import type { FolderBreadcrumbLabels } from './folder-breadcrumb.js';
@@ -33,6 +35,7 @@ export interface DocumentsExplorerLabels {
   readonly upload?: UploadButtonLabels;
   readonly dropZone?: UploadDropZoneLabels;
   readonly detail?: DocumentDetailLabels;
+  readonly quickLook?: DocumentQuickLookLabels;
 }
 
 export interface DocumentsExplorerProps {
@@ -99,6 +102,8 @@ export function DocumentsExplorer({
   const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(() => new Set());
   const [selectedDocs, setSelectedDocs] = useState<readonly DocumentResponse[]>([]);
   const [focusedDoc, setFocusedDoc] = useState<DocumentResponse | null>(null);
+  const [items, setItems] = useState<readonly DocumentResponse[]>([]);
+  const [previewId, setPreviewId] = useState<string | null>(null);
   const [inspectorVisible, setInspectorVisible] = useState(showInspector);
   const [clearSignal, setClearSignal] = useState(0);
   const { viewMode, tileSize, setViewMode, setTileSize } =
@@ -220,12 +225,21 @@ export function DocumentsExplorer({
               tileSize={tileSize}
               clearSignal={clearSignal}
               onOpenDocument={onOpenDocument}
+              onPreviewDocument={(doc) => setPreviewId(doc.id)}
               onSelectionChange={handleSelectionChange}
               onFocusChange={setFocusedDoc}
+              onItemsChange={setItems}
               labels={labels?.list}
             />
           </section>
         </UploadDropZone>
+        <DocumentQuickLook
+          documentId={previewId}
+          siblings={items}
+          onNavigate={setPreviewId}
+          onClose={() => setPreviewId(null)}
+          labels={labels?.quickLook}
+        />
         {showInspector && inspectorVisible && (
           <aside data-granit-documents-explorer-inspector="">
             {focusedDoc ? (

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -45,6 +45,12 @@ export interface DocumentsListProps {
   readonly tileSize?: TileSizeStep;
   /** Open / preview a single document (Enter key or single click on name). */
   readonly onOpenDocument?: (id: string) => void;
+  /**
+   * Quick Look — invoked when the user presses `Space` on the focused row,
+   * matching macOS Finder. When omitted, `Space` falls back to its previous
+   * behavior of toggling the focused row's selection.
+   */
+  readonly onPreviewDocument?: (doc: DocumentResponse) => void;
   /** Bubbles the current selection (ids) to a parent toolbar or inspector. */
   readonly onSelectionChange?: (
     ids: ReadonlySet<string>,
@@ -52,6 +58,12 @@ export interface DocumentsListProps {
   ) => void;
   /** Bubbles the focused row (last single-clicked) for inspector binding. */
   readonly onFocusChange?: (doc: DocumentResponse | null) => void;
+  /**
+   * Bubbles the current page of items so a parent can use them for sibling
+   * navigation (e.g. ← / → in `<DocumentQuickLook>`). Fires whenever the
+   * underlying query returns a new page.
+   */
+  readonly onItemsChange?: (items: readonly DocumentResponse[]) => void;
   /**
    * Monotonic signal: bumping the value tells the list to clear its inner
    * selection + focus state. Useful when a parent toolbar exposes a
@@ -118,8 +130,10 @@ function DocumentsListBody({
   viewMode = 'list',
   tileSize = DEFAULT_TILE_SIZE,
   onOpenDocument,
+  onPreviewDocument,
   onSelectionChange,
   onFocusChange,
+  onItemsChange,
   clearSignal,
   labels,
   className,
@@ -184,6 +198,11 @@ function DocumentsListBody({
     const doc = focusedId ? (items.find((d) => d.id === focusedId) ?? null) : null;
     onFocusChange(doc);
   }, [focusedId, items, onFocusChange]);
+
+  useEffect(() => {
+    if (!onItemsChange) return;
+    onItemsChange(items);
+  }, [items, onItemsChange]);
 
   function setRowMode(id: string, mode: RowMode): void {
     setRowModes((prev) => ({ ...prev, [id]: mode }));
@@ -270,7 +289,14 @@ function DocumentsListBody({
       onOpenDocument?.(focusedId);
     } else if (event.key === ' ' && focusedId) {
       event.preventDefault();
-      selection.toggle(focusedId);
+      if (onPreviewDocument) {
+        const doc = items.find((d) => d.id === focusedId);
+        if (doc) onPreviewDocument(doc);
+      } else {
+        // No preview handler wired → fall back to the legacy
+        // "Space toggles selection" behavior to stay accessible.
+        selection.toggle(focusedId);
+      }
     } else if (event.key === 'F2' && focusedId && canManage) {
       event.preventDefault();
       setRowMode(focusedId, 'renaming');

--- a/packages/@granit/react-documents/src/index.ts
+++ b/packages/@granit/react-documents/src/index.ts
@@ -75,6 +75,12 @@ export { useTenantStorageQuota } from './hooks/use-quota.js';
 export { DocumentDetail } from './components/document-detail.js';
 export type { DocumentDetailLabels, DocumentDetailProps } from './components/document-detail.js';
 
+export { DocumentQuickLook } from './components/document-quick-look.js';
+export type {
+  DocumentQuickLookLabels,
+  DocumentQuickLookProps,
+} from './components/document-quick-look.js';
+
 export { DocumentsExplorer } from './components/documents-explorer.js';
 export type {
   DocumentsExplorerLabels,

--- a/packages/@granit/react-documents/src/locales/en.ts
+++ b/packages/@granit/react-documents/src/locales/en.ts
@@ -148,6 +148,19 @@ export interface DocumentsTranslations {
     readonly InspectorEmpty: string;
     readonly InspectorMultiple: string;
   };
+  readonly QuickLook: {
+    readonly Title: string;
+    readonly Close: string;
+    readonly Download: string;
+    readonly Previous: string;
+    readonly Next: string;
+    readonly Loading: string;
+    readonly LoadingPreview: string;
+    readonly Unsupported: string;
+    readonly DownloadToView: string;
+    readonly PreviewError: string;
+    readonly Position: string;
+  };
 }
 
 export const documentsTranslationsEn: DocumentsTranslations = {
@@ -288,5 +301,18 @@ export const documentsTranslationsEn: DocumentsTranslations = {
     Title: 'Documents',
     InspectorEmpty: 'Select a document to see its details.',
     InspectorMultiple: '{{count}} documents selected.',
+  },
+  QuickLook: {
+    Title: 'Preview',
+    Close: 'Close',
+    Download: 'Download',
+    Previous: 'Previous',
+    Next: 'Next',
+    Loading: 'Loading…',
+    LoadingPreview: 'Loading preview…',
+    Unsupported: 'No preview available for {{kind}} files.',
+    DownloadToView: 'Download to view',
+    PreviewError: 'Failed to load preview.',
+    Position: '{{current}} / {{total}}',
   },
 };

--- a/packages/@granit/react-documents/src/locales/fr.ts
+++ b/packages/@granit/react-documents/src/locales/fr.ts
@@ -141,4 +141,17 @@ export const documentsTranslationsFr: DocumentsTranslations = {
     InspectorEmpty: 'Sélectionnez un document pour voir ses détails.',
     InspectorMultiple: '{{count}} documents sélectionnés.',
   },
+  QuickLook: {
+    Title: 'Aperçu',
+    Close: 'Fermer',
+    Download: 'Télécharger',
+    Previous: 'Précédent',
+    Next: 'Suivant',
+    Loading: 'Chargement…',
+    LoadingPreview: 'Chargement de l’aperçu…',
+    Unsupported: 'Aucun aperçu disponible pour les fichiers {{kind}}.',
+    DownloadToView: 'Télécharger pour ouvrir',
+    PreviewError: 'Échec du chargement de l’aperçu.',
+    Position: '{{current}} / {{total}}',
+  },
 };


### PR DESCRIPTION
## Summary

Finder-style Quick Look — press `Space` on the focused list row to open a full-viewport preview without leaving the explorer. Headless: ships as a native `<dialog>` with `data-granit-*` markers, apps own styling.

- **`<DocumentQuickLook documentId siblings onNavigate onClose>`** — controlled modal. Renderer dispatched on the extension-based kind:
  - image → `<img>` (`object-fit: contain`)
  - video → `<video controls autoPlay>`
  - audio → `<audio controls autoPlay>`
  - pdf → `<iframe>` (browser-native PDF viewer)
  - text / code → fetch URL via the existing axios client + render as `<pre>`, capped at 512 KB
  - other → "Download to view" placeholder
- Native `<dialog>` + `showModal()` → free focus trap, Esc-to-close, top-layer rendering (no portal dep).
- `←` / `→` walk sibling ids; header shows `n / total` position.
- **`<DocumentsList>`** — new optional `onPreviewDocument(doc)` callback bound to `Space`. When omitted, `Space` keeps its legacy "toggle selection" behavior. New `onItemsChange` so a parent can mirror the current page for sibling navigation.
- **`<DocumentsExplorer>`** — manages `previewId` + `items`, mounts QuickLook with the current page as siblings.
- i18n EN + FR: full `QuickLook.*` bundle.

## Why this shape

No new deps. PDF in iframe leverages the browser's built-in viewer (Chrome / Firefox / Safari) — good enough for v1; richer PDF interactions (annotations, etc.) can plug in `react-pdf` later. Text fetched via the same axios client so auth headers + interceptors apply automatically.

## Test plan

- [x] `pnpm vitest run packages/@granit/react-documents` — 191/191 pass (27 files). New: kind dispatch (image / pdf / text / unsupported), sibling navigation + clamping, prev/next disabled states, native close event fires onClose, Space → onPreviewDocument with fallback to selection toggle.
- [x] `pnpm eslint packages/@granit/react-documents/src/**/*.{ts,tsx} --max-warnings 0` clean
- [x] `pnpm -r --filter @granit/react-documents... build` clean
- [ ] Manual QA via showcase PR — Space opens, Esc closes, ←/→ paginate, images/PDFs/videos/audio/text all render