### PR TITLE
fix(security): add PKCE (S256) + state + nonce to the Cognito Hosted-UI flow

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2604,6 +2604,18 @@
               "signature": "logout: (options?: LogoutOptions) => void"
             }
           ]
+        },
+        {
+          "name": "CognitoAuthTransaction",
+          "kind": "interface",
+          "signature": "interface CognitoAuthTransaction",
+          "members": []
+        },
+        {
+          "name": "PkcePair",
+          "kind": "interface",
+          "signature": "interface PkcePair",
+          "members": []
         }
       ]
     },

--- a/packages/@granit/react-authentication-cognito/src/__tests__/pkce.test.ts
+++ b/packages/@granit/react-authentication-cognito/src/__tests__/pkce.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  COGNITO_AUTH_TX_KEY,
+  buildCognitoAuthorizeUrl,
+  clearCognitoAuthTransaction,
+  generatePkce,
+  persistCognitoAuthTransaction,
+  randomToken,
+  readCognitoAuthTransaction,
+} from '../pkce';
+
+const BASE64URL = /^[A-Za-z0-9_-]+$/u;
+
+describe('randomToken', () => {
+  it('returns an unpadded base64url string with >= 256 bits of entropy', () => {
+    const token = randomToken();
+    expect(token).toMatch(BASE64URL);
+    expect(token).not.toContain('=');
+    expect(token.length).toBeGreaterThanOrEqual(43); // 32 bytes → 43 base64url chars
+  });
+
+  it('is unique per call', () => {
+    expect(randomToken()).not.toBe(randomToken());
+  });
+});
+
+describe('generatePkce', () => {
+  it('derives a base64url S256 challenge from the verifier', async () => {
+    const { verifier, challenge } = await generatePkce();
+    expect(verifier).toMatch(BASE64URL);
+    expect(challenge).toMatch(BASE64URL);
+    expect(challenge).not.toBe(verifier);
+  });
+
+  it('challenge equals base64url(SHA-256(verifier)) (S256)', async () => {
+    const { verifier, challenge } = await generatePkce();
+    const digest = await globalThis.crypto.subtle.digest(
+      'SHA-256',
+      new TextEncoder().encode(verifier)
+    );
+    let binary = '';
+    for (const byte of new Uint8Array(digest)) binary += String.fromCharCode(byte);
+    const expected = btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+    expect(challenge).toBe(expected);
+  });
+});
+
+describe('authorization transaction persistence', () => {
+  afterEach(() => globalThis.sessionStorage.clear());
+
+  it('round-trips verifier/state/nonce via sessionStorage', () => {
+    persistCognitoAuthTransaction({ verifier: 'v', state: 's', nonce: 'n' });
+    expect(readCognitoAuthTransaction()).toEqual({ verifier: 'v', state: 's', nonce: 'n' });
+  });
+
+  it('returns null when absent', () => {
+    expect(readCognitoAuthTransaction()).toBeNull();
+  });
+
+  it('returns null on malformed JSON', () => {
+    globalThis.sessionStorage.setItem(COGNITO_AUTH_TX_KEY, '{not json');
+    expect(readCognitoAuthTransaction()).toBeNull();
+  });
+
+  it('returns null on a partial transaction', () => {
+    globalThis.sessionStorage.setItem(COGNITO_AUTH_TX_KEY, JSON.stringify({ verifier: 'v' }));
+    expect(readCognitoAuthTransaction()).toBeNull();
+  });
+
+  it('clear removes the stored transaction (single-use)', () => {
+    persistCognitoAuthTransaction({ verifier: 'v', state: 's', nonce: 'n' });
+    clearCognitoAuthTransaction();
+    expect(readCognitoAuthTransaction()).toBeNull();
+  });
+});
+
+describe('buildCognitoAuthorizeUrl', () => {
+  it('builds an S256 PKCE authorize URL with every parameter encoded (VULN-301)', () => {
+    const url = buildCognitoAuthorizeUrl({
+      domain: 'auth.example.com',
+      clientId: 'client 1', // space must be encoded, not concatenated raw
+      redirectUri: 'https://app.example/cb',
+      scopes: ['openid', 'profile'],
+      challenge: 'CHAL',
+      state: 'STATE',
+      nonce: 'NONCE',
+    });
+    const parsed = new URL(url);
+    expect(parsed.origin + parsed.pathname).toBe('https://auth.example.com/login');
+    expect(parsed.searchParams.get('client_id')).toBe('client 1');
+    expect(parsed.searchParams.get('response_type')).toBe('code');
+    expect(parsed.searchParams.get('scope')).toBe('openid profile');
+    expect(parsed.searchParams.get('redirect_uri')).toBe('https://app.example/cb');
+    expect(parsed.searchParams.get('code_challenge')).toBe('CHAL');
+    expect(parsed.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(parsed.searchParams.get('state')).toBe('STATE');
+    expect(parsed.searchParams.get('nonce')).toBe('NONCE');
+    // Raw serialization must encode the space rather than emit it literally.
+    expect(url).toContain('client_id=client+1');
+  });
+});

--- a/packages/@granit/react-authentication-cognito/src/__tests__/use-cognito-init.test.tsx
+++ b/packages/@granit/react-authentication-cognito/src/__tests__/use-cognito-init.test.tsx
@@ -214,11 +214,16 @@ describe('useCognitoInit', () => {
       );
       await waitFor(() => expect(result.current.loading).toBe(false));
       result.current.login();
+      await waitFor(() => expect(hrefSetter).toHaveBeenCalled());
 
-      expect(hrefSetter).toHaveBeenCalledWith(
-        expect.stringContaining('https://auth.example.com/login?client_id=test-client-id')
-      );
-      expect(hrefSetter.mock.calls[0]?.[0]).toContain('scope=openid+profile+email');
+      const url = hrefSetter.mock.calls[0]?.[0] as string;
+      expect(url).toContain('https://auth.example.com/login?client_id=test-client-id');
+      expect(url).toContain('scope=openid+profile+email');
+      // PKCE + anti-forgery parameters (VULN-103 / VULN-301)
+      expect(url).toContain('code_challenge_method=S256');
+      expect(url).toMatch(/[?&]code_challenge=[\w-]+/u);
+      expect(url).toMatch(/[?&]state=[\w-]+/u);
+      expect(url).toMatch(/[?&]nonce=[\w-]+/u);
     } finally {
       Object.defineProperty(globalThis, 'location', {
         configurable: true,
@@ -251,9 +256,11 @@ describe('useCognitoInit', () => {
       );
       await waitFor(() => expect(result.current.loading).toBe(false));
       result.current.login({ redirectUri: 'https://app.example/cb' });
+      await waitFor(() => expect(hrefSetter).toHaveBeenCalled());
 
-      expect(hrefSetter.mock.calls[0]?.[0]).toContain('scope=openid+foo');
-      expect(hrefSetter.mock.calls[0]?.[0]).toContain(encodeURIComponent('https://app.example/cb'));
+      const url = hrefSetter.mock.calls[0]?.[0] as string;
+      expect(url).toContain('scope=openid+foo');
+      expect(url).toContain(encodeURIComponent('https://app.example/cb'));
     } finally {
       Object.defineProperty(globalThis, 'location', {
         configurable: true,

--- a/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
+++ b/packages/@granit/react-authentication-cognito/src/hooks/use-cognito-init.ts
@@ -2,6 +2,13 @@ import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
 import { CognitoUserPool } from 'amazon-cognito-identity-js';
 import * as React from 'react';
 
+import {
+  buildCognitoAuthorizeUrl,
+  generatePkce,
+  persistCognitoAuthTransaction,
+  randomToken,
+} from '../pkce';
+
 import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
 import type { CognitoAuthContextType, CognitoCoreConfig } from '@granit/authentication-cognito';
 
@@ -118,10 +125,30 @@ export function useCognitoInit(config: CognitoCoreConfig): CognitoCoreResult {
 
   const login = React.useCallback(
     (options?: LoginOptions) => {
-      if (!config.domain) return;
-      const scopes = config.scopes?.join('+') ?? 'openid+profile+email';
+      const domain = config.domain;
+      if (!domain) return;
+      const scopes = config.scopes ?? ['openid', 'profile', 'email'];
       const redirectUri = options?.redirectUri ?? globalThis.location.origin;
-      globalThis.location.href = `https://${config.domain}/login?client_id=${config.clientId}&response_type=code&scope=${scopes}&redirect_uri=${encodeURIComponent(redirectUri)}`;
+      // Public SPA client → PKCE (S256) + single-use `state` + `nonce`
+      // (RFC 7636 / RFC 9700). The redirect is deferred by one microtask while
+      // the S256 challenge is derived; `login()` stays fire-and-forget. The
+      // verifier/state/nonce are stashed in sessionStorage for the callback to
+      // validate and exchange. See security audit VULN-103 / VULN-301.
+      void (async () => {
+        const { verifier, challenge } = await generatePkce();
+        const state = randomToken();
+        const nonce = randomToken();
+        persistCognitoAuthTransaction({ verifier, state, nonce });
+        globalThis.location.href = buildCognitoAuthorizeUrl({
+          domain,
+          clientId: config.clientId,
+          redirectUri,
+          scopes,
+          challenge,
+          state,
+          nonce,
+        });
+      })();
     },
     [config.domain, config.clientId, config.scopes]
   );

--- a/packages/@granit/react-authentication-cognito/src/index.ts
+++ b/packages/@granit/react-authentication-cognito/src/index.ts
@@ -1,2 +1,14 @@
 export { useCognitoInit } from './hooks/use-cognito-init';
 export type { CognitoCoreResult } from './hooks/use-cognito-init';
+
+// PKCE / authorization-transaction helpers — for completing the Hosted-UI
+// callback (validate `state`, read the `code_verifier`, then clear).
+export {
+  readCognitoAuthTransaction,
+  clearCognitoAuthTransaction,
+  buildCognitoAuthorizeUrl,
+  generatePkce,
+  randomToken,
+  COGNITO_AUTH_TX_KEY,
+} from './pkce';
+export type { CognitoAuthTransaction, PkcePair } from './pkce';

--- a/packages/@granit/react-authentication-cognito/src/pkce.ts
+++ b/packages/@granit/react-authentication-cognito/src/pkce.ts
@@ -1,0 +1,113 @@
+// ---------------------------------------------------------------------------
+// PKCE (RFC 7636) + anti-forgery helpers for the Cognito Hosted-UI code flow.
+//
+// A public SPA client must use PKCE with S256 (RFC 9700 §2.1.1): the
+// authorization `code` is bound to a one-time `code_verifier` so an
+// intercepted code cannot be redeemed. `state` defends the authorization
+// response against CSRF / code-injection; `nonce` binds the resulting
+// id_token to this login attempt. All three are persisted in sessionStorage
+// for the redirect round-trip and consumed once on the callback.
+// ---------------------------------------------------------------------------
+
+/** sessionStorage key holding the in-flight authorization transaction. */
+export const COGNITO_AUTH_TX_KEY = 'granit.cognito.authtx';
+
+/** 256 bits of entropy → a 43-char base64url verifier (RFC 7636 §4.1). */
+const TOKEN_BYTES = 32;
+
+/** base64url-encode without padding (RFC 7636 Appendix A). */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/u, '');
+}
+
+/** Cryptographically-random URL-safe token (verifier, `state`, `nonce`). */
+export function randomToken(byteLength: number = TOKEN_BYTES): string {
+  const buffer = new Uint8Array(byteLength);
+  globalThis.crypto.getRandomValues(buffer);
+  return base64UrlEncode(buffer);
+}
+
+export interface PkcePair {
+  /** High-entropy secret kept in the browser and sent at token exchange. */
+  readonly verifier: string;
+  /** `S256(verifier)` sent on the authorization request. */
+  readonly challenge: string;
+}
+
+/** Generate a PKCE verifier + its S256 challenge (RFC 7636). */
+export async function generatePkce(): Promise<PkcePair> {
+  const verifier = randomToken();
+  const digest = await globalThis.crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(verifier)
+  );
+  return { verifier, challenge: base64UrlEncode(new Uint8Array(digest)) };
+}
+
+/** One-time authorization transaction stored across the IdP redirect. */
+export interface CognitoAuthTransaction {
+  readonly verifier: string;
+  readonly state: string;
+  readonly nonce: string;
+}
+
+/** Persist the transaction for the redirect round-trip (sessionStorage). */
+export function persistCognitoAuthTransaction(tx: CognitoAuthTransaction): void {
+  globalThis.sessionStorage?.setItem(COGNITO_AUTH_TX_KEY, JSON.stringify(tx));
+}
+
+/**
+ * Read the in-flight authorization transaction (or `null`). Call on the
+ * callback to validate the returned `state` and obtain the `code_verifier`
+ * for the token exchange, then call {@link clearCognitoAuthTransaction}.
+ */
+export function readCognitoAuthTransaction(): CognitoAuthTransaction | null {
+  const raw = globalThis.sessionStorage?.getItem(COGNITO_AUTH_TX_KEY);
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as Partial<CognitoAuthTransaction>;
+    if (
+      typeof parsed.verifier === 'string' &&
+      typeof parsed.state === 'string' &&
+      typeof parsed.nonce === 'string'
+    ) {
+      return { verifier: parsed.verifier, state: parsed.state, nonce: parsed.nonce };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** Remove the stored transaction (single-use). */
+export function clearCognitoAuthTransaction(): void {
+  globalThis.sessionStorage?.removeItem(COGNITO_AUTH_TX_KEY);
+}
+
+/**
+ * Build the Cognito Hosted-UI authorization URL with PKCE (S256), `state` and
+ * `nonce`. All parameters are properly URL-encoded via `URLSearchParams`
+ * (closes the prior unencoded string concatenation, VULN-301).
+ */
+export function buildCognitoAuthorizeUrl(params: {
+  readonly domain: string;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly scopes: readonly string[];
+  readonly challenge: string;
+  readonly state: string;
+  readonly nonce: string;
+}): string {
+  const url = new URL(`https://${params.domain}/login`);
+  url.searchParams.set('client_id', params.clientId);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('scope', params.scopes.join(' '));
+  url.searchParams.set('redirect_uri', params.redirectUri);
+  url.searchParams.set('code_challenge', params.challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', params.state);
+  url.searchParams.set('nonce', params.nonce);
+  return url.toString();
+}


### PR DESCRIPTION
## Summary

Security-audit remediation — **Cognito OIDC flow** (branch 5 of 5). Split out from #530 because it changes `login()` timing (async PKCE) and needs consumer coordination on the token exchange.

## Findings closed

| ID | Sev | What |
|----|-----|------|
| VULN-103 | HIGH | Cognito Hosted-UI `login()` built a `response_type=code` URL with **no PKCE, no `state`, no `nonce`** — for a public SPA client an intercepted code was redeemable and the auth response had no CSRF protection (RFC 9700) |
| VULN-301 | LOW | The URL was built by string concatenation with unencoded `scope`/`client_id` |

## Changes

- **New `pkce.ts`** — `generatePkce()` (verifier + S256 challenge via Web Crypto), `randomToken()` (state/nonce), sessionStorage transaction persistence (`persist`/`read`/`clear`), and `buildCognitoAuthorizeUrl()` (every param encoded via `URLSearchParams` — closes VULN-301).
- **`login()`** now derives PKCE + single-use `state` + `nonce`, stores them for the callback, and redirects to a fully-encoded authorize URL with `code_challenge` / `code_challenge_method=S256`. The `(options?) => void` signature is unchanged — the redirect is deferred by one microtask while the challenge is computed.
- The transaction/consume helpers are exported so the callback can validate `state` and exchange the code with the `code_verifier`.

## ⚠️ Consumer coordination

Apps that complete the Hosted-UI callback must now send the `code_verifier` (from `readCognitoAuthTransaction()`) at the token endpoint — Cognito requires it once `code_challenge` is present. The everyday SRP flow (`amazon-cognito-identity-js`) is unaffected.

## Merge note

Touches the same file as #530 (`use-cognito-init.ts`) but a **different function** (`login()` vs pool construction / storage) — they auto-merge. If #530 lands first, this rebases cleanly.

## Verification

- `tsc --noEmit` clean, ESLint `--max-warnings 0` clean
- Tests: `pkce.test.ts` (randomToken entropy/format, `challenge == base64url(SHA-256(verifier))`, transaction round-trip / malformed / partial / clear, URL encoding) + updated `login()` tests asserting `code_challenge` / `S256` / `state` / `nonce` (21 in the two suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)