### PR TITLE
fix(deps): sync pnpm-lock with the msw testing peers

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -894,6 +894,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
 
   packages/@granit/react-ai:
     dependencies:
@@ -971,6 +974,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
 
   packages/@granit/react-api-client:
     dependencies:
@@ -1328,6 +1334,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.100.14
         version: 5.100.14(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1586,6 +1595,9 @@ importers:
       '@granit/utils':
         specifier: workspace:*
         version: link:../utils
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
 
   packages/@granit/react-data-exchange:
     dependencies:
@@ -2631,6 +2643,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
 
   packages/@granit/react-templating:
     dependencies:
@@ -2881,6 +2896,9 @@ importers:
       '@granit/workspaces':
         specifier: workspace:*
         version: link:../workspaces
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
 
   packages/@granit/reference-data:
     devDependencies:


### PR DESCRIPTION
## Problème
CI rouge : `pnpm install --frozen-lockfile` échoue avec `ERR_PNPM_OUTDATED_LOCKFILE` —
`react-catalog/package.json` déclare `msw` mais le lockfile n'avait pas d'entrée importer correspondante.

## Cause racine
Les modules `testing/` framework (`react-{activities,analytics,dashboards,workspaces,catalog,taxonomy}`)
ont ajouté `msw` en peer optionnel + devDependency **sans régénérer** `pnpm-lock.yaml`.

## Fix
Régénération du lockfile (`pnpm install --lockfile-only`) pour ajouter les 6 entrées `msw` manquantes.
`pnpm install --frozen-lockfile` passe désormais. **+18 lignes, msw uniquement** — aucune autre
modification de dépendance (i18next reste single `26.3.0`).