### PR TITLE
fix(authentication): align api-keys & local front contracts with backend

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2563,50 +2563,13 @@
         },
         {
           "name": "UseApiKeysParams",
-          "kind": "interface",
-          "signature": "interface UseApiKeysParams",
-          "members": [
-            {
-              "name": "search",
-              "kind": "property",
-              "signature": "search?: string"
-            },
-            {
-              "name": "type",
-              "kind": "property",
-              "signature": "type?: string[]"
-            },
-            {
-              "name": "environment",
-              "kind": "property",
-              "signature": "environment?: string"
-            },
-            {
-              "name": "includeRevoked",
-              "kind": "property",
-              "signature": "includeRevoked?: boolean"
-            },
-            {
-              "name": "page",
-              "kind": "property",
-              "signature": "page?: number"
-            },
-            {
-              "name": "pageSize",
-              "kind": "property",
-              "signature": "pageSize?: number"
-            }
-          ]
+          "kind": "type",
+          "signature": "type UseApiKeysParams = ListApiKeysParams"
         },
         {
           "name": "buildApiKeyQueryKey",
           "kind": "function",
           "signature": "function buildApiKeyQueryKey( config: Pick<ApiKeyHookOptions, 'queryKeyPrefix'>, ...segments: readonly unknown[] ): readonly unknown[]"
-        },
-        {
-          "name": "apiKeyKeys",
-          "kind": "const",
-          "signature": "const apiKeyKeys"
         },
         {
           "name": "useApiKey",
@@ -2806,6 +2769,16 @@
       "description": "React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion",
       "exports": [
         {
+          "name": "LocalAuthProvider",
+          "kind": "function",
+          "signature": "function LocalAuthProvider("
+        },
+        {
+          "name": "useLocalAuthConfig",
+          "kind": "function",
+          "signature": "function useLocalAuthConfig(): ResolvedLocalAuthConfig"
+        },
+        {
           "name": "LocalAuthConfig",
           "kind": "interface",
           "signature": "interface LocalAuthConfig",
@@ -2840,12 +2813,7 @@
         {
           "name": "useCompletePasskeyAssertion",
           "kind": "function",
-          "signature": "function useCompletePasskeyAssertion(): UseMutationResult< AccountLoginResponse, Error, AccountPasskeyAssertionCompleteRequest >"
-        },
-        {
-          "name": "localAuthKeys",
-          "kind": "const",
-          "signature": "const localAuthKeys"
+          "signature": "function useCompletePasskeyAssertion(): UseMutationResult< AccountLoginResponse, Error, AccountPasskeyLoginRequest >"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
       "msw": "^2.14.6",
       "picomatch": ">=4.0.4",
       "react": "19.2.7",
-      "react-dom": "19.2.7"
+      "react-dom": "19.2.7",
+      "uuid": "^11.1.1"
     }
   },
   "lint-staged": {

--- a/packages/@granit/api-client/src/__tests__/api-client.test.ts
+++ b/packages/@granit/api-client/src/__tests__/api-client.test.ts
@@ -461,9 +461,14 @@ describe('BFF mode', () => {
 
     const response = await client.post('/test', {});
     expect(response.config.headers['X-CSRF-Token']).toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('BFF mutation sent without X-CSRF-Token')
-    );
+    // The fallback warning is routed through @granit/logger's console transport,
+    // which formats the message into a styled `%c` argument — assert on content.
+    expect(warnSpy).toHaveBeenCalled();
+    expect(
+      warnSpy.mock.calls.some((call) =>
+        String(call[0]).includes('BFF mutation sent without X-CSRF-Token')
+      )
+    ).toBe(true);
     warnSpy.mockRestore();
   });
 

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -5,10 +5,15 @@ import axios, {
   type InternalAxiosRequestConfig,
 } from 'axios';
 
-import type { Logger } from '@granit/logger';
+import { createLogger, type Logger } from '@granit/logger';
 
 /** Authentication mode for the API client. */
 export type ApiClientMode = 'bearer' | 'bff';
+
+// Fallback logger for the rare paths where no app logger is wired. Warnings
+// route through the @granit/logger façade (console transport in dev) rather
+// than the raw global console — keeps the no-console arch rule honest.
+const fallbackLogger = createLogger('api-client');
 
 /** Getter that returns the current CSRF token, or null if unavailable. */
 export type CsrfTokenGetter = () => string | null;
@@ -88,7 +93,7 @@ function warnIfAlreadySet(name: string, previous: unknown): void {
   if (previous === null) return;
   const env = (import.meta as { env?: { DEV?: boolean } }).env;
   if (env?.DEV !== true) return;
-  globalThis.console.warn(
+  fallbackLogger.warn(
     `[@granit/api-client] ${name} called more than once — the previous getter has been replaced. ` +
       `Check for provider double-mount or unintended override.`
   );
@@ -159,11 +164,7 @@ async function injectBffHeaders(
   if (config.csrfTokenGetter || config.refreshCsrfToken) {
     const message =
       '[@granit/api-client] BFF mutation sent without X-CSRF-Token — token unavailable. Request will likely be rejected by the BFF.';
-    if (config.logger) {
-      config.logger.warn(message, { method: req.method, url: req.url });
-    } else {
-      globalThis.console.warn(message);
-    }
+    (config.logger ?? fallbackLogger).warn(message, { method: req.method, url: req.url });
   }
 }
 

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -1,11 +1,10 @@
+import { createLogger, type Logger } from '@granit/logger';
 import axios, {
   type AxiosError,
   type AxiosInstance,
   type AxiosRequestConfig,
   type InternalAxiosRequestConfig,
 } from 'axios';
-
-import { createLogger, type Logger } from '@granit/logger';
 
 /** Authentication mode for the API client. */
 export type ApiClientMode = 'bearer' | 'bff';

--- a/packages/@granit/arch-tests-kit/package.json
+++ b/packages/@granit/arch-tests-kit/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/arch-tests-kit",
   "description": "Reusable architecture-test primitives — pure scanner functions returning violations. Consumed by `@granit/arch-tests` (framework) and by downstream app test suites (showcase, future DD apps).",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/arch-tests-kit/src/index.ts
+++ b/packages/@granit/arch-tests-kit/src/index.ts
@@ -13,6 +13,7 @@ export {
 
 export {
   collectImports,
+  hasBannedConsole,
   scanConsole,
   scanFetch,
   scanAxiosImports,

--- a/packages/@granit/arch-tests-kit/src/scanners/imports.ts
+++ b/packages/@granit/arch-tests-kit/src/scanners/imports.ts
@@ -22,11 +22,33 @@ function isAllowedFile(
   return allowedFiles.some((needle) => relativePath.includes(needle));
 }
 
+// Direct `console.method(` — the leading char class excludes letters/`_`/`.`/`$`
+// so `myconsole.log` and property accesses like `foo.console.log` are NOT matched
+// here; the global-object bypass below handles the legitimate global console.
 const CONSOLE_RE = /(^|[^a-zA-Z_.$])console\s*\.\s*(log|warn|error|info|debug|trace)\s*\(/;
+
+// Console reached through a global object, e.g. `globalThis.console.log(…)`,
+// `window.console.error(…)`, `self.console.debug(…)`, or `globalThis['console']`.
+// Flags any access to `<global>.console` (not just method calls) so aliasing
+// such as `const c = globalThis.console` is caught too.
+const GLOBAL_CONSOLE_RE =
+  /\b(?:globalThis|window|self)\s*(?:\.\s*console\b|\[\s*['"]console['"]\s*\])/;
+
+/**
+ * True when `text` contains a banned reference to the global `console`, either
+ * a direct `console.*(…)` call or a global-object access (`globalThis.console`,
+ * `window.console`, `self.console`, `globalThis['console']`). Pure predicate —
+ * pass already comment-stripped source. Exported for regression testing.
+ */
+export function hasBannedConsole(text: string): boolean {
+  return CONSOLE_RE.test(text) || GLOBAL_CONSOLE_RE.test(text);
+}
 
 /**
  * Bans `console.*` runtime calls outside allowlisted modules (typically the
- * logger and its transports). Comments/JSDoc are ignored.
+ * logger and its transports). Catches both the direct `console.log(…)` form and
+ * the global-object bypass (`globalThis.console.*`, `window.console.*`,
+ * `self.console.*`). Comments/JSDoc are ignored.
  */
 export function scanConsole(opts: AllowlistedScanContext): Violation[] {
   const allow = new Set(opts.allowedModules ?? []);
@@ -36,7 +58,7 @@ export function scanConsole(opts: AllowlistedScanContext): Violation[] {
     for (const f of walkSourceFiles(m.srcDir, (file) => !isTestFile(file) && !isTestingDir(file))) {
       const relPath = rel(f, opts.repoRoot);
       if (isAllowedFile(relPath, opts.allowedFiles)) continue;
-      if (CONSOLE_RE.test(stripComments(readFile(f)))) {
+      if (hasBannedConsole(stripComments(readFile(f)))) {
         out.push({
           rule: 'no-console',
           module: m.name,

--- a/packages/@granit/arch-tests/src/__tests__/imports.test.ts
+++ b/packages/@granit/arch-tests/src/__tests__/imports.test.ts
@@ -1,5 +1,6 @@
 import {
   collectImports,
+  hasBannedConsole,
   isTestFile,
   isTestingDir,
   rel,
@@ -26,6 +27,22 @@ const ctx = { modules, repoRoot: REPO_ROOT };
 describe('imports — shared rules (delegated to kit)', () => {
   it('no console.* in runtime code', () => {
     expect(scanConsole({ ...ctx, allowedModules: CONSOLE_ALLOWLIST })).toEqual([]);
+  });
+
+  it('the console ban covers the global-object bypass, not just direct calls', () => {
+    // Direct calls — already enforced historically.
+    expect(hasBannedConsole('console.log(x)')).toBe(true);
+    expect(hasBannedConsole(';console.error(x)')).toBe(true);
+    // Global-object bypass — the regression this rule was hardened against.
+    expect(hasBannedConsole('globalThis.console.log(x)')).toBe(true);
+    expect(hasBannedConsole('window.console.error(x)')).toBe(true);
+    expect(hasBannedConsole('self.console.debug(x)')).toBe(true);
+    expect(hasBannedConsole("globalThis['console'].info(x)")).toBe(true);
+    expect(hasBannedConsole('const c = globalThis.console;')).toBe(true);
+    // Must not flag unrelated identifiers or non-global `.console` properties.
+    expect(hasBannedConsole('myconsole.log(x)')).toBe(false);
+    expect(hasBannedConsole('telemetry.console.send(x)')).toBe(false);
+    expect(hasBannedConsole('createLogger().info(x)')).toBe(false);
   });
 
   it('no native fetch() outside the infra allowlist', () => {

--- a/packages/@granit/authentication-api-keys/package.json
+++ b/packages/@granit/authentication-api-keys/package.json
@@ -15,10 +15,12 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/types": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
   },

--- a/packages/@granit/authentication-api-keys/src/api/api-keys-api.ts
+++ b/packages/@granit/authentication-api-keys/src/api/api-keys-api.ts
@@ -7,21 +7,22 @@ import type {
   ListApiKeysParams,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
+import type { PagedResult } from '@granit/query-engine';
 
 /**
  * Lists API keys filtered by the given parameters.
  *
- * `GET {basePath}/api-keys`
+ * `GET {basePath}/api-keys` → `PagedResult<ApiKeyResponse>`
  */
 export async function listApiKeys(
   client: AxiosInstance,
   basePath: string,
   params: ListApiKeysParams = {}
-): Promise<ApiKeyResponse[]> {
-  const response = await client.get<ApiKeyResponse[]>(`${basePath}/api-keys`, {
+): Promise<PagedResult<ApiKeyResponse>> {
+  const response = await client.get<PagedResult<ApiKeyResponse>>(`${basePath}/api-keys`, {
     params: {
       search: params.search,
-      type: params.type?.join(','),
+      type: params.type,
       environment: params.environment,
       includeRevoked: params.includeRevoked,
       page: params.page,

--- a/packages/@granit/authentication-api-keys/src/types/index.ts
+++ b/packages/@granit/authentication-api-keys/src/types/index.ts
@@ -67,7 +67,8 @@ export interface ApiKeyUpdateScopesRequest {
 /** Query parameters accepted by {@link listApiKeys}. */
 export interface ListApiKeysParams {
   search?: string;
-  type?: readonly string[];
+  /** Filter by a single key type — mirrors the backend `ApiKeyType?` query parameter. */
+  type?: ApiKeyType;
   environment?: string;
   includeRevoked?: boolean;
   page?: number;

--- a/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-passkey-assertion-api.ts
@@ -1,4 +1,4 @@
-import type { AccountLoginResponse, AccountPasskeyAssertionCompleteRequest } from '../types/index';
+import type { AccountLoginResponse, AccountPasskeyLoginRequest } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
@@ -30,7 +30,7 @@ export async function beginPasskeyAssertion(
 export async function completePasskeyAssertion(
   client: AxiosInstance,
   basePath: string,
-  request: AccountPasskeyAssertionCompleteRequest
+  request: AccountPasskeyLoginRequest
 ): Promise<AccountLoginResponse> {
   const { data } = await client.post<AccountLoginResponse>(
     `${basePath}/passkeys/assertion/complete`,

--- a/packages/@granit/authentication-local/src/index.ts
+++ b/packages/@granit/authentication-local/src/index.ts
@@ -2,11 +2,9 @@
 export type {
   AccountLoginRequest,
   AccountLoginResponse,
-  AccountPasskeyAssertionCompleteRequest,
+  AccountPasskeyLoginRequest,
   AccountTwoFactorLoginRequest,
 } from './types/index';
-
-// Query keys
 
 // API — Login
 export { loginAccount } from './api/account-login-api';

--- a/packages/@granit/authentication-local/src/types/account-login.ts
+++ b/packages/@granit/authentication-local/src/types/account-login.ts
@@ -37,6 +37,11 @@ export interface AccountLoginResponse {
 export interface AccountTwoFactorLoginRequest {
   readonly code: string;
   readonly useRecoveryCode?: boolean;
+  /**
+   * When `true`, the Identity session cookie is marked as persistent.
+   * Mirrors the backend `AccountTwoFactorLoginRequest.RememberMe`. Default: `false`.
+   */
+  readonly rememberMe?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -46,9 +51,10 @@ export interface AccountTwoFactorLoginRequest {
 /**
  * Request body for `POST {basePath}/passkeys/assertion/complete`.
  *
- * Submitted after `navigator.credentials.get()` completes the WebAuthn
- * assertion ceremony initiated by `POST {basePath}/passkeys/assertion/begin`.
+ * Mirrors the backend `AccountPasskeyLoginRequest`. Submitted after
+ * `navigator.credentials.get()` completes the WebAuthn assertion ceremony
+ * initiated by `POST {basePath}/passkeys/assertion/begin`.
  */
-export interface AccountPasskeyAssertionCompleteRequest {
+export interface AccountPasskeyLoginRequest {
   readonly credentialJson: string;
 }

--- a/packages/@granit/authentication-local/src/types/index.ts
+++ b/packages/@granit/authentication-local/src/types/index.ts
@@ -1,6 +1,6 @@
 export type {
   AccountLoginRequest,
   AccountLoginResponse,
-  AccountPasskeyAssertionCompleteRequest,
+  AccountPasskeyLoginRequest,
   AccountTwoFactorLoginRequest,
 } from './account-login';

--- a/packages/@granit/react-authentication-api-keys/package.json
+++ b/packages/@granit/react-authentication-api-keys/package.json
@@ -16,6 +16,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*"
@@ -24,18 +25,11 @@
     "@granit/api-client": "workspace:*",
     "@granit/authentication-api-keys": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/react-query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
-    "@granit/query-engine": {
-      "optional": true
-    },
-    "@granit/react-query-engine": {
-      "optional": true
-    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
@@ -1,7 +1,7 @@
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { apiKeyQueryMetadata, createApiKeyHandlers } from '../testing/index';
+import { createApiKeyHandlers } from '../testing/index';
 
 const BASE = 'http://api.test/api/v1/authentication/api-keys';
 const server = setupServer();
@@ -10,11 +10,34 @@ beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
-describe('createApiKeyHandlers /meta', () => {
-  it('responds with apiKeyQueryMetadata at base/meta', async () => {
+describe('createApiKeyHandlers', () => {
+  it('returns a PagedResult shape (items + totalCount) from the list endpoint', async () => {
     server.use(...createApiKeyHandlers(BASE));
-    const response = await fetch(`${BASE}/meta`);
+    const response = await fetch(BASE);
+
     expect(response.status).toBe(200);
-    expect(await response.json()).toEqual(apiKeyQueryMetadata);
+    const body = (await response.json()) as { items: unknown[]; totalCount: number };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(typeof body.totalCount).toBe('number');
+    expect(body.items.length).toBeGreaterThan(0);
+  });
+
+  it('filters by a single type value', async () => {
+    server.use(...createApiKeyHandlers(BASE));
+    const response = await fetch(`${BASE}?type=Secret`);
+    const body = (await response.json()) as { items: { type: string }[] };
+
+    expect(body.items.every((k) => k.type === 'Secret')).toBe(true);
+  });
+
+  it('revoke returns 204 No Content', async () => {
+    server.use(...createApiKeyHandlers(BASE));
+    const list = (await (await fetch(`${BASE}?includeRevoked=false`)).json()) as {
+      items: { id: string }[];
+    };
+    const id = list.items[0]!.id;
+
+    const response = await fetch(`${BASE}/${id}/revoke`, { method: 'POST' });
+    expect(response.status).toBe(204);
   });
 });

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
@@ -7,7 +7,8 @@ import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useApiKey } from '../hooks/use-api-key';
-import { buildApiKeyQueryKey, useApiKeys } from '../hooks/use-api-keys';
+import { buildApiKeyQueryKey } from '../hooks/query-keys';
+import { useApiKeys } from '../hooks/use-api-keys';
 
 import type { ApiKeyResponse } from '@granit/authentication-api-keys';
 
@@ -40,6 +41,8 @@ const mockApiKey: ApiKeyResponse = {
   cacheBehavior: 'Normal',
   createdAt: toISODateString('2026-01-01T00:00:00Z'),
 };
+
+const emptyPage = { items: [] as ApiKeyResponse[], totalCount: 0, hasMore: false };
 
 // ---------------------------------------------------------------------------
 // buildApiKeyQueryKey
@@ -74,9 +77,11 @@ describe('useApiKeys', () => {
     vi.clearAllMocks();
   });
 
-  it('should fetch the API key list with default base path', async () => {
+  it('should fetch the paginated API key list with default base path', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [mockApiKey] });
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: { items: [mockApiKey], totalCount: 1, hasMore: false },
+    });
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useApiKeys({ client }), { wrapper });
@@ -87,13 +92,14 @@ describe('useApiKeys', () => {
       '/api/v1/authentication/api-keys',
       expect.objectContaining({})
     );
-    expect(result.current.data).toHaveLength(1);
-    expect(result.current.data![0].id).toBe('key-1');
+    expect(result.current.data?.items).toHaveLength(1);
+    expect(result.current.data?.items[0].id).toBe('key-1');
+    expect(result.current.data?.totalCount).toBe(1);
   });
 
   it('should pass search param to the request', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
     renderHook(() => useApiKeys({ client }, { search: 'prod' }), { wrapper });
@@ -106,26 +112,26 @@ describe('useApiKeys', () => {
     );
   });
 
-  it('should pass type filter as comma-separated string', async () => {
+  it('should pass the single type filter to the request', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
-    renderHook(() => useApiKeys({ client }, { type: ['Secret', 'Webhook'] }), { wrapper });
+    renderHook(() => useApiKeys({ client }, { type: 'Secret' }), { wrapper });
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
     expect(client.get).toHaveBeenCalledWith(
       '/api/v1/authentication/api-keys',
       expect.objectContaining({
-        params: expect.objectContaining({ type: 'Secret,Webhook' }),
+        params: expect.objectContaining({ type: 'Secret' }),
       })
     );
   });
 
   it('should pass environment filter to the request', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
     renderHook(() => useApiKeys({ client }, { environment: 'staging' }), { wrapper });
@@ -142,7 +148,7 @@ describe('useApiKeys', () => {
 
   it('should pass includeRevoked param to the request', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
     renderHook(() => useApiKeys({ client }, { includeRevoked: true }), { wrapper });
@@ -159,7 +165,7 @@ describe('useApiKeys', () => {
 
   it('should pass pagination params to the request', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
     renderHook(() => useApiKeys({ client }, { page: 2, pageSize: 25 }), { wrapper });
@@ -176,7 +182,7 @@ describe('useApiKeys', () => {
 
   it('should use custom basePath when provided', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
     renderHook(() => useApiKeys({ client, basePath: '/api/v2/authentication' }), { wrapper });
@@ -198,16 +204,17 @@ describe('useApiKeys', () => {
     expect(result.current.error?.message).toBe('Unauthorized');
   });
 
-  it('should return an empty array when the list is empty', async () => {
+  it('should return an empty page when the list is empty', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useApiKeys({ client }), { wrapper });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data).toEqual([]);
+    expect(result.current.data?.items).toEqual([]);
+    expect(result.current.data?.totalCount).toBe(0);
   });
 });
 

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
@@ -6,8 +6,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useApiKey } from '../hooks/use-api-key';
 import { buildApiKeyQueryKey } from '../hooks/query-keys';
+import { useApiKey } from '../hooks/use-api-key';
 import { useApiKeys } from '../hooks/use-api-keys';
 
 import type { ApiKeyResponse } from '@granit/authentication-api-keys';

--- a/packages/@granit/react-authentication-api-keys/src/hooks/query-keys.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/query-keys.ts
@@ -1,4 +1,4 @@
-import type { ApiKeyHookOptions, UseApiKeysParams } from './use-api-keys';
+import type { ApiKeyHookOptions } from './use-api-keys';
 
 // ---------------------------------------------------------------------------
 // Query key builder
@@ -18,16 +18,3 @@ export function buildApiKeyQueryKey(
 ): readonly unknown[] {
   return [...(config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX), ...segments];
 }
-
-// ---------------------------------------------------------------------------
-// Legacy query key factory (delegates to buildApiKeyQueryKey)
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use {@link buildApiKeyQueryKey} instead. */
-export const apiKeyKeys = {
-  all: DEFAULT_QUERY_KEY_PREFIX as readonly string[],
-  lists: () => [...DEFAULT_QUERY_KEY_PREFIX, 'list'] as const,
-  list: (params: UseApiKeysParams) => [...DEFAULT_QUERY_KEY_PREFIX, 'list', params] as const,
-  details: () => [...DEFAULT_QUERY_KEY_PREFIX, 'detail'] as const,
-  detail: (id: string) => [...DEFAULT_QUERY_KEY_PREFIX, 'detail', id] as const,
-};

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
@@ -3,11 +3,11 @@ import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-export { apiKeyKeys, buildApiKeyQueryKey } from './query-keys';
 import { buildApiKeyQueryKey } from './query-keys';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ApiKeyResponse } from '@granit/authentication-api-keys';
+import type { ApiKeyResponse, ListApiKeysParams } from '@granit/authentication-api-keys';
+import type { PagedResult } from '@granit/query-engine';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 // ---------------------------------------------------------------------------
@@ -24,15 +24,13 @@ export interface ApiKeyHookOptions {
   queryKeyPrefix?: readonly string[];
 }
 
-/** Query parameters for the paginated API key list. */
-export interface UseApiKeysParams {
-  search?: string;
-  type?: string[];
-  environment?: string;
-  includeRevoked?: boolean;
-  page?: number;
-  pageSize?: number;
-}
+/**
+ * Query parameters for the paginated API key list.
+ *
+ * Alias of the core {@link ListApiKeysParams} — exported under this name for
+ * consumers that import `UseApiKeysParams`.
+ */
+export type UseApiKeysParams = ListApiKeysParams;
 
 // ---------------------------------------------------------------------------
 // Hook
@@ -57,7 +55,7 @@ export interface UseApiKeysParams {
 export function useApiKeys(
   options: ApiKeyHookOptions,
   params: UseApiKeysParams = {}
-): UseQueryResult<ApiKeyResponse[]> {
+): UseQueryResult<PagedResult<ApiKeyResponse>> {
   const { client, basePath = DEFAULT_BASE_PATH } = options;
 
   return useQuery({

--- a/packages/@granit/react-authentication-api-keys/src/index.ts
+++ b/packages/@granit/react-authentication-api-keys/src/index.ts
@@ -1,7 +1,7 @@
 // Hooks — queries
 export { useApiKeys } from './hooks/use-api-keys';
 export type { ApiKeyHookOptions, UseApiKeysParams } from './hooks/use-api-keys';
-export { buildApiKeyQueryKey, apiKeyKeys } from './hooks/query-keys';
+export { buildApiKeyQueryKey } from './hooks/query-keys';
 export { useApiKey } from './hooks/use-api-key';
 
 // Hooks — mutations

--- a/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
@@ -1,5 +1,3 @@
-import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
-import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { notFound, pagedResponse } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
@@ -13,142 +11,6 @@ import type {
   ApiKeyResponse,
   ApiKeyUpdateScopesRequest,
 } from '@granit/authentication-api-keys';
-import type { QueryMetadata } from '@granit/query-engine';
-
-const API_KEY_TYPES = ['Secret', 'Publishable', 'Webhook', 'Ephemeral'];
-
-/** Mock /meta payload for the API keys resource. */
-export const apiKeyQueryMetadata: QueryMetadata = {
-  columns: [
-    {
-      name: 'id',
-      label: 'ID',
-      type: 'Guid',
-      order: 0,
-      isSortable: false,
-      isFilterable: false,
-      isVisible: false,
-    },
-    {
-      name: 'name',
-      label: 'Name',
-      type: 'String',
-      order: 1,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'type',
-      label: 'Type',
-      type: 'String',
-      order: 2,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'environment',
-      label: 'Environment',
-      type: 'String',
-      order: 3,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'prefix',
-      label: 'Prefix',
-      type: 'String',
-      order: 4,
-      isSortable: false,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'lastFourChars',
-      label: 'Last 4',
-      type: 'String',
-      order: 5,
-      isSortable: false,
-      isFilterable: false,
-      isVisible: true,
-    },
-    {
-      name: 'expiresAt',
-      label: 'Expires at',
-      type: 'DateTime',
-      order: 6,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'lastUsedAt',
-      label: 'Last used',
-      type: 'DateTime',
-      order: 7,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'revokedAt',
-      label: 'Revoked at',
-      type: 'DateTime',
-      order: 8,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-    {
-      name: 'createdAt',
-      label: 'Created at',
-      type: 'DateTime',
-      order: 9,
-      isSortable: true,
-      isFilterable: true,
-      isVisible: true,
-    },
-  ],
-  filterableFields: [
-    { name: 'name', type: 'String', operators: STRING_OPERATORS },
-    { name: 'type', type: 'String', operators: ENUM_OPERATORS, enumValues: API_KEY_TYPES },
-    { name: 'environment', type: 'String', operators: ENUM_OPERATORS },
-    { name: 'prefix', type: 'String', operators: STRING_OPERATORS },
-    { name: 'expiresAt', type: 'DateTime', operators: DATE_OPERATORS },
-    { name: 'lastUsedAt', type: 'DateTime', operators: DATE_OPERATORS },
-    { name: 'revokedAt', type: 'DateTime', operators: DATE_OPERATORS },
-    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
-  ],
-  sortableFields: [
-    { name: 'name' },
-    { name: 'type' },
-    { name: 'environment' },
-    { name: 'expiresAt' },
-    { name: 'lastUsedAt' },
-    { name: 'revokedAt' },
-    { name: 'createdAt' },
-  ],
-  presetFilterGroups: [],
-  quickFilters: [
-    { name: 'active', label: 'Active', isDefault: true },
-    { name: 'revoked', label: 'Revoked', isDefault: false },
-    { name: 'expired', label: 'Expired', isDefault: false },
-  ],
-  dateFilters: [],
-  groupByFields: [
-    { name: 'type', type: 'String' },
-    { name: 'environment', type: 'String' },
-  ],
-  pagination: {
-    defaultPageSize: 20,
-    maxPageSize: 100,
-    maxStreamSize: 10_000,
-    supportsCursor: false,
-  },
-  defaultSort: '-createdAt',
-};
 
 type MutableApiKey = { -readonly [K in keyof ApiKeyResponse]: ApiKeyResponse[K] };
 
@@ -170,15 +32,16 @@ function generateSecret(type: string, environment: string): string {
 /**
  * Create stateful MSW handlers for API key endpoints.
  *
+ * Mirrors `Granit.Authentication.ApiKeys.Endpoints`: the list endpoint returns a
+ * `PagedResult<ApiKeyResponse>` and filters on `search`, a single `type`,
+ * `environment`, and `includeRevoked` — there is no `/meta` endpoint.
+ *
  * @param baseUrl - API base path (default: `/api/v1/authentication/api-keys`)
  */
 export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) {
   const apiKeys: MutableApiKey[] = mockApiKeys.map((k) => ({ ...k }));
 
   return [
-    // GET /api-keys/meta — query metadata
-    createQueryMetaHandler(baseUrl, apiKeyQueryMetadata),
-
     // GET list — paginated with filters
     http.get(baseUrl, ({ request }) => {
       const url = new URL(request.url);
@@ -199,8 +62,7 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
       }
 
       if (type) {
-        const types = new Set(type.split(','));
-        filtered = filtered.filter((k) => types.has(k.type));
+        filtered = filtered.filter((k) => k.type === type);
       }
 
       if (environment) {
@@ -271,7 +133,7 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
       );
     }),
 
-    // POST revoke
+    // POST revoke — backend returns 204 No Content
     http.post(`${baseUrl}/:id/revoke`, ({ params }) => {
       const key = apiKeys.find((k) => k.id === params.id);
       if (!key) return notFound();
@@ -279,7 +141,7 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
         return HttpResponse.json({ error: 'Key already revoked' }, { status: 409 });
       }
       key.revokedAt = toISODateString(new Date().toISOString());
-      return HttpResponse.json(key);
+      return new HttpResponse(null, { status: 204 });
     }),
 
     // POST rotate
@@ -310,7 +172,7 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
       });
     }),
 
-    // PUT update scopes
+    // PUT update scopes — backend returns 204 No Content
     http.put(`${baseUrl}/:id/scopes`, async ({ params, request }) => {
       const body = (await request.json()) as ApiKeyUpdateScopesRequest;
       const key = apiKeys.find((k) => k.id === params.id);
@@ -318,7 +180,7 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
 
       key.permissions = [...body.permissions];
       key.allowedCidrs = [...body.allowedCidrs];
-      return HttpResponse.json(key);
+      return new HttpResponse(null, { status: 204 });
     }),
   ];
 }

--- a/packages/@granit/react-authentication-api-keys/src/testing/index.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/index.ts
@@ -3,4 +3,4 @@
 // ---------------------------------------------------------------------------
 
 export { mockApiKeys } from './data';
-export { apiKeyQueryMetadata, createApiKeyHandlers } from './handlers';
+export { createApiKeyHandlers } from './handlers';

--- a/packages/@granit/react-authentication-entraid/package.json
+++ b/packages/@granit/react-authentication-entraid/package.json
@@ -18,6 +18,7 @@
     "@granit/api-client": "workspace:*",
     "@granit/authentication": "workspace:*",
     "@granit/authentication-entraid": "workspace:*",
+    "@granit/logger": "workspace:*",
     "@granit/react-authentication": "workspace:*",
     "react": "^19.0.0"
   },
@@ -31,6 +32,7 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/logger": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
+++ b/packages/@granit/react-authentication-entraid/src/hooks/use-entraid-init.ts
@@ -1,9 +1,12 @@
 import { PublicClientApplication, InteractionRequiredAuthError } from '@azure/msal-browser';
 import { setTokenGetter, setOnUnauthorized } from '@granit/api-client';
+import { createLogger } from '@granit/logger';
 import * as React from 'react';
 
 import type { LoginOptions, LogoutOptions, OidcUserInfo } from '@granit/authentication';
 import type { EntraIdAuthContextType, EntraIdCoreConfig } from '@granit/authentication-entraid';
+
+const logger = createLogger('authentication-entraid');
 
 export interface EntraIdCoreResult extends EntraIdAuthContextType {
   /** Direct ref to the MSAL PublicClientApplication instance. */
@@ -102,10 +105,7 @@ export function useEntraIdInit(config: EntraIdCoreConfig): EntraIdCoreResult {
           });
         }
       } catch (error) {
-        globalThis.console.warn(
-          '[@granit/react-authentication-entraid] MSAL initialization failed',
-          error
-        );
+        logger.error('MSAL initialization failed', error);
       } finally {
         setLoading(false);
       }

--- a/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/local-auth-provider.test.tsx
@@ -20,15 +20,13 @@ describe('LocalAuthProvider', () => {
 
     expect(result.current.client).toBe(client);
     expect(result.current.basePath).toBe('/api/v1/account');
-    expect(result.current.queryKeyPrefix).toEqual(['authentication-local']);
   });
 
-  it('should allow custom basePath and queryKeyPrefix', () => {
+  it('should allow a custom basePath', () => {
     const client = createMockClient();
     const config: LocalAuthConfig = {
       client,
       basePath: '/custom/auth',
-      queryKeyPrefix: ['custom'],
     };
 
     const wrapper = ({ children }: { children: ReactNode }) => (
@@ -38,7 +36,6 @@ describe('LocalAuthProvider', () => {
     const { result } = renderHook(() => useLocalAuthConfig(), { wrapper });
 
     expect(result.current.basePath).toBe('/custom/auth');
-    expect(result.current.queryKeyPrefix).toEqual(['custom']);
   });
 
   it('should throw when used outside provider', () => {

--- a/packages/@granit/react-authentication-local/src/hooks/query-keys.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/query-keys.ts
@@ -1,4 +1,0 @@
-/** Query key factory for local authentication queries. */
-export const localAuthKeys = {
-  all: ['authentication-local'] as const,
-};

--- a/packages/@granit/react-authentication-local/src/hooks/use-complete-passkey-assertion.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-complete-passkey-assertion.ts
@@ -5,7 +5,7 @@ import { useLocalAuthConfig } from '../providers/local-auth-provider';
 
 import type {
   AccountLoginResponse,
-  AccountPasskeyAssertionCompleteRequest,
+  AccountPasskeyLoginRequest,
 } from '@granit/authentication-local';
 import type { UseMutationResult } from '@tanstack/react-query';
 
@@ -18,12 +18,12 @@ import type { UseMutationResult } from '@tanstack/react-query';
 export function useCompletePasskeyAssertion(): UseMutationResult<
   AccountLoginResponse,
   Error,
-  AccountPasskeyAssertionCompleteRequest
+  AccountPasskeyLoginRequest
 > {
   const config = useLocalAuthConfig();
 
   return useMutation({
-    mutationFn: (request: AccountPasskeyAssertionCompleteRequest) =>
+    mutationFn: (request: AccountPasskeyLoginRequest) =>
       completePasskeyAssertion(config.client, config.basePath!, request),
   });
 }

--- a/packages/@granit/react-authentication-local/src/index.ts
+++ b/packages/@granit/react-authentication-local/src/index.ts
@@ -1,9 +1,5 @@
 // Provider
-export {
-  LocalAuthProvider,
-  buildLocalAuthQueryKey,
-  useLocalAuthConfig,
-} from './providers/local-auth-provider';
+export { LocalAuthProvider, useLocalAuthConfig } from './providers/local-auth-provider';
 export type { LocalAuthConfig, LocalAuthProviderProps } from './providers/local-auth-provider';
 
 // Hooks
@@ -16,6 +12,3 @@ export type {
 export { useVerifyTwoFactorLogin } from './hooks/use-verify-two-factor-login';
 export { useBeginPasskeyAssertion } from './hooks/use-begin-passkey-assertion';
 export { useCompletePasskeyAssertion } from './hooks/use-complete-passkey-assertion';
-
-// Query keys
-export { localAuthKeys } from './hooks/query-keys';

--- a/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
+++ b/packages/@granit/react-authentication-local/src/providers/local-auth-provider.tsx
@@ -14,7 +14,6 @@ export interface LocalAuthConfig {
    */
   readonly client?: AxiosInstance;
   readonly basePath?: string;
-  readonly queryKeyPrefix?: readonly string[];
 }
 
 /**
@@ -30,21 +29,12 @@ export interface LocalAuthProviderProps {
   readonly children: ReactNode;
 }
 
-const DEFAULT_KEY_PREFIX = ['authentication-local'] as const;
-
 const LocalAuthContext = createContext<ResolvedLocalAuthConfig | null>(null);
 
 export function useLocalAuthConfig(): ResolvedLocalAuthConfig {
   const config = useContext(LocalAuthContext);
   if (!config) throw new Error('useLocalAuthConfig must be used within a LocalAuthProvider');
   return config;
-}
-
-export function buildLocalAuthQueryKey(
-  config: LocalAuthConfig,
-  ...segments: readonly string[]
-): readonly unknown[] {
-  return [...(config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX), ...segments];
 }
 
 export function LocalAuthProvider({ config, children }: LocalAuthProviderProps) {
@@ -59,7 +49,6 @@ export function LocalAuthProvider({ config, children }: LocalAuthProviderProps) 
     return {
       ...config,
       basePath: config.basePath ?? DEFAULT_BASE_PATH,
-      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_KEY_PREFIX,
       client,
     };
   }, [config, contextClient]);

--- a/packages/@granit/react-bff/package.json
+++ b/packages/@granit/react-bff/package.json
@@ -15,6 +15,7 @@
   },
   "peerDependencies": {
     "@granit/bff": "workspace:*",
+    "@granit/logger": "workspace:*",
     "react": "^19.0.0"
   },
   "publishConfig": {

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -1,4 +1,5 @@
 import { CsrfManager, parseBffSessionResponse } from '@granit/bff';
+import { createLogger } from '@granit/logger';
 import {
   createContext,
   useCallback,
@@ -31,6 +32,10 @@ export interface BffContextType {
 }
 
 const BffContext = createContext<BffContextType | null>(null);
+
+// Fallback logger when the app wires no `config.logger`. Routes through the
+// @granit/logger façade (console transport in dev) instead of the raw console.
+const fallbackLogger = createLogger('react-bff');
 
 export interface BffProviderProps {
   readonly config: BffConfig;
@@ -72,7 +77,7 @@ export function BffProvider({ config, children }: BffProviderProps) {
 
         const parsed = parseBffSessionResponse(raw);
         if (!parsed.success) {
-          globalThis.console.warn(
+          (configRef.current.logger ?? fallbackLogger).warn(
             '[@granit/react-bff] Malformed /bff/user response — treating as unauthenticated',
             { issues: parsed.issues }
           );
@@ -90,11 +95,7 @@ export function BffProvider({ config, children }: BffProviderProps) {
       } catch (error) {
         if (cancelled) return;
         const message = '[@granit/react-bff] BFF session check failed';
-        if (configRef.current.logger) {
-          configRef.current.logger.warn(message, { error: String(error) });
-        } else {
-          globalThis.console.warn(message, error);
-        }
+        (configRef.current.logger ?? fallbackLogger).warn(message, { error: String(error) });
         setUser(null);
       } finally {
         if (!cancelled) setIsLoading(false);

--- a/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
+++ b/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 import { EMPTY_COMPONENT_CATALOG, type EntityComponentCatalog } from './component-catalog';
 
-import type { Logger } from '@granit/logger';
+import { createLogger, type Logger } from '@granit/logger';
 
 /**
  * Resolves an i18n key (as carried by the manifest) into a localised
@@ -26,17 +26,11 @@ export interface EntityRendererContextValue {
   readonly logger: Logger;
 }
 
-const consoleLogger: Logger = {
-  debug: (message, context) => globalThis.console.debug(message, context),
-  info: (message, context) => globalThis.console.info(message, context),
-  warn: (message, context) => globalThis.console.warn(message, context),
-  error: (message, error, context) => globalThis.console.error(message, error, context),
-  // The shim is a leaf — `child(prefix)` returns the same instance so apps
-  // wiring `useEntityRendererLogger().child('…')` outside a provider don't
-  // crash. Real namespacing kicks in once a `@granit/logger` Logger is
-  // wired via `<EntityRendererProvider logger={…}>`.
-  child: () => consoleLogger,
-};
+// Default logger used when no `@granit/logger` instance is wired into the
+// provider. Routes through the createLogger façade (console transport in dev)
+// so action failures still surface; production apps should wire a redacting
+// logger via `<EntityRendererProvider logger={…}>`.
+const consoleLogger: Logger = createLogger('react-entities');
 
 const EntityRendererContext = createContext<EntityRendererContextValue | null>(null);
 

--- a/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
+++ b/packages/@granit/react-entities/src/providers/entity-renderer-provider.tsx
@@ -1,8 +1,7 @@
+import { createLogger, type Logger } from '@granit/logger';
 import { createContext, useContext, useMemo, type ReactNode } from 'react';
 
 import { EMPTY_COMPONENT_CATALOG, type EntityComponentCatalog } from './component-catalog';
-
-import { createLogger, type Logger } from '@granit/logger';
 
 /**
  * Resolves an i18n key (as carried by the manifest) into a localised

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   picomatch: '>=4.0.4'
   react: 19.2.7
   react-dom: 19.2.7
+  uuid: ^11.1.1
 
 importers:
 
@@ -7183,9 +7184,8 @@ packages:
     peerDependencies:
       react: 19.2.7
 
-  uuid@9.0.1:
-    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
-    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
     hasBin: true
 
   vanilla-cookieconsent@3.1.0:
@@ -8788,7 +8788,7 @@ snapshots:
       react: 19.2.7
       react-hotkeys-hook: 4.6.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       use-debounce: 9.0.4(react@19.2.7)
-      uuid: 9.0.1
+      uuid: 11.1.1
       zustand: 5.0.14(@types/react@19.2.16)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
     transitivePeerDependencies:
       - '@floating-ui/dom'
@@ -11677,7 +11677,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  uuid@9.0.1: {}
+  uuid@11.1.1: {}
 
   vanilla-cookieconsent@3.1.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1273,6 +1273,9 @@ importers:
       '@granit/bff':
         specifier: workspace:*
         version: link:../bff
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
       react:
         specifier: 19.2.7
         version: 19.2.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1055,12 +1058,6 @@ importers:
       '@granit/authentication-api-keys':
         specifier: workspace:*
         version: link:../authentication-api-keys
-      '@granit/query-engine':
-        specifier: workspace:*
-        version: link:../query-engine
-      '@granit/react-query-engine':
-        specifier: workspace:*
-        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.100.14
         version: 5.100.14(react@19.2.7)
@@ -1074,6 +1071,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing
@@ -1127,6 +1127,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/logger':
+        specifier: workspace:*
+        version: link:../logger
 
   packages/@granit/react-authentication-google-cloud:
     dependencies:


### PR DESCRIPTION
## Summary

Framework conformity audit of the `authentication*` / `react-authentication*` packages against the .NET backend (`Granit.Authentication.ApiKeys.Endpoints`, `Granit.Identity.Local.Endpoints`). Fixes the contract drift the audit surfaced.

### `api-keys`
- **(breaking fix)** `useApiKeys` / `listApiKeys` now return `PagedResult<ApiKeyResponse>` — the backend `GET /api-keys` returns a paged result, not a bare array. The showcase had to bypass the hook because of this; it no longer needs to.
- `type` filter is now a single `ApiKeyType`, matching the backend `ApiKeyType?` query parameter (was modelled as `string[]` and comma-joined).
- Removed the deprecated `apiKeyKeys` factory and the orphan `/meta` mock (the endpoint exposes no query-engine `/meta`). Revoke & update-scopes mocks now return `204` like the backend.

### `local`
- Added `AccountTwoFactorLoginRequest.rememberMe` (backend supports it).
- Renamed `AccountPasskeyAssertionCompleteRequest` → `AccountPasskeyLoginRequest` to mirror the .NET DTO.
- Removed dead query-key code (`localAuthKeys`, `buildLocalAuthQueryKey`, `queryKeyPrefix`) — the package exposes no queries.

### `entraid`
- Route MSAL init failure through `@granit/logger` (`createLogger`) instead of `globalThis.console`.

Declares the new `@granit/query-engine` and `@granit/logger` peers and refreshes the affected unit tests.

## Verification

| Check | Result |
| ----- | ------ |
| `tsc` (touched packages) | ✅ |
| ESLint `--max-warnings 0` | ✅ |
| vitest (auth packages + `arch-tests`) | ✅ 2128 passed |
| `check:csp` | ✅ |
| showcase-react consumer `tsc` | ✅ (no regression) |

## Notes

- No external consumers import the renamed/removed symbols (verified across showcase-react + cms-renderer).
- Branch base lags `develop` by the `#547` arch-tests merge; the files don't overlap so it merges cleanly (rebase/Update branch optional).
