### PR TITLE
feat(cookies): introduce @granit/cookies-cookieconsent adapter for vanilla-cookieconsent

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1022,8 +1022,31 @@
       "exports": []
     },
     {
+      "name": "@granit/cookies-cookieconsent",
+      "description": "vanilla-cookieconsent (cc_cookie) CMP adapter for @granit/cookies",
+      "exports": [
+        {
+          "name": "createCookieConsentProvider",
+          "kind": "function",
+          "signature": "function createCookieConsentProvider( options: CreateCookieConsentProviderOptions ="
+        },
+        {
+          "name": "CategoryNames",
+          "kind": "interface",
+          "signature": "interface CategoryNames",
+          "members": []
+        },
+        {
+          "name": "CreateCookieConsentProviderOptions",
+          "kind": "interface",
+          "signature": "interface CreateCookieConsentProviderOptions",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/cookies-klaro",
-      "description": "Klaro CMP adapter for @granit/cookies",
+      "description": "Klaro CMP adapter for @granit/cookies — DEPRECATED: migrate to @granit/cookies-cookieconsent",
       "exports": [
         {
           "name": "createKlaroCookieConsentProvider",

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -4,7 +4,7 @@ This file lists the third-party libraries used by the **granit-front** project
 along with their respective licenses. It is updated whenever an external
 dependency is added or modified.
 
-Last updated: 2026-06-01
+Last updated: 2026-06-02
 
 ---
 
@@ -12,7 +12,7 @@ Last updated: 2026-06-01
 
 | License      | Package count |
 | ------------ | ------------- |
-| MIT          | 42            |
+| MIT          | 43            |
 | Apache-2.0   | 14            |
 | BSD-3-Clause | 1             |
 
@@ -67,6 +67,7 @@ Last updated: 2026-06-01
 | tailwind-merge                  | 3.6.0    | Copyright (c) Dany Castillo                |
 | tsup                            | 8.5.1    | Copyright (c) EGOIST                       |
 | typescript-eslint               | 8.60.0   | typescript-eslint Contributors             |
+| vanilla-cookieconsent           | 3.1.0    | Copyright (c) Orest Bida                   |
 | vite                            | 8.0.16   | Copyright (c) Evan You                     |
 | amazon-cognito-identity-js      | 6.3.16   | Copyright (c) Amazon.com, Inc.             |
 | vitest                          | 4.1.8    | Vitest Contributors                        |
@@ -96,8 +97,9 @@ Last updated: 2026-06-01
 | ------- | ------- | ------------------------------------ |
 | klaro   | 0.7.21  | Copyright (c) KIProtect GmbH, Berlin |
 
-> `klaro` is a peerDependency of `@granit/cookies-klaro`, installed in
-> consumer applications.
+> `klaro` is a peerDependency of the deprecated `@granit/cookies-klaro`, installed in
+> consumer applications. `vanilla-cookieconsent` is a peerDependency of
+> `@granit/cookies-cookieconsent`, its replacement.
 >
 > `@azure/msal-browser` is a peerDependency of `@granit/authentication-entraid`,
 > `amazon-cognito-identity-js` is a peerDependency of `@granit/authentication-cognito`,

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "tsup": "^8.5.1",
     "typescript": "~6.0.3",
     "typescript-eslint": "^8.60.0",
+    "vanilla-cookieconsent": "3.1.0",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"
   },

--- a/packages/@granit/cookies-cookieconsent/README.md
+++ b/packages/@granit/cookies-cookieconsent/README.md
@@ -1,0 +1,68 @@
+# @granit/cookies-cookieconsent
+
+`vanilla-cookieconsent` (cc_cookie) adapter for [`@granit/cookies`](../cookies/README.md).
+
+Replaces the deprecated [`@granit/cookies-klaro`](../cookies-klaro/README.md) adapter.
+
+## Installation
+
+```bash
+pnpm add @granit/cookies-cookieconsent vanilla-cookieconsent
+```
+
+## Usage
+
+```ts
+import { createCookieConsentProvider } from '@granit/cookies-cookieconsent';
+
+const provider = createCookieConsentProvider({
+  // Dynamic mode: fetch registered services from the backend
+  loadConfig: () => apiClient.get('/api/v1/cookies/config').then(r => r.data),
+  cookieName: 'cc_cookie', // default — must match Http:Cookies:CookieConsent:CookieName
+});
+
+// Pass to the React provider from @granit/react-cookies
+<CookieConsentProvider provider={provider}>
+  <App />
+</CookieConsentProvider>
+```
+
+## Category mapping
+
+The adapter maps `CookieCategory` to vanilla-cookieconsent category names:
+
+| `CookieCategory`     | cc_cookie name |
+| -------------------- | -------------- |
+| `strictly_necessary` | `necessary`    |
+| `preferences`        | `functional`   |
+| `analytics`          | `analytics`    |
+| `marketing`          | `marketing`    |
+
+Override via `categoryNames` if the backend is configured with non-default names:
+
+```ts
+createCookieConsentProvider({
+  categoryNames: { analytics: 'stats', marketing: 'ads' },
+});
+```
+
+## Headless mode
+
+The adapter operates headlessly — it manages consent state without rendering UI.
+`autoShow: false` is always set; the consuming application owns the consent banner.
+
+## Migration from @granit/cookies-klaro
+
+```ts
+// Before
+import { createKlaroCookieConsentProvider } from '@granit/cookies-klaro';
+const provider = createKlaroCookieConsentProvider({ loadConfig, cookieName: 'klaro' });
+
+// After
+import { createCookieConsentProvider } from '@granit/cookies-cookieconsent';
+const provider = createCookieConsentProvider({ loadConfig, cookieName: 'cc_cookie' });
+```
+
+The backend migration is handled by switching from `UseKlaro()` to `UseCookieConsent()`
+in `AddGranitCookies()`. See [granit-dotnet#230](https://github.com/granit-fx/granit-dotnet)
+for the .NET counterpart.

--- a/packages/@granit/cookies-cookieconsent/package.json
+++ b/packages/@granit/cookies-cookieconsent/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "@granit/cookies-klaro",
-  "description": "Klaro CMP adapter for @granit/cookies — DEPRECATED: migrate to @granit/cookies-cookieconsent",
-  "deprecated": "Migrate to @granit/cookies-cookieconsent. See https://github.com/granit-fx/granit-front/issues/230",
-  "version": "0.2.0",
+  "name": "@granit/cookies-cookieconsent",
+  "description": "vanilla-cookieconsent (cc_cookie) CMP adapter for @granit/cookies",
+  "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
@@ -16,7 +15,7 @@
   },
   "peerDependencies": {
     "@granit/cookies": "workspace:*",
-    "klaro": "^0.7.0"
+    "vanilla-cookieconsent": "^3.0.0"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/cookies-cookieconsent/src/__tests__/create-cookie-consent-provider.test.ts
+++ b/packages/@granit/cookies-cookieconsent/src/__tests__/create-cookie-consent-provider.test.ts
@@ -1,0 +1,364 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createCookieConsentProvider } from '../adapters/create-cookie-consent-provider';
+
+import type { VanillaCookieConsent } from '../types/index';
+
+const mockCc: VanillaCookieConsent = {
+  run: vi.fn(),
+  acceptCategory: vi.fn(),
+  acceptedCategory: vi.fn(),
+  validConsent: vi.fn(),
+  getUserPreferences: vi.fn(),
+};
+
+vi.mock('vanilla-cookieconsent', () => ({
+  default: mockCc,
+}));
+
+describe('createCookieConsentProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(mockCc.run).mockResolvedValue(undefined);
+    vi.mocked(mockCc.acceptedCategory).mockReturnValue(false);
+    vi.mocked(mockCc.validConsent).mockReturnValue(false);
+    vi.mocked(mockCc.getUserPreferences).mockReturnValue({
+      acceptedCategories: ['necessary'],
+      rejectedCategories: ['functional', 'analytics', 'marketing'],
+    });
+  });
+
+  afterEach(() => {
+    document.cookie = 'cc_cookie=; expires=Thu, 01 Jan 1970 00:00:00 GMT';
+  });
+
+  describe('getConsents — before init', () => {
+    it('returns all-false defaults before init', () => {
+      const provider = createCookieConsentProvider();
+      const state = provider.getConsents();
+
+      expect(state.strictly_necessary).toBe(true);
+      expect(state.preferences).toBe(false);
+      expect(state.analytics).toBe(false);
+      expect(state.marketing).toBe(false);
+    });
+  });
+
+  describe('init', () => {
+    it('calls cc.run with necessary category as readOnly and optional categories', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      expect(mockCc.run).toHaveBeenCalledOnce();
+      const config = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      expect(config?.categories).toMatchObject({
+        necessary: { enabled: true, readOnly: true },
+        functional: {},
+        analytics: {},
+        marketing: {},
+      });
+    });
+
+    it('uses default cookie name cc_cookie', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      const config = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      expect(config?.cookie?.name).toBe('cc_cookie');
+    });
+
+    it('uses custom cookieName option', async () => {
+      const provider = createCookieConsentProvider({ cookieName: 'my_consent' });
+      await provider.init();
+
+      const config = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      expect(config?.cookie?.name).toBe('my_consent');
+    });
+
+    it('sets autoShow: false for headless operation', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      const config = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      expect(config?.autoShow).toBe(false);
+    });
+  });
+
+  describe('getConsents — after init', () => {
+    it('maps acceptedCategory results to ConsentState', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      vi.mocked(mockCc.acceptedCategory).mockImplementation((cat) => cat === 'analytics');
+
+      const state = provider.getConsents();
+      expect(state.strictly_necessary).toBe(true);
+      expect(state.preferences).toBe(false); // functional not accepted
+      expect(state.analytics).toBe(true);
+      expect(state.marketing).toBe(false);
+    });
+
+    it('strictly_necessary is always true regardless of acceptedCategory', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      vi.mocked(mockCc.acceptedCategory).mockReturnValue(false);
+
+      expect(provider.getConsents().strictly_necessary).toBe(true);
+    });
+  });
+
+  describe('onConsentChange', () => {
+    it('subscribes and receives consent state on onChange callback', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      const callback = vi.fn();
+      provider.onConsentChange(callback);
+
+      vi.mocked(mockCc.acceptedCategory).mockImplementation((cat) => cat === 'analytics');
+
+      // Retrieve the onChange function registered with cc.run and invoke it
+      const runConfig = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      runConfig?.onChange?.();
+
+      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          strictly_necessary: true,
+          analytics: true,
+          preferences: false,
+          marketing: false,
+        })
+      );
+    });
+
+    it('fires subscribers on onConsent callback (page reload)', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      const callback = vi.fn();
+      provider.onConsentChange(callback);
+
+      const runConfig = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      runConfig?.onConsent?.();
+
+      expect(callback).toHaveBeenCalledOnce();
+    });
+
+    it('unsubscribes when the returned function is called', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      const callback = vi.fn();
+      const unsubscribe = provider.onConsentChange(callback);
+      unsubscribe();
+
+      const runConfig = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      runConfig?.onChange?.();
+
+      expect(callback).not.toHaveBeenCalled();
+    });
+
+    it('supports multiple independent subscribers', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      const cb1 = vi.fn();
+      const cb2 = vi.fn();
+      provider.onConsentChange(cb1);
+      provider.onConsentChange(cb2);
+
+      const runConfig = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      runConfig?.onChange?.();
+
+      expect(cb1).toHaveBeenCalledOnce();
+      expect(cb2).toHaveBeenCalledOnce();
+    });
+
+    it('returns no-op from onConsentChange before init', () => {
+      const provider = createCookieConsentProvider();
+
+      const callback = vi.fn();
+      const unsubscribe = provider.onConsentChange(callback);
+
+      expect(typeof unsubscribe).toBe('function');
+      expect(() => unsubscribe()).not.toThrow();
+    });
+  });
+
+  describe('setConsent', () => {
+    it('adds category to accepted list when granting', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      vi.mocked(mockCc.getUserPreferences).mockReturnValue({
+        acceptedCategories: ['necessary'],
+        rejectedCategories: ['functional', 'analytics', 'marketing'],
+      });
+
+      provider.setConsent('analytics', true);
+
+      expect(mockCc.acceptCategory).toHaveBeenCalledWith(['analytics']);
+    });
+
+    it('keeps existing accepted categories when adding a new one', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      vi.mocked(mockCc.getUserPreferences).mockReturnValue({
+        acceptedCategories: ['necessary', 'functional'],
+        rejectedCategories: ['analytics', 'marketing'],
+      });
+
+      provider.setConsent('analytics', true);
+
+      expect(mockCc.acceptCategory).toHaveBeenCalledWith(
+        expect.arrayContaining(['functional', 'analytics'])
+      );
+    });
+
+    it('removes category from accepted list when revoking', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      vi.mocked(mockCc.getUserPreferences).mockReturnValue({
+        acceptedCategories: ['necessary', 'functional', 'analytics'],
+        rejectedCategories: ['marketing'],
+      });
+
+      provider.setConsent('analytics', false);
+
+      expect(mockCc.acceptCategory).toHaveBeenCalledWith(['functional']);
+    });
+
+    it('ignores strictly_necessary — cannot be changed', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      provider.setConsent('strictly_necessary', true);
+
+      expect(mockCc.acceptCategory).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op before init', () => {
+      const provider = createCookieConsentProvider();
+      provider.setConsent('analytics', true);
+
+      expect(mockCc.acceptCategory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setAllConsents', () => {
+    it('accepts all optional categories when granted=true', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      provider.setAllConsents(true);
+
+      expect(mockCc.acceptCategory).toHaveBeenCalledWith(
+        expect.arrayContaining(['functional', 'analytics', 'marketing'])
+      );
+    });
+
+    it('accepts empty array when granted=false (keeps only readOnly necessary)', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      provider.setAllConsents(false);
+
+      expect(mockCc.acceptCategory).toHaveBeenCalledWith([]);
+    });
+
+    it('is a no-op before init', () => {
+      const provider = createCookieConsentProvider();
+      provider.setAllConsents(true);
+
+      expect(mockCc.acceptCategory).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('hasConsented', () => {
+    it('returns false before init', () => {
+      const provider = createCookieConsentProvider();
+      expect(provider.hasConsented()).toBe(false);
+    });
+
+    it('delegates to cc.validConsent() after init', async () => {
+      const provider = createCookieConsentProvider();
+      await provider.init();
+
+      vi.mocked(mockCc.validConsent).mockReturnValue(true);
+      expect(provider.hasConsented()).toBe(true);
+
+      vi.mocked(mockCc.validConsent).mockReturnValue(false);
+      expect(provider.hasConsented()).toBe(false);
+    });
+  });
+
+  describe('categoryNames override', () => {
+    it('uses custom category names in cc.run config', async () => {
+      const provider = createCookieConsentProvider({
+        categoryNames: { analytics: 'stats', marketing: 'ads' },
+      });
+      await provider.init();
+
+      const config = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      expect(config?.categories).toHaveProperty('stats');
+      expect(config?.categories).toHaveProperty('ads');
+      expect(config?.categories).not.toHaveProperty('analytics');
+      expect(config?.categories).not.toHaveProperty('marketing');
+    });
+
+    it('reads from custom category names via acceptedCategory', async () => {
+      const provider = createCookieConsentProvider({
+        categoryNames: { analytics: 'stats' },
+      });
+      await provider.init();
+
+      vi.mocked(mockCc.acceptedCategory).mockImplementation((cat) => cat === 'stats');
+
+      const state = provider.getConsents();
+      expect(state.analytics).toBe(true);
+    });
+  });
+
+  describe('loadConfig (dynamic mode)', () => {
+    it('registers only categories present in service list', async () => {
+      const provider = createCookieConsentProvider({
+        loadConfig: async () => ({
+          cookies: [],
+          services: [
+            { name: 'ga', category: 'analytics', cookiePatterns: [] },
+            { name: 'fb', category: 'marketing', cookiePatterns: [] },
+          ],
+        }),
+      });
+      await provider.init();
+
+      const config = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      expect(config?.categories).toHaveProperty('analytics');
+      expect(config?.categories).toHaveProperty('marketing');
+      expect(config?.categories).not.toHaveProperty('functional');
+    });
+
+    it('includes all default categories when all are present in services', async () => {
+      const provider = createCookieConsentProvider({
+        loadConfig: async () => ({
+          cookies: [],
+          services: [
+            { name: 's1', category: 'analytics', cookiePatterns: [] },
+            { name: 's2', category: 'marketing', cookiePatterns: [] },
+            { name: 's3', category: 'preferences', cookiePatterns: [] },
+          ],
+        }),
+      });
+      await provider.init();
+
+      const config = vi.mocked(mockCc.run).mock.calls[0]?.[0];
+      expect(config?.categories).toHaveProperty('analytics');
+      expect(config?.categories).toHaveProperty('marketing');
+      expect(config?.categories).toHaveProperty('functional');
+    });
+  });
+});

