### PR TITLE
fix(hostnames): align front API contract with Granit.Hostnames.Endpoints

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1326,6 +1326,16 @@
       "description": "Managed hostname types and API functions — mirrors Granit.Hostnames .NET contract",
       "exports": [
         {
+          "name": "CertificateStatus",
+          "kind": "type",
+          "signature": "type CertificateStatus = 'Unprovisioned' | 'Provisioning' | 'Secured' | 'Error'"
+        },
+        {
+          "name": "ManagedHostnameStatus",
+          "kind": "type",
+          "signature": "type ManagedHostnameStatus = 'Pending' | 'Verifying' | 'Active' | 'Error'"
+        },
+        {
           "name": "HostnamesPermissions",
           "kind": "const",
           "signature": "const HostnamesPermissions"
@@ -4523,9 +4533,19 @@
       "description": "React hooks for managed hostname management — useHostnames, useHostname, useCreateHostname, useUpdateHostname, useDeleteHostname, useVerifyNow, useCheckAvailability",
       "exports": [
         {
+          "name": "HostnamesProvider",
+          "kind": "function",
+          "signature": "function HostnamesProvider("
+        },
+        {
+          "name": "useHostnamesConfig",
+          "kind": "function",
+          "signature": "function useHostnamesConfig(): ResolvedHostnamesConfig"
+        },
+        {
           "name": "useHostnames",
           "kind": "function",
-          "signature": "function useHostnames( params?: ListHostnamesParams ): UseQueryResult<PagedResponse<ManagedHostnameResponse>>"
+          "signature": "function useHostnames( params: ListHostnamesParams ): UseQueryResult<readonly ManagedHostnameResponse[]>"
         },
         {
           "name": "useCheckAvailability",

--- a/packages/@granit/hostnames/src/__tests__/hostnames-api.test.ts
+++ b/packages/@granit/hostnames/src/__tests__/hostnames-api.test.ts
@@ -3,21 +3,18 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   checkAvailability,
+  clearPrimary,
   createHostname,
   deleteHostname,
   getHostname,
   listHostnames,
   reportCertificateStatus,
-  updateHostname,
+  setPrimary,
   verifyNow,
 } from '../api/hostnames-api';
 import { CertificateStatus, ManagedHostnameStatus } from '../types/index';
 
-import type {
-  CheckAvailabilityResponse,
-  ManagedHostnameResponse,
-  PagedResponse,
-} from '../types/index';
+import type { CheckAvailabilityResponse, ManagedHostnameResponse } from '../types/index';
 
 const BASE = '/api/hostnames';
 
@@ -38,39 +35,34 @@ const mockHostname: ManagedHostnameResponse = {
   certificateStatus: CertificateStatus.Secured,
   certExpiresAt: '2027-06-01T10:00:00Z',
   createdAt: '2026-01-01T00:00:00Z',
-  updatedAt: '2026-06-01T10:00:00Z',
+  createdBy: 'user@example.com',
+  modifiedAt: '2026-06-01T10:00:00Z',
+  modifiedBy: 'user@example.com',
   concurrencyStamp: 'stamp-abc',
 };
 
 describe('hostnames-api', () => {
   describe('listHostnames', () => {
-    it('sends GET to basePath without params', async () => {
+    it('sends GET to basePath with required owner params', async () => {
       const client = createMockClient();
-      const response: PagedResponse<ManagedHostnameResponse> = {
-        items: [mockHostname],
-        totalCount: 1,
-        page: 0,
-        pageSize: 20,
-      };
+      const response: readonly ManagedHostnameResponse[] = [mockHostname];
       vi.mocked(client.get).mockResolvedValueOnce({ data: response });
 
-      const result = await listHostnames(client, BASE);
+      const params = { ownerType: 'cms.site', ownerId: 'owner-1' };
+      const result = await listHostnames(client, BASE, params);
 
-      expect(client.get).toHaveBeenCalledWith(BASE, { params: undefined });
+      expect(client.get).toHaveBeenCalledWith(BASE, { params });
       expect(result).toEqual(response);
     });
 
-    it('passes pagination and filter params', async () => {
+    it('passes maxResults param', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValueOnce({
-        data: { items: [], totalCount: 0, page: 1, pageSize: 10 },
-      });
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
 
-      await listHostnames(client, BASE, { page: 1, pageSize: 10, ownerType: 'cms.site' });
+      const params = { ownerType: 'cms.site', ownerId: 'owner-1', maxResults: 50 };
+      await listHostnames(client, BASE, params);
 
-      expect(client.get).toHaveBeenCalledWith(BASE, {
-        params: { page: 1, pageSize: 10, ownerType: 'cms.site' },
-      });
+      expect(client.get).toHaveBeenCalledWith(BASE, { params });
     });
   });
 
@@ -100,7 +92,12 @@ describe('hostnames-api', () => {
       const client = createMockClient();
       vi.mocked(client.post).mockResolvedValueOnce({ data: mockHostname });
 
-      const request = { host: 'app.example.com', ownerType: 'cms.site', ownerId: 'owner-1', isPrimary: true };
+      const request = {
+        host: 'app.example.com',
+        ownerType: 'cms.site',
+        ownerId: 'owner-1',
+        isPrimary: true,
+      };
       const result = await createHostname(client, BASE, request);
 
       expect(client.post).toHaveBeenCalledWith(BASE, request);
@@ -108,16 +105,25 @@ describe('hostnames-api', () => {
     });
   });
 
-  describe('updateHostname', () => {
-    it('sends PATCH to /{id} with isPrimary', async () => {
+  describe('setPrimary', () => {
+    it('sends POST to /{id}/primary', async () => {
       const client = createMockClient();
-      const updated = { ...mockHostname, isPrimary: false };
-      vi.mocked(client.patch).mockResolvedValueOnce({ data: updated });
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
-      const result = await updateHostname(client, BASE, mockHostname.id, { isPrimary: false });
+      await setPrimary(client, BASE, mockHostname.id);
 
-      expect(client.patch).toHaveBeenCalledWith(`${BASE}/${mockHostname.id}`, { isPrimary: false });
-      expect(result).toEqual(updated);
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/${mockHostname.id}/primary`);
+    });
+  });
+
+  describe('clearPrimary', () => {
+    it('sends DELETE to /{id}/primary', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await clearPrimary(client, BASE, mockHostname.id);
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/${mockHostname.id}/primary`);
     });
   });
 
@@ -133,14 +139,14 @@ describe('hostnames-api', () => {
   });
 
   describe('checkAvailability', () => {
-    it('sends GET to /check-availability with host param', async () => {
+    it('sends GET to /availability with host param', async () => {
       const client = createMockClient();
-      const response: CheckAvailabilityResponse = { isAvailable: true };
+      const response: CheckAvailabilityResponse = { host: 'new.example.com', isAvailable: true };
       vi.mocked(client.get).mockResolvedValueOnce({ data: response });
 
       const result = await checkAvailability(client, BASE, 'new.example.com');
 
-      expect(client.get).toHaveBeenCalledWith(`${BASE}/check-availability`, {
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/availability`, {
         params: { host: 'new.example.com' },
       });
       expect(result).toEqual(response);
@@ -148,7 +154,9 @@ describe('hostnames-api', () => {
 
     it('returns isAvailable false for taken hostnames', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValueOnce({ data: { isAvailable: false } });
+      vi.mocked(client.get).mockResolvedValueOnce({
+        data: { host: 'taken.example.com', isAvailable: false },
+      });
 
       const result = await checkAvailability(client, BASE, 'taken.example.com');
 
@@ -157,13 +165,14 @@ describe('hostnames-api', () => {
   });
 
   describe('verifyNow', () => {
-    it('sends POST to /{id}/verify-now', async () => {
+    it('sends POST to /{id}/verify-now and returns the updated hostname', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockHostname });
 
-      await verifyNow(client, BASE, mockHostname.id);
+      const result = await verifyNow(client, BASE, mockHostname.id);
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/${mockHostname.id}/verify-now`);
+      expect(result).toEqual(mockHostname);
     });
   });
 
@@ -174,14 +183,12 @@ describe('hostnames-api', () => {
 
       await reportCertificateStatus(client, BASE, mockHostname.id, {
         status: CertificateStatus.Secured,
-        certExpiresAt: '2027-06-01T10:00:00Z',
-        errorDetails: null,
+        expiresAt: '2027-06-01T10:00:00Z',
       });
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/${mockHostname.id}/certificate-status`, {
         status: CertificateStatus.Secured,
-        certExpiresAt: '2027-06-01T10:00:00Z',
-        errorDetails: null,
+        expiresAt: '2027-06-01T10:00:00Z',
       });
     });
   });

--- a/packages/@granit/hostnames/src/api/hostnames-api.ts
+++ b/packages/@granit/hostnames/src/api/hostnames-api.ts
@@ -4,22 +4,22 @@ import type {
   CreateManagedHostnameRequest,
   ListHostnamesParams,
   ManagedHostnameResponse,
-  PagedResponse,
-  UpdateManagedHostnameRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
- * List managed hostnames (paginated).
+ * List managed hostnames for an owner.
  *
- * `GET {basePath}`
+ * `GET {basePath}?ownerType=&ownerId=&maxResults=`
+ *
+ * Returns at most `maxResults` entries (default 100, capped at 500 server-side).
  */
 export async function listHostnames(
   client: AxiosInstance,
   basePath: string,
-  params?: ListHostnamesParams
-): Promise<PagedResponse<ManagedHostnameResponse>> {
-  const { data } = await client.get<PagedResponse<ManagedHostnameResponse>>(basePath, { params });
+  params: ListHostnamesParams
+): Promise<readonly ManagedHostnameResponse[]> {
+  const { data } = await client.get<readonly ManagedHostnameResponse[]>(basePath, { params });
   return data;
 }
 
@@ -54,21 +54,29 @@ export async function createHostname(
 }
 
 /**
- * Update a managed hostname (currently only `isPrimary` is patchable).
+ * Mark a hostname as the owner's canonical (primary) hostname.
  *
- * `PATCH {basePath}/{id}`
+ * `POST {basePath}/{id}/primary` — responds 204 No Content.
  */
-export async function updateHostname(
+export async function setPrimary(
   client: AxiosInstance,
   basePath: string,
-  id: string,
-  request: UpdateManagedHostnameRequest
-): Promise<ManagedHostnameResponse> {
-  const { data } = await client.patch<ManagedHostnameResponse>(
-    `${basePath}/${encodeURIComponent(id)}`,
-    request
-  );
-  return data;
+  id: string
+): Promise<void> {
+  await client.post(`${basePath}/${encodeURIComponent(id)}/primary`);
+}
+
+/**
+ * Clear the canonical (primary) flag from a hostname.
+ *
+ * `DELETE {basePath}/{id}/primary` — responds 204 No Content.
+ */
+export async function clearPrimary(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(`${basePath}/${encodeURIComponent(id)}/primary`);
 }
 
 /**
@@ -87,31 +95,33 @@ export async function deleteHostname(
 /**
  * Check whether a hostname is available (not already claimed by another owner).
  *
- * `GET {basePath}/check-availability?host=`
+ * `GET {basePath}/availability?host=`
  */
 export async function checkAvailability(
   client: AxiosInstance,
   basePath: string,
   host: string
 ): Promise<CheckAvailabilityResponse> {
-  const { data } = await client.get<CheckAvailabilityResponse>(
-    `${basePath}/check-availability`,
-    { params: { host } }
-  );
+  const { data } = await client.get<CheckAvailabilityResponse>(`${basePath}/availability`, {
+    params: { host },
+  });
   return data;
 }
 
 /**
  * Trigger an immediate re-verification of the hostname's DNS records.
  *
- * `POST {basePath}/{id}/verify-now` — responds 204 No Content.
+ * `POST {basePath}/{id}/verify-now` — responds 202 Accepted with the updated hostname record.
  */
 export async function verifyNow(
   client: AxiosInstance,
   basePath: string,
   id: string
-): Promise<void> {
-  await client.post(`${basePath}/${encodeURIComponent(id)}/verify-now`);
+): Promise<ManagedHostnameResponse> {
+  const { data } = await client.post<ManagedHostnameResponse>(
+    `${basePath}/${encodeURIComponent(id)}/verify-now`
+  );
+  return data;
 }
 
 /**

--- a/packages/@granit/hostnames/src/index.ts
+++ b/packages/@granit/hostnames/src/index.ts
@@ -1,8 +1,5 @@
 // Types
-export {
-  CertificateStatus,
-  ManagedHostnameStatus,
-} from './types/index';
+export { CertificateStatus, ManagedHostnameStatus } from './types/index';
 
 export type {
   CertificateStatusReportRequest,
@@ -13,19 +10,18 @@ export type {
   HostnameConflict,
   ListHostnamesParams,
   ManagedHostnameResponse,
-  PagedResponse,
-  UpdateManagedHostnameRequest,
 } from './types/index';
 
 // API
 export {
   checkAvailability,
+  clearPrimary,
   createHostname,
   deleteHostname,
   getHostname,
   listHostnames,
   reportCertificateStatus,
-  updateHostname,
+  setPrimary,
   verifyNow,
 } from './api/hostnames-api';
 

--- a/packages/@granit/hostnames/src/types/index.ts
+++ b/packages/@granit/hostnames/src/types/index.ts
@@ -39,7 +39,7 @@ export type DnsRecordType = 'Cname' | 'Txt' | 'A';
 
 /** A DNS record that must be present for the hostname to pass verification. */
 export interface ExpectedDnsRecord {
-  readonly type: DnsRecordType;
+  readonly recordType: DnsRecordType;
   readonly name: string;
   readonly value: string;
 }
@@ -48,23 +48,8 @@ export interface ExpectedDnsRecord {
 
 /** A conflict preventing a hostname from becoming active. */
 export interface HostnameConflict {
-  readonly type: string;
+  readonly conflictType: string;
   readonly details: string;
-}
-
-// ── Paginated list ───────────────────────────────────────────────────────────
-
-/**
- * Generic pagination envelope used by the hostnames list endpoint.
- * Mirrors the Granit framework's standard `PagedResponse<T>`.
- *
- * `page` is **0-based**, matching the backend convention.
- */
-export interface PagedResponse<T> {
-  readonly items: readonly T[];
-  readonly totalCount: number;
-  readonly page: number;
-  readonly pageSize: number;
 }
 
 // ── Main DTO ─────────────────────────────────────────────────────────────────
@@ -87,46 +72,42 @@ export interface ManagedHostnameResponse {
   readonly certificateStatus: CertificateStatus;
   readonly certExpiresAt: string | null;
   readonly createdAt: string;
-  readonly updatedAt: string;
+  readonly createdBy: string;
+  readonly modifiedAt: string | null;
+  readonly modifiedBy: string | null;
   readonly concurrencyStamp: string;
 }
 
 // ── Requests ─────────────────────────────────────────────────────────────────
 
-/** Request body for `POST /`. */
+/** Request body for `POST /`. Mirrors `CreateManagedHostnameRequest` (.NET). */
 export interface CreateManagedHostnameRequest {
   readonly host: string;
   readonly ownerType: string;
   readonly ownerId: string;
+  readonly tenantId?: string | null;
   readonly isPrimary?: boolean;
 }
 
-/** Request body for `PATCH /{id}`. */
-export interface UpdateManagedHostnameRequest {
-  readonly isPrimary: boolean;
-}
-
-/** Query params for `GET /`. */
+/** Query params for `GET /`. `ownerType` and `ownerId` are required by the backend. */
 export interface ListHostnamesParams {
-  readonly page?: number;
-  readonly pageSize?: number;
-  readonly ownerType?: string;
-  readonly ownerId?: string;
-  readonly status?: ManagedHostnameStatus;
+  readonly ownerType: string;
+  readonly ownerId: string;
+  readonly maxResults?: number;
 }
 
 // ── Availability ─────────────────────────────────────────────────────────────
 
-/** Response from `GET /check-availability?host=`. */
+/** Response from `GET /availability?host=`. Mirrors `HostnameAvailabilityResponse` (.NET). */
 export interface CheckAvailabilityResponse {
+  readonly host: string;
   readonly isAvailable: boolean;
 }
 
 // ── Certificate status webhook ────────────────────────────────────────────────
 
-/** Request body for `POST /{id}/certificate-status` (host-level webhook from certificate provider). */
+/** Request body for `POST /{id}/certificate-status`. Mirrors `ReportCertificateStatusRequest` (.NET). */
 export interface CertificateStatusReportRequest {
   readonly status: CertificateStatus;
-  readonly certExpiresAt?: string | null;
-  readonly errorDetails?: string | null;
+  readonly expiresAt?: string | null;
 }

--- a/packages/@granit/react-hostnames/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-hostnames/src/__tests__/testing-handlers.test.ts
@@ -4,7 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { mockHostnames } from '../testing/data';
 import { createHostnamesHandlers } from '../testing/handlers';
 
-import type { CheckAvailabilityResponse, ManagedHostnameResponse, PagedResponse } from '@granit/hostnames';
+import type { CheckAvailabilityResponse, ManagedHostnameResponse } from '@granit/hostnames';
 
 const BASE = 'http://api.test/api/hostnames';
 const server = setupServer();
@@ -14,19 +14,20 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('createHostnamesHandlers', () => {
-  describe('GET /check-availability', () => {
+  describe('GET /availability', () => {
     it('returns isAvailable true for unknown host', async () => {
       server.use(...createHostnamesHandlers(BASE));
-      const res = await fetch(`${BASE}/check-availability?host=brand-new.example.com`);
+      const res = await fetch(`${BASE}/availability?host=brand-new.example.com`);
       expect(res.status).toBe(200);
       const data = (await res.json()) as CheckAvailabilityResponse;
       expect(data.isAvailable).toBe(true);
+      expect(data.host).toBe('brand-new.example.com');
     });
 
     it('returns isAvailable false for seeded host', async () => {
       server.use(...createHostnamesHandlers(BASE));
       const takenHost = mockHostnames[0]!.host;
-      const res = await fetch(`${BASE}/check-availability?host=${takenHost}`);
+      const res = await fetch(`${BASE}/availability?host=${takenHost}`);
       expect(res.status).toBe(200);
       const data = (await res.json()) as CheckAvailabilityResponse;
       expect(data.isAvailable).toBe(false);
@@ -34,20 +35,19 @@ describe('createHostnamesHandlers', () => {
   });
 
   describe('GET /', () => {
-    it('returns paginated list of seeded hostnames', async () => {
+    it('returns a list of seeded hostnames', async () => {
       server.use(...createHostnamesHandlers(BASE));
       const res = await fetch(BASE);
       expect(res.status).toBe(200);
-      const data = (await res.json()) as PagedResponse<ManagedHostnameResponse>;
-      expect(data.items.length).toBeGreaterThan(0);
-      expect(typeof data.totalCount).toBe('number');
+      const data = (await res.json()) as ManagedHostnameResponse[];
+      expect(data.length).toBeGreaterThan(0);
     });
 
     it('filters by ownerType', async () => {
       server.use(...createHostnamesHandlers(BASE));
       const res = await fetch(`${BASE}?ownerType=cms.site`);
-      const data = (await res.json()) as PagedResponse<ManagedHostnameResponse>;
-      expect(data.items.every((h) => h.ownerType === 'cms.site')).toBe(true);
+      const data = (await res.json()) as ManagedHostnameResponse[];
+      expect(data.every((h) => h.ownerType === 'cms.site')).toBe(true);
     });
   });
 
@@ -89,17 +89,28 @@ describe('createHostnamesHandlers', () => {
     });
   });
 
-  describe('PATCH /{id}', () => {
-    it('updates isPrimary', async () => {
+  describe('POST /{id}/primary', () => {
+    it('sets isPrimary and returns 204', async () => {
+      server.use(...createHostnamesHandlers(BASE));
+      const id = mockHostnames[1]!.id;
+      const res = await fetch(`${BASE}/${id}/primary`, { method: 'POST' });
+      expect(res.status).toBe(204);
+
+      const updated = await fetch(`${BASE}/${id}`);
+      const data = (await updated.json()) as ManagedHostnameResponse;
+      expect(data.isPrimary).toBe(true);
+    });
+  });
+
+  describe('DELETE /{id}/primary', () => {
+    it('clears isPrimary and returns 204', async () => {
       server.use(...createHostnamesHandlers(BASE));
       const id = mockHostnames[0]!.id;
-      const res = await fetch(`${BASE}/${id}`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ isPrimary: false }),
-      });
-      expect(res.status).toBe(200);
-      const data = (await res.json()) as ManagedHostnameResponse;
+      const res = await fetch(`${BASE}/${id}/primary`, { method: 'DELETE' });
+      expect(res.status).toBe(204);
+
+      const updated = await fetch(`${BASE}/${id}`);
+      const data = (await updated.json()) as ManagedHostnameResponse;
       expect(data.isPrimary).toBe(false);
     });
   });
@@ -114,11 +125,13 @@ describe('createHostnamesHandlers', () => {
   });
 
   describe('POST /{id}/verify-now', () => {
-    it('returns 204', async () => {
+    it('returns 202 with updated hostname in Verifying status', async () => {
       server.use(...createHostnamesHandlers(BASE));
       const id = mockHostnames[0]!.id;
       const res = await fetch(`${BASE}/${id}/verify-now`, { method: 'POST' });
-      expect(res.status).toBe(204);
+      expect(res.status).toBe(202);
+      const data = (await res.json()) as ManagedHostnameResponse;
+      expect(data.status).toBe('Verifying');
     });
   });
 });

--- a/packages/@granit/react-hostnames/src/__tests__/use-hostname-mutations.test.tsx
+++ b/packages/@granit/react-hostnames/src/__tests__/use-hostname-mutations.test.tsx
@@ -7,9 +7,11 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { hostnamesKeys } from '../hooks/query-keys';
 import {
+  useClearPrimary,
   useCreateHostname,
   useDeleteHostname,
-  useUpdateHostname,
+  useReportCertificateStatus,
+  useSetPrimary,
   useVerifyNow,
 } from '../hooks/use-hostname-mutations';
 import { HostnamesProvider } from '../providers/hostnames-provider';
@@ -46,7 +48,9 @@ const mockHostname: ManagedHostnameResponse = {
   certificateStatus: 'Secured',
   certExpiresAt: '2027-06-01T08:00:00Z',
   createdAt: '2026-01-01T00:00:00Z',
-  updatedAt: '2026-06-01T08:00:00Z',
+  createdBy: 'admin@acme.com',
+  modifiedAt: '2026-06-01T08:00:00Z',
+  modifiedBy: 'admin@acme.com',
   concurrencyStamp: 'stamp-0001',
 };
 
@@ -97,24 +101,46 @@ describe('useCreateHostname', () => {
   });
 });
 
-describe('useUpdateHostname', () => {
-  it('sends PATCH and invalidates hostname + list on success', async () => {
+describe('useSetPrimary', () => {
+  it('sends POST to /{id}/primary and invalidates hostname + list on success', async () => {
     const client = createMockClient();
-    const updated = { ...mockHostname, isPrimary: false };
-    vi.mocked(client.patch).mockResolvedValueOnce({ data: updated });
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
 
     const { wrapper, queryClient } = createWrapper(client);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const { result } = renderHook(() => useUpdateHostname(), { wrapper });
+    const { result } = renderHook(() => useSetPrimary(), { wrapper });
 
-    result.current.mutate({ id: '11111111-0001-4000-a000-000000000001', request: { isPrimary: false } });
+    result.current.mutate('11111111-0001-4000-a000-000000000001');
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.patch).toHaveBeenCalledWith(
-      '/api/hostnames/11111111-0001-4000-a000-000000000001',
-      { isPrimary: false }
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/hostnames/11111111-0001-4000-a000-000000000001/primary'
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: hostnamesKeys.hostname('11111111-0001-4000-a000-000000000001'),
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: hostnamesKeys.lists() });
+  });
+});
+
+describe('useClearPrimary', () => {
+  it('sends DELETE to /{id}/primary and invalidates hostname + list on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper, queryClient } = createWrapper(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useClearPrimary(), { wrapper });
+
+    result.current.mutate('11111111-0001-4000-a000-000000000001');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.delete).toHaveBeenCalledWith(
+      '/api/hostnames/11111111-0001-4000-a000-000000000001/primary'
     );
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: hostnamesKeys.hostname('11111111-0001-4000-a000-000000000001'),
@@ -137,7 +163,9 @@ describe('useDeleteHostname', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.delete).toHaveBeenCalledWith('/api/hostnames/11111111-0001-4000-a000-000000000001');
+    expect(client.delete).toHaveBeenCalledWith(
+      '/api/hostnames/11111111-0001-4000-a000-000000000001'
+    );
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: hostnamesKeys.lists() });
   });
 
@@ -156,9 +184,10 @@ describe('useDeleteHostname', () => {
 });
 
 describe('useVerifyNow', () => {
-  it('sends POST to /verify-now and invalidates hostname query on success', async () => {
+  it('sends POST to /verify-now, returns updated hostname, and invalidates hostname query', async () => {
     const client = createMockClient();
-    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+    const verifying = { ...mockHostname, status: 'Verifying' as const };
+    vi.mocked(client.post).mockResolvedValueOnce({ data: verifying });
 
     const { wrapper, queryClient } = createWrapper(client);
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
@@ -171,6 +200,34 @@ describe('useVerifyNow', () => {
 
     expect(client.post).toHaveBeenCalledWith(
       '/api/hostnames/11111111-0001-4000-a000-000000000001/verify-now'
+    );
+    expect(result.current.data).toEqual(verifying);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: hostnamesKeys.hostname('11111111-0001-4000-a000-000000000001'),
+    });
+  });
+});
+
+describe('useReportCertificateStatus', () => {
+  it('sends POST to /{id}/certificate-status and invalidates hostname query', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper, queryClient } = createWrapper(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useReportCertificateStatus(), { wrapper });
+
+    result.current.mutate({
+      id: '11111111-0001-4000-a000-000000000001',
+      request: { status: 'Secured', expiresAt: '2027-06-01T00:00:00Z' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/hostnames/11111111-0001-4000-a000-000000000001/certificate-status',
+      { status: 'Secured', expiresAt: '2027-06-01T00:00:00Z' }
     );
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: hostnamesKeys.hostname('11111111-0001-4000-a000-000000000001'),

--- a/packages/@granit/react-hostnames/src/__tests__/use-hostname.test.tsx
+++ b/packages/@granit/react-hostnames/src/__tests__/use-hostname.test.tsx
@@ -39,7 +39,9 @@ const mockHostname: ManagedHostnameResponse = {
   certificateStatus: 'Secured',
   certExpiresAt: '2027-06-01T08:00:00Z',
   createdAt: '2026-01-01T00:00:00Z',
-  updatedAt: '2026-06-01T08:00:00Z',
+  createdBy: 'admin@acme.com',
+  modifiedAt: '2026-06-01T08:00:00Z',
+  modifiedBy: 'admin@acme.com',
   concurrencyStamp: 'stamp-0001',
 };
 
@@ -55,9 +57,7 @@ describe('useHostname', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/hostnames/11111111-0001-4000-a000-000000000001'
-    );
+    expect(client.get).toHaveBeenCalledWith('/api/hostnames/11111111-0001-4000-a000-000000000001');
     expect(result.current.data).toEqual(mockHostname);
   });
 
@@ -74,14 +74,16 @@ describe('useHostname', () => {
 describe('useCheckAvailability', () => {
   it('checks hostname availability', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: { isAvailable: true } });
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: { host: 'new.example.com', isAvailable: true },
+    });
 
     const { wrapper } = createWrapper(client);
     const { result } = renderHook(() => useCheckAvailability('new.example.com'), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/hostnames/check-availability', {
+    expect(client.get).toHaveBeenCalledWith('/api/hostnames/availability', {
       params: { host: 'new.example.com' },
     });
     expect(result.current.data?.isAvailable).toBe(true);
@@ -89,7 +91,9 @@ describe('useCheckAvailability', () => {
 
   it('returns false for taken hostnames', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: { isAvailable: false } });
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: { host: 'taken.example.com', isAvailable: false },
+    });
 
     const { wrapper } = createWrapper(client);
     const { result } = renderHook(() => useCheckAvailability('taken.example.com'), { wrapper });

--- a/packages/@granit/react-hostnames/src/__tests__/use-hostnames.test.tsx
+++ b/packages/@granit/react-hostnames/src/__tests__/use-hostnames.test.tsx
@@ -9,7 +9,7 @@ import { useHostnames } from '../hooks/use-hostnames';
 import { HostnamesProvider } from '../providers/hostnames-provider';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ManagedHostnameResponse, PagedResponse } from '@granit/hostnames';
+import type { ManagedHostnameResponse } from '@granit/hostnames';
 
 function createWrapper(client: AxiosInstance) {
   const queryClient = createTestQueryClient();
@@ -23,63 +23,68 @@ function createWrapper(client: AxiosInstance) {
   };
 }
 
-const mockPage: PagedResponse<ManagedHostnameResponse> = {
-  items: [
-    {
-      id: '11111111-0001-4000-a000-000000000001',
-      host: 'app.acme.com',
-      ownerType: 'cms.site',
-      ownerId: 'aaaaaaaa-0001-4000-a000-000000000001',
-      tenantId: 'tttttttt-0001-4000-a000-000000000001',
-      isPrimary: true,
-      status: 'Active',
-      verificationToken: null,
-      expectedDnsRecords: [],
-      lastCheckedAt: '2026-06-01T08:00:00Z',
-      conflicts: [],
-      failedCheckCount: 0,
-      nextCheckAt: '2026-06-02T08:00:00Z',
-      certificateStatus: 'Secured',
-      certExpiresAt: '2027-06-01T08:00:00Z',
-      createdAt: '2026-01-01T00:00:00Z',
-      updatedAt: '2026-06-01T08:00:00Z',
-      concurrencyStamp: 'stamp-0001',
-    },
-  ],
-  totalCount: 1,
-  page: 0,
-  pageSize: 20,
-};
+const mockList: readonly ManagedHostnameResponse[] = [
+  {
+    id: '11111111-0001-4000-a000-000000000001',
+    host: 'app.acme.com',
+    ownerType: 'cms.site',
+    ownerId: 'aaaaaaaa-0001-4000-a000-000000000001',
+    tenantId: 'tttttttt-0001-4000-a000-000000000001',
+    isPrimary: true,
+    status: 'Active',
+    verificationToken: null,
+    expectedDnsRecords: [],
+    lastCheckedAt: '2026-06-01T08:00:00Z',
+    conflicts: [],
+    failedCheckCount: 0,
+    nextCheckAt: '2026-06-02T08:00:00Z',
+    certificateStatus: 'Secured',
+    certExpiresAt: '2027-06-01T08:00:00Z',
+    createdAt: '2026-01-01T00:00:00Z',
+    createdBy: 'admin@acme.com',
+    modifiedAt: '2026-06-01T08:00:00Z',
+    modifiedBy: 'admin@acme.com',
+    concurrencyStamp: 'stamp-0001',
+  },
+];
 
 describe('useHostnames', () => {
-  it('fetches the list with no params', async () => {
+  it('fetches the list with required owner params', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: mockPage });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: mockList });
 
     const { wrapper } = createWrapper(client);
-    const { result } = renderHook(() => useHostnames(), { wrapper });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(client.get).toHaveBeenCalledWith('/api/hostnames', { params: undefined });
-    expect(result.current.data).toEqual(mockPage);
-  });
-
-  it('passes pagination and filter params', async () => {
-    const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({
-      data: { items: [], totalCount: 0, page: 1, pageSize: 10 },
-    });
-
-    const { wrapper } = createWrapper(client);
-    const params = { page: 1, pageSize: 10, ownerType: 'cms.site' };
+    const params = { ownerType: 'cms.site', ownerId: 'aaaaaaaa-0001-4000-a000-000000000001' };
     const { result } = renderHook(() => useHostnames(params), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith('/api/hostnames', {
-      params: { page: 1, pageSize: 10, ownerType: 'cms.site' },
+    expect(client.get).toHaveBeenCalledWith('/api/hostnames', { params });
+    expect(result.current.data).toEqual(mockList);
+  });
+
+  it('passes maxResults param', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+
+    const { wrapper } = createWrapper(client);
+    const params = { ownerType: 'cms.site', ownerId: 'owner-1', maxResults: 50 };
+    const { result } = renderHook(() => useHostnames(params), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith('/api/hostnames', { params });
+  });
+
+  it('is disabled when ownerType is empty', () => {
+    const client = createMockClient();
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useHostnames({ ownerType: '', ownerId: 'owner-1' }), {
+      wrapper,
     });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
   });
 
   it('surfaces query errors', async () => {
@@ -87,7 +92,10 @@ describe('useHostnames', () => {
     vi.mocked(client.get).mockRejectedValueOnce(new Error('Unauthorized'));
 
     const { wrapper } = createWrapper(client);
-    const { result } = renderHook(() => useHostnames(), { wrapper });
+    const { result } = renderHook(
+      () => useHostnames({ ownerType: 'cms.site', ownerId: 'owner-1' }),
+      { wrapper }
+    );
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error?.message).toBe('Unauthorized');

--- a/packages/@granit/react-hostnames/src/hooks/use-hostname-mutations.ts
+++ b/packages/@granit/react-hostnames/src/hooks/use-hostname-mutations.ts
@@ -1,7 +1,9 @@
 import {
+  clearPrimary,
   createHostname,
   deleteHostname,
-  updateHostname,
+  reportCertificateStatus,
+  setPrimary,
   verifyNow,
 } from '@granit/hostnames';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
@@ -11,9 +13,9 @@ import { useHostnamesConfig } from '../providers/hostnames-provider';
 import { hostnamesKeys } from './query-keys';
 
 import type {
+  CertificateStatusReportRequest,
   CreateManagedHostnameRequest,
   ManagedHostnameResponse,
-  UpdateManagedHostnameRequest,
 } from '@granit/hostnames';
 import type { UseMutationResult } from '@tanstack/react-query';
 
@@ -46,27 +48,49 @@ export function useCreateHostname(): UseMutationResult<
 }
 
 /**
- * Mutation hook to update a managed hostname's `isPrimary` flag.
+ * Mutation hook to mark a hostname as the owner's canonical (primary) hostname.
  *
  * Invalidates the affected hostname and list queries on success.
  *
  * @example
  * ```tsx
- * const { mutate: update } = useUpdateHostname();
- * update({ id: 'hostname-id', request: { isPrimary: true } });
+ * const { mutate: set } = useSetPrimary();
+ * set('hostname-id');
  * ```
  */
-export function useUpdateHostname(): UseMutationResult<
-  ManagedHostnameResponse,
-  Error,
-  { id: string; request: UpdateManagedHostnameRequest }
-> {
+export function useSetPrimary(): UseMutationResult<void, Error, string> {
   const { client, basePath } = useHostnamesConfig();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, request }) => updateHostname(client, basePath, id, request),
-    onSuccess: async (_, { id }) => {
+    mutationFn: (id: string) => setPrimary(client, basePath, id),
+    onSuccess: async (_, id) => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: hostnamesKeys.hostname(id) }),
+        queryClient.invalidateQueries({ queryKey: hostnamesKeys.lists() }),
+      ]);
+    },
+  });
+}
+
+/**
+ * Mutation hook to clear the canonical (primary) flag from a hostname.
+ *
+ * Invalidates the affected hostname and list queries on success.
+ *
+ * @example
+ * ```tsx
+ * const { mutate: clear } = useClearPrimary();
+ * clear('hostname-id');
+ * ```
+ */
+export function useClearPrimary(): UseMutationResult<void, Error, string> {
+  const { client, basePath } = useHostnamesConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => clearPrimary(client, basePath, id),
+    onSuccess: async (_, id) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: hostnamesKeys.hostname(id) }),
         queryClient.invalidateQueries({ queryKey: hostnamesKeys.lists() }),
@@ -109,13 +133,40 @@ export function useDeleteHostname(): UseMutationResult<void, Error, string> {
  * trigger('hostname-id');
  * ```
  */
-export function useVerifyNow(): UseMutationResult<void, Error, string> {
+export function useVerifyNow(): UseMutationResult<ManagedHostnameResponse, Error, string> {
   const { client, basePath } = useHostnamesConfig();
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: (id: string) => verifyNow(client, basePath, id),
     onSuccess: async (_, id) => {
+      await queryClient.invalidateQueries({ queryKey: hostnamesKeys.hostname(id) });
+    },
+  });
+}
+
+/**
+ * Mutation hook to report a certificate status update from an external provider.
+ *
+ * Invalidates the affected hostname query on success.
+ *
+ * @example
+ * ```tsx
+ * const { mutate: report } = useReportCertificateStatus();
+ * report({ id: 'hostname-id', request: { status: 'Secured', expiresAt: '2027-01-01T00:00:00Z' } });
+ * ```
+ */
+export function useReportCertificateStatus(): UseMutationResult<
+  void,
+  Error,
+  { id: string; request: CertificateStatusReportRequest }
+> {
+  const { client, basePath } = useHostnamesConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }) => reportCertificateStatus(client, basePath, id, request),
+    onSuccess: async (_, { id }) => {
       await queryClient.invalidateQueries({ queryKey: hostnamesKeys.hostname(id) });
     },
   });

--- a/packages/@granit/react-hostnames/src/hooks/use-hostnames.ts
+++ b/packages/@granit/react-hostnames/src/hooks/use-hostnames.ts
@@ -5,24 +5,28 @@ import { useHostnamesConfig } from '../providers/hostnames-provider';
 
 import { hostnamesKeys } from './query-keys';
 
-import type { ListHostnamesParams, ManagedHostnameResponse, PagedResponse } from '@granit/hostnames';
+import type { ListHostnamesParams, ManagedHostnameResponse } from '@granit/hostnames';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
- * Query hook that fetches a paginated list of managed hostnames.
+ * Query hook that fetches the list of managed hostnames for an owner.
+ *
+ * `ownerType` and `ownerId` are required by the backend. The query is disabled
+ * when either is empty.
  *
  * @example
  * ```tsx
- * const { data } = useHostnames({ page: 0, pageSize: 20, ownerType: 'cms.site' });
+ * const { data: hostnames } = useHostnames({ ownerType: 'cms.site', ownerId: 'owner-id' });
  * ```
  */
 export function useHostnames(
-  params?: ListHostnamesParams
-): UseQueryResult<PagedResponse<ManagedHostnameResponse>> {
+  params: ListHostnamesParams
+): UseQueryResult<readonly ManagedHostnameResponse[]> {
   const { client, basePath } = useHostnamesConfig();
 
   return useQuery({
     queryKey: hostnamesKeys.list(params),
     queryFn: () => listHostnames(client, basePath, params),
+    enabled: params.ownerType.length > 0 && params.ownerId.length > 0,
   });
 }

--- a/packages/@granit/react-hostnames/src/index.ts
+++ b/packages/@granit/react-hostnames/src/index.ts
@@ -1,8 +1,5 @@
 // Provider
-export {
-  HostnamesProvider,
-  useHostnamesConfig,
-} from './providers/hostnames-provider';
+export { HostnamesProvider, useHostnamesConfig } from './providers/hostnames-provider';
 export type {
   HostnamesConfig,
   HostnamesProviderProps,
@@ -15,9 +12,11 @@ export { useCheckAvailability, useHostname } from './hooks/use-hostname';
 
 // Hooks — mutations
 export {
+  useClearPrimary,
   useCreateHostname,
   useDeleteHostname,
-  useUpdateHostname,
+  useReportCertificateStatus,
+  useSetPrimary,
   useVerifyNow,
 } from './hooks/use-hostname-mutations';
 

--- a/packages/@granit/react-hostnames/src/testing/data.ts
+++ b/packages/@granit/react-hostnames/src/testing/data.ts
@@ -24,7 +24,9 @@ export const mockHostnames: ManagedHostnameResponse[] = [
     certificateStatus: C.Secured,
     certExpiresAt: '2027-06-01T08:00:00Z',
     createdAt: '2026-01-01T00:00:00Z',
-    updatedAt: '2026-06-01T08:00:00Z',
+    createdBy: 'admin@acme.com',
+    modifiedAt: '2026-06-01T08:00:00Z',
+    modifiedBy: 'admin@acme.com',
     concurrencyStamp: 'stamp-0001',
   },
   {
@@ -44,7 +46,9 @@ export const mockHostnames: ManagedHostnameResponse[] = [
     certificateStatus: C.Secured,
     certExpiresAt: '2027-06-01T08:00:00Z',
     createdAt: '2026-01-05T00:00:00Z',
-    updatedAt: '2026-06-01T08:05:00Z',
+    createdBy: 'admin@acme.com',
+    modifiedAt: '2026-06-01T08:05:00Z',
+    modifiedBy: 'admin@acme.com',
     concurrencyStamp: 'stamp-0002',
   },
   {
@@ -58,11 +62,11 @@ export const mockHostnames: ManagedHostnameResponse[] = [
     verificationToken: 'mock-verify-pending-001',
     expectedDnsRecords: [
       {
-        type: 'Txt',
+        recordType: 'Txt',
         name: '_granit-verify.pending.beta.com',
         value: 'granit-verify=mock-verify-pending-001',
       },
-      { type: 'Cname', name: 'pending.beta.com', value: 'proxy.granit.io' },
+      { recordType: 'Cname', name: 'pending.beta.com', value: 'proxy.granit.io' },
     ],
     lastCheckedAt: null,
     conflicts: [],
@@ -71,7 +75,9 @@ export const mockHostnames: ManagedHostnameResponse[] = [
     certificateStatus: C.Unprovisioned,
     certExpiresAt: null,
     createdAt: '2026-06-01T12:00:00Z',
-    updatedAt: '2026-06-01T12:00:00Z',
+    createdBy: 'admin@beta.com',
+    modifiedAt: null,
+    modifiedBy: null,
     concurrencyStamp: 'stamp-0003',
   },
   {
@@ -85,19 +91,23 @@ export const mockHostnames: ManagedHostnameResponse[] = [
     verificationToken: 'mock-verify-error-002',
     expectedDnsRecords: [
       {
-        type: 'Txt',
+        recordType: 'Txt',
         name: '_granit-verify.error.example.org',
         value: 'granit-verify=mock-verify-error-002',
       },
     ],
     lastCheckedAt: '2026-06-01T06:00:00Z',
-    conflicts: [{ type: 'DnsNotPropagated', details: 'TXT record not found after 3 checks' }],
+    conflicts: [
+      { conflictType: 'DnsNotPropagated', details: 'TXT record not found after 3 checks' },
+    ],
     failedCheckCount: 5,
     nextCheckAt: '2026-06-03T06:00:00Z',
     certificateStatus: C.Error,
     certExpiresAt: null,
     createdAt: '2026-05-01T00:00:00Z',
-    updatedAt: '2026-06-01T06:00:00Z',
+    createdBy: 'admin@example.org',
+    modifiedAt: '2026-06-01T06:00:00Z',
+    modifiedBy: 'system',
     concurrencyStamp: 'stamp-0004',
   },
 ];

--- a/packages/@granit/react-hostnames/src/testing/handlers.ts
+++ b/packages/@granit/react-hostnames/src/testing/handlers.ts
@@ -1,4 +1,3 @@
-import { paginate } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -17,24 +16,23 @@ export function createHostnamesHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const store: ManagedHostnameResponse[] = [...mockHostnames];
 
   return [
-    http.get(`${baseUrl}/check-availability`, ({ request }) => {
+    http.get(`${baseUrl}/availability`, ({ request }) => {
       const host = new URL(request.url).searchParams.get('host') ?? '';
-      const isAvailable = !store.some((h) => h.host === host);
-      return HttpResponse.json({ isAvailable });
+      const existing = store.find((h) => h.host === host);
+      return HttpResponse.json({ host, isAvailable: existing === undefined });
     }),
 
     http.get(`${baseUrl}`, ({ request }) => {
       const url = new URL(request.url);
       const ownerType = url.searchParams.get('ownerType');
       const ownerId = url.searchParams.get('ownerId');
-      const status = url.searchParams.get('status');
+      const maxResults = Number(url.searchParams.get('maxResults') ?? 100);
 
       let filtered = [...store];
       if (ownerType) filtered = filtered.filter((h) => h.ownerType === ownerType);
       if (ownerId) filtered = filtered.filter((h) => h.ownerId === ownerId);
-      if (status) filtered = filtered.filter((h) => h.status === status);
 
-      return HttpResponse.json(paginate(filtered, url));
+      return HttpResponse.json(filtered.slice(0, maxResults));
     }),
 
     http.post<never, CreateManagedHostnameRequest>(`${baseUrl}`, async ({ request }) => {
@@ -45,13 +43,13 @@ export function createHostnamesHandlers(baseUrl = DEFAULT_BASE_PATH) {
         host: body.host,
         ownerType: body.ownerType,
         ownerId: body.ownerId,
-        tenantId: null,
+        tenantId: body.tenantId ?? null,
         isPrimary: body.isPrimary ?? false,
         status: 'Pending',
         verificationToken: `tok_${randomId().slice(0, 12)}`,
         expectedDnsRecords: [
           {
-            type: 'Txt',
+            recordType: 'Txt',
             name: `_granit-verify.${body.host}`,
             value: `granit-verify=tok_${randomId().slice(0, 12)}`,
           },
@@ -63,7 +61,9 @@ export function createHostnamesHandlers(baseUrl = DEFAULT_BASE_PATH) {
         certificateStatus: 'Unprovisioned',
         certExpiresAt: null,
         createdAt: now,
-        updatedAt: now,
+        createdBy: 'mock-user',
+        modifiedAt: null,
+        modifiedBy: null,
         concurrencyStamp: randomId(),
       };
       store.push(created);
@@ -76,17 +76,18 @@ export function createHostnamesHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(hostname);
     }),
 
-    http.patch<{ id: string }>(`${baseUrl}/:id`, async ({ params, request }) => {
+    http.post(`${baseUrl}/:id/primary`, ({ params }) => {
       const idx = store.findIndex((h) => h.id === params.id);
       if (idx === -1) return new HttpResponse(null, { status: 404 });
-      const body = (await request.json()) as { isPrimary: boolean };
-      const updated: ManagedHostnameResponse = {
-        ...store[idx]!,
-        isPrimary: body.isPrimary,
-        updatedAt: new Date().toISOString(),
-      };
-      store[idx] = updated;
-      return HttpResponse.json(updated);
+      store[idx] = { ...store[idx]!, isPrimary: true, modifiedAt: new Date().toISOString() };
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    http.delete(`${baseUrl}/:id/primary`, ({ params }) => {
+      const idx = store.findIndex((h) => h.id === params.id);
+      if (idx === -1) return new HttpResponse(null, { status: 404 });
+      store[idx] = { ...store[idx]!, isPrimary: false, modifiedAt: new Date().toISOString() };
+      return new HttpResponse(null, { status: 204 });
     }),
 
     http.delete(`${baseUrl}/:id`, ({ params }) => {
@@ -99,7 +100,12 @@ export function createHostnamesHandlers(baseUrl = DEFAULT_BASE_PATH) {
     http.post(`${baseUrl}/:id/verify-now`, ({ params }) => {
       const hostname = store.find((h) => h.id === params.id);
       if (!hostname) return new HttpResponse(null, { status: 404 });
-      return new HttpResponse(null, { status: 204 });
+      const updated: ManagedHostnameResponse = {
+        ...hostname,
+        status: 'Verifying',
+        modifiedAt: new Date().toISOString(),
+      };
+      return HttpResponse.json(updated, { status: 202 });
     }),
 
     http.post(`${baseUrl}/:id/certificate-status`, () => {


### PR DESCRIPTION
## Summary

- Replace non-existent `PATCH /{id}` with `POST /{id}/primary` (`setPrimary`) and `DELETE /{id}/primary` (`clearPrimary`)
- Fix `checkAvailability` URL: `/check-availability` → `/availability`
- Replace `PagedResponse` pagination with plain array; `ListHostnamesParams` now requires `ownerType`/`ownerId` and accepts `maxResults` (capped at 500 server-side)
- Rename `updatedAt` → `modifiedAt`; add `createdBy` and `modifiedBy` to `ManagedHostnameResponse`
- Fix `ExpectedDnsRecord.type` → `recordType` (matches .NET `RecordType`)
- Fix `HostnameConflict.type` → `conflictType` (matches .NET `ConflictType`)
- Add missing `host` field to `CheckAvailabilityResponse`
- Fix `CertificateStatusReportRequest`: `certExpiresAt` → `expiresAt`, remove non-existent `errorDetails`
- Add `tenantId` to `CreateManagedHostnameRequest`
- `verifyNow` now returns `ManagedHostnameResponse` (202 body)
- Add `useReportCertificateStatus` hook to `@granit/react-hostnames`
- Update all tests, MSW handlers, and mock fixtures accordingly

## Test plan

- [x] 40/40 tests passing (`@granit/hostnames` + `@granit/react-hostnames`)
- [x] `pnpm tsc` clean (no type errors)
- [x] ESLint clean (pre-commit hook)