### PR TITLE
fix(security): fail-safe tenant cache isolation + Host impersonation permission

### DIFF
--- a/packages/@granit/multi-tenancy/src/__tests__/permissions.test.ts
+++ b/packages/@granit/multi-tenancy/src/__tests__/permissions.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+
+import { MultiTenancyPermissions } from '../permissions';
+
+describe('MultiTenancyPermissions', () => {
+  it('exposes the tenant management permission strings', () => {
+    expect(MultiTenancyPermissions.Tenants).toEqual({
+      Read: 'MultiTenancy.Tenants.Read',
+      Create: 'MultiTenancy.Tenants.Create',
+      Update: 'MultiTenancy.Tenants.Update',
+      Manage: 'MultiTenancy.Tenants.Manage',
+    });
+  });
+
+  it('exposes the Host.Impersonate permission for tenant impersonation gating (VULN-203)', () => {
+    // Contract string — must match the .NET backend permission exactly.
+    expect(MultiTenancyPermissions.Host.Impersonate).toBe('MultiTenancy.Host.Impersonate');
+  });
+});

--- a/packages/@granit/multi-tenancy/src/permissions.ts
+++ b/packages/@granit/multi-tenancy/src/permissions.ts
@@ -5,4 +5,15 @@ export const MultiTenancyPermissions = {
     Update: 'MultiTenancy.Tenants.Update',
     Manage: 'MultiTenancy.Tenants.Manage',
   },
+  Host: {
+    /**
+     * Required for a Host user to act in a tenant's context (send an
+     * `X-Tenant-Id` header). The front must NEVER auto-inject a tenant header
+     * for a Host: the default JWT resolver upholds this by construction (a Host
+     * token carries no `tenant_id` claim, so the tenant getter returns
+     * `undefined`). Gate any explicit Host "switch tenant" UI on this
+     * permission before setting a tenant. See security audit VULN-203.
+     */
+    Impersonate: 'MultiTenancy.Host.Impersonate',
+  },
 } as const;

--- a/packages/@granit/react-multi-tenancy/src/__tests__/tenant-provider.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/tenant-provider.test.tsx
@@ -4,11 +4,17 @@ import { describe, expect, it, vi } from 'vitest';
 import { TenantProvider, useTenant } from '../providers/tenant-provider';
 
 import type { TenantResolver } from '@granit/multi-tenancy';
+import type { QueryClient } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
 vi.mock('@granit/api-client', () => ({
   setTenantGetter: vi.fn(),
 }));
+
+/** Minimal QueryClient stub — TenantProvider only calls `.clear()`. */
+function fakeQueryClient(): { clear: ReturnType<typeof vi.fn> } & QueryClient {
+  return { clear: vi.fn() } as unknown as { clear: ReturnType<typeof vi.fn> } & QueryClient;
+}
 
 function wrapper(resolvers: readonly TenantResolver[], isEnabled?: boolean) {
   return ({ children }: { children: ReactNode }) => (
@@ -106,6 +112,53 @@ describe('TenantProvider', () => {
     rerender();
 
     expect(onTenantChange).toHaveBeenCalledTimes(1);
+    expect(onTenantChange).toHaveBeenCalledWith('tenant-b', 'tenant-a');
+  });
+
+  it('does not clear the query cache on initial mount (VULN-200)', () => {
+    const queryClient = fakeQueryClient();
+    const resolvers: TenantResolver[] = [
+      { order: 100, name: 'test', resolve: () => ({ id: 'tenant-1' }) },
+    ];
+
+    renderHook(() => useTenant(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <TenantProvider resolvers={resolvers} queryClient={queryClient}>
+          {children}
+        </TenantProvider>
+      ),
+    });
+
+    expect(queryClient.clear).not.toHaveBeenCalled();
+  });
+
+  it('clears the query cache when the tenant id changes, before onTenantChange (VULN-200)', () => {
+    const queryClient = fakeQueryClient();
+    const onTenantChange = vi.fn(() => {
+      // Cache must already be cleared by the time custom side effects run.
+      expect(queryClient.clear).toHaveBeenCalledTimes(1);
+    });
+    let currentTenantId = 'tenant-a';
+    const resolvers: TenantResolver[] = [
+      { order: 100, name: 'dynamic', resolve: () => ({ id: currentTenantId }) },
+    ];
+
+    const { rerender } = renderHook(() => useTenant(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <TenantProvider
+          resolvers={[...resolvers]}
+          queryClient={queryClient}
+          onTenantChange={onTenantChange}
+        >
+          {children}
+        </TenantProvider>
+      ),
+    });
+
+    currentTenantId = 'tenant-b';
+    rerender();
+
+    expect(queryClient.clear).toHaveBeenCalledTimes(1);
     expect(onTenantChange).toHaveBeenCalledWith('tenant-b', 'tenant-a');
   });
 });