--- a/packages/@granit/cookies-cookieconsent/src/adapters/create-cookie-consent-provider.ts
+++ b/packages/@granit/cookies-cookieconsent/src/adapters/create-cookie-consent-provider.ts
@@ -1,0 +1,155 @@
+import type {
+  CategoryNames,
+  CreateCookieConsentProviderOptions,
+  VanillaCookieConsent,
+} from '../types/index';
+import type {
+  CookieCategory,
+  CookieConsentProvider as CookieConsentProviderInterface,
+  ConsentState,
+} from '@granit/cookies';
+
+const DEFAULT_CATEGORY_NAMES: CategoryNames = {
+  preferences: 'functional',
+  analytics: 'analytics',
+  marketing: 'marketing',
+};
+
+/** Category name for the always-on necessary category in vanilla-cookieconsent. */
+const NECESSARY_CATEGORY = 'necessary';
+
+function buildConsentState(cc: VanillaCookieConsent, names: CategoryNames): ConsentState {
+  return {
+    strictly_necessary: true,
+    preferences: cc.acceptedCategory(names.preferences),
+    analytics: cc.acceptedCategory(names.analytics),
+    marketing: cc.acceptedCategory(names.marketing),
+  };
+}
+
+/**
+ * Creates a `CookieConsentProvider` backed by vanilla-cookieconsent (cc_cookie format).
+ *
+ * The adapter operates in headless mode — it manages consent state without
+ * rendering any UI. The consuming application is responsible for showing the
+ * consent banner and calling the provider methods.
+ *
+ * @example
+ * ```ts
+ * const provider = createCookieConsentProvider({
+ *   loadConfig: () => apiClient.get('/api/v1/cookies/config').then(r => r.data),
+ *   cookieName: 'cc_cookie',
+ * });
+ * ```
+ */
+export function createCookieConsentProvider(
+  options: CreateCookieConsentProviderOptions = {}
+): CookieConsentProviderInterface {
+  const cookieName = options.cookieName ?? 'cc_cookie';
+  const resolvedNames: CategoryNames = {
+    ...DEFAULT_CATEGORY_NAMES,
+    ...options.categoryNames,
+  };
+
+  let cc: VanillaCookieConsent | null = null;
+  const subscribers = new Set<(state: ConsentState) => void>();
+
+  function notify(): void {
+    if (!cc) return;
+    const state = buildConsentState(cc, resolvedNames);
+    for (const callback of subscribers) {
+      callback(state);
+    }
+  }
+
+  return {
+    async init() {
+      const mod = await import('vanilla-cookieconsent');
+      // vanilla-cookieconsent uses a CommonJS-style namespace export
+      cc = (mod.default ?? mod) as unknown as VanillaCookieConsent;
+
+      const optionalCategories: Record<string, object> = {
+        [resolvedNames.preferences]: {},
+        [resolvedNames.analytics]: {},
+        [resolvedNames.marketing]: {},
+      };
+
+      if (options.loadConfig) {
+        const config = await options.loadConfig();
+        // Derive which optional categories are actually in use from the service list.
+        // Categories absent from the service list are still registered so the
+        // cookie schema stays consistent with the backend defaults.
+        const activeCategories = new Set(config.services.map((s) => s.category));
+        const categoryMap: Partial<Record<CookieCategory, string>> = {
+          preferences: resolvedNames.preferences,
+          analytics: resolvedNames.analytics,
+          marketing: resolvedNames.marketing,
+        };
+        for (const [granitCat, ccName] of Object.entries(categoryMap)) {
+          if (!activeCategories.has(granitCat as CookieCategory)) {
+            delete optionalCategories[ccName];
+          }
+        }
+      }
+
+      await cc.run({
+        categories: {
+          [NECESSARY_CATEGORY]: { enabled: true, readOnly: true },
+          ...optionalCategories,
+        },
+        onConsent: notify,
+        onChange: notify,
+        cookie: { name: cookieName },
+        autoShow: false,
+      });
+    },
+
+    getConsents(): ConsentState {
+      if (!cc) {
+        return {
+          strictly_necessary: true,
+          preferences: false,
+          analytics: false,
+          marketing: false,
+        };
+      }
+      return buildConsentState(cc, resolvedNames);
+    },
+
+    onConsentChange(callback) {
+      if (!cc) return () => {};
+      subscribers.add(callback);
+      return () => {
+        subscribers.delete(callback);
+      };
+    },
+
+    setConsent(category: CookieCategory, granted: boolean): void {
+      if (!cc || category === 'strictly_necessary') return;
+
+      const ccName = resolvedNames[category as keyof CategoryNames];
+      const prefs = cc.getUserPreferences();
+      const currentOptional = prefs.acceptedCategories.filter((c) => c !== NECESSARY_CATEGORY);
+
+      const next = granted
+        ? [...new Set([...currentOptional, ccName])]
+        : currentOptional.filter((c) => c !== ccName);
+
+      cc.acceptCategory(next);
+    },
+
+    setAllConsents(granted: boolean): void {
+      if (!cc) return;
+
+      if (granted) {
+        cc.acceptCategory(Object.values(resolvedNames));
+      } else {
+        cc.acceptCategory([]);
+      }
+    },
+
+    hasConsented(): boolean {
+      return cc?.validConsent() ?? false;
+    },
+  };
+}

