### PR TITLE
fix(security): close backslash open-redirect in the Keycloak Trusted Types policy

### DIFF
--- a/packages/@granit/react-authentication-keycloak/src/csp/__tests__/install-policy.test.ts
+++ b/packages/@granit/react-authentication-keycloak/src/csp/__tests__/install-policy.test.ts
@@ -85,6 +85,17 @@ describe('granit-keycloak createScriptURL', () => {
     expect(() => getCreateScriptURL()('//evil.example.org/login')).toThrow();
   });
 
+  it('rejects backslash-authority bypasses that resolve off-origin (VULN-202)', () => {
+    setKeycloakAuthorities(['https://idp.example.com']);
+    const createScriptURL = getCreateScriptURL();
+    // Browsers normalise `\` → `/` in the authority, so these resolve to
+    // `//evil.example.org` — they must be refused exactly like a
+    // protocol-relative URL, never waved through as a "same-origin relative".
+    expect(() => createScriptURL('/\\evil.example.org/login')).toThrow();
+    expect(() => createScriptURL('\\\\evil.example.org/login')).toThrow();
+    expect(() => createScriptURL('/\\/evil.example.org/login')).toThrow();
+  });
+
   it('throws when no authority is registered', () => {
     setKeycloakAuthorities([]);
     expect(() => getCreateScriptURL()('https://idp.example.com/realms/my')).toThrow(

--- a/packages/@granit/react-authentication-keycloak/src/csp/index.ts
+++ b/packages/@granit/react-authentication-keycloak/src/csp/index.ts
@@ -34,7 +34,9 @@ export function setKeycloakAuthorities(authorities: readonly string[]): void {
       try {
         return new URL(a).origin;
       } catch {
-        throw new TypeError(`[@granit/react-authentication-keycloak/csp] Invalid authority URL: ${a}`);
+        throw new TypeError(
+          `[@granit/react-authentication-keycloak/csp] Invalid authority URL: ${a}`
+        );
       }
     })
   );
@@ -46,23 +48,25 @@ export function __getAllowedOriginsForTests(): ReadonlySet<string> {
 }
 
 function assertAllowedScriptUrl(input: string): string {
-  // Same-origin relative URLs (e.g. silent-check-sso.html) are always OK —
-  // they cannot be redirected off-origin without crossing the
-  // protocol-relative or absolute-URL boundary, which we reject.
-  if (input.startsWith('/') && !input.startsWith('//')) return input;
-
+  // Always resolve against the document before deciding — never trust a raw
+  // string prefix. `new URL` normalises backslash-authority tricks
+  // (`/\evil.com`, `\\evil.com`) to their true off-origin form exactly as the
+  // browser would, so a leading slash can no longer smuggle an absolute URL
+  // past this gate (the same open-redirect class as VULN-202).
   let url: URL;
   try {
     url = new URL(input, globalThis.location?.href);
   } catch {
-    throw new TypeError(
-      `[granit-keycloak] Refused script URL "${input.slice(0, 60)}": malformed`
-    );
+    throw new TypeError(`[granit-keycloak] Refused script URL "${input.slice(0, 60)}": malformed`);
   }
   if (url.protocol !== 'https:' && url.protocol !== 'http:') {
     throw new TypeError(
       `[granit-keycloak] Refused script URL scheme "${url.protocol}". Only http(s) allowed.`
     );
+  }
+  // Same-origin URLs (app-hosted, e.g. silent-check-sso.html) are always OK.
+  if (globalThis.location !== undefined && url.origin === globalThis.location.origin) {
+    return input;
   }
   if (allowedOrigins.size === 0) {
     throw new TypeError(


### PR DESCRIPTION
## Summary

Follow-up to the audit remediation (#529–#533). Sweeping the codebase for **every** instance of the `startsWith('/')` backslash-bypass class (the VULN-202 root cause) turned up one the audit and the 5 PRs missed — in a security-critical spot.

## The finding

[`react-authentication-keycloak/src/csp/index.ts`](packages/@granit/react-authentication-keycloak/src/csp/index.ts) is the **Trusted Types `createScriptURL` policy** gating the URL Keycloak.js writes into `iframe.setAttribute('src', …)` (silent check-sso / session iframe) under CSP `require-trusted-types-for 'script'`. Its header calls it the defense ensuring "an XSS that attempts to redirect the silent renew to a rogue origin cannot succeed."

Its same-origin fast path was:

```ts
if (input.startsWith('/') && !input.startsWith('//')) return input;
```

`/\evil.com` / `\\evil.com` pass it (one leading `/`, not `//`), but browsers normalise `\` → `/` in the authority, so they resolve to `https://evil.com/`. An XSS (or compromised Keycloak.js / malicious config) could point the silent-renew iframe **off-origin past the Trusted Types gate** — exactly what the policy exists to stop.

## Fix

Resolve every input via `new URL(input, location.href)` and **compare origins** instead of trusting a raw string prefix (same approach as the `extractReturnUrl` fix in #530): same-origin (app-hosted `silent-check-sso.html`) allowed; otherwise must match the registered Keycloak authority allow-list. `new URL` normalises the backslash tricks to their true off-origin form.

## Verification

- `tsc --noEmit` clean, ESLint `--max-warnings 0` clean
- Tests: all existing `createScriptURL` cases preserved + **3 new backslash-bypass rejections** (`/\evil`, `\\evil`, `/\/evil`)

Lesson reinforced: a bad guard pattern, once written, gets copied. `isSafeUrl` is now the canonical primitive — these hand-rolled variants should migrate to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)