--- a/packages/@granit/react-multi-tenancy/src/providers/tenant-provider.tsx
+++ b/packages/@granit/react-multi-tenancy/src/providers/tenant-provider.tsx
@@ -3,6 +3,7 @@ import { resolveTenant } from '@granit/multi-tenancy';
 import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
 
 import type { CurrentTenant, MultiTenancyOptions, TenantResolver } from '@granit/multi-tenancy';
+import type { QueryClient } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
 const NO_TENANT: CurrentTenant = {
@@ -17,18 +18,26 @@ export interface TenantProviderProps {
   /** Multi-tenancy options. */
   readonly options?: MultiTenancyOptions;
   /**
-   * Fired when the resolved tenant id changes (not on mount). Use to clear
-   * tenant-scoped caches — typically `queryClient.clear()` — to prevent
-   * cross-tenant data leakage via stale React Query entries.
+   * React Query client to clear automatically whenever the active tenant id
+   * changes (cleared *before* `onTenantChange` runs, never on initial mount).
+   *
+   * Passing this is the recommended **fail-safe** against cross-tenant cache
+   * leakage: query keys are not tenant-partitioned, so without a clear, a
+   * tenant-A response can be served briefly under tenant-B after an in-place
+   * switch. One prop removes the need to remember `useClearQueriesOnTenantChange`
+   * or to wire `onTenantChange` by hand. See security audit VULN-200.
    *
    * @example
    * ```tsx
    * const queryClient = useQueryClient();
-   * <TenantProvider
-   *   resolvers={resolvers}
-   *   onTenantChange={() => queryClient.clear()}
-   * >...</TenantProvider>
+   * <TenantProvider resolvers={resolvers} queryClient={queryClient}>...</TenantProvider>
    * ```
+   */
+  readonly queryClient?: QueryClient;
+  /**
+   * Fired when the resolved tenant id changes (not on mount). Use for custom
+   * side effects on tenant switch. For cache isolation, prefer `queryClient`
+   * above — it is applied automatically and cannot be forgotten.
    */
   readonly onTenantChange?: (
     tenantId: string | undefined,
@@ -42,6 +51,7 @@ const TenantContext = createContext<CurrentTenant | null>(null);
 export function TenantProvider({
   resolvers,
   options,
+  queryClient,
   onTenantChange,
   children,
 }: Readonly<TenantProviderProps>): React.JSX.Element {
@@ -68,10 +78,15 @@ export function TenantProvider({
   const previousTenantIdRef = useRef<string | undefined>(tenant.tenantId);
   const onTenantChangeRef = useRef(onTenantChange);
   onTenantChangeRef.current = onTenantChange;
+  const queryClientRef = useRef(queryClient);
+  queryClientRef.current = queryClient;
 
   useEffect(() => {
     const previous = previousTenantIdRef.current;
     if (previous !== tenant.tenantId) {
+      // Fail-safe: drop tenant-A cache entries before tenant-B renders, so a
+      // stale (un-partitioned) query key cannot leak across the boundary.
+      queryClientRef.current?.clear();
       onTenantChangeRef.current?.(tenant.tenantId, previous);
       previousTenantIdRef.current = tenant.tenantId;
     }


### PR DESCRIPTION
## Summary

Security-audit remediation — **multi-tenancy isolation** domain (branch 3 of 5). Both changes are additive and backward-compatible.

## Findings closed

| ID | Sev | What |
|----|-----|------|
| VULN-200 | MEDIUM | No React Query key is tenant-partitioned and the cache wasn't auto-cleared on tenant switch → tenant-A data could render under tenant-B until refetch |
| VULN-203 | MEDIUM | `MultiTenancyPermissions` had no `Host.Impersonate`, so the documented Host-impersonation gate couldn't be enforced client-side |

## Changes

- **`@granit/react-multi-tenancy`** — `TenantProvider` gains an optional `queryClient` prop. When supplied, `queryClient.clear()` runs automatically on every tenant-id change — **before** `onTenantChange`, **never** on initial mount. One prop replaces the easy-to-forget `useClearQueriesOnTenantChange` hook / hand-wired `onTenantChange`.
- **`@granit/multi-tenancy`** — add `MultiTenancyPermissions.Host.Impersonate` (`'MultiTenancy.Host.Impersonate'`). The runtime invariant (front never auto-injects `X-Tenant-Id` for a Host) is already upheld by the default JWT resolver — this constant lets apps gate an explicit Host "switch tenant" UI.

## Notes

- Stronger isolation (physically threading `tenantId` into every `react-*` query-key factory) is a larger cross-package follow-up; this PR delivers the fail-safe default-clear and the permission contract.
- `Host.Impersonate` is a contract string locked by a test — it must match the .NET backend permission exactly.

## Verification

- `tsc --noEmit` clean (multi-tenancy, react-multi-tenancy)
- ESLint `--max-warnings 0` clean
- Tests: cache cleared on change / not on mount / before `onTenantChange`; permission contract asserted

🤖 Generated with [Claude Code](https://claude.com/claude-code)