### PR TITLE
fix(security): redact OTLP logs by default, mark AI output untrusted, floor peer ranges

### DIFF
--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -108,6 +108,11 @@ export interface AIChatUsageResponse {
 export interface AIChatResponse {
   readonly workspaceName: string;
   readonly model: string;
+  /**
+   * Generated text. ⚠️ **Untrusted** model output — sanitize and
+   * scheme-allowlist any links before rendering as HTML/markdown. Never pass
+   * it to a DOM HTML sink unsanitized. See security audit VULN-303.
+   */
   readonly content: string;
   readonly usage: AIChatUsageResponse | null;
   readonly duration: string;

--- a/packages/@granit/api-client/package.json
+++ b/packages/@granit/api-client/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "@granit/logger": "workspace:*",
-    "axios": "*"
+    "axios": "^1.6.0"
   },
   "peerDependenciesMeta": {
     "@granit/logger": {

--- a/packages/@granit/authentication-keycloak/package.json
+++ b/packages/@granit/authentication-keycloak/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@granit/authentication": "workspace:*",
-    "keycloak-js": "*"
+    "keycloak-js": "^26.0.0"
   },
   "devDependencies": {
     "@granit/authentication": "workspace:*",

--- a/packages/@granit/logger-otlp/src/__tests__/otlp-transport.test.ts
+++ b/packages/@granit/logger-otlp/src/__tests__/otlp-transport.test.ts
@@ -269,6 +269,37 @@ describe('createOtlpTransport', () => {
     expect(init.keepalive).toBe(true);
   });
 
+  it('redacts PII in the body and attributes by default (VULN-205)', async () => {
+    const transport = createOtlpTransport({
+      endpoint: '/v1/logs',
+      serviceName: 'test',
+      batchSize: 100,
+    });
+    transport.send(
+      makeEntry({ message: 'login john.doe@example.com', context: { email: 'a@b.com' } })
+    );
+    await transport.flush!();
+
+    const body = vi.mocked(fetch).mock.calls[0]![1]!.body as string;
+    // Raw email addresses must not reach the collector when no redactor is set.
+    expect(body).not.toContain('john.doe@example.com');
+    expect(body).not.toContain('a@b.com');
+  });
+
+  it('honors an explicit opt-out via identity redactor', async () => {
+    const transport = createOtlpTransport({
+      endpoint: '/v1/logs',
+      serviceName: 'test',
+      batchSize: 100,
+      redact: (s) => s,
+    });
+    transport.send(makeEntry({ message: 'login john.doe@example.com' }));
+    await transport.flush!();
+
+    const body = vi.mocked(fetch).mock.calls[0]![1]!.body as string;
+    expect(body).toContain('john.doe@example.com');
+  });
+
   it('should not throw when fetch fails', async () => {
     vi.mocked(fetch).mockRejectedValueOnce(new Error('network error'));
     const transport = createOtlpTransport({

--- a/packages/@granit/logger-otlp/src/otlp-transport.ts
+++ b/packages/@granit/logger-otlp/src/otlp-transport.ts
@@ -2,6 +2,8 @@
 // @granit/logger-otlp — OTLP HTTP transport for @granit/logger
 // ---------------------------------------------------------------------------
 
+import { defaultPiiRedactor } from './pii-redactor';
+
 import type { LogContext, LogEntry, LogLevelName, LogTransport } from '@granit/logger';
 
 // ---------------------------------------------------------------------------
@@ -42,9 +44,13 @@ export interface OtlpTransportOptions {
   /** Optional callback to retrieve trace context for log-to-trace correlation */
   getTraceContext?: () => TraceContext | undefined;
   /**
-   * Optional PII scrubber applied to the log body and every attribute
-   * value before serialization. Use `defaultPiiRedactor` for a built-in
-   * baseline (email, JWT, Bearer tokens, IBAN, credit card, E.164 phone).
+   * PII scrubber applied to the log body and every attribute value before
+   * serialization. **Defaults to `defaultPiiRedactor`** (email, JWT, Bearer
+   * tokens, IBAN, credit card, E.164 phone) so PII is redacted by default —
+   * protection by default per GDPR Art. 25. See security audit VULN-205.
+   *
+   * Pass a custom function to extend the baseline, or pass the identity
+   * function `(s) => s` to explicitly opt out of redaction.
    */
   redact?: (text: string) => string;
 }
@@ -144,6 +150,11 @@ function buildPayload(entries: LogEntry[], options: OtlpTransportOptions) {
 export function createOtlpTransport(options: OtlpTransportOptions): LogTransport {
   const batchSize = options.batchSize ?? 10;
   const flushInterval = options.flushInterval ?? 5_000;
+  // Redact by default — opt out explicitly with `redact: (s) => s`. (VULN-205)
+  const resolvedOptions: OtlpTransportOptions = {
+    ...options,
+    redact: options.redact ?? defaultPiiRedactor,
+  };
 
   let buffer: LogEntry[] = [];
   let timer: ReturnType<typeof setTimeout> | null = null;
@@ -170,7 +181,7 @@ export function createOtlpTransport(options: OtlpTransportOptions): LogTransport
     const batch = buffer;
     buffer = [];
 
-    const payload = JSON.stringify(buildPayload(batch, options));
+    const payload = JSON.stringify(buildPayload(batch, resolvedOptions));
 
     try {
       const response = await fetch(options.endpoint, {

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
@@ -6,7 +6,15 @@ import { useAIConfig } from '../providers/ai-provider';
 import type { AIChatRequest, AIChatStreamUsage } from '@granit/ai';
 
 export interface UseAIChatStreamReturn {
-  /** Accumulated content received so far. Reset on each new `send()` call. */
+  /**
+   * Accumulated content received so far. Reset on each new `send()` call.
+   *
+   * ⚠️ **Untrusted.** This is raw model output — steerable by prompt
+   * injection, poisoned RAG, or echoed tool results. Render it as plain text,
+   * or sanitize it (and scheme-allowlist any links via `@granit/utils`
+   * `isSafeUrl`) before rendering as HTML/markdown. Never pass it to
+   * `dangerouslySetInnerHTML` unsanitized. See security audit VULN-303.
+   */
   readonly content: string;
   /** Whether a stream is currently active. */
   readonly isStreaming: boolean;
@@ -25,6 +33,12 @@ export interface UseAIChatStreamReturn {
  *
  * Accumulates content chunks into `content` as they arrive.
  * Each call to `send()` resets the accumulated content.
+ *
+ * @remarks
+ * Security: `content` is untrusted model output — see the field doc before
+ * rendering it. Request size is bounded server-side; keep client `messages`
+ * reasonable to avoid wasted bandwidth (no hard client clamp is imposed —
+ * tracked as VULN-304).
  *
  * @example
  * ```tsx

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat.ts
@@ -9,6 +9,12 @@ import type { AIChatRequest, AIChatResponse } from '@granit/ai';
 export interface UseAIChatReturn {
   readonly send: (workspaceName: string, request: AIChatRequest) => void;
   readonly sendAsync: (workspaceName: string, request: AIChatRequest) => Promise<AIChatResponse>;
+  /**
+   * Completion result. ⚠️ **Untrusted**: `data.content` is raw model output —
+   * sanitize it (and scheme-allowlist any links) before rendering as
+   * HTML/markdown; never pass it to `dangerouslySetInnerHTML` unsanitized.
+   * See security audit VULN-303.
+   */
   readonly data: AIChatResponse | undefined;
   readonly isPending: boolean;
   readonly error: Error | null;

--- a/packages/@granit/react-authentication-keycloak/package.json
+++ b/packages/@granit/react-authentication-keycloak/package.json
@@ -20,7 +20,7 @@
     "@granit/authentication-keycloak": "workspace:*",
     "@granit/csp": "workspace:*",
     "@granit/react-authentication": "workspace:*",
-    "keycloak-js": "*",
+    "keycloak-js": "^26.0.0",
     "react": "^19.0.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-authorization/package.json
+++ b/packages/@granit/react-authorization/package.json
@@ -18,7 +18,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/authorization": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
+    "axios": "^1.6.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-query-engine/package.json
+++ b/packages/@granit/react-query-engine/package.json
@@ -19,7 +19,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
-    "axios": "*",
+    "axios": "^1.6.0",
     "msw": "^2.12.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"

--- a/packages/@granit/utils/package.json
+++ b/packages/@granit/utils/package.json
@@ -14,10 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "clsx": "*",
-    "@date-fns/tz": "*",
-    "date-fns": "*",
-    "tailwind-merge": "*"
+    "clsx": "^2.0.0",
+    "@date-fns/tz": "^1.0.0",
+    "date-fns": "^4.0.0",
+    "tailwind-merge": "^3.0.0"
   },
   "devDependencies": {
     "@granit/testing": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -312,7 +312,7 @@ importers:
   packages/@granit/authentication-keycloak:
     dependencies:
       keycloak-js:
-        specifier: '*'
+        specifier: ^26.0.0
         version: 26.2.4
     devDependencies:
       '@granit/authentication':
@@ -1156,7 +1156,7 @@ importers:
         specifier: workspace:*
         version: link:../react-authentication
       keycloak-js:
-        specifier: '*'
+        specifier: ^26.0.0
         version: 26.2.4
       react:
         specifier: 19.2.7
@@ -3019,16 +3019,16 @@ importers:
   packages/@granit/utils:
     dependencies:
       '@date-fns/tz':
-        specifier: '*'
+        specifier: ^1.0.0
         version: 1.5.0
       clsx:
-        specifier: '*'
+        specifier: ^2.0.0
         version: 2.1.1
       date-fns:
-        specifier: '*'
+        specifier: ^4.0.0
         version: 4.4.0
       tailwind-merge:
-        specifier: '*'
+        specifier: ^3.0.0
         version: 3.6.0
     devDependencies:
       '@granit/testing':


### PR DESCRIPTION
## Summary

Security-audit remediation — **observability + supply-chain** domain (branch 4 of 5).

## Findings closed

| ID | Sev | What |
|----|-----|------|
| VULN-205 | MEDIUM | OTLP transport's PII redactor was opt-in — raw PII could reach the collector when `redact` wasn't passed |
| VULN-303 | LOW | AI chat `content` had no "untrusted output" contract (latent XSS sink for consumers rendering it) |
| VULN-305 | LOW | `"*"` peer-dependency ranges on security-relevant packages (`axios`, `keycloak-js`) accept future CVE'd majors |

## Changes

- **`@granit/logger-otlp`** — `createOtlpTransport` applies `defaultPiiRedactor` by default (email, JWT, Bearer, IBAN, card, E.164). Body **and** attributes are scrubbed unless the caller opts out with `redact: (s) => s`. Protection by default (GDPR Art. 25).
- **`@granit/ai` + `@granit/react-ai`** — JSDoc marks chat `content` (sync `AIChatResponse`, `useAIChat().data`, `useAIChatStream().content`) as **untrusted** model output: sanitize + scheme-allowlist links before any HTML/markdown render; never `dangerouslySetInnerHTML` it raw.
- **peer ranges** — `"*"` → floors that block known-CVE-old versions while staying in the targeted major: `axios: ^1.6.0` (api-client, react-authorization, react-query-engine), `keycloak-js: ^26.0.0` (authentication-keycloak ×2), and the `@granit/utils` cosmetic peers.

## Deferred (noted)

- **VULN-304** (hard client AI payload clamp) — silent truncation would corrupt prompts; an arbitrary throw risks rejecting valid requests. Needs backend-coordinated limits; the server already enforces them. Documented in the hook JSDoc.
- **Dependabot #32** (`uuid < 11.1.1`, medium) — a **dev/admin-tooling transitive** via `@puckeditor/core` (CMS editor), exploitable only when `buf` is passed to uuid v3/v5/v6 (Puck uses v4). A forced root override to uuid 11 risks breaking Puck for ~zero real risk; better handled by a Dependabot PR / Puck bump.

## Verification

- `tsc --noEmit` clean (logger-otlp, ai, react-ai)
- ESLint `--max-warnings 0` clean
- `pnpm install --frozen-lockfile` passes (lockfile in sync)
- Tests: OTLP redaction-by-default + explicit opt-out (17 in suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)