### PR TITLE
feat(react-documents): cmd+k palette + sidebar tabs + favorites & recents

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3355,6 +3355,21 @@
           "signature": "function DocumentQuickLook("
         },
         {
+          "name": "DocumentSearchPalette",
+          "kind": "function",
+          "signature": "function DocumentSearchPalette(props: Readonly<DocumentSearchPaletteProps>): ReactNode"
+        },
+        {
+          "name": "DocumentsSidebar",
+          "kind": "function",
+          "signature": "function DocumentsSidebar("
+        },
+        {
+          "name": "useDocumentBookmarks",
+          "kind": "function",
+          "signature": "function useDocumentBookmarks( storageKey: string | null, options: UseDocumentBookmarksOptions ="
+        },
+        {
           "name": "DocumentsExplorer",
           "kind": "function",
           "signature": "function DocumentsExplorer("

--- a/packages/@granit/react-documents/src/__tests__/document-search-palette.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/document-search-palette.test.tsx
@@ -1,0 +1,177 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DocumentSearchPalette } from '../components/document-search-palette.tsx';
+import { DocumentsProvider } from '../providers/documents-provider.js';
+
+import type { DocumentBookmark } from '../hooks/use-document-bookmarks.js';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <DocumentsProvider config={{ client }}>{children}</DocumentsProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function bookmark(id: string, name: string): DocumentBookmark {
+  return { id, name, folderId: null, recordedAt: 0 };
+}
+
+describe('DocumentSearchPalette', () => {
+  // jsdom doesn't implement <dialog>.showModal / close
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = function showModal() {
+      this.setAttribute('open', '');
+    };
+    HTMLDialogElement.prototype.close = function close() {
+      this.removeAttribute('open');
+      this.dispatchEvent(new Event('close'));
+    };
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the closed shell when open is false', () => {
+    const client = createMockClient();
+    render(<DocumentSearchPalette open={false} onClose={vi.fn()} onPickDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+    const dialog = document.querySelector<HTMLDialogElement>(
+      '[data-granit-document-search-palette]'
+    );
+    expect(dialog?.hasAttribute('open')).toBe(false);
+  });
+
+  it('opens when open=true and shows favorites + recents with an empty query', async () => {
+    const client = createMockClient();
+    render(
+      <DocumentSearchPalette
+        open
+        onClose={vi.fn()}
+        onPickDocument={vi.fn()}
+        favorites={[bookmark('doc-1', 'contract.pdf')]}
+        recents={[bookmark('doc-2', 'invoice.pdf')]}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const dialog = await waitFor(() =>
+      document.querySelector<HTMLDialogElement>('[data-granit-document-search-palette]')
+    );
+    expect(dialog?.hasAttribute('open')).toBe(true);
+    expect(screen.getByText('contract.pdf')).toBeInTheDocument();
+    expect(screen.getByText('invoice.pdf')).toBeInTheDocument();
+  });
+
+  it('dedupes when a favorite is also a recent', async () => {
+    const client = createMockClient();
+    render(
+      <DocumentSearchPalette
+        open
+        onClose={vi.fn()}
+        onPickDocument={vi.fn()}
+        favorites={[bookmark('doc-1', 'shared.pdf')]}
+        recents={[bookmark('doc-1', 'shared.pdf')]}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await waitFor(() => expect(screen.getByText('shared.pdf')).toBeInTheDocument());
+    expect(screen.getAllByText('shared.pdf').length).toBe(1);
+  });
+
+  it('debounces remote search and triggers GET /documents with a Contains filter', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      data: {
+        items: [{ id: 'doc-9', folderId: null, name: 'matching.pdf', status: 'Active' }],
+        totalCount: 1,
+        page: 1,
+        pageSize: 20,
+      },
+    });
+
+    render(<DocumentSearchPalette open onClose={vi.fn()} onPickDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const input = await waitFor(() =>
+      document.querySelector<HTMLInputElement>('[data-granit-document-search-palette-input]')
+    );
+    await userEvent.type(input!, 'match');
+
+    await waitFor(() => expect(screen.getByText('matching.pdf')).toBeInTheDocument());
+    const url = vi.mocked(client.get).mock.calls.at(-1)?.[0] ?? '';
+    expect(url).toContain('Contains');
+    expect(url).toMatch(/match/i);
+  });
+
+  it('Enter fires onPickDocument with the highlighted entry', async () => {
+    const client = createMockClient();
+    const onPick = vi.fn();
+    render(
+      <DocumentSearchPalette
+        open
+        onClose={vi.fn()}
+        onPickDocument={onPick}
+        favorites={[bookmark('doc-1', 'contract.pdf')]}
+        recents={[bookmark('doc-2', 'invoice.pdf')]}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const dialog = await waitFor(() =>
+      document.querySelector<HTMLDialogElement>('[data-granit-document-search-palette]')
+    );
+    fireEvent.keyDown(dialog!, { key: 'ArrowDown' });
+    fireEvent.keyDown(dialog!, { key: 'Enter' });
+    expect(onPick).toHaveBeenCalled();
+    expect(onPick.mock.calls[0]?.[0]).toBe('doc-2');
+  });
+
+  it('shows the no-results state for an empty remote search', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      data: { items: [], totalCount: 0, page: 1, pageSize: 20 },
+    });
+    render(
+      <DocumentSearchPalette
+        open
+        onClose={vi.fn()}
+        onPickDocument={vi.fn()}
+        labels={{ noResults: 'Nada.' }}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const input = await waitFor(() =>
+      document.querySelector<HTMLInputElement>('[data-granit-document-search-palette-input]')
+    );
+    await userEvent.type(input!, 'xyzzy');
+    await waitFor(() => expect(screen.getByText('Nada.')).toBeInTheDocument());
+  });
+
+  it('calls onClose when the dialog dispatches close', async () => {
+    const client = createMockClient();
+    const onClose = vi.fn();
+    render(<DocumentSearchPalette open onClose={onClose} onPickDocument={vi.fn()} />, {
+      wrapper: createWrapper(client),
+    });
+
+    const dialog = await waitFor(() =>
+      document.querySelector<HTMLDialogElement>('[data-granit-document-search-palette]')
+    );
+    dialog!.close();
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/documents-sidebar.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/documents-sidebar.test.tsx
@@ -1,0 +1,144 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DocumentsSidebar } from '../components/documents-sidebar.tsx';
+import { DocumentsProvider } from '../providers/documents-provider.js';
+
+import type { DocumentBookmark } from '../hooks/use-document-bookmarks.js';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const qc = createTestQueryClient();
+    return (
+      <QueryClientProvider client={qc}>
+        <DocumentsProvider config={{ client }}>{children}</DocumentsProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function bookmark(id: string, name: string): DocumentBookmark {
+  return { id, name, folderId: null, recordedAt: 0 };
+}
+
+describe('DocumentsSidebar', () => {
+  it('defaults to the folders tab and renders the FolderTree', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+
+    render(
+      <DocumentsSidebar folderTree={{}} favorites={[]} recents={[]} onPickBookmark={vi.fn()} />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const foldersBtn = screen.getByRole('tab', { name: /Folders/i });
+    expect(foldersBtn.getAttribute('aria-selected')).toBe('true');
+    expect(document.querySelector('[data-granit-folder-tree]')).not.toBeNull();
+  });
+
+  it('switches to favorites and lists bookmarks', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+    const onPick = vi.fn();
+
+    render(
+      <DocumentsSidebar
+        folderTree={{}}
+        favorites={[bookmark('doc-1', 'contract.pdf')]}
+        recents={[]}
+        onPickBookmark={onPick}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: /Favorites/i }));
+    expect(screen.getByText('contract.pdf')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('contract.pdf'));
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ id: 'doc-1' }));
+  });
+
+  it('shows an empty state on the favorites tab when none are pinned', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+
+    render(
+      <DocumentsSidebar
+        folderTree={{}}
+        favorites={[]}
+        recents={[]}
+        onPickBookmark={vi.fn()}
+        labels={{ favoritesEmpty: 'Pin docs to see them here.' }}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: /Favorites/i }));
+    expect(screen.getByText('Pin docs to see them here.')).toBeInTheDocument();
+  });
+
+  it('switches to recents and triggers onPickBookmark on click', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+    const onPick = vi.fn();
+
+    render(
+      <DocumentsSidebar
+        folderTree={{}}
+        favorites={[]}
+        recents={[bookmark('doc-2', 'invoice.pdf')]}
+        onPickBookmark={onPick}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: /Recent/i }));
+    await userEvent.click(screen.getByText('invoice.pdf'));
+    expect(onPick).toHaveBeenCalledWith(expect.objectContaining({ id: 'doc-2' }));
+  });
+
+  it('shows the favorites count badge', () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+
+    render(
+      <DocumentsSidebar
+        folderTree={{}}
+        favorites={[bookmark('a', 'a.pdf'), bookmark('b', 'b.pdf')]}
+        recents={[]}
+        onPickBookmark={vi.fn()}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    const counts = document.querySelectorAll('[data-granit-documents-sidebar-count]');
+    expect(counts[0]?.textContent).toBe('2');
+  });
+
+  it('fires onRemoveFavorite when the remove button is clicked', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { folders: [] } });
+    const onRemove = vi.fn();
+
+    render(
+      <DocumentsSidebar
+        folderTree={{}}
+        favorites={[bookmark('doc-1', 'contract.pdf')]}
+        recents={[]}
+        onPickBookmark={vi.fn()}
+        onRemoveFavorite={onRemove}
+        labels={{ removeFavorite: 'Unpin' }}
+      />,
+      { wrapper: createWrapper(client) }
+    );
+
+    await userEvent.click(screen.getByRole('tab', { name: /Favorites/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Unpin' }));
+    expect(onRemove).toHaveBeenCalledWith('doc-1');
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/use-document-bookmarks.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-bookmarks.test.tsx
@@ -1,0 +1,103 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { useDocumentBookmarks } from '../hooks/use-document-bookmarks.ts';
+
+const KEY = 'test:bookmarks';
+
+describe('useDocumentBookmarks', () => {
+  beforeEach(() => {
+    globalThis.localStorage.clear();
+  });
+  afterEach(() => {
+    globalThis.localStorage.clear();
+  });
+
+  it('starts empty', () => {
+    const { result } = renderHook(() => useDocumentBookmarks(KEY));
+    expect(result.current.favorites).toEqual([]);
+    expect(result.current.recents).toEqual([]);
+  });
+
+  it('toggleFavorite adds and removes', () => {
+    const { result } = renderHook(() => useDocumentBookmarks(KEY));
+    act(() => result.current.toggleFavorite({ id: 'doc-1', name: 'a.pdf', folderId: 'fld-1' }));
+    expect(result.current.isFavorite('doc-1')).toBe(true);
+    expect(result.current.favorites.length).toBe(1);
+
+    act(() => result.current.toggleFavorite({ id: 'doc-1', name: 'a.pdf', folderId: 'fld-1' }));
+    expect(result.current.isFavorite('doc-1')).toBe(false);
+    expect(result.current.favorites.length).toBe(0);
+  });
+
+  it('recordOpen pushes to the front and dedupes', () => {
+    const { result } = renderHook(() => useDocumentBookmarks(KEY));
+    act(() => result.current.recordOpen({ id: 'doc-1', name: 'a.pdf', folderId: null }));
+    act(() => result.current.recordOpen({ id: 'doc-2', name: 'b.pdf', folderId: null }));
+    act(() => result.current.recordOpen({ id: 'doc-1', name: 'a.pdf', folderId: null }));
+
+    expect(result.current.recents.map((r) => r.id)).toEqual(['doc-1', 'doc-2']);
+  });
+
+  it('caps recents to the configured size', () => {
+    const { result } = renderHook(() => useDocumentBookmarks(KEY, { recentsCap: 3 }));
+    for (const id of ['a', 'b', 'c', 'd', 'e']) {
+      act(() => result.current.recordOpen({ id, name: `${id}.pdf`, folderId: null }));
+    }
+    expect(result.current.recents.map((r) => r.id)).toEqual(['e', 'd', 'c']);
+  });
+
+  it('persists across mounts via localStorage', () => {
+    const first = renderHook(() => useDocumentBookmarks(KEY));
+    act(() => first.result.current.toggleFavorite({ id: 'doc-1', name: 'a.pdf', folderId: null }));
+    act(() => first.result.current.recordOpen({ id: 'doc-2', name: 'b.pdf', folderId: null }));
+
+    const second = renderHook(() => useDocumentBookmarks(KEY));
+    expect(second.result.current.favorites.map((f) => f.id)).toEqual(['doc-1']);
+    expect(second.result.current.recents.map((r) => r.id)).toEqual(['doc-2']);
+  });
+
+  it('forget removes from both lists', () => {
+    const { result } = renderHook(() => useDocumentBookmarks(KEY));
+    act(() => {
+      result.current.toggleFavorite({ id: 'doc-1', name: 'a.pdf', folderId: null });
+      result.current.recordOpen({ id: 'doc-1', name: 'a.pdf', folderId: null });
+    });
+    expect(result.current.favorites.length).toBe(1);
+    expect(result.current.recents.length).toBe(1);
+
+    act(() => result.current.forget('doc-1'));
+    expect(result.current.favorites.length).toBe(0);
+    expect(result.current.recents.length).toBe(0);
+  });
+
+  it('null storageKey keeps state in memory only', () => {
+    const { result } = renderHook(() => useDocumentBookmarks(null));
+    act(() => result.current.toggleFavorite({ id: 'doc-1', name: 'a.pdf', folderId: null }));
+    expect(result.current.favorites.length).toBe(1);
+    expect(globalThis.localStorage.length).toBe(0);
+  });
+
+  it('ignores corrupt storage payload', () => {
+    globalThis.localStorage.setItem(KEY, '{not json');
+    const { result } = renderHook(() => useDocumentBookmarks(KEY));
+    expect(result.current.favorites).toEqual([]);
+  });
+
+  it('drops malformed bookmark entries from storage', () => {
+    globalThis.localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        favorites: [
+          { id: 'doc-1', name: 'a.pdf', folderId: null, recordedAt: 1 },
+          { id: 'doc-2' }, // missing fields
+          'nope',
+        ],
+        recents: 'not-an-array',
+      })
+    );
+    const { result } = renderHook(() => useDocumentBookmarks(KEY));
+    expect(result.current.favorites.map((f) => f.id)).toEqual(['doc-1']);
+    expect(result.current.recents).toEqual([]);
+  });
+});

