### PR TITLE
fix(gitleaks): extend allowlist to testing/ dirs + defuse mock tokens

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,4 +7,6 @@ useDefault = true
   paths = [
     '''.*\.test\.tsx?$''',
     '''.*__tests__/.*''',
+    # Fixture data in testing/ dirs is always mock — never real secrets.
+    '''.*\/testing\/.*''',
   ]

--- a/packages/@granit/react-hostnames/src/testing/data.ts
+++ b/packages/@granit/react-hostnames/src/testing/data.ts
@@ -55,9 +55,13 @@ export const mockHostnames: ManagedHostnameResponse[] = [
     tenantId: 'tttttttt-0002-4000-a000-000000000002',
     isPrimary: true,
     status: S.Pending,
-    verificationToken: 'tok_abc123xyz',
+    verificationToken: 'mock-verify-pending-001',
     expectedDnsRecords: [
-      { type: 'Txt', name: '_granit-verify.pending.beta.com', value: 'granit-verify=tok_abc123xyz' },
+      {
+        type: 'Txt',
+        name: '_granit-verify.pending.beta.com',
+        value: 'granit-verify=mock-verify-pending-001',
+      },
       { type: 'Cname', name: 'pending.beta.com', value: 'proxy.granit.io' },
     ],
     lastCheckedAt: null,
@@ -78,9 +82,13 @@ export const mockHostnames: ManagedHostnameResponse[] = [
     tenantId: null,
     isPrimary: true,
     status: S.Error,
-    verificationToken: 'tok_def456uvw',
+    verificationToken: 'mock-verify-error-002',
     expectedDnsRecords: [
-      { type: 'Txt', name: '_granit-verify.error.example.org', value: 'granit-verify=tok_def456uvw' },
+      {
+        type: 'Txt',
+        name: '_granit-verify.error.example.org',
+        value: 'granit-verify=mock-verify-error-002',
+      },
     ],
     lastCheckedAt: '2026-06-01T06:00:00Z',
     conflicts: [{ type: 'DnsNotPropagated', details: 'TXT record not found after 3 checks' }],


### PR DESCRIPTION
## Summary

- `.gitleaks.toml`: extend the paths allowlist to cover `*/testing/*` directories, alongside the existing `__tests__/` exclusion. Fixture data in `src/testing/` is always mock — never real credentials.
- `react-hostnames/src/testing/data.ts`: rename `tok_abc123xyz` → `mock-verify-pending-001` and `tok_def456uvw` → `mock-verify-error-002`. The `tok_` prefix + alphanumeric pattern hits the generic-api-key entropy threshold; descriptive mock names don't.

## Why both changes

The allowlist alone suppresses the historical commit findings from `--all` scans (the paths allowlist applies retroactively to matched file paths). The token rename ensures future scans of the fixture file never re-trigger the rule, regardless of gitleaks version or threshold changes.

## Verification

```
gitleaks detect --source . --verbose --log-opts="--all"
# → no leaks found (501 commits scanned)
```

## Test plan

- [ ] `gitleaks detect --source . --verbose --log-opts="--all"` exits 0
- [ ] `pnpm test` still passes (token values updated consistently in fixture)