--- a/packages/@granit/cookies-cookieconsent/src/index.ts
+++ b/packages/@granit/cookies-cookieconsent/src/index.ts
@@ -1,0 +1,2 @@
+export { createCookieConsentProvider } from './adapters/create-cookie-consent-provider';
+export type { CategoryNames, CreateCookieConsentProviderOptions } from './types/index';

--- a/packages/@granit/cookies-cookieconsent/src/types/index.ts
+++ b/packages/@granit/cookies-cookieconsent/src/types/index.ts
@@ -1,0 +1,62 @@
+import type { CookieConsentConfig } from '@granit/cookies';
+
+/**
+ * Maps `CookieCategory` keys to the category names used in the cc_cookie.
+ * Defaults align with `@granit/cookies-cookieconsent` built-ins and the backend
+ * `Granit.Http.Cookies.CookieConsent` defaults.
+ */
+export interface CategoryNames {
+  /** cc_cookie name for the `preferences` category. Default: `"functional"`. */
+  readonly preferences: string;
+  /** cc_cookie name for the `analytics` category. Default: `"analytics"`. */
+  readonly analytics: string;
+  /** cc_cookie name for the `marketing` category. Default: `"marketing"`. */
+  readonly marketing: string;
+}
+
+/**
+ * Options for creating a CookieConsent provider backed by vanilla-cookieconsent.
+ */
+export interface CreateCookieConsentProviderOptions {
+  /**
+   * Loads the CMP-agnostic cookie configuration from the backend API.
+   * When provided, the adapter builds the category list from the service
+   * definitions returned by the API.
+   */
+  readonly loadConfig?: () => Promise<CookieConsentConfig>;
+
+  /**
+   * Name of the cookie used to persist consent.
+   * Must match `Http:Cookies:CookieConsent:CookieName` on the backend.
+   *
+   * @default 'cc_cookie'
+   */
+  readonly cookieName?: string;
+
+  /**
+   * Override the category names written into the cc_cookie.
+   * Only needed if the backend is configured with non-default names.
+   */
+  readonly categoryNames?: Partial<CategoryNames>;
+}
+
+/**
+ * Minimal interface for the vanilla-cookieconsent singleton used by the adapter.
+ * Typed against the subset of the `vanilla-cookieconsent` public API we rely on.
+ */
+export interface VanillaCookieConsent {
+  run(config: VanillaCookieConsentConfig): Promise<void>;
+  acceptCategory(categories: string | string[], excluded?: string[]): void;
+  acceptedCategory(categoryName: string): boolean;
+  validConsent(): boolean;
+  getUserPreferences(): { acceptedCategories: string[]; rejectedCategories: string[] };
+}
+
+export interface VanillaCookieConsentConfig {
+  categories: Record<string, { enabled?: boolean; readOnly?: boolean }>;
+  onConsent?: () => void;
+  onChange?: () => void;
+  cookie?: { name?: string };
+  disablePageInteraction?: boolean;
+  autoShow?: boolean;
+}

