### PR TITLE
feat(react-cms): document picker + picker-item GUID resolution

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3093,34 +3093,7 @@
         {
           "name": "catalogToConfig",
           "kind": "function",
-          "signature": "function catalogToConfig( catalog: BlockCatalogResponse, options?: CatalogConfigOptions ): Config"
-        },
-        {
-          "name": "CatalogConfigOptions",
-          "kind": "interface",
-          "signature": "interface CatalogConfigOptions",
-          "members": [
-            {
-              "name": "resolveBlockData",
-              "kind": "property",
-              "signature": "resolveBlockData?: ResolveBlockDataFn"
-            },
-            {
-              "name": "siteId",
-              "kind": "property",
-              "signature": "siteId?: string"
-            },
-            {
-              "name": "culture",
-              "kind": "property",
-              "signature": "culture?: string"
-            }
-          ]
-        },
-        {
-          "name": "ResolveBlockDataFn",
-          "kind": "type",
-          "signature": "type ResolveBlockDataFn = (params: { dataSourceKey: string; query: string | null; siteId: string; culture: string; }) => Promise<{ data: unknown; consumedContentKeys: string[] }>"
+          "signature": "function catalogToConfig( catalog: BlockCatalogResponse, options: CatalogConfigOptions ="
         },
         {
           "name": "CmsMenuNav",

--- a/packages/@granit/react-cms/src/__tests__/resolve-documents.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/resolve-documents.test.ts
@@ -197,4 +197,48 @@ describe('resolveDocumentReferencesInData', () => {
 
     expect(result.content[0].props.items).toBeNull();
   });
+
+  it('resolves a DocumentPickerItem object ({id, title}) the same as a plain GUID string', async () => {
+    const resolveFn: ResolveDocumentsFn = vi
+      .fn()
+      .mockResolvedValue(new Map([['guid-picker', asset1]]));
+    const pickerItem = { id: 'guid-picker', title: 'My Document', mimeType: 'image/png' };
+    const data = {
+      content: [{ type: 'Hero', props: { imageId: pickerItem } }],
+    };
+
+    const result = await resolveDocumentReferencesInData(data, catalog, resolveFn);
+
+    expect(result.content[0].props._resolved_imageId).toEqual(asset1);
+    expect(resolveFn).toHaveBeenCalledWith(['guid-picker']);
+  });
+
+  it('deduplicates picker-object GUIDs against plain-string GUIDs in the same batch', async () => {
+    const resolveFn: ResolveDocumentsFn = vi
+      .fn()
+      .mockResolvedValue(new Map([['shared-guid', asset1]]));
+    const data = {
+      content: [
+        { type: 'Hero', props: { imageId: 'shared-guid' } },
+        { type: 'Hero', props: { imageId: { id: 'shared-guid', title: 'Doc' } } },
+      ],
+    };
+
+    await resolveDocumentReferencesInData(data, catalog, resolveFn);
+
+    expect(resolveFn).toHaveBeenCalledTimes(1);
+    expect(resolveFn).toHaveBeenCalledWith(['shared-guid']);
+  });
+
+  it('ignores a DocumentPickerItem with an empty id', async () => {
+    const resolveFn: ResolveDocumentsFn = vi.fn().mockResolvedValue(new Map());
+    const data = {
+      content: [{ type: 'Hero', props: { imageId: { id: '', title: 'Empty' } } }],
+    };
+
+    const result = await resolveDocumentReferencesInData(data, catalog, resolveFn);
+
+    expect(result).toBe(data);
+    expect(resolveFn).not.toHaveBeenCalled();
+  });
 });

--- a/packages/@granit/react-cms/src/blocks/resolve-documents.ts
+++ b/packages/@granit/react-cms/src/blocks/resolve-documents.ts
@@ -83,6 +83,24 @@ function buildSchema(
   return result;
 }
 