--- a/packages/@granit/react-documents/src/components/document-detail.tsx
+++ b/packages/@granit/react-documents/src/components/document-detail.tsx
@@ -22,6 +22,8 @@ export interface DocumentDetailLabels {
   readonly versions?: string;
   readonly shares?: string;
   readonly tags?: string;
+  readonly addFavorite?: string;
+  readonly removeFavorite?: string;
 }
 
 export interface DocumentDetailProps {
@@ -29,6 +31,14 @@ export interface DocumentDetailProps {
   readonly canManage?: boolean;
   readonly onOpenVersions?: (id: string) => void;
   readonly onOpenShares?: (id: string) => void;
+  /**
+   * When `true`, shows a filled star action. Toggling the star fires
+   * `onToggleFavorite` with the current document. Omit the prop to hide
+   * the favorite action entirely (e.g. when the host doesn't wire
+   * `useDocumentBookmarks`).
+   */
+  readonly isFavorite?: boolean;
+  readonly onToggleFavorite?: () => void;
   readonly labels?: DocumentDetailLabels;
   readonly className?: string;
 }
@@ -45,6 +55,8 @@ const DEFAULT_LABELS: Required<DocumentDetailLabels> = {
   versions: 'Versions',
   shares: 'Shares',
   tags: 'Tags',
+  addFavorite: 'Add to favorites',
+  removeFavorite: 'Remove from favorites',
 };
 
 /**
@@ -58,6 +70,8 @@ export function DocumentDetail({
   canManage = false,
   onOpenVersions,
   onOpenShares,
+  isFavorite,
+  onToggleFavorite,
   labels,
   className,
 }: DocumentDetailProps): ReactNode {
@@ -141,6 +155,18 @@ export function DocumentDetail({
         ) : (
           <h2 data-granit-document-detail-name="">
             {document.name}
+            {onToggleFavorite && (
+              <button
+                type="button"
+                data-granit-document-detail-favorite=""
+                data-granit-document-detail-favorite-on={isFavorite ? '' : undefined}
+                aria-pressed={isFavorite ?? false}
+                aria-label={isFavorite ? labelStrings.removeFavorite : labelStrings.addFavorite}
+                onClick={onToggleFavorite}
+              >
+                {isFavorite ? '★' : '☆'}
+              </button>
+            )}
             {canManage && (
               <button type="button" onClick={startEdit} aria-label={labelStrings.rename}>
                 {labelStrings.rename}

--- a/packages/@granit/react-documents/src/components/document-search-palette.tsx
+++ b/packages/@granit/react-documents/src/components/document-search-palette.tsx
@@ -1,0 +1,420 @@
+import { QueryProvider, useQueryEndpoint } from '@granit/react-query-engine';
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import { useDocumentsConfig } from '../providers/documents-provider.js';
+
+import { classifyDocumentName, documentBadge } from './document-kind.js';
+
+import type { DocumentBookmark } from '../hooks/use-document-bookmarks.js';
+import type { DocumentResponse } from '@granit/documents';
+import type { FilterEntry, SortEntry } from '@granit/query-engine';
+import type { ChangeEvent, KeyboardEvent as ReactKeyboardEvent, ReactNode } from 'react';
+
+const SEARCH_QUERY_KEY_PREFIX = ['documents', 'documents', 'search'] as const;
+const DEFAULT_LIMIT = 20;
+const SEARCH_DEBOUNCE_MS = 200;
+
+export interface DocumentSearchPaletteLabels {
+  readonly title?: string;
+  readonly placeholder?: string;
+  readonly searching?: string;
+  readonly noResults?: string;
+  readonly recents?: string;
+  readonly favorites?: string;
+  readonly results?: string;
+  readonly close?: string;
+  readonly hint?: string;
+}
+
+export interface DocumentSearchPaletteProps {
+  /** When `true`, the modal is open. */
+  readonly open: boolean;
+  readonly onClose: () => void;
+  /** Called when the user picks a result (Enter or click). */
+  readonly onPickDocument: (id: string, doc: DocumentResponse | DocumentBookmark) => void;
+  /** Recent bookmarks shown when the query is empty. */
+  readonly recents?: readonly DocumentBookmark[];
+  /** Favorite bookmarks shown when the query is empty. */
+  readonly favorites?: readonly DocumentBookmark[];
+  /** Cap results per page. Defaults to 20. */
+  readonly limit?: number;
+  readonly labels?: DocumentSearchPaletteLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<DocumentSearchPaletteLabels> = {
+  title: 'Search documents',
+  placeholder: 'Type a name…',
+  searching: 'Searching…',
+  noResults: 'No results.',
+  recents: 'Recent',
+  favorites: 'Favorites',
+  results: 'Results',
+  close: 'Close',
+  hint: '↑↓ to navigate, ↵ to open, Esc to close',
+};
+
+/**
+ * Command-palette style document search — `⌘K` / `Ctrl+K` opens it from
+ * the explorer. Live full-text search over the QueryEngine
+ * `name Contains <query>` filter (debounced), with arrow-key navigation
+ * and Enter to open. When the query is empty, falls back to two ranked
+ * sections — Favorites + Recents — so the modal is useful as a "jump to
+ * recently opened" launcher even without typing.
+ *
+ * Self-mounts a `<QueryProvider>` so it can be dropped anywhere under
+ * `<DocumentsProvider>` without the caller wiring the basePath. The modal
+ * uses the native `<dialog>` element (focus trap + Esc gratis); apps own
+ * the visual layer via `data-granit-document-search-*` markers.
+ */
+export function DocumentSearchPalette(props: Readonly<DocumentSearchPaletteProps>): ReactNode {
+  const config = useDocumentsConfig();
+  if (!props.open) {
+    // Render the closed-dialog shell so the ref-driven open effect inside
+    // the body can still toggle on first prop flip without a remount jitter.
+    return <ClosedDialogShell />;
+  }
+  return (
+    <QueryProvider
+      config={{
+        client: config.client,
+        basePath: `${config.basePath}/documents`,
+        queryKeyPrefix: [...SEARCH_QUERY_KEY_PREFIX],
+      }}
+    >
+      <DocumentSearchPaletteBody {...props} />
+    </QueryProvider>
+  );
+}
+
+function ClosedDialogShell(): ReactNode {
+  return <dialog data-granit-document-search-palette="" aria-hidden hidden />;
+}
+
+interface PickableEntry {
+  readonly id: string;
+  readonly name: string;
+  readonly folderId: string | null;
+  readonly source: 'result' | 'favorite' | 'recent';
+}
+
+function bookmarkToEntry(b: DocumentBookmark, source: 'favorite' | 'recent'): PickableEntry {
+  return { id: b.id, name: b.name, folderId: b.folderId, source };
+}
+
+function DocumentSearchPaletteBody({
+  open,
+  onClose,
+  onPickDocument,
+  recents,
+  favorites,
+  limit,
+  labels,
+  className,
+}: Readonly<DocumentSearchPaletteProps>): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const dialogRef = useRef<HTMLDialogElement | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const [draftQuery, setDraftQuery] = useState('');
+  const [activeQuery, setActiveQuery] = useState('');
+  const [highlight, setHighlight] = useState(0);
+
+  // Reset state on every open so the palette doesn't show stale results.
+  useEffect(() => {
+    if (open) {
+      setDraftQuery('');
+      setActiveQuery('');
+      setHighlight(0);
+    }
+  }, [open]);
+
+  // Debounce — fires the QueryEngine call ~200 ms after the user stops typing
+  // to avoid hammering the server on every keystroke. A trimmed query of
+  // length 0 short-circuits to "no remote query" so we don't ship an empty
+  // Contains filter (the backend would return everything in the folder).
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      setActiveQuery(draftQuery.trim());
+    }, SEARCH_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+  }, [draftQuery]);
+
+  // Sync the native <dialog> open state with the `open` prop.
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) return;
+    if (open && !dialog.open) {
+      try {
+        dialog.showModal();
+      } catch {
+        /* jsdom corner cases */
+      }
+      // Defer focus until after layout — `showModal()` doesn't always grab.
+      queueMicrotask(() => inputRef.current?.focus());
+    } else if (!open && dialog.open) {
+      dialog.close();
+    }
+  }, [open]);
+
+  const effectiveLimit = limit ?? DEFAULT_LIMIT;
+  const initialFilters: readonly FilterEntry[] = useMemo(
+    () => [{ field: 'status', operator: 'Eq', value: 'Active' }],
+    []
+  );
+  const sort: readonly SortEntry[] = useMemo(() => [{ field: 'name', direction: 'asc' }], []);
+
+  const { query, setFilters } = useQueryEndpoint<DocumentResponse>({
+    initialParams: {
+      page: 1,
+      pageSize: effectiveLimit,
+      filters: initialFilters,
+      sort,
+    },
+    // Only hit the network when there's actually a query — empty searches
+    // are served from the local Favorites / Recents lists.
+    enabled: activeQuery.length > 0,
+  });
+
+  // Push the live `Contains` filter into the reducer whenever the debounced
+  // active query changes. The reducer only captures `initialParams` once at
+  // mount, so subsequent filter shape changes have to go through `setFilters`.
+  useEffect(() => {
+    if (activeQuery.length === 0) {
+      setFilters([{ field: 'status', operator: 'Eq', value: 'Active' }]);
+      return;
+    }
+    setFilters([
+      { field: 'status', operator: 'Eq', value: 'Active' },
+      { field: 'name', operator: 'Contains', value: activeQuery },
+    ]);
+  }, [activeQuery, setFilters]);
+
+  // Merge the visible items into a flat ordered list so arrow-key nav
+  // walks a single index regardless of section. Search results take
+  // precedence when present; otherwise fall back to favorites + recents.
+  const entries: readonly PickableEntry[] = useMemo(() => {
+    if (activeQuery.length > 0) {
+      const items = query.data?.items ?? [];
+      return items.map<PickableEntry>((d) => ({
+        id: d.id,
+        name: d.name,
+        folderId: d.folderId,
+        source: 'result',
+      }));
+    }
+    const out: PickableEntry[] = [];
+    for (const f of favorites ?? []) out.push(bookmarkToEntry(f, 'favorite'));
+    for (const r of recents ?? []) {
+      if (!out.some((e) => e.id === r.id)) out.push(bookmarkToEntry(r, 'recent'));
+    }
+    return out;
+  }, [activeQuery, query.data, favorites, recents]);
+
+  // Clamp the highlight when entries shrink (e.g. user typed → fewer matches).
+  useEffect(() => {
+    if (highlight >= entries.length) setHighlight(Math.max(0, entries.length - 1));
+  }, [entries.length, highlight]);
+
+  function handleKeyDown(event: ReactKeyboardEvent<HTMLDialogElement>): void {
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setHighlight((h) => Math.min(entries.length - 1, h + 1));
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setHighlight((h) => Math.max(0, h - 1));
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const picked = entries[highlight];
+      if (!picked) return;
+      onPickDocument(picked.id, {
+        id: picked.id,
+        name: picked.name,
+        folderId: picked.folderId,
+        recordedAt: Date.now(),
+      });
+    }
+  }
+
+  function handleInputChange(event: ChangeEvent<HTMLInputElement>): void {
+    setDraftQuery(event.target.value);
+    setHighlight(0);
+  }
+
+  const hasQuery = activeQuery.length > 0;
+  const isLoading = hasQuery && query.isLoading;
+  const isEmpty = hasQuery && !isLoading && entries.length === 0;
+
+  return (
+    <dialog
+      ref={dialogRef}
+      data-granit-document-search-palette=""
+      aria-label={labelStrings.title}
+      className={className}
+      onClose={onClose}
+      onCancel={onClose}
+      onKeyDown={handleKeyDown}
+    >
+      <div data-granit-document-search-palette-input-row="">
+        <input
+          ref={inputRef}
+          type="search"
+          data-granit-document-search-palette-input=""
+          value={draftQuery}
+          aria-label={labelStrings.title}
+          placeholder={labelStrings.placeholder}
+          onChange={handleInputChange}
+        />
+        <button
+          type="button"
+          data-granit-document-search-palette-close=""
+          aria-label={labelStrings.close}
+          onClick={onClose}
+        >
+          ×
+        </button>
+      </div>
+      <div data-granit-document-search-palette-body="">
+        {isLoading && (
+          <div data-granit-document-search-palette-loading="">{labelStrings.searching}</div>
+        )}
+        {isEmpty && (
+          <div data-granit-document-search-palette-empty="">{labelStrings.noResults}</div>
+        )}
+        {!hasQuery && entries.length > 0 && (
+          <SectionedEntries
+            entries={entries}
+            highlight={highlight}
+            labels={labelStrings}
+            onPick={(picked) =>
+              onPickDocument(picked.id, {
+                id: picked.id,
+                name: picked.name,
+                folderId: picked.folderId,
+                recordedAt: Date.now(),
+              })
+            }
+            onHover={setHighlight}
+          />
+        )}
+        {hasQuery && !isLoading && entries.length > 0 && (
+          <ul
+            data-granit-document-search-palette-list=""
+            data-granit-document-search-palette-section="results"
+          >
+            {entries.map((entry, index) => (
+              <EntryRow
+                key={`${entry.source}-${entry.id}`}
+                entry={entry}
+                highlighted={index === highlight}
+                onPick={() =>
+                  onPickDocument(entry.id, {
+                    id: entry.id,
+                    name: entry.name,
+                    folderId: entry.folderId,
+                    recordedAt: Date.now(),
+                  })
+                }
+                onHover={() => setHighlight(index)}
+              />
+            ))}
+          </ul>
+        )}
+      </div>
+      <footer data-granit-document-search-palette-footer="">
+        <span>{labelStrings.hint}</span>
+      </footer>
+    </dialog>
+  );
+}
+
+interface SectionedEntriesProps {
+  readonly entries: readonly PickableEntry[];
+  readonly highlight: number;
+  readonly labels: Required<DocumentSearchPaletteLabels>;
+  readonly onPick: (entry: PickableEntry) => void;
+  readonly onHover: (index: number) => void;
+}
+
+function SectionedEntries({
+  entries,
+  highlight,
+  labels,
+  onPick,
+  onHover,
+}: SectionedEntriesProps): ReactNode {
+  const favorites = entries.filter((e) => e.source === 'favorite');
+  const recents = entries.filter((e) => e.source === 'recent');
+  const indexOf = (entry: PickableEntry): number => entries.indexOf(entry);
+
+  return (
+    <>
+      {favorites.length > 0 && (
+        <ul
+          data-granit-document-search-palette-list=""
+          data-granit-document-search-palette-section="favorites"
+        >
+          <li data-granit-document-search-palette-section-title="">{labels.favorites}</li>
+          {favorites.map((entry) => {
+            const index = indexOf(entry);
+            return (
+              <EntryRow
+                key={`fav-${entry.id}`}
+                entry={entry}
+                highlighted={index === highlight}
+                onPick={() => onPick(entry)}
+                onHover={() => onHover(index)}
+              />
+            );
+          })}
+        </ul>
+      )}
+      {recents.length > 0 && (
+        <ul
+          data-granit-document-search-palette-list=""
+          data-granit-document-search-palette-section="recents"
+        >
+          <li data-granit-document-search-palette-section-title="">{labels.recents}</li>
+          {recents.map((entry) => {
+            const index = indexOf(entry);
+            return (
+              <EntryRow
+                key={`rec-${entry.id}`}
+                entry={entry}
+                highlighted={index === highlight}
+                onPick={() => onPick(entry)}
+                onHover={() => onHover(index)}
+              />
+            );
+          })}
+        </ul>
+      )}
+    </>
+  );
+}
+
+interface EntryRowProps {
+  readonly entry: PickableEntry;
+  readonly highlighted: boolean;
+  readonly onPick: () => void;
+  readonly onHover: () => void;
+}
+
+function EntryRow({ entry, highlighted, onPick, onHover }: EntryRowProps): ReactNode {
+  const kind = classifyDocumentName(entry.name);
+  const badge = documentBadge(entry.name);
+  return (
+    <li
+      data-granit-document-search-palette-entry=""
+      data-granit-document-id={entry.id}
+      data-granit-document-kind={kind}
+      data-granit-document-search-palette-source={entry.source}
+      data-granit-document-search-palette-highlighted={highlighted ? '' : undefined}
+      onMouseMove={onHover}
+    >
+      <button type="button" data-granit-document-search-palette-entry-button="" onClick={onPick}>
+        <span data-granit-document-search-palette-entry-badge="">{badge}</span>
+        <span data-granit-document-search-palette-entry-name="">{entry.name}</span>
+      </button>
+    </li>
+  );
+}

