### PR TITLE
test: raise workspace branch coverage above the 80% gate

### DIFF
--- a/packages/@granit/react-charts/src/__tests__/use-echarts-theme.test.tsx
+++ b/packages/@granit/react-charts/src/__tests__/use-echarts-theme.test.tsx
@@ -1,0 +1,138 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useEChartsTheme } from '../hooks/use-echarts-theme.js';
+
+import type { ChartThemeTokens } from '@granit/charts';
+
+const LIGHT: ChartThemeTokens = {
+  background: '#ffffff',
+  foreground: '#0f172a',
+  muted: '#64748b',
+  border: '#e2e8f0',
+  palette: ['#0ea5e9', '#22c55e', '#f97316'],
+};
+
+const DARK: ChartThemeTokens = {
+  background: '#0f172a',
+  foreground: '#e2e8f0',
+  muted: '#94a3b8',
+  border: '#1e293b',
+  palette: ['#38bdf8', '#4ade80', '#fb923c'],
+};
+
+afterEach(() => {
+  document.documentElement.classList.remove('dark');
+  vi.restoreAllMocks();
+});
+
+describe('useEChartsTheme — class strategy', () => {
+  it('returns the light theme name when no `.dark` class is on <html>', () => {
+    const { result } = renderHook(() => useEChartsTheme({ lightTokens: LIGHT, darkTokens: DARK }));
+
+    expect(result.current).toBe('granit-light');
+  });
+
+  it('initialises to the dark theme name when `.dark` is already on <html>', () => {
+    document.documentElement.classList.add('dark');
+    const { result } = renderHook(() => useEChartsTheme({ lightTokens: LIGHT, darkTokens: DARK }));
+
+    expect(result.current).toBe('granit-dark');
+  });
+
+  it('reacts to <html> class mutations via the MutationObserver', async () => {
+    const { result } = renderHook(() => useEChartsTheme({ lightTokens: LIGHT, darkTokens: DARK }));
+
+    expect(result.current).toBe('granit-light');
+
+    act(() => {
+      document.documentElement.classList.add('dark');
+    });
+
+    // The observer notifies microtask-style; flush.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBe('granit-dark');
+  });
+
+  it('falls back to the light theme name when no dark tokens are provided', () => {
+    document.documentElement.classList.add('dark');
+    const { result } = renderHook(() => useEChartsTheme({ lightTokens: LIGHT }));
+
+    // Even with `.dark` on <html>, without darkTokens the hook must return the
+    // light name — there is no dark theme registered.
+    expect(result.current).toBe('granit-light');
+  });
+
+  it('honours custom theme names', () => {
+    document.documentElement.classList.add('dark');
+    const { result } = renderHook(() =>
+      useEChartsTheme({
+        lightTokens: LIGHT,
+        darkTokens: DARK,
+        themeNames: ['app-light', 'app-dark'] as const,
+      })
+    );
+
+    expect(result.current).toBe('app-dark');
+  });
+});
+
+describe('useEChartsTheme — media strategy', () => {
+  function stubMatchMedia(matches: boolean) {
+    const listeners = new Set<(event: { matches: boolean }) => void>();
+    const mq = {
+      matches,
+      media: '(prefers-color-scheme: dark)',
+      addEventListener: (_type: string, cb: (event: { matches: boolean }) => void) => {
+        listeners.add(cb);
+      },
+      removeEventListener: (_type: string, cb: (event: { matches: boolean }) => void) => {
+        listeners.delete(cb);
+      },
+      dispatch(next: boolean) {
+        mq.matches = next;
+        for (const cb of listeners) cb({ matches: next });
+      },
+    };
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn(() => mq)
+    );
+    return mq;
+  }
+
+  it('initialises from prefers-color-scheme and reacts to the media-query event', async () => {
+    const mq = stubMatchMedia(false);
+    const { result } = renderHook(() =>
+      useEChartsTheme({
+        lightTokens: LIGHT,
+        darkTokens: DARK,
+        darkModeStrategy: 'media',
+      })
+    );
+
+    expect(result.current).toBe('granit-light');
+
+    await act(async () => {
+      mq.dispatch(true);
+    });
+
+    expect(result.current).toBe('granit-dark');
+  });
+
+  it('initialises to dark when prefers-color-scheme already matches', () => {
+    stubMatchMedia(true);
+    const { result } = renderHook(() =>
+      useEChartsTheme({
+        lightTokens: LIGHT,
+        darkTokens: DARK,
+        darkModeStrategy: 'media',
+      })
+    );
+
+    expect(result.current).toBe('granit-dark');
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/use-multi-select.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-multi-select.test.tsx
@@ -1,0 +1,145 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useMultiSelect } from '../hooks/use-multi-select.js';
+
+const IDS = ['a', 'b', 'c', 'd', 'e'] as const;
+
+describe('useMultiSelect', () => {
+  it('toggles ids on and off and tracks them as the anchor', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.toggle('b'));
+    expect(result.current.isSelected('b')).toBe(true);
+
+    act(() => result.current.toggle('b'));
+    expect(result.current.isSelected('b')).toBe(false);
+  });
+
+  it('select is idempotent and updates the anchor for subsequent ranges', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.select('b'));
+    act(() => result.current.select('b'));
+    expect([...result.current.selected]).toEqual(['b']);
+
+    act(() => result.current.selectRange('d'));
+    expect([...result.current.selected]).toEqual(['b', 'c', 'd']);
+  });
+
+  it('selectOnly replaces the current selection and resets the anchor', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.selectAll(['a', 'b']));
+    act(() => result.current.selectOnly('c'));
+    expect([...result.current.selected]).toEqual(['c']);
+  });
+
+  it('selectRange falls back to selecting the click target when no anchor is set', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.selectRange('c'));
+    expect([...result.current.selected]).toEqual(['c']);
+  });
+
+  it('selectRange falls back when the anchor is no longer in the listing', () => {
+    const { result, rerender } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.select('b'));
+    rerender({ ids: ['x', 'y', 'z'] });
+
+    act(() => result.current.selectRange('y'));
+    expect([...result.current.selected]).toEqual(['y']);
+  });
+
+  it('selectRange is a no-op when the click target is no longer in the listing', () => {
+    const { result, rerender } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.select('a'));
+    rerender({ ids: ['a', 'b', 'c'] });
+    act(() => result.current.selectRange('missing'));
+    expect([...result.current.selected]).toEqual(['a']);
+  });
+
+  it('selectRange handles ranges in both directions', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.select('d'));
+    act(() => result.current.selectRange('b'));
+    expect([...result.current.selected]).toEqual(['b', 'c', 'd']);
+
+    act(() => result.current.select('a'));
+    act(() => result.current.selectRange('c'));
+    expect([...result.current.selected]).toEqual(['a', 'b', 'c']);
+  });
+
+  it('selectAll sets the anchor to the last id, and to null for an empty list', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.selectAll(['a', 'b', 'c']));
+    expect([...result.current.selected]).toEqual(['a', 'b', 'c']);
+    act(() => result.current.selectRange('e'));
+    expect([...result.current.selected]).toEqual(['c', 'd', 'e']);
+
+    act(() => result.current.selectAll([]));
+    expect([...result.current.selected]).toEqual([]);
+    // Anchor reset to null — next range click selects only the target.
+    act(() => result.current.selectRange('b'));
+    expect([...result.current.selected]).toEqual(['b']);
+  });
+
+  it('clear empties the selection and resets the anchor', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.selectAll(['a', 'b']));
+    act(() => result.current.clear());
+    expect([...result.current.selected]).toEqual([]);
+    act(() => result.current.selectRange('d'));
+    expect([...result.current.selected]).toEqual(['d']);
+  });
+
+  it('remove drops the requested ids and leaves the rest', () => {
+    const { result } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.selectAll(['a', 'b', 'c']));
+    act(() => result.current.remove(['a', 'c']));
+    expect([...result.current.selected]).toEqual(['b']);
+  });
+
+  it('prunes ids from the selection when they leave the listing, but keeps the set stable otherwise', () => {
+    const { result, rerender } = renderHook(({ ids }) => useMultiSelect(ids), {
+      initialProps: { ids: IDS as readonly string[] },
+    });
+
+    act(() => result.current.selectAll(['a', 'b']));
+    const before = result.current.selected;
+
+    // Re-render with the same listing — selection set must be the same reference
+    // (cheap React Query Engine prop comparisons rely on this).
+    rerender({ ids: IDS as readonly string[] });
+    expect(result.current.selected).toBe(before);
+
+    rerender({ ids: ['b', 'c'] });
+    expect([...result.current.selected]).toEqual(['b']);
+  });
+});

