### PR TITLE
fix(lockfile): sync pnpm-lock.yaml for @granit/cookies-cookieconsent peer deps

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -371,6 +371,15 @@ importers:
 
   packages/@granit/cookies: {}
 
+  packages/@granit/cookies-cookieconsent:
+    dependencies:
+      '@granit/cookies':
+        specifier: workspace:*
+        version: link:../cookies
+      vanilla-cookieconsent:
+        specifier: ^3.0.0
+        version: 3.1.0
+
   packages/@granit/cookies-klaro:
     dependencies:
       '@granit/cookies':


### PR DESCRIPTION
## Summary

CI failed with `ERR_PNPM_OUTDATED_LOCKFILE` after #518 was merged: the lockfile didn't include the `@granit/cookies@workspace:*` and `vanilla-cookieconsent@^3.0.0` peer dependency entries for the new `@granit/cookies-cookieconsent` package.

Ran `pnpm install` locally to regenerate the lockfile (+9 lines).