### PR TITLE
fix(security): keep auth tokens out of web storage; harden open-redirect & CSRF

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -675,6 +675,11 @@
               "signature": "scopes?: readonly string[]"
             },
             {
+              "name": "tokenStorage",
+              "kind": "property",
+              "signature": "tokenStorage?: 'memory' | 'sessionStorage' | 'localStorage'"
+            },
+            {
               "name": "onTokenRefreshError",
               "kind": "method",
               "signature": "onTokenRefreshError?: () => void"
@@ -788,6 +793,11 @@
               "name": "scopes",
               "kind": "property",
               "signature": "scopes?: readonly string[]"
+            },
+            {
+              "name": "tokenStorage",
+              "kind": "property",
+              "signature": "tokenStorage?: 'memory' | 'sessionStorage' | 'localStorage'"
             },
             {
               "name": "onTokenRefreshError",

--- a/packages/@granit/authentication-cognito/src/types/index.ts
+++ b/packages/@granit/authentication-cognito/src/types/index.ts
@@ -27,6 +27,17 @@ export interface CognitoCoreConfig {
   /** OAuth scopes to request. */
   scopes?: readonly string[];
 
+  /**
+   * Where the Cognito SDK stores its tokens (id, access, **and the long-lived
+   * refresh token**). Defaults to `'memory'` so tokens are never readable by
+   * same-origin JavaScript (XSS, malicious browser extensions). Override only
+   * when cross-tab / cross-reload persistence is required AND the app ships an
+   * XSS-hardened CSP. Persisting tokens in `localStorage`/`sessionStorage` is a
+   * known high-severity risk (CWE-922) — prefer the BFF cookie pattern
+   * (`@granit/bff`) for durable sessions. See security audit VULN-102.
+   */
+  tokenStorage?: 'memory' | 'sessionStorage' | 'localStorage';
+
   /** Called when a token refresh fails. */
   onTokenRefreshError?: () => void;
   /** Called when the session expires. */

--- a/packages/@granit/authentication-google-cloud/src/types/index.ts
+++ b/packages/@granit/authentication-google-cloud/src/types/index.ts
@@ -25,6 +25,19 @@ export interface GoogleCloudCoreConfig {
 
   /** OAuth scopes to request on sign-in. */
   scopes?: readonly string[];
+
+  /**
+   * Where Firebase Auth persists its tokens (including the refresh token).
+   * Defaults to `'memory'` (`inMemoryPersistence`) so credentials are not left
+   * in browser-accessible storage (IndexedDB / `localStorage`) where a
+   * same-origin script (XSS, extension) could lift them. Override only when
+   * cross-tab / cross-reload persistence is required AND the app ships an
+   * XSS-hardened CSP. `'localStorage'` maps to Firebase IndexedDB persistence.
+   * Prefer the BFF cookie pattern (`@granit/bff`) for durable sessions. See
+   * security audit VULN-201.
+   */
+  tokenStorage?: 'memory' | 'sessionStorage' | 'localStorage';
+
   /** Called when a token refresh fails. */
   onTokenRefreshError?: () => void;
   /** Called when the session expires. */

--- a/packages/@granit/authentication-local/src/__tests__/extract-return-url.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/extract-return-url.test.ts
@@ -38,6 +38,14 @@ describe('extractReturnUrl', () => {
     expect(extractReturnUrl('?returnUrl=%2F%2Fevil.com')).toBeNull();
   });
 
+  it('rejects backslash-authority bypasses (open redirect)', () => {
+    // Browsers normalise `\` → `/` in the authority, so these resolve
+    // off-origin despite the leading single slash. See security audit VULN-202.
+    expect(extractReturnUrl('?returnUrl=%2F%5Cevil.com')).toBeNull(); // /\evil.com
+    expect(extractReturnUrl('?returnUrl=%5C%5Cevil.com')).toBeNull(); // \\evil.com
+    expect(extractReturnUrl('?returnUrl=%2F%5C%2Fevil.com')).toBeNull(); // /\/evil.com
+  });
+
   it('falls back to globalThis.location.search when no argument', () => {
     vi.stubGlobal('location', { search: '?returnUrl=%2Fhome' });
     expect(extractReturnUrl()).toBe('/home');

--- a/packages/@granit/authentication-local/src/utils/extract-return-url.ts
+++ b/packages/@granit/authentication-local/src/utils/extract-return-url.ts
@@ -4,21 +4,34 @@
  * Used after headless login to redirect the browser to the OIDC authorization
  * endpoint (`/connect/authorize`) that the Identity Server originally intended.
  *
- * Only relative URLs (starting with `/`) are accepted — absolute URLs and
- * protocol-relative URLs (`//evil.com`) are rejected to prevent open-redirect
- * attacks.
+ * Only same-origin relative URLs are accepted — absolute URLs,
+ * protocol-relative URLs (`//evil.com`), and backslash-authority bypasses
+ * (`/\evil.com`, `\\evil.com`, which browsers normalise off-origin) are all
+ * rejected to prevent open-redirect attacks.
  *
  * @param search - URL search string (e.g. `?returnUrl=%2Fconnect%2Fauthorize`).
  *                 Defaults to `globalThis.location.search`.
- * @returns The decoded return URL, or `null` if absent or unsafe.
+ * @returns The same-origin path (`pathname` + `search` + `hash`), or `null` if
+ *          absent or unsafe.
  */
 export function extractReturnUrl(search?: string): string | null {
   const params = new URLSearchParams(search ?? globalThis.location?.search ?? '');
   const returnUrl = params.get('returnUrl');
   if (!returnUrl) return null;
 
-  // Only allow relative paths — reject absolute and protocol-relative URLs
-  if (returnUrl.startsWith('/') && !returnUrl.startsWith('//')) return returnUrl;
+  // Resolve against the current origin and accept only when it stays
+  // same-origin. `new URL` normalises `\` → `/` in the authority exactly as a
+  // browser would, so `/\evil.com` and `\\evil.com` resolve off-origin and are
+  // rejected here just like `//evil.com`. Return only the path portion — never
+  // a full absolute URL. See security audit VULN-202.
+  const origin = globalThis.location?.origin ?? 'http://localhost';
+  let resolved: URL;
+  try {
+    resolved = new URL(returnUrl, origin);
+  } catch {
+    return null;
+  }
+  if (resolved.origin !== origin) return null;
 
-  return null;
+  return `${resolved.pathname}${resolved.search}${resolved.hash}`;
 }

--- a/packages/@granit/bff/src/__tests__/csrf-manager.test.ts
+++ b/packages/@granit/bff/src/__tests__/csrf-manager.test.ts
@@ -153,18 +153,50 @@ describe('CsrfManager', () => {
       expect(init?.credentials).toBe('include');
     });
 
-    it('should NOT inject X-CSRF-Token when no token is available', async () => {
+    it('fetches a CSRF token on demand for a mutation when none is cached (VULN-300)', async () => {
       const manager = new CsrfManager('/app');
-
-      vi.mocked(globalThis.fetch).mockResolvedValue(new Response('ok'));
+      vi.mocked(globalThis.fetch).mockImplementation((input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.endsWith('/bff/csrf-token')) {
+          return Promise.resolve(
+            new Response(JSON.stringify({ csrfToken: 'csrf-lazy' }), { status: 200 })
+          );
+        }
+        return Promise.resolve(new Response('ok'));
+      });
 
       const wrappedFetch = manager.createFetchWithCsrf();
       await wrappedFetch('/api/data', { method: 'POST' });
 
-      const [, init] = vi.mocked(globalThis.fetch).mock.calls[0];
-      const headers = new Headers(init?.headers);
+      // The token endpoint was hit, then the mutation carried the fresh token.
+      expect(globalThis.fetch).toHaveBeenCalledWith('/app/bff/csrf-token', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const dataCall = vi.mocked(globalThis.fetch).mock.calls.find(([u]) => u === '/api/data');
+      const headers = new Headers(dataCall?.[1]?.headers);
+      expect(headers.get('X-CSRF-Token')).toBe('csrf-lazy');
+      expect(dataCall?.[1]?.credentials).toBe('include');
+    });
+
+    it('falls back to a header-less mutation when the on-demand token fetch fails', async () => {
+      const manager = new CsrfManager('/app');
+      vi.mocked(globalThis.fetch).mockImplementation((input) => {
+        const url = typeof input === 'string' ? input : (input as Request).url;
+        if (url.endsWith('/bff/csrf-token')) {
+          return Promise.resolve(new Response('nope', { status: 500 }));
+        }
+        return Promise.resolve(new Response('ok'));
+      });
+
+      const wrappedFetch = manager.createFetchWithCsrf();
+      // Must not throw — the BFF rejects the header-less mutation server-side.
+      await wrappedFetch('/api/data', { method: 'POST' });
+
+      const dataCall = vi.mocked(globalThis.fetch).mock.calls.find(([u]) => u === '/api/data');
+      const headers = new Headers(dataCall?.[1]?.headers);
       expect(headers.get('X-CSRF-Token')).toBeNull();
-      expect(init?.credentials).toBe('include');
+      expect(dataCall?.[1]?.credentials).toBe('include');
     });
 
     it('should always set credentials to include', async () => {

--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -12,6 +12,7 @@ const MUTATION_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
 /** Manages CSRF token lifecycle for BFF-authenticated SPAs. */
 export class CsrfManager {
   private token: string | null = null;
+  private pendingFetch: Promise<string | null> | null = null;
   private readonly pathPrefix: string;
 
   constructor(pathPrefix: string) {
@@ -57,13 +58,37 @@ export class CsrfManager {
     return async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
       assertSameOrigin(input);
       const method = (init?.method ?? 'GET').toUpperCase();
-      if (MUTATION_METHODS.has(method) && this.token) {
-        const headers = new Headers(init?.headers);
-        headers.set('X-CSRF-Token', this.token);
-        return fetch(input, { ...init, headers, credentials: 'include' });
+      if (MUTATION_METHODS.has(method)) {
+        // Ensure a token is present before sending a mutation. During the
+        // bootstrap window (or after a reset) `this.token` may still be null;
+        // fetch it on demand rather than sending a header-less mutation that
+        // depends entirely on the BFF rejecting it. Mirrors the async-refresh
+        // fallback in the @granit/api-client interceptor. See VULN-300.
+        const token = this.token ?? (await this.ensureToken());
+        if (token) {
+          const headers = new Headers(init?.headers);
+          headers.set('X-CSRF-Token', token);
+          return fetch(input, { ...init, headers, credentials: 'include' });
+        }
       }
       return fetch(input, { ...init, credentials: 'include' });
     };
+  }
+
+  /**
+   * Resolve a CSRF token, fetching one if the cache is empty. Concurrent
+   * callers share a single in-flight request. Returns `null` if the fetch
+   * fails — the caller then falls back to a header-less request that the BFF
+   * will reject, which is no worse than the previous behaviour.
+   */
+  private async ensureToken(): Promise<string | null> {
+    if (this.token) return this.token;
+    this.pendingFetch ??= this.fetchToken().catch(() => null);
+    try {
+      return await this.pendingFetch;
+    } finally {
+      this.pendingFetch = null;
+    }
   }
 }
 

--- a/packages/@granit/react-authentication-cognito/src/__tests__/use-cognito-init.test.tsx
+++ b/packages/@granit/react-authentication-cognito/src/__tests__/use-cognito-init.test.tsx
@@ -5,6 +5,12 @@ import { useCognitoInit } from '../hooks/use-cognito-init';
 
 import type { CognitoCoreConfig } from '@granit/authentication-cognito';
 
+/** Minimal duck type for the Cognito storage contract under assertion. */
+interface ICognitoStorageLike {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
 const {
   mockGetCurrentUser,
   mockGetSession,
@@ -12,19 +18,27 @@ const {
   mockSignOut,
   mockSetTokenGetter,
   mockSetOnUnauthorized,
-} = vi.hoisted(() => ({
-  mockGetCurrentUser: vi.fn(),
-  mockGetSession: vi.fn(),
-  mockGetUserAttributes: vi.fn(),
-  mockSignOut: vi.fn(),
-  mockSetTokenGetter: vi.fn(),
-  mockSetOnUnauthorized: vi.fn(),
-}));
+  CognitoUserPoolCtor,
+} = vi.hoisted(() => {
+  const mockGetCurrentUser = vi.fn();
+  return {
+    mockGetCurrentUser,
+    mockGetSession: vi.fn(),
+    mockGetUserAttributes: vi.fn(),
+    mockSignOut: vi.fn(),
+    mockSetTokenGetter: vi.fn(),
+    mockSetOnUnauthorized: vi.fn(),
+    CognitoUserPoolCtor: vi.fn(function CognitoUserPool(
+      this: { getCurrentUser: () => unknown },
+      _config: { Storage?: ICognitoStorageLike }
+    ) {
+      this.getCurrentUser = mockGetCurrentUser;
+    }),
+  };
+});
 
 vi.mock('amazon-cognito-identity-js', () => ({
-  CognitoUserPool: vi.fn(function CognitoUserPool(this: { getCurrentUser: () => unknown }) {
-    this.getCurrentUser = mockGetCurrentUser;
-  }),
+  CognitoUserPool: CognitoUserPoolCtor,
 }));
 
 vi.mock('@granit/api-client', () => ({
@@ -54,6 +68,7 @@ describe('useCognitoInit', () => {
     mockSignOut.mockReset();
     mockSetTokenGetter.mockReset();
     mockSetOnUnauthorized.mockReset();
+    CognitoUserPoolCtor.mockClear();
   });
 
   afterEach(() => {
@@ -65,6 +80,25 @@ describe('useCognitoInit', () => {
     const { result } = renderHook(() => useCognitoInit(baseConfig));
     expect(result.current.authenticated).toBe(false);
     expect(result.current.user).toBeNull();
+  });
+
+  it('constructs the pool with an in-memory Storage by default (VULN-102)', () => {
+    mockGetCurrentUser.mockReturnValue(null);
+    renderHook(() => useCognitoInit(baseConfig));
+    const poolConfig = CognitoUserPoolCtor.mock.calls[0]?.[0] as { Storage?: ICognitoStorageLike };
+    expect(poolConfig.Storage).toBeDefined();
+    // Not a Web Storage object → tokens are not readable by same-origin scripts.
+    expect(poolConfig.Storage).not.toBe(globalThis.localStorage);
+    expect(poolConfig.Storage).not.toBe(globalThis.sessionStorage);
+    expect(typeof poolConfig.Storage?.getItem).toBe('function');
+    expect(typeof poolConfig.Storage?.setItem).toBe('function');
+  });
+
+  it('honors tokenStorage="localStorage" as an explicit opt-in', () => {
+    mockGetCurrentUser.mockReturnValue(null);
+    renderHook(() => useCognitoInit({ ...baseConfig, tokenStorage: 'localStorage' }));
+    const poolConfig = CognitoUserPoolCtor.mock.calls[0]?.[0] as { Storage?: ICognitoStorageLike };
+    expect(poolConfig.Storage).toBe(globalThis.localStorage);
   });
 
   it('settles loading=false when no Cognito user is present', async () => {

--- a/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
+++ b/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
@@ -4,6 +4,37 @@ import * as React from 'react';
 
 import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
 import type { CognitoAuthContextType, CognitoCoreConfig } from '@granit/authentication-cognito';
+import type { ICognitoStorage } from 'amazon-cognito-identity-js';
+
+/**
+ * In-memory implementation of the Cognito SDK storage contract. Tokens live
+ * only for the lifetime of the tab and are never readable by other same-origin
+ * scripts via `localStorage`/`sessionStorage`. This is the default so a
+ * compromised script (XSS, extension) cannot lift the refresh token. See
+ * security audit VULN-102.
+ */
+class InMemoryCognitoStorage implements ICognitoStorage {
+  private readonly store = new Map<string, string>();
+  getItem(key: string): string | null {
+    return this.store.get(key) ?? null;
+  }
+  setItem(key: string, value: string): void {
+    this.store.set(key, value);
+  }
+  removeItem(key: string): void {
+    this.store.delete(key);
+  }
+  clear(): void {
+    this.store.clear();
+  }
+}
+
+/** Resolve the Cognito token store from the configured posture (default: memory). */
+function resolveCognitoStorage(tokenStorage: CognitoCoreConfig['tokenStorage']): ICognitoStorage {
+  if (tokenStorage === 'localStorage') return globalThis.localStorage;
+  if (tokenStorage === 'sessionStorage') return globalThis.sessionStorage;
+  return new InMemoryCognitoStorage();
+}
 
 export interface CognitoCoreResult extends CognitoAuthContextType {
   /** Direct ref to the Cognito UserPool instance. */
@@ -75,6 +106,7 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
     const pool = new CognitoUserPool({
       UserPoolId: config.userPoolId,
       ClientId: config.clientId,
+      Storage: resolveCognitoStorage(config.tokenStorage),
     });
     userPoolRef.current = pool;
 
@@ -114,7 +146,13 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
         setUser(null);
       });
     });
-  }, [config.userPoolId, config.clientId, config.onSessionExpired, config.onTokenRefreshError]);
+  }, [
+    config.userPoolId,
+    config.clientId,
+    config.tokenStorage,
+    config.onSessionExpired,
+    config.onTokenRefreshError,
+  ]);
 
   const login = React.useCallback(
     (options?: LoginOptions) => {

--- a/packages/@granit/react-authentication-google-cloud/src/__tests__/use-google-cloud-init.test.tsx
+++ b/packages/@granit/react-authentication-google-cloud/src/__tests__/use-google-cloud-init.test.tsx
@@ -7,7 +7,7 @@ import type { GoogleCloudCoreConfig } from '@granit/authentication-google-cloud'
 
 const {
   mockInitializeApp,
-  mockGetAuth,
+  mockInitializeAuth,
   mockOnAuthStateChanged,
   mockSignInWithRedirect,
   mockSignOut,
@@ -15,11 +15,14 @@ const {
   mockSetTokenGetter,
   mockSetOnUnauthorized,
   GoogleAuthProviderCtor,
+  IN_MEMORY_PERSISTENCE,
+  SESSION_PERSISTENCE,
+  INDEXEDDB_PERSISTENCE,
 } = vi.hoisted(() => {
   const mockAddScope = vi.fn();
   return {
     mockInitializeApp: vi.fn(),
-    mockGetAuth: vi.fn(),
+    mockInitializeAuth: vi.fn(),
     mockOnAuthStateChanged: vi.fn(),
     mockSignInWithRedirect: vi.fn(),
     mockSignOut: vi.fn(),
@@ -29,6 +32,9 @@ const {
     GoogleAuthProviderCtor: vi.fn(function GoogleAuthProvider() {
       return { addScope: mockAddScope };
     }),
+    IN_MEMORY_PERSISTENCE: { __persistence: 'NONE' },
+    SESSION_PERSISTENCE: { __persistence: 'SESSION' },
+    INDEXEDDB_PERSISTENCE: { __persistence: 'LOCAL' },
   };
 });
 
@@ -37,7 +43,10 @@ vi.mock('firebase/app', () => ({
 }));
 
 vi.mock('firebase/auth', () => ({
-  getAuth: mockGetAuth,
+  initializeAuth: mockInitializeAuth,
+  inMemoryPersistence: IN_MEMORY_PERSISTENCE,
+  browserSessionPersistence: SESSION_PERSISTENCE,
+  indexedDBLocalPersistence: INDEXEDDB_PERSISTENCE,
   onAuthStateChanged: mockOnAuthStateChanged,
   signInWithRedirect: mockSignInWithRedirect,
   signOut: mockSignOut,
@@ -74,8 +83,8 @@ describe('useGoogleCloudInit', () => {
     authStateCallback = null;
     mockInitializeApp.mockReset();
     mockInitializeApp.mockReturnValue({});
-    mockGetAuth.mockReset();
-    mockGetAuth.mockReturnValue({});
+    mockInitializeAuth.mockReset();
+    mockInitializeAuth.mockReturnValue({});
     mockOnAuthStateChanged.mockReset();
     mockOnAuthStateChanged.mockImplementation((_auth: unknown, cb: (user: unknown) => void) => {
       authStateCallback = cb as typeof authStateCallback;
@@ -103,6 +112,27 @@ describe('useGoogleCloudInit', () => {
       projectId: 'app-id',
     });
     expect(mockOnAuthStateChanged).toHaveBeenCalled();
+  });
+
+  it('defaults to in-memory persistence so tokens are not stored in IndexedDB (VULN-201)', () => {
+    renderHook(() => useGoogleCloudInit(baseConfig));
+    expect(mockInitializeAuth).toHaveBeenCalledWith(expect.anything(), {
+      persistence: IN_MEMORY_PERSISTENCE,
+    });
+  });
+
+  it('maps tokenStorage="localStorage" to Firebase IndexedDB persistence', () => {
+    renderHook(() => useGoogleCloudInit({ ...baseConfig, tokenStorage: 'localStorage' }));
+    expect(mockInitializeAuth).toHaveBeenCalledWith(expect.anything(), {
+      persistence: INDEXEDDB_PERSISTENCE,
+    });
+  });
+
+  it('maps tokenStorage="sessionStorage" to Firebase session persistence', () => {
+    renderHook(() => useGoogleCloudInit({ ...baseConfig, tokenStorage: 'sessionStorage' }));
+    expect(mockInitializeAuth).toHaveBeenCalledWith(expect.anything(), {
+      persistence: SESSION_PERSISTENCE,
+    });
   });
 
   it('flips authenticated=true and extracts the user when a Firebase user appears', async () => {
@@ -256,8 +286,8 @@ describe('useGoogleCloudInit', () => {
 
   it('logout() is a no-op for signOut when authRef is null', async () => {
     // Simulate an unmounted instance: clear authRef before logout by
-    // making getAuth return undefined.
-    mockGetAuth.mockReturnValue(undefined);
+    // making initializeAuth return undefined.
+    mockInitializeAuth.mockReturnValue(undefined);
     const { result } = renderHook(() => useGoogleCloudInit(baseConfig));
     await waitFor(() => expect(authStateCallback).not.toBeNull());
     // First logout: authRef.current was set to undefined → signOut should not be called.

--- a/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
+++ b/packages/@granit/react-authentication-google-cloud/src/hooks/use-google-cloud-init.ts
@@ -1,7 +1,10 @@
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
 import { initializeApp } from 'firebase/app';
 import {
-  getAuth,
+  initializeAuth,
+  inMemoryPersistence,
+  browserSessionPersistence,
+  indexedDBLocalPersistence,
   onAuthStateChanged,
   signInWithRedirect,
   signOut,
@@ -14,7 +17,14 @@ import type {
   GoogleCloudAuthContextType,
   GoogleCloudCoreConfig,
 } from '@granit/authentication-google-cloud';
-import type { Auth, User } from 'firebase/auth';
+import type { Auth, Persistence, User } from 'firebase/auth';
+
+/** Resolve the Firebase persistence from the configured posture (default: memory). */
+function resolvePersistence(tokenStorage: GoogleCloudCoreConfig['tokenStorage']): Persistence {
+  if (tokenStorage === 'localStorage') return indexedDBLocalPersistence;
+  if (tokenStorage === 'sessionStorage') return browserSessionPersistence;
+  return inMemoryPersistence;
+}
 
 export interface GoogleCloudCoreResult extends GoogleCloudAuthContextType {
   /** Direct ref to the Firebase Auth instance. */
@@ -60,7 +70,10 @@ export function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCo
       projectId: config.projectId,
     });
 
-    const auth = getAuth(app);
+    // `initializeAuth` (not `getAuth`) lets us pin the persistence backend.
+    // Default is in-memory so the refresh token never lands in IndexedDB /
+    // localStorage. See security audit VULN-201.
+    const auth = initializeAuth(app, { persistence: resolvePersistence(config.tokenStorage) });
     authRef.current = auth;
 
     const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
@@ -93,6 +106,7 @@ export function useGoogleCloudInit(config: GoogleCloudCoreConfig): GoogleCloudCo
     config.apiKey,
     config.authDomain,
     config.projectId,
+    config.tokenStorage,
     config.onTokenRefreshError,
     config.onSessionExpired,
   ]);


### PR DESCRIPTION
## Summary

Security-audit remediation — **IAM / token storage & session** domain (branch 2 of 5).

## Findings closed

| ID | Sev | What |
|----|-----|------|
| VULN-102 | HIGH | Cognito SDK stored id/access/**refresh** tokens in `localStorage` by default → readable by any same-origin script |
| VULN-201 | MEDIUM | Firebase/Google refresh token persisted in IndexedDB by default |
| VULN-202 | MEDIUM | `extractReturnUrl` open-redirect via backslash authority (`/\evil.com`, `\\evil.com`) |
| VULN-300 | LOW | BFF `createFetchWithCsrf` sent a header-less mutation when the CSRF token wasn't yet cached |

## Changes

- **`@granit/authentication-cognito` + `react-…`** — new `tokenStorage?: 'memory' | 'sessionStorage' | 'localStorage'` (default **`'memory'`**, an in-memory `ICognitoStorage`). Mirrors the Entra ID provider's `cacheLocation`.
- **`@granit/authentication-google-cloud` + `react-…`** — `getAuth()` → `initializeAuth(app, { persistence })`, default `inMemoryPersistence`; same `tokenStorage` opt-in (`'localStorage'` → Firebase IndexedDB persistence).
- **`@granit/authentication-local`** — `extractReturnUrl` resolves against `location.origin` and returns only same-origin `pathname+search+hash`; rejects absolute, protocol-relative, and backslash-authority URLs.
- **`@granit/bff`** — `createFetchWithCsrf` fetches a token on demand for mutations when the cache is empty (concurrent calls deduped via a shared in-flight promise), with a header-less fallback if the fetch fails.

## ⚠️ Behavioural change (security-motivated default)

Cognito and Google sessions **no longer persist across a full page reload by default** (tokens live in memory). Apps that need cross-reload persistence must either set `tokenStorage: 'localStorage'` **and** ship a strict CSP, or adopt the BFF cookie pattern (`@granit/bff`). This follows the precedent the Entra ID provider already set. Flagging for consumer coordination (showcase-admin-react).

> Cognito Hosted-UI PKCE/`state`/`nonce` (VULN-103/301) is intentionally **not** in this PR — it changes `login()` timing and needs the verifier wired into the code-exchange (consumer coordination). It will follow in a dedicated branch.

## Verification

- `tsc --noEmit` clean across all 6 packages
- ESLint `--max-warnings 0` clean
- Tests green: Cognito Storage default + opt-in, Firebase persistence mapping, `extractReturnUrl` backslash rejection, CSRF on-demand fetch + fallback (50 tests in the affected suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)