--- a/packages/@granit/react-settings/src/__tests__/settings-provider.test.tsx
+++ b/packages/@granit/react-settings/src/__tests__/settings-provider.test.tsx
@@ -1,6 +1,8 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { createMockClient } from '@granit/testing';
 import { renderHook } from '@testing-library/react';
 import * as React from 'react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   SettingsProvider,
@@ -36,6 +38,33 @@ describe('SettingsProvider', () => {
     expect(() => {
       renderHook(() => useSettingsConfig());
     }).toThrow('useSettingsConfig must be used within a SettingsProvider');
+  });
+
+  it('falls back to the GranitClientProvider context client when config.client is omitted', () => {
+    const contextClient = createMockClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <GranitClientProvider client={contextClient as unknown as AxiosInstance}>
+        <SettingsProvider config={{}}>{children}</SettingsProvider>
+      </GranitClientProvider>
+    );
+
+    const { result } = renderHook(() => useSettingsConfig(), { wrapper });
+
+    expect(result.current.client).toBe(contextClient);
+  });
+
+  it('throws when no client is available (neither config nor context)', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <SettingsProvider config={{}}>{children}</SettingsProvider>
+      );
+      expect(() => renderHook(() => useSettingsConfig(), { wrapper })).toThrow(
+        /SettingsProvider requires an Axios client/
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
   });
 });
 