--- a/packages/@granit/react-documents/src/components/documents-explorer.tsx
+++ b/packages/@granit/react-documents/src/components/documents-explorer.tsx
@@ -1,21 +1,25 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { useDocumentBookmarks } from '../hooks/use-document-bookmarks.js';
 import { useFolder } from '../hooks/use-folders.js';
 import { useViewPreferences } from '../hooks/use-view-preferences.js';
 
 import { DocumentDetail } from './document-detail.js';
 import { DocumentQuickLook } from './document-quick-look.js';
+import { DocumentSearchPalette } from './document-search-palette.js';
 import { DocumentsList } from './documents-list.js';
+import { DocumentsSidebar } from './documents-sidebar.js';
 import { DocumentsToolbar } from './documents-toolbar.js';
 import { FolderBreadcrumb } from './folder-breadcrumb.js';
-import { FolderTree } from './folder-tree.js';
 import { QuotaBadge } from './quota-badge.js';
 import { UploadButton } from './upload-button.js';
 import { UploadDropZone } from './upload-drop-zone.js';
 
 import type { DocumentDetailLabels } from './document-detail.js';
 import type { DocumentQuickLookLabels } from './document-quick-look.js';
+import type { DocumentSearchPaletteLabels } from './document-search-palette.js';
 import type { DocumentsListLabels } from './documents-list.js';
