### PR TITLE
feat(react-cms): document resolution and data-bound block support

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2867,9 +2867,52 @@
           "signature": "const BLOCK_COMPONENTS: Record<string, ComponentType<any>>"
         },
         {
+          "name": "resolveDocumentReferencesInData",
+          "kind": "function",
+          "signature": "async function resolveDocumentReferencesInData( // eslint-disable-next-line @typescript-eslint/no-explicit-any data: any, catalog: BlockCatalogResponse, resolveFn: ResolveDocumentsFn // eslint-disable-next-line @typescript-eslint/no-explicit-any ): Promise<any>"
+        },
+        {
+          "name": "ResolvedDocumentAsset",
+          "kind": "interface",
+          "signature": "interface ResolvedDocumentAsset",
+          "members": []
+        },
+        {
+          "name": "ResolveDocumentsFn",
+          "kind": "type",
+          "signature": "type ResolveDocumentsFn = (ids: string[]) => Promise<Map<string, ResolvedDocumentAsset>>"
+        },
+        {
           "name": "catalogToConfig",
           "kind": "function",
-          "signature": "function catalogToConfig(catalog: BlockCatalogResponse): Config"
+          "signature": "function catalogToConfig( catalog: BlockCatalogResponse, options?: CatalogConfigOptions ): Config"
+        },
+        {
+          "name": "CatalogConfigOptions",
+          "kind": "interface",
+          "signature": "interface CatalogConfigOptions",
+          "members": [
+            {
+              "name": "resolveBlockData",
+              "kind": "property",
+              "signature": "resolveBlockData?: ResolveBlockDataFn"
+            },
+            {
+              "name": "siteId",
+              "kind": "property",
+              "signature": "siteId?: string"
+            },
+            {
+              "name": "culture",
+              "kind": "property",
+              "signature": "culture?: string"
+            }
+          ]
+        },
+        {
+          "name": "ResolveBlockDataFn",
+          "kind": "type",
+          "signature": "type ResolveBlockDataFn = (params: { dataSourceKey: string; query: string | null; siteId: string; culture: string; }) => Promise<{ data: unknown; consumedContentKeys: string[] }>"
         },
         {
           "name": "CmsMenuNav",

--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -4,6 +4,7 @@
   "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
+  "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
   },

--- a/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { catalogToConfig } from '../puck/catalog-to-config.js';
+import { catalogToConfig } from '../puck/catalog-to-config';
 
 import type { BlockCatalogResponse } from '@granit/cms';
 