--- a/packages/@granit/react-webhooks/src/__tests__/webhooks-provider.test.tsx
+++ b/packages/@granit/react-webhooks/src/__tests__/webhooks-provider.test.tsx
@@ -1,0 +1,78 @@
+import { GranitClientProvider } from '@granit/react-api-client';
+import { createMockClient } from '@granit/testing';
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useWebhooksConfig, WebhooksProvider } from '../providers/webhooks-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+
+describe('WebhooksProvider', () => {
+  it('uses config.client when provided', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WebhooksProvider config={{ client }}>{children}</WebhooksProvider>
+    );
+
+    const { result } = renderHook(() => useWebhooksConfig(), { wrapper });
+
+    expect(result.current.client).toBe(client);
+    expect(result.current.basePath).toBe('/api/v1/webhooks');
+  });
+
+  it('falls back to the GranitClientProvider context client when config.client is omitted', () => {
+    const contextClient = createMockClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <GranitClientProvider client={contextClient as unknown as AxiosInstance}>
+        <WebhooksProvider config={{}}>{children}</WebhooksProvider>
+      </GranitClientProvider>
+    );
+
+    const { result } = renderHook(() => useWebhooksConfig(), { wrapper });
+
+    expect(result.current.client).toBe(contextClient);
+  });
+
+  it('honours a custom basePath', () => {
+    const client = createMockClient();
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <WebhooksProvider config={{ client, basePath: '/api/v2/webhooks' }}>
+        {children}
+      </WebhooksProvider>
+    );
+
+    const { result } = renderHook(() => useWebhooksConfig(), { wrapper });
+
+    expect(result.current.basePath).toBe('/api/v2/webhooks');
+  });
+
+  it('throws when no client is available (neither config nor context)', () => {
+    // React surfaces render-time throws via the error boundary path; suppress
+    // the noisy console.error so test output stays readable.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const wrapper = ({ children }: { children: React.ReactNode }) => (
+        <WebhooksProvider config={{}}>{children}</WebhooksProvider>
+      );
+      expect(() => renderHook(() => useWebhooksConfig(), { wrapper })).toThrow(
+        /WebhooksProvider requires an Axios client/
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});
+
+describe('useWebhooksConfig', () => {
+  it('throws when used outside a WebhooksProvider', () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      expect(() => renderHook(() => useWebhooksConfig())).toThrow(
+        /must be used within a <WebhooksProvider>/
+      );
+    } finally {
+      consoleError.mockRestore();
+    }
+  });
+});

