### PR TITLE
fix(tests): restore helper exports and correct BFF CSRF mock shape

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -21,6 +21,10 @@ audit without the checklist — it contains the full verification matrix.
 2. All paginated responses must use `PagedResult<T>` from `@granit/query-engine`
 3. All paginated request params must use `PaginationParams` (no inline duplication)
 4. Every backend endpoint must have a corresponding frontend API function
+5. API functions use `get*` / `list*` for reads (NEVER `fetch*`) and
+   `create*` / `update*` / `delete*` for writes
+6. Business/domain HTTP goes through `@granit/api-client` (Axios); native
+   `fetch` is allowed only in BFF / telemetry / SSE infra layers (see CLAUDE.md)
 
 ---
 
@@ -121,10 +125,14 @@ For each target package, collect:
    using the naming convention `@granit/{name}` → `Granit.{PascalName}`
    (e.g., `@granit/query-engine` → `Granit.QueryEngine`,
    `@granit/blob-storage` → `Granit.BlobStorage`,
-   `@granit/audit-log` → `Granit.AuditLog`).
+   `@granit/audit-log` → `Granit.AuditLog`). Mirror sub-module granularity
+   (`@granit/authentication-api-keys` → `Granit.Authentication.ApiKeys`).
+   **Framework** modules live in `~/dev/granit-fx/granit-dotnet`; **business/domain**
+   modules (Parties, Documents, Invoicing, Taxonomy, Workspaces, …) expose their
+   endpoints in `~/dev/granit-fx/granit-business` as `Granit.{Module}.Endpoints`.
 
-   b. **Type discovery**: use `mcp__granit-docs__search_code` and
-   `mcp__granit-docs__get_public_api` to find the corresponding .NET module
+   b. **Type discovery**: use `mcp__granit-tools__code_search` and
+   `mcp__granit-tools__code_get_api` to find the corresponding .NET module
    types. If available, also use `mcp__roslyn-lens__get_public_api` for
    precise signatures.
 
@@ -139,27 +147,31 @@ For each target package, collect:
    [HTTP method] [route template] → [handler method] → [request DTO] → [response DTO]
    ```
 
-   If `roslyn-lens` is unavailable, fall back to `mcp__granit-docs__search_code`
+   If `roslyn-lens` is unavailable, fall back to `mcp__granit-tools__code_search`
    with queries like `Map{Module}Endpoints`, `MapGet`, `MapPost` in the module
    namespace, then read the endpoint registration file via Read tool.
 
    d. **Naming convention map**: record the .NET → TypeScript naming for the
    module to verify consistency in Step 3:
 
-   | .NET                                   | TypeScript                              | Convention                                             |
-   | -------------------------------------- | --------------------------------------- | ------------------------------------------------------ |
-   | Namespace `Granit.{Module}`            | Package `@granit/{kebab-name}`          | PascalCase → kebab-case                                |
-   | DTO `{Name}Request` / `{Name}Response` | Type `{Name}Request` / `{Name}Response` | Identical (minus namespace)                            |
-   | Endpoint method `Get{Resources}`       | API function `fetch{Resources}`         | Get→fetch, Create→create, Update→update, Delete→delete |
-   | Route `/api/{module}/{resource}`       | basePath + `/{resource}`                | Segments match exactly                                 |
+   | .NET                                   | TypeScript                              | Convention                                         |
+   | -------------------------------------- | --------------------------------------- | -------------------------------------------------- |
+   | Namespace `Granit.{Module}`            | Package `@granit/{kebab-name}`          | PascalCase → kebab-case                            |
+   | DTO `{Name}Request` / `{Name}Response` | Type `{Name}Request` / `{Name}Response` | Identical (minus namespace)                        |
+   | Endpoint `Get*` / `List*`              | API fn `get*` / `list*`                 | Get→get, List→list; Create/Update/Delete unchanged |
+   | Route `/api/{module}/{resource}`       | basePath + `/{resource}`                | Segments match exactly                             |
 
 5. **Peer dependencies**: read `package.json`
 6. **Consumer usage**: if the audit may lead to renaming or removing an exported
    symbol, search for references in consumer apps before flagging:
 
    ```bash
+   # Primary consumer (CLAUDE.md): showcase-admin-react
+   grep -r "@granit/{package}" ~/dev/granit-fx/granit-showcase-react/src/
+   # CMS renderer (Next.js) — imports under app/ and src/
+   grep -r "@granit/{package}" ~/dev/granit-fx/granit-cms-renderer/{app,src}/
+   # Downstream app (if present)
    grep -r "@granit/{package}" ~/dev/digital-dynamics/guava-platform/applications/guava-front/src/
