### PR TITLE
fix(api-client): surface ProblemDetails.errors, publish react-api-client, declare testing peer

### DIFF
--- a/packages/@granit/api-client/package.json
+++ b/packages/@granit/api-client/package.json
@@ -20,10 +20,14 @@
   },
   "peerDependencies": {
     "@granit/logger": "workspace:*",
+    "@granit/testing": "workspace:*",
     "axios": "^1.6.0"
   },
   "peerDependenciesMeta": {
     "@granit/logger": {
+      "optional": true
+    },
+    "@granit/testing": {
       "optional": true
     }
   },

--- a/packages/@granit/api-client/src/errors.ts
+++ b/packages/@granit/api-client/src/errors.ts
@@ -38,6 +38,10 @@ export class HttpError extends Error {
  *
  * Used by `@granit/query-engine` (filter syntax) and `@granit/data-exchange` (import mapping).
  *
+ * For server-returned validation failures, prefer reading the `errors` map on
+ * the `ProblemDetailsPayload` of an {@link HttpError} (sourced from
+ * `Granit.Http.ExceptionHandling`).
+ *
  * @example
  * ```ts
  * throw new ValidationError('Invalid filter syntax', {
@@ -86,6 +90,12 @@ export interface ProblemDetailsPayload {
   readonly instance?: string;
   readonly traceId?: string;
   readonly errorCode?: string;
+  /**
+   * Per-field validation errors. Populated by the backend on validation
+   * failures (typically HTTP 422) via `ProblemDetails.Extensions["errors"]`
+   * — see `Granit.Http.ExceptionHandling` (`GranitExceptionHandler`).
+   */
+  readonly errors?: Readonly<Record<string, readonly string[]>>;
 }
 
 /** Structured validation failure details. */

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -53,7 +53,7 @@ export interface ApiClientConfig {
 // ---------------------------------------------------------------------------
 
 // RFC 7807 Problem Details — standard error format from Granit .NET backend.
-// See: Granit.ExceptionHandling (400 BusinessException, 404 NotFoundException,
+// See: Granit.Http.ExceptionHandling (400 BusinessException, 404 NotFoundException,
 // 403 ForbiddenException, 409 ConflictException, 422 ValidationException, 500).
 //
 // Re-exported from errors.ts as ProblemDetailsPayload (readonly variant for

--- a/packages/@granit/react-api-client/README.md
+++ b/packages/@granit/react-api-client/README.md
@@ -1,3 +1,42 @@
+<img src="https://granit-fx.dev/images/granit-icon.svg" alt="" height="32" align="left" style="margin-right:10px" />
+
 # @granit/react-api-client
 
-React context provider for sharing an Axios instance across Granit framework packages
+React context provider for sharing a single Axios instance across all Granit
+framework providers and hooks.
+
+Part of the [Granit](https://granit-fx.dev) framework.
+
+## Usage
+
+Place `GranitClientProvider` at the root of your app so that domain providers
+(`QueryProvider`, `DataExchangeProvider`, …) resolve the client from context
+instead of receiving it in every config object.
+
+```tsx
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+
+const api = createApiClient({ baseURL: '/api' });
+
+<GranitClientProvider client={api}>
+  <App />
+</GranitClientProvider>;
+```
+
+Consume the shared client inside framework packages or application code:
+
+```tsx
+import { useGranitClient, useOptionalGranitClient } from '@granit/react-api-client';
+
+const client = useGranitClient(); // throws if no provider is mounted
+const maybe = useOptionalGranitClient(); // null when no provider — `config.client ?? context`
+```
+
+## Installation
+
+Consumed via `link:` protocol — see the [integration documentation](https://granit-fx.dev).
+
+## Documentation
+
+See the [full documentation](https://granit-fx.dev/frontend/api/http-client/).

--- a/packages/@granit/react-api-client/package.json
+++ b/packages/@granit/react-api-client/package.json
@@ -7,7 +7,12 @@
   "exports": {
     ".": "./src/index.ts"
   },
-  "scripts": {},
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "react": "^19.0.0"
@@ -18,6 +23,12 @@
     "@granit/testing": "workspace:*"
   },
   "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
     "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/@granit/react-api-client/tsup.config.ts
+++ b/packages/@granit/react-api-client/tsup.config.ts
@@ -1,0 +1,6 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig({
+  entry: ['src/index.ts'],
+  external: [/^@granit\//, 'react'],
+});


### PR DESCRIPTION
## Summary

Framework audit of the two HTTP-client infrastructure packages — `@granit/api-client` and `@granit/react-api-client` — against the .NET contracts they mirror (`Granit.Http.ExceptionHandling`, `Granit.Http.Idempotency`). Split out from the framework-audit batch so it lands independently and conflict-free.

## Changes

**GAP — `ProblemDetailsPayload.errors`** (api-client/src/errors.ts)
Add the optional per-field validation map the backend emits via `ProblemDetails.Extensions["errors"]` (`GranitExceptionHandler`, on 422s). Additive/optional — no impact on the ~330 existing import sites.

**INCONSISTENCY — react-api-client publish build**
Add the tsup build (`tsup.config.ts`, `build` script, `files`, `publishConfig.exports → dist`). It was the only 1-of-62 `react-*` package declaring `publishConfig` without a build (would have published raw `.tsx`).

**INCONSISTENCY — `@granit/testing` peer** (api-client/package.json)
Declare it as an optional `peerDependency`; the published `./test-utils` subpath re-exports it at runtime. (Kept develop's floored `axios: ^1.6.0` from #532.)

**IMPROVEMENT** — correct backend module name in doc comments (`Granit.Http.ExceptionHandling`); expand the react-api-client README.

## Verification

| Check | Result |
| --- | --- |
| `tsc` (both) | PASS |
| `tsup build` (react-api-client) | PASS — emits `dist/index.{js,d.ts}` |
| Unit tests | 62 passed |
| ESLint `--max-warnings 0` | clean |

The idempotency-tombstone contract was verified exactly aligned with `Granit.Http.Idempotency` (header, `ResponseTooLarge` value, 413 status, forward-compatible reason) — no change needed.