### PR TITLE
docs(hostnames): add README to @granit/hostnames and @granit/react-hostnames

### DIFF
--- a/packages/@granit/hostnames/README.md
+++ b/packages/@granit/hostnames/README.md
@@ -1,0 +1,67 @@
+<img src="https://granit-fx.dev/images/granit-icon.svg" alt="" height="32" align="left" style="margin-right:10px" />
+
+# @granit/hostnames
+
+Framework-agnostic core package for the **Granit Hostnames** module: DTOs, Axios
+API calls, and permission constants.
+
+Mirrors the `Granit.Hostnames` .NET domain. Consumed by
+[`@granit/react-hostnames`](../react-hostnames/README.md).
+
+Part of the [Granit](https://granit-fx.dev) framework.
+
+## Exports
+
+### Types
+
+| Type                           | Description                                              |
+| ------------------------------ | -------------------------------------------------------- |
+| `ManagedHostnameResponse`      | Full hostname descriptor (id, host, status, DNS, TLS, …) |
+| `ManagedHostnameStatus`        | `Pending \| Verifying \| Active \| Error`                |
+| `CertificateStatus`            | `Unprovisioned \| Provisioning \| Secured \| Error`      |
+| `CreateManagedHostnameRequest` | Request body for hostname creation                       |
+| `UpdateManagedHostnameRequest` | Request body to toggle `isPrimary`                       |
+| `ListHostnamesParams`          | Query params for the paginated list endpoint             |
+| `CheckAvailabilityResponse`    | `{ isAvailable: boolean }`                               |
+| `ExpectedDnsRecord`            | DNS record required for domain ownership verification    |
+| `HostnameConflict`             | Conflict preventing a hostname from becoming active      |
+| `PagedResponse<T>`             | Generic 0-based pagination envelope                      |
+
+### API functions
+
+All functions take an `AxiosInstance` (from `@granit/api-client`) and a
+`basePath` string. The default base path is `/api/hostnames`.
+
+| Function                  | HTTP call                                 |
+| ------------------------- | ----------------------------------------- |
+| `listHostnames`           | `GET {basePath}`                          |
+| `getHostname`             | `GET {basePath}/{id}`                     |
+| `createHostname`          | `POST {basePath}`                         |
+| `updateHostname`          | `PATCH {basePath}/{id}`                   |
+| `deleteHostname`          | `DELETE {basePath}/{id}`                  |
+| `checkAvailability`       | `GET {basePath}/check-availability?host=` |
+| `verifyNow`               | `POST {basePath}/{id}/verify-now`         |
+| `reportCertificateStatus` | `POST {basePath}/{id}/certificate-status` |
+
+### Permissions
+
+```ts
+import { HostnamesPermissions } from '@granit/hostnames';
+
+// Hostnames.Hostnames.Read
+// Hostnames.Hostnames.Manage
+// Hostnames.Certificates.Report
+```
+
+## Usage
+
+This package is consumed indirectly through `@granit/react-hostnames`. Direct
+use is only needed for headless scenarios (server-side or non-React clients).
+
+```ts
+import { listHostnames, ManagedHostnameStatus } from '@granit/hostnames';
+import type { ListHostnamesParams } from '@granit/hostnames';
+
+const params: ListHostnamesParams = { page: 0, pageSize: 20, status: ManagedHostnameStatus.Active };
+const { items, totalCount } = await listHostnames(axiosClient, '/api/hostnames', params);
+```

--- a/packages/@granit/react-hostnames/README.md
+++ b/packages/@granit/react-hostnames/README.md
@@ -1,0 +1,92 @@
+<img src="https://granit-fx.dev/images/granit-icon.svg" alt="" height="32" align="left" style="margin-right:10px" />
+
+# @granit/react-hostnames
+
+React hooks and provider for the **Granit Hostnames** module — lets applications
+manage custom domains (DNS verification, TLS provisioning, primary flag).
+
+Depends on [`@granit/hostnames`](../hostnames/README.md) for the core API.
+
+Part of the [Granit](https://granit-fx.dev) framework.
+
+## Setup
+
+Wrap the relevant part of your tree with `HostnamesProvider`. The provider
+reads the Axios client from the nearest `<GranitClientProvider>` by default.
+
+```tsx
+import { HostnamesProvider } from '@granit/react-hostnames';
+
+<HostnamesProvider config={{ basePath: '/api/hostnames' }}>
+  <MyApp />
+</HostnamesProvider>;
+```
+
+Pass `config.client` explicitly if the module uses a different Axios instance:
+
+```tsx
+<HostnamesProvider config={{ client: myClient, basePath: '/api/hostnames' }}>
+  <MyApp />
+</HostnamesProvider>
+```
+
+## Hooks
+
+### Query hooks
+
+```tsx
+import { useHostnames, useHostname, useCheckAvailability } from '@granit/react-hostnames';
+
+// Paginated list
+const { data } = useHostnames({ page: 0, pageSize: 20, ownerType: 'cms.site' });
+
+// Single hostname
+const { data: hostname } = useHostname('hostname-id');
+
+// Availability check
+const { data } = useCheckAvailability('app.example.com');
+```
+
+### Mutation hooks
+
+```tsx
+import {
+  useCreateHostname,
+  useUpdateHostname,
+  useDeleteHostname,
+  useVerifyNow,
+} from '@granit/react-hostnames';
+
+const { mutateAsync: create } = useCreateHostname();
+await create({ host: 'app.example.com', ownerType: 'cms.site', ownerId: 'site-1' });
+
+const { mutate: setPrimary } = useUpdateHostname();
+setPrimary({ id: 'hostname-id', request: { isPrimary: true } });
+
+const { mutate: remove } = useDeleteHostname();
+remove('hostname-id');
+
+const { mutate: recheck } = useVerifyNow();
+recheck('hostname-id'); // triggers immediate DNS re-verification
+```
+
+All mutation hooks invalidate the relevant queries on success.
+
+## Query keys
+
+```ts
+import { hostnamesKeys } from '@granit/react-hostnames';
+
+hostnamesKeys.all(); // root key for all hostnames queries
+hostnamesKeys.lists(); // all list queries
+hostnamesKeys.list(params); // list with specific params
+hostnamesKeys.hostname(id); // single hostname detail
+```
+
+## Testing
+
+```ts
+import { hostnameHandlers, mockHostname } from '@granit/react-hostnames/testing';
+```
+
+MSW handlers covering all endpoints are available from the `/testing` subpath.


### PR DESCRIPTION
## Summary

- Adds missing `README.md` to `@granit/hostnames`: types table, API functions with HTTP routes, permissions, usage example
- Adds missing `README.md` to `@granit/react-hostnames`: provider setup, query/mutation hooks, query keys, testing subpath

Both packages were introduced in #516 without READMEs.