### PR TITLE
feat(arch-tests): CSP-sink, phantom-dep & use-client scanners + core-peer test

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -449,6 +449,50 @@
               "signature": "sections?: ReadonlyArray<SectionKey>"
             }
           ]
+        },
+        {
+          "name": "scanDomScriptSinks",
+          "kind": "function",
+          "signature": "function scanDomScriptSinks(opts: DomScriptSinksOptions): Violation[]"
+        },
+        {
+          "name": "DomScriptSinksOptions",
+          "kind": "interface",
+          "signature": "interface DomScriptSinksOptions extends AllowlistedScanContext",
+          "members": [
+            {
+              "name": "cspSubpath",
+              "kind": "property",
+              "signature": "cspSubpath?: string"
+            }
+          ]
+        },
+        {
+          "name": "scanUndeclaredDeps",
+          "kind": "function",
+          "signature": "function scanUndeclaredDeps(opts: UndeclaredDepsOptions): Violation[]"
+        },
+        {
+          "name": "UndeclaredDepsOptions",
+          "kind": "interface",
+          "signature": "interface UndeclaredDepsOptions extends ScanContext",
+          "members": [
+            {
+              "name": "packageJsonPath",
+              "kind": "method",
+              "signature": "packageJsonPath?: (m: { dir: string }) => string"
+            },
+            {
+              "name": "ignore",
+              "kind": "property",
+              "signature": "ignore?: ReadonlyArray<string>"
+            }
+          ]
+        },
+        {
+          "name": "scanUseClientDirective",
+          "kind": "function",
+          "signature": "function scanUseClientDirective(opts: AllowlistedScanContext): Violation[]"
         }
       ]
     },

--- a/packages/@granit/arch-tests-kit/README.md
+++ b/packages/@granit/arch-tests-kit/README.md
@@ -125,6 +125,9 @@ A complete reference setup lives in
 | `scanBarrelDefaultExports` | No `export default` in module barrels                                                    |
 | `scanLeakedInternals`      | No underscore-prefixed exports leaked from barrels                                       |
 | `scanLocaleParity`         | `locales/` ships `en.ts` + `fr.ts` + `index.ts` + matching `TranslationsEn/Fr` constants |
+| `scanDomScriptSinks`       | Any package writing to a DOM-script sink ships a `<pkg>/csp` subpath (Trusted Types)     |
+| `scanUndeclaredDeps`       | Every bare import is declared in the package's own `package.json` (no phantom deps)      |
+| `scanUseClientDirective`   | RSC-consumed modules mark every client-hook file with `'use client'` (opt-in)            |
 
 All scanners return `Violation[]`. Empty array means the rule passes.
 
@@ -159,6 +162,21 @@ Available on `scanKebabCase`, `scanConsole`, `scanFetch`, `scanAxiosImports`.
 **recursively** under each module's `srcDir`, so they find every
 `hooks/` / `components/` / `api/` subdir regardless of depth — the same
 rule works for a flat package and a feature-folder app.
+
+### Opt-in scanners
+
+`scanUseClientDirective` is **opt-in by module**: it flags only the modules
+you pass in `ctx.modules`. Scope it to the packages a React Server Components
+app actually imports — server-only modules never need the directive:
+
+```ts
+const rsc = new Set(['@granit/react-cms']);
+scanUseClientDirective({ ...ctx, modules: ctx.modules.filter((m) => rsc.has(m.name)) });
+```
+
+`scanDomScriptSinks` and `scanUndeclaredDeps` read each module's
+`package.json`/`src/csp/index.ts` from `Module.dir`/`Module.srcDir`. Override
+the lookup with `packageJsonPath` / `cspSubpath` for non-standard layouts.
 
 ## Violation shape
 

