### PR TITLE
feat(cms): add subscribedContentTypes to BlockCatalogEntry

### DIFF
--- a/packages/@granit/cms/src/__tests__/blocks.test.ts
+++ b/packages/@granit/cms/src/__tests__/blocks.test.ts
@@ -22,6 +22,7 @@ const catalog: BlockCatalogResponse = {
           sourceModule: 'Granit.Cms.Blocks.Hero',
           renderSide: 'Server',
           dataSourceKey: null,
+          subscribedContentTypes: [],
           fields: {
             headline: { kind: 'Text' },
             imageId: { kind: 'DocumentReference' },

--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -56,6 +56,7 @@ export interface BlockCatalogEntry {
   readonly sourceModule: string;
   readonly renderSide: BlockRenderSide;
   readonly dataSourceKey: string | null;
+  readonly subscribedContentTypes: readonly string[];
   readonly fields: Readonly<Record<string, BlockFieldDescriptor>>;
 }
 

--- a/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/catalog-to-config.test.ts
@@ -15,6 +15,7 @@ const catalog: BlockCatalogResponse = {
           sourceModule: 'Granit.Cms.Blocks',
           renderSide: 'Server',
           dataSourceKey: null,
+          subscribedContentTypes: [],
           fields: {
             headline: { kind: 'Text' },
             imageId: { kind: 'DocumentReference' },
@@ -47,6 +48,7 @@ const catalog: BlockCatalogResponse = {
           sourceModule: 'Granit.Cms.Blocks',
           renderSide: 'Server',
           dataSourceKey: null,
+          subscribedContentTypes: [],
           fields: {},
         },
       ],


### PR DESCRIPTION
## Summary

Adds `subscribedContentTypes: readonly string[]` to `BlockCatalogEntry` to expose the `IBlockDataSource.SubscribedContentTypes` DIM introduced in story **#139 R1 (B-F5)**.

The field is always present (the DIM defaults to `[]`) so it is modelled as a required field rather than optional — presentational blocks carry an empty array.

## Integration

Used by `granit-cms-renderer` to map a `ContentKey` received via `cms.blocks.data_invalidated` webhook to the `block-data:<siteId>:<dataSourceKey>` ISR tags of every data source subscribed to that content type, enabling targeted ISR invalidation without time-based fallback.

## Test plan

- [ ] `pnpm --filter @granit/cms test` — fixtures updated with `subscribedContentTypes: []`
- [ ] `pnpm tsc` — no type errors
- [ ] `pnpm lint` — no warnings