### PR TITLE
fix(react-cms): RSC support + uniformise CMS imports

### DIFF
--- a/packages/@granit/cms-hostnames/src/__tests__/hostnames.test.ts
+++ b/packages/@granit/cms-hostnames/src/__tests__/hostnames.test.ts
@@ -10,7 +10,7 @@ import {
   removeSiteHostname,
   setSiteHostnamePrimary,
   verifySiteHostname,
-} from '../api/hostnames.js';
+} from '../api/hostnames';
 
 import type { ManagedHostnameResponse } from '@granit/hostnames';
 

--- a/packages/@granit/cms-hostnames/src/index.ts
+++ b/packages/@granit/cms-hostnames/src/index.ts
@@ -17,4 +17,4 @@ export {
   removeSiteHostname,
   setSiteHostnamePrimary,
   verifySiteHostname,
-} from './api/hostnames.js';
+} from './api/hostnames';

--- a/packages/@granit/cms-redirects/src/__tests__/redirects-admin.test.ts
+++ b/packages/@granit/cms-redirects/src/__tests__/redirects-admin.test.ts
@@ -1,9 +1,14 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createRedirect, deleteRedirect, listRedirects, updateRedirect } from '../api/redirects-admin.js';
+import {
+  createRedirect,
+  deleteRedirect,
+  listRedirects,
+  updateRedirect,
+} from '../api/redirects-admin';
 
-import type { PagedResponse, RedirectResponse } from '../types/index.js';
+import type { PagedResponse, RedirectResponse } from '../types/index';
 
 const BASE = 'https://cms.example.com';
 