+/**
+ * Extracts a document GUID from either a plain string or a `DocumentPickerItem`
+ * object `{ id: string }`. Returns `null` when the value carries no usable GUID.
+ */
+function extractGuid(value: unknown): string | null {
+  if (typeof value === 'string' && value.length > 0) return value;
+  if (
+    value != null &&
+    typeof value === 'object' &&
+    'id' in value &&
+    typeof (value as { id: unknown }).id === 'string' &&
+    (value as { id: string }).id.length > 0
+  ) {
+    return (value as { id: string }).id;
+  }
+  return null;
+}
+
 function collectGuids(
   props: Record<string, unknown>,
   fieldSchema: Map<string, BlockFieldDescriptor>,
@@ -91,7 +109,8 @@ function collectGuids(
   for (const [key, descriptor] of fieldSchema) {
     const value = props[key];
     if (descriptor.kind === 'DocumentReference') {
-      if (typeof value === 'string' && value.length > 0) out.add(value);
+      const guid = extractGuid(value);
+      if (guid) out.add(guid);
     } else if (descriptor.kind === 'List' && Array.isArray(value) && descriptor.itemFields) {
       const itemSchema = new Map(Object.entries(descriptor.itemFields));
       for (const item of value as Record<string, unknown>[]) {
@@ -119,8 +138,9 @@ function injectResolved(
   for (const [key, descriptor] of fieldSchema) {
     const value = props[key];
     if (descriptor.kind === 'DocumentReference') {
-      if (typeof value === 'string' && value.length > 0) {
-        const asset = resolved.get(value);
+      const guid = extractGuid(value);
+      if (guid) {
+        const asset = resolved.get(guid);
         if (asset) next[`_resolved_${key}`] = asset;
       }
     } else if (descriptor.kind === 'List' && Array.isArray(value) && descriptor.itemFields) {

--- a/packages/@granit/react-cms/src/index.ts
+++ b/packages/@granit/react-cms/src/index.ts
@@ -40,7 +40,12 @@ export type { ResolvedDocumentAsset, ResolveDocumentsFn } from './blocks/resolve
 
 // Puck config generator
 export { catalogToConfig } from './puck/catalog-to-config';
-export type { CatalogConfigOptions, ResolveBlockDataFn } from './puck/catalog-to-config';
+export type {
+  CatalogConfigOptions,
+  DocumentPickerItem,
+  FetchDocumentsFn,
+  ResolveBlockDataFn,
+} from './puck/catalog-to-config';
 
 // Components
 export { CmsMenuNav } from './components/cms-menu-nav';

--- a/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
+++ b/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
@@ -16,6 +16,26 @@ export type ResolveBlockDataFn = (params: {
   culture: string;
 }) => Promise<{ data: unknown; consumedContentKeys: string[] }>;
 
+/**
+ * A document item returned by the editor-side document picker.
+ * Stored as the prop value for `DocumentReference` fields when the editor
+ * uses the picker. `resolve-documents.ts` accepts this shape alongside plain
+ * GUID strings so both paths resolve transparently.
+ */
+export interface DocumentPickerItem {
+  readonly id: string;
+  readonly title: string;
+  readonly mimeType?: string | null;
+}
+
+/**
+ * Callback supplied by the renderer so the Puck editor can search for
+ * documents to assign to `DocumentReference` fields. Receives the user's
+ * search query and returns matching items. The editor runs this client-side
+ * via a server-proxied route — the Bearer token never leaves the server.
+ */
+export type FetchDocumentsFn = (query: string) => Promise<DocumentPickerItem[]>;
+
 export interface CatalogConfigOptions {
   /**
    * When provided, data-bound blocks (`dataSourceKey != null`) get a `resolveData`
@@ -27,6 +47,12 @@ export interface CatalogConfigOptions {
   siteId?: string;
   /** BCP-47 locale forwarded to the data resolver. Required when `resolveBlockData` is set. */
   culture?: string;
+  /**
+   * When provided, `DocumentReference` fields show a search-driven document
+   * picker in the Puck editor sidebar. Without this, the field is rendered as
+   * a no-op external field (empty list).
+   */
+  fetchDocuments?: FetchDocumentsFn;
 }
 
 /**
@@ -45,7 +71,7 @@ export interface CatalogConfigOptions {
  */
 export function catalogToConfig(
   catalog: BlockCatalogResponse,
-  options?: CatalogConfigOptions
+  options: CatalogConfigOptions = {}
 ): Config {
   const components: Config['components'] = {};
   const categories: Config['categories'] = {};
@@ -62,14 +88,14 @@ export function catalogToConfig(
       const CapturedComponent = BlockComponent;
       const componentConfig: Config['components'][string] = {
         label: entry.name,
-        fields: buildFields(entry.fields),
+        fields: buildFields(entry.fields, options.fetchDocuments),
         defaultProps: buildDefaultProps(entry.fields),
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         render: (props: any) => <CapturedComponent {...props} />,
       };
 
       // Data-bound blocks: add resolveData to fetch live content at SSR time.
-      if (entry.dataSourceKey && options?.resolveBlockData) {
+      if (entry.dataSourceKey && options.resolveBlockData) {
         const capturedKey = entry.dataSourceKey;
         const resolveFn = options.resolveBlockData;
         const siteId = options.siteId ?? '';
@@ -118,17 +144,19 @@ export function catalogToConfig(
 }
 
 function buildFields(
-  fieldMap: Readonly<Record<string, BlockFieldDescriptor>>
+  fieldMap: Readonly<Record<string, BlockFieldDescriptor>>,
+  fetchDocuments?: FetchDocumentsFn
 ): Fields<Record<string, unknown>> {
   const result: Fields<Record<string, unknown>> = {};
   for (const [key, descriptor] of Object.entries(fieldMap)) {
-    result[key] = descriptorToField(descriptor);
+    result[key] = descriptorToField(descriptor, fetchDocuments);
   }
   return result;
 }
 
 function descriptorToField(
-  descriptor: BlockFieldDescriptor
+  descriptor: BlockFieldDescriptor,
+  fetchDocuments?: FetchDocumentsFn
 ): Fields<Record<string, unknown>>[string] {
   const kind: BlockFieldKind = descriptor.kind;
 
@@ -149,19 +177,20 @@ function descriptorToField(
       };
 
     case 'Choice': {
-      const options = (descriptor.options ?? []).map((o) => ({
+      const opts = (descriptor.options ?? []).map((o) => ({
         label: o.label,
         value: o.value,
       }));
-      return { type: 'select', options };
+      return { type: 'select', options: opts };
     }
 
     case 'DocumentReference':
-      return buildDocumentReferenceField();
+      return buildDocumentReferenceField(fetchDocuments);
 
     case 'List': {
       const itemFields = buildFields(
-        (descriptor.itemFields ?? {}) as Record<string, BlockFieldDescriptor>
+        (descriptor.itemFields ?? {}) as Record<string, BlockFieldDescriptor>,
+        fetchDocuments
       );
       return {
         type: 'array',
@@ -172,7 +201,8 @@ function descriptorToField(
 
     case 'Nested': {
       const objectFields = buildFields(
-        (descriptor.fields ?? {}) as Record<string, BlockFieldDescriptor>
+        (descriptor.fields ?? {}) as Record<string, BlockFieldDescriptor>,
+        fetchDocuments
       );
       return { type: 'object', objectFields };
     }
@@ -184,13 +214,23 @@ function descriptorToField(
   }
 }
 
-function buildDocumentReferenceField(): ExternalField<unknown> {
+function buildDocumentReferenceField(fetchDocuments?: FetchDocumentsFn): ExternalField<unknown> {
   return {
     type: 'external',
     placeholder: 'Select a document…',
-    fetchList: async (): Promise<{ title: string; id: string }[]> => [],
-    mapRow: (item: unknown) => ({ title: (item as { title: string }).title }),
-    getItemSummary: (value: unknown) => (value as string | null) ?? '—',
+    showSearch: true,
+    fetchList: async ({ query }: { query: string }): Promise<DocumentPickerItem[]> => {
+      if (!fetchDocuments) return [];
+      return fetchDocuments(query);
+    },
+    mapRow: (item: unknown) => {
+      const doc = item as DocumentPickerItem;
+      return {
+        title: doc.title,
+        ...(doc.mimeType ? { type: doc.mimeType } : {}),
+      };
+    },
+    getItemSummary: (item: unknown) => (item as DocumentPickerItem | null)?.title ?? '—',
   };
 }
 


### PR DESCRIPTION
## Summary

- **`DocumentPickerItem`** (`{ id, title, mimeType? }`) and **`FetchDocumentsFn`** added to `CatalogConfigOptions` and exported from `@granit/react-cms`
- **`catalogToConfig`** wires `fetchDocuments` into `buildDocumentReferenceField` as a live Puck `ExternalField` with `showSearch`, full `fetchList`, `mapRow` (shows title + mime type), and `getItemSummary`
- **`resolve-documents.ts`** gains `extractGuid()` — accepts both plain GUID strings (existing) and `{ id: string }` picker objects (new), maintaining full backward compatibility; `collectGuids` and `injectResolved` updated accordingly
- 3 new unit tests: picker-object resolution, dedup vs plain-string GUIDs, empty-id guard

## Consumer wiring (granit-cms-renderer)

The renderer passes `fetchDocuments` that calls `GET /api/admin/documents?q=` — a server-side proxy route that forwards the Bearer token from the httpOnly `cms_admin_token` cookie. The token never reaches client JS.

## Test plan

- [ ] `pnpm exec vitest run packages/@granit/react-cms/src/__tests__/resolve-documents.test.ts` — 14 tests pass
- [ ] `pnpm exec tsc --noEmit -p packages/@granit/react-cms/tsconfig.json` — clean
- [ ] `pnpm lint` — clean