### PR TITLE
fix(query-engine): tolerate non-conforming /meta payloads in useSmartFilter

### DIFF
--- a/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
+++ b/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
@@ -267,3 +267,43 @@ describe('useSmartFilter — lookup-backed fields', () => {
     expect(result.current.selectedFieldLookup).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Malformed / partial `/meta` payloads — degrade gracefully, never crash
+// ---------------------------------------------------------------------------
+
+describe('useSmartFilter — resilient to non-conforming metadata', () => {
+  it('does not crash when the /meta response is an HTML string (SPA fallthrough)', () => {
+    // An unintercepted /meta request resolves to the SPA `index.html` — a
+    // truthy string. It must not throw `filterableFields is not iterable`.
+    const html = '<!doctype html><html><body>app</body></html>' as unknown as QueryMetadata;
+    const { result } = renderHook(() => useSmartFilter({ metadata: html }));
+
+    expect(result.current.phase).toBe('idle');
+    expect(result.current.suggestions).toEqual([]);
+  });
+
+  it('does not crash when metadata is missing array fields', () => {
+    const partial = { ...MOCK_METADATA, filterableFields: undefined } as unknown as QueryMetadata;
+    const { result } = renderHook(() => useSmartFilter({ metadata: partial }));
+
+    // No field suggestions (filterableFields gone), but the still-present
+    // preset / quick-filter arrays keep producing suggestions.
+    expect(result.current.suggestions.some((s) => s.field === 'LastName')).toBe(false);
+    expect(result.current.suggestions.some((s) => s.type === 'preset')).toBe(true);
+  });
+
+  it('does not crash selecting a field when filterableFields is missing', () => {
+    const partial = { ...MOCK_METADATA, filterableFields: undefined } as unknown as QueryMetadata;
+    const { result } = renderHook(() => useSmartFilter({ metadata: partial }));
+
+    act(() => result.current.selectField('LastName'));
+    expect(result.current.selectedFieldType).toBeUndefined();
+    expect(result.current.selectedFieldLookup).toBeUndefined();
+  });
+
+  it('treats an empty object as empty metadata rather than throwing', () => {
+    const { result } = renderHook(() => useSmartFilter({ metadata: {} as QueryMetadata }));
+    expect(result.current.suggestions).toEqual([]);
+  });
+});

--- a/packages/@granit/react-query-engine/src/hooks/use-smart-filter.ts
+++ b/packages/@granit/react-query-engine/src/hooks/use-smart-filter.ts
@@ -428,6 +428,37 @@ function buildSuggestions(
   }
 }
 
+/**
+ * Defensive normalization of the `/meta` payload.
+ *
+ * Suggestion building iterates the array fields of {@link QueryMetadata}
+ * (`filterableFields`, `columns`, `presetFilterGroups`, `quickFilters`). A
+ * `/meta` response that is missing, partial, or not the expected shape — a
+ * backend that omits a field, an API-version skew, or (in dev) an
+ * unintercepted request falling through to the SPA's `index.html` — would
+ * otherwise throw `metadata.filterableFields is not iterable` and take down
+ * the whole route through the router error boundary.
+ *
+ * Returns `undefined` for anything that isn't a metadata-shaped object;
+ * otherwise backfills missing array fields with `[]` so every consumer sees a
+ * guaranteed shape. A malformed `/meta` then degrades to an empty suggestion
+ * list instead of crashing the page.
+ */
+function normalizeMetadata(metadata: QueryMetadata | undefined): QueryMetadata | undefined {
+  if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) return undefined;
+  const asArray = <T>(value: readonly T[]): readonly T[] => (Array.isArray(value) ? value : []);
+  return {
+    ...metadata,
+    columns: asArray(metadata.columns),
+    filterableFields: asArray(metadata.filterableFields),
+    sortableFields: asArray(metadata.sortableFields),
+    presetFilterGroups: asArray(metadata.presetFilterGroups),
+    quickFilters: asArray(metadata.quickFilters),
+    dateFilters: asArray(metadata.dateFilters),
+    groupByFields: asArray(metadata.groupByFields),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Hook options & return
 // ---------------------------------------------------------------------------
@@ -504,13 +535,18 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
     nextId: 1,
   });
 