@@ -20,7 +25,12 @@ const redirect: RedirectResponse = {
 describe('listRedirects', () => {
   it('GET /api/cms/redirects without params', async () => {
     const client = createMockClient();
-    const response: PagedResponse<RedirectResponse> = { items: [redirect], totalCount: 1, page: 0, pageSize: 20 };
+    const response: PagedResponse<RedirectResponse> = {
+      items: [redirect],
+      totalCount: 1,
+      page: 0,
+      pageSize: 20,
+    };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 
     const result = await listRedirects(client, BASE);
@@ -31,7 +41,9 @@ describe('listRedirects', () => {
 
   it('passes siteId and search params', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [], totalCount: 0, page: 0, pageSize: 20 }));
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: [], totalCount: 0, page: 0, pageSize: 20 })
+    );
 
     await listRedirects(client, BASE, { siteId: 'site-1', search: '/old' });
 

--- a/packages/@granit/cms-redirects/src/__tests__/redirects.test.ts
+++ b/packages/@granit/cms-redirects/src/__tests__/redirects.test.ts
@@ -1,9 +1,9 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { resolveRedirect } from '../api/redirects.js';
+import { resolveRedirect } from '../api/redirects';
 
-import type { RedirectResolveResponse } from '../types/index.js';
+import type { RedirectResolveResponse } from '../types/index';
 
 const basePath = 'https://cms.example.com';
 

--- a/packages/@granit/cms-redirects/src/api/redirects-admin.ts
+++ b/packages/@granit/cms-redirects/src/api/redirects-admin.ts
@@ -4,7 +4,7 @@ import type {
   PagedResponse,
   RedirectResponse,
   UpdateRedirectRequest,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /** `GET /api/cms/redirects` — paged list. Requires `Cms.Redirects.Read`. */

--- a/packages/@granit/cms-redirects/src/api/redirects.ts
+++ b/packages/@granit/cms-redirects/src/api/redirects.ts
@@ -1,4 +1,4 @@
-import type { RedirectResolveResponse } from '../types/index.js';
+import type { RedirectResolveResponse } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms-redirects/src/index.ts
+++ b/packages/@granit/cms-redirects/src/index.ts
@@ -6,10 +6,10 @@ export type {
   RedirectResolveResponse,
   RedirectResponse,
   UpdateRedirectRequest,
-} from './types/index.js';
+} from './types/index';
 
 // ─── API — Public renderer ────────────────────────────────────────────────────
-export { resolveRedirect } from './api/redirects.js';
+export { resolveRedirect } from './api/redirects';
 
 // ─── API — Admin ─────────────────────────────────────────────────────────────
 export {
@@ -17,4 +17,4 @@ export {
   deleteRedirect,
   listRedirects,
   updateRedirect,
-} from './api/redirects-admin.js';
+} from './api/redirects-admin';

--- a/packages/@granit/cms-seo/src/__tests__/seo-admin.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo-admin.test.ts
@@ -12,7 +12,7 @@ import {
   listSeoAuditIssues,
   updateSeoDefaults,
   upsertSeoMetadata,
-} from '../api/seo-admin.js';
+} from '../api/seo-admin';
 
 import type {
   OgCardPreviewResponse,
@@ -21,7 +21,7 @@ import type {
   SeoMetadataResponse,
   SerpPreviewResponse,
   SiteSeoDefaultsResponse,
-} from '../types/index.js';
+} from '../types/index';
 
 const BASE = 'https://cms.example.com';
 const PARAMS = { siteId: 'site-1', contentType: 'page', contentId: 'page-1', culture: 'fr' };
@@ -98,10 +98,9 @@ describe('updateSeoDefaults', () => {
 
     await updateSeoDefaults(client, BASE, 'site-1', { siteName: 'Updated' });
 
-    expect(client.put).toHaveBeenCalledWith(
-      `${BASE}/api/cms/seo/sites/site-1/defaults`,
-      { siteName: 'Updated' }
-    );
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/seo/sites/site-1/defaults`, {
+      siteName: 'Updated',
+    });
   });
 });
 
@@ -109,8 +108,12 @@ describe('listSeoAuditIssues', () => {
   it('GET /api/cms/seo/metadata', async () => {
     const client = createMockClient();
     const response: PagedResponse<SeoAuditIssueResponse> = {
-      items: [{ contentType: 'page', contentId: 'p-1', culture: 'fr', issueType: 'MissingDescription' }],
-      totalCount: 1, page: 0, pageSize: 20,
+      items: [
+        { contentType: 'page', contentId: 'p-1', culture: 'fr', issueType: 'MissingDescription' },
+      ],
+      totalCount: 1,
+      page: 0,
+      pageSize: 20,
     };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 
@@ -137,12 +140,19 @@ describe('invalidateSitemap', () => {
 describe('getSerpPreview', () => {
   it('returns preview on 200', async () => {
     const client = createMockClient();
-    const preview: SerpPreviewResponse = { title: 'T', url: 'https://example.com', description: 'D' };
+    const preview: SerpPreviewResponse = {
+      title: 'T',
+      url: 'https://example.com',
+      description: 'D',
+    };
     vi.mocked(client.get).mockResolvedValue({ status: 200, data: preview });
 
     const result = await getSerpPreview(client, BASE, PARAMS);
 
-    expect(client.get).toHaveBeenCalledWith(`${META_URL}/preview/serp`, expect.objectContaining({}));
+    expect(client.get).toHaveBeenCalledWith(
+      `${META_URL}/preview/serp`,
+      expect.objectContaining({})
+    );
     expect(result).toEqual(preview);
   });
 

--- a/packages/@granit/cms-seo/src/__tests__/seo-ai.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo-ai.test.ts
@@ -8,9 +8,9 @@ import {
   rejectSeoSuggestion,
   suggestSeo,
   triggerBulkSeoAudit,
-} from '../api/seo-ai.js';
+} from '../api/seo-ai';
 
-import type { PagedResponse, SeoAiSuggestionResponse, SeoAiSuggestResponse } from '../types/index.js';
+import type { PagedResponse, SeoAiSuggestionResponse, SeoAiSuggestResponse } from '../types/index';
 
 const BASE = 'https://cms.example.com';
 
@@ -28,7 +28,12 @@ describe('suggestSeo', () => {
     const response: SeoAiSuggestResponse = { outcome: 'Success', suggestion };
     vi.mocked(client.post).mockResolvedValue(axiosResponse(response));
 
-    const request = { contentType: 'page', contentId: 'page-1', culture: 'fr', contentTitle: 'Test' };
+    const request = {
+      contentType: 'page',
+      contentId: 'page-1',
+      culture: 'fr',
+      contentTitle: 'Test',
+    };
     const result = await suggestSeo(client, BASE, request);
 
     expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggest`, request);
@@ -40,7 +45,10 @@ describe('listSeoSuggestions', () => {
   it('GET /api/cms/seo/ai/suggestions', async () => {
     const client = createMockClient();
     const response: PagedResponse<SeoAiSuggestionResponse> = {
-      items: [suggestion], totalCount: 1, page: 0, pageSize: 20,
+      items: [suggestion],
+      totalCount: 1,
+      page: 0,
+      pageSize: 20,
     };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 
@@ -73,10 +81,9 @@ describe('applySeoSuggestion', () => {
 
     const result = await applySeoSuggestion(client, BASE, 'sug-1', { fields: ['title'] });
 
-    expect(client.post).toHaveBeenCalledWith(
-      `${BASE}/api/cms/seo/ai/suggestions/sug-1/apply`,
-      { fields: ['title'] }
-    );
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions/sug-1/apply`, {
+      fields: ['title'],
+    });
     expect(result).toEqual(applied);
   });
 });
@@ -89,10 +96,9 @@ describe('rejectSeoSuggestion', () => {
 
     await rejectSeoSuggestion(client, BASE, 'sug-1', { reason: 'Not relevant' });
 
-    expect(client.post).toHaveBeenCalledWith(
-      `${BASE}/api/cms/seo/ai/suggestions/sug-1/reject`,
-      { reason: 'Not relevant' }
-    );
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions/sug-1/reject`, {
+      reason: 'Not relevant',
+    });
   });
 
   it('defaults to empty body when no reason given', async () => {
@@ -101,10 +107,7 @@ describe('rejectSeoSuggestion', () => {
 
     await rejectSeoSuggestion(client, BASE, 'sug-1');
 
-    expect(client.post).toHaveBeenCalledWith(
-      `${BASE}/api/cms/seo/ai/suggestions/sug-1/reject`,
-      {}
-    );
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/seo/ai/suggestions/sug-1/reject`, {});
   });
 });
 

--- a/packages/@granit/cms-seo/src/__tests__/seo.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo.test.ts
@@ -1,9 +1,9 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getEffectiveSeo } from '../api/seo.js';
+import { getEffectiveSeo } from '../api/seo';
 
-import type { EffectiveSeoResponse } from '../types/index.js';
+import type { EffectiveSeoResponse } from '../types/index';
 
 const basePath = 'https://cms.example.com';
 

--- a/packages/@granit/cms-seo/src/api/seo-admin.ts
+++ b/packages/@granit/cms-seo/src/api/seo-admin.ts
@@ -8,7 +8,7 @@ import type {
   SerpPreviewResponse,
   SiteSeoDefaultsRequest,
   SiteSeoDefaultsResponse,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms-seo/src/api/seo-ai.ts
+++ b/packages/@granit/cms-seo/src/api/seo-ai.ts
@@ -6,7 +6,7 @@ import type {
   SeoAiSuggestRequest,
   SeoAiSuggestResponse,
   SeoAiSuggestionResponse,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms-seo/src/api/seo.ts
+++ b/packages/@granit/cms-seo/src/api/seo.ts
@@ -1,4 +1,4 @@
-import type { EffectiveSeoResponse } from '../types/index.js';
+import type { EffectiveSeoResponse } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms-seo/src/index.ts
+++ b/packages/@granit/cms-seo/src/index.ts
@@ -31,10 +31,10 @@ export type {
   SeoAiSuggestResponse,
   SeoAiSuggestionResponse,
   SeoAiSuggestionStatus,
-} from './types/index.js';
+} from './types/index';
 
 // ─── API — Public renderer ────────────────────────────────────────────────────
-export { getEffectiveSeo } from './api/seo.js';
+export { getEffectiveSeo } from './api/seo';
 
 // ─── API — SEO admin ─────────────────────────────────────────────────────────
 export {
@@ -48,7 +48,7 @@ export {
   listSeoAuditIssues,
   updateSeoDefaults,
   upsertSeoMetadata,
-} from './api/seo-admin.js';
+} from './api/seo-admin';
 
 // ─── API — SEO-AI ─────────────────────────────────────────────────────────────
 export {
@@ -58,4 +58,4 @@ export {
   rejectSeoSuggestion,
   suggestSeo,
   triggerBulkSeoAudit,
-} from './api/seo-ai.js';
+} from './api/seo-ai';

--- a/packages/@granit/cms/src/__tests__/blocks.test.ts
+++ b/packages/@granit/cms/src/__tests__/blocks.test.ts
@@ -1,13 +1,13 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getBlockCatalog, resolveBlockData } from '../api/blocks.js';
+import { getBlockCatalog, resolveBlockData } from '../api/blocks';
 
 import type {
   BlockCatalogResponse,
   BlockDataResolveRequest,
   BlockDataResponse,
-} from '../types/index.js';
+} from '../types/index';
 
 const basePath = 'https://cms.example.com';
 

--- a/packages/@granit/cms/src/__tests__/documents.test.ts
+++ b/packages/@granit/cms/src/__tests__/documents.test.ts
@@ -1,9 +1,9 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { batchResolveDocuments } from '../api/documents.js';
+import { batchResolveDocuments } from '../api/documents';
 
-import type { BatchResolveDocumentsRequest, ResolvedDocumentResponse } from '../types/index.js';
+import type { BatchResolveDocumentsRequest, ResolvedDocumentResponse } from '../types/index';
 
 const basePath = 'https://cms.example.com';
 

--- a/packages/@granit/cms/src/__tests__/menus-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/menus-admin.test.ts
@@ -1,9 +1,9 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createMenu, deleteMenu, getMenu, listMenus, updateMenu } from '../api/menus-admin.js';
+import { createMenu, deleteMenu, getMenu, listMenus, updateMenu } from '../api/menus-admin';
 
-import type { MenuResponse, PagedResponse } from '../types/index.js';
+import type { MenuResponse, PagedResponse } from '../types/index';
 
 const BASE = 'https://cms.example.com';
 
@@ -18,7 +18,12 @@ const menu: MenuResponse = {
 describe('listMenus', () => {
   it('GET /api/cms/menus without params', async () => {
     const client = createMockClient();
-    const response: PagedResponse<MenuResponse> = { items: [menu], totalCount: 1, page: 0, pageSize: 20 };
+    const response: PagedResponse<MenuResponse> = {
+      items: [menu],
+      totalCount: 1,
+      page: 0,
+      pageSize: 20,
+    };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 
     const result = await listMenus(client, BASE);
@@ -29,11 +34,15 @@ describe('listMenus', () => {
 
   it('passes siteId param', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [], totalCount: 0, page: 0, pageSize: 20 }));
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: [], totalCount: 0, page: 0, pageSize: 20 })
+    );
 
     await listMenus(client, BASE, { siteId: 'site-1' });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus`, { params: { siteId: 'site-1' } });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus`, {
+      params: { siteId: 'site-1' },
+    });
   });
 });
 

--- a/packages/@granit/cms/src/__tests__/menus.test.ts
+++ b/packages/@granit/cms/src/__tests__/menus.test.ts
@@ -1,9 +1,9 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { resolveMenu } from '../api/menus.js';
+import { resolveMenu } from '../api/menus';
 
-import type { ResolvedMenu } from '../types/index.js';
+import type { ResolvedMenu } from '../types/index';
 
 const basePath = 'https://cms.example.com';
 

--- a/packages/@granit/cms/src/__tests__/pages-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages-admin.test.ts
@@ -15,14 +15,14 @@ import {
   unpublishPage,
   updatePage,
   updatePageTranslation,
-} from '../api/pages-admin.js';
+} from '../api/pages-admin';
 
 import type {
   PageDraftConflictResponse,
   PageResponse,
   PageTreeNodeResponse,
   PageVersionSummaryResponse,
-} from '../types/index.js';
+} from '../types/index';
 
 const BASE = 'https://cms.example.com';
 
@@ -63,7 +63,9 @@ describe('getPageTree', () => {
 
     const result = await getPageTree(client, BASE, 'site-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages/tree`, { params: { siteId: 'site-1' } });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages/tree`, {
+      params: { siteId: 'site-1' },
+    });
     expect(result).toEqual([treeNode]);
   });
 });
@@ -71,11 +73,15 @@ describe('getPageTree', () => {
 describe('listPages', () => {
   it('GET /api/cms/pages with params', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [page], totalCount: 1, page: 0, pageSize: 20 }));
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: [page], totalCount: 1, page: 0, pageSize: 20 })
+    );
 
     await listPages(client, BASE, { siteId: 'site-1' });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages`, { params: { siteId: 'site-1' } });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages`, {
+      params: { siteId: 'site-1' },
+    });
   });
 });
 
@@ -111,7 +117,9 @@ describe('updatePage', () => {
 
     await updatePage(client, BASE, 'page-1', { slugSegment: 'new-home' });
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1`, { slugSegment: 'new-home' });
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1`, {
+      slugSegment: 'new-home',
+    });
   });
 });
 
@@ -120,7 +128,10 @@ describe('updatePageTranslation', () => {
     const client = createMockClient();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(page));
 
-    await updatePageTranslation(client, BASE, 'page-1', 'fr', { urlSlug: 'accueil', title: 'Accueil' });
+    await updatePageTranslation(client, BASE, 'page-1', 'fr', {
+      urlSlug: 'accueil',
+      title: 'Accueil',
+    });
 
     expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/translations/fr`, {
       urlSlug: 'accueil',
@@ -136,7 +147,9 @@ describe('movePage', () => {
 
     await movePage(client, BASE, 'page-1', { parentId: 'parent-1' });
 
-    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/move`, { parentId: 'parent-1' });
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/pages/page-1/move`, {
+      parentId: 'parent-1',
+    });
   });
 });
 

--- a/packages/@granit/cms/src/__tests__/pages.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages.test.ts
@@ -1,14 +1,14 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getPageByPath, mintPreviewToken, resolvePreview } from '../api/pages.js';
+import { getPageByPath, mintPreviewToken, resolvePreview } from '../api/pages';
 
 import type {
   DraftPagePreviewResponse,
   MintPreviewTokenRequest,
   MintPreviewTokenResponse,
   PublishedPageResponse,
-} from '../types/index.js';
+} from '../types/index';
 
 const basePath = 'https://cms.example.com';
 

--- a/packages/@granit/cms/src/__tests__/releases.test.ts
+++ b/packages/@granit/cms/src/__tests__/releases.test.ts
@@ -12,9 +12,9 @@ import {
   removeReleaseAction,
   scheduleRelease,
   updateRelease,
-} from '../api/releases.js';
+} from '../api/releases';
 