--- a/packages/@granit/arch-tests-kit/src/index.ts
+++ b/packages/@granit/arch-tests-kit/src/index.ts
@@ -32,3 +32,11 @@ export {
 
 export { scanReadmePresence, scanSharedDepVersions } from './scanners/uniformity';
 export type { ReadmePresenceOptions, SharedDepVersionsOptions } from './scanners/uniformity';
+
+export { scanDomScriptSinks } from './scanners/csp';
+export type { DomScriptSinksOptions } from './scanners/csp';
+
+export { scanUndeclaredDeps } from './scanners/deps';
+export type { UndeclaredDepsOptions } from './scanners/deps';
+
+export { scanUseClientDirective } from './scanners/react';

--- a/packages/@granit/arch-tests-kit/src/scanners/csp.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/csp.ts
@@ -1,0 +1,77 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isTestFile, isTestingDir, readFile, rel, stripComments, walkSourceFiles } from '../fs';
+
+import type { AllowlistedScanContext, Violation } from '../types';
+
+// DOM-script sinks that, under CSP `require-trusted-types-for 'script'`, need a
+// TrustedHTML / TrustedScriptURL minted by a named policy. A package writing to
+// any of these MUST expose a `<pkg>/csp` subpath with an idempotent
+// installPolicy() so its CSP requirement stays co-located with the code that
+// needs it. See granit-docs/frontend/security/csp.mdx.
+//
+// NOSONAR: these regexes run only on bounded developer source files — no user
+// input, no ReDoS risk.
+const SINK_PATTERNS: ReadonlyArray<RegExp> = [
+  /\.innerHTML\s*=/,
+  /\.outerHTML\s*=/,
+  /\.insertAdjacentHTML\s*\(/,
+  /\bsetAttribute\s*\(\s*['"]src['"]/,
+];
+
+export interface DomScriptSinksOptions extends AllowlistedScanContext {
+  /**
+   * Path to the CSP policy entry, relative to each module's `srcDir`. A module
+   * with sinks satisfies the rule when this file exists (it backs the
+   * `<pkg>/csp` subpath). Defaults to `csp/index.ts`.
+   */
+  cspSubpath?: string;
+}
+
+function findSinkFile(srcDir: string): { file: string; count: number } | undefined {
+  let first: string | undefined;
+  let count = 0;
+  for (const f of walkSourceFiles(srcDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
+    const src = stripComments(readFile(f));
+    if (SINK_PATTERNS.some((re) => re.test(src))) {
+      first ??= f;
+      count++;
+    }
+  }
+  return first ? { file: first, count } : undefined;
+}
+
+/**
+ * Every module that writes to a DOM-script sink (`.innerHTML`, `.outerHTML`,
+ * `.insertAdjacentHTML`, `setAttribute('src', …)`) MUST ship a `<pkg>/csp`
+ * subpath (default `src/csp/index.ts`) exposing an idempotent `installPolicy()`.
+ * Mirrors `scripts/check-csp-policies.mjs` so apps can enforce the same rule
+ * inside their own Vitest suite.
+ */
+export function scanDomScriptSinks(opts: DomScriptSinksOptions): Violation[] {
+  const cspSubpath = opts.cspSubpath ?? path.join('csp', 'index.ts');
+  const allow = new Set(opts.allowedModules ?? []);
+  const allowedFiles = opts.allowedFiles ?? [];
+  const out: Violation[] = [];
+
+  for (const m of opts.modules) {
+    if (allow.has(m.name)) continue;
+    const hit = findSinkFile(m.srcDir);
+    if (!hit) continue;
+
+    const relPath = rel(hit.file, opts.repoRoot);
+    if (allowedFiles.some((needle) => relPath.includes(needle))) continue;
+
+    if (fs.existsSync(path.join(m.srcDir, cspSubpath))) continue;
+
+    out.push({
+      rule: 'csp-subpath',
+      module: m.name,
+      file: relPath,
+      message: `writes to a DOM-script sink (${hit.count} file(s)) but ships no ${cspSubpath} — add it with an idempotent installPolicy() and a "./csp" exports entry (see granit-docs/frontend/security/csp.mdx)`,
+    });
+  }
+
+  return out;
+}

--- a/packages/@granit/arch-tests-kit/src/scanners/deps.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/deps.ts
@@ -1,0 +1,108 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { isTestFile, isTestingDir, rel, walkSourceFiles } from '../fs';
+
+import { collectImports } from './imports';
+
+import type { ScanContext, Violation } from '../types';
+
+export interface UndeclaredDepsOptions extends ScanContext {
+  /**
+   * Where to read each module's `package.json`. Defaults to
+   * `<dir>/package.json` (works for npm packages).
+   */
+  packageJsonPath?: (m: { dir: string }) => string;
+  /**
+   * Bare specifiers (or package names) to never flag — e.g. ambient
+   * globals provided by the build that have no `package.json` entry.
+   */
+  ignore?: ReadonlyArray<string>;
+}
+
+type DepSection = Record<string, string> | undefined;
+interface PkgJson {
+  name?: string;
+  dependencies?: DepSection;
+  peerDependencies?: DepSection;
+  devDependencies?: DepSection;
+  optionalDependencies?: DepSection;
+}
+
+/** Reduce an import specifier to the npm package name (scope-aware). */
+function packageName(spec: string): string {
+  if (spec.startsWith('@')) {
+    const [scope = spec, name] = spec.split('/');
+    return name ? `${scope}/${name}` : scope;
+  }
+  return spec.split('/')[0] ?? spec;
+}
+
+/**
+ * A specifier we should not resolve to an npm package: relative paths, Node
+ * builtins, Vite virtual/query modules, and tsconfig path aliases (`@/…`,
+ * `~/…`). Bare scopes with no package name (`@/lib`) are aliases, not packages.
+ */
+function isNonPackageSpecifier(spec: string): boolean {
+  return (
+    spec.startsWith('.') ||
+    spec.startsWith('node:') ||
+    spec.startsWith('virtual:') ||
+    spec.startsWith('@/') ||
+    spec.startsWith('~') ||
+    spec.includes('?')
+  );
+}
+
+function declaredDeps(pkg: PkgJson): Set<string> {
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ]);
+}
+
+/**
+ * Every bare import in a module's runtime source must be declared in that
+ * module's own `package.json` (any of deps / peerDeps / devDeps /
+ * optionalDeps). Source-direct packages are consumed by `link:`, so an
+ * undeclared dep resolves through the workspace hoist locally but breaks for
+ * external consumers — this catches the phantom before it ships.
+ *
+ * Test and `testing/` files are skipped (their tooling is provided by the
+ * consuming context). Comments are stripped, so documented `import` examples
+ * in JSDoc never false-positive.
+ */
+export function scanUndeclaredDeps(opts: UndeclaredDepsOptions): Violation[] {
+  const resolvePkgJson = opts.packageJsonPath ?? ((m) => path.join(m.dir, 'package.json'));
+  const ignore = new Set(opts.ignore ?? []);
+  const out: Violation[] = [];
+
+  for (const m of opts.modules) {
+    const pkgPath = resolvePkgJson(m);
+    if (!fs.existsSync(pkgPath)) continue;
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8')) as PkgJson;
+    const declared = declaredDeps(pkg);
+    const self = pkg.name ?? m.name;
+
+    const reported = new Set<string>();
+    for (const f of walkSourceFiles(m.srcDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
+      for (const spec of collectImports(f)) {
+        if (isNonPackageSpecifier(spec) || ignore.has(spec)) continue;
+        const name = packageName(spec);
+        if (name === self || ignore.has(name) || declared.has(name)) continue;
+        if (reported.has(name)) continue;
+        reported.add(name);
+        out.push({
+          rule: 'no-undeclared-dep',
+          module: m.name,
+          file: rel(f, opts.repoRoot),
+          message: `imports "${name}" but it is not declared in package.json (add it to dependencies / peerDependencies / devDependencies)`,
+        });
+      }
+    }
+  }
+
+  return out;
+}

--- a/packages/@granit/arch-tests-kit/src/scanners/react.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/react.ts
@@ -1,0 +1,60 @@
+import { isTestFile, isTestingDir, readFile, rel, stripComments, walkSourceFiles } from '../fs';
+
+import type { AllowlistedScanContext, Violation } from '../types';
+
+// React APIs that establish a client boundary: using any of them in a module
+// imported by a React Server Components app (e.g. the Next.js CMS renderer)
+// requires a top-of-file `'use client'` directive, or the build errors.
+//
+// NOSONAR: bounded developer source files only — no user input, no ReDoS risk.
+const CLIENT_API_RE =
+  /\buse(State|Effect|LayoutEffect|InsertionEffect|Reducer|Ref|Context|Memo|Callback|Id|SyncExternalStore|Transition|DeferredValue|ImperativeHandle)\s*\(|\bcreateContext\s*\(/;
+
+const USE_CLIENT_RE = /^\s*['"]use client['"]\s*;?\s*$/;
+
+/** True when `'use client'` appears as one of the file's first statements. */
+function hasUseClientDirective(src: string): boolean {
+  let seen = 0;
+  for (const line of src.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed === '') continue;
+    if (USE_CLIENT_RE.test(trimmed)) return true;
+    // The directive is only valid before any import/statement. Give it a few
+    // lines of slack (a leading line break after stripped comments) then stop.
+    if (++seen >= 3) return false;
+  }
+  return false;
+}
+
+/**
+ * For modules consumed by a React Server Components app, every file using a
+ * client-only React API must carry a `'use client'` directive. This scanner is
+ * **opt-in**: pass only the RSC-consumed modules in `ctx.modules` (the framework
+ * suite scopes it to the packages the CMS renderer imports). Server-safe files
+ * (pure types, constants, server utilities) are untouched.
+ */
+export function scanUseClientDirective(opts: AllowlistedScanContext): Violation[] {
+  const allow = new Set(opts.allowedModules ?? []);
+  const allowedFiles = opts.allowedFiles ?? [];
+  const out: Violation[] = [];
+
+  for (const m of opts.modules) {
+    if (allow.has(m.name)) continue;
+    for (const f of walkSourceFiles(m.srcDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
+      const relPath = rel(f, opts.repoRoot);
+      if (allowedFiles.some((needle) => relPath.includes(needle))) continue;
+      const stripped = stripComments(readFile(f));
+      if (!CLIENT_API_RE.test(stripped)) continue;
+      if (hasUseClientDirective(stripped)) continue;
+      out.push({
+        rule: 'use-client-directive',
+        module: m.name,
+        file: relPath,
+        message:
+          "uses a client-only React hook but has no 'use client' directive — add it as the first line so the file is RSC-safe",
+      });
+    }
+  }
+
+  return out;
+}

--- a/packages/@granit/arch-tests/src/__tests__/csp.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/csp.test.ts
@@ -1,0 +1,15 @@
+import { scanDomScriptSinks } from '@granit/arch-tests-kit';
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, listPackages, toModules } from './helpers';
+
+const ctx = { modules: toModules(listPackages()), repoRoot: REPO_ROOT };
+
+describe('csp (delegated to kit)', () => {
+  it('every package writing to a DOM-script sink ships a <pkg>/csp subpath', () => {
+    // Mirrors `pnpm check:csp` inside the Vitest suite. Packages that legitimately
+    // touch a sink (react-map, react-authentication-keycloak) already ship
+    // src/csp/index.ts and pass without an allowlist.
+    expect(scanDomScriptSinks(ctx)).toEqual([]);
+  });
+});

--- a/packages/@granit/arch-tests/src/__tests__/deps.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/deps.test.ts
@@ -1,0 +1,36 @@
+import { scanUndeclaredDeps } from '@granit/arch-tests-kit';
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, listPackages, toModules } from './helpers';
+
+const packages = listPackages();
+const ctx = { modules: toModules(packages), repoRoot: REPO_ROOT };
+
+describe('deps (delegated to kit)', () => {
+  it('every bare import is declared in the package own package.json', () => {
+    expect(scanUndeclaredDeps(ctx)).toEqual([]);
+  });
+});
+
+describe('deps: react-* declares its core counterpart', () => {
+  const coreNames = new Set(packages.map((p) => p.name));
+  // Only react-* packages whose core sibling actually exists in the workspace.
+  const reactWithCore = packages.filter(
+    (p) => p.isReact && coreNames.has(`@granit/${p.dirName.replace(/^react-/, '')}`)
+  );
+
+  it.each(reactWithCore.map((p) => [p.name, p]))(
+    '%s lists its core @granit/* counterpart as a (peer)dependency',
+    (_n, pkg) => {
+      const core = `@granit/${pkg.dirName.replace(/^react-/, '')}`;
+      const declared = {
+        ...((pkg.packageJson.dependencies ?? {}) as Record<string, string>),
+        ...((pkg.packageJson.peerDependencies ?? {}) as Record<string, string>),
+      };
+      expect(
+        Object.keys(declared),
+        `react package ${pkg.name} must declare its core counterpart ${core}`
+      ).toContain(core);
+    }
+  );
+});

--- a/packages/@granit/arch-tests/src/__tests__/helpers.ts
+++ b/packages/@granit/arch-tests/src/__tests__/helpers.ts
@@ -68,3 +68,11 @@ export const CONSOLE_ALLOWLIST: ReadonlyArray<string> = [
   '@granit/logger-otlp',
   '@granit/react-tracing',
 ];
+
+/**
+ * Packages imported by a React Server Components app (the Next.js CMS renderer).
+ * Files in these using a client-only React hook must carry `'use client'`.
+ * Discover with:
+ *   grep -rhoE "@granit/react-[a-z0-9-]+" ~/dev/granit-fx/granit-cms-renderer/{app,src}
+ */
+export const RSC_PACKAGES: ReadonlyArray<string> = ['@granit/react-cms'];

--- a/packages/@granit/arch-tests/src/__tests__/use-client.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/use-client.test.ts
@@ -1,0 +1,16 @@
+import { scanUseClientDirective } from '@granit/arch-tests-kit';
+import { describe, expect, it } from 'vitest';
+
+import { REPO_ROOT, RSC_PACKAGES, listPackages, toModules } from './helpers';
+
+const rscSet = new Set(RSC_PACKAGES);
+const ctx = {
+  modules: toModules(listPackages()).filter((m) => rscSet.has(m.name)),
+  repoRoot: REPO_ROOT,
+};
+
+describe('use-client (delegated to kit)', () => {
+  it("RSC-consumed packages mark every client-hook file with 'use client'", () => {
+    expect(scanUseClientDirective(ctx)).toEqual([]);
+  });
+});

--- a/packages/@granit/react-tracing/package.json
+++ b/packages/@granit/react-tracing/package.json
@@ -18,6 +18,7 @@
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/context-zone": "^2.6.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.213.0",
+    "@opentelemetry/instrumentation": "^0.213.0",
     "@opentelemetry/instrumentation-document-load": "^0.57.0",
     "@opentelemetry/instrumentation-fetch": "^0.213.0",
     "@opentelemetry/instrumentation-xml-http-request": "^0.213.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2754,6 +2754,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-http':
         specifier: ^0.213.0
         version: 0.213.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/instrumentation':
+        specifier: ^0.213.0
+        version: 0.213.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/instrumentation-document-load':
         specifier: ^0.57.0
         version: 0.57.0(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
## What

Adds three reusable architecture-test scanners to `@granit/arch-tests-kit` (so
both the framework suite and downstream apps can enforce them), wires them into
`@granit/arch-tests`, and fixes the one real violation they surfaced.

These enforce conventions that ESLint and unit tests can't catch — and the
phantom-dep scanner already found a genuine bug (see below).

## New scanners (kit + framework wiring)

| Scanner | Rule | Test |
| --- | --- | --- |
| `scanDomScriptSinks` | every package writing to a DOM-script sink (`.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`, `setAttribute('src', …)`) must ship a `<pkg>/csp` subpath. Ports `pnpm check:csp` into the reusable kit so apps get it too and it runs inside Vitest | `csp.test.ts` |
| `scanUndeclaredDeps` | every bare import is declared in the package's own `package.json` (phantom-dep guard — not covered by ESLint; matters for source-direct packages consumed via `link:`) | `deps.test.ts` |
| `scanUseClientDirective` | RSC-consumed packages mark every client-hook file with a `'use client'` directive. **Opt-in**, scoped via `RSC_PACKAGES` (currently `@granit/react-cms`, the only package the Next.js CMS renderer imports) | `use-client.test.ts` |

Plus one inline arch-test in `deps.test.ts`: every `@granit/react-*` package
declares its core `@granit/*` counterpart as a `(peer)dependency`.

## Real bug found

`scanUndeclaredDeps` surfaced a phantom dependency:
`react-tracing/src/providers/tracing-provider.tsx` type-imports
`Instrumentation` from `@opentelemetry/instrumentation`, but the package was
undeclared (resolved transitively via the `instrumentation-*` siblings). Fixed
in a separate commit — declared as a peer (`^0.213.0`, matching the sibling
range) so the package is self-contained for external consumers.

## Scanner correctness

Each scanner was validated with **positive and negative controls** (a synthetic
fixture that trips the rule → exactly one violation; a clean fixture → empty),
so the green suite means "the framework is genuinely conformant", not "the
scanner is a no-op".

## Verification (DoD)

| Check | Result |
| --- | --- |
| `pnpm tsc` | ✅ |
| `pnpm lint` | ✅ (0 warnings) |
| `pnpm check:csp` | ✅ |
| `markdownlint` (kit README) | ✅ |
| arch-tests (`vitest run`) | ✅ 11 files, 2104 tests |

## Notes

- `@granit/arch-tests-kit` README updated with the three new scanners + an
  "opt-in scanners" section.
- `dist/` is gitignored (built at publish time) — not part of this diff.
- `account` / `multi-tenancy` (core api covered only via their `react-*`
  sibling) are a known small follow-up under the "direct test" policy — not in
  scope here.
