### PR TITLE
fix(bff): BFF audit conformity — validator nullability, react-bff testing mocks

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2954,6 +2954,11 @@
           "signature": "function useBffFetch()"
         },
         {
+          "name": "resolveBffTenantId",
+          "kind": "function",
+          "signature": "function resolveBffTenantId(user: BffUser | null): string | undefined"
+        },
+        {
           "name": "useBffTenantGetter",
           "kind": "function",
           "signature": "function useBffTenantGetter(): () => string | undefined"

--- a/packages/@granit/bff/src/csrf/csrf-manager.ts
+++ b/packages/@granit/bff/src/csrf/csrf-manager.ts
@@ -7,6 +7,8 @@
 // auto-injects it on mutation methods.
 // ---------------------------------------------------------------------------
 
+import type { BffCsrfTokenResponse } from '../types/index';
+
 const MUTATION_METHODS = new Set(['POST', 'PUT', 'DELETE', 'PATCH']);
 
 /** Manages CSRF token lifecycle for BFF-authenticated SPAs. */
@@ -28,7 +30,7 @@ export class CsrfManager {
     if (!response.ok) {
       throw new Error(`CSRF token fetch failed: ${response.status}`);
     }
-    const data = (await response.json()) as { csrfToken: string };
+    const data = (await response.json()) as BffCsrfTokenResponse;
     this.token = data.csrfToken;
     return this.token;
   }

--- a/packages/@granit/bff/src/index.ts
+++ b/packages/@granit/bff/src/index.ts
@@ -1,5 +1,6 @@
 export type {
   BffConfig,
+  BffCsrfTokenResponse,
   BffHostUser,
   BffSessionId,
   BffSessionInfo,

--- a/packages/@granit/bff/src/types/index.ts
+++ b/packages/@granit/bff/src/types/index.ts
@@ -16,7 +16,9 @@ import type { EntityId, ISODateString, TenantId } from '@granit/types';
 interface BffAuthenticatedUserBase {
   readonly authenticated: true;
   readonly sub: string;
+  /** Display name. `''` when the id_token carries no `name` claim (backend `string?`). */
   readonly name: string;
+  /** Email. `''` when the id_token carries no `email` claim (backend `string?`). */
   readonly email: string;
   readonly roles: readonly string[];
   readonly sessionExpiresAt: ISODateString;
@@ -62,6 +64,11 @@ export interface BffSessionInfo {
 /** Response from GET /{prefix}/bff/sessions. */
 export interface BffSessionListResponse {
   readonly sessions: readonly BffSessionInfo[];
+}
+
+/** Response from POST /{prefix}/bff/csrf-token. Mirrors Granit.Bff `BffCsrfTokenResponse`. */
+export interface BffCsrfTokenResponse {
+  readonly csrfToken: string;
 }
 
 /** Configuration for the BFF authentication provider. */

--- a/packages/@granit/bff/src/validation/parse-bff-user.ts
+++ b/packages/@granit/bff/src/validation/parse-bff-user.ts
@@ -59,12 +59,19 @@ function readAuthenticatedBase(
     issues.push('field "sub" must be a non-empty string');
     ok = false;
   }
-  if (!isString(obj.name)) {
-    issues.push('field "name" must be a string');
+  // Backend emits `name`/`email` as nullable (`string?`): a session whose
+  // id_token carries no profile/email claim is still authenticated. Map a
+  // null/absent claim to '' instead of rejecting the whole response — the
+  // previous strict check silently forced such a valid user into the
+  // unauthenticated state. A present-but-non-string value is still malformed.
+  const name = obj.name ?? '';
+  if (typeof name !== 'string') {
+    issues.push('field "name" must be a string when present');
     ok = false;
   }
-  if (!isString(obj.email)) {
-    issues.push('field "email" must be a string');
+  const email = obj.email ?? '';
+  if (typeof email !== 'string') {
+    issues.push('field "email" must be a string when present');
     ok = false;
   }
   if (!isStringArray(obj.roles)) {
@@ -78,8 +85,8 @@ function readAuthenticatedBase(
   if (!ok) return null;
   return {
     sub: obj.sub as string,
-    name: obj.name as string,
-    email: obj.email as string,
+    name: name as string,
+    email: email as string,
     roles: obj.roles as readonly string[],
     sessionExpiresAt: obj.sessionExpiresAt as ISODateString,
   };

--- a/packages/@granit/react-bff/package.json
+++ b/packages/@granit/react-bff/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"
@@ -16,15 +17,29 @@
   "peerDependencies": {
     "@granit/bff": "workspace:*",
     "@granit/logger": "workspace:*",
+    "msw": "^2.12.0",
     "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   },
   "publishConfig": {
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   }
 }

--- a/packages/@granit/react-bff/src/index.ts
+++ b/packages/@granit/react-bff/src/index.ts
@@ -4,7 +4,7 @@ export type { BffContextType, BffProviderProps } from './providers/bff-provider'
 export { useBffAuth } from './hooks/use-bff-auth';
 export { useBffCsrf } from './hooks/use-bff-csrf';
 export { useBffFetch } from './hooks/use-bff-fetch';
-export { useBffTenantGetter } from './hooks/use-bff-tenant';
+export { resolveBffTenantId, useBffTenantGetter } from './hooks/use-bff-tenant';
 
 export {
   useBffSessions,

--- a/packages/@granit/react-bff/src/testing/data.ts
+++ b/packages/@granit/react-bff/src/testing/data.ts
@@ -1,0 +1,54 @@
+import { toEntityId, toISODateString } from '@granit/types';
+
+import type { BffHostUser, BffSessionInfo, BffTenantUser } from '@granit/bff';
+
+/** Canonical CSRF token returned by the mock `POST /bff/csrf-token` handler. */
+export const mockBffCsrfToken = 'csrf-mock-token';
+
+/** Authenticated tenant-scoped user (carries a `tenantId`, `isHost: false`). */
+export const mockBffTenantUser: BffTenantUser = {
+  authenticated: true,
+  isHost: false,
+  sub: 'user-123',
+  name: 'Alice Tenant',
+  email: 'alice@acme.test',
+  roles: ['Admin'],
+  sessionExpiresAt: toISODateString('2026-12-31T23:59:59Z'),
+  tenantId: toEntityId<'Tenant'>('acme'),
+};
+
+/** Authenticated Host (cross-tenant) user — never carries a `tenantId`. */
+export const mockBffHostUser: BffHostUser = {
+  authenticated: true,
+  isHost: true,
+  sub: 'host-1',
+  name: 'Henry Host',
+  email: 'henry@host.test',
+  roles: ['Host'],
+  sessionExpiresAt: toISODateString('2026-12-31T23:59:59Z'),
+};
+
+/**
+ * Active BFF sessions for the current user. Session IDs are masked
+ * server-side, mirroring `Granit.Bff` `MaskSessionId` output.
+ */
+export const mockBffSessions: BffSessionInfo[] = [
+  {
+    sessionId: toEntityId<'BffSession'>('ab12...cd34'),
+    isCurrent: true,
+    createdAt: toISODateString('2026-03-23T08:15:00Z'),
+    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/134.0.0.0',
+  },
+  {
+    sessionId: toEntityId<'BffSession'>('ef56...gh78'),
+    isCurrent: false,
+    createdAt: toISODateString('2026-03-22T14:30:00Z'),
+    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 19_0) Safari/605.1.15',
+  },
+  {
+    sessionId: toEntityId<'BffSession'>('ij90...kl12'),
+    isCurrent: false,
+    createdAt: toISODateString('2026-03-20T09:45:00Z'),
+    userAgent: null,
+  },
+];

--- a/packages/@granit/react-bff/src/testing/handlers.ts
+++ b/packages/@granit/react-bff/src/testing/handlers.ts
@@ -1,0 +1,60 @@
+import { noContent } from '@granit/testing/msw';
+import { http, HttpResponse } from 'msw';
+
+import { mockBffCsrfToken, mockBffSessions, mockBffTenantUser } from './data';
+
+import type {
+  BffCsrfTokenResponse,
+  BffSessionInfo,
+  BffSessionListResponse,
+  BffUser,
+} from '@granit/bff';
+
+/**
+ * Create stateful MSW handlers for the BFF authentication endpoints.
+ *
+ * MSW intercepts native `fetch`, so these cover the bootstrap flow that sits
+ * below the Axios client — `@granit/bff` uses `fetch` deliberately:
+ * - `GET  {prefix}/bff/user`         — current user (default: an authenticated tenant user)
+ * - `POST {prefix}/bff/csrf-token`   — CSRF token issuance
+ * - `GET  {prefix}/bff/sessions`     — active sessions (wrapped in `{ sessions }`)
+ * - `DELETE {prefix}/bff/sessions/:id` — revoke one session (mutates in-memory state)
+ * - `DELETE {prefix}/bff/sessions`     — revoke all other sessions (keeps the current one)
+ *
+ * Session state is per-handler-set: a revoke is reflected by subsequent list calls.
+ *
+ * @param pathPrefix - Frontend path prefix (e.g. `'/admin'`). Default: `''`.
+ * @param user       - User returned by `GET /bff/user`. Default: {@link mockBffTenantUser}.
+ *                     Pass `{ authenticated: false }` to mock an anonymous session.
+ */
+export function createBffHandlers(
+  pathPrefix = '',
+  user: BffUser | { authenticated: false } = mockBffTenantUser
+) {
+  const base = `${pathPrefix}/bff`;
+  let sessions: BffSessionInfo[] = [...mockBffSessions];
+
+  return [
+    http.get(`${base}/user`, () => HttpResponse.json(user)),
+
+    http.post(`${base}/csrf-token`, () =>
+      HttpResponse.json({ csrfToken: mockBffCsrfToken } satisfies BffCsrfTokenResponse)
+    ),
+
+    http.get(`${base}/sessions`, () =>
+      HttpResponse.json({ sessions } satisfies BffSessionListResponse)
+    ),
+
+    // Revoke a single session by its (masked) id.
+    http.delete(`${base}/sessions/:sessionId`, ({ params }) => {
+      sessions = sessions.filter((s) => s.sessionId !== params.sessionId);
+      return noContent();
+    }),
+
+    // Revoke all other sessions — keep only the current one ("log out everywhere else").
+    http.delete(`${base}/sessions`, () => {
+      sessions = sessions.filter((s) => s.isCurrent);
+      return noContent();
+    }),
+  ];
+}

--- a/packages/@granit/react-bff/src/testing/index.ts
+++ b/packages/@granit/react-bff/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-bff/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockBffCsrfToken, mockBffHostUser, mockBffSessions, mockBffTenantUser } from './data';
+export { createBffHandlers } from './handlers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1277,9 +1277,19 @@ importers:
       '@granit/logger':
         specifier: workspace:*
         version: link:../logger
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
+    devDependencies:
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-blob-storage:
     dependencies:


### PR DESCRIPTION
## Context

Conformity audit of `@granit/bff` + `@granit/react-bff` against the `Granit.Bff` / `Granit.Bff.Endpoints` backend contract, plus the showcase integration. This PR lands the safe, front-side fixes from that audit.

## Changes

### `@granit/bff`
- **Validator nullability (BREAKING fix).** The .NET `BffUserResponse` types `Sub`/`Name`/`Email` as `string?`, but the `/bff/user` validator required non-null `name`/`email` and rejected the whole response when a claim was absent — silently forcing a valid session to the **unauthenticated** state (e.g. a minimal-scope token or service account without a `name`/`email` claim). Null/absent now maps to `''`; a present-but-non-string value is still rejected.
- **`BffCsrfTokenResponse` type.** Exported, mirroring the .NET record, replacing the inline `{ csrfToken: string }` shape in `CsrfManager`.

### `@granit/react-bff`
- **New `./testing` subpath (GAP fix).** `react-bff` was the **only** `react-*` package without reusable MSW mocks — every other one ships `create*Handlers` + mock data (consumed in 80+ sites by the showcase), so consumers had to hand-roll BFF mocks. Adds `createBffHandlers()` (MSW handlers for `/bff/user`, `/bff/csrf-token`, `/bff/sessions` list + delete, with the correct `{ sessions }` shape) plus `mockBffTenantUser` / `mockBffHostUser` / `mockBffSessions` / `mockBffCsrfToken`.
- **Re-export `resolveBffTenantId`** from the barrel (pure helper, previously reachable only via deep import).

## Verification
| Check | Result |
| --- | --- |
| `tsc --noEmit` (both packages) | PASS |
| ESLint (`--max-warnings 0`) | PASS |
| Vitest (both packages) | PASS — 59/59 |
| `pnpm install --frozen-lockfile` | PASS |

## Out of scope (tracked separately)
- **Session revoke masked-vs-raw ID mismatch** — the backend `/bff/sessions` list masks IDs (`MaskSessionId`, lossy, a deliberate XSS control) while the revoke endpoint resolves by the raw ID, so `revokeBffSession` can't succeed against the real backend. This needs a **backend** change (an opaque, non-reversible revoke handle) — no safe front-side fix.