### PR TITLE
fix(react-authentication): dedup BFF session mocks to react-bff/testing

### DIFF
--- a/packages/@granit/react-authentication/package.json
+++ b/packages/@granit/react-authentication/package.json
@@ -38,7 +38,6 @@
     "registry": "https://npm.pkg.github.com"
   },
   "devDependencies": {
-    "@granit/bff": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/react-bff": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication/src/testing/data.ts
+++ b/packages/@granit/react-authentication/src/testing/data.ts
@@ -1,24 +1,3 @@
-import { toEntityId, toISODateString } from '@granit/types';
-
-import type { BffSessionInfo } from '@granit/bff';
-
-export const mockBffSessions: BffSessionInfo[] = [
-  {
-    sessionId: toEntityId<'BffSession'>('ab12...cd34'),
-    isCurrent: true,
-    createdAt: toISODateString('2026-03-23T08:15:00Z'),
-    userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) Chrome/134.0.0.0',
-  },
-  {
-    sessionId: toEntityId<'BffSession'>('ef56...gh78'),
-    isCurrent: false,
-    createdAt: toISODateString('2026-03-22T14:30:00Z'),
-    userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 19_0) Safari/605.1.15',
-  },
-  {
-    sessionId: toEntityId<'BffSession'>('ij90...kl12'),
-    isCurrent: false,
-    createdAt: toISODateString('2026-03-20T09:45:00Z'),
-    userAgent: null,
-  },
-];
+// BFF session mocks are owned by @granit/react-bff/testing (single source of
+// truth). Re-exported here for the BFF session handlers and existing imports.
+export { mockBffSessions } from '@granit/react-bff/testing';

--- a/packages/@granit/react-authentication/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication/src/testing/handlers.ts
@@ -113,9 +113,11 @@ export function createAuthHandlers(baseUrl = '/api/v1/auth', bffSessionsUrl = '/
       });
     }),
 
-    // BFF session endpoints
+    // BFF session endpoints — list is wrapped in `{ sessions }`, mirroring
+    // the Granit.Bff `BffSessionListResponse` contract that `listBffSessions`
+    // reads (`data.sessions`).
     http.get(bffSessionsUrl, () => {
-      return HttpResponse.json(mockBffSessions);
+      return HttpResponse.json({ sessions: mockBffSessions });
     }),
 
     http.delete(`${bffSessionsUrl}/:sessionId`, () => {

--- a/packages/@granit/react-authentication/tsconfig.json
+++ b/packages/@granit/react-authentication/tsconfig.json
@@ -4,8 +4,7 @@
     "paths": {
       "@granit/api-client": ["../api-client/src/index.ts"],
       "@granit/authentication": ["../authentication/src/index.ts"],
-      "@granit/bff": ["../bff/src/index.ts"],
-      "@granit/types": ["../types/src/index.ts"]
+      "@granit/react-bff/testing": ["../react-bff/src/testing/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1047,12 +1047,9 @@ importers:
         specifier: 19.2.7
         version: 19.2.7
     devDependencies:
-      '@granit/bff':
+      '@granit/react-bff':
         specifier: workspace:*
-        version: link:../bff
-      '@granit/types':
-        specifier: workspace:*
-        version: link:../types
+        version: link:../react-bff
 
   packages/@granit/react-authentication-api-keys:
     dependencies:


### PR DESCRIPTION
Follow-up cleanup to #549 (BFF audit). Now that `@granit/react-bff/testing` owns the canonical BFF mocks, this removes the duplication/leak in `@granit/react-authentication/testing`.

## Changes
- **Bug fix:** the `/bff/sessions` MSW handler returned a **bare array** instead of the `{ sessions }` envelope that `listBffSessions` reads (`data.sessions`) — it would have broken `useBffSessions` if exercised through MSW.
- **Dedup:** `mockBffSessions` is re-exported from `@granit/react-bff/testing` (single source of truth) instead of being redefined; drops the `@granit/bff` + `@granit/types` dev-deps in favour of `@granit/react-bff`.
- `createAuthHandlers` keeps its signature → **no consumer (showcase) change required**.

## Verification
| Check | Result |
| --- | --- |
| `tsc --noEmit` | PASS |
| ESLint (`--max-warnings 0`) | PASS |
| Vitest (`react-authentication`) | PASS — 154/154 |
| `pnpm install --frozen-lockfile` | PASS |

## Note
Fully relocating the BFF session *handlers* out of `createAuthHandlers` (so the showcase composes `createBffHandlers()` directly) is the remaining coordinated step — it requires a paired change in the showcase repo (separate GitLab MR) and is intentionally out of scope here to keep this non-breaking.