### PR TITLE
fix(security): validate URLs at CMS and document render sinks

### DIFF
--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -13,6 +13,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/utils": "workspace:*",
     "@puckeditor/core": "^0.21.2",
     "@tanstack/react-query": "^5.0.0"
   },
@@ -20,6 +21,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/cms": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/utils": "workspace:*",
     "@puckeditor/core": "^0.21.0",
     "@tanstack/react-query": "^5.0.0",
     "react": "^19.0.0"

--- a/packages/@granit/react-cms/src/__tests__/blocks.test.tsx
+++ b/packages/@granit/react-cms/src/__tests__/blocks.test.tsx
@@ -224,6 +224,58 @@ describe('VideoBlock', () => {
   });
 });
 
+describe('block link/media XSS hardening (VULN-100/101/204)', () => {
+  const UNSAFE_HREFS = [
+    'javascript:alert(document.cookie)',
+    'JaVaScRiPt:alert(1)',
+    'data:text/html,<script>alert(1)</script>',
+    'vbscript:msgbox(1)',
+    '/\\evil.com',
+  ];
+
+  it.each(UNSAFE_HREFS)('HeroBlock drops unsafe CTA href %s', (href) => {
+    const { container } = render(<HeroBlock headline="Welcome" ctaLabel="Go" ctaHref={href} />);
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it('HeroBlock keeps a safe CTA href', () => {
+    const { container } = render(
+      <HeroBlock headline="Welcome" ctaLabel="Go" ctaHref="https://example.com" />
+    );
+    expect(container.querySelector('a')?.getAttribute('href')).toBe('https://example.com');
+  });
+
+  it.each(UNSAFE_HREFS)('CtaBlock drops unsafe button href %s', (href) => {
+    const { container } = render(<CtaBlock title="T" buttonLabel="Go" buttonHref={href} />);
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it.each(UNSAFE_HREFS)('PricingBlock drops unsafe plan CTA href %s', (href) => {
+    const { container } = render(
+      <PricingBlock
+        title="Pricing"
+        plans={[{ name: 'Pro', price: '€9', features: [], ctaLabel: 'Buy', ctaHref: href }]}
+      />
+    );
+    expect(container.querySelector('a')).toBeNull();
+  });
+
+  it.each(['javascript:alert(1)', 'data:text/html,x', '/\\evil.com'])(
+    'VideoBlock drops unsafe video src %s',
+    (src) => {
+      const { container } = render(<VideoBlock videoUrl={src} />);
+      expect(container.querySelector('video')).toBeNull();
+    }
+  );
+
+  it('VideoBlock keeps a safe https video src', () => {
+    const { container } = render(<VideoBlock videoUrl="https://cdn.example.com/v.mp4" />);
+    expect(container.querySelector('video')?.getAttribute('src')).toBe(
+      'https://cdn.example.com/v.mp4'
+    );
+  });
+});
+
 describe('MapBlock', () => {
   it('renders with required props only', () => {
     const { container } = render(<MapBlock />);

--- a/packages/@granit/react-cms/src/__tests__/cms-menu-nav.test.tsx
+++ b/packages/@granit/react-cms/src/__tests__/cms-menu-nav.test.tsx
@@ -54,6 +54,22 @@ describe('CmsMenuNav', () => {
     expect(link).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
+  it.each([
+    'javascript:alert(document.cookie)',
+    'data:text/html,<script>alert(1)</script>',
+    '/\\evil.com',
+  ])('drops an unsafe ExternalUrl href %s and renders an inert span (VULN-101)', (href) => {
+    render(
+      <CmsMenuNav
+        menu={menu({
+          items: [{ label: 'Trap', kind: 'ExternalUrl', href, children: [] }],
+        })}
+      />
+    );
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.getByText('Trap')).toBeInTheDocument();
+  });
+
   it('renders a None item as a span (no link)', () => {
     render(
       <CmsMenuNav

--- a/packages/@granit/react-cms/src/blocks/cta-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/cta-block.tsx
@@ -1,13 +1,16 @@
 'use client';
 
+import { safeLinkHref } from '../lib/safe-href';
+
 import type { CtaBlockProps } from './types';
 
 export function CtaBlock({ title, description, buttonLabel, buttonHref }: CtaBlockProps) {
+  const buttonSafeHref = safeLinkHref(buttonHref);
   return (
     <section data-block="cta">
       <h2>{title}</h2>
       {description && <p>{description}</p>}
-      {buttonLabel && buttonHref && <a href={buttonHref}>{buttonLabel}</a>}
+      {buttonLabel && buttonSafeHref && <a href={buttonSafeHref}>{buttonLabel}</a>}
     </section>
   );
 }

--- a/packages/@granit/react-cms/src/blocks/hero-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/hero-block.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { safeLinkHref } from '../lib/safe-href';
+
 import type { HeroBlockProps } from './types';
 
 export function HeroBlock({
@@ -9,6 +11,7 @@ export function HeroBlock({
   ctaHref,
   _resolved_imageId,
 }: HeroBlockProps) {
+  const ctaSafeHref = safeLinkHref(ctaHref);
   return (
     <section data-block="hero">
       {_resolved_imageId && (
@@ -21,7 +24,7 @@ export function HeroBlock({
       )}
       <h1>{headline}</h1>
       {subline && <p>{subline}</p>}
-      {ctaLabel && ctaHref && <a href={ctaHref}>{ctaLabel}</a>}
+      {ctaLabel && ctaSafeHref && <a href={ctaSafeHref}>{ctaLabel}</a>}
     </section>
   );
 }

--- a/packages/@granit/react-cms/src/blocks/pricing-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/pricing-block.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { safeLinkHref } from '../lib/safe-href';
+
 import type { PricingBlockProps } from './types';
 
 export function PricingBlock({ title, plans }: PricingBlockProps) {
@@ -7,19 +9,22 @@ export function PricingBlock({ title, plans }: PricingBlockProps) {
     <section data-block="pricing">
       <h2>{title}</h2>
       <ul>
-        {plans.map((plan) => (
-          <li key={plan.name} data-highlighted={plan.highlighted ? 'true' : undefined}>
-            <strong>{plan.name}</strong>
-            <span>{plan.price}</span>
-            {plan.description && <p>{plan.description}</p>}
-            <ul>
-              {plan.features.map((f) => (
-                <li key={f}>{f}</li>
-              ))}
-            </ul>
-            {plan.ctaLabel && plan.ctaHref && <a href={plan.ctaHref}>{plan.ctaLabel}</a>}
-          </li>
-        ))}
+        {plans.map((plan) => {
+          const ctaSafeHref = safeLinkHref(plan.ctaHref);
+          return (
+            <li key={plan.name} data-highlighted={plan.highlighted ? 'true' : undefined}>
+              <strong>{plan.name}</strong>
+              <span>{plan.price}</span>
+              {plan.description && <p>{plan.description}</p>}
+              <ul>
+                {plan.features.map((f) => (
+                  <li key={f}>{f}</li>
+                ))}
+              </ul>
+              {plan.ctaLabel && ctaSafeHref && <a href={ctaSafeHref}>{plan.ctaLabel}</a>}
+            </li>
+          );
+        })}
       </ul>
     </section>
   );

--- a/packages/@granit/react-cms/src/blocks/video-block.tsx
+++ b/packages/@granit/react-cms/src/blocks/video-block.tsx
@@ -1,14 +1,19 @@
 'use client';
 
+import { safeMediaSrc } from '../lib/safe-href';
+
 import type { VideoBlockProps } from './types';
 
 export function VideoBlock({ title, videoUrl, _resolved_thumbnailId }: VideoBlockProps) {
+  const safeSrc = safeMediaSrc(videoUrl);
   return (
     <section data-block="video">
       {title && <h2>{title}</h2>}
-      <video src={videoUrl} controls poster={_resolved_thumbnailId?.url ?? undefined}>
-        <track kind="captions" />
-      </video>
+      {safeSrc && (
+        <video src={safeSrc} controls poster={_resolved_thumbnailId?.url ?? undefined}>
+          <track kind="captions" />
+        </video>
+      )}
     </section>
   );
 }

--- a/packages/@granit/react-cms/src/components/cms-menu-nav.tsx
+++ b/packages/@granit/react-cms/src/components/cms-menu-nav.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { safeLinkHref } from '../lib/safe-href';
+
 import type { ResolvedMenu, ResolvedMenuItem } from '@granit/cms';
 
 interface CmsMenuNavProps {
@@ -26,12 +28,15 @@ export function CmsMenuNav({ menu, className }: CmsMenuNavProps) {
 }
 
 function MenuItemNode({ item }: { readonly item: ResolvedMenuItem }) {
+  // Editor-authored `ExternalUrl` items may carry a `javascript:` scheme —
+  // drop the href and render an inert grouping header instead. See VULN-101.
+  const safeHref = safeLinkHref(item.href);
   const label =
-    item.kind === 'None' || !item.href ? (
+    item.kind === 'None' || !safeHref ? (
       <span className={item.cssClass ?? undefined}>{item.label}</span>
     ) : (
       <a
-        href={item.href}
+        href={safeHref}
         className={item.cssClass ?? undefined}
         target={item.kind === 'ExternalUrl' ? '_blank' : undefined}
         rel={item.kind === 'ExternalUrl' ? 'noopener noreferrer' : undefined}

--- a/packages/@granit/react-cms/src/lib/safe-href.ts
+++ b/packages/@granit/react-cms/src/lib/safe-href.ts
@@ -1,0 +1,26 @@
+import { LINK_URL_SCHEMES, NAV_URL_SCHEMES, isSafeUrl } from '@granit/utils';
+
+/**
+ * Returns `href` when it is a content-editor-safe link target — an `http(s)`,
+ * `mailto:` or `tel:` URL, or a same-origin relative path — otherwise
+ * `undefined`.
+ *
+ * CMS content is authored by lower-trust editors. A `javascript:` / `data:` /
+ * `vbscript:` URL rendered straight into `<a href>` is stored XSS that runs in
+ * every visitor's session on the public site. Callers render the label as inert
+ * text (or drop the link) when this returns `undefined`. See security audit
+ * VULN-100 / VULN-101.
+ */
+export function safeLinkHref(href: string | null | undefined): string | undefined {
+  return typeof href === 'string' && isSafeUrl(href, LINK_URL_SCHEMES) ? href : undefined;
+}
+
+/**
+ * Returns `src` when it is a safe media source — an `http(s)` URL or a
+ * same-origin relative path — otherwise `undefined`. Rejects `data:`,
+ * `javascript:`, `blob:` and protocol-relative URLs. See security audit
+ * VULN-204.
+ */
+export function safeMediaSrc(src: string | null | undefined): string | undefined {
+  return typeof src === 'string' && isSafeUrl(src, NAV_URL_SCHEMES) ? src : undefined;
+}

--- a/packages/@granit/react-documents/package.json
+++ b/packages/@granit/react-documents/package.json
@@ -20,6 +20,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
+    "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.14.6",
     "react": "^19.0.0"
@@ -50,6 +51,7 @@
     "@granit/react-query-engine": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
+    "@granit/utils": "workspace:*",
     "msw": "^2.14.6"
   }
 }

--- a/packages/@granit/react-documents/src/components/document-quick-look.tsx
+++ b/packages/@granit/react-documents/src/components/document-quick-look.tsx
@@ -1,3 +1,4 @@
+import { NAV_URL_SCHEMES, isSafeUrl } from '@granit/utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useDocument, useDocumentDownloadUrl } from '../hooks/use-documents';
@@ -253,7 +254,14 @@ export function DocumentQuickLook({
   });
 
   const document = docQuery.data ?? null;
-  const downloadUrl = urlQuery.data?.url ?? null;
+  // The presigned URL is server-issued, but gate it before it can reach
+  // `<iframe src>` / `window.open` / a media `src` so a malformed or
+  // non-http(s) value can never become a navigation/script sink. An unsafe
+  // value collapses to `null`, which the preview already renders as a no-op.
+  // Defence-in-depth — see security audit VULN-302.
+  const rawDownloadUrl = urlQuery.data?.url ?? null;
+  const downloadUrl =
+    rawDownloadUrl !== null && isSafeUrl(rawDownloadUrl, NAV_URL_SCHEMES) ? rawDownloadUrl : null;
   const kind = useMemo<DocumentKind>(
     () => (document ? classifyDocumentName(document.name) : 'other'),
     [document]

--- a/packages/@granit/utils/src/__tests__/safe-url.test.ts
+++ b/packages/@granit/utils/src/__tests__/safe-url.test.ts
@@ -17,6 +17,15 @@ describe('isSafeUrl', () => {
     expect(isSafeUrl('//evil.com/path')).toBe(false);
   });
 
+  it('rejects backslash authority bypasses (open redirect)', () => {
+    // Browsers normalise `\` to `/` in the authority, so these resolve
+    // off-origin despite the leading single slash. See security audit VULN-202.
+    expect(isSafeUrl('/\\evil.com')).toBe(false);
+    expect(isSafeUrl('\\\\evil.com')).toBe(false);
+    expect(isSafeUrl('/\\/evil.com')).toBe(false);
+    expect(isSafeUrl('\\/evil.com')).toBe(false);
+  });
+
   it('rejects javascript: scheme (XSS)', () => {
     expect(isSafeUrl('javascript:alert(1)')).toBe(false);
     expect(isSafeUrl('JaVaScRiPt:alert(1)')).toBe(false);
@@ -61,6 +70,10 @@ describe('assertSafeUrl', () => {
 
   it('throws on protocol-relative URL', () => {
     expect(() => assertSafeUrl('//evil.com')).toThrow(/Unsafe URL/);
+  });
+
+  it('throws on backslash authority bypass', () => {
+    expect(() => assertSafeUrl('/\\evil.com')).toThrow(/Unsafe URL/);
   });
 
   it('truncates very long URLs in the error message', () => {

--- a/packages/@granit/utils/src/safe-url.ts
+++ b/packages/@granit/utils/src/safe-url.ts
@@ -35,8 +35,13 @@ export function isSafeUrl(
   allowedSchemes: ReadonlySet<string> = NAV_URL_SCHEMES
 ): boolean {
   if (typeof input !== 'string' || input === '') return false;
-  if (input.startsWith('//')) return false;
-  if (input.startsWith('/')) return true;
+  // Browsers normalise backslashes to forward slashes in the authority, so
+  // `/\evil.com`, `\\evil.com` and `/\/evil.com` all resolve off-origin just
+  // like `//evil.com`. Normalise before the relative-path fast paths so the
+  // leading-slash shortcut cannot be tricked into accepting an absolute URL.
+  const normalized = input.replace(/\\/g, '/');
+  if (normalized.startsWith('//')) return false;
+  if (normalized.startsWith('/')) return true;
   const url = parseUrl(input);
   if (url === null) return false;
   return allowedSchemes.has(url.protocol);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1387,6 +1387,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
       '@puckeditor/core':
         specifier: ^0.21.2
         version: 0.21.2(@floating-ui/dom@1.7.6)(@types/react-dom@19.2.3(@types/react@19.2.16))(@types/react@19.2.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
@@ -1701,6 +1704,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)


### PR DESCRIPTION
## Summary

Security-audit remediation — **URL-safety / rendering** domain (branch 1 of 4).

Applies the framework's existing `isSafeUrl` guard at every DOM sink that renders a content-editor- or server-supplied URL, and closes a backslash-authority bypass in the guard itself.

## Findings closed

| ID | Sev | What |
|----|-----|------|
| VULN-100 | HIGH | CMS hero/cta/pricing CTA `href` rendered editor URLs without scheme validation → stored XSS (`javascript:`) on the public site |
| VULN-101 | HIGH | CMS menu `ExternalUrl` `href` (rendered site-wide) had the same gap |
| VULN-204 | MEDIUM | CMS `video-block` `src` unvalidated (`data:`/off-origin) |
| VULN-302 | LOW | `react-documents` presigned URL reached `<iframe src>`/`window.open` without the guard (defence-in-depth) |
| VULN-202* | — | `isSafeUrl` itself accepted `/\evil.com` (backslash authority) — hardened |

## Changes

- **`@granit/utils`** — `isSafeUrl` normalises backslashes before the relative-path fast paths, so `/\evil.com`, `\\evil.com`, `/\/evil.com` are rejected like `//evil.com`. This also strengthens every existing consumer (react-entities, dashboards, map).
- **`@granit/react-cms`** — new internal `lib/safe-href.ts` (`safeLinkHref` / `safeMediaSrc`); applied to hero/cta/pricing CTA hrefs, the menu `ExternalUrl` href, and the video `src`. Unsafe URLs degrade to inert text / dropped media (no executable sink).
- **`@granit/react-documents`** — the presigned download URL is gated at its single derivation point before reaching any media/iframe/`window.open` sink.

## Verification

- `tsc --noEmit` clean (utils, react-cms, react-documents)
- ESLint `--max-warnings 0` clean
- Tests: +20 hardening cases; full suites green (safe-url, blocks, cms-menu-nav, document-quick-look)

No public API changes (`safeLinkHref`/`safeMediaSrc` are internal to react-cms). No new third-party dependencies (`@granit/utils` is an internal workspace package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)