+  // Normalize the `/meta` payload once so a missing / partial / non-conforming
+  // response degrades to empty suggestions instead of crashing the route. Every
+  // consumer below reads `metadata` (never `options?.metadata`) for this reason.
+  const metadata = useMemo(() => normalizeMetadata(options?.metadata), [options?.metadata]);
+
   const suggestions = useMemo(
     () =>
-      buildSuggestions(state, options?.metadata, {
+      buildSuggestions(state, metadata, {
         booleanLabels: options?.booleanLabels,
         operatorLabels: options?.operatorLabels,
       }),
-    [state, options?.metadata, options?.booleanLabels, options?.operatorLabels]
+    [state, metadata, options?.booleanLabels, options?.operatorLabels]
   );
 
   // Extract structured data from tokens
@@ -558,11 +594,11 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
     (value: string) => {
       const field = state.selectedField;
       const operator = state.selectedOperator;
-      const col = options?.metadata?.columns.find((c) => c.name === field);
+      const col = metadata?.columns.find((c) => c.name === field);
       const fieldLabel = col?.label ?? field ?? '';
       const opLabel = (operator && options?.operatorLabels?.[operator]) ?? operator ?? '';
       const isBool =
-        options?.metadata?.filterableFields.find((f) => f.name === field)?.type === 'Boolean';
+        metadata?.filterableFields.find((f) => f.name === field)?.type === 'Boolean';
       let valLabel = value;
       if (isBool && options?.booleanLabels) {
         valLabel = value === 'true' ? options.booleanLabels.true : options.booleanLabels.false;
@@ -577,7 +613,7 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
     [
       state.selectedField,
       state.selectedOperator,
-      options?.metadata,
+      metadata,
       options?.operatorLabels,
       options?.booleanLabels,
     ]
@@ -605,14 +641,14 @@ export function useSmartFilter(options?: UseSmartFilterOptions): UseSmartFilterR
   const cancel = useCallback(() => dispatch({ type: 'CANCEL' }), []);
 
   const selectedFieldType = useMemo(() => {
-    if (!state.selectedField || !options?.metadata) return undefined;
-    return options.metadata.filterableFields.find((f) => f.name === state.selectedField)?.type;
-  }, [state.selectedField, options?.metadata]);
+    if (!state.selectedField || !metadata) return undefined;
+    return metadata.filterableFields.find((f) => f.name === state.selectedField)?.type;
+  }, [state.selectedField, metadata]);
 
   const selectedFieldLookup = useMemo(() => {
-    if (!state.selectedField || !options?.metadata) return undefined;
-    return options.metadata.filterableFields.find((f) => f.name === state.selectedField)?.lookup;
-  }, [state.selectedField, options?.metadata]);
+    if (!state.selectedField || !metadata) return undefined;
+    return metadata.filterableFields.find((f) => f.name === state.selectedField)?.lookup;
+  }, [state.selectedField, metadata]);
 
   return {
     phase: state.phase,


### PR DESCRIPTION
## Problem

A `/meta` response that is **missing, partial, or not the expected shape** made `useSmartFilter` crash the entire route with:

```
TypeError: metadata.filterableFields is not iterable
    at buildFieldSuggestions (use-smart-filter.ts)
```

The hook guards `if (!metadata)` but then trusts the *shape* — it unconditionally iterates `metadata.filterableFields` / `.columns` / `.presetFilterGroups` / `.quickFilters`. Any truthy-but-non-conforming payload sails past the guard and throws, and the error propagates to the router error boundary (white-screens the page).

Realistic triggers:
- A backend that omits a field, or an API-version skew.
- In dev: an **unintercepted request falling through to the SPA `index.html`** — `response.data` becomes a truthy HTML *string*. (This is how it surfaced in the showcase scheduling page.)

## Fix

Normalize the payload **once** in `useSmartFilter`:
- Return `undefined` for anything that isn't a metadata-shaped object (string, array, primitive).
- Otherwise backfill missing array fields with `[]`.

Every consumer (suggestion builders, `confirmValue`, `selectedFieldType`, `selectedFieldLookup`) now reads the normalized value, so a malformed `/meta` **degrades to an empty suggestion list instead of crashing the page**.

## Tests

Adds regression coverage for HTML-string (SPA fallthrough), missing-array, and empty-object payloads. Full `@granit/react-query-engine` suite: **97 passing**, lint clean, `tsc --noEmit` clean.