### PR TITLE
fix(background-jobs): align test fixtures with backend contract, drop query-engine ghost

### DIFF
--- a/packages/@granit/background-jobs/src/__tests__/background-jobs-api.test.ts
+++ b/packages/@granit/background-jobs/src/__tests__/background-jobs-api.test.ts
@@ -2,7 +2,13 @@ import { createMockClient } from '@granit/testing';
 import { toISODateString } from '@granit/types';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getBackgroundJob, listBackgroundJobs } from '../api/background-jobs-api';
+import {
+  getBackgroundJob,
+  listBackgroundJobs,
+  pauseJob,
+  resumeJob,
+  triggerJob,
+} from '../api/background-jobs-api';
 
 import type { BackgroundJobStatus } from '../types/index';
 import type { PagedResult } from '@granit/query-engine';
@@ -87,5 +93,43 @@ describe('getBackgroundJob', () => {
     expect(result.isEnabled).toBe(false);
     expect(result.lastError).toBe('Timeout');
     expect(result.consecutiveFailures).toBe(3);
+  });
+});
+
+describe('pauseJob', () => {
+  it('POSTs to /{name}/pause', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+    await pauseJob(client, BASE, 'SendEmails');
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/SendEmails/pause`);
+  });
+
+  it('encodes the job name', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+    await pauseJob(client, BASE, 'Send Emails');
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/Send%20Emails/pause`);
+  });
+});
+
+describe('resumeJob', () => {
+  it('POSTs to /{name}/resume', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+    await resumeJob(client, BASE, 'SendEmails');
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/SendEmails/resume`);
+  });
+});
+
+describe('triggerJob', () => {
+  it('POSTs to /{name}/trigger', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+    await triggerJob(client, BASE, 'SendEmails');
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/SendEmails/trigger`);
   });
 });

--- a/packages/@granit/react-background-jobs/package.json
+++ b/packages/@granit/react-background-jobs/package.json
@@ -19,16 +19,12 @@
     "@granit/background-jobs": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
-    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
     "@granit/query-engine": {
-      "optional": true
-    },
-    "@granit/react-query-engine": {
       "optional": true
     },
     "msw": {

--- a/packages/@granit/react-background-jobs/src/__tests__/background-jobs-provider.test.tsx
+++ b/packages/@granit/react-background-jobs/src/__tests__/background-jobs-provider.test.tsx
@@ -4,7 +4,6 @@ import { describe, expect, it } from 'vitest';
 import { DEFAULT_BASE_PATH } from '../constants';
 import {
   BackgroundJobsProvider,
-  buildBackgroundJobsQueryKey,
   useBackgroundJobsConfig,
 } from '../providers/background-jobs-provider';
 
@@ -42,28 +41,5 @@ describe('BackgroundJobsProvider', () => {
     expect(() => {
       renderHook(() => useBackgroundJobsConfig());
     }).toThrow('useBackgroundJobsConfig must be used within a BackgroundJobsProvider');
-  });
-});
-
-describe('buildBackgroundJobsQueryKey', () => {
-  it('should build key with default prefix', () => {
-    const config: BackgroundJobsConfig = { client: mockClient };
-    const key = buildBackgroundJobsQueryKey(config, 'jobs');
-    expect(key).toEqual(['background-jobs', 'jobs']);
-  });
-
-  it('should build key with custom prefix', () => {
-    const config: BackgroundJobsConfig = {
-      client: mockClient,
-      queryKeyPrefix: ['custom'],
-    };
-    const key = buildBackgroundJobsQueryKey(config, 'jobs');
-    expect(key).toEqual(['custom', 'jobs']);
-  });
-
-  it('should support multiple segments', () => {
-    const config: BackgroundJobsConfig = { client: mockClient };
-    const key = buildBackgroundJobsQueryKey(config, 'jobs', 'active');
-    expect(key).toEqual(['background-jobs', 'jobs', 'active']);
   });
 });

--- a/packages/@granit/react-background-jobs/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-background-jobs/src/__tests__/testing-handlers.test.ts
@@ -1,20 +1,88 @@
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { backgroundJobQueryMetadata, createBackgroundJobHandlers } from '../testing/index';
+import { createBackgroundJobHandlers } from '../testing/index';
+
+import type { BackgroundJobStatus } from '@granit/background-jobs';
+import type { PagedResult } from '@granit/query-engine';
 
 const BASE = 'http://api.test/api/v1/background-jobs';
