### PR TITLE
refactor: deduplicate shared helpers across @granit packages

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1706,6 +1706,38 @@
           "signature": "const NotificationChannels"
         },
         {
+          "name": "createTransportListeners",
+          "kind": "function",
+          "signature": "function createTransportListeners( initialState: ConnectionState = 'disconnected' ): TransportListeners"
+        },
+        {
+          "name": "TransportListeners",
+          "kind": "interface",
+          "signature": "interface TransportListeners",
+          "members": [
+            {
+              "name": "setState",
+              "kind": "method",
+              "signature": "setState(state: ConnectionState): void"
+            },
+            {
+              "name": "emit",
+              "kind": "method",
+              "signature": "emit(message: NotificationTransportMessage): void"
+            },
+            {
+              "name": "onNotification",
+              "kind": "method",
+              "signature": "onNotification(callback: (message: NotificationTransportMessage) => void): () => void"
+            },
+            {
+              "name": "onStateChange",
+              "kind": "method",
+              "signature": "onStateChange(callback: (state: ConnectionState) => void): () => void"
+            }
+          ]
+        },
+        {
           "name": "NotificationPermissions",
           "kind": "const",
           "signature": "const NotificationPermissions"

--- a/packages/@granit/arch-tests-kit/src/fs.ts
+++ b/packages/@granit/arch-tests-kit/src/fs.ts
@@ -41,6 +41,38 @@ export function walkSourceFiles(rootDir: string, filter?: (file: string) => bool
   return out;
 }
 
+function processSubdirEntry(
+  entry: fs.Dirent,
+  cur: string,
+  name: string,
+  stack: string[],
+  out: string[]
+): void {
+  if (!entry.isDirectory()) return;
+  if (entry.name === 'node_modules' || entry.name === 'dist') return;
+  const full = path.join(cur, entry.name);
+  if (entry.name === name) out.push(full);
+  else stack.push(full);
+}
+
+/**
+ * Find every directory named `name` under `root` (e.g. all `hooks/` or `api/`
+ * subdirs of a module's `src/`). Skips `node_modules` and `dist`.
+ */
+export function findSubdirs(root: string, name: string): string[] {
+  if (!fs.existsSync(root)) return [];
+  const out: string[] = [];
+  const stack = [root];
+  while (stack.length) {
+    const cur = stack.pop();
+    if (cur === undefined) break;
+    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
+      processSubdirEntry(entry, cur, name, stack, out);
+    }
+  }
+  return out;
+}
+
 export function isTestFile(file: string): boolean {
   return /(^|[\\/])__tests__[\\/]/.test(file) || /\.test\.tsx?$/.test(file);
 }

--- a/packages/@granit/arch-tests-kit/src/scanners/naming.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/naming.ts
@@ -1,7 +1,6 @@
-import fs from 'node:fs';
 import path from 'node:path';
 
-import { isTestFile, readFile, rel, walkSourceFiles } from '../fs';
+import { findSubdirs, isTestFile, readFile, rel, walkSourceFiles } from '../fs';
 
 import type { AllowlistedScanContext, ScanContext, Violation } from '../types';
 
