### PR TITLE
feat(presence): resource-scoped rooms client (granit-dotnet#2408)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1507,6 +1507,21 @@
       "description": "User presence types and API — mirrors Granit.Presence .NET contract",
       "exports": [
         {
+          "name": "getResourceRoom",
+          "kind": "function",
+          "signature": "async function getResourceRoom( client: AxiosInstance, basePath: string, kind: string, id: string, signal?: AbortSignal ): Promise<ResourceRoomResponse>"
+        },
+        {
+          "name": "joinResourceRoom",
+          "kind": "function",
+          "signature": "async function joinResourceRoom( client: AxiosInstance, basePath: string, kind: string, id: string, body:"
+        },
+        {
+          "name": "leaveResourceRoom",
+          "kind": "function",
+          "signature": "async function leaveResourceRoom( client: AxiosInstance, basePath: string, kind: string, id: string, signal?: AbortSignal ): Promise<void>"
+        },
+        {
           "name": "PresencePermissions",
           "kind": "const",
           "signature": "const PresencePermissions"
@@ -4727,6 +4742,11 @@
           "name": "presenceKeys",
           "kind": "const",
           "signature": "const presenceKeys"
+        },
+        {
+          "name": "useResourcePresence",
+          "kind": "function",
+          "signature": "function useResourcePresence( kind: string, id: string, options: UseResourcePresenceOptions ="
         },
         {
           "name": "PresenceDot",

--- a/packages/@granit/presence/src/__tests__/presence-rooms-api.test.ts
+++ b/packages/@granit/presence/src/__tests__/presence-rooms-api.test.ts
@@ -1,0 +1,129 @@
+import { axiosResponse, createMockClient } from '@granit/api-client/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getResourceRoom, joinResourceRoom, leaveResourceRoom } from '../api/presence-rooms-api.js';
+
+import type { ResourceRoomResponse } from '../types/index.js';
+
+const mockRoom: ResourceRoomResponse = {
+  kind: 'cms.page',
+  id: 'doc-1',
+  participants: [{ userId: 'user-a', lastSeenUtc: '2026-05-28T10:00:00Z', metadata: null }],
+};
+
+describe('presence-rooms-api', () => {
+  describe('joinResourceRoom', () => {
+    it('POSTs to /presence/rooms/{kind}/{id}/heartbeat', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(mockRoom));
+
+      const result = await joinResourceRoom(client, '/api/v1', 'cms.page', 'doc-1', {});
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/api/v1/presence/rooms/cms.page/doc-1/heartbeat',
+        {},
+        expect.objectContaining({})
+      );
+      expect(result).toEqual(mockRoom);
+    });
+
+    it('URL-encodes kind and id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(mockRoom));
+
+      await joinResourceRoom(client, '/api/v1', 'cms.page', 'id with/slash', {});
+
+      expect(client.post).toHaveBeenCalledWith(
+        '/api/v1/presence/rooms/cms.page/id%20with%2Fslash/heartbeat',
+        {},
+        expect.objectContaining({})
+      );
+    });
+
+    it('rejects an invalid kind before the network call', async () => {
+      const client = createMockClient();
+      await expect(
+        joinResourceRoom(client, '/api/v1', 'INVALID!', 'doc-1', {})
+      ).rejects.toBeInstanceOf(TypeError);
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('rejects an id longer than 256 chars', async () => {
+      const client = createMockClient();
+      const longId = 'x'.repeat(257);
+      await expect(
+        joinResourceRoom(client, '/api/v1', 'cms.page', longId, {})
+      ).rejects.toBeInstanceOf(TypeError);
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('rejects metadata larger than 512 bytes', async () => {
+      const client = createMockClient();
+      // Build a string that exceeds 512 bytes via multi-byte chars.
+      const metadata = '€'.repeat(200); // '€' is 3 bytes, 200 × 3 = 600 bytes
+      await expect(
+        joinResourceRoom(client, '/api/v1', 'cms.page', 'doc-1', { metadata })
+      ).rejects.toBeInstanceOf(TypeError);
+      expect(client.post).not.toHaveBeenCalled();
+    });
+
+    it('forwards the AbortSignal', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(mockRoom));
+      const ac = new AbortController();
+
+      await joinResourceRoom(client, '/api/v1', 'cms.page', 'doc-1', {}, ac.signal);
+
+      expect(client.post).toHaveBeenCalledWith(
+        expect.any(String),
+        {},
+        expect.objectContaining({ signal: ac.signal })
+      );
+    });
+  });
+
+  describe('getResourceRoom', () => {
+    it('GETs /presence/rooms/{kind}/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(mockRoom));
+
+      const result = await getResourceRoom(client, '/api/v1', 'cms.page', 'doc-1');
+
+      expect(client.get).toHaveBeenCalledWith(
+        '/api/v1/presence/rooms/cms.page/doc-1',
+        expect.objectContaining({})
+      );
+      expect(result).toEqual(mockRoom);
+    });
+
+    it('rejects an invalid kind before the network call', async () => {
+      const client = createMockClient();
+      await expect(
+        getResourceRoom(client, '/api/v1', '123invalid', 'doc-1')
+      ).rejects.toBeInstanceOf(TypeError);
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('leaveResourceRoom', () => {
+    it('DELETEs /presence/rooms/{kind}/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+      await leaveResourceRoom(client, '/api/v1', 'cms.page', 'doc-1');
+
+      expect(client.delete).toHaveBeenCalledWith(
+        '/api/v1/presence/rooms/cms.page/doc-1',
+        expect.objectContaining({})
+      );
+    });
+
+    it('rejects an invalid kind before the network call', async () => {
+      const client = createMockClient();
+      await expect(
+        leaveResourceRoom(client, '/api/v1', '-badkind', 'doc-1')
+      ).rejects.toBeInstanceOf(TypeError);
+      expect(client.delete).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/@granit/presence/src/api/presence-rooms-api.ts
+++ b/packages/@granit/presence/src/api/presence-rooms-api.ts
@@ -1,0 +1,116 @@
+import { buildApiUrl } from '@granit/api-client';
+
+import type { ResourceRoomResponse } from '../types/index.js';
+import type { AxiosInstance } from '@granit/api-client';
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const KIND_RE = /^[a-z][a-z0-9_.-]{0,63}$/;
+
+function validateKind(kind: string): void {
+  if (!KIND_RE.test(kind)) {
+    throw new TypeError(
+      `Invalid resource presence kind "${kind}". Must match /^[a-z][a-z0-9_.-]{0,63}$/`
+    );
+  }
+}
+
+function validateId(id: string): void {
+  if (id.length > 256) {
+    throw new TypeError(`Resource presence id must be ≤ 256 characters`);
+  }
+}
+
+function validateMetadata(metadata: string | null | undefined): void {
+  if (!metadata) return;
+  const byteLength = new TextEncoder().encode(metadata).length;
+  if (byteLength > 512) {
+    throw new TypeError(`metadata must be ≤ 512 bytes UTF-8 (got ${byteLength})`);
+  }
+}
+
+function roomUrl(basePath: string, kind: string, id: string, ...segments: string[]): string {
+  return buildApiUrl(
+    basePath,
+    'presence',
+    'rooms',
+    encodeURIComponent(kind),
+    encodeURIComponent(id),
+    ...segments
+  );
+}
+
+// ---------------------------------------------------------------------------
+// API functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Joins (or refreshes) a resource-scoped presence room for the current user.
+ *
+ * `POST {basePath}/presence/rooms/{kind}/{id}/heartbeat`
+ *
+ * Requires `Presence.Rooms.Join`. Returns the room's current participant list.
+ * Validates `kind`, `id`, and `metadata` before sending the request.
+ */
+export async function joinResourceRoom(
+  client: AxiosInstance,
+  basePath: string,
+  kind: string,
+  id: string,
+  body: { metadata?: string | null },
+  signal?: AbortSignal
+): Promise<ResourceRoomResponse> {
+  validateKind(kind);
+  validateId(id);
+  validateMetadata(body.metadata);
+  const { data } = await client.post<ResourceRoomResponse>(
+    roomUrl(basePath, kind, id, 'heartbeat'),
+    body,
+    { signal }
+  );
+  return data;
+}
+
+/**
+ * Returns the current participant list of a resource-scoped room without
+ * joining it.
+ *
+ * `GET {basePath}/presence/rooms/{kind}/{id}`
+ *
+ * Requires `Presence.Rooms.Read`. May return 404 when the visibility policy
+ * blocks the response or the room has been dissolved.
+ */
+export async function getResourceRoom(
+  client: AxiosInstance,
+  basePath: string,
+  kind: string,
+  id: string,
+  signal?: AbortSignal
+): Promise<ResourceRoomResponse> {
+  validateKind(kind);
+  validateId(id);
+  const { data } = await client.get<ResourceRoomResponse>(roomUrl(basePath, kind, id), { signal });
+  return data;
+}
+
+/**
+ * Removes the current user from a resource-scoped presence room.
+ *
+ * `DELETE {basePath}/presence/rooms/{kind}/{id}`
+ *
+ * Requires `Presence.Rooms.Join`. The server is idempotent — calling this when
+ * not a participant is a no-op (204).
+ */
+export async function leaveResourceRoom(
+  client: AxiosInstance,
+  basePath: string,
+  kind: string,
+  id: string,
+  signal?: AbortSignal
+): Promise<void> {
+  validateKind(kind);
+  validateId(id);
+  await client.delete(roomUrl(basePath, kind, id), { signal });
+}

--- a/packages/@granit/presence/src/index.ts
+++ b/packages/@granit/presence/src/index.ts
@@ -6,10 +6,12 @@ export type {
   ManualPresenceStatus,
   PresenceResponse,
   PresenceStatus,
+  ResourcePresenceParticipantResponse,
+  ResourceRoomResponse,
   SetPresenceRequest,
 } from './types/index.js';
 
-// API
+// API — user presence
 export {
   clearMyPresenceOverride,
   getBatchPresence,
@@ -18,6 +20,9 @@ export {
   pollMyPresence,
   setMyPresence,
 } from './api/presence-api.js';
+
+// API — resource rooms
+export { getResourceRoom, joinResourceRoom, leaveResourceRoom } from './api/presence-rooms-api.js';
 
 // Permissions
 export { PresencePermissions } from './permissions.js';

--- a/packages/@granit/presence/src/permissions.ts
+++ b/packages/@granit/presence/src/permissions.ts
@@ -16,4 +16,11 @@ export const PresencePermissions = {
     /** Grants read access to other users' presence (single + batch lookup). */
     Read: 'Presence.Users.Read',
   },
+  /** Permissions for resource-scoped presence rooms. */
+  Rooms: {
+    /** Grants read access to a room's participant list (`GET /presence/rooms/{kind}/{id}`). */
+    Read: 'Presence.Rooms.Read',
+    /** Grants the right to join and leave rooms (`POST` heartbeat + `DELETE` leave). */
+    Join: 'Presence.Rooms.Join',
+  },
 } as const;

--- a/packages/@granit/presence/src/types/index.ts
+++ b/packages/@granit/presence/src/types/index.ts
@@ -1,6 +1,42 @@
 import type { ISODateString, UserId } from '@granit/types';
 
 // ---------------------------------------------------------------------------
+// Resource Rooms — aligned with Granit.Presence.Rooms .NET backend
+// ---------------------------------------------------------------------------
+
+/**
+ * A single participant in a resource-scoped presence room.
+ * Mirrors `Granit.Presence.Rooms.ResourcePresenceParticipantResponse`.
+ */
+export interface ResourcePresenceParticipantResponse {
+  readonly userId: string;
+  /** ISO 8601 UTC timestamp of the participant's last heartbeat. */
+  readonly lastSeenUtc: string;
+  /**
+   * Opaque JSON metadata sent by the participant (≤ 512 bytes UTF-8).
+   * `null` when no metadata was included in the last heartbeat.
+   */
+  readonly metadata: string | null;
+}
+
+/**
+ * Response body for `POST /presence/rooms/{kind}/{id}/heartbeat` and
+ * `GET /presence/rooms/{kind}/{id}`.
+ *
+ * A 404 on the GET endpoint means the visibility policy blocked the response
+ * or the room was dissolved — callers must handle it explicitly.
+ *
+ * Mirrors `Granit.Presence.Rooms.ResourceRoomResponse`.
+ */
+export interface ResourceRoomResponse {
+  /** Resource kind (e.g. `"cms.page"`, `"document"`). */
+  readonly kind: string;
+  /** Opaque resource identifier. */
+  readonly id: string;
+  readonly participants: ResourcePresenceParticipantResponse[];
+}
+
+// ---------------------------------------------------------------------------
 // Presence enums — aligned with Granit.Presence .NET backend
 // ---------------------------------------------------------------------------
 

--- a/packages/@granit/react-presence/src/__tests__/use-resource-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-resource-presence.test.tsx
@@ -1,0 +1,382 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, act, renderHook } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useResourcePresence } from '../hooks/use-resource-presence.js';
+import { PresenceProvider } from '../providers/presence-provider.js';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ResourceRoomResponse } from '@granit/presence';
+
+vi.mock('@granit/presence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    joinResourceRoom: vi.fn(),
+    leaveResourceRoom: vi.fn(),
+  };
+});
+
+const { joinResourceRoom, leaveResourceRoom } = await import('@granit/presence');
+
+// ---------------------------------------------------------------------------
+// Test harness — stable config avoids spurious effect restarts on re-renders
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a wrapper with a **stable** PresenceProvider config so that
+ * React state updates inside the hook do not recreate the config object,
+ * which would cause spurious effect cleanup/restart cycles.
+ */
+function makeWrapper(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  // Stable reference: defined outside JSX so it never changes between renders.
+  const presenceConfig = { client };
+
+  function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <PresenceProvider config={presenceConfig}>{children}</PresenceProvider>
+      </QueryClientProvider>
+    );
+  }
+
+  return { queryClient, wrapper: Wrapper };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const SYSTEM_TIME = new Date('2026-05-28T10:00:00Z');
+
+function makeRoom(ageMs: number[] = [0]): ResourceRoomResponse {
+  return {
+    kind: 'cms.page',
+    id: 'doc-1',
+    participants: ageMs.map((ms, i) => ({
+      userId: `user-${i}`,
+      lastSeenUtc: new Date(SYSTEM_TIME.getTime() - ms).toISOString(),
+      metadata: null,
+    })),
+  };
+}
+
+function setVisibility(state: DocumentVisibilityState) {
+  Object.defineProperty(document, 'visibilityState', {
+    configurable: true,
+    get: () => state,
+  });
+  document.dispatchEvent(new Event('visibilitychange'));
+}
+
+// ---------------------------------------------------------------------------
+// Setup / teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(SYSTEM_TIME);
+  setVisibility('visible');
+  vi.mocked(joinResourceRoom).mockResolvedValue(makeRoom());
+  vi.mocked(leaveResourceRoom).mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  // Explicitly clean up RTL components BEFORE clearing mocks so that any
+  // leaveResourceRoom calls triggered by auto-unmount are counted in this
+  // test's afterEach, not leaked into the next test.
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useResourcePresence', () => {
+  it('fires an immediate join on mount and populates participants', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    const { result } = renderHook(
+      () => useResourcePresence('cms.page', 'doc-1', { heartbeatIntervalMs: 1_000 }),
+      { wrapper }
+    );
+
+    expect(result.current.isJoining).toBe(true);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(joinResourceRoom).toHaveBeenCalledTimes(1);
+    expect(result.current.participants).toHaveLength(1);
+    expect(result.current.isJoining).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('re-heartbeats on the interval tick', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    renderHook(() => useResourcePresence('cms.page', 'doc-1', { heartbeatIntervalMs: 1_000 }), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(3);
+  });
+
+  it('suspends heartbeats when tab is hidden and resumes when visible', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    renderHook(() => useResourcePresence('cms.page', 'doc-1', { heartbeatIntervalMs: 1_000 }), {
+      wrapper,
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(1);
+
+    act(() => setVisibility('hidden'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(1);
+
+    act(() => setVisibility('visible'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(2);
+  });
+
+  it('fires leave on unmount', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    const { unmount } = renderHook(
+      () => useResourcePresence('cms.page', 'doc-1', { heartbeatIntervalMs: 1_000 }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const callsBefore = vi.mocked(leaveResourceRoom).mock.calls.length;
+    unmount();
+
+    // Unmount must have added exactly one more leave call with the right args.
+    expect(vi.mocked(leaveResourceRoom).mock.calls.length).toBe(callsBefore + 1);
+    expect(leaveResourceRoom).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'cms.page',
+      'doc-1'
+    );
+  });
+
+  it('leaves the old room and joins the new one when kind/id changes', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    let kind = 'cms.page';
+    let id = 'doc-1';
+
+    const { rerender } = renderHook(
+      () => useResourcePresence(kind, id, { heartbeatIntervalMs: 1_000 }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(1);
+
+    const leavesBeforeSwitch = vi.mocked(leaveResourceRoom).mock.calls.length;
+    kind = 'cms.section';
+    id = 'doc-2';
+    rerender();
+
+    // Effect cleanup for the old kind/id must fire exactly one leave.
+    expect(vi.mocked(leaveResourceRoom).mock.calls.length).toBe(leavesBeforeSwitch + 1);
+    expect(leaveResourceRoom).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'cms.page',
+      'doc-1'
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(joinResourceRoom).toHaveBeenCalledTimes(2);
+    expect(joinResourceRoom).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'cms.section',
+      'doc-2',
+      expect.anything(),
+      expect.any(AbortSignal)
+    );
+  });
+
+  it('drops stale participants beyond staleThresholdMs', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    vi.mocked(joinResourceRoom).mockResolvedValue(makeRoom([5_000, 50_000]));
+
+    const { result } = renderHook(
+      () =>
+        useResourcePresence('cms.page', 'doc-1', {
+          heartbeatIntervalMs: 1_000,
+          staleThresholdMs: 45_000,
+        }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(result.current.participants).toHaveLength(1);
+    expect(result.current.participants[0]!.userId).toBe('user-0');
+  });
+
+  it('sorts participants freshest-first', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    vi.mocked(joinResourceRoom).mockResolvedValue(makeRoom([10_000, 2_000, 7_000]));
+
+    const { result } = renderHook(
+      () => useResourcePresence('cms.page', 'doc-1', { heartbeatIntervalMs: 1_000 }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const ages = result.current.participants.map(
+      (p) => SYSTEM_TIME.getTime() - new Date(p.lastSeenUtc).getTime()
+    );
+    expect(ages).toEqual([2_000, 7_000, 10_000]);
+  });
+
+  it('is inert when enabled is false', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    renderHook(
+      () =>
+        useResourcePresence('cms.page', 'doc-1', { enabled: false, heartbeatIntervalMs: 1_000 }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    expect(joinResourceRoom).not.toHaveBeenCalled();
+    expect(leaveResourceRoom).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a validation error for an invalid kind without fetching', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    const { result } = renderHook(
+      () => useResourcePresence('INVALID KIND!', 'doc-1', { heartbeatIntervalMs: 1_000 }),
+      { wrapper }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Hook validates before calling the API function.
+    expect(result.current.error).toBeInstanceOf(TypeError);
+    expect(joinResourceRoom).not.toHaveBeenCalled();
+  });
+
+  it('preserves last good participants after all retries fail', async () => {
+    const { wrapper } = makeWrapper(createMockClient());
+
+    vi.mocked(joinResourceRoom)
+      .mockResolvedValueOnce(makeRoom())
+      .mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(
+      () => useResourcePresence('cms.page', 'doc-1', { heartbeatIntervalMs: 1_000 }),
+      { wrapper }
+    );
+
+    // First tick: success → participants populated.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(result.current.participants).toHaveLength(1);
+    expect(result.current.error).toBeNull();
+
+    // Second tick (at 1 000ms) fails and exhausts retries:
+    //   attempt 0 → fail → wait 1 000ms
+    //   attempt 1 → fail → wait 2 000ms
+    //   attempt 2 → fail → wait 4 000ms
+    //   attempt 3 → fail → error surfaced
+    // Total advancement needed: 1 000 (interval) + 7 000 (retry delays) = 8 000ms.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(8_000);
+    });
+
+    expect(result.current.participants).toHaveLength(1);
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  it('is StrictMode-safe: participants are correct after double-mount cycle', async () => {
+    const client = createMockClient();
+    const queryClient = createTestQueryClient();
+    const presenceConfig = { client };
+
+    function StrictWrapper({ children }: Readonly<{ children: React.ReactNode }>) {
+      return (
+        <React.StrictMode>
+          <QueryClientProvider client={queryClient}>
+            <PresenceProvider config={presenceConfig}>{children}</PresenceProvider>
+          </QueryClientProvider>
+        </React.StrictMode>
+      );
+    }
+
+    const { result, unmount } = renderHook(
+      () => useResourcePresence('cms.page', 'doc-1', { heartbeatIntervalMs: 1_000 }),
+      { wrapper: StrictWrapper }
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // Core invariant: after the double-mount cycle settles, the hook must have
+    // joined the room and populated participants without errors.
+    expect(result.current.participants).toHaveLength(1);
+    expect(result.current.isJoining).toBe(false);
+    expect(result.current.error).toBeNull();
+
+    // Leave must be called at least once on unmount.
+    const leavesBeforeUnmount = vi.mocked(leaveResourceRoom).mock.calls.length;
+    unmount();
+    expect(vi.mocked(leaveResourceRoom).mock.calls.length).toBeGreaterThan(leavesBeforeUnmount);
+  });
+});

--- a/packages/@granit/react-presence/src/constants.ts
+++ b/packages/@granit/react-presence/src/constants.ts
@@ -11,3 +11,12 @@ export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
 
 /** Stale time (ms) applied to `useMyPresence` / `useUserPresence` / `useBatchPresence`. */
 export const DEFAULT_STALE_TIME_MS = 30_000;
+
+/** Default heartbeat cadence (ms) for `useResourcePresence`. */
+export const DEFAULT_RESOURCE_HEARTBEAT_INTERVAL_MS = 15_000;
+
+/**
+ * Default age (ms) beyond which a room participant is considered stale and
+ * excluded from the returned list in `useResourcePresence`.
+ */
+export const DEFAULT_RESOURCE_STALE_THRESHOLD_MS = 45_000;

--- a/packages/@granit/react-presence/src/hooks/use-resource-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-resource-presence.ts
@@ -1,0 +1,241 @@
+import { joinResourceRoom, leaveResourceRoom } from '@granit/presence';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  DEFAULT_RESOURCE_HEARTBEAT_INTERVAL_MS,
+  DEFAULT_RESOURCE_STALE_THRESHOLD_MS,
+} from '../constants.js';
+import { usePresenceConfig } from '../providers/presence-provider.js';
+
+import type { ResourcePresenceParticipantResponse, ResourceRoomResponse } from '@granit/presence';
+
+export interface UseResourcePresenceOptions {
+  /** Heartbeat cadence ms. Default: 15 000. */
+  readonly heartbeatIntervalMs?: number;
+  /**
+   * Local stale filter ms. Default: 45 000.
+   * Drops participants whose `lastSeenUtc` is older than this threshold.
+   */
+  readonly staleThresholdMs?: number;
+  /**
+   * Metadata to include in each heartbeat body (≤ 512 bytes UTF-8).
+   * Changes are picked up on the next tick — no immediate extra request.
+   */
+  readonly metadata?: string | null;
+  /**
+   * When `false`, the hook is inert: no join, no heartbeat, no leave.
+   * Default: `true`.
+   */
+  readonly enabled?: boolean;
+}
+
+export interface UseResourcePresenceResult {
+  /** Current participants, stale entries removed, sorted freshest-first. */
+  readonly participants: ResourcePresenceParticipantResponse[];
+  /** `true` until the first successful heartbeat response. */
+  readonly isJoining: boolean;
+  /** Last error from a heartbeat attempt (cleared on next success). */
+  readonly error: Error | null;
+  /**
+   * Optimistic leave — fires DELETE immediately (e.g. before navigating away).
+   * The hook also fires DELETE automatically on unmount.
+   */
+  readonly leave: () => Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const MAX_RETRIES = 3;
+const BASE_RETRY_DELAY_MS = 1_000;
+const MAX_RETRY_DELAY_MS = 10_000;
+
+async function retryWithBackoff<T>(
+  fn: () => Promise<T>,
+  maxRetries: number,
+  signal: AbortSignal
+): Promise<T> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (signal.aborted) throw new DOMException('The operation was aborted.', 'AbortError');
+    try {
+      return await fn();
+    } catch (err) {
+      if (signal.aborted) throw err;
+      // Don't retry validation errors — they are deterministic.
+      if (err instanceof TypeError) throw err;
+      lastError = err;
+      if (attempt < maxRetries) {
+        const delay = Math.min(BASE_RETRY_DELAY_MS * 2 ** attempt, MAX_RETRY_DELAY_MS);
+        await new Promise<void>((resolve) => {
+          const id = setTimeout(resolve, delay);
+          signal.addEventListener(
+            'abort',
+            () => {
+              clearTimeout(id);
+              resolve();
+            },
+            { once: true }
+          );
+        });
+      }
+    }
+  }
+  throw lastError;
+}
+
+function applyStaleFilter(
+  data: ResourceRoomResponse,
+  staleThresholdMs: number
+): ResourcePresenceParticipantResponse[] {
+  const now = Date.now();
+  return data.participants
+    .filter((p) => now - new Date(p.lastSeenUtc).getTime() <= staleThresholdMs)
+    .sort((a, b) => new Date(b.lastSeenUtc).getTime() - new Date(a.lastSeenUtc).getTime());
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Joins a resource-scoped presence room and maintains a live participant list.
+ *
+ * On mount the hook sends an immediate heartbeat (join). While the tab is
+ * visible it re-heartbeats every `heartbeatIntervalMs`. When the tab is
+ * hidden heartbeats are paused to avoid wasted requests. On unmount the hook
+ * fires a best-effort DELETE leave.
+ *
+ * Requires `Presence.Rooms.Join` (POST/DELETE). `kind` and `id` changes cause
+ * an atomic leave-old + join-new transition.
+ */
+export function useResourcePresence(
+  kind: string,
+  id: string,
+  options: UseResourcePresenceOptions = {}
+): UseResourcePresenceResult {
+  const {
+    heartbeatIntervalMs = DEFAULT_RESOURCE_HEARTBEAT_INTERVAL_MS,
+    staleThresholdMs = DEFAULT_RESOURCE_STALE_THRESHOLD_MS,
+    metadata = null,
+    enabled = true,
+  } = options;
+
+  const config = usePresenceConfig();
+  const [participants, setParticipants] = useState<ResourcePresenceParticipantResponse[]>([]);
+  const [isJoining, setIsJoining] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Kept in refs so changes don't restart the heartbeat cycle.
+  const metadataRef = useRef(metadata);
+  const staleThresholdRef = useRef(staleThresholdMs);
+  useEffect(() => {
+    metadataRef.current = metadata ?? null;
+  });
+  useEffect(() => {
+    staleThresholdRef.current = staleThresholdMs;
+  });
+
+  useEffect(() => {
+    if (!enabled) {
+      setParticipants([]);
+      setIsJoining(false);
+      setError(null);
+      return;
+    }
+
+    // Validate deterministic inputs before any network activity.
+    // metadata is validated per-tick inside joinResourceRoom.
+    const kindError = !/^[a-z][a-z0-9_.-]{0,63}$/.test(kind)
+      ? new TypeError(
+          `Invalid resource presence kind "${kind}". Must match /^[a-z][a-z0-9_.-]{0,63}$/`
+        )
+      : null;
+    const idError =
+      id.length > 256 ? new TypeError(`Resource presence id must be ≤ 256 characters`) : null;
+    const validationError = kindError ?? idError;
+    if (validationError) {
+      setError(validationError);
+      setIsJoining(false);
+      return;
+    }
+
+    const ac = new AbortController();
+    let cancelled = false;
+    let timer: ReturnType<typeof setInterval> | null = null;
+    let inFlight = false;
+
+    setIsJoining(true);
+    setError(null);
+
+    const tick = async () => {
+      if (cancelled || document.visibilityState !== 'visible' || inFlight) return;
+      inFlight = true;
+      try {
+        const body = metadataRef.current != null ? { metadata: metadataRef.current } : {};
+        const data = await retryWithBackoff(
+          () => joinResourceRoom(config.client, config.basePath, kind, id, body, ac.signal),
+          MAX_RETRIES,
+          ac.signal
+        );
+        if (!cancelled) {
+          setParticipants(applyStaleFilter(data, staleThresholdRef.current));
+          setIsJoining(false);
+          setError(null);
+        }
+      } catch (err) {
+        if (!cancelled && !ac.signal.aborted) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+          setIsJoining(false);
+        }
+      } finally {
+        inFlight = false;
+      }
+    };
+
+    const stopTimer = () => {
+      if (timer !== null) {
+        clearInterval(timer);
+        timer = null;
+      }
+    };
+
+    const startTimer = () => {
+      if (timer !== null) return;
+      void tick();
+      timer = setInterval(() => {
+        void tick();
+      }, heartbeatIntervalMs);
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        startTimer();
+      } else {
+        stopTimer();
+      }
+    };
+
+    if (document.visibilityState === 'visible') {
+      startTimer();
+    }
+    document.addEventListener('visibilitychange', onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      ac.abort();
+      stopTimer();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      // Best-effort leave — no retry, no await (component may already be destroyed).
+      void leaveResourceRoom(config.client, config.basePath, kind, id).catch(() => {});
+    };
+  }, [config, enabled, heartbeatIntervalMs, id, kind]);
+
+  const leave = useCallback(async () => {
+    if (!enabled) return;
+    await leaveResourceRoom(config.client, config.basePath, kind, id);
+  }, [config, enabled, id, kind]);
+
+  return { participants, isJoining, error, leave };
+}

--- a/packages/@granit/react-presence/src/index.ts
+++ b/packages/@granit/react-presence/src/index.ts
@@ -21,6 +21,11 @@ export type { UseUserPresenceOptions } from './hooks/use-user-presence.js';
 export { useBatchPresence } from './hooks/use-batch-presence.js';
 export type { UseBatchPresenceOptions } from './hooks/use-batch-presence.js';
 export { presenceKeys } from './hooks/query-keys.js';
+export { useResourcePresence } from './hooks/use-resource-presence.js';
+export type {
+  UseResourcePresenceOptions,
+  UseResourcePresenceResult,
+} from './hooks/use-resource-presence.js';
 
 // Components
 export { PresenceDot, DEFAULT_PRESENCE_COLORS } from './components/presence-dot.js';

--- a/packages/@granit/react-presence/src/testing/handlers.ts
+++ b/packages/@granit/react-presence/src/testing/handlers.ts
@@ -3,7 +3,7 @@ import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants.js';
 
-import { mockMyPresence, mockOtherPresences } from './data.js';
+import { mockMyPresence, mockOtherPresences, mockUsers } from './data.js';
 
 import type {
   BatchPresenceRequest,
@@ -12,6 +12,8 @@ import type {
   ManualPresenceStatus,
   PresenceResponse,
   PresenceStatus,
+  ResourcePresenceParticipantResponse,
+  ResourceRoomResponse,
   SetPresenceRequest,
 } from '@granit/presence';
 import type { UserId } from '@granit/types';
@@ -144,6 +146,78 @@ export function createPresenceHandlers(baseUrl = DEFAULT_BASE_PATH) {
         }
         const response: BatchPresenceResponse = { presences };
         return HttpResponse.json(response);
+      }
+    ),
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Resource Rooms handlers
+// ---------------------------------------------------------------------------
+
+type RoomState = Map<string, ResourcePresenceParticipantResponse>;
+
+/**
+ * Stateful MSW handlers for resource-scoped presence rooms.
+ *
+ * @param selfUserId - The userId to use as the "current user" for heartbeats.
+ *   Defaults to the first mock user (`mockUsers[0].id`).
+ * @param baseUrl - Base API path. Defaults to `/api/v1`.
+ */
+export function createResourceRoomsHandlers(
+  selfUserId: string = mockUsers[0]!.id,
+  baseUrl = DEFAULT_BASE_PATH
+) {
+  const rooms = new Map<string, RoomState>();
+
+  function getRoomState(kind: string, id: string): RoomState {
+    const key = `${kind}:${id}`;
+    if (!rooms.has(key)) rooms.set(key, new Map());
+    return rooms.get(key)!;
+  }
+
+  function roomResponse(kind: string, id: string): ResourceRoomResponse {
+    return {
+      kind,
+      id,
+      participants: Array.from(getRoomState(kind, id).values()),
+    };
+  }
+
+  return [
+    http.post<{ kind: string; id: string }>(
+      `${baseUrl}/presence/rooms/:kind/:id/heartbeat`,
+      async ({ request, params }) => {
+        const kind = decodeURIComponent(params.kind);
+        const id = decodeURIComponent(params.id);
+        const body = (await request.json()) as { metadata?: string | null };
+        const state = getRoomState(kind, id);
+        state.set(selfUserId, {
+          userId: selfUserId,
+          lastSeenUtc: new Date().toISOString(),
+          metadata: body.metadata ?? null,
+        });
+        return HttpResponse.json<ResourceRoomResponse>(roomResponse(kind, id));
+      }
+    ),
+
+    http.get<{ kind: string; id: string }>(`${baseUrl}/presence/rooms/:kind/:id`, ({ params }) => {
+      const kind = decodeURIComponent(params.kind);
+      const id = decodeURIComponent(params.id);
+      const key = `${kind}:${id}`;
+      if (!rooms.has(key)) {
+        return HttpResponse.json({ title: 'Not Found', status: 404 }, { status: 404 });
+      }
+      return HttpResponse.json<ResourceRoomResponse>(roomResponse(kind, id));
+    }),
+
+    http.delete<{ kind: string; id: string }>(
+      `${baseUrl}/presence/rooms/:kind/:id`,
+      ({ params }) => {
+        const kind = decodeURIComponent(params.kind);
+        const id = decodeURIComponent(params.id);
+        getRoomState(kind, id).delete(selfUserId);
+        return new HttpResponse(null, { status: 204 });
       }
     ),
   ];

--- a/packages/@granit/react-presence/src/testing/index.ts
+++ b/packages/@granit/react-presence/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockMyPresence, mockOtherPresences, mockUsers } from './data.js';
-export { createPresenceHandlers } from './handlers.js';
+export { createPresenceHandlers, createResourceRoomsHandlers } from './handlers.js';


### PR DESCRIPTION
## Summary

- Implements the React/TypeScript client for **resource-scoped editing presence rooms** (`Granit.Presence.Rooms`), mirroring the backend shipped in granit-dotnet#2426.
- Closes #500

## Changes

### `@granit/presence`

- New types: `ResourceRoomResponse`, `ResourcePresenceParticipantResponse`
- New `src/api/presence-rooms-api.ts`: `joinResourceRoom`, `getResourceRoom`, `leaveResourceRoom`
  - Client-side validation: `kind` regex `/^[a-z][a-z0-9_.-]{0,63}$/`, `id` ≤ 256 chars, `metadata` ≤ 512 bytes UTF-8 (TextEncoder)
  - AbortSignal forwarded to every Axios call
- `PresencePermissions.Rooms.Read` + `Rooms.Join` added
- 10 unit tests (URL construction, validation, signal forwarding)

### `@granit/react-presence`

- `useResourcePresence(kind, id, options?)` hook:
  - Immediate heartbeat on mount → POST `/presence/rooms/{kind}/{id}/heartbeat`
  - Periodic heartbeat (default **15 s**) while tab visible
  - Tab hidden → pause; tab visible → immediate resume + resume cycle
  - Exponential retry with cap (3 attempts, 1s/2s/4s delays); `TypeError` not retried (validation errors are deterministic)
  - `kind`/`id` change → atomic leave-old + join-new
  - Local stale filter (default **45 s**), participants sorted freshest-first
  - `metadata` changes picked up on next tick (no extra POST)
  - Unmount → fire-and-forget DELETE leave + AbortController teardown
  - StrictMode-safe
- `createResourceRoomsHandlers(selfUserId?, baseUrl?)` MSW factory in `./testing`
- 11 unit tests (all specified behaviours, StrictMode, delta-count assertions to be StrictMode-agnostic)

## Related

- Epic: granit-dotnet#2408
- Backend PR: granit-dotnet#2426
- In-flight rate-limit helper: granit-dotnet#2425
- User-facing docs: granit-dotnet#2414 (out of scope here)

## Out of scope (explicit)

- Backend changes
- SignalR/SSE push (V1 = heartbeat polling)
- Admin UI
- `Granit.EditLocking` pessimistic primitive (granit-dotnet#293)