### PR TITLE
fix(auditing): align front contract with Granit.Auditing query-engine endpoints

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2490,6 +2490,27 @@
           "kind": "interface",
           "signature": "interface AuditLogProviderProps",
           "members": []
+        },
+        {
+          "name": "AuditEntityChangesProvider",
+          "kind": "function",
+          "signature": "function AuditEntityChangesProvider("
+        },
+        {
+          "name": "AuditEntityChangesProviderProps",
+          "kind": "interface",
+          "signature": "interface AuditEntityChangesProviderProps",
+          "members": []
+        },
+        {
+          "name": "useAuditEntries",
+          "kind": "function",
+          "signature": "function useAuditEntries( options?: UseQueryEndpointOptions ): UseQueryEndpointReturn<AuditEntry>"
+        },
+        {
+          "name": "useAuditEntityChanges",
+          "kind": "function",
+          "signature": "function useAuditEntityChanges( options?: UseQueryEndpointOptions ): UseQueryEndpointReturn<AuditEntityChangeSummary>"
         }
       ]
     },

--- a/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
+++ b/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
@@ -2,7 +2,12 @@ import { axiosResponse, createMockClient } from '@granit/testing';
 import { toEntityId, toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
-import { listAuditLogEntries, getAuditLogEntry, listEntityAuditTrail } from '../api/audit-log-api';
+import {
+  getAuditEntriesByCorrelationId,
+  getAuditLogEntry,
+  listAuditLogEntries,
+  listEntityAuditTrail,
+} from '../api/audit-log-api';
 import { AuditCategory } from '../types/index';
 
 import type { AuditEntryDetail, AuditPage } from '../types/index';
@@ -96,6 +101,19 @@ describe('audit-log-api', () => {
       expect(client.get).toHaveBeenCalledWith('/audit-log/entity/Type%2FSub/id%20with%20spaces', {
         params: undefined,
       });
+    });
+  });
+
+  describe('getAuditEntriesByCorrelationId', () => {
+    it('should GET the correlation endpoint with an encoded id and return the array', async () => {
+      const client = createMockClient();
+      const details: AuditEntryDetail[] = [];
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(details));
+
+      const result = await getAuditEntriesByCorrelationId(client, basePath, 'corr/42');
+
+      expect(client.get).toHaveBeenCalledWith('/audit-log/correlation/corr%2F42');
+      expect(result).toBe(details);
     });
   });
 });