@@ -34,34 +33,6 @@ export function scanKebabCase(opts: AllowlistedScanContext): Violation[] {
 // NOSONAR: these regexes run only on bounded developer source files — no user input, no ReDoS risk
 const HOOK_DECL_RE = /\bexport\s+(?:async\s+)?(?:function|const)\s+use[A-Z]\w*/;
 const HOOK_REEXPORT_RE = /\bexport\s*\{[^}]*\buse[A-Z]\w*/;
-
-function processSubdirEntry(
-  entry: fs.Dirent,
-  cur: string,
-  name: string,
-  stack: string[],
-  out: string[]
-): void {
-  if (!entry.isDirectory()) return;
-  if (entry.name === 'node_modules' || entry.name === 'dist') return;
-  const full = path.join(cur, entry.name);
-  if (entry.name === name) out.push(full);
-  else stack.push(full);
-}
-
-function findSubdirs(root: string, name: string): string[] {
-  if (!fs.existsSync(root)) return [];
-  const out: string[] = [];
-  const stack = [root];
-  while (stack.length) {
-    const cur = stack.pop();
-    if (cur === undefined) break;
-    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
-      processSubdirEntry(entry, cur, name, stack, out);
-    }
-  }
-  return out;
-}
 
 function checkHookFile(f: string, moduleName: string, repoRoot: string, out: Violation[]): void {
   const base = path.basename(f);

--- a/packages/@granit/arch-tests-kit/src/scanners/patterns.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/patterns.ts
@@ -1,37 +1,14 @@
-import fs from 'node:fs';
-import path from 'node:path';
-
-import { isTestFile, isTestingDir, readFile, rel, stripComments, walkSourceFiles } from '../fs';
+import {
+  findSubdirs,
+  isTestFile,
+  isTestingDir,
+  readFile,
+  rel,
+  stripComments,
+  walkSourceFiles,
+} from '../fs';
 
 import type { AllowlistedScanContext, ScanContext, Violation } from '../types';
-
-function processSubdirEntry(
-  entry: fs.Dirent,
-  cur: string,
-  name: string,
-  stack: string[],
-  out: string[]
-): void {
-  if (!entry.isDirectory()) return;
-  if (entry.name === 'node_modules' || entry.name === 'dist') return;
-  const full = path.join(cur, entry.name);
-  if (entry.name === name) out.push(full);
-  else stack.push(full);
-}
-
-function findSubdirs(root: string, name: string): string[] {
-  if (!fs.existsSync(root)) return [];
-  const out: string[] = [];
-  const stack = [root];
-  while (stack.length) {
-    const cur = stack.pop();
-    if (cur === undefined) break;
-    for (const entry of fs.readdirSync(cur, { withFileTypes: true })) {
-      processSubdirEntry(entry, cur, name, stack, out);
-    }
-  }
-  return out;
-}
 
 // `export default <X>` is OK only when <X> is a named declaration or a bare
 // identifier reference — both give React DevTools / stack traces a useful

--- a/packages/@granit/notifications-signalr/src/transports/create-signalr-transport.ts
+++ b/packages/@granit/notifications-signalr/src/transports/create-signalr-transport.ts
@@ -1,10 +1,7 @@
+import { createTransportListeners } from '@granit/notifications';
 import { HttpTransportType, HubConnectionBuilder, LogLevel } from '@microsoft/signalr';
 
-import type {
-  ConnectionState,
-  NotificationTransportMessage,
-  NotificationTransport,
-} from '@granit/notifications';
+import type { NotificationTransportMessage, NotificationTransport } from '@granit/notifications';
 import type { HubConnection } from '@microsoft/signalr';
 
 export interface SignalRTransportConfig {
@@ -29,20 +26,12 @@ export interface SignalRTransportConfig {
  */
 export function createSignalRTransport(config: SignalRTransportConfig): NotificationTransport {
   let connection: HubConnection | null = null;
-  let currentState: ConnectionState = 'disconnected';
-  const notificationListeners = new Set<(message: NotificationTransportMessage) => void>();
-  const stateListeners = new Set<(state: ConnectionState) => void>();
-
-  function setState(state: ConnectionState) {
-    currentState = state;
-    for (const listener of stateListeners) {
-      listener(state);
-    }
-  }
+  const listeners = createTransportListeners();
+  const setState = listeners.setState;
 
   return {
     get state() {
-      return currentState;
+      return listeners.state;
     },
 
     async connect() {
@@ -58,9 +47,7 @@ export function createSignalRTransport(config: SignalRTransportConfig): Notifica
         .build();
 
       connection.on('ReceiveNotification', (message: NotificationTransportMessage) => {
-        for (const listener of notificationListeners) {
-          listener(message);
-        }
+        listeners.emit(message);
       });
 
       connection.onreconnecting(() => setState('reconnecting'));
@@ -78,18 +65,7 @@ export function createSignalRTransport(config: SignalRTransportConfig): Notifica
       setState('disconnected');
     },
 
-    onNotification(callback) {
-      notificationListeners.add(callback);
-      return () => {
-        notificationListeners.delete(callback);
-      };
-    },
-
-    onStateChange(callback) {
-      stateListeners.add(callback);
-      return () => {
-        stateListeners.delete(callback);
-      };
-    },
+    onNotification: listeners.onNotification,
+    onStateChange: listeners.onStateChange,
   };
 }

--- a/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
+++ b/packages/@granit/notifications-sse/src/transports/create-sse-transport.ts
@@ -1,10 +1,7 @@
+import { createTransportListeners } from '@granit/notifications';
 import { EventStreamContentType, fetchEventSource } from '@microsoft/fetch-event-source';
 
-import type {
-  ConnectionState,
-  NotificationTransportMessage,
-  NotificationTransport,
-} from '@granit/notifications';
+import type { NotificationTransportMessage, NotificationTransport } from '@granit/notifications';
 
 export interface SseTransportConfig {
   /** SSE endpoint URL, e.g. '/api/v1/notifications/stream'. */
@@ -62,20 +59,12 @@ export function createSseTransport(config: SseTransportConfig): NotificationTran
   assertStreamUrlOrigin(config.streamUrl, config.allowCrossOrigin === true);
   const heartbeatType = config.heartbeatTypeName ?? '__heartbeat__';
   let abortController: AbortController | null = null;
-  let currentState: ConnectionState = 'disconnected';
-  const notificationListeners = new Set<(message: NotificationTransportMessage) => void>();
-  const stateListeners = new Set<(state: ConnectionState) => void>();
-
-  function setState(state: ConnectionState) {
-    currentState = state;
-    for (const listener of stateListeners) {
-      listener(state);
-    }
-  }
+  const listeners = createTransportListeners();
+  const setState = listeners.setState;
 
   return {
     get state() {
-      return currentState;
+      return listeners.state;
     },
 
     async connect() {
@@ -101,9 +90,7 @@ export function createSseTransport(config: SseTransportConfig): NotificationTran
 
           try {
             const message = JSON.parse(event.data) as NotificationTransportMessage;
-            for (const listener of notificationListeners) {
-              listener(message);
-            }
+            listeners.emit(message);
           } catch {
             // Malformed events are silently skipped.
           }
@@ -144,18 +131,7 @@ export function createSseTransport(config: SseTransportConfig): NotificationTran
       setState('disconnected');
     },
 
-    onNotification(callback) {
-      notificationListeners.add(callback);
-      return () => {
-        notificationListeners.delete(callback);
-      };
-    },
-
-    onStateChange(callback) {
-      stateListeners.add(callback);
-      return () => {
-        stateListeners.delete(callback);
-      };
-    },
+    onNotification: listeners.onNotification,
+    onStateChange: listeners.onStateChange,
   };
 }

--- a/packages/@granit/notifications/src/index.ts
+++ b/packages/@granit/notifications/src/index.ts
@@ -23,6 +23,10 @@ export type {
 
 export { NotificationChannels } from './types/index';
 
+// Transport helpers (shared by transport adapters)
+export { createTransportListeners } from './transport-listeners';
+export type { TransportListeners } from './transport-listeners';
+
 // API (pure TypeScript functions)
 export {
   followEntity,

--- a/packages/@granit/notifications/src/transport-listeners.ts
+++ b/packages/@granit/notifications/src/transport-listeners.ts
@@ -1,0 +1,69 @@
+import type { ConnectionState, NotificationTransportMessage } from './types/index';
+
+/**
+ * Shared listener bookkeeping for {@link NotificationTransport} implementations.
+ *
+ * Holds the current connection state plus the notification/state listener sets,
+ * and exposes the `onNotification`/`onStateChange` subscribe methods that every
+ * transport implements identically. Transport adapters
+ * (`@granit/notifications-signalr`, `@granit/notifications-sse`) own the
+ * connection lifecycle and delegate listener management here.
+ */
+export interface TransportListeners {
+  /** Current connection state. */
+  readonly state: ConnectionState;
+  /** Updates the state and notifies every state listener. */
+  setState(state: ConnectionState): void;
+  /** Dispatches an incoming message to every notification listener. */
+  emit(message: NotificationTransportMessage): void;
+  /** Subscribes to incoming real-time notifications. Returns an unsubscribe function. */
+  onNotification(callback: (message: NotificationTransportMessage) => void): () => void;
+  /** Subscribes to connection state changes. Returns an unsubscribe function. */
+  onStateChange(callback: (state: ConnectionState) => void): () => void;
+}
+
+/**
+ * Creates the listener registry shared by every `NotificationTransport`.
+ *
+ * @param initialState - Connection state before the first `connect()`. Default `'disconnected'`.
+ */
+export function createTransportListeners(
+  initialState: ConnectionState = 'disconnected'
+): TransportListeners {
+  let currentState: ConnectionState = initialState;
+  const notificationListeners = new Set<(message: NotificationTransportMessage) => void>();
+  const stateListeners = new Set<(state: ConnectionState) => void>();
+
+  return {
+    get state() {
+      return currentState;
+    },
+
+    setState(state) {
+      currentState = state;
+      for (const listener of stateListeners) {
+        listener(state);
+      }
+    },
+
+    emit(message) {
+      for (const listener of notificationListeners) {
+        listener(message);
+      }
+    },
+
+    onNotification(callback) {
+      notificationListeners.add(callback);
+      return () => {
+        notificationListeners.delete(callback);
+      };
+    },
+
+    onStateChange(callback) {
+      stateListeners.add(callback);
+      return () => {
+        stateListeners.delete(callback);
+      };
+    },
+  };
+}

--- a/packages/@granit/react-taxonomy/src/components/document-tag-chip-strip.tsx
+++ b/packages/@granit/react-taxonomy/src/components/document-tag-chip-strip.tsx
@@ -7,6 +7,7 @@ import {
 } from '../hooks/use-document-tags';
 
 import { TagAutocomplete } from './tag-autocomplete.tsx';
+import { DEFAULT_TAG_CHIP_STRIP_LABELS } from './tag-chip-strip.tsx';
 import { TagChip } from './tag-chip.tsx';
 
 import type { TagChipStripLabels } from './tag-chip-strip.tsx';
@@ -22,16 +23,6 @@ export interface DocumentTagChipStripProps {
   readonly labels?: TagChipStripLabels;
   readonly className?: string;
 }
-
-const DEFAULT_LABELS: Required<TagChipStripLabels> = {
-  add: '+ Tag',
-  loading: 'Loading…',
-  error: 'Failed to load tags.',
-  empty: 'No tags.',
-  placeholder: 'Add tag…',
-  create: 'Create',
-  remove: 'Remove',
-};
 
 /**
  * Documents-proxy variant of {@link TagChipStrip}. Same UX, different data
@@ -52,7 +43,7 @@ export function DocumentTagChipStrip({
   labels,
   className,
 }: DocumentTagChipStripProps): ReactNode {
-  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const labelStrings = { ...DEFAULT_TAG_CHIP_STRIP_LABELS, ...labels };
   const [editing, setEditing] = useState(false);
 
   const bindings = { basePath, documentId };

--- a/packages/@granit/react-taxonomy/src/components/tag-chip-strip.tsx
+++ b/packages/@granit/react-taxonomy/src/components/tag-chip-strip.tsx
@@ -29,7 +29,8 @@ export interface TagChipStripProps {
   readonly className?: string;
 }
 
-const DEFAULT_LABELS: Required<TagChipStripLabels> = {
+/** Default labels shared by {@link TagChipStrip} and `DocumentTagChipStrip`. */
+export const DEFAULT_TAG_CHIP_STRIP_LABELS: Required<TagChipStripLabels> = {
   add: '+ Tag',
   loading: 'Loading…',
   error: 'Failed to load tags.',
@@ -54,7 +55,7 @@ export function TagChipStrip({
   labels,
   className,
 }: TagChipStripProps): ReactNode {
-  const labelStrings = { ...DEFAULT_LABELS, ...labels };
+  const labelStrings = { ...DEFAULT_TAG_CHIP_STRIP_LABELS, ...labels };
   const [editing, setEditing] = useState(false);
 
   const target = { targetType, targetId };


### PR DESCRIPTION
## Summary

Removes structural code duplication surfaced by the `/audit` framework audit (jscpd, source pass). **No behaviour change** — the only public-API additions are additive. Net **−72 lines** of duplication across 3 packages.

## Changes

| Package | What |
| --- | --- |
| `@granit/arch-tests-kit` | Hoisted the **byte-identical** `findSubdirs`/`processSubdirEntry` (31 lines) into `fs.ts` next to `walkSourceFiles`; `naming.ts` and `patterns.ts` import the single copy and drop now-unused `node:fs`/`node:path` imports. _(Published package — duplication shipped externally.)_ |
| `@granit/notifications` | Extracted `createTransportListeners()` into the core package; the **SignalR** and **SSE** transport adapters delegate listener-set / `setState` / `emit` bookkeeping to it instead of each reimplementing the `Set`-based registry. |
| `@granit/react-taxonomy` | Shared the identical `DEFAULT_TAG_CHIP_STRIP_LABELS` constant between `TagChipStrip` and `DocumentTagChipStrip`. |

New public exports (additive, non-breaking): `createTransportListeners`, `TransportListeners` (`@granit/notifications`); `DEFAULT_TAG_CHIP_STRIP_LABELS` (`@granit/react-taxonomy`).

## Not included (deliberately)

The audit also flagged near-duplicate delete-hooks, mount-guard hooks, and `QueryMetadata` test fixtures. These were **left as-is**: extracting them would force inappropriate cross-package dependencies (e.g. `react-settings` → `react-query-engine`) or abstract over only 2 occurrences / distinct test data — worse than the duplication. See audit discussion.

## Verification

Run in an **isolated worktree off `develop`** (no contamination from unrelated in-progress work):

- `pnpm tsc` (146 packages) — ✅ PASS
- `pnpm lint` (touched files, `--max-warnings 0`) — ✅ PASS
- Tests (arch-tests + notifications core/sse/signalr + react-taxonomy) — ✅ **1034 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)