--- a/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
+++ b/packages/@granit/webhooks/src/__tests__/webhooks-api.test.ts
@@ -7,7 +7,9 @@ import {
   createSubscription,
   deactivateSubscription,
   deleteSubscription,
+  getConfig,
   getDeliveries,
+  getEventTypes,
   getStats,
   getSubscription,
   retryDelivery,
@@ -20,6 +22,8 @@ import { WebhookSubscriptionStatus } from '../types/index.js';
 
 import type {
   WebhookDeliveryAttemptResponse,
+  WebhookEventTypeResponse,
+  WebhookModuleConfig,
   WebhookSubscriptionCreatedResponse,
   WebhookSubscriptionResponse,
   WebhookSubscriptionRotateSecretResponse,
@@ -210,6 +214,41 @@ describe('webhooks-api', () => {
       const result = await getStats(client, BASE);
 
       expect(client.get).toHaveBeenCalledWith(`${BASE}/stats`);
+      expect(result).toEqual(response);
+    });
+  });
+
+  // ── Discovery ─────────────────────────────────────────────────────────────
+
+  describe('getEventTypes', () => {
+    it('sends GET to /event-types on the webhooks root path', async () => {
+      const client = createMockClient();
+      const response: WebhookEventTypeResponse[] = [
+        {
+          eventType: 'document.uploaded',
+          displayName: 'Document uploaded',
+          description: null,
+          category: 'Documents',
+        },
+      ];
+      vi.mocked(client.get).mockResolvedValueOnce({ data: response });
+
+      const result = await getEventTypes(client, '/api/v1/webhooks');
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/event-types');
+      expect(result).toEqual(response);
+    });
+  });
+
+  describe('getConfig', () => {
+    it('sends GET to /config on the webhooks root path', async () => {
+      const client = createMockClient();
+      const response: WebhookModuleConfig = { storePayload: false };
+      vi.mocked(client.get).mockResolvedValueOnce({ data: response });
+
+      const result = await getConfig(client, '/api/v1/webhooks');
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/webhooks/config');
       expect(result).toEqual(response);
     });
   });


### PR DESCRIPTION
## Summary

The `branches` threshold in [vitest.config.ts](vitest.config.ts) is 80% but the trunk had drifted to **79.44%**, failing the workspace coverage CI job. This PR adds focused tests on five small, high-leverage targets to push branches back to **80.02%** (4694/5866). No production code changes.

| Package | What's covered now |
| --- | --- |
| `@granit/react-webhooks` | `WebhooksProvider` — `config.client ?? contextClient` fallback, missing-client throw, `useWebhooksConfig` outside-provider throw. |
| `@granit/webhooks` | `getEventTypes` + `getConfig` API wrappers (previously uncovered statements). |
| `@granit/react-settings` | `SettingsProvider` — context-client fallback + missing-client throw, mirroring the webhooks pattern. |
| `@granit/react-documents` | Full `useMultiSelect` suite — anchor handling, range fallback when the anchor leaves the listing, no-op range when target leaves, stable-reference pruning. |
| `@granit/react-charts` | `useEChartsTheme` — class + media dark-mode strategies, `MutationObserver` reactivity, custom theme names, no-`darkTokens` fallback. |

## Test plan

- [x] `pnpm lint`
- [x] `pnpm test:coverage` — branches **80.02%** (4694/5866), statements 89.27%, functions 88.19%, lines 90.9%.
- [ ] CI coverage gate passes.

## Why these targets

Picked files where a handful of tests cover many branches per file — small providers with the same error-path shape, a self-contained pure-logic hook (`useMultiSelect`), and a theme hook with several dark-mode dispatch branches. Avoided opening up unrelated UI components, which would balloon scope for marginal coverage gain.