--- a/packages/@granit/auditing/src/api/audit-log-api.ts
+++ b/packages/@granit/auditing/src/api/audit-log-api.ts
@@ -5,7 +5,13 @@ import type { PaginationParams } from '@granit/query-engine';
 /**
  * List audit log entries with optional filters and pagination.
  *
- * `GET {basePath}/`
+ * `GET {basePath}`
+ *
+ * @deprecated `{basePath}` is a Granit QueryEngine endpoint
+ * (`MapGranitQuery<AuditEntry>`). The flat filter params in {@link AuditListParams}
+ * are ignored by the backend binder (only `page`/`pageSize` work). Use
+ * `getPage<AuditEntry>(client, basePath, request)` from `@granit/query-engine`,
+ * or the `useAuditEntries()` hook from `@granit/react-auditing`.
  */
 export async function listAuditLogEntries(
   client: AxiosInstance,
@@ -27,6 +33,25 @@ export async function getAuditLogEntry(
   id: string
 ): Promise<AuditEntryDetail> {
   const { data } = await client.get<AuditEntryDetail>(`${basePath}/${encodeURIComponent(id)}`);
+  return data;
+}
+
+/**
+ * Get all audit log entries sharing a distributed-tracing correlation ID.
+ *
+ * Returns full detail entries (with entity changes), ordered newest-first.
+ * Not paginated — the backend returns the complete correlated set.
+ *
+ * `GET {basePath}/correlation/{correlationId}`
+ */
+export async function getAuditEntriesByCorrelationId(
+  client: AxiosInstance,
+  basePath: string,
+  correlationId: string
+): Promise<readonly AuditEntryDetail[]> {
+  const { data } = await client.get<readonly AuditEntryDetail[]>(
+    `${basePath}/correlation/${encodeURIComponent(correlationId)}`
+  );
   return data;
 }
 

--- a/packages/@granit/auditing/src/index.ts
+++ b/packages/@granit/auditing/src/index.ts
@@ -12,6 +12,8 @@ export type {
   AuditEntryDetail,
   AuditEntryId,
   AuditEntityChange,
+  AuditEntityChangeId,
+  AuditEntityChangeSummary,
   AuditListParams,
   AuditPage,
   AuditPropertyChange,
@@ -21,6 +23,7 @@ export type {
 export {
   listAuditLogEntries,
   getAuditLogEntry,
+  getAuditEntriesByCorrelationId,
   listEntityAuditTrail,
   pseudonymizeUserAuditLogs,
 } from './api/audit-log-api';

--- a/packages/@granit/auditing/src/types/index.ts
+++ b/packages/@granit/auditing/src/types/index.ts
@@ -11,6 +11,7 @@ export const AuditCategory = {
   ConfigurationChange: 'ConfigurationChange',
   DataAccess: 'DataAccess',
   AccessDenied: 'AccessDenied',
+  PrivilegedAccess: 'PrivilegedAccess',
 } as const;
 
 export type AuditCategoryValue = (typeof AuditCategory)[keyof typeof AuditCategory];
@@ -27,6 +28,9 @@ export type AuditChangeTypeValue = (typeof AuditChangeType)[keyof typeof AuditCh
 
 /** Branded audit entry identifier. */
 export type AuditEntryId = EntityId<'AuditEntry'>;
+
+/** Branded audit entity-change identifier. */
+export type AuditEntityChangeId = EntityId<'AuditEntityChange'>;
 
 /** Property-level change within an entity. */
 export type AuditPropertyChange = {
@@ -69,7 +73,17 @@ export type AuditEntryDetail = {
   readonly entityChanges: readonly AuditEntityChange[];
 };
 
-/** Query parameters for listing audit log entries — mirrors `AuditingQueryParameters`. */
+/**
+ * Flat query parameters for the legacy audit list call.
+ *
+ * @deprecated The audit list endpoint (`GET /audit-entries`) is a Granit
+ * QueryEngine endpoint (`MapGranitQuery<AuditEntry>`), so flat filter params
+ * (`category`, `userId`, `from`, `to`, …) are ignored by the backend binder —
+ * only `page`/`pageSize` are honored. Use the QueryEngine surface instead:
+ * `useAuditEntries()` (from `@granit/react-auditing`) or `getPage<AuditEntry>()`
+ * (from `@granit/query-engine`), which serialize filters as `filter[field.op]=value`.
+ * There is no `AuditingQueryParameters` DTO on the backend.
+ */
 export type AuditListParams = PaginationParams & {
   readonly userId?: string;
   readonly entityType?: string;
@@ -77,6 +91,16 @@ export type AuditListParams = PaginationParams & {
   readonly category?: AuditCategoryValue;
   readonly from?: ISODateString;
   readonly to?: ISODateString;
+};
+
+/** Summary projection of an entity change — mirrors `AuditEntityChangeSummaryResponse`. */
+export type AuditEntityChangeSummary = {
+  readonly id: AuditEntityChangeId;
+  readonly auditEntryId: AuditEntryId;
+  readonly entityType: string;
+  readonly entityId: string;
+  readonly changeType: AuditChangeTypeValue;
+  readonly propertyChangeCount: number;
 };
 
 /** Paginated response for audit log entries. */

--- a/packages/@granit/react-auditing/package.json
+++ b/packages/@granit/react-auditing/package.json
@@ -32,12 +32,6 @@
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
-    "@granit/query-engine": {
-      "optional": true
-    },
-    "@granit/react-query-engine": {
-      "optional": true
-    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
@@ -1,7 +1,14 @@
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { auditEntryQueryMetadata, createAuditHandlers } from '../testing/index';
+import {
+  auditEntityChangeQueryMetadata,
+  auditEntryQueryMetadata,
+  createAuditEntityChangesHandlers,
+  createAuditHandlers,
+} from '../testing/index';
+
+import type { AuditEntryDetail, AuditPage } from '@granit/auditing';
 
 const BASE = 'http://api.test/api/v1/auditing';
 const server = setupServer();
@@ -10,11 +17,87 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('createAuditHandlers /meta', () => {
-  it('responds with auditEntryQueryMetadata at /audit-entries/meta', async () => {
+describe('createAuditHandlers — audit-entries', () => {
+  it('serves query metadata at /audit-entries/meta', async () => {
     server.use(...createAuditHandlers(BASE));
     const response = await fetch(`${BASE}/audit-entries/meta`);
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(auditEntryQueryMetadata);
+  });
+
+  it('lists entries newest-first', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries?page=1&pageSize=25`);
+    const page = (await response.json()) as AuditPage;
+    expect(page.totalCount).toBe(10);
+    expect(page.items.length).toBe(10);
+    // Newest first: timestamps are already in descending order.
+    const timestamps = page.items.map((e) => e.timestamp as string);
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => b.localeCompare(a)));
+  });
+
+  it('filters by query-engine category filter', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries?filter[category.eq]=ConfigurationChange`);
+    const page = (await response.json()) as AuditPage;
+    expect(page.totalCount).toBe(3);
+    expect(page.items.every((e) => e.category === 'ConfigurationChange')).toBe(true);
+  });
+
+  it('returns a detail entry without entityChangeCount', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries/audit-001`);
+    expect(response.status).toBe(200);
+    const detail = (await response.json()) as AuditEntryDetail & { entityChangeCount?: number };
+    expect(detail.entityChangeCount).toBeUndefined();
+    expect(detail.entityChanges.length).toBeGreaterThan(0);
+  });
+
+  it('returns 404 for an unknown detail id', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries/does-not-exist`);
+    expect(response.status).toBe(404);
+  });
+
+  it('returns correlated detail entries', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries/correlation/corr-1`);
+    const details = (await response.json()) as AuditEntryDetail[];
+    expect(Array.isArray(details)).toBe(true);
+    expect(details.length).toBe(2);
+    expect(details[0]).toHaveProperty('entityChanges');
+  });
+
+  it('returns a per-entity audit trail page', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries/entity/User/user-001`);
+    const page = (await response.json()) as AuditPage;
+    expect(page.totalCount).toBe(10);
+  });
+
+  it('responds 204 to pseudonymize', async () => {
+    server.use(...createAuditHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entries/pseudonymize/user-1`, { method: 'POST' });
+    expect(response.status).toBe(204);
+  });
+});
+
+describe('createAuditEntityChangesHandlers — audit-entity-changes', () => {
+  it('serves query metadata at /audit-entity-changes/meta', async () => {
+    server.use(...createAuditEntityChangesHandlers(BASE));
+    const response = await fetch(`${BASE}/audit-entity-changes/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(auditEntityChangeQueryMetadata);
+  });
+
+  it('lists entity changes and filters by entityType', async () => {
+    server.use(...createAuditEntityChangesHandlers(BASE));
+    const all = await (await fetch(`${BASE}/audit-entity-changes`)).json();
+    expect(all.totalCount).toBe(3);
+
+    const filtered = await (
+      await fetch(`${BASE}/audit-entity-changes?filter[entityType.eq]=User`)
+    ).json();
+    expect(filtered.totalCount).toBe(2);
   });
 });

--- a/packages/@granit/react-auditing/src/__tests__/use-audit-query-engine.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/use-audit-query-engine.test.tsx
@@ -1,0 +1,115 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useAuditEntityChanges } from '../hooks/use-audit-entity-changes';
+import {
+  useAuditEntries,
+  useAuditEntriesByCorrelation,
+  usePseudonymizeUserAuditLogs,
+} from '../hooks/use-audit-log';
+import { AuditEntityChangesProvider } from '../providers/audit-entity-changes-provider';
+import { AuditLogProvider } from '../providers/audit-log-provider';
+
+import type { AuditEntryDetail, AuditPage } from '@granit/auditing';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const emptyPage: AuditPage = { items: [], totalCount: 0, hasMore: false, nextCursor: null };
+
+function auditWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuditLogProvider config={{ client, basePath: '/api/v1/auditing' }}>
+          {children}
+        </AuditLogProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function changesWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <AuditEntityChangesProvider client={client} basePath="/api/v1/auditing">
+          {children}
+        </AuditEntityChangesProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useAuditEntries (query engine)', () => {
+  it('fetches a page from the audit-entries query endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(emptyPage));
+
+    const { result } = renderHook(() => useAuditEntries(), { wrapper: auditWrapper(client) });
+
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+    expect(result.current.query.data).toEqual(emptyPage);
+    expect(client.get).toHaveBeenCalled();
+    const url = String(vi.mocked(client.get).mock.calls[0]?.[0]);
+    expect(url).toMatch(/^\/api\/v1\/auditing\/audit-entries/);
+  });
+});
+
+describe('useAuditEntityChanges (query engine)', () => {
+  it('fetches a page from the audit-entity-changes query endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(emptyPage));
+
+    const { result } = renderHook(() => useAuditEntityChanges(), {
+      wrapper: changesWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.query.isSuccess).toBe(true));
+    const url = String(vi.mocked(client.get).mock.calls[0]?.[0]);
+    expect(url).toMatch(/^\/api\/v1\/auditing\/audit-entity-changes/);
+  });
+});
+
+describe('useAuditEntriesByCorrelation', () => {
+  it('fetches correlated detail entries', async () => {
+    const client = createMockClient();
+    const details: AuditEntryDetail[] = [];
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(details));
+
+    const { result } = renderHook(() => useAuditEntriesByCorrelation('corr-1'), {
+      wrapper: auditWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/audit-entries/correlation/corr-1');
+  });
+
+  it('does not fetch when correlationId is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useAuditEntriesByCorrelation(''), {
+      wrapper: auditWrapper(client),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+  });
+});
+
+describe('usePseudonymizeUserAuditLogs', () => {
+  it('posts to the pseudonymize endpoint', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => usePseudonymizeUserAuditLogs(), {
+      wrapper: auditWrapper(client),
+    });
+
+    await result.current.mutateAsync('user-1');
+
+    expect(client.post).toHaveBeenCalledWith('/api/v1/auditing/audit-entries/pseudonymize/user-1');
+  });
+});