-   grep -r "@granit/{package}" ~/dev/digital-dynamics/guava-platform/applications/guava-admin/src/
    ```
 
    Record the blast radius (number of import sites) for each exported symbol.
@@ -172,8 +184,9 @@ For each target package, collect:
 ## Step 3 — Run the checklist
 
 Apply every category from [checklist.md](checklist.md) against the gathered context.
-Work through the checklist **in order** — type conformity first, then API, hooks,
-dependencies, and finally cross-cutting concerns.
+Work through the checklist **in order** — type conformity first, then API (including
+HTTP-client conformity and endpoint drift), hooks, dependencies, cross-cutting
+concerns, and finally module decomposition (backend bounded-context alignment).
 
 For each finding, classify it:
 
@@ -206,12 +219,13 @@ Output findings using this format:
 
 ### Endpoint Alignment — @granit/{package}
 
-| .NET Endpoint      | Route           | Frontend Function  | Match |
-| ------------------ | --------------- | ------------------ | ----- |
-| `Get{Resources}`   | `GET /api/...`  | `fetch{Resources}` | OK    |
-| `Create{Resource}` | `POST /api/...` | `create{Resource}` | OK    |
-| `Update{Resource}` | `PUT /api/...`  | _(none)_           | GAP   |
-| ...                | ...             | ...                | ...   |
+| .NET Endpoint      | Route               | Frontend Function  | Match |
+| ------------------ | ------------------- | ------------------ | ----- |
+| `List{Resources}`  | `GET /api/...`      | `list{Resources}`  | OK    |
+| `Get{Resource}`    | `GET /api/.../{id}` | `get{Resource}`    | OK    |
+| `Create{Resource}` | `POST /api/...`     | `create{Resource}` | OK    |
+| `Update{Resource}` | `PUT /api/...`      | _(none)_           | GAP   |
+| ...                | ...                 | ...                | ...   |
 
 Coverage: {covered}/{total} endpoints ({percentage}%)
 
@@ -303,18 +317,27 @@ When auditing all packages, perform these additional checks:
 3. **Peer dependency matrix**: verify that the peer deps in CLAUDE.md match
    actual `package.json` declarations
 4. **Export surface stability**: flag any exported symbol that is not used by
-   any consumer (guava-front, guava-admin) — candidate for removal
+   any consumer (showcase-admin-react, cms-renderer, guava-front) — candidate
+   for removal
 5. **Pattern uniformity**: verify all domain modules follow the same structure
    (core types package + react hooks package, same file organization)
 6. **Cross-package naming consistency**: verify that all packages follow the
    same naming conventions relative to their .NET counterpart:
-   - All packages use the same verb mapping (`Get*` → `fetch*`, etc.) — flag
-     any package that deviates (e.g., one uses `get*` while others use `fetch*`)
+   - All packages use the same verb mapping (`Get*` → `get*`, `List*` → `list*`,
+     `Create*`/`Update*`/`Delete*` unchanged) — flag any package that deviates
+     (e.g., one uses `fetch*` while the convention is `get*` / `list*`)
    - All packages use the same DTO naming strategy (no mix of `*Response` and
      `*Result` or `*Dto` across packages for the same pattern)
    - Provider names follow `{Module}Provider` uniformly (not `{Module}Context`
      in some and `{Module}Provider` in others)
    - Query key factories follow the same pattern across all `react-*` packages
+7. **Module decomposition** (checklist section 6): verify the frontend package
+   graph mirrors the backend bounded-context slicing — one `.Endpoints` context
+   per `@granit/{module}` pair, sub-modules split at the same granularity as the
+   backend, cross-domain integration in glue packages (never merged upstream)
+8. **HTTP client + CSP conformity**: no domain `fetch()` outside the allowed
+   infra layers (checklist 2d); every package writing to a DOM script sink
+   exposes a `<pkg>/csp` subpath — run `pnpm check:csp` to confirm
 
 ---
 
@@ -396,12 +419,28 @@ For any new or modified function in `src/api/`:
 
 - Fetch the corresponding .NET endpoint via MCP tools (same discovery as
   checklist 2b)
-- Verify **verb mapping**: `Get*` → `fetch*`, `Create*` → `create*`,
-  `Update*` → `update*`, `Delete*` → `delete*`
+- Verify **verb mapping**: `Get*` → `get*`, `List*` → `list*`,
+  `Create*` → `create*`, `Update*` → `update*`, `Delete*` → `delete*`
+  (NEVER `fetch*` — see the CLAUDE.md verb convention)
 - Verify **route alignment**: URL path built in the function matches the
   .NET route template (same segments, same parameter names)
 - Verify **HTTP method** matches the backend endpoint
 - Produce the Endpoint Alignment table for the PR report
+
+#### New HTTP calls & module placement
+
+```bash
+git diff origin/develop...HEAD -- "packages/@granit/{pkg}/src/" | grep -nE "^\+.*\bfetch\("
+```
+
+- Flag any added `fetch(` in a domain package as **BREAKING** — domain calls go
+  through `@granit/api-client` (native `fetch` allowed only in BFF/telemetry/SSE
+  infra; checklist 2d)
+- For a **new** package, verify it maps to a backend `.Endpoints` context at the
+  right granularity (checklist 6a) and that cross-domain glue is not merged into
+  an upstream package (6b)
+- Verify no forbidden structure mix (checklist 5a); if the package writes to a
+  DOM script sink, confirm it exposes `<pkg>/csp` (run `pnpm check:csp`)
 
 #### Test coverage
 
@@ -498,10 +537,10 @@ before producing the final verdict.
 - **No speculative refactoring.** Only propose changes backed by evidence
   (backend contract, pattern in 3+ other packages, or measurable improvement).
   "Could be cleaner" is not a finding.
-- **Respect the monorepo.** Changes to exported types affect guava-front and
-  guava-admin. Before proposing any rename or removal, run the consumer grep
-  from Step 2.6 and report the blast radius. If > 5 import sites, flag it as
-  requiring a coordinated PR.
+- **Respect the monorepo.** Changes to exported types affect showcase-admin-react,
+  the CMS renderer, and downstream apps. Before proposing any rename or removal,
+  run the consumer grep from Step 2.6 and report the blast radius. If > 5 import
+  sites, flag it as requiring a coordinated PR.
 - **One thing at a time.** Fix one category before moving to the next.
   Don't mix type fixes with hook refactoring in the same pass.
 - **Context window discipline.** When auditing `all` packages, process them

--- a/.claude/skills/audit/checklist.md
+++ b/.claude/skills/audit/checklist.md
@@ -1,7 +1,7 @@
 # Audit Checklist — Granit Front Packages
 
 Work through each category **in order**. For each check, compare the frontend
-package against the backend .NET module. Use MCP tools (`granit-docs`,
+package against the backend .NET module. Use MCP tools (`granit-tools`,
 `roslyn-lens`) to retrieve backend contracts efficiently.
 
 ---
@@ -17,8 +17,10 @@ package against the backend .NET module. Use MCP tools (`granit-docs`,
       `@granit/blob-storage` → `Granit.BlobStorage`,
       `@granit/audit-log` → `Granit.AuditLog`)
 - [ ] **API function verb mapping**: frontend functions follow the convention
-      `Get*` → `fetch*`, `Create*` → `create*`, `Update*` → `update*`,
-      `Delete*` → `delete*`, `List*` → `fetch*` (consistent across all packages)
+      `Get*` → `get*`, `List*` → `list*`, `Create*` → `create*`,
+      `Update*` → `update*`, `Delete*` → `delete*` (consistent across all
+      packages). **NEVER `fetch*`** — reads are `get*` (single) / `list*`
+      (collection). Flag any `fetch*` API function as INCONSISTENCY.
 - [ ] **Route segment alignment**: URL path segments built in frontend API
       functions match the .NET route templates exactly (same resource names,
       same nesting)
@@ -49,7 +51,11 @@ For each type exported from the package's `src/types/`:
 
 ### 1c. Export surface
 
-- [ ] **Single barrel**: `src/index.ts` is the only entry point
+- [ ] **Single barrel (source-direct)**: `src/index.ts` is the only entry point
+      for source-direct packages. **Exception**: published packages
+      (`@granit/csp`, `@granit/arch-tests-kit`) and any package exposing a
+      `<pkg>/csp` Trusted-Types subpath ship additional documented `exports` —
+      these are intentional, verify them against `package.json`, do not flag as leaks
 - [ ] **No internal leaks**: types not meant for consumers are not exported
 - [ ] **`import type`**: type-only imports use `import type` syntax
 - [ ] **Re-exports**: if a type is used across packages, it's re-exported from
@@ -79,7 +85,7 @@ For each function in `src/api/`:
 checking coverage. Use `mcp__roslyn-lens__find_symbol` to locate the
 `Map{Module}Endpoints` method, then `mcp__roslyn-lens__analyze_method` or
 `mcp__roslyn-lens__get_symbol_detail` to extract every route registration.
-If roslyn-lens is unavailable, use `mcp__granit-docs__search_code` with the
+If roslyn-lens is unavailable, use `mcp__granit-tools__code_search` with the
 module name, then read the endpoint file directly.
 
 Build the inventory as:
@@ -95,9 +101,16 @@ Then check each entry against the frontend `src/api/` functions:
       table from the report template)
 - [ ] **No orphan functions**: every frontend API function maps to a real
       backend endpoint (flag stale functions targeting removed endpoints)
+- [ ] **No contract drift** (freshness — re-verify, don't assume): for each
+      covered endpoint, re-check against the CURRENT backend source
+      (`~/dev/granit-fx/granit-dotnet` for framework modules,
+      `~/dev/granit-fx/granit-business` for business modules) that the route
+      template, HTTP method, and request/response DTO STILL match. A function
+      that compiled months ago drifts silently when the backend renames a route,
+      changes a verb, or adds a required field. Flag any drift as BREAKING
 - [ ] **Saved views**: if the module uses `MapQueryEndpoints`, saved view CRUD
       functions exist
-- [ ] **Meta endpoint**: if the module exposes `/meta`, a `fetch*Meta` function
+- [ ] **Meta endpoint**: if the module exposes `/meta`, a `get*Meta` function
       exists
 - [ ] **Route consistency**: dynamic segments use the same parameter names
       as the .NET route template (e.g., `{id}` not `{entityId}` if .NET uses `{id}`)
@@ -109,6 +122,19 @@ Then check each entry against the frontend `src/api/` functions:
 - [ ] **Boolean serialization**: `true`/`false` strings (not `1`/`0`)
 - [ ] **Array serialization**: comma-separated (e.g., `quickFilters=A,B`)
 - [ ] **Date serialization**: ISO 8601 format
+
+### 2d. HTTP client conformity (CLAUDE.md)
+
+- [ ] **Axios for domain calls**: every business/domain HTTP call goes through
+      the centralized `@granit/api-client` Axios instance (to inherit CSRF, auth,
+      and tenant interceptors) — NOT native `fetch`
+- [ ] **`fetch` only below the client**: native `fetch` is allowed ONLY in infra
+      layers that sit below the Axios client — `@granit/bff` (session/CSRF
+      bootstrap), `@granit/react-bff`, telemetry transports (`@granit/logger-otlp`,
+      `@granit/react-tracing`), and Fetch-contract adapters
+      (`@granit/notifications-sse`). Any new `fetch()` for a domain endpoint is
+      BREAKING — route it through Axios (streaming via `adapter: 'fetch'` +
+      `responseType: 'stream'`)
 
 ---
 
@@ -182,8 +208,14 @@ Then check each entry against the frontend `src/api/` functions:
 
 - [ ] **Directory structure**: `src/types/`, `src/api/`, `src/hooks/`,
       `src/providers/`, `src/__tests__/` — consistent across all packages
-- [ ] **Naming conventions**: functions follow `fetch*`, `create*`, `update*`,
-      `delete*` pattern; hooks follow `use*` pattern
+- [ ] **No forbidden structure mixes** (CLAUDE.md): a core `@granit/{module}`
+      has NO `hooks/` dir; a `react-{module}` has NO `api/` dir (its hooks live
+      in `hooks/`); NO `types.ts` flat file at `src/` root (always
+      `types/index.ts`, even for ≤3 types); NO `endpoints/` dir (DTOs go in
+      `types/`). `query-keys.ts` lives in the react package's `hooks/`, never in
+      the core package
+- [ ] **Naming conventions**: functions follow `get*` / `list*` (reads),
+      `create*`, `update*`, `delete*` pattern; hooks follow `use*` pattern
 - [ ] **Error types**: API errors are `AxiosError<ProblemDetails>` everywhere
 - [ ] **Config pattern**: all `react-*` packages use Provider + useConfig
       (not module-level singletons)
@@ -199,11 +231,79 @@ Then check each entry against the frontend `src/api/` functions:
 
 ### 5c. Consumer compatibility
 
-- [ ] **guava-front imports**: check `grep -r "@granit/{package}" ~/dev/digital-dynamics/guava-platform/applications/guava-front/src/`
+- [ ] **showcase-admin-react imports** (primary consumer): check
+      `grep -r "@granit/{package}" ~/dev/granit-fx/granit-showcase-react/src/`
       for any usage that would break with proposed changes
-- [ ] **guava-admin imports**: same check on guava-admin
+- [ ] **cms-renderer imports**: same check on
+      `~/dev/granit-fx/granit-cms-renderer/{app,src}/`
+- [ ] **guava-front imports** (downstream app, if present): same check on
+      `~/dev/digital-dynamics/guava-platform/applications/guava-front/src/`
 - [ ] **No breaking exports**: if an exported symbol is renamed/removed,
       consumers must be updated in the same PR
+
+### 5d. Runtime conformity (arch-tests territory)
+
+Before flagging these by hand, check whether `@granit/arch-tests` already covers
+the rule — extend the arch-test rather than duplicating an ad-hoc check.
+
+- [ ] **Logging façade**: runtime code uses `@granit/logger` (`createLogger`),
+      never `console.*`
+- [ ] **CSP / Trusted Types**: any package that writes to a DOM script sink
+      (`.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`, direct `.src =` or
+      `setAttribute('src', …)` on `iframe`/`script`) MUST expose a `<pkg>/csp`
+      subpath with an idempotent `installPolicy()`. Verify with `pnpm check:csp`;
+      a new sink without a `/csp` export is BREAKING
+- [ ] **`'use client'` boundaries**: in `react-*` packages consumed by RSC apps
+      (e.g. the CMS renderer), components using hooks/browser APIs carry the
+      `'use client'` directive; server-only entries stay free of client code
+
+---
+
+## 6. Module Decomposition & Backend Alignment (--scope all)
+
+The frontend package graph must mirror the .NET backend's bounded-context slicing.
+The backend slices every module the same way — framework modules in
+`~/dev/granit-fx/granit-dotnet`, business/domain modules in
+`~/dev/granit-fx/granit-business`:
+
+```text
+Granit.{Module}                     → core abstractions / types
+Granit.{Module}.Endpoints           → HTTP contract   ← the frontend mirrors THIS
+Granit.{Module}.EntityFrameworkCore → persistence     (no frontend equivalent)
+Granit.{Module}.BackgroundJobs/.Notifications → out of frontend scope
+Granit.{Parent}.{Child}             → sub-module (e.g. Authentication.ApiKeys)
+```
+
+### 6a. Bounded-context mapping
+
+- [ ] **One backend context = one frontend package pair**: each `Granit.{Module}`
+      that ships a `.Endpoints` project maps to `@granit/{module}` (+
+      `react-{module}`). A frontend package bundling two unrelated backend
+      contexts is an INCONSISTENCY
+- [ ] **Sub-modules stay split**: backend sub-modules map to sub-packages at the
+      SAME granularity, never merged into the parent — e.g.
+      `Granit.Authentication.ApiKeys` → `@granit/authentication-api-keys`,
+      notification transports → `@granit/notifications-{signalr,sse,…}`, CMS
+      domains → `@granit/cms-{seo,redirects,hostnames}`
+- [ ] **Endpoints sourced from `.Endpoints`**: a domain's `src/api/` functions
+      mirror the routes of that module's `.Endpoints` project — in `granit-dotnet`
+      for framework modules, in `granit-business` for business modules (Parties,
+      Documents, Invoicing, Taxonomy, Workspaces, Dashboards, …)
+- [ ] **No persistence/jobs leakage**: nothing in the frontend mirrors
+      `.EntityFrameworkCore`, `.BackgroundJobs`, or `.Notifications` internals —
+      only the `.Endpoints` HTTP contract is a frontend concern
+
+### 6b. Cross-domain integration (glue packages)
+
+- [ ] **Glue, don't merge**: integration spanning two domains lives in a
+      dedicated glue package, NEVER inside an upstream infra/domain package
+      (e.g. `@granit/entity-merge` is generic; dedup is a separate package). The
+      dependency points glue → domains, never domain → glue — arch-test the
+      inverse edge
+- [ ] **Layering matches the backend seam**: where the backend splits a concern
+      across layers (framework vs business vs endpoints), the frontend split
+      follows the same seam (generic mechanism in `@granit/{module}`, domain
+      wiring in a glue package or the consuming app)
 
 ---
 

--- a/.claude/skills/perf/SKILL.md
+++ b/.claude/skills/perf/SKILL.md
@@ -1,0 +1,375 @@
+---
+name: perf
+description: 'Performance & scalability engineer: audit @granit/* packages for high-scale readiness — request cancellation, list virtualization, pagination strategy, cache hygiene, bundle/tree-shaking, and real-time transport efficiency. Complements /audit (backend conformity) and /quality (lint, tests, SonarQube).'
+argument-hint: '[<package> | all | pr] [--fix] [--scope data|render|cache|bundle|realtime|all]'
+---
+
+# Performance & Scalability Audit — Granit Front
+
+You are a **performance engineer** specialized in high-scale React/TypeScript
+front-ends. Your mission: audit `@granit/*` packages for patterns that are fine
+at small scale but **degrade, leak, or freeze** when the dataset, the request
+rate, the user count, or the package graph grows large — the issues that
+conformity checks (`/audit`) and linters (`/quality`) do not catch.
+
+Read [checklist.md](checklist.md) before proceeding.
+**If the file cannot be read, STOP and report the error.** Do not attempt to
+audit without the checklist — it contains the full scale-readiness matrix.
+
+**Absolute minimum rules** (in case checklist is partially loaded):
+
+1. Every list/table/gallery that can render an unbounded or infinite-scroll
+   dataset MUST virtualize (`@tanstack/react-virtual`) — never a raw `.map()`
+   over the whole array
+2. Every `src/api/` function MUST accept and forward an `AbortSignal` (axios
+   `{ signal }`) so superseded requests are cancelled
+3. High-cardinality / unbounded lists use **cursor** pagination (`nextCursor`),
+   not offset — offset degrades server-side as the page number grows
+4. Paginated params go through `validateQueryRequest` / `serializeQueryRequest`
+   (clamped to server limits) — never hand-built unbounded params
+5. **Evidence over intuition**: back every finding with a concrete scale scenario
+   (N rows, M req/s, bundle KB). Never flag "could be faster" without a number
+
+---
+
+## Relationship to other skills
+
+| Skill       | Answers                                                    |
+| ----------- | ---------------------------------------------------------- |
+| `/perf`     | Will this hold up at high scale? (this skill)              |
+| `/audit`    | Does this match the .NET backend contract and conventions? |
+| `/quality`  | Lint, format, tests, SonarQube quality gate                |
+| `/security` | Is this safe? (XSS, IAM, CSP, supply chain)                |
+
+Do not duplicate `/audit` or `/quality` findings here. If a scale issue is also
+a conformity issue (e.g. unbounded params that bypass `validateQueryRequest`),
+flag it here through the **scale** lens (load amplification) and let `/audit`
+own the conformity angle.
+
+---
+
+## Invocation modes
+
+| Argument          | Scope                                                   |
+| ----------------- | ------------------------------------------------------- |
+| `help`            | Show available commands, flags, and examples            |
+| _(none)_ or `all` | Full scale audit across all `@granit/*` packages        |
+| `<package>`       | Single package (e.g., `query-engine`, `react-entities`) |
+| `pr`              | Scale audit of only the packages touched by the branch  |
+
+### Flags
+
+| Flag               | Effect                                                |
+| ------------------ | ----------------------------------------------------- |
+| `--fix`            | Apply safe fixes automatically (default: report only) |
+| `--scope data`     | Data fetching: cancellation, pagination, N+1          |
+| `--scope render`   | Rendering: virtualization, debounce, memoization      |
+| `--scope cache`    | TanStack Query cache hygiene and invalidation         |
+| `--scope bundle`   | Tree-shaking, code-splitting, dependency weight       |
+| `--scope realtime` | SSE / SignalR transports, polling, subscriptions      |
+| `--scope all`      | Full scale audit (default)                            |
+| `--base <branch>`  | Base branch for `pr` mode (default: `develop`)        |
+
+### Help (`/perf help`)
+
+If the argument is `help`, output the following reference card and **stop**
+(do not run any audit):
+
+```text
+/perf — Scalability & performance audit for @granit/* packages
+
+USAGE
+  /perf [target] [flags]
+
+TARGETS
+  help              Show this help
+  all               Full scale audit — all packages (default)
+  pr                PR mode — only packages changed vs develop
+  <package>         Single package (e.g., query-engine, react-entities)
+
+FLAGS
+  --fix             Apply safe fixes automatically (default: report only)
+  --scope <scope>   Limit audit to a category:
+                      data      Cancellation, pagination, N+1 fetches
+                      render    Virtualization, debounce, memoization
+                      cache     Query cache hygiene and invalidation
+                      bundle    Tree-shaking, code-splitting, dep weight
+                      realtime  SSE/SignalR, polling, subscriptions
+                      all       Everything (default)
+  --base <branch>   Base branch for pr mode (default: develop)
+
+EXAMPLES
+  /perf                          Full scale audit, report only
+  /perf react-entities           Audit one package for scale readiness
+  /perf react-entities --fix     Audit and apply safe fixes
+  /perf pr                       Check packages modified in current branch
+  /perf all --scope render       Only check rendering/virtualization
+  /perf query-engine --scope data   Only check data-fetching scale patterns
+
+SEVERITY (scale impact)
+  CRITICAL    Unbounded resource use — freezes/fails at high scale
+  HIGH        Superlinear cost or load amplification
+  MEDIUM      Avoidable overhead per interaction
+  LOW         Micro-optimization — consider
+
+RELATED SKILLS
+  /audit      Backend conformity + cross-package conventions
+  /quality    Lint, format, tests, SonarQube
+```
+
+---
+
+## Step 1 — Identify target packages
+
+If a specific package was given, resolve it (same rule as `/audit`):
+
+- `query-engine` → `packages/@granit/query-engine` + `packages/@granit/react-query-engine`
+- Any name → `packages/@granit/{name}` + `packages/@granit/react-{name}` if it exists
+
+If `all`, list packages under `packages/@granit/` and prioritize the ones most
+exposed to scale: anything with `src/components/` rendering lists, anything with
+`src/api/` (data load), and the transport packages (`notifications-*`).
+
+---
+
+## Step 2 — Gather context (evidence-first)
+
+Performance findings must be grounded in code, not guessed. For each target,
+collect the following with concrete recipes:
+
+**Request cancellation** — which api functions never accept a signal:
+
+```bash
+# api files that DON'T thread an AbortSignal (each is a candidate finding)
+grep -L "AbortSignal\|signal" packages/@granit/{pkg}/src/api/*.ts 2>/dev/null
+```
+
+**Unvirtualized large lists** — `.map()` render over query data with no virtualizer:
+
+```bash
+grep -rln "\.map(" packages/@granit/{pkg}/src/components/ 2>/dev/null
+grep -rL "useVirtualizer\|react-virtual" packages/@granit/{pkg}/src/components/ 2>/dev/null
+```
+
+**Pagination strategy** — offset vs cursor for the module's lists:
+
+```bash
+grep -rnE "nextCursor|cursor|offset|\bskip\b|page\b" packages/@granit/{pkg}/src/ 2>/dev/null
+```
+
+**Client-side N+1** — awaited calls inside loops:
+
+```bash
+grep -rnE "for *\(.*await|\.map\(async|Promise\.all\(.*map" packages/@granit/{pkg}/src/ 2>/dev/null
+```
+
+**Cache invalidation breadth** — argument-less invalidation = refetch storm:
+
+```bash
+grep -rn "invalidateQueries()" packages/@granit/{pkg}/src/ 2>/dev/null
+```
+
+**Tree-shaking** — packages missing `sideEffects`:
+
+```bash
+grep -L '"sideEffects"' packages/@granit/{pkg}/package.json 2>/dev/null
+```
+
+**Debounce on inputs** — search/filter components firing per keystroke:
+
+```bash
+grep -rln "onChange\|onValueChange" packages/@granit/{pkg}/src/components/ 2>/dev/null
+grep -rL "debounce\|throttle" packages/@granit/{pkg}/src/components/ 2>/dev/null
+```
+
+Then read the flagged files fully before judging. Run `git log -p -- <file>` for
+anything that looks intentionally written that way (a deliberate non-virtualized
+list capped at N items is fine — read the cap before flagging).
+
+---
+
+## Step 3 — Run the checklist
+
+Apply every category from [checklist.md](checklist.md) against the gathered
+context, **in order**: data fetching, rendering, cache, bundle, real-time, then
+the cross-cutting concurrency checks.
+
+For each finding, classify it by **scale impact**:
+
+| Severity     | Meaning                                             | Action         |
+| ------------ | --------------------------------------------------- | -------------- |
+| **CRITICAL** | Unbounded resource use; freezes/fails at high scale | Must fix       |
+| **HIGH**     | Superlinear cost or server-side load amplification  | Should fix     |
+| **MEDIUM**   | Avoidable overhead on every interaction             | Should improve |
+| **LOW**      | Micro-optimization with measurable but small gain   | Consider       |
+
+Every finding MUST state the **scale scenario** that triggers it — the number
+that makes it matter (e.g. "freezes at ~5k rows", "fires 1 req/keystroke =
+~8 req/word", "+40 KB unconditionally in every consumer bundle").
+
+---
+
+## Step 4 — Report or fix
+
+### Report mode (default)
+
+```markdown
+## Scale Audit — @granit/{package} — {date}
+
+### Scale budget
+
+| Dimension                | Target              | Observed        | Verdict |
+| ------------------------ | ------------------- | --------------- | ------- |
+| Largest rendered list    | virtualized         | {virtualized?}  | OK/RISK |
+| Requests per interaction | ≤ 1 (cancellable)   | {observed}      | OK/RISK |
+| Pagination strategy      | cursor for big sets | {offset/cursor} | OK/RISK |
+| Tree-shakeable           | sideEffects: false  | {yes/no}        | OK/RISK |
+
+### Summary
+
+| Severity | Count |
+| -------- | ----- |
+| CRITICAL | {n}   |
+| HIGH     | {n}   |
+| MEDIUM   | {n}   |
+| LOW      | {n}   |
+
+### CRITICAL
+
+- [{file}:{line}] {description}
+  Scale scenario: {the number that makes it break}
+  Current: {what the code does}
+  Fix: {concrete change — API + reference to the framework primitive}
+
+### HIGH / MEDIUM / LOW
+
+(same format)
+```
+
+When auditing `all`, produce one report per package, then a **cross-package
+scale summary**: systemic gaps (e.g. "0/146 packages set `sideEffects`",
+"N api functions thread no signal") with counts.
+
+### Fix mode (`--fix`)
+
+Apply only **safe, mechanical** fixes — process findings one at a time:
+
+- **Safe to auto-fix**: add `"sideEffects": false` to a package with no
+  module-level side effects; thread an existing `signal` param into an axios
+  call; add `staleTime` to a metadata query; replace `invalidateQueries()` with
+  a scoped key.
+- **NEVER auto-fix** (report only): introducing virtualization (changes markup
+  and UX), changing pagination from offset to cursor (backend coordination),
+  code-splitting boundaries. These need human design — flag with a concrete
+  proposal instead.
+
+After each fix run `pnpm --filter @granit/{package} exec tsc --noEmit`. Two
+attempts max per finding; on second failure, revert and log
+`UNFIXABLE — manual: {error}`. After all fixes:
+
+```bash
+pnpm tsc && pnpm lint && npx vitest run
+```
+
+If a check fails on code you did not touch, **stop and report** — never fix
+pre-existing failures outside scope.
+
+---
+
+## Step 5 — Cross-package scale analysis (full audit only)
+
+1. **Virtualization coverage**: list every component rendering a query-backed
+   collection and whether it virtualizes. `@tanstack/react-virtual` is in the
+   approved dependency set — flag list components that don't use it.
+2. **Cancellation coverage**: ratio of `src/api/` functions that thread a signal
+   vs total. Report the gap.
+3. **Bundle hygiene**: count packages missing `"sideEffects": false`; flag heavy
+   optional deps (editors, charting, PDF) that are statically imported instead of
+   `lazy()` / dynamic `import()`.
+4. **Shared scale primitives**: verify packages reuse `usePagination` /
+   `useInfiniteScroll` / `validateQueryRequest` from `@granit/*query-engine`
+   rather than reinventing unbounded variants.
+5. **Real-time fan-out**: verify transport packages share a single connection per
+   client (not one per subscribing component) and coalesce high-frequency events.
+
+---
+
+## PR Mode (`/perf pr`)
+
+Focused scale audit of only the packages modified in the current branch — run it
+before merging a feature that adds lists, data fetching, or dependencies.
+
+### PR Step 1 — Determine scope
+
+```bash
+git fetch origin develop --quiet
+git diff origin/develop...HEAD --name-only
+```
+
+If on `develop`/`main`: **"Nothing to audit — you're on the base branch."** and
+stop. Extract affected `@granit/*` packages; if none, **"No framework packages
+modified."** and stop.
+
+### PR Step 2 — Scale-sensitive diff review
+
+For the diff in each affected package, check:
+
+- **New list render**: any added `.map()` in a component over query data →
+  does it virtualize? (CRITICAL if unbounded)
+- **New api function**: does it accept and forward an `AbortSignal`? Does it use
+  cursor pagination for a high-cardinality resource?
+- **New mutation**: does `onSuccess` invalidate a scoped key (not `()`)?
+- **New dependency**: weight and whether it should be `lazy()`-loaded; is the
+  package still tree-shakeable (`sideEffects`)?
+- **New input**: search/filter/autocomplete debounced before firing a query?
+
+### PR Step 3 — Verdict
+
+```bash
+pnpm tsc && pnpm lint && npx vitest run
+```
+
+```markdown
+## PR Scale Audit — {branch} → develop — {date}
+
+### Packages touched
+
+- @granit/{pkg} ({n} files)
+
+### Findings
+
+| Severity | Count |
+| -------- | ----- |
+| CRITICAL | {n}   |
+| HIGH     | {n}   |
+| MEDIUM   | {n}   |
+
+{findings — same format as standard report}
+
+### Verdict
+
+SCALE-READY | BLOCKED — {reasons}
+```
+
+---
+
+## Rules
+
+- **Read before judging.** A non-virtualized list capped at a small fixed N is
+  fine — read the cap and the data source before flagging. Run `git log -p`
+  on anything that looks deliberately written that way.
+- **Numbers, not vibes.** Every finding names the scale at which it bites. No
+  number → not a finding. "Premature optimization" is itself a smell; don't add
+  complexity the data doesn't justify.
+- **Respect source-direct consumption.** These packages ship TS source consumed
+  via Vite path aliases — the consuming app's bundler does the tree-shaking.
+  Frame bundle findings in terms of what reaches the _app_ bundle, not a
+  per-package `dist/`.
+- **Don't fight the backend.** Pagination clamping and limits live in
+  `query-engine` / the .NET QueryEngine. Reuse them; never propose a frontend
+  workaround that bypasses a server-enforced limit.
+- **One dimension at a time.** Finish data-fetching findings before rendering,
+  rendering before cache, etc. Don't interleave categories in one pass.
+- **Context window discipline.** For `all`, process packages one at a time and
+  emit each report before the next. If the audit goes shallow, split into a
+  follow-up rather than producing a low-signal report.

--- a/.claude/skills/perf/checklist.md
+++ b/.claude/skills/perf/checklist.md
@@ -1,0 +1,172 @@
+# Scale Readiness Checklist — Granit Front Packages
+
+Work through each category **in order**. Every box that fails MUST be reported
+with the **scale scenario** that makes it matter (a concrete number: rows,
+requests/s, KB). A box with no plausible high-scale trigger is not a finding.
+
+References to framework primitives below are real and verified:
+`@granit/query-engine` ships `validateQueryRequest` (clamps page/pageSize),
+`nextCursor` cursor support, and `usePagination` / `useInfiniteScroll`;
+`@tanstack/react-virtual` is in the approved dependency set.
+
+---
+
+## 1. Data Fetching at Scale (--scope data)
+
+### 1a. Request cancellation
+
+- [ ] **Signal accepted**: every `src/api/` function accepts an optional
+      `signal?: AbortSignal` and forwards it to axios as `{ signal }`. Without
+      it, superseded requests (fast filter/page changes) keep running and race
+      on cache write. _Scale: any fast-changing query — search-as-you-type,
+      paginated tables._
+- [ ] **Signal wired from the hook**: query hooks pass the `signal` from the
+      TanStack Query `queryFn` context (`queryFn: ({ signal }) => getX(client, …, signal)`)
+- [ ] **Cleanup on unmount**: ad-hoc effects that fetch (outside TanStack Query)
+      abort via `AbortController` in their cleanup
+
+### 1b. Pagination strategy
+
+- [ ] **Cursor for unbounded sets**: high-cardinality or append-only lists
+      (audit logs, notifications, activity feeds, search) use **cursor**
+      pagination (`nextCursor`), not offset/`skip` — offset cost grows with page
+      depth on the server
+- [ ] **Clamped params**: paginated requests go through `validateQueryRequest` /
+      `serializeQueryRequest`; no hand-built `{ page, pageSize }` that can request
+      an unbounded page size
+- [ ] **`placeholderData` / `keepPreviousData`**: paginated/infinite UIs keep the
+      previous page visible while fetching the next (no spinner-flash storm)
+- [ ] **Bounded accumulation**: infinite scroll caps the in-memory window (drops
+      or virtualizes off-screen pages) — it does not grow an unbounded array in
+      memory
+
+### 1c. Request fan-out
+
+- [ ] **No client-side N+1**: no `await` inside a `for`/`map` over a collection,
+      and no per-row fetch. Use a batch endpoint or a single query.
+      _Scale: a 200-row list issuing 200 requests._
+- [ ] **Deduplicated**: the same logical resource is not fetched by multiple
+      uncoordinated hooks with different keys (TanStack dedups identical keys —
+      keep keys identical for shared data)
+- [ ] **Parallel where independent**: independent requests use `Promise.all`,
+      not sequential `await`s
+
+---
+
+## 2. Rendering at Scale (--scope render)
+
+### 2a. Virtualization
+
+- [ ] **Large lists virtualize**: any list / table / gallery that can render a
+      large or infinite-scroll dataset uses `@tanstack/react-virtual`
+      (`useVirtualizer`) — NOT a raw `items.map()` over the whole array.
+      _Scale: DOM nodes ∝ dataset; freezes in the low thousands of rows._
+- [ ] **Fixed vs dynamic measurement**: virtualizer uses `estimateSize` /
+      `measureElement` appropriately for variable-height rows
+- [ ] **No off-screen heavy work**: rows don't mount heavy widgets (charts,
+      editors) for off-screen items
+
+### 2b. Input responsiveness
+
+- [ ] **Debounced inputs**: search / filter / autocomplete inputs debounce (or
+      throttle) before firing a query — never one request per keystroke.
+      _Scale: ~8 requests per typed word without it._
+- [ ] **Deferred values**: expensive derived UI off a fast-changing input uses
+      `useDeferredValue` / `startTransition` to keep typing responsive
+
+### 2c. Re-render discipline
+
+- [ ] **Stable keys**: list item `key` is a stable ID, never the array index
+      (index keys break reconciliation on reorder/insert)
+- [ ] **Memoized row handlers**: per-row callbacks are `useCallback` (or hoisted),
+      not new closures each render that re-render every row
+- [ ] **No inline object/array props** on hot list items (new reference each
+      render defeats `memo`)
+- [ ] **Derived data memoized**: filtering/sorting/grouping of large arrays is in
+      `useMemo`, not recomputed every render
+- [ ] **`select` to narrow**: query hooks use `select` so a component re-renders
+      only when its slice changes, not on any cache write
+
+---
+
+## 3. Cache & State at Scale (--scope cache)
+
+- [ ] **`staleTime` on hot/metadata data**: reference data, schemas, permissions
+      set a meaningful `staleTime` (often `Infinity` for static metadata) to avoid
+      refetch storms across many mounted components
+- [ ] **`gcTime` tuned**: long lists / heavy responses don't linger in cache
+      unbounded; inactive heavy queries are garbage-collected
+- [ ] **Scoped invalidation**: mutations invalidate the **specific** affected
+      query keys in `onSuccess` — never argument-less `invalidateQueries()`,
+      which refetches everything. _Scale: one write triggering dozens of refetches._
+- [ ] **Optimistic over refetch**: list mutations update the cache optimistically
+      instead of refetching the whole list
+- [ ] **`structuralSharing` preserved**: large responses rely on TanStack's
+      structural sharing (don't deep-clone responses, which breaks referential
+      stability and forces re-renders)
+- [ ] **No large server data in component state**: big datasets live in the query
+      cache, not copied into `useState` (double memory + stale copies)
+
+---
+
+## 4. Bundle & Load at Scale (--scope bundle)
+
+- [ ] **`"sideEffects": false`**: every package without module-level side effects
+      declares it (or a precise file list) so consuming-app bundlers tree-shake
+      unused barrel exports. _Scale: 146 barrels; missing flag = dead code shipped._
+- [ ] **No eager heavy imports**: heavy/optional UI (rich text / Puck editors,
+      charting, PDF, map, code highlighters) is `lazy()` / dynamic `import()`,
+      not statically imported into a barrel that every consumer pulls
+- [ ] **Barrel hygiene**: `src/index.ts` does not eagerly re-export an optional
+      heavy submodule that drags its deps into every importer — expose it on a
+      subpath instead
+- [ ] **Peer, not bundled**: React, axios, `@tanstack/*` are `peerDependencies`
+      so they are not duplicated across packages in the final bundle
+- [ ] **No duplicate heavy deps**: two packages don't pull different major
+      versions of the same heavy library into one app
+
+---
+
+## 5. Real-time & Background at Scale (--scope realtime)
+
+- [ ] **Reconnect with backoff**: SSE / SignalR transports reconnect with
+      exponential backoff (verified present in `notifications-sse` /
+      `notifications-signalr` — keep it when extending)
+- [ ] **Shared connection**: one transport connection per client, shared via
+      provider/context — NOT one connection per subscribing component.
+      _Scale: 50 widgets = 50 sockets without sharing._
+- [ ] **Event coalescing / backpressure**: high-frequency streams batch or
+      coalesce updates before touching the query cache (no re-render per event)
+- [ ] **Subscription cleanup**: every subscription / `addEventListener` /
+      `setInterval` is torn down on unmount (no leaks accumulating over a long
+      session)
+- [ ] **Polling is paused when hidden**: polling intervals use a sane period and
+      pause when the tab is backgrounded (`refetchIntervalInBackground: false`
+      or visibility-aware)
+
+---
+
+## 6. Concurrency & Resilience (cross-cutting)
+
+- [ ] **Timeouts**: long-running calls set a timeout so a slow backend doesn't
+      pin a connection indefinitely
+- [ ] **Bounded retries**: TanStack `retry` is bounded with backoff; no infinite
+      retry loop hammering a failing endpoint
+- [ ] **Race-safe writes**: concurrent mutations to the same entity reconcile via
+      the cache (last-write-wins is explicit, not accidental)
+- [ ] **No unbounded growth**: nothing accumulates without bound over a long
+      session — caches, event buffers, in-memory lists all have a ceiling
+
+---
+
+## Suppressions — DO NOT flag
+
+- Micro-optimizations with no measurable effect at realistic scale
+- Virtualization for lists with a small fixed cap (read the cap first)
+- Memoization of trivially cheap computations (memo overhead > the work)
+- "Could be lazy-loaded" for small always-used modules
+- `staleTime` tuning on data that is genuinely real-time (must be fresh)
+- Anything already owned by `/audit` (conformity) or `/quality` (lint, tests) —
+  cross-reference, don't duplicate
+- Backend-side performance (query plans, indexes, N+1 in EF Core) — that is the
+  .NET repo's concern, not this front-end audit

--- a/packages/@granit/react-analytics/src/hooks/use-metric.ts
+++ b/packages/@granit/react-analytics/src/hooks/use-metric.ts
@@ -89,7 +89,7 @@ function refetchIntervalFromResponse(
  * to the same query key (and therefore the same cache entry, in-flight
  * request, and — once streaming lands — subscription identity).
  */
-function normalizeMetricRequest(request: MetricRequest): MetricRequest {
+export function normalizeMetricRequest(request: MetricRequest): MetricRequest {
   const period =
     'token' in request.period
       ? { token: request.period.token }

--- a/packages/@granit/react-bff/src/__tests__/bff-sessions.test.tsx
+++ b/packages/@granit/react-bff/src/__tests__/bff-sessions.test.tsx
@@ -22,7 +22,7 @@ const authenticatedResponse = {
   sessionExpiresAt: '2026-03-23T20:00:00Z',
 };
 
-const csrfResponse = { token: 'csrf-test-token' };
+const csrfResponse = { csrfToken: 'csrf-test-token' };
 
 const sessionsResponse = {
   sessions: [

--- a/packages/@granit/react-bff/src/hooks/use-bff-tenant.ts
+++ b/packages/@granit/react-bff/src/hooks/use-bff-tenant.ts
@@ -17,7 +17,7 @@ import type { BffUser } from '@granit/bff';
  * @returns `tenantId` for an authenticated tenant user, `undefined` for
  *   Host users, anonymous sessions, or while bootstrapping.
  */
-function resolveBffTenantId(user: BffUser | null): string | undefined {
+export function resolveBffTenantId(user: BffUser | null): string | undefined {
   if (!user) return undefined;
   if (user.isHost) return undefined;
   return user.tenantId;

--- a/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
+++ b/packages/@granit/react-diagnostics/src/__tests__/use-monitoring-health.test.tsx
@@ -5,11 +5,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  buildDiagnosticsQueryKey,
-  diagnosticsKeys,
-  useMonitoringHealth,
-} from '../hooks/use-monitoring-health';
+import { buildDiagnosticsQueryKey, diagnosticsKeys } from '../hooks/query-keys';
+import { useMonitoringHealth } from '../hooks/use-monitoring-health';
 
 import type { MonitoringHealthResponse } from '@granit/diagnostics';
 


### PR DESCRIPTION
## Why

CI was failing with 16 test failures across 4 files, caused by two recently-merged changes whose test fallout wasn't caught:

- **#527** (homogeneity audit) dropped the `export` keyword on `normalizeMetricRequest` (react-analytics) and `resolveBffTenantId` (react-bff), and moved the diagnostics query-key helpers into `query-keys.ts` — breaking their co-located unit tests (`X is not a function`).
- **#530** (CSRF hardening, VULN-300) added on-demand CSRF token fetching on mutation requests. This surfaced a latent bug in the BFF sessions test: the CSRF mock used the wrong shape `{ token }` instead of the real `{ csrfToken }` contract, leaving `this.token` undefined so the DELETE fired an extra token fetch and desynced the mock queue.

## Changes

- Re-export `normalizeMetricRequest` (`react-analytics`)
- Re-export `resolveBffTenantId` (`react-bff`)
- Import the diagnostics query-key helpers from `query-keys.ts` in the test (matches the #527 move)
- Correct the CSRF mock shape to `{ csrfToken }` in the BFF sessions test

The two re-exported helpers are reachable only by their co-located unit tests; they are **not** added to the package barrels, so the public API is unchanged.

## Verification

- `vitest run` on the 4 affected files → **24 passed**
- ESLint (`--max-warnings 0`) clean on changed files
- `tsc --noEmit` clean on the 3 packages