+import type { DocumentsSidebarLabels } from './documents-sidebar.js';
 import type { DocumentsToolbarLabels } from './documents-toolbar.js';
 import type { FolderBreadcrumbLabels } from './folder-breadcrumb.js';
 import type { FolderTreeLabels } from './folder-tree.js';
@@ -36,6 +40,8 @@ export interface DocumentsExplorerLabels {
   readonly dropZone?: UploadDropZoneLabels;
   readonly detail?: DocumentDetailLabels;
   readonly quickLook?: DocumentQuickLookLabels;
+  readonly searchPalette?: DocumentSearchPaletteLabels;
+  readonly sidebar?: DocumentsSidebarLabels;
 }
 
 export interface DocumentsExplorerProps {
@@ -52,6 +58,18 @@ export interface DocumentsExplorerProps {
    * pass a tenant-scoped key.
    */
   readonly viewPreferencesStorageKey?: string | null;
+  /**
+   * `localStorage` key for favorites + recent documents. Pass `null` to
+   * disable persistence (state still works in-memory). Defaults to
+   * `granit-documents-bookmarks`.
+   */
+  readonly bookmarksStorageKey?: string | null;
+  /**
+   * Enable the global Cmd+K / Ctrl+K shortcut to open the search palette.
+   * Defaults to `true`. Set to `false` if the host app already owns that
+   * shortcut at a higher level.
+   */
+  readonly enableSearchShortcut?: boolean;
   readonly onOpenDocument?: (id: string) => void;
   readonly labels?: DocumentsExplorerLabels;
   readonly className?: string;
@@ -93,6 +111,8 @@ export function DocumentsExplorer({
   showQuotaBadge = false,
   showInspector = true,
   viewPreferencesStorageKey = 'granit-documents-view',
+  bookmarksStorageKey = 'granit-documents-bookmarks',
+  enableSearchShortcut = true,
   onOpenDocument,
   labels,
   className,
@@ -105,9 +125,11 @@ export function DocumentsExplorer({
   const [items, setItems] = useState<readonly DocumentResponse[]>([]);
   const [previewId, setPreviewId] = useState<string | null>(null);
   const [inspectorVisible, setInspectorVisible] = useState(showInspector);
+  const [searchOpen, setSearchOpen] = useState(false);
   const [clearSignal, setClearSignal] = useState(0);
   const { viewMode, tileSize, setViewMode, setTileSize } =
     useViewPreferences(viewPreferencesStorageKey);
+  const bookmarks = useDocumentBookmarks(bookmarksStorageKey);
 
   // Watch the live status of the current selection. After a trash mutation
   // (direct or cascading from an ancestor), the cache is invalidated and
@@ -158,6 +180,50 @@ export function DocumentsExplorer({
     setClearSignal((n) => n + 1);
   }, []);
 
+  // Wrap the host's onOpenDocument so every open also records the doc in
+  // the recents list. Bookmarks need name + folderId to render in the
+  // sidebar without re-fetching, so we pull them from the items the list
+  // already gave us.
+  const handleOpenDocument = useCallback(
+    (id: string) => {
+      const match = items.find((d) => d.id === id);
+      if (match) {
+        bookmarks.recordOpen({ id: match.id, name: match.name, folderId: match.folderId });
+      }
+      onOpenDocument?.(id);
+    },
+    [items, bookmarks, onOpenDocument]
+  );
+
+  // Cmd+K / Ctrl+K opens the search palette. Skip when an input / textarea
+  // / contenteditable is focused so we don't hijack typing in those fields.
+  useEffect(() => {
+    if (!enableSearchShortcut) return;
+    if (typeof globalThis.window === 'undefined') return;
+    const win = globalThis.window;
+    function handler(event: KeyboardEvent): void {
+      if ((event.ctrlKey || event.metaKey) && event.key.toLowerCase() === 'k') {
+        const target = event.target as HTMLElement | null;
+        const tag = target?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target?.isContentEditable) return;
+        event.preventDefault();
+        setSearchOpen(true);
+      }
+    }
+    win.addEventListener('keydown', handler);
+    return () => win.removeEventListener('keydown', handler);
+  }, [enableSearchShortcut]);
+
+  const focusedIsFavorite = focusedDoc ? bookmarks.isFavorite(focusedDoc.id) : false;
+  const handleToggleFavorite = useCallback(() => {
+    if (!focusedDoc) return;
+    bookmarks.toggleFavorite({
+      id: focusedDoc.id,
+      name: focusedDoc.name,
+      folderId: focusedDoc.folderId,
+    });
+  }, [focusedDoc, bookmarks]);
+
   const folderId = currentFolder?.id ?? '';
 
   return (
@@ -173,13 +239,25 @@ export function DocumentsExplorer({
         }
       >
         <aside data-granit-documents-explorer-tree="">
-          <FolderTree
-            rootFolderId={rootFolderId}
-            canManage={canManage}
-            currentFolderId={currentFolder?.id ?? null}
-            onSelect={setCurrentFolder}
-            onDeleted={handleFolderDeleted}
-            labels={labels?.tree}
+          <DocumentsSidebar
+            folderTree={{
+              rootFolderId,
+              canManage,
+              currentFolderId: currentFolder?.id ?? null,
+              onSelect: setCurrentFolder,
+              onDeleted: handleFolderDeleted,
+            }}
+            favorites={bookmarks.favorites}
+            recents={bookmarks.recents}
+            onPickBookmark={(bookmark) => handleOpenDocument(bookmark.id)}
+            onRemoveFavorite={bookmarks.removeFavorite}
+            labels={
+              labels?.sidebar
+                ? { ...labels.sidebar, tree: labels.tree }
+                : labels?.tree
+                  ? { tree: labels.tree }
+                  : undefined
+            }
           />
         </aside>
         <UploadDropZone
@@ -224,7 +302,7 @@ export function DocumentsExplorer({
               viewMode={viewMode}
               tileSize={tileSize}
               clearSignal={clearSignal}
-              onOpenDocument={onOpenDocument}
+              onOpenDocument={handleOpenDocument}
               onPreviewDocument={(doc) => setPreviewId(doc.id)}
               onSelectionChange={handleSelectionChange}
               onFocusChange={setFocusedDoc}
@@ -240,12 +318,25 @@ export function DocumentsExplorer({
           onClose={() => setPreviewId(null)}
           labels={labels?.quickLook}
         />
+        <DocumentSearchPalette
+          open={searchOpen}
+          onClose={() => setSearchOpen(false)}
+          recents={bookmarks.recents}
+          favorites={bookmarks.favorites}
+          onPickDocument={(id) => {
+            setSearchOpen(false);
+            handleOpenDocument(id);
+          }}
+          labels={labels?.searchPalette}
+        />
         {showInspector && inspectorVisible && (
           <aside data-granit-documents-explorer-inspector="">
             {focusedDoc ? (
               <DocumentDetail
                 documentId={focusedDoc.id}
                 canManage={canManage}
+                isFavorite={focusedIsFavorite}
+                onToggleFavorite={handleToggleFavorite}
                 labels={labels?.detail}
               />
             ) : selectedIds.size > 1 ? (

--- a/packages/@granit/react-documents/src/components/documents-sidebar.tsx
+++ b/packages/@granit/react-documents/src/components/documents-sidebar.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+
+import { classifyDocumentName, documentBadge } from './document-kind.js';
+import { FolderTree } from './folder-tree.js';
+
+import type { FolderTreeLabels, FolderTreeProps } from './folder-tree.js';
+import type { DocumentBookmark } from '../hooks/use-document-bookmarks.js';
+import type { FolderResponse } from '@granit/documents';
+import type { ReactNode } from 'react';
+
+export type DocumentsSidebarTab = 'folders' | 'favorites' | 'recents';
+
+export interface DocumentsSidebarLabels {
+  readonly foldersTab?: string;
+  readonly favoritesTab?: string;
+  readonly recentsTab?: string;
+  readonly favoritesEmpty?: string;
+  readonly recentsEmpty?: string;
+  readonly removeFavorite?: string;
+  readonly tree?: FolderTreeLabels;
+}
+
+export interface DocumentsSidebarProps {
+  /** Folder tree props forwarded verbatim — the sidebar owns the tab shell. */
+  readonly folderTree: Omit<FolderTreeProps, 'labels' | 'onSelect'> & {
+    readonly onSelect?: (folder: FolderResponse) => void;
+  };
+  readonly favorites: readonly DocumentBookmark[];
+  readonly recents: readonly DocumentBookmark[];
+  /** Opens a document — wired to the explorer's `onOpenDocument`. */
+  readonly onPickBookmark: (bookmark: DocumentBookmark) => void;
+  /** Optional unpin action; when omitted, favorites are read-only. */
+  readonly onRemoveFavorite?: (id: string) => void;
+  readonly labels?: DocumentsSidebarLabels;
+  readonly className?: string;
+}
+
+const DEFAULT_LABELS: Required<Omit<DocumentsSidebarLabels, 'tree'>> = {
+  foldersTab: 'Folders',
+  favoritesTab: 'Favorites',
+  recentsTab: 'Recent',
+  favoritesEmpty: 'No favorites yet. Star a document in the inspector to pin it here.',
+  recentsEmpty: 'No recent documents. Open one to see it here.',
+  removeFavorite: 'Remove favorite',
+};
+
+/**
+ * Tabbed left-pane shell for the documents explorer. Three sections:
+ *
+ * - **Folders** — wraps the existing `<FolderTree>`.
+ * - **Favorites** — pinned bookmarks (from `useDocumentBookmarks`).
+ * - **Recents** — auto-recorded list of last-opened documents.
+ *
+ * Tab state is local — switches do not refetch folders (the tree's lazy
+ * loading is preserved). Bookmark sections are flat lists; clicking an
+ * item fires `onPickBookmark` (the explorer routes this through its
+ * own `onOpenDocument`, which also feeds the recents recorder, so an
+ * opened recent stays at the top).
+ */
+export function DocumentsSidebar({
+  folderTree,
+  favorites,
+  recents,
+  onPickBookmark,
+  onRemoveFavorite,
+  labels,
+  className,
+}: DocumentsSidebarProps): ReactNode {
+  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const [activeTab, setActiveTab] = useState<DocumentsSidebarTab>('folders');
+
+  return (
+    <div data-granit-documents-sidebar="" className={className}>
+      <nav
+        data-granit-documents-sidebar-tabs=""
+        role="tablist"
+        aria-label={labelStrings.foldersTab}
+      >
+        <button
+          type="button"
+          role="tab"
+          data-granit-documents-sidebar-tab="folders"
+          aria-selected={activeTab === 'folders'}
+          aria-pressed={activeTab === 'folders'}
+          onClick={() => setActiveTab('folders')}
+        >
+          {labelStrings.foldersTab}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          data-granit-documents-sidebar-tab="favorites"
+          aria-selected={activeTab === 'favorites'}
+          aria-pressed={activeTab === 'favorites'}
+          onClick={() => setActiveTab('favorites')}
+        >
+          {labelStrings.favoritesTab}
+          {favorites.length > 0 && (
+            <span data-granit-documents-sidebar-count="">{favorites.length}</span>
+          )}
+        </button>
+        <button
+          type="button"
+          role="tab"
+          data-granit-documents-sidebar-tab="recents"
+          aria-selected={activeTab === 'recents'}
+          aria-pressed={activeTab === 'recents'}
+          onClick={() => setActiveTab('recents')}
+        >
+          {labelStrings.recentsTab}
+          {recents.length > 0 && (
+            <span data-granit-documents-sidebar-count="">{recents.length}</span>
+          )}
+        </button>
+      </nav>
+      <div
+        data-granit-documents-sidebar-panel=""
+        data-granit-documents-sidebar-active-tab={activeTab}
+        role="tabpanel"
+      >
+        {activeTab === 'folders' && <FolderTree {...folderTree} labels={labels?.tree} />}
+        {activeTab === 'favorites' && (
+          <BookmarkList
+            bookmarks={favorites}
+            emptyLabel={labelStrings.favoritesEmpty}
+            onPick={onPickBookmark}
+            onRemove={onRemoveFavorite}
+            removeLabel={labelStrings.removeFavorite}
+          />
+        )}
+        {activeTab === 'recents' && (
+          <BookmarkList
+            bookmarks={recents}
+            emptyLabel={labelStrings.recentsEmpty}
+            onPick={onPickBookmark}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+interface BookmarkListProps {
+  readonly bookmarks: readonly DocumentBookmark[];
+  readonly emptyLabel: string;
+  readonly onPick: (bookmark: DocumentBookmark) => void;
+  readonly onRemove?: (id: string) => void;
+  readonly removeLabel?: string;
+}
+
+function BookmarkList({
+  bookmarks,
+  emptyLabel,
+  onPick,
+  onRemove,
+  removeLabel,
+}: BookmarkListProps): ReactNode {
+  if (bookmarks.length === 0) {
+    return <p data-granit-documents-sidebar-empty="">{emptyLabel}</p>;
+  }
+  return (
+    <ul data-granit-documents-sidebar-list="">
+      {bookmarks.map((bookmark) => {
+        const kind = classifyDocumentName(bookmark.name);
+        return (
+          <li
+            key={bookmark.id}
+            data-granit-documents-sidebar-item=""
+            data-granit-document-id={bookmark.id}
+            data-granit-document-kind={kind}
+          >
+            <button
+              type="button"
+              data-granit-documents-sidebar-item-pick=""
+              onClick={() => onPick(bookmark)}
+            >
+              <span data-granit-documents-sidebar-item-badge="">
+                {documentBadge(bookmark.name)}
+              </span>
+              <span data-granit-documents-sidebar-item-name="">{bookmark.name}</span>
+            </button>
+            {onRemove && removeLabel && (
+              <button
+                type="button"
+                data-granit-documents-sidebar-item-remove=""
+                aria-label={removeLabel}
+                onClick={() => onRemove(bookmark.id)}
+              >
+                ×
+              </button>
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/packages/@granit/react-documents/src/hooks/use-document-bookmarks.ts
+++ b/packages/@granit/react-documents/src/hooks/use-document-bookmarks.ts
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useState } from 'react';
+
+export interface DocumentBookmark {
+  readonly id: string;
+  readonly name: string;
+  readonly folderId: string | null;
+  /** Unix ms — used to sort recents and decay favorites in future versions. */
+  readonly recordedAt: number;
+}
+
+export interface DocumentBookmarksApi {
+  readonly favorites: readonly DocumentBookmark[];
+  readonly recents: readonly DocumentBookmark[];
+  readonly isFavorite: (id: string) => boolean;
+  readonly toggleFavorite: (entry: Omit<DocumentBookmark, 'recordedAt'>) => void;
+  readonly recordOpen: (entry: Omit<DocumentBookmark, 'recordedAt'>) => void;
+  readonly removeFavorite: (id: string) => void;
+  readonly forget: (id: string) => void;
+}
+
+interface StoredBookmarks {
+  readonly favorites?: readonly DocumentBookmark[];
+  readonly recents?: readonly DocumentBookmark[];
+}
+
+const DEFAULT_RECENTS_CAP = 20;
+
+function isBookmark(value: unknown): value is DocumentBookmark {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    typeof obj.id === 'string' &&
+    typeof obj.name === 'string' &&
+    (obj.folderId === null || typeof obj.folderId === 'string') &&
+    typeof obj.recordedAt === 'number'
+  );
+}
+
+function readStorage(key: string): StoredBookmarks | null {
+  if (typeof globalThis.localStorage === 'undefined') return null;
+  try {
+    const raw = globalThis.localStorage.getItem(key);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredBookmarks;
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key: string, value: StoredBookmarks): void {
+  if (typeof globalThis.localStorage === 'undefined') return;
+  try {
+    globalThis.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* quota / disabled — silently ignore */
+  }
+}
+
+export interface UseDocumentBookmarksOptions {
+  /** Max recents to keep. Defaults to 20. Older entries fall off the end. */
+  readonly recentsCap?: number;
+}
+
+/**
+ * Manages two ordered bookmark lists in `localStorage`:
+ *
+ * - **Favorites** — explicit user pins. Toggled via `toggleFavorite`. Survive
+ *   reloads; safe to render as a sidebar without re-fetching the underlying
+ *   documents (denormalized name + folder id).
+ * - **Recents** — auto-recorded when the explorer opens a document. Ring
+ *   buffer capped at `recentsCap` (20 by default). The most recent entry is
+ *   pulled to the front on every reopen.
+ *
+ * Pass `null` as `storageKey` to disable persistence (in-memory only) —
+ * useful for tests and stateless mounts. Both lists prune themselves of
+ * stale entries via `forget(id)` when a document goes away (trashed or
+ * permanently deleted) and the consumer wires the callback.
+ */
+export function useDocumentBookmarks(
+  storageKey: string | null,
+  options: UseDocumentBookmarksOptions = {}
+): DocumentBookmarksApi {
+  const cap = options.recentsCap ?? DEFAULT_RECENTS_CAP;
+  const [favorites, setFavorites] = useState<readonly DocumentBookmark[]>([]);
+  const [recents, setRecents] = useState<readonly DocumentBookmark[]>([]);
+
+  useEffect(() => {
+    if (!storageKey) return;
+    const stored = readStorage(storageKey);
+    if (!stored) return;
+    if (Array.isArray(stored.favorites)) {
+      setFavorites(stored.favorites.filter(isBookmark));
+    }
+    if (Array.isArray(stored.recents)) {
+      setRecents(stored.recents.filter(isBookmark).slice(0, cap));
+    }
+  }, [storageKey, cap]);
+
+  // Persist on every state change. The dep array keeps both lists in sync
+  // even when only one of them updates.
+  useEffect(() => {
+    if (!storageKey) return;
+    writeStorage(storageKey, { favorites, recents });
+  }, [storageKey, favorites, recents]);
+
+  const isFavorite = useCallback((id: string) => favorites.some((f) => f.id === id), [favorites]);
+
+  const toggleFavorite = useCallback((entry: Omit<DocumentBookmark, 'recordedAt'>) => {
+    setFavorites((prev) => {
+      const existing = prev.find((f) => f.id === entry.id);
+      if (existing) return prev.filter((f) => f.id !== entry.id);
+      const bookmark: DocumentBookmark = { ...entry, recordedAt: Date.now() };
+      return [bookmark, ...prev];
+    });
+  }, []);
+
+  const removeFavorite = useCallback((id: string) => {
+    setFavorites((prev) => prev.filter((f) => f.id !== id));
+  }, []);
+
+  const recordOpen = useCallback(
+    (entry: Omit<DocumentBookmark, 'recordedAt'>) => {
+      setRecents((prev) => {
+        const bookmark: DocumentBookmark = { ...entry, recordedAt: Date.now() };
+        const filtered = prev.filter((r) => r.id !== entry.id);
+        return [bookmark, ...filtered].slice(0, cap);
+      });
+    },
+    [cap]
+  );
+
+  const forget = useCallback((id: string) => {
+    setFavorites((prev) => prev.filter((f) => f.id !== id));
+    setRecents((prev) => prev.filter((r) => r.id !== id));
+  }, []);
+
+  return {
+    favorites,
+    recents,
+    isFavorite,
+    toggleFavorite,
+    recordOpen,
+    removeFavorite,
+    forget,
+  };
+}

--- a/packages/@granit/react-documents/src/index.ts
+++ b/packages/@granit/react-documents/src/index.ts
@@ -81,6 +81,26 @@ export type {
   DocumentQuickLookProps,
 } from './components/document-quick-look.js';
 
+export { DocumentSearchPalette } from './components/document-search-palette.js';
+export type {
+  DocumentSearchPaletteLabels,
+  DocumentSearchPaletteProps,
+} from './components/document-search-palette.js';
+
+export { DocumentsSidebar } from './components/documents-sidebar.js';
+export type {
+  DocumentsSidebarLabels,
+  DocumentsSidebarProps,
+  DocumentsSidebarTab,
+} from './components/documents-sidebar.js';
+
+export { useDocumentBookmarks } from './hooks/use-document-bookmarks.js';
+export type {
+  DocumentBookmark,
+  DocumentBookmarksApi,
+  UseDocumentBookmarksOptions,
+} from './hooks/use-document-bookmarks.js';
+
 export { DocumentsExplorer } from './components/documents-explorer.js';
 export type {
   DocumentsExplorerLabels,

--- a/packages/@granit/react-documents/src/locales/en.ts
+++ b/packages/@granit/react-documents/src/locales/en.ts
@@ -42,6 +42,8 @@ export interface DocumentsTranslations {
       readonly Versions: string;
       readonly Shares: string;
       readonly Tags: string;
+      readonly AddFavorite: string;
+      readonly RemoveFavorite: string;
     };
     readonly List: {
       readonly Empty: string;
@@ -161,6 +163,25 @@ export interface DocumentsTranslations {
     readonly PreviewError: string;
     readonly Position: string;
   };
+  readonly SearchPalette: {
+    readonly Title: string;
+    readonly Placeholder: string;
+    readonly Searching: string;
+    readonly NoResults: string;
+    readonly Recents: string;
+    readonly Favorites: string;
+    readonly Results: string;
+    readonly Close: string;
+    readonly Hint: string;
+  };
+  readonly Sidebar: {
+    readonly FoldersTab: string;
+    readonly FavoritesTab: string;
+    readonly RecentsTab: string;
+    readonly FavoritesEmpty: string;
+    readonly RecentsEmpty: string;
+    readonly RemoveFavorite: string;
+  };
 }
 
 export const documentsTranslationsEn: DocumentsTranslations = {
@@ -196,6 +217,8 @@ export const documentsTranslationsEn: DocumentsTranslations = {
       Versions: 'Versions',
       Shares: 'Shares',
       Tags: 'Tags',
+      AddFavorite: 'Add to favorites',
+      RemoveFavorite: 'Remove from favorites',
     },
     List: {
       Empty: 'This folder is empty.',
@@ -314,5 +337,24 @@ export const documentsTranslationsEn: DocumentsTranslations = {
     DownloadToView: 'Download to view',
     PreviewError: 'Failed to load preview.',
     Position: '{{current}} / {{total}}',
+  },
+  SearchPalette: {
+    Title: 'Search documents',
+    Placeholder: 'Type a name…',
+    Searching: 'Searching…',
+    NoResults: 'No results.',
+    Recents: 'Recent',
+    Favorites: 'Favorites',
+    Results: 'Results',
+    Close: 'Close',
+    Hint: '↑↓ to navigate, ↵ to open, Esc to close',
+  },
+  Sidebar: {
+    FoldersTab: 'Folders',
+    FavoritesTab: 'Favorites',
+    RecentsTab: 'Recent',
+    FavoritesEmpty: 'No favorites yet. Star a document in the inspector to pin it here.',
+    RecentsEmpty: 'No recent documents. Open one to see it here.',
+    RemoveFavorite: 'Remove favorite',
   },
 };

--- a/packages/@granit/react-documents/src/locales/fr.ts
+++ b/packages/@granit/react-documents/src/locales/fr.ts
@@ -34,6 +34,8 @@ export const documentsTranslationsFr: DocumentsTranslations = {
       Versions: 'Versions',
       Shares: 'Partages',
       Tags: 'Étiquettes',
+      AddFavorite: 'Ajouter aux favoris',
+      RemoveFavorite: 'Retirer des favoris',
     },
     List: {
       Empty: 'Ce dossier est vide.',
@@ -153,5 +155,24 @@ export const documentsTranslationsFr: DocumentsTranslations = {
     DownloadToView: 'Télécharger pour ouvrir',
     PreviewError: 'Échec du chargement de l’aperçu.',
     Position: '{{current}} / {{total}}',
+  },
+  SearchPalette: {
+    Title: 'Rechercher des documents',
+    Placeholder: 'Tapez un nom…',
+    Searching: 'Recherche…',
+    NoResults: 'Aucun résultat.',
+    Recents: 'Récents',
+    Favorites: 'Favoris',
+    Results: 'Résultats',
+    Close: 'Fermer',
+    Hint: '↑↓ pour naviguer, ↵ pour ouvrir, Esc pour fermer',
+  },
+  Sidebar: {
+    FoldersTab: 'Dossiers',
+    FavoritesTab: 'Favoris',
+    RecentsTab: 'Récents',
+    FavoritesEmpty: 'Aucun favori. Étoilez un document dans l’inspecteur pour l’épingler ici.',
+    RecentsEmpty: 'Aucun document récent. Ouvrez-en un pour le voir ici.',
+    RemoveFavorite: 'Retirer des favoris',
   },
 };


### PR DESCRIPTION
## Summary

Three coordinated affordances that make the explorer act like a real "jump anywhere" file manager.

- **`useDocumentBookmarks(storageKey, { recentsCap })`** — two ordered bookmark lists in `localStorage`:
  - **Favorites** — explicit pins, toggled from the inspector star.
  - **Recents** — auto-recorded on every `onOpenDocument`, ring-buffer capped at 20.
  Denormalized (id + name + folderId) so the sidebar renders without re-fetching.
- **`<DocumentSearchPalette open onPickDocument …>`** — Finder / command-K modal. Live `name Contains <query>` search via QueryEngine, debounced 200 ms. `↑↓` walks results, `↵` opens, `Esc` closes. Empty query falls back to sectioned Favorites + Recents (deduped) so the palette doubles as a "jump to recently opened" launcher.
- **`<DocumentsSidebar>`** — three-tab shell for the left pane (Folders / Favorites / Recents) wrapping the existing `<FolderTree>` verbatim. Tab state is local; the tree keeps lazy loading across switches.
- **`<DocumentsExplorer>`** — wires `useDocumentBookmarks`, mounts the palette + a global `⌘K` / `Ctrl+K` listener (opt out via `enableSearchShortcut={false}`; shortcut skips inputs / textareas / contenteditable), and wraps host `onOpenDocument` so opens auto-record as recents. Replaces the bare `<FolderTree>` aside with the new sidebar.
- **`<DocumentDetail>`** — new optional `isFavorite` + `onToggleFavorite` add a star button in the header; the explorer wires it to the focused document.
- **i18n EN + FR** — `SearchPalette.*`, `Sidebar.*`, `Document.Detail.{AddFavorite,RemoveFavorite}`.

## Why this shape

`localStorage` keeps the MR self-contained (no backend dep) while preserving the door to a server-backed `Granit.Settings` migration (the hook accepts a `storageKey`; switching to a network-backed store is one swap). The palette uses `setFilters` on the existing QueryEngine reducer rather than re-instantiating it, so toolbar + palette share invalidation behavior.

## Test plan

- [x] `pnpm vitest run packages/@granit/react-documents` — 213/213 pass (30 files). New: bookmarks (toggle, dedupe + cap recents, persistence, corrupt/malformed storage, null opt-out, forget), sidebar (default tab, switch, empty state, count badge, pick, remove), palette (closed/open, dedupe favorite+recent, debounced Contains search, Enter on highlight, no-results, native close fires onClose).
- [x] `pnpm eslint packages/@granit/react-documents/src/**/*.{ts,tsx} --max-warnings 0` clean
- [x] `pnpm -r --filter @granit/react-documents... build` clean
- [ ] Manual QA via showcase — Cmd+K opens palette, type to search, ↑↓ navigates, Enter opens; sidebar tabs switch without losing folder-tree state; star a document in the inspector → appears in Favorites tab; opening a doc surfaces it in Recents