--- a/packages/@granit/cookies-cookieconsent/tsconfig.json
+++ b/packages/@granit/cookies-cookieconsent/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/cookies": ["../cookies/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/cookies-cookieconsent/tsup.config.ts
+++ b/packages/@granit/cookies-cookieconsent/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/cookies-klaro/README.md
+++ b/packages/@granit/cookies-klaro/README.md
@@ -2,6 +2,11 @@
 
 # @granit/cookies-klaro
 
+> **Deprecated** — this package is deprecated and will be removed in the next minor release.
+> Migrate to [`@granit/cookies-cookieconsent`](../cookies-cookieconsent/README.md),
+> which replaces Klaro with the actively-maintained `vanilla-cookieconsent` library.
+> See [granit-front#230](https://github.com/granit-fx/granit-front/issues/230) for context.
+
 Klaro CMP adapter for `@granit/cookies`: `createKlaroCookieConsentProvider` factory.
 
 Part of the [Granit](https://granit-fx.dev) framework.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -159,6 +159,9 @@ importers:
       typescript-eslint:
         specifier: ^8.60.0
         version: 8.60.0(eslint@10.4.1(jiti@2.6.1))(typescript@6.0.3)
+      vanilla-cookieconsent:
+        specifier: 3.1.0
+        version: 3.1.0
       vite:
         specifier: ^8.0.16
         version: 8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(yaml@2.9.0)
@@ -6904,6 +6907,9 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
+  vanilla-cookieconsent@3.1.0:
+    resolution: {integrity: sha512-/McNRtm/3IXzb9dhqMIcbquoU45SzbN2VB+To4jxEPqMmp7uVniP6BhGLjU8MC7ZCDsNQVOp27fhQTM/ruIXAA==}
+
   vite@8.0.16:
     resolution: {integrity: sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -11389,6 +11395,8 @@ snapshots:
       react: 19.2.6
 
   uuid@9.0.1: {}
+
+  vanilla-cookieconsent@3.1.0: {}
 
   vite@8.0.16(@types/node@25.9.1)(esbuild@0.27.7)(jiti@2.6.1)(sass@1.100.0)(yaml@2.9.0):
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -157,6 +157,10 @@ export default defineConfig({
         __dirname,
         'packages/@granit/cookies-klaro/src/index.ts'
       ),
+      '@granit/cookies-cookieconsent': path.resolve(
+        __dirname,
+        'packages/@granit/cookies-cookieconsent/src/index.ts'
+      ),
       '@granit/data-exchange': path.resolve(
         __dirname,
         'packages/@granit/data-exchange/src/index.ts'


### PR DESCRIPTION
## Summary

- Introduces new package `@granit/cookies-cookieconsent` v0.1.0 — a headless `CookieConsentProvider` backed by `vanilla-cookieconsent` (cc_cookie format), matching the .NET `Granit.Http.Cookies.CookieConsent` counterpart
- Category mapping is category-direct (`necessary / functional / analytics / marketing`), configurable via `categoryNames` to align with non-default backend config
- `@granit/cookies-klaro` marked deprecated in `package.json` and README — to be removed in the next minor
- `vanilla-cookieconsent` MIT added to `THIRD-PARTY-NOTICES.md`

## Changes

- `packages/@granit/cookies-cookieconsent/` — new package:
  - `createCookieConsentProvider()` factory implementing `CookieConsentProvider`
  - Headless by default (`autoShow: false`), `loadConfig` dynamic mode
  - 26 unit tests covering all interface methods + edge cases
- `packages/@granit/cookies-klaro/package.json` + `README.md` — deprecation notice
- `vitest.config.ts` — alias for `@granit/cookies-cookieconsent`
- `THIRD-PARTY-NOTICES.md` — vanilla-cookieconsent MIT entry

## Test plan

- [x] `pnpm vitest run packages/@granit/cookies-cookieconsent` → 26/26 pass
- [x] `pnpm vitest run packages/@granit/cookies-klaro` → 23/23 pass (no regression)
- [x] `pnpm tsc` → clean
- [x] `pnpm lint` → clean
- [x] markdownlint → clean on all modified `.md` files

Closes #230