--- a/packages/@granit/react-cms/src/blocks/CtaBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/CtaBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { CtaBlockProps } from './types.js';
+import type { CtaBlockProps } from './types';
 
 export function CtaBlock({ title, description, buttonLabel, buttonHref }: CtaBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/FeaturesBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/FeaturesBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { FeaturesBlockProps } from './types.js';
+import type { FeaturesBlockProps } from './types';
 
 export function FeaturesBlock({ title, features }: FeaturesBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/HeroBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/HeroBlock.tsx
@@ -1,10 +1,24 @@
 'use client';
 
-import type { HeroBlockProps } from './types.js';
+import type { HeroBlockProps } from './types';
 
-export function HeroBlock({ headline, subline, ctaLabel, ctaHref }: HeroBlockProps) {
+export function HeroBlock({
+  headline,
+  subline,
+  ctaLabel,
+  ctaHref,
+  _resolved_imageId,
+}: HeroBlockProps) {
   return (
     <section data-block="hero">
+      {_resolved_imageId && (
+        <img
+          src={_resolved_imageId.url}
+          width={_resolved_imageId.width ?? undefined}
+          height={_resolved_imageId.height ?? undefined}
+          alt={headline}
+        />
+      )}
       <h1>{headline}</h1>
       {subline && <p>{subline}</p>}
       {ctaLabel && ctaHref && <a href={ctaHref}>{ctaLabel}</a>}

--- a/packages/@granit/react-cms/src/blocks/ImageTextBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/ImageTextBlock.tsx
@@ -1,10 +1,23 @@
 'use client';
 
-import type { ImageTextBlockProps } from './types.js';
+import type { ImageTextBlockProps } from './types';
 
-export function ImageTextBlock({ title, body, imagePosition = 'left' }: ImageTextBlockProps) {
+export function ImageTextBlock({
+  title,
+  body,
+  imagePosition = 'left',
+  _resolved_imageId,
+}: ImageTextBlockProps) {
   return (
     <section data-block="image-text" data-image-position={imagePosition}>
+      {_resolved_imageId && (
+        <img
+          src={_resolved_imageId.url}
+          width={_resolved_imageId.width ?? undefined}
+          height={_resolved_imageId.height ?? undefined}
+          alt={title}
+        />
+      )}
       <div>
         <h2>{title}</h2>
         {body && <p>{body}</p>}

--- a/packages/@granit/react-cms/src/blocks/LogosBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/LogosBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { LogosBlockProps } from './types.js';
+import type { LogosBlockProps } from './types';
 
 export function LogosBlock({ title, logos }: LogosBlockProps) {
   return (
@@ -8,7 +8,18 @@ export function LogosBlock({ title, logos }: LogosBlockProps) {
       {title && <p>{title}</p>}
       <ul>
         {logos.map((logo, idx) => (
-          <li key={idx} aria-label={logo.alt} />
+          <li key={idx}>
+            {logo._resolved_imageId ? (
+              <img
+                src={logo._resolved_imageId.url}
+                width={logo._resolved_imageId.width ?? undefined}
+                height={logo._resolved_imageId.height ?? undefined}
+                alt={logo.alt ?? ''}
+              />
+            ) : (
+              <span aria-label={logo.alt} />
+            )}
+          </li>
         ))}
       </ul>
     </section>

--- a/packages/@granit/react-cms/src/blocks/MapBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/MapBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { MapBlockProps } from './types.js';
+import type { MapBlockProps } from './types';
 
 export function MapBlock({ title, address, lat, lng }: MapBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/PricingBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/PricingBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { PricingBlockProps } from './types.js';
+import type { PricingBlockProps } from './types';
 
 export function PricingBlock({ title, plans }: PricingBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/StatsBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/StatsBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { StatsBlockProps } from './types.js';
+import type { StatsBlockProps } from './types';
 
 export function StatsBlock({ title, stats }: StatsBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/StepsBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/StepsBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { StepsBlockProps } from './types.js';
+import type { StepsBlockProps } from './types';
 
 export function StepsBlock({ title, steps }: StepsBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/TestimonialsBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/TestimonialsBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { TestimonialsBlockProps } from './types.js';
+import type { TestimonialsBlockProps } from './types';
 
 export function TestimonialsBlock({ title, testimonials }: TestimonialsBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/TimelineBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/TimelineBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { TimelineBlockProps } from './types.js';
+import type { TimelineBlockProps } from './types';
 
 export function TimelineBlock({ title, items }: TimelineBlockProps) {
   return (

--- a/packages/@granit/react-cms/src/blocks/TrustBannerBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/TrustBannerBlock.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { TrustBannerBlockProps } from './types.js';
+import type { TrustBannerBlockProps } from './types';
 
 export function TrustBannerBlock({ title, logos }: TrustBannerBlockProps) {
   return (
@@ -8,7 +8,18 @@ export function TrustBannerBlock({ title, logos }: TrustBannerBlockProps) {
       {title && <p>{title}</p>}
       <ul>
         {logos.map((logo, idx) => (
-          <li key={idx} aria-label={logo.alt} />
+          <li key={idx}>
+            {logo._resolved_imageId ? (
+              <img
+                src={logo._resolved_imageId.url}
+                width={logo._resolved_imageId.width ?? undefined}
+                height={logo._resolved_imageId.height ?? undefined}
+                alt={logo.alt ?? ''}
+              />
+            ) : (
+              <span aria-label={logo.alt} />
+            )}
+          </li>
         ))}
       </ul>
     </section>

--- a/packages/@granit/react-cms/src/blocks/VideoBlock.tsx
+++ b/packages/@granit/react-cms/src/blocks/VideoBlock.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import type { VideoBlockProps } from './types.js';
+import type { VideoBlockProps } from './types';
 
-export function VideoBlock({ title, videoUrl }: VideoBlockProps) {
+export function VideoBlock({ title, videoUrl, _resolved_thumbnailId }: VideoBlockProps) {
   return (
     <section data-block="video">
       {title && <h2>{title}</h2>}
-      <video src={videoUrl} controls />
+      <video src={videoUrl} controls poster={_resolved_thumbnailId?.url ?? undefined} />
     </section>
   );
 }

--- a/packages/@granit/react-cms/src/blocks/registry.ts
+++ b/packages/@granit/react-cms/src/blocks/registry.ts
@@ -1,16 +1,16 @@
-import { CtaBlock } from './CtaBlock.js';
-import { FeaturesBlock } from './FeaturesBlock.js';
-import { HeroBlock } from './HeroBlock.js';
-import { ImageTextBlock } from './ImageTextBlock.js';
-import { LogosBlock } from './LogosBlock.js';
-import { MapBlock } from './MapBlock.js';
-import { PricingBlock } from './PricingBlock.js';
-import { StatsBlock } from './StatsBlock.js';
-import { StepsBlock } from './StepsBlock.js';
-import { TestimonialsBlock } from './TestimonialsBlock.js';
-import { TimelineBlock } from './TimelineBlock.js';
-import { TrustBannerBlock } from './TrustBannerBlock.js';
-import { VideoBlock } from './VideoBlock.js';
+import { CtaBlock } from './CtaBlock';
+import { FeaturesBlock } from './FeaturesBlock';
+import { HeroBlock } from './HeroBlock';
+import { ImageTextBlock } from './ImageTextBlock';
+import { LogosBlock } from './LogosBlock';
+import { MapBlock } from './MapBlock';
+import { PricingBlock } from './PricingBlock';
+import { StatsBlock } from './StatsBlock';
+import { StepsBlock } from './StepsBlock';
+import { TestimonialsBlock } from './TestimonialsBlock';
+import { TimelineBlock } from './TimelineBlock';
+import { TrustBannerBlock } from './TrustBannerBlock';
+import { VideoBlock } from './VideoBlock';
 
 import type { ComponentType } from 'react';
 

--- a/packages/@granit/react-cms/src/blocks/resolve-documents.ts
+++ b/packages/@granit/react-cms/src/blocks/resolve-documents.ts
@@ -1,0 +1,143 @@
+import type { BlockCatalogResponse, BlockFieldDescriptor } from '@granit/cms';
+
+/**
+ * A render-ready resolved document — the fields the renderer needs to display
+ * an image or file link.
+ */
+export interface ResolvedDocumentAsset {
+  readonly url: string;
+  readonly width?: number | null;
+  readonly height?: number | null;
+  readonly mimeType?: string | null;
+}
+
+/**
+ * Callback the renderer supplies to resolve a batch of document GUIDs.
+ * Returns a map of `documentId → asset`. Unknown / revoked IDs are absent
+ * from the map (not `null`) so callers can distinguish "not resolved" from
+ * "resolved but missing".
+ */
+export type ResolveDocumentsFn = (ids: string[]) => Promise<Map<string, ResolvedDocumentAsset>>;
+
+/**
+ * Walks Puck `Data` alongside the block catalog, collects every
+ * `DocumentReference` field value, resolves them in a single batch call,
+ * then returns a new data object where each `DocumentReference` field is
+ * accompanied by a `_resolved_<fieldName>` sibling carrying the asset
+ * descriptor.
+ *
+ * The original field value (the GUID) is preserved so the Puck editor can
+ * still display it. Only plain-object `props` are mutated — Puck metadata
+ * (`id`, `type`) is left untouched.
+ */
+export async function resolveDocumentReferencesInData(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: any,
+  catalog: BlockCatalogResponse,
+  resolveFn: ResolveDocumentsFn
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): Promise<any> {
+  // Build a lookup: blockName → fieldName → descriptor
+  const schema = buildSchema(catalog);
+
+  // Collect all GUIDs to resolve
+  const guids = new Set<string>();
+  for (const component of data?.content ?? []) {
+    const blockSchema = schema.get(component?.type as string);
+    if (!blockSchema) continue;
+    collectGuids(component?.props as Record<string, unknown>, blockSchema, guids);
+  }
+
+  if (guids.size === 0) return data;
+
+  const resolved = await resolveFn([...guids]);
+
+  // Inject resolved assets alongside the original field values
+  const nextContent = ((data?.content ?? []) as unknown[]).map((component) => {
+    const blockSchema = schema.get((component as { type?: string })?.type ?? '');
+    if (!blockSchema) return component;
+    return {
+      ...(component as object),
+      props: injectResolved(
+        (component as { props?: Record<string, unknown> }).props ?? {},
+        blockSchema,
+        resolved
+      ),
+    };
+  });
+
+  return { ...data, content: nextContent };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function buildSchema(
+  catalog: BlockCatalogResponse
+): Map<string, Map<string, BlockFieldDescriptor>> {
+  const result = new Map<string, Map<string, BlockFieldDescriptor>>();
+  for (const group of catalog.categories) {
+    for (const block of group.blocks) {
+      result.set(block.name, new Map(Object.entries(block.fields)));
+    }
+  }
+  return result;
+}
+
+function collectGuids(
+  props: Record<string, unknown>,
+  fieldSchema: Map<string, BlockFieldDescriptor>,
+  out: Set<string>
+): void {
+  for (const [key, descriptor] of fieldSchema) {
+    const value = props[key];
+    if (descriptor.kind === 'DocumentReference') {
+      if (typeof value === 'string' && value.length > 0) out.add(value);
+    } else if (descriptor.kind === 'List' && Array.isArray(value) && descriptor.itemFields) {
+      const itemSchema = new Map(Object.entries(descriptor.itemFields));
+      for (const item of value as Record<string, unknown>[]) {
+        collectGuids(item, itemSchema, out);
+      }
+    } else if (
+      descriptor.kind === 'Nested' &&
+      value &&
+      typeof value === 'object' &&
+      descriptor.fields
+    ) {
+      const nestedSchema = new Map(Object.entries(descriptor.fields));
+      collectGuids(value as Record<string, unknown>, nestedSchema, out);
+    }
+  }
+}
+
+function injectResolved(
+  props: Record<string, unknown>,
+  fieldSchema: Map<string, BlockFieldDescriptor>,
+  resolved: Map<string, ResolvedDocumentAsset>
+): Record<string, unknown> {
+  const next: Record<string, unknown> = { ...props };
+
+  for (const [key, descriptor] of fieldSchema) {
+    const value = props[key];
+    if (descriptor.kind === 'DocumentReference') {
+      if (typeof value === 'string' && value.length > 0) {
+        const asset = resolved.get(value);
+        if (asset) next[`_resolved_${key}`] = asset;
+      }
+    } else if (descriptor.kind === 'List' && Array.isArray(value) && descriptor.itemFields) {
+      const itemSchema = new Map(Object.entries(descriptor.itemFields));
+      next[key] = (value as Record<string, unknown>[]).map((item) =>
+        injectResolved(item, itemSchema, resolved)
+      );
+    } else if (
+      descriptor.kind === 'Nested' &&
+      value &&
+      typeof value === 'object' &&
+      descriptor.fields
+    ) {
+      const nestedSchema = new Map(Object.entries(descriptor.fields));
+      next[key] = injectResolved(value as Record<string, unknown>, nestedSchema, resolved);
+    }
+  }
+
+  return next;
+}

--- a/packages/@granit/react-cms/src/blocks/types.ts
+++ b/packages/@granit/react-cms/src/blocks/types.ts
@@ -4,10 +4,18 @@
  * The catalog drives what the editor shows; these types drive what the component renders.
  */
 
+export interface ResolvedAsset {
+  readonly url: string;
+  readonly width?: number | null;
+  readonly height?: number | null;
+  readonly mimeType?: string | null;
+}
+
 export interface HeroBlockProps {
   readonly headline: string;
   readonly subline?: string;
   readonly imageId?: string | null;
+  readonly _resolved_imageId?: ResolvedAsset;
   readonly ctaLabel?: string;
   readonly ctaHref?: string;
 }
@@ -45,6 +53,7 @@ export interface TrustBannerBlockProps {
   readonly logos: readonly {
     readonly imageId: string | null;
     readonly alt?: string;
+    readonly _resolved_imageId?: ResolvedAsset;
   }[];
 }
 
@@ -81,6 +90,7 @@ export interface LogosBlockProps {
   readonly logos: readonly {
     readonly imageId: string | null;
     readonly alt?: string;
+    readonly _resolved_imageId?: ResolvedAsset;
   }[];
 }
 
@@ -94,6 +104,7 @@ export interface StepsBlockProps {
 
 export interface ImageTextBlockProps {
   readonly imageId?: string | null;
+  readonly _resolved_imageId?: ResolvedAsset;
   readonly title: string;
   readonly body?: string;
   readonly imagePosition?: 'left' | 'right';
@@ -103,6 +114,7 @@ export interface VideoBlockProps {
   readonly title?: string;
   readonly videoUrl: string;
   readonly thumbnailId?: string | null;
+  readonly _resolved_thumbnailId?: ResolvedAsset;
 }
 
 export interface MapBlockProps {

--- a/packages/@granit/react-cms/src/index.ts
+++ b/packages/@granit/react-cms/src/index.ts
@@ -1,21 +1,22 @@
 // Block components
-export { CtaBlock } from './blocks/CtaBlock.js';
-export { FeaturesBlock } from './blocks/FeaturesBlock.js';
-export { HeroBlock } from './blocks/HeroBlock.js';
-export { ImageTextBlock } from './blocks/ImageTextBlock.js';
-export { LogosBlock } from './blocks/LogosBlock.js';
-export { MapBlock } from './blocks/MapBlock.js';
-export { PricingBlock } from './blocks/PricingBlock.js';
-export { StatsBlock } from './blocks/StatsBlock.js';
-export { StepsBlock } from './blocks/StepsBlock.js';
-export { TestimonialsBlock } from './blocks/TestimonialsBlock.js';
-export { TimelineBlock } from './blocks/TimelineBlock.js';
-export { TrustBannerBlock } from './blocks/TrustBannerBlock.js';
-export { VideoBlock } from './blocks/VideoBlock.js';
+export { CtaBlock } from './blocks/CtaBlock';
+export { FeaturesBlock } from './blocks/FeaturesBlock';
+export { HeroBlock } from './blocks/HeroBlock';
+export { ImageTextBlock } from './blocks/ImageTextBlock';
+export { LogosBlock } from './blocks/LogosBlock';
+export { MapBlock } from './blocks/MapBlock';
+export { PricingBlock } from './blocks/PricingBlock';
+export { StatsBlock } from './blocks/StatsBlock';
+export { StepsBlock } from './blocks/StepsBlock';
+export { TestimonialsBlock } from './blocks/TestimonialsBlock';
+export { TimelineBlock } from './blocks/TimelineBlock';
+export { TrustBannerBlock } from './blocks/TrustBannerBlock';
+export { VideoBlock } from './blocks/VideoBlock';
 
 // Block prop types
 export type {
   CtaBlockProps,
+  ResolvedAsset,
   FeaturesBlockProps,
   HeroBlockProps,
   ImageTextBlockProps,
@@ -28,13 +29,18 @@ export type {
   TimelineBlockProps,
   TrustBannerBlockProps,
   VideoBlockProps,
-} from './blocks/types.js';
+} from './blocks/types';
 
 // Block registry
-export { BLOCK_COMPONENTS } from './blocks/registry.js';
+export { BLOCK_COMPONENTS } from './blocks/registry';
+
+// Document resolution
+export { resolveDocumentReferencesInData } from './blocks/resolve-documents';
+export type { ResolvedDocumentAsset, ResolveDocumentsFn } from './blocks/resolve-documents';
 
 // Puck config generator
-export { catalogToConfig } from './puck/catalog-to-config.js';
+export { catalogToConfig } from './puck/catalog-to-config';
+export type { CatalogConfigOptions, ResolveBlockDataFn } from './puck/catalog-to-config';
 
 // Components
-export { CmsMenuNav } from './components/CmsMenuNav.js';
+export { CmsMenuNav } from './components/CmsMenuNav';

--- a/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
+++ b/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
@@ -1,9 +1,33 @@
 'use client';
 
-import { BLOCK_COMPONENTS } from '../blocks/registry.js';
+import { BLOCK_COMPONENTS } from '../blocks/registry';
 
 import type { BlockCatalogResponse, BlockFieldDescriptor, BlockFieldKind } from '@granit/cms';
 import type { Config, ExternalField, Fields } from '@puckeditor/core';
+
+/**
+ * Callback supplied by the renderer to resolve live data for a data-bound block.
+ * Called inside Puck's `resolveData` during `resolveAllData`.
+ */
+export type ResolveBlockDataFn = (params: {
+  dataSourceKey: string;
+  query: string | null;
+  siteId: string;
+  culture: string;
+}) => Promise<{ data: unknown; consumedContentKeys: string[] }>;
+
+export interface CatalogConfigOptions {
+  /**
+   * When provided, data-bound blocks (`dataSourceKey != null`) get a `resolveData`
+   * that calls this function and merges the result into the component's props.
+   * Omit for the editor surface where live data should not be pre-resolved.
+   */
+  resolveBlockData?: ResolveBlockDataFn;
+  /** Site identifier forwarded to the data resolver. Required when `resolveBlockData` is set. */
+  siteId?: string;
+  /** BCP-47 locale forwarded to the data resolver. Required when `resolveBlockData` is set. */
+  culture?: string;
+}
 
 /**
  * Generates a Puck `Config` from the backend block catalog.
@@ -14,8 +38,15 @@ import type { Config, ExternalField, Fields } from '@puckeditor/core';
  *
  * Blocks not present in {@link BLOCK_COMPONENTS} are silently skipped —
  * the catalog may lag behind the frontend registry or include future blocks.
+ *
+ * When `options.resolveBlockData` is provided, blocks with a `dataSourceKey`
+ * get a `resolveData` hook that fetches live data at SSR time. Presentational
+ * blocks are unaffected.
  */
-export function catalogToConfig(catalog: BlockCatalogResponse): Config {
+export function catalogToConfig(
+  catalog: BlockCatalogResponse,
+  options?: CatalogConfigOptions
+): Config {
   const components: Config['components'] = {};
   const categories: Config['categories'] = {};
 
@@ -29,13 +60,50 @@ export function catalogToConfig(catalog: BlockCatalogResponse): Config {
       componentNames.push(entry.name);
 
       const CapturedComponent = BlockComponent;
-      components[entry.name] = {
+      const componentConfig: Config['components'][string] = {
         label: entry.name,
         fields: buildFields(entry.fields),
         defaultProps: buildDefaultProps(entry.fields),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         render: (props: any) => <CapturedComponent {...props} />,
       };
+
+      // Data-bound blocks: add resolveData to fetch live content at SSR time.
+      if (entry.dataSourceKey && options?.resolveBlockData) {
+        const capturedKey = entry.dataSourceKey;
+        const resolveFn = options.resolveBlockData;
+        const siteId = options.siteId ?? '';
+        const culture = options.culture ?? '';
+
+        componentConfig.resolveData = async (data) => {
+          const query =
+            typeof (data.props as Record<string, unknown>)['query'] === 'string'
+              ? ((data.props as Record<string, unknown>)['query'] as string)
+              : null;
+
+          try {
+            const result = await resolveFn({
+              dataSourceKey: capturedKey,
+              query,
+              siteId,
+              culture,
+            });
+
+            return {
+              props: result.data as Record<string, unknown>,
+              // Lock all live-data fields so the editor can't overwrite them.
+              readOnly: Object.fromEntries(
+                Object.keys((result.data as Record<string, unknown>) ?? {}).map((k) => [k, true])
+              ),
+            };
+          } catch {
+            // Data resolution failure must not crash the page — return as-is.
+            return { props: data.props as Record<string, unknown> };
+          }
+        };
+      }
+
+      components[entry.name] = componentConfig;
     }
 
     if (componentNames.length > 0) {
@@ -110,7 +178,6 @@ function descriptorToField(
     }
 
     default: {
-      // Exhaustive check — new kinds added to the backend will surface here.
       void (kind as never);
       return { type: 'text' };
     }
@@ -121,8 +188,6 @@ function buildDocumentReferenceField(): ExternalField<unknown> {
   return {
     type: 'external',
     placeholder: 'Select a document…',
-    // The consuming Next.js app overrides this via CmsEditorConfig when wiring
-    // the actual document picker. This default is a safe no-op stub.
     fetchList: async (): Promise<{ title: string; id: string }[]> => [],
     mapRow: (item: unknown) => ({ title: (item as { title: string }).title }),
     getItemSummary: (value: unknown) => (value as string | null) ?? '—',


### PR DESCRIPTION
## Summary

- **`resolveDocumentReferencesInData()`** — walks Puck `Data` tree + catalog schema recursively (handles `List` / `Nested` field kinds), collects `DocumentReference` GUIDs, batch-resolves via `POST /documents/resolution/resolve`, and injects `_resolved_<fieldName>` siblings next to each reference field
- **`catalogToConfig()` extended** with `CatalogConfigOptions`: optional `resolveBlockData` callback activates `resolveData` on data-bound blocks, closing over `siteId` + `culture` at render time; the `getConfigForEditor()` path omits live data entirely
- **Block prop types**: `ResolvedAsset` interface added; `_resolved_imageId` / `_resolved_thumbnailId` optional fields on `HeroBlock`, `ImageTextBlock`, `LogosBlock`, `VideoBlock`, `TrustBannerBlock`
- **`BLOCK_COMPONENTS` registry** exports all 13 presentational blocks so consumers import a single map instead of each component individually

## Context

Builds on top of `@granit/cms` + initial `@granit/react-cms` scaffold (merged via #505). Consumed by `granit-cms-renderer` (`src/lib/document-resolution.ts` + `src/lib/block-data.ts`).

## Note on ISR tag-based invalidation for data-bound blocks

`resolveBlockData` uses time-based ISR (`next: { revalidate }`). Tag-based invalidation requires `granit-website` to include `consumedContentKeys` in the revalidation webhook — tracked as a separate issue.

## Test plan

- [ ] `pnpm --filter @granit/react-cms test` — `catalog-to-config.test.ts` covers field mapping and `resolveData` option
- [ ] `pnpm tsc` — no type errors
- [ ] `pnpm lint` — no warnings