### PR TITLE
feat(webhooks): expose signingSecretHint on WebhookSubscriptionResponse

### DIFF
--- a/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
@@ -3,6 +3,8 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { createWebhooksHandlers, webhookSubscriptionQueryMetadata } from '../testing/index.js';
 
+import type { WebhookSubscriptionResponse } from '@granit/webhooks';
+
 const BASE = 'http://api.test/api/v1/webhooks';
 const server = setupServer();
 
@@ -10,11 +12,70 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
+// Backend contract — see WebhookSubscriptionResponse.SigningSecretHint XML doc.
+const HINT_PATTERN = /^whsec_[0-9a-f]{4}\*{16}[0-9a-f]{4}$/;
+
 describe('createWebhooksHandlers /meta', () => {
   it('responds with webhookSubscriptionQueryMetadata at /subscriptions/meta', async () => {
     server.use(...createWebhooksHandlers(BASE));
     const response = await fetch(`${BASE}/subscriptions/meta`);
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(webhookSubscriptionQueryMetadata);
+  });
+});
+
+describe('createWebhooksHandlers signingSecretHint', () => {
+  it('fixtures expose both populated hints and a legacy null hint', async () => {
+    server.use(...createWebhooksHandlers(BASE));
+    const response = await fetch(`${BASE}/subscriptions?pageSize=100`);
+    const page = (await response.json()) as { items: WebhookSubscriptionResponse[] };
+
+    const withHint = page.items.filter((s) => s.signingSecretHint !== null);
+    const legacy = page.items.filter((s) => s.signingSecretHint === null);
+
+    expect(withHint.length).toBeGreaterThan(0);
+    expect(legacy.length).toBeGreaterThan(0);
+    for (const sub of withHint) {
+      expect(sub.signingSecretHint).toMatch(HINT_PATTERN);
+    }
+  });
+
+  it('create emits a freshly-shaped hint and never exposes plaintext on the returned subscription', async () => {
+    server.use(...createWebhooksHandlers(BASE));
+    const response = await fetch(`${BASE}/subscriptions`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        targetUrl: 'https://new.example.com/webhook',
+        eventType: 'document.uploaded',
+      }),
+    });
+    expect(response.status).toBe(201);
+    const created = (await response.json()) as WebhookSubscriptionResponse & {
+      signingSecret?: string;
+    };
+
+    expect(created.signingSecretHint).toMatch(HINT_PATTERN);
+    // The subscription resource never carries the plaintext secret; only the
+    // create-/rotate-response DTOs do (and the UI's one-shot modal consumes those).
+    expect(created.signingSecret).toBeUndefined();
+  });
+
+  it('rotate-secret refreshes the hint exposed by subsequent GETs', async () => {
+    server.use(...createWebhooksHandlers(BASE));
+
+    const before = (await (
+      await fetch(`${BASE}/subscriptions/ws-1`)
+    ).json()) as WebhookSubscriptionResponse;
+    expect(before.signingSecretHint).toMatch(HINT_PATTERN);
+
+    const rotate = await fetch(`${BASE}/subscriptions/ws-1/rotate-secret`, { method: 'POST' });
+    expect(rotate.status).toBe(200);
+
+    const after = (await (
+      await fetch(`${BASE}/subscriptions/ws-1`)
+    ).json()) as WebhookSubscriptionResponse;
+    expect(after.signingSecretHint).toMatch(HINT_PATTERN);
+    expect(after.signingSecretHint).not.toBe(before.signingSecretHint);
   });
 });

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription-lifecycle.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription-lifecycle.test.tsx
@@ -37,8 +37,10 @@ const mockSubscription: WebhookSubscriptionResponse = {
   status: WebhookSubscriptionStatus.Active,
   consecutiveFailureCount: 0,
   lastSuccessAt: null,
+  // Legacy subscription created before the hint was introduced — exercises the null path.
   createdAt: toISODateString('2026-03-01T08:00:00Z'),
   modifiedAt: null,
+  signingSecretHint: null,
 };
 
 describe('useActivateSubscription', () => {

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription-mutations.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription-mutations.test.tsx
@@ -42,6 +42,7 @@ const mockSubscription: WebhookSubscriptionResponse = {
   lastSuccessAt: null,
   createdAt: toISODateString('2026-03-01T08:00:00Z'),
   modifiedAt: null,
+  signingSecretHint: 'whsec_3f2c****************9d11',
 };
 
 describe('useCreateSubscription', () => {

--- a/packages/@granit/react-webhooks/src/__tests__/use-subscription.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/use-subscription.test.tsx
@@ -34,6 +34,7 @@ const mockSubscription: WebhookSubscriptionResponse = {
   lastSuccessAt: toISODateString('2026-03-20T10:00:00Z'),
   createdAt: toISODateString('2026-03-01T08:00:00Z'),
   modifiedAt: null,
+  signingSecretHint: 'whsec_b46a****************5182',
 };
 
 describe('useSubscription', () => {

--- a/packages/@granit/react-webhooks/src/testing/data.ts
+++ b/packages/@granit/react-webhooks/src/testing/data.ts
@@ -18,6 +18,7 @@ export const mockWebhookSubscriptions: WebhookSubscriptionResponse[] = [
     lastSuccessAt: toISODateString('2026-03-09T08:15:00Z'),
     createdAt: toISODateString('2025-11-10T09:00:00Z'),
     modifiedAt: toISODateString('2025-11-10T09:00:00Z'),
+    signingSecretHint: 'whsec_b46a****************5182',
   },
   {
     id: toEntityId<'WebhookSubscription'>('ws-2'),
@@ -28,6 +29,7 @@ export const mockWebhookSubscriptions: WebhookSubscriptionResponse[] = [
     lastSuccessAt: toISODateString('2026-03-09T07:45:00Z'),
     createdAt: toISODateString('2025-12-01T14:30:00Z'),
     modifiedAt: toISODateString('2025-12-01T14:30:00Z'),
+    signingSecretHint: 'whsec_3f2c****************9d11',
   },
   {
     id: toEntityId<'WebhookSubscription'>('ws-3'),
@@ -38,6 +40,7 @@ export const mockWebhookSubscriptions: WebhookSubscriptionResponse[] = [
     lastSuccessAt: toISODateString('2026-02-20T16:00:00Z'),
     createdAt: toISODateString('2025-10-05T11:00:00Z'),
     modifiedAt: toISODateString('2026-02-25T10:30:00Z'),
+    signingSecretHint: 'whsec_7e88****************a4f0',
   },
   {
     id: toEntityId<'WebhookSubscription'>('ws-4'),
@@ -48,8 +51,10 @@ export const mockWebhookSubscriptions: WebhookSubscriptionResponse[] = [
     lastSuccessAt: toISODateString('2026-03-08T22:10:00Z'),
     createdAt: toISODateString('2026-01-15T08:00:00Z'),
     modifiedAt: toISODateString('2026-01-15T08:00:00Z'),
+    signingSecretHint: 'whsec_19ce****************6b73',
   },
   {
+    // Legacy: created before the hint was introduced — UI falls back to placeholder.
     id: toEntityId<'WebhookSubscription'>('ws-5'),
     targetUrl: 'https://legacy.partner.com/v1/events',
     eventType: 'user.created',
@@ -58,6 +63,7 @@ export const mockWebhookSubscriptions: WebhookSubscriptionResponse[] = [
     lastSuccessAt: toISODateString('2025-09-01T12:00:00Z'),
     createdAt: toISODateString('2025-06-01T10:00:00Z'),
     modifiedAt: toISODateString('2025-12-15T09:00:00Z'),
+    signingSecretHint: null,
   },
   {
     id: toEntityId<'WebhookSubscription'>('ws-6'),
@@ -68,6 +74,7 @@ export const mockWebhookSubscriptions: WebhookSubscriptionResponse[] = [
     lastSuccessAt: toISODateString('2026-03-09T09:00:00Z'),
     createdAt: toISODateString('2026-02-01T16:00:00Z'),
     modifiedAt: toISODateString('2026-02-01T16:00:00Z'),
+    signingSecretHint: 'whsec_5a4d****************0e2f',
   },
   {
     id: toEntityId<'WebhookSubscription'>('ws-7'),
@@ -78,6 +85,7 @@ export const mockWebhookSubscriptions: WebhookSubscriptionResponse[] = [
     lastSuccessAt: toISODateString('2026-03-01T14:00:00Z'),
     createdAt: toISODateString('2026-01-20T10:00:00Z'),
     modifiedAt: toISODateString('2026-03-05T08:00:00Z'),
+    signingSecretHint: 'whsec_c2b1****************8a90',
   },
 ];
 

--- a/packages/@granit/react-webhooks/src/testing/handlers.ts
+++ b/packages/@granit/react-webhooks/src/testing/handlers.ts
@@ -192,12 +192,24 @@ function applyQuickFilters(
 }
 
 function generateSecret(): string {
-  const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  // Hex alphabet mirrors the backend's wire format so that hint derivation
+  // (`hintFromSecret`) yields the same `[0-9a-f]{4}***…***[0-9a-f]{4}` shape
+  // as production.
+  const chars = '0123456789abcdef';
   let result = 'whsec_';
   for (let i = 0; i < 32; i++) {
     result += chars[Math.floor(Math.random() * chars.length)];
   }
   return result;
+}
+
+/**
+ * Derive a Stripe-style masked hint from a plaintext signing secret.
+ * Mirrors the backend format: `whsec_` + 4 hex + 16 × `*` + 4 hex (30 chars).
+ */
+function hintFromSecret(secret: string): string {
+  const body = secret.slice('whsec_'.length);
+  return `whsec_${body.slice(0, 4)}${'*'.repeat(16)}${body.slice(-4)}`;
 }
 
 /**
@@ -330,6 +342,7 @@ export function createWebhooksHandlers(baseUrl = DEFAULT_WEBHOOKS_BASE_PATH) {
         eventType: string;
       };
       const now = toISODateString(new Date().toISOString());
+      const initialSecret = generateSecret();
       const newSub: WebhookSubscriptionResponse = {
         id: toEntityId<'WebhookSubscription'>(`ws-${Date.now()}`),
         targetUrl: body.targetUrl,
@@ -339,6 +352,7 @@ export function createWebhooksHandlers(baseUrl = DEFAULT_WEBHOOKS_BASE_PATH) {
         lastSuccessAt: null,
         createdAt: now,
         modifiedAt: now,
+        signingSecretHint: hintFromSecret(initialSecret),
       };
       subscriptions.push(newSub);
       return HttpResponse.json(newSub, { status: 201 });
@@ -536,6 +550,7 @@ export function createWebhooksHandlers(baseUrl = DEFAULT_WEBHOOKS_BASE_PATH) {
       subscriptions[idx] = {
         ...existing,
         modifiedAt: toISODateString(new Date().toISOString()),
+        signingSecretHint: hintFromSecret(newSecret),
       };
       return HttpResponse.json({ signingSecret: newSecret });
     }),

--- a/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
+++ b/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
@@ -38,6 +38,7 @@ const mockSubscription: WebhookSubscriptionResponse = {
   lastSuccessAt: toISODateString('2026-03-20T10:00:00Z'),
   createdAt: toISODateString('2026-03-01T08:00:00Z'),
   modifiedAt: null,
+  signingSecretHint: 'whsec_b46a****************5182',
 };
 
 describe('webhooks-api', () => {

--- a/packages/@granit/webhooks/src/types/index.ts
+++ b/packages/@granit/webhooks/src/types/index.ts
@@ -55,6 +55,16 @@ export interface WebhookSubscriptionResponse {
   readonly lastSuccessAt: string | null;
   readonly createdAt: string;
   readonly modifiedAt: string | null;
+  /**
+   * Stripe-style masked preview of the active signing secret
+   * (e.g. `whsec_b46a****************5182`) — a fixed 30-char hint
+   * for admin UIs to display on the detail/edit view without ever
+   * re-exposing the plaintext. Refreshed on every signing-key rotation.
+   *
+   * `null` for legacy subscriptions created before the hint was introduced —
+   * UIs should fall back to a static placeholder in that case.
+   */
+  readonly signingSecretHint: string | null;
 }
 
 /** Response from `POST /subscriptions` (201 Created). Contains the signing secret (shown once). */


### PR DESCRIPTION
## Summary

- Adds `signingSecretHint: string | null` to `WebhookSubscriptionResponse` (mirrors granit-dotnet#2380). It's a fixed 30-char Stripe-style preview — `whsec_XXXX****************XXXX` — so admin UIs can render a non-secret marker without ever re-exposing the plaintext. `null` for legacy rows created before the hint existed.
- Propagates the field through the `@granit/react-webhooks` MSW testing harness: fixtures cover both the populated and legacy-null cases; `POST /subscriptions` emits a fresh hint; `POST /subscriptions/:id/rotate-secret` refreshes it on the stored record. `generateSecret()` switched to a hex alphabet so derived hints match the backend's wire format.
- Adds MSW-level contract tests asserting the hint shape on create, the refresh-on-rotate behaviour, and that the subscription resource never carries plaintext (only the create-/rotate-response DTOs do).

## Scope note

granit-front is a library — it has no webhook UI components. The view-side work from the task brief (rendering the hint with a monospaced no-copy affordance, label tooltip, i18n bundles, component tests) lands in **showcase-admin-react** and is intentionally **not** in this PR.

## Test plan

- [x] `pnpm lint`
- [x] `pnpm exec tsc --noEmit` in `@granit/webhooks` and `@granit/react-webhooks`
- [x] `pnpm exec vitest run packages/@granit/webhooks packages/@granit/react-webhooks` — 50/50 green
- [ ] Verified downstream in showcase-admin-react after typecheck/test pass picks up the new field