--- a/packages/@granit/react-auditing/src/hooks/use-audit-entity-changes.ts
+++ b/packages/@granit/react-auditing/src/hooks/use-audit-entity-changes.ts
@@ -1,0 +1,27 @@
+import { useQueryEndpoint } from '@granit/react-query-engine';
+
+import type { AuditEntityChangeSummary } from '@granit/auditing';
+import type { UseQueryEndpointOptions, UseQueryEndpointReturn } from '@granit/react-query-engine';
+
+/**
+ * QueryEngine endpoint for audit entity changes ({@link AuditEntityChangeSummary}),
+ * backed by the `MapGranitQuery<AuditEntityChange>()` group of
+ * `Granit.Auditing.Endpoints`. Cross-cutting view over every recorded entity
+ * change (the per-property diff lives on the parent {@link AuditEntryDetail}).
+ *
+ * Must be used within an {@link AuditEntityChangesProvider}.
+ *
+ * @example
+ * ```tsx
+ * const changes = useAuditEntityChanges();
+ * changes.addFilter({ field: 'entityType', operator: 'Eq', value: 'Patient' });
+ * ```
+ */
+export function useAuditEntityChanges(
+  options?: UseQueryEndpointOptions
+): UseQueryEndpointReturn<AuditEntityChangeSummary> {
+  return useQueryEndpoint<AuditEntityChangeSummary>(options);
+}
+
+/** Query metadata for the audit entity-changes surface. */
+export { useQueryMeta as useAuditEntityChangesMeta } from '@granit/react-query-engine';

--- a/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
+++ b/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
@@ -1,19 +1,53 @@
 import {
+  getAuditEntriesByCorrelationId,
   getAuditLogEntry,
   listAuditLogEntries,
   listEntityAuditTrail,
   pseudonymizeUserAuditLogs,
 } from '@granit/auditing';
+import { useQueryEndpoint } from '@granit/react-query-engine';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { buildAuditLogQueryKey, useAuditLogConfig } from '../providers/audit-log-provider';
 
-import type { AuditEntryDetail, AuditListParams, AuditPage } from '@granit/auditing';
+import type { AxiosError, ProblemDetails } from '@granit/api-client';
+import type { AuditEntry, AuditEntryDetail, AuditListParams, AuditPage } from '@granit/auditing';
 import type { PaginationParams } from '@granit/query-engine';
+import type { UseQueryEndpointOptions, UseQueryEndpointReturn } from '@granit/react-query-engine';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /**
+ * QueryEngine endpoint for audit entries ({@link AuditEntry}), backed by the
+ * `MapGranitQuery<AuditEntry>()` group of `Granit.Auditing.Endpoints`. Exposes
+ * pagination / search / filter / sort / group-by dispatchers and the paged
+ * (or grouped) result. Filters are serialized as `filter[field.op]=value`, so
+ * they are honored by the backend (unlike the deprecated {@link useAuditLogEntries}).
+ *
+ * Must be used within an {@link AuditLogProvider}.
+ *
+ * @example
+ * ```tsx
+ * const audit = useAuditEntries();
+ * audit.addFilter({ field: 'category', operator: 'Eq', value: 'DataMutation' });
+ * audit.query.data?.items.map((e) => e.userName);
+ * ```
+ */
+export function useAuditEntries(
+  options?: UseQueryEndpointOptions
+): UseQueryEndpointReturn<AuditEntry> {
+  return useQueryEndpoint<AuditEntry>(options);
+}
+
+/** Query metadata (columns, filterable/sortable/group-by fields) for the audit-entries surface. */
+export { useQueryMeta as useAuditEntriesMeta } from '@granit/react-query-engine';
+
+/**
  * List paginated audit log entries with optional filters.
+ *
+ * @deprecated The list endpoint is a QueryEngine endpoint, so the flat filter
+ * params (`category`, `userId`, `from`, `to`, …) are ignored by the backend —
+ * only `page`/`pageSize` take effect. Use {@link useAuditEntries} instead, which
+ * serializes filters in the format the backend understands.
  *
  * @example
  * ```tsx
@@ -22,8 +56,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
  */
 export function useAuditLogEntries(params?: AuditListParams): UseQueryResult<AuditPage> {
   const config = useAuditLogConfig();
-  const basePath = config.basePath;
-  const auditEntriesPath = `${basePath}/audit-entries`;
+  const auditEntriesPath = `${config.basePath}/audit-entries`;
 
   return useQuery({
     queryKey: buildAuditLogQueryKey(config, 'list', params),
@@ -41,8 +74,7 @@ export function useAuditLogEntries(params?: AuditListParams): UseQueryResult<Aud
  */
 export function useAuditLogEntry(id: string): UseQueryResult<AuditEntryDetail> {
   const config = useAuditLogConfig();
-  const basePath = config.basePath;
-  const auditEntriesPath = `${basePath}/audit-entries`;
+  const auditEntriesPath = `${config.basePath}/audit-entries`;
 
   return useQuery({
     queryKey: buildAuditLogQueryKey(config, 'detail', id),
@@ -65,8 +97,7 @@ export function useEntityAuditTrail(
   params?: PaginationParams
 ): UseQueryResult<AuditPage> {
   const config = useAuditLogConfig();
-  const basePath = config.basePath;
-  const auditEntriesPath = `${basePath}/audit-entries`;
+  const auditEntriesPath = `${config.basePath}/audit-entries`;
 
   return useQuery({
     queryKey: buildAuditLogQueryKey(config, 'entity', entityType, entityId, params),
@@ -77,11 +108,35 @@ export function useEntityAuditTrail(
 }
 
 /**
+ * Get all audit entries sharing a distributed-tracing correlation ID.
+ *
+ * Returns full detail entries (with entity changes), newest-first — useful for
+ * tracing a single logical transaction across services.
+ *
+ * @example
+ * ```tsx
+ * const { data: related } = useAuditEntriesByCorrelation(correlationId);
+ * ```
+ */
+export function useAuditEntriesByCorrelation(
+  correlationId: string
+): UseQueryResult<readonly AuditEntryDetail[]> {
+  const config = useAuditLogConfig();
+  const auditEntriesPath = `${config.basePath}/audit-entries`;
+
+  return useQuery({
+    queryKey: buildAuditLogQueryKey(config, 'correlation', correlationId),
+    queryFn: () => getAuditEntriesByCorrelationId(config.client, auditEntriesPath, correlationId),
+    enabled: correlationId.length > 0,
+  });
+}
+
+/**
  * Pseudonymize all audit entries for a specific user (GDPR Art. 17).
  *
  * Replaces personal data with a SHA-256 hash to preserve audit trail
  * correlation without re-identification. Invalidates the cached audit log
- * list on success.
+ * queries (QueryEngine list + custom lookups) on success.
  *
  * @example
  * ```tsx
@@ -89,17 +144,25 @@ export function useEntityAuditTrail(
  * await pseudonymize.mutateAsync(userId);
  * ```
  */
-export function usePseudonymizeUserAuditLogs(): UseMutationResult<void, Error, string> {
+export function usePseudonymizeUserAuditLogs(): UseMutationResult<
+  void,
+  AxiosError<ProblemDetails>,
+  string
+> {
   const config = useAuditLogConfig();
-  const basePath = config.basePath;
-  const auditEntriesPath = `${basePath}/audit-entries`;
+  const auditEntriesPath = `${config.basePath}/audit-entries`;
   const queryClient = useQueryClient();
 
-  return useMutation({
+  return useMutation<void, AxiosError<ProblemDetails>, string>({
     mutationFn: (userId: string) =>
       pseudonymizeUserAuditLogs(config.client, auditEntriesPath, userId),
     onSuccess: () => {
+      // Custom-lookup hooks (detail / entity / correlation / deprecated list).
       queryClient.invalidateQueries({ queryKey: buildAuditLogQueryKey(config) });
+      // QueryEngine list/meta cache (keyed by the audit-entries path segments).
+      queryClient.invalidateQueries({
+        queryKey: auditEntriesPath.split('/').filter(Boolean),
+      });
     },
   });
 }

--- a/packages/@granit/react-auditing/src/index.ts
+++ b/packages/@granit/react-auditing/src/index.ts
@@ -2,14 +2,23 @@
 // @granit/react-auditing — public API
 // ---------------------------------------------------------------------------
 
-// Provider
+// Providers
 export { AuditLogProvider, useAuditLogConfig } from './providers/audit-log-provider';
 export type { AuditLogConfig, AuditLogProviderProps } from './providers/audit-log-provider';
+export { AuditEntityChangesProvider } from './providers/audit-entity-changes-provider';
+export type { AuditEntityChangesProviderProps } from './providers/audit-entity-changes-provider';
 
-// Hooks
+// QueryEngine hooks (audit-entries list/meta)
+export { useAuditEntries, useAuditEntriesMeta } from './hooks/use-audit-log';
+
+// QueryEngine hooks (audit-entity-changes list/meta)
+export { useAuditEntityChanges, useAuditEntityChangesMeta } from './hooks/use-audit-entity-changes';
+
+// Custom-lookup hooks
 export {
   useAuditLogEntries,
   useAuditLogEntry,
+  useAuditEntriesByCorrelation,
   useEntityAuditTrail,
   usePseudonymizeUserAuditLogs,
 } from './hooks/use-audit-log';

--- a/packages/@granit/react-auditing/src/providers/audit-entity-changes-provider.tsx
+++ b/packages/@granit/react-auditing/src/providers/audit-entity-changes-provider.tsx
@@ -1,0 +1,48 @@
+// ---------------------------------------------------------------------------
+// AuditEntityChangesProvider — wires the QueryEngine endpoint for the
+// `MapGranitQuery<AuditEntityChange>()` group of Granit.Auditing.Endpoints
+// (cross-cutting entity-change analysis, mounted at `{basePath}/audit-entity-changes`).
+// ---------------------------------------------------------------------------
+
+import { QueryProvider } from '@granit/react-query-engine';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+export interface AuditEntityChangesProviderProps {
+  /**
+   * Axios client. Optional when a `GranitClientProvider` from
+   * `@granit/react-api-client` sits higher in the tree — the query-engine
+   * resolves the client from context.
+   */
+  readonly client?: AxiosInstance;
+  /** Base path of the audit module. Defaults to `/api/v1/auditing`. */
+  readonly basePath?: string;
+  readonly children: ReactNode;
+}
+
+/**
+ * Provides the audit entity-changes query surface to
+ * {@link useAuditEntityChanges} / `useAuditEntityChangesMeta`.
+ *
+ * ```tsx
+ * <AuditEntityChangesProvider>
+ *   <AuditEntityChangesTable />
+ * </AuditEntityChangesProvider>
+ * ```
+ */
+export function AuditEntityChangesProvider({
+  client,
+  basePath,
+  children,
+}: Readonly<AuditEntityChangesProviderProps>) {
+  return (
+    <QueryProvider
+      config={{ client, basePath: `${basePath ?? DEFAULT_BASE_PATH}/audit-entity-changes` }}
+    >
+      {children}
+    </QueryProvider>
+  );
+}

--- a/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
+++ b/packages/@granit/react-auditing/src/providers/audit-log-provider.tsx
@@ -1,9 +1,11 @@
 import { useOptionalGranitClient } from '@granit/react-api-client';
+import { QueryProvider } from '@granit/react-query-engine';
 import { createContext, useContext, useMemo } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
+import type { QueryConfig } from '@granit/query-engine';
 import type { ReactNode } from 'react';
 
 /** Configuration for the audit log provider. */
@@ -32,10 +34,18 @@ const AuditLogConfigContext = createContext<ResolvedAuditLogConfig | null>(null)
 
 const DEFAULT_QUERY_KEY_PREFIX = ['audit-log'] as const;
 
-/** Provides audit log configuration to child components and hooks. */
+/**
+ * Provides audit log configuration to child components and hooks.
+ *
+ * Wires two surfaces under `{basePath}/audit-entries`:
+ * - the QueryEngine list/meta (consumed by {@link useAuditEntries} /
+ *   `useAuditEntriesMeta`) via an inner `<QueryProvider>`;
+ * - the custom lookups (detail, entity trail, correlation) and GDPR
+ *   pseudonymization, consumed via {@link useAuditLogConfig}.
+ */
 export function AuditLogProvider({ config, children }: Readonly<AuditLogProviderProps>) {
   const contextClient = useOptionalGranitClient();
-  const value = useMemo(() => {
+  const value = useMemo<ResolvedAuditLogConfig>(() => {
     const client = config.client ?? contextClient;
     if (!client) {
       throw new Error(
@@ -48,7 +58,17 @@ export function AuditLogProvider({ config, children }: Readonly<AuditLogProvider
       client,
     };
   }, [config, contextClient]);
-  return <AuditLogConfigContext value={value}>{children}</AuditLogConfigContext>;
+
+  const queryConfig = useMemo<QueryConfig>(
+    () => ({ client: value.client, basePath: `${value.basePath}/audit-entries` }),
+    [value]
+  );
+
+  return (
+    <AuditLogConfigContext value={value}>
+      <QueryProvider config={queryConfig}>{children}</QueryProvider>
+    </AuditLogConfigContext>
+  );
 }
 
 /** Returns the audit log configuration from the nearest `AuditLogProvider`. */

--- a/packages/@granit/react-auditing/src/testing/data.ts
+++ b/packages/@granit/react-auditing/src/testing/data.ts
@@ -1,4 +1,4 @@
-import type { AuditEntry } from '@granit/auditing';
+import type { AuditEntityChangeSummary, AuditEntry } from '@granit/auditing';
 import type { Mutable } from '@granit/testing';
 
 export const mockAuditEntries: Mutable<AuditEntry>[] = [
@@ -71,7 +71,9 @@ export const mockAuditEntries: Mutable<AuditEntry>[] = [
   {
     id: 'audit-007' as AuditEntry['id'],
     timestamp: '2026-02-24T11:00:00Z' as AuditEntry['timestamp'],
-    userId: null as unknown as AuditEntry['userId'],
+    // System-initiated entry: backend UserId is a non-nullable string (string.Empty
+    // for system actors), only UserName is null. Never null on the wire.
+    userId: 'system' as AuditEntry['userId'],
     userName: null,
     category: 'DataAccess',
     ipAddress: '10.0.4.1',
@@ -111,5 +113,33 @@ export const mockAuditEntries: Mutable<AuditEntry>[] = [
     tenantId: null,
     correlationId: null,
     entityChangeCount: 1,
+  },
+];
+
+/** Mock entity-change summaries for the `audit-entity-changes` query resource. */
+export const mockAuditEntityChanges: Mutable<AuditEntityChangeSummary>[] = [
+  {
+    id: 'change-001' as AuditEntityChangeSummary['id'],
+    auditEntryId: 'audit-001' as AuditEntityChangeSummary['auditEntryId'],
+    entityType: 'User',
+    entityId: 'user-001',
+    changeType: 'Modified',
+    propertyChangeCount: 2,
+  },
+  {
+    id: 'change-002' as AuditEntityChangeSummary['id'],
+    auditEntryId: 'audit-002' as AuditEntityChangeSummary['auditEntryId'],
+    entityType: 'Tenant',
+    entityId: 'tenant-007',
+    changeType: 'Created',
+    propertyChangeCount: 5,
+  },
+  {
+    id: 'change-003' as AuditEntityChangeSummary['id'],
+    auditEntryId: 'audit-005' as AuditEntityChangeSummary['auditEntryId'],
+    entityType: 'User',
+    entityId: 'user-001',
+    changeType: 'SoftDeleted',
+    propertyChangeCount: 1,
   },
 ];

--- a/packages/@granit/react-auditing/src/testing/handlers.ts
+++ b/packages/@granit/react-auditing/src/testing/handlers.ts
@@ -1,32 +1,32 @@
-import {
-  DATE_OPERATORS,
-  ENUM_OPERATORS,
-  NUMBER_OPERATORS,
-  STRING_OPERATORS,
-} from '@granit/query-engine';
+import { AuditCategory, AuditChangeType } from '@granit/auditing';
+import { ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { notFound, pagedResponse } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import { mockAuditEntries } from './data';
+import { mockAuditEntityChanges, mockAuditEntries } from './data';
 
-import type { AuditEntry, AuditEntryDetail } from '@granit/auditing';
+import type { AuditEntityChangeSummary, AuditEntry, AuditEntryDetail } from '@granit/auditing';
 import type { QueryMetadata } from '@granit/query-engine';
 
-const AUDIT_CATEGORIES = ['DataMutation', 'ConfigurationChange', 'DataAccess', 'AccessDenied'];
+const AUDIT_CATEGORIES = Object.values(AuditCategory);
+const CHANGE_TYPES = Object.values(AuditChangeType);
 
-/** Mock /meta payload for the audit-entries resource. */
+/**
+ * Mock `/meta` payload for the audit-entries resource.
+ * Mirrors `Granit.Auditing.Queries.AuditEntryQueryDefinition`.
+ */
 export const auditEntryQueryMetadata: QueryMetadata = {
   columns: [
     {
-      name: 'id',
-      label: 'ID',
+      name: 'tenantId',
+      label: 'Tenant',
       type: 'Guid',
       order: 0,
-      isSortable: false,
-      isFilterable: false,
+      isSortable: true,
+      isFilterable: true,
       isVisible: false,
     },
     {
@@ -35,12 +35,12 @@ export const auditEntryQueryMetadata: QueryMetadata = {
       type: 'DateTime',
       order: 1,
       isSortable: true,
-      isFilterable: true,
+      isFilterable: false,
       isVisible: true,
     },
     {
-      name: 'userName',
-      label: 'User',
+      name: 'category',
+      label: 'Category',
       type: 'String',
       order: 2,
       isSortable: true,
@@ -48,31 +48,31 @@ export const auditEntryQueryMetadata: QueryMetadata = {
       isVisible: true,
     },
     {
-      name: 'category',
-      label: 'Category',
+      name: 'userId',
+      label: 'User ID',
       type: 'String',
       order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'userName',
+      label: 'User Name',
+      type: 'String',
+      order: 4,
       isSortable: true,
       isFilterable: true,
       isVisible: true,
     },
     {
       name: 'ipAddress',
-      label: 'IP address',
+      label: 'IP Address',
       type: 'String',
-      order: 4,
-      isSortable: false,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'tenantId',
-      label: 'Tenant',
-      type: 'Guid',
       order: 5,
       isSortable: false,
       isFilterable: true,
-      isVisible: false,
+      isVisible: true,
     },
     {
       name: 'correlationId',
@@ -83,33 +83,21 @@ export const auditEntryQueryMetadata: QueryMetadata = {
       isFilterable: true,
       isVisible: false,
     },
-    {
-      name: 'entityChangeCount',
-      label: 'Changes',
-      type: 'Int32',
-      order: 7,
-      isSortable: true,
-      isFilterable: false,
-      isVisible: true,
-    },
   ],
   filterableFields: [
-    { name: 'timestamp', type: 'DateTime', operators: DATE_OPERATORS },
-    { name: 'userName', type: 'String', operators: STRING_OPERATORS },
-    { name: 'userId', type: 'Guid', operators: ENUM_OPERATORS },
-    { name: 'category', type: 'String', operators: ENUM_OPERATORS, enumValues: AUDIT_CATEGORIES },
-    { name: 'ipAddress', type: 'String', operators: STRING_OPERATORS },
-    { name: 'entityType', type: 'String', operators: STRING_OPERATORS },
-    { name: 'entityId', type: 'String', operators: STRING_OPERATORS },
     { name: 'tenantId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'category', type: 'String', operators: ENUM_OPERATORS, enumValues: AUDIT_CATEGORIES },
+    { name: 'userId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'userName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'ipAddress', type: 'String', operators: STRING_OPERATORS },
     { name: 'correlationId', type: 'String', operators: STRING_OPERATORS },
-    { name: 'entityChangeCount', type: 'Int32', operators: NUMBER_OPERATORS },
   ],
   sortableFields: [
+    { name: 'tenantId' },
     { name: 'timestamp' },
-    { name: 'userName' },
     { name: 'category' },
-    { name: 'entityChangeCount' },
+    { name: 'userId' },
+    { name: 'userName' },
   ],
   presetFilterGroups: [],
   quickFilters: [],
@@ -128,12 +116,9 @@ export const auditEntryQueryMetadata: QueryMetadata = {
       ],
     },
   ],
-  groupByFields: [
-    { name: 'category', type: 'String' },
-    { name: 'userName', type: 'String' },
-  ],
+  groupByFields: [],
   pagination: {
-    defaultPageSize: 20,
+    defaultPageSize: 25,
     maxPageSize: 100,
     maxStreamSize: 50_000,
     supportsCursor: false,
@@ -142,7 +127,94 @@ export const auditEntryQueryMetadata: QueryMetadata = {
 };
 
 /**
- * Create stateful MSW handlers for audit log endpoints.
+ * Mock `/meta` payload for the audit-entity-changes resource.
+ * Mirrors `Granit.Auditing.Queries.AuditEntityChangeQueryDefinition`.
+ */
+export const auditEntityChangeQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'auditEntryId',
+      label: 'Audit Entry ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'entityType',
+      label: 'Entity Type',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'entityId',
+      label: 'Entity ID',
+      type: 'String',
+      order: 2,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'changeType',
+      label: 'Change Type',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'auditEntryId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'entityType', type: 'String', operators: STRING_OPERATORS },
+    { name: 'entityId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'changeType', type: 'String', operators: ENUM_OPERATORS, enumValues: CHANGE_TYPES },
+  ],
+  sortableFields: [{ name: 'auditEntryId' }, { name: 'entityType' }, { name: 'changeType' }],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-auditEntryId',
+};
+
+/** Builds an {@link AuditEntryDetail} from a summary entry (drops `entityChangeCount`). */
+function toDetail(entry: AuditEntry): AuditEntryDetail {
+  return {
+    id: entry.id,
+    timestamp: entry.timestamp,
+    userId: entry.userId,
+    userName: entry.userName,
+    category: entry.category,
+    ipAddress: entry.ipAddress,
+    tenantId: entry.tenantId,
+    correlationId: entry.correlationId,
+    entityChanges: [
+      {
+        entityType: 'User',
+        entityId: 'user-001',
+        changeType: 'Modified',
+        propertyChanges: [
+          { propertyName: 'email', originalValue: 'old@test.com', newValue: 'new@test.com' },
+        ],
+      },
+    ],
+  };
+}
+
+/**
+ * Create stateful MSW handlers for the audit-entries endpoints.
  *
  * @param baseUrl - API base path (default: `/api/v1/auditing`)
  */
@@ -152,45 +224,84 @@ export function createAuditHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // GET /audit-entries/meta — query metadata
     createQueryMetaHandler(auditEntriesUrl, auditEntryQueryMetadata),
 
-    // GET list — filtered, sorted newest-first, paginated
+    // GET /audit-entries — query-engine list (filtered by `filter[category.eq]`, sorted newest-first)
     http.get(auditEntriesUrl, ({ request }) => {
       const url = new URL(request.url);
       const page = Number(url.searchParams.get('page') ?? 1);
-      const pageSize = Number(url.searchParams.get('pageSize') ?? 20);
-      const category = url.searchParams.get('category');
+      const pageSize = Number(url.searchParams.get('pageSize') ?? 25);
+      // QueryEngine serializes filters as `filter[field.op]=value`.
+      const category =
+        url.searchParams.get('filter[category.eq]') ?? url.searchParams.get('category');
 
       let filtered: AuditEntry[] = [...mockAuditEntries];
-
       if (category) {
         filtered = filtered.filter((e) => e.category === category);
       }
-
-      // Default sort: newest first
       filtered.sort((a, b) => (b.timestamp as string).localeCompare(a.timestamp as string));
 
       const start = (page - 1) * pageSize;
       return pagedResponse<AuditEntry>(filtered.slice(start, start + pageSize), filtered.length);
     }),
 
-    // GET single entry detail
+    // GET /audit-entries/entity/:entityType/:entityId — per-entity audit trail
+    http.get(`${auditEntriesUrl}/entity/:entityType/:entityId`, ({ request }) => {
+      const url = new URL(request.url);
+      const page = Number(url.searchParams.get('page') ?? 1);
+      const pageSize = Number(url.searchParams.get('pageSize') ?? 25);
+      const start = (page - 1) * pageSize;
+      return pagedResponse<AuditEntry>(
+        mockAuditEntries.slice(start, start + pageSize),
+        mockAuditEntries.length
+      );
+    }),
+
+    // GET /audit-entries/correlation/:correlationId — correlated detail set
+    http.get(`${auditEntriesUrl}/correlation/:correlationId`, () =>
+      HttpResponse.json(mockAuditEntries.slice(0, 2).map(toDetail))
+    ),
+
+    // POST /audit-entries/pseudonymize/:userId — GDPR pseudonymization (204)
+    http.post(
+      `${auditEntriesUrl}/pseudonymize/:userId`,
+      () => new HttpResponse(null, { status: 204 })
+    ),
+
+    // GET /audit-entries/:id — single entry detail
     http.get(`${auditEntriesUrl}/:id`, ({ params }) => {
       const entry = mockAuditEntries.find((e) => e.id === params.id);
       if (!entry) return notFound();
+      return HttpResponse.json(toDetail(entry));
+    }),
+  ];
+}
 
-      const detail: AuditEntryDetail = {
-        ...entry,
-        entityChanges: [
-          {
-            entityType: 'User',
-            entityId: 'user-001',
-            changeType: 'Modified',
-            propertyChanges: [
-              { propertyName: 'email', originalValue: 'old@test.com', newValue: 'new@test.com' },
-            ],
-          },
-        ],
-      };
-      return HttpResponse.json(detail);
+/**
+ * Create stateful MSW handlers for the audit-entity-changes query endpoints.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/auditing`)
+ */
+export function createAuditEntityChangesHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  const changesUrl = `${baseUrl}/audit-entity-changes`;
+  return [
+    createQueryMetaHandler(changesUrl, auditEntityChangeQueryMetadata),
+
+    http.get(changesUrl, ({ request }) => {
+      const url = new URL(request.url);
+      const page = Number(url.searchParams.get('page') ?? 1);
+      const pageSize = Number(url.searchParams.get('pageSize') ?? 25);
+      const entityType =
+        url.searchParams.get('filter[entityType.eq]') ?? url.searchParams.get('entityType');
+
+      let filtered: AuditEntityChangeSummary[] = [...mockAuditEntityChanges];
+      if (entityType) {
+        filtered = filtered.filter((c) => c.entityType === entityType);
+      }
+
+      const start = (page - 1) * pageSize;
+      return pagedResponse<AuditEntityChangeSummary>(
+        filtered.slice(start, start + pageSize),
+        filtered.length
+      );
     }),
   ];
 }

--- a/packages/@granit/react-auditing/src/testing/index.ts
+++ b/packages/@granit/react-auditing/src/testing/index.ts
@@ -2,5 +2,10 @@
 // @granit/react-auditing/testing — Mock data & MSW handlers
 // ---------------------------------------------------------------------------
 
-export { mockAuditEntries } from './data';
-export { auditEntryQueryMetadata, createAuditHandlers } from './handlers';
+export { mockAuditEntries, mockAuditEntityChanges } from './data';
+export {
+  auditEntryQueryMetadata,
+  auditEntityChangeQueryMetadata,
+  createAuditHandlers,
+  createAuditEntityChangesHandlers,
+} from './handlers';


### PR DESCRIPTION
## Context

`/audit` of `@granit/auditing` + `@granit/react-auditing` against `Granit.Auditing` / `Granit.Auditing.Endpoints` surfaced a structural mismatch: the audit **list** endpoint (`GET /audit-entries`) is a `MapGranitQuery<AuditEntry>()` query-engine endpoint, but the front consumed it as a flat-param REST call. Every filter (`category`, `userId`, `from`, `to`, …) was **silently ignored** by the backend binder — only `page`/`pageSize` worked. This adopts the query-engine surface, the same pattern as the recently-aligned `@granit/react-ai` usage module.

## Findings addressed

| Sev | Finding |
| --- | --- |
| BREAKING | List is a query-engine endpoint, consumed as flat-param REST → filters were no-ops |
| BREAKING | `AuditCategory` was missing `PrivilegedAccess` (backend has 5 values, front had 4) |
| GAP | `GET /audit-entries/correlation/{id}` had no front function/hook |
| GAP | `audit-entity-changes` query resource (`MapGranitQuery<AuditEntityChange>`) entirely unimplemented |
| GAP | `/meta` not exposed at runtime (mock-only) |
| INCONSISTENCY | `AuditListParams` claimed to mirror a non-existent `AuditingQueryParameters` DTO |
| INCONSISTENCY | Mock `/meta` diverged from the real `AuditEntryQueryDefinition` (fake filterable/group-by fields, wrong page size) |
| CLEANUP | Mock detail leaked `entityChangeCount`; mock data fabricated a `null` userId (backend `UserId` is non-nullable) |

## Changes

**`@granit/auditing`**
- Add `AuditCategory.PrivilegedAccess`.
- Add `getAuditEntriesByCorrelationId` + `AuditEntityChangeSummary` type.
- Deprecate `listAuditLogEntries` / `AuditListParams`; fix the false "mirrors" comment.

**`@granit/react-auditing`**
- `AuditLogProvider` now wraps `QueryProvider`; add `useAuditEntries` + `useAuditEntriesMeta` (filter-capable list).
- Add `useAuditEntriesByCorrelation`; pseudonymize error typed as `AxiosError<ProblemDetails>`, invalidates both cache namespaces.
- Add `AuditEntityChangesProvider` + `useAuditEntityChanges(+Meta)`.
- Deprecate `useAuditLogEntries` (kept for backward compat).
- Testing: `/meta` mocks rebuilt to mirror the real query definitions; add entity-trail / correlation / pseudonymize / entity-changes handlers; drop the `entityChangeCount` leak; fix the impossible `null` userId.
- `@granit/query-engine` + `@granit/react-query-engine` are now required peers.

## Compatibility

**Additive / backward-compatible** — existing consumers keep compiling on the deprecated hooks. The only consumer (`granit-showcase-react`) is unaffected by this PR; migrating its audit page to `useAuditEntries` (which actually fixes the broken category filter) + the missing `Audit.Categories.*` i18n keys is a **follow-up in the showcase repo**.

## Verification

- `tsc --noEmit`: PASS (both packages)
- ESLint (`--max-warnings 0`): PASS
- Vitest: **28 passing** (5 files)