-const server = setupServer();
+const JOBS = `${BASE}/jobs`;
+const server = setupServer(...createBackgroundJobHandlers(BASE));
 
 beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
-afterEach(() => server.resetHandlers());
+afterEach(() => server.resetHandlers(...createBackgroundJobHandlers(BASE)));
 afterAll(() => server.close());
 
-describe('createBackgroundJobHandlers /meta', () => {
-  it('responds with backgroundJobQueryMetadata at /jobs/meta', async () => {
-    server.use(...createBackgroundJobHandlers(BASE));
-    const response = await fetch(`${BASE}/jobs/meta`);
+describe('createBackgroundJobHandlers — list', () => {
+  it('returns a paginated PagedResult of jobs', async () => {
+    const response = await fetch(`${JOBS}?page=1&pageSize=20`);
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(backgroundJobQueryMetadata);
+
+    const body = (await response.json()) as PagedResult<BackgroundJobStatus>;
+    expect(body.items.length).toBeGreaterThan(0);
+    expect(body.totalCount).toBe(body.items.length);
+    // sorted by jobName ascending
+    expect(body.items[0].jobName).toBe('audit-log-archival');
+  });
+
+  it('honors page/pageSize', async () => {
+    const response = await fetch(`${JOBS}?page=1&pageSize=2`);
+    const body = (await response.json()) as PagedResult<BackgroundJobStatus>;
+    expect(body.items).toHaveLength(2);
+    expect(body.totalCount).toBeGreaterThan(body.items.length);
+  });
+});
+
+describe('createBackgroundJobHandlers — detail', () => {
+  it('returns a single job by name', async () => {
+    const response = await fetch(`${JOBS}/vault-credential-renewal`);
+    expect(response.status).toBe(200);
+    const job = (await response.json()) as BackgroundJobStatus;
+    expect(job.jobName).toBe('vault-credential-renewal');
+  });
+
+  it('returns 404 for an unknown job', async () => {
+    const response = await fetch(`${JOBS}/does-not-exist`);
+    expect(response.status).toBe(404);
+  });
+});
+
+describe('createBackgroundJobHandlers — mutations', () => {
+  it('pause disables the job and clears its next execution', async () => {
+    const pause = await fetch(`${JOBS}/vault-credential-renewal/pause`, { method: 'POST' });
+    expect(pause.status).toBe(204);
+
+    const job = (await (
+      await fetch(`${JOBS}/vault-credential-renewal`)
+    ).json()) as BackgroundJobStatus;
+    expect(job.isEnabled).toBe(false);
+    expect(job.nextExecutionAt).toBeNull();
+  });
+
+  it('resume re-enables the job and schedules a next execution', async () => {
+    await fetch(`${JOBS}/vault-credential-renewal/pause`, { method: 'POST' });
+    const resume = await fetch(`${JOBS}/vault-credential-renewal/resume`, { method: 'POST' });
+    expect(resume.status).toBe(204);
+
+    const job = (await (
+      await fetch(`${JOBS}/vault-credential-renewal`)
+    ).json()) as BackgroundJobStatus;
+    expect(job.isEnabled).toBe(true);
+    expect(job.nextExecutionAt).not.toBeNull();
+  });
+
+  it('trigger returns 202 and resets failure tracking', async () => {
+    const trigger = await fetch(`${JOBS}/keycloak-user-sync/trigger`, { method: 'POST' });
+    expect(trigger.status).toBe(202);
+
+    const job = (await (await fetch(`${JOBS}/keycloak-user-sync`)).json()) as BackgroundJobStatus;
+    expect(job.consecutiveFailures).toBe(0);
+    expect(job.lastError).toBeNull();
+  });
+
+  it('returns 404 when mutating an unknown job', async () => {
+    const response = await fetch(`${JOBS}/does-not-exist/pause`, { method: 'POST' });
+    expect(response.status).toBe(404);
   });
 });

--- a/packages/@granit/react-background-jobs/src/index.ts
+++ b/packages/@granit/react-background-jobs/src/index.ts
@@ -1,7 +1,6 @@
 // Provider
 export {
   BackgroundJobsProvider,
-  buildBackgroundJobsQueryKey,
   useBackgroundJobsConfig,
 } from './providers/background-jobs-provider';
 
@@ -19,4 +18,5 @@ export {
 export type {
   BackgroundJobsConfig,
   BackgroundJobsProviderProps,
+  ResolvedBackgroundJobsConfig,
 } from './providers/background-jobs-provider';

--- a/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
+++ b/packages/@granit/react-background-jobs/src/providers/background-jobs-provider.tsx
@@ -11,7 +11,6 @@ export interface BackgroundJobsConfig {
   readonly client?: AxiosInstance;
   /** Base path for background-jobs endpoints (default: `/api/v1/background-jobs`). */
   readonly basePath?: string;
-  readonly queryKeyPrefix?: readonly string[];
 }
 
 /**
@@ -58,13 +57,4 @@ export function useBackgroundJobsConfig(): ResolvedBackgroundJobsConfig {
     throw new Error('useBackgroundJobsConfig must be used within a BackgroundJobsProvider');
   }
   return ctx;
-}
-
-/** Builds a consistent React Query key for background jobs operations. */
-export function buildBackgroundJobsQueryKey(
-  config: BackgroundJobsConfig,
-  ...segments: readonly string[]
-): readonly unknown[] {
-  const prefix = config.queryKeyPrefix ?? ['background-jobs'];
-  return [...prefix, ...segments];
 }

--- a/packages/@granit/react-background-jobs/src/testing/handlers.ts
+++ b/packages/@granit/react-background-jobs/src/testing/handlers.ts
@@ -1,10 +1,3 @@
-import {
-  BOOLEAN_OPERATORS,
-  DATE_OPERATORS,
-  NUMBER_OPERATORS,
-  STRING_OPERATORS,
-} from '@granit/query-engine';
-import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { accepted, noContent, notFound, pagedResponse } from '@granit/testing/msw';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -14,123 +7,16 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import { mockBackgroundJobs } from './data';
 
 import type { BackgroundJobStatus } from '@granit/background-jobs';
-import type { QueryMetadata } from '@granit/query-engine';
-
-/** Mock /meta payload for the background jobs resource. */
-export const backgroundJobQueryMetadata: QueryMetadata = {
-  columns: [
-    {
-      name: 'jobName',
-      label: 'Job name',
-      type: 'String',
-      order: 0,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'cronExpression',
-      label: 'Schedule',
-      type: 'String',
-      order: 1,
-      isSortable: false,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'isEnabled',
-      label: 'Enabled',
-      type: 'Boolean',
-      order: 2,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'lastExecutedAt',
-      label: 'Last executed',
-      type: 'DateTime',
-      order: 3,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'nextExecutionAt',
-      label: 'Next execution',
-      type: 'DateTime',
-      order: 4,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'consecutiveFailures',
-      label: 'Failures',
-      type: 'Int32',
-      order: 5,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'deadLetterCount',
-      label: 'Dead-lettered',
-      type: 'Int32',
-      order: 6,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'lastError',
-      label: 'Last error',
-      type: 'String',
-      order: 7,
-      isSortable: false,
-      isFilterable: true,
-      isVisible: true,
-    },
-  ],
-  filterableFields: [
-    { name: 'jobName', type: 'String', operators: STRING_OPERATORS },
-    { name: 'cronExpression', type: 'String', operators: STRING_OPERATORS },
-    { name: 'isEnabled', type: 'Boolean', operators: BOOLEAN_OPERATORS },
-    { name: 'lastExecutedAt', type: 'DateTime', operators: DATE_OPERATORS },
-    { name: 'nextExecutionAt', type: 'DateTime', operators: DATE_OPERATORS },
-    { name: 'consecutiveFailures', type: 'Int32', operators: NUMBER_OPERATORS },
-    { name: 'deadLetterCount', type: 'Int32', operators: NUMBER_OPERATORS },
-    { name: 'lastError', type: 'String', operators: STRING_OPERATORS },
-  ],
-  sortableFields: [
-    { name: 'jobName' },
-    { name: 'isEnabled' },
-    { name: 'lastExecutedAt' },
-    { name: 'nextExecutionAt' },
-    { name: 'consecutiveFailures' },
-    { name: 'deadLetterCount' },
-  ],
-  presetFilterGroups: [],
-  quickFilters: [
-    { name: 'enabled', label: 'Enabled', isDefault: true },
-    { name: 'paused', label: 'Paused', isDefault: false },
-    { name: 'failing', label: 'Failing', isDefault: false },
-  ],
-  dateFilters: [],
-  groupByFields: [],
-  pagination: {
-    defaultPageSize: 20,
-    maxPageSize: 100,
-    maxStreamSize: 10_000,
-    supportsCursor: false,
-  },
-  defaultSort: 'jobName',
-};
 
 /**
  * Create stateful MSW handlers for background job endpoints.
  * Handlers mutate the in-memory `mockBackgroundJobs` array — pause/resume/trigger
  * calls update state that subsequent GET calls reflect.
+ *
+ * Mirrors the five `Granit.BackgroundJobs.Endpoints` routes (paginated list,
+ * detail, pause, resume, trigger). Background jobs are NOT a query-engine
+ * resource: the backend exposes plain `page`/`pageSize` pagination with no
+ * `/meta`, filtering, or sorting endpoint.
  *
  * @param baseUrl - Module base path (default: `/api/v1/background-jobs`)
  */
@@ -138,9 +24,6 @@ export function createBackgroundJobHandlers(baseUrl = DEFAULT_BASE_PATH) {
   const jobsUrl = `${baseUrl}/jobs`;
 
   return [
-    // GET /jobs/meta — query metadata
-    createQueryMetaHandler(jobsUrl, backgroundJobQueryMetadata),
-
     // GET list — sorted, paginated
     http.get(jobsUrl, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-background-jobs/src/testing/index.ts
+++ b/packages/@granit/react-background-jobs/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockBackgroundJobs } from './data';
-export { backgroundJobQueryMetadata, createBackgroundJobHandlers } from './handlers';
+export { createBackgroundJobHandlers } from './handlers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1239,9 +1239,6 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
-      '@granit/react-query-engine':
-        specifier: workspace:*
-        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.14
         version: 5.100.14(react@19.2.7)


### PR DESCRIPTION
## Context

`/audit` of `@granit/background-jobs` + `@granit/react-background-jobs` against the
authoritative backend source (`Granit.BackgroundJobs.Endpoints`). The **runtime code
(types, API, hooks, permissions, routes) was already fully conformant** — all issues
were in the test/mock fixtures, which had drifted to a query-engine shape the backend
does not expose.

Backend reality (`BackgroundJobsReadEndpoints` / `BackgroundJobsWriteEndpoints`):
plain `page`/`pageSize` pagination over 5 routes — `GET /jobs`, `GET /jobs/{name}`,
`POST /jobs/{name}/{pause,resume,trigger}`. **No `/meta`, no filtering/sorting, no
query-engine.**

## Changes

- **Remove the fabricated `GET /jobs/meta` handler + `backgroundJobQueryMetadata`**
  (filterable/sortable fields, quickFilters) from `@granit/react-background-jobs/testing`.
  The mock modelled background-jobs as a query-engine resource; nothing consumed it.
- **Drop the now-unused `@granit/react-query-engine` peer dependency** (+ lockfile sync).
- **Remove dead `buildBackgroundJobsQueryKey` + `config.queryKeyPrefix`** — the hooks key
  off `backgroundJobKeys`, so `queryKeyPrefix` was a silent no-op (a cache-isolation trap).
- **Export `ResolvedBackgroundJobsConfig`** (the return type of `useBackgroundJobsConfig`).
- **Add direct unit tests** for `pauseJob`/`resumeJob`/`triggerJob` and the MSW handlers
  (list pagination, detail 200/404, pause/resume/trigger state mutations, 404).

## Verification

- `tsc --noEmit` ✅ (both packages)
- `vitest run` ✅ 47 passed / 6 files
- `eslint --max-warnings 0` ✅

## Blast radius

Removed symbols (`buildBackgroundJobsQueryKey`, `backgroundJobQueryMetadata`,
`queryKeyPrefix`) have **zero external consumers** (verified in showcase-admin-react /
cms-renderer). The `createBackgroundJobHandlers` factory signature is unchanged.

> Coordinated follow-up in `granit-showcase-react` (MR !32): the showcase was calling
> `createBackgroundJobHandlers(.../background-jobs/jobs)` — double `/jobs`, since the
> factory appends its own — so its MSW mocks never intercepted the page's requests.