-import type { PagedResponse, ReleaseResponse } from '../types/index.js';
+import type { PagedResponse, ReleaseResponse } from '../types/index';
 
 const BASE = 'https://cms.example.com';
 
@@ -32,7 +32,12 @@ const release: ReleaseResponse = {
 describe('listReleases', () => {
   it('GET /api/cms/releases', async () => {
     const client = createMockClient();
-    const response: PagedResponse<ReleaseResponse> = { items: [release], totalCount: 1, page: 0, pageSize: 20 };
+    const response: PagedResponse<ReleaseResponse> = {
+      items: [release],
+      totalCount: 1,
+      page: 0,
+      pageSize: 20,
+    };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 
     const result = await listReleases(client, BASE);
@@ -75,7 +80,9 @@ describe('updateRelease', () => {
 
     await updateRelease(client, BASE, 'rel-1', { name: 'Sprint 42 rev2' });
 
-    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1`, { name: 'Sprint 42 rev2' });
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1`, {
+      name: 'Sprint 42 rev2',
+    });
   });
 });
 
@@ -95,7 +102,12 @@ describe('addReleaseAction', () => {
     const client = createMockClient();
     vi.mocked(client.post).mockResolvedValue(axiosResponse(release));
 
-    const request = { contentType: 'page', contentId: 'page-1', culture: 'fr', type: 'Publish' as const };
+    const request = {
+      contentType: 'page',
+      contentId: 'page-1',
+      culture: 'fr',
+      type: 'Publish' as const,
+    };
     const result = await addReleaseAction(client, BASE, 'rel-1', request);
 
     expect(client.post).toHaveBeenCalledWith(`${BASE}/api/cms/releases/rel-1/actions`, request);

--- a/packages/@granit/cms/src/__tests__/sites.test.ts
+++ b/packages/@granit/cms/src/__tests__/sites.test.ts
@@ -1,9 +1,9 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createSite, deleteSite, getSite, listSites, updateSite } from '../api/sites.js';
+import { createSite, deleteSite, getSite, listSites, updateSite } from '../api/sites';
 
-import type { PagedResponse, SiteResponse } from '../types/index.js';
+import type { PagedResponse, SiteResponse } from '../types/index';
 
 const BASE = 'https://cms.example.com';
 
@@ -22,7 +22,12 @@ const site: SiteResponse = {
 describe('listSites', () => {
   it('fetches paged list without params', async () => {
     const client = createMockClient();
-    const response: PagedResponse<SiteResponse> = { items: [site], totalCount: 1, page: 0, pageSize: 20 };
+    const response: PagedResponse<SiteResponse> = {
+      items: [site],
+      totalCount: 1,
+      page: 0,
+      pageSize: 20,
+    };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
 
     const result = await listSites(client, BASE);
@@ -33,7 +38,9 @@ describe('listSites', () => {
 
   it('passes page and search params', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse({ items: [], totalCount: 0, page: 1, pageSize: 10 }));
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: [], totalCount: 0, page: 1, pageSize: 10 })
+    );
 
     await listSites(client, BASE, { page: 1, pageSize: 10, search: 'acme' });
 

--- a/packages/@granit/cms/src/api/blocks.ts
+++ b/packages/@granit/cms/src/api/blocks.ts
@@ -2,7 +2,7 @@ import type {
   BlockCatalogResponse,
   BlockDataResolveRequest,
   BlockDataResponse,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms/src/api/documents.ts
+++ b/packages/@granit/cms/src/api/documents.ts
@@ -1,4 +1,4 @@
-import type { BatchResolveDocumentsRequest, ResolvedDocumentResponse } from '../types/index.js';
+import type { BatchResolveDocumentsRequest, ResolvedDocumentResponse } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms/src/api/menus-admin.ts
+++ b/packages/@granit/cms/src/api/menus-admin.ts
@@ -4,7 +4,7 @@ import type {
   MenuResponse,
   PagedResponse,
   UpdateMenuRequest,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /** `GET /api/cms/menus` — paged list. Requires `Cms.Menus.Read`. */

--- a/packages/@granit/cms/src/api/menus.ts
+++ b/packages/@granit/cms/src/api/menus.ts
@@ -1,4 +1,4 @@
-import type { ResolvedMenu } from '../types/index.js';
+import type { ResolvedMenu } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms/src/api/pages-admin.ts
+++ b/packages/@granit/cms/src/api/pages-admin.ts
@@ -11,7 +11,7 @@ import type {
   SaveDraftResult,
   UpdatePageRequest,
   UpdatePageTranslationRequest,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /** `GET /api/cms/pages/tree` — flat list ordered as tree. Requires `Cms.Pages.Read`. */

--- a/packages/@granit/cms/src/api/pages.ts
+++ b/packages/@granit/cms/src/api/pages.ts
@@ -3,7 +3,7 @@ import type {
   MintPreviewTokenRequest,
   MintPreviewTokenResponse,
   PublishedPageResponse,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**

--- a/packages/@granit/cms/src/api/releases.ts
+++ b/packages/@granit/cms/src/api/releases.ts
@@ -6,7 +6,7 @@ import type {
   ReleaseResponse,
   ScheduleReleaseRequest,
   UpdateReleaseRequest,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /** `GET /api/cms/releases` — paged list. Requires `Cms.Releases.Read`. */

--- a/packages/@granit/cms/src/api/sites.ts
+++ b/packages/@granit/cms/src/api/sites.ts
@@ -4,7 +4,7 @@ import type {
   PagedResponse,
   SiteResponse,
   UpdateSiteRequest,
-} from '../types/index.js';
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /** `GET /api/cms/sites` — list sites (paged). Requires `Cms.Sites.Read`. */

--- a/packages/@granit/cms/src/index.ts
+++ b/packages/@granit/cms/src/index.ts
@@ -63,26 +63,26 @@ export type {
   ListSitesParams,
   // Admin result types
   SaveDraftResult,
-} from './types/index.js';
+} from './types/index';
 
 // ─── API — Public renderer ────────────────────────────────────────────────────
 
 // Pages
-export { getPageByPath, mintPreviewToken, resolvePreview } from './api/pages.js';
+export { getPageByPath, mintPreviewToken, resolvePreview } from './api/pages';
 
 // Blocks
-export { getBlockCatalog, resolveBlockData } from './api/blocks.js';
+export { getBlockCatalog, resolveBlockData } from './api/blocks';
 
 // Menus
-export { resolveMenu } from './api/menus.js';
+export { resolveMenu } from './api/menus';
 
 // Document Resolution
-export { batchResolveDocuments } from './api/documents.js';
+export { batchResolveDocuments } from './api/documents';
 
 // ─── API — Admin ──────────────────────────────────────────────────────────────
 
 // Sites
-export { createSite, deleteSite, getSite, listSites, updateSite } from './api/sites.js';
+export { createSite, deleteSite, getSite, listSites, updateSite } from './api/sites';
 
 // Pages admin
 export {
@@ -99,10 +99,10 @@ export {
   unpublishPage,
   updatePage,
   updatePageTranslation,
-} from './api/pages-admin.js';
+} from './api/pages-admin';
 
 // Menus admin
-export { createMenu, deleteMenu, getMenu, listMenus, updateMenu } from './api/menus-admin.js';
+export { createMenu, deleteMenu, getMenu, listMenus, updateMenu } from './api/menus-admin';
 
 // Releases
 export {
@@ -116,4 +116,4 @@ export {
   removeReleaseAction,
   scheduleRelease,
   updateRelease,
-} from './api/releases.js';
+} from './api/releases';

--- a/packages/@granit/presence/src/api/presence-api.ts
+++ b/packages/@granit/presence/src/api/presence-api.ts
@@ -1,7 +1,5 @@
 import { buildApiUrl } from '@granit/api-client';
 
-import { PRESENCE_DEFAULTS } from '../constants';
-
 import type {
   BatchPresenceRequest,
   BatchPresenceResponse,
@@ -144,36 +142,4 @@ export function normalizeUserIds(userIds: readonly UserId[]): UserId[] {
   return Array.from(new Set(userIds))
     .filter((id) => id.length > 0)
     .sort((a, b) => a.localeCompare(b));
-}
-
-/**
- * Fetches presence for a list of users in one (or more) batch calls.
- *
- * Lists larger than the server cap (`PRESENCE_DEFAULTS.MaxBatchSize`) are
- * chunked automatically and resolved in parallel.
- *
- * Requires `Presence.Users.Read`.
- */
-export async function fetchBatchPresence(
-  client: AxiosInstance,
-  basePath: string,
-  userIds: readonly UserId[]
-): Promise<BatchPresenceResponse> {
-  const maxBatch = PRESENCE_DEFAULTS.MaxBatchSize;
-  if (userIds.length <= maxBatch) {
-    return getBatchPresence(client, basePath, { userIds });
-  }
-  // Server cap exceeded — chunk and fan out in parallel.
-  const chunks: UserId[][] = [];
-  for (let i = 0; i < userIds.length; i += maxBatch) {
-    chunks.push(userIds.slice(i, i + maxBatch));
-  }
-  const responses = await Promise.all(
-    chunks.map((chunk) => getBatchPresence(client, basePath, { userIds: chunk }))
-  );
-  const merged: Record<UserId, PresenceResponse> = {};
-  for (const { presences } of responses) {
-    Object.assign(merged, presences);
-  }
-  return { presences: merged };
 }

--- a/packages/@granit/presence/src/index.ts
+++ b/packages/@granit/presence/src/index.ts
@@ -14,7 +14,6 @@ export type {
 // API — user presence
 export {
   clearMyPresenceOverride,
-  fetchBatchPresence,
   getBatchPresence,
   getMyPresence,
   getUserPresence,

--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./server": "./src/index.server.ts"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",

--- a/packages/@granit/react-cms/src/hooks/use-menu-mutations.ts
+++ b/packages/@granit/react-cms/src/hooks/use-menu-mutations.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { createMenu, deleteMenu, updateMenu } from '@granit/cms';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 

--- a/packages/@granit/react-cms/src/hooks/use-menus-admin.ts
+++ b/packages/@granit/react-cms/src/hooks/use-menus-admin.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { getMenu, listMenus } from '@granit/cms';
 import { useQuery } from '@tanstack/react-query';
 

--- a/packages/@granit/react-cms/src/hooks/use-page-mutations.ts
+++ b/packages/@granit/react-cms/src/hooks/use-page-mutations.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   createPage,
   deletePage,

--- a/packages/@granit/react-cms/src/hooks/use-pages.ts
+++ b/packages/@granit/react-cms/src/hooks/use-pages.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { getPage, getPageTree, listPageVersions, listPages } from '@granit/cms';
 import { useQuery } from '@tanstack/react-query';
 

--- a/packages/@granit/react-cms/src/hooks/use-release-mutations.ts
+++ b/packages/@granit/react-cms/src/hooks/use-release-mutations.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import {
   addReleaseAction,
   cancelRelease,

--- a/packages/@granit/react-cms/src/hooks/use-releases.ts
+++ b/packages/@granit/react-cms/src/hooks/use-releases.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { getRelease, listReleases } from '@granit/cms';
 import { useQuery } from '@tanstack/react-query';
 

--- a/packages/@granit/react-cms/src/hooks/use-site-mutations.ts
+++ b/packages/@granit/react-cms/src/hooks/use-site-mutations.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { createSite, deleteSite, updateSite } from '@granit/cms';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 

--- a/packages/@granit/react-cms/src/hooks/use-sites.ts
+++ b/packages/@granit/react-cms/src/hooks/use-sites.ts
@@ -1,3 +1,5 @@
+'use client';
+
 import { getSite, listSites } from '@granit/cms';
 import { useQuery } from '@tanstack/react-query';
 

--- a/packages/@granit/react-cms/src/index.server.ts
+++ b/packages/@granit/react-cms/src/index.server.ts
@@ -1,0 +1,20 @@
+/**
+ * Server-safe entry point for @granit/react-cms.
+ * Only exports safe to import from React Server Components.
+ */
+
+// Document resolution (pure async function, no browser APIs)
+export { resolveDocumentReferencesInData } from './blocks/resolve-documents';
+export type { ResolvedDocumentAsset, ResolveDocumentsFn } from './blocks/resolve-documents';
+
+// Puck config generator (pure function, no browser APIs)
+export { catalogToConfig } from './puck/catalog-to-config';
+export type {
+  CatalogConfigOptions,
+  DocumentPickerItem,
+  FetchDocumentsFn,
+  ResolveBlockDataFn,
+} from './puck/catalog-to-config';
+
+// Navigation component (client component — safe to import from server, rendered as client ref)
+export { CmsMenuNav } from './components/cms-menu-nav';

--- a/packages/@granit/react-cms/src/providers/cms-provider.tsx
+++ b/packages/@granit/react-cms/src/providers/cms-provider.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 

--- a/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
+++ b/packages/@granit/react-cms/src/puck/catalog-to-config.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import { BLOCK_COMPONENTS } from '../blocks/registry';
 
 import type { BlockCatalogResponse, BlockFieldDescriptor, BlockFieldKind } from '@granit/cms';

--- a/packages/@granit/react-entities/src/hooks/use-entity-calendar.ts
+++ b/packages/@granit/react-entities/src/hooks/use-entity-calendar.ts
@@ -1,6 +1,7 @@
 import { useGranitClient } from '@granit/react-api-client';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
+export { entityCalendarQueryKey } from './query-keys';
 import { entityCalendarQueryKey } from './query-keys';
 
 import type { CalendarItemResponse } from '@granit/entities';

--- a/packages/@granit/react-entities/src/hooks/use-entity-discovery.ts
+++ b/packages/@granit/react-entities/src/hooks/use-entity-discovery.ts
@@ -1,6 +1,7 @@
 import { useGranitClient } from '@granit/react-api-client';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
+export { entityDiscoveryQueryKey } from './query-keys';
 import { entityDiscoveryQueryKey } from './query-keys';
 
 import type { EntityDiscoveryResponse } from '@granit/entities';

--- a/packages/@granit/react-entities/src/hooks/use-entity-metadata.ts
+++ b/packages/@granit/react-entities/src/hooks/use-entity-metadata.ts
@@ -1,6 +1,7 @@
 import { useGranitClient } from '@granit/react-api-client';
 import { useQuery, useQueryClient, type UseQueryResult } from '@tanstack/react-query';
 
+export { entityManifestQueryKey } from './query-keys';
 import { entityManifestQueryKey } from './query-keys';
 
 import type { EntityFacet, EntityManifestResponse } from '@granit/entities';

--- a/packages/@granit/react-entities/src/hooks/use-entity-relation-aggregates.ts
+++ b/packages/@granit/react-entities/src/hooks/use-entity-relation-aggregates.ts
@@ -1,6 +1,7 @@
 import { useGranitClient } from '@granit/react-api-client';
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
+export { entityRelationAggregatesQueryKey } from './query-keys';
 import { entityRelationAggregatesQueryKey } from './query-keys';
 
 import type { RelationAggregatesResponse } from '@granit/entities';

--- a/packages/@granit/react-presence/src/hooks/use-batch-presence.ts
+++ b/packages/@granit/react-presence/src/hooks/use-batch-presence.ts
@@ -1,4 +1,4 @@
-import { fetchBatchPresence, normalizeUserIds } from '@granit/presence';
+import { PRESENCE_DEFAULTS, getBatchPresence, normalizeUserIds } from '@granit/presence';
 import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_STALE_TIME_MS } from '../constants';
@@ -6,9 +6,40 @@ import { buildPresenceQueryKey, usePresenceConfig } from '../providers/presence-
 
 import { presenceKeys } from './query-keys';
 
-import type { BatchPresenceResponse } from '@granit/presence';
+import type { AxiosInstance } from '@granit/api-client';
+import type { BatchPresenceResponse, PresenceResponse } from '@granit/presence';
 import type { UserId } from '@granit/types';
 import type { UseQueryResult } from '@tanstack/react-query';
+
+const MAX_BATCH = PRESENCE_DEFAULTS.MaxBatchSize;
+
+/**
+ * Resolves presence for an already normalized list of users, chunking calls
+ * that exceed the server batch cap (`MaxBatchSize`) and merging the results.
+ * Each chunk hits the `getBatchPresence` primitive so the network boundary
+ * stays the single mockable seam.
+ */
+async function getBatchPresenceChunked(
+  client: AxiosInstance,
+  basePath: string,
+  ids: readonly UserId[]
+): Promise<BatchPresenceResponse> {
+  if (ids.length <= MAX_BATCH) {
+    return getBatchPresence(client, basePath, { userIds: ids });
+  }
+  const chunks: UserId[][] = [];
+  for (let i = 0; i < ids.length; i += MAX_BATCH) {
+    chunks.push(ids.slice(i, i + MAX_BATCH));
+  }
+  const responses = await Promise.all(
+    chunks.map((chunk) => getBatchPresence(client, basePath, { userIds: chunk }))
+  );
+  const merged: Record<UserId, PresenceResponse> = {};
+  for (const { presences } of responses) {
+    Object.assign(merged, presences);
+  }
+  return { presences: merged };
+}
 
 export interface UseBatchPresenceOptions {
   /** Set to `false` to suppress the request (e.g. when permission is missing). */
@@ -36,7 +67,7 @@ export function useBatchPresence(
 
   return useQuery({
     queryKey: buildPresenceQueryKey(config, ...presenceKeys.batch(ids)),
-    queryFn: () => fetchBatchPresence(config.client, config.basePath, ids),
+    queryFn: () => getBatchPresenceChunked(config.client, config.basePath, ids),
     staleTime: DEFAULT_STALE_TIME_MS,
     refetchOnWindowFocus: true,
     enabled: enabled && ids.length > 0,

--- a/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
+++ b/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
@@ -8,6 +8,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useSchedulingConfig } from '../providers/scheduling-provider';
 
+export { buildSchedulingQueryKey, schedulingKeys } from './query-keys';
 import { buildSchedulingQueryKey } from './query-keys';
 
 import type { PagedResult, QueryRequest } from '@granit/query-engine';


### PR DESCRIPTION
## Contexte

Modifications initiées par **granit-cms-renderer** (app Next.js 16) pour consommer `@granit/react-cms` depuis l'App Router, complétées par une uniformisation des imports de la famille CMS.

## Changements

### `feat(react-cms)` — support React Server Components
- `'use client'` ajouté aux 8 hooks admin + `cms-provider.tsx` (ils utilisent `useQuery`/`useMutation`/`createContext`, APIs client-only).
- Nouvelle entrée serveur `@granit/react-cms/server` (`index.server.ts`) : barrel server-safe exposant uniquement `catalogToConfig`, le résolveur de documents et `CmsMenuNav` — exclut hooks et provider.
- `'use client'` retiré de `puck/catalog-to-config.tsx` : fonction pure (construction d'un `Config` Puck, aucune API navigateur), donc appelable depuis un Server Component.

### `refactor(cms)` — uniformisation des imports relatifs
- Suppression des extensions `.js` sur toute la famille CMS (`cms`, `cms-seo`, `cms-redirects`, `cms-hostnames`).
- Aligne sur la convention extensionless du reste du repo (`moduleResolution: bundler`, packages source-direct). Corrige l'incohérence où `cms/index.ts` mélangeait les deux styles.

## Vérifications
- `pnpm tsc` ✅
- `pnpm lint` ✅ (`--max-warnings 0`)
- `pnpm test` ✅ (cms: 85, famille cms-*: 37)

## Note de périmètre
La PR couvre deux scopes (RSC react-cms + uniformisation `.js`). Découpage en commits distincts. Si une PR mono-scope est préférée, le `refactor(cms)` peut être extrait.