### PR TITLE
feat(react-cms): /testing MSW handler factories for CMS admin mocks

### DIFF
--- a/packages/@granit/react-cms-hostnames/package.json
+++ b/packages/@granit/react-cms-hostnames/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
@@ -22,6 +23,12 @@
     "@granit/hostnames": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   }
 }

--- a/packages/@granit/react-cms-hostnames/src/testing/data.ts
+++ b/packages/@granit/react-cms-hostnames/src/testing/data.ts
@@ -1,0 +1,61 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-hostnames/testing — mock fixtures
+// ---------------------------------------------------------------------------
+
+import type { ManagedHostnameResponse } from '@granit/cms-hostnames';
+
+export const CORPORATE_SITE_ID = 'b1f0c3a4-1d2e-4f5a-8b6c-1a2b3c4d5e6f';
+
+/**
+ * Mock managed hostnames for the corporate site. `useSiteHostnames` returns a
+ * BARE ARRAY (not a paged envelope).
+ */
+export const mockHostnames: ManagedHostnameResponse[] = [
+  {
+    id: '60000000-0000-4000-8000-000000000001',
+    host: 'www.example.com',
+    ownerType: 'cms.site',
+    ownerId: CORPORATE_SITE_ID,
+    tenantId: null,
+    isPrimary: true,
+    status: 'Active',
+    verificationToken: null,
+    expectedDnsRecords: [{ recordType: 'Cname', name: 'www', value: 'edge.granit.app' }],
+    lastCheckedAt: '2026-06-01T08:00:00Z',
+    conflicts: [],
+    failedCheckCount: 0,
+    nextCheckAt: null,
+    certificateStatus: 'Secured',
+    certExpiresAt: '2026-09-01T00:00:00Z',
+    createdAt: '2026-05-01T10:00:00Z',
+    createdBy: 'marie.dupont',
+    modifiedAt: null,
+    modifiedBy: null,
+    concurrencyStamp: 'stamp-hostname-1',
+  },
+  {
+    id: '60000000-0000-4000-8000-000000000002',
+    host: 'promo.example.com',
+    ownerType: 'cms.site',
+    ownerId: CORPORATE_SITE_ID,
+    tenantId: null,
+    isPrimary: false,
+    status: 'Pending',
+    verificationToken: 'granit-verify-7f3a9c2e',
+    expectedDnsRecords: [
+      { recordType: 'Txt', name: '_granit-challenge.promo', value: 'granit-verify-7f3a9c2e' },
+      { recordType: 'Cname', name: 'promo', value: 'edge.granit.app' },
+    ],
+    lastCheckedAt: null,
+    conflicts: [],
+    failedCheckCount: 0,
+    nextCheckAt: '2026-06-04T12:00:00Z',
+    certificateStatus: 'Unprovisioned',
+    certExpiresAt: null,
+    createdAt: '2026-06-03T14:30:00Z',
+    createdBy: 'marie.dupont',
+    modifiedAt: null,
+    modifiedBy: null,
+    concurrencyStamp: 'stamp-hostname-2',
+  },
+];

--- a/packages/@granit/react-cms-hostnames/src/testing/handlers.ts
+++ b/packages/@granit/react-cms-hostnames/src/testing/handlers.ts
@@ -1,0 +1,101 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-hostnames/testing — MSW handler factory
+// ---------------------------------------------------------------------------
+
+import { http, HttpResponse, type RequestHandler } from 'msw';
+
+import { mockHostnames } from './data';
+
+import type { ManagedHostnameResponse } from '@granit/cms-hostnames';
+
+type AddHostnameBody = { readonly host: string; readonly isPrimary?: boolean };
+
+/**
+ * MSW handlers for the site-scoped managed-hostnames API
+ * (`{baseUrl}/sites/{siteId}/hostnames`). The list endpoint returns a BARE
+ * ARRAY; mutations cover add/remove/set-primary/verify.
+ *
+ * @param baseUrl - CMS API base (default `/api/cms`).
+ */
+export function createCmsHostnamesHandlers(baseUrl = '/api/cms'): RequestHandler[] {
+  const collection = `${baseUrl}/sites/:siteId/hostnames`;
+  const hostnames: ManagedHostnameResponse[] = mockHostnames.map((hostname) => ({ ...hostname }));
+
+  return [
+    http.get(collection, ({ params }) => {
+      const siteId = params.siteId as string;
+      return HttpResponse.json(hostnames.filter((hostname) => hostname.ownerId === siteId));
+    }),
+
+    http.post(collection, async ({ params, request }) => {
+      const siteId = params.siteId as string;
+      const dto = (await request.json()) as AddHostnameBody;
+      const hostname: ManagedHostnameResponse = {
+        id: crypto.randomUUID(),
+        host: dto.host,
+        ownerType: 'cms.site',
+        ownerId: siteId,
+        tenantId: null,
+        isPrimary: dto.isPrimary ?? false,
+        status: 'Pending',
+        verificationToken: `granit-verify-${crypto.randomUUID().slice(0, 8)}`,
+        expectedDnsRecords: [
+          {
+            recordType: 'Cname',
+            name: dto.host.split('.')[0] ?? dto.host,
+            value: 'edge.granit.app',
+          },
+        ],
+        lastCheckedAt: null,
+        conflicts: [],
+        failedCheckCount: 0,
+        nextCheckAt: null,
+        certificateStatus: 'Unprovisioned',
+        certExpiresAt: null,
+        createdAt: '2026-06-04T00:00:00Z',
+        createdBy: 'marie.dupont',
+        modifiedAt: null,
+        modifiedBy: null,
+        concurrencyStamp: crypto.randomUUID(),
+      };
+      hostnames.push(hostname);
+      return HttpResponse.json(hostname, { status: 201 });
+    }),
+
+    http.post(`${collection}/:hostnameId/primary`, ({ params }) => {
+      const target = hostnames.find((hostname) => hostname.id === params.hostnameId);
+      if (!target) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      hostnames.forEach((hostname, i) => {
+        if (hostname.ownerId === target.ownerId) {
+          hostnames[i] = { ...hostname, isPrimary: hostname.id === target.id };
+        }
+      });
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    http.post(`${collection}/:hostnameId/verify-now`, ({ params }) => {
+      const existing = hostnames.find((hostname) => hostname.id === params.hostnameId);
+      if (!existing) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      const updated: ManagedHostnameResponse = {
+        ...existing,
+        status: 'Verifying',
+        lastCheckedAt: '2026-06-04T00:00:00Z',
+      };
+      hostnames[hostnames.indexOf(existing)] = updated;
+      return HttpResponse.json(updated, { status: 202 });
+    }),
+
+    http.delete(`${collection}/:hostnameId`, ({ params }) => {
+      const existing = hostnames.find((hostname) => hostname.id === params.hostnameId);
+      if (!existing) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      hostnames.splice(hostnames.indexOf(existing), 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}

--- a/packages/@granit/react-cms-hostnames/src/testing/index.ts
+++ b/packages/@granit/react-cms-hostnames/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-hostnames/testing — mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { CORPORATE_SITE_ID, mockHostnames } from './data';
+export { createCmsHostnamesHandlers } from './handlers';

--- a/packages/@granit/react-cms-redirects/package.json
+++ b/packages/@granit/react-cms-redirects/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
@@ -20,6 +21,12 @@
     "@granit/cms-redirects": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   }
 }

--- a/packages/@granit/react-cms-redirects/src/testing/data.ts
+++ b/packages/@granit/react-cms-redirects/src/testing/data.ts
@@ -1,0 +1,29 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-redirects/testing — mock fixtures
+// ---------------------------------------------------------------------------
+
+import type { RedirectResponse } from '@granit/cms-redirects';
+
+const CORPORATE_SITE_ID = 'b1f0c3a4-1d2e-4f5a-8b6c-1a2b3c4d5e6f';
+
+/** Mock redirects for the corporate site. */
+export const mockRedirects: RedirectResponse[] = [
+  {
+    id: '50000000-0000-4000-8000-000000000001',
+    siteId: CORPORATE_SITE_ID,
+    fromPath: '/old-about',
+    toPath: '/about',
+    culture: null,
+    statusCode: 301,
+    isEnabled: true,
+  },
+  {
+    id: '50000000-0000-4000-8000-000000000002',
+    siteId: CORPORATE_SITE_ID,
+    fromPath: '/promo',
+    toPath: '/campaign-2026',
+    culture: 'en-GB',
+    statusCode: 302,
+    isEnabled: false,
+  },
+];

--- a/packages/@granit/react-cms-redirects/src/testing/handlers.ts
+++ b/packages/@granit/react-cms-redirects/src/testing/handlers.ts
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-redirects/testing — MSW handler factory
+// ---------------------------------------------------------------------------
+
+import { http, HttpResponse, type RequestHandler } from 'msw';
+
+import { mockRedirects } from './data';
+
+import type {
+  CreateRedirectRequest,
+  PagedResponse,
+  RedirectResponse,
+  UpdateRedirectRequest,
+} from '@granit/cms-redirects';
+
+/**
+ * MSW handlers for the CMS redirects API (`/api/cms/redirects`). List returns a
+ * `PagedResponse<RedirectResponse>`; create/update return a single redirect.
+ */
+export function createCmsRedirectsHandlers(baseUrl = '/api/cms/redirects'): RequestHandler[] {
+  const redirects: RedirectResponse[] = mockRedirects.map((redirect) => ({ ...redirect }));
+
+  return [
+    http.get(baseUrl, ({ request }) => {
+      const url = new URL(request.url);
+      const siteId = url.searchParams.get('siteId');
+      const page = Number(url.searchParams.get('page') ?? '1');
+      const pageSize = Number(url.searchParams.get('pageSize') ?? '20');
+      const filtered = siteId
+        ? redirects.filter((redirect) => redirect.siteId === siteId)
+        : redirects;
+      const start = (page - 1) * pageSize;
+      const body: PagedResponse<RedirectResponse> = {
+        items: filtered.slice(start, start + pageSize),
+        totalCount: filtered.length,
+        page,
+        pageSize,
+      };
+      return HttpResponse.json(body);
+    }),
+
+    http.post(baseUrl, async ({ request }) => {
+      const dto = (await request.json()) as CreateRedirectRequest;
+      const redirect: RedirectResponse = {
+        id: crypto.randomUUID(),
+        siteId: dto.siteId,
+        fromPath: dto.fromPath,
+        toPath: dto.toPath,
+        culture: dto.culture ?? null,
+        statusCode: dto.statusCode ?? 301,
+        isEnabled: true,
+      };
+      redirects.push(redirect);
+      return HttpResponse.json(redirect, { status: 201 });
+    }),
+
+    http.put(`${baseUrl}/:id`, async ({ params, request }) => {
+      const existing = redirects.find((redirect) => redirect.id === params.id);
+      if (!existing) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      const dto = (await request.json()) as UpdateRedirectRequest;
+      const updated: RedirectResponse = {
+        ...existing,
+        fromPath: dto.fromPath,
+        toPath: dto.toPath,
+        culture: dto.culture ?? null,
+        statusCode: dto.statusCode ?? existing.statusCode,
+        isEnabled: dto.isEnabled ?? existing.isEnabled,
+      };
+      redirects[redirects.indexOf(existing)] = updated;
+      return HttpResponse.json(updated);
+    }),
+
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const existing = redirects.find((redirect) => redirect.id === params.id);
+      if (!existing) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      redirects.splice(redirects.indexOf(existing), 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}

--- a/packages/@granit/react-cms-redirects/src/testing/index.ts
+++ b/packages/@granit/react-cms-redirects/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-redirects/testing — mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockRedirects } from './data';
+export { createCmsRedirectsHandlers } from './handlers';

--- a/packages/@granit/react-cms-seo/package.json
+++ b/packages/@granit/react-cms-seo/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
@@ -20,6 +21,12 @@
     "@granit/cms-seo": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
   }
 }

--- a/packages/@granit/react-cms-seo/src/testing/data.ts
+++ b/packages/@granit/react-cms-seo/src/testing/data.ts
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-seo/testing — mock fixtures
+// ---------------------------------------------------------------------------
+
+import type {
+  SeoAiSuggestionResponse,
+  SeoAuditIssueResponse,
+  SiteSeoDefaultsResponse,
+} from '@granit/cms-seo';
+
+const CORPORATE_SITE_ID = 'b1f0c3a4-1d2e-4f5a-8b6c-1a2b3c4d5e6f';
+
+/** Default SEO settings keyed by site id, returned by `useSeoDefaults`. */
+export const mockSeoDefaults: Record<string, SiteSeoDefaultsResponse> = {
+  [CORPORATE_SITE_ID]: {
+    siteId: CORPORATE_SITE_ID,
+    titleTemplate: '%s | Granit Corporate',
+    siteName: 'Granit Corporate',
+    robots: { index: true, follow: true },
+    canonicalHost: 'www.example.com',
+    enableAutomaticSeoGeneration: true,
+    sitemapMaxItems: 5000,
+    robotsTxtRules: 'User-agent: *\nAllow: /',
+  },
+};
+
+/** Audit issues returned by `useSeoAuditIssues`. */
+export const mockSeoAuditIssues: SeoAuditIssueResponse[] = [
+  {
+    contentType: 'cms.page',
+    contentId: '10000000-0000-4000-8000-000000000002',
+    culture: 'en-GB',
+    issueType: 'MissingDescription',
+    detail: 'Page "/about" has no meta description.',
+  },
+  {
+    contentType: 'cms.page',
+    contentId: '10000000-0000-4000-8000-000000000004',
+    culture: 'en-GB',
+    issueType: 'TitleTooLong',
+    detail: 'Title exceeds 60 characters.',
+  },
+];
+
+/** AI suggestions inbox returned by `useSeoSuggestions`. */
+export const mockSeoSuggestions: SeoAiSuggestionResponse[] = [
+  {
+    id: '40000000-0000-4000-8000-000000000001',
+    contentType: 'cms.page',
+    contentId: '10000000-0000-4000-8000-000000000002',
+    culture: 'en-GB',
+    status: 'Ready',
+    suggestion: {
+      title: 'About Granit — Our team and mission',
+      description: 'Meet the people behind Granit and learn what drives us.',
+    },
+    diff: {
+      description: {
+        current: null,
+        proposed: 'Meet the people behind Granit and learn what drives us.',
+      },
+    },
+  },
+];

--- a/packages/@granit/react-cms-seo/src/testing/handlers.ts
+++ b/packages/@granit/react-cms-seo/src/testing/handlers.ts
@@ -1,0 +1,70 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-seo/testing — MSW handler factory
+// ---------------------------------------------------------------------------
+
+import { http, HttpResponse, type RequestHandler } from 'msw';
+
+import { mockSeoAuditIssues, mockSeoDefaults, mockSeoSuggestions } from './data';
+
+import type {
+  PagedResponse,
+  SeoAiSuggestionResponse,
+  SeoAuditIssueResponse,
+  SiteSeoDefaultsRequest,
+  SiteSeoDefaultsResponse,
+} from '@granit/cms-seo';
+
+function paged<T>(items: readonly T[]): PagedResponse<T> {
+  return { items, totalCount: items.length, page: 1, pageSize: items.length };
+}
+
+/**
+ * MSW handlers for the CMS SEO API (`/api/cms/seo`). Covers site defaults
+ * (single object), the audit issues list and the AI suggestions inbox (both
+ * paged), plus apply/reject mutations.
+ */
+export function createCmsSeoHandlers(baseUrl = '/api/cms/seo'): RequestHandler[] {
+  const defaultsBySite: Record<string, SiteSeoDefaultsResponse> = { ...mockSeoDefaults };
+  const auditIssues: SeoAuditIssueResponse[] = mockSeoAuditIssues.map((issue) => ({ ...issue }));
+  const suggestions: SeoAiSuggestionResponse[] = mockSeoSuggestions.map((item) => ({ ...item }));
+
+  return [
+    http.get(`${baseUrl}/sites/:siteId/defaults`, ({ params }) => {
+      const siteId = params.siteId as string;
+      const defaults = defaultsBySite[siteId] ?? { siteId, robots: { index: true, follow: true } };
+      return HttpResponse.json(defaults);
+    }),
+
+    http.put(`${baseUrl}/sites/:siteId/defaults`, async ({ params, request }) => {
+      const siteId = params.siteId as string;
+      const dto = (await request.json()) as SiteSeoDefaultsRequest;
+      const updated: SiteSeoDefaultsResponse = { ...dto, siteId };
+      defaultsBySite[siteId] = updated;
+      return HttpResponse.json(updated);
+    }),
+
+    http.get(`${baseUrl}/metadata`, () => HttpResponse.json(paged(auditIssues))),
+
+    http.get(`${baseUrl}/ai/suggestions`, () => HttpResponse.json(paged(suggestions))),
+
+    http.post(`${baseUrl}/ai/suggestions/:id/apply`, ({ params }) => {
+      const existing = suggestions.find((item) => item.id === params.id);
+      if (!existing) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      const updated: SeoAiSuggestionResponse = { ...existing, status: 'Applied' };
+      suggestions[suggestions.indexOf(existing)] = updated;
+      return HttpResponse.json(updated);
+    }),
+
+    http.post(`${baseUrl}/ai/suggestions/:id/reject`, ({ params }) => {
+      const existing = suggestions.find((item) => item.id === params.id);
+      if (!existing) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      const updated: SeoAiSuggestionResponse = { ...existing, status: 'Rejected' };
+      suggestions[suggestions.indexOf(existing)] = updated;
+      return HttpResponse.json(updated);
+    }),
+  ];
+}

--- a/packages/@granit/react-cms-seo/src/testing/index.ts
+++ b/packages/@granit/react-cms-seo/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms-seo/testing — mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockSeoAuditIssues, mockSeoDefaults, mockSeoSuggestions } from './data';
+export { createCmsSeoHandlers } from './handlers';

--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -6,7 +6,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./server": "./src/index.server.ts"
+    "./server": "./src/index.server.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
@@ -25,6 +26,7 @@
     "@granit/utils": "workspace:*",
     "@puckeditor/core": "^0.21.0",
     "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
@@ -32,6 +34,9 @@
       "optional": true
     },
     "@granit/react-api-client": {
+      "optional": true
+    },
+    "msw": {
       "optional": true
     }
   }

--- a/packages/@granit/react-cms/src/testing/data.ts
+++ b/packages/@granit/react-cms/src/testing/data.ts
@@ -1,0 +1,205 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms/testing — mock fixtures
+// ---------------------------------------------------------------------------
+
+import type {
+  MenuResponse,
+  PageTreeNodeResponse,
+  ReleaseResponse,
+  SiteResponse,
+} from '@granit/cms';
+
+/** Site id of the seeded "corporate" site, shared across the CMS fixtures. */
+export const CORPORATE_SITE_ID = 'b1f0c3a4-1d2e-4f5a-8b6c-1a2b3c4d5e6f';
+
+/**
+ * Mock CMS sites. `displayNames` always carries the `defaultCulture` key so a
+ * label can be resolved via `displayNames[defaultCulture] ?? slug`.
+ */
+export const mockSites: SiteResponse[] = [
+  {
+    id: CORPORATE_SITE_ID,
+    slug: 'corporate',
+    defaultCulture: 'en-GB',
+    allowedCultures: ['en-GB', 'fr-FR', 'nl-BE'],
+    domains: [],
+    defaultTheme: 'granit',
+    activated: true,
+    tenantId: null,
+    displayNames: {
+      'en-GB': 'Corporate Website',
+      'fr-FR': 'Site corporatif',
+      'nl-BE': 'Bedrijfswebsite',
+    },
+  },
+  {
+    id: 'c2e1d4b5-2e3f-4a6b-9c7d-2b3c4d5e6f70',
+    slug: 'support',
+    defaultCulture: 'en-GB',
+    allowedCultures: ['en-GB', 'fr-FR'],
+    domains: [],
+    defaultTheme: 'granit',
+    activated: true,
+    tenantId: null,
+    displayNames: {
+      'en-GB': 'Support Portal',
+      'fr-FR': 'Portail de support',
+    },
+  },
+  {
+    id: 'd3f2e5c6-3f40-4b7c-ad8e-3c4d5e6f7081',
+    slug: 'campaign-2026',
+    defaultCulture: 'fr-FR',
+    allowedCultures: ['fr-FR'],
+    domains: [],
+    defaultTheme: 'granit',
+    activated: false,
+    tenantId: null,
+    displayNames: {
+      'fr-FR': 'Campagne 2026',
+    },
+  },
+];
+
+/**
+ * Flat, tree-ordered page nodes for the corporate site. `usePageTree` returns a
+ * bare array (NOT a paged envelope).
+ */
+export const mockPageTree: PageTreeNodeResponse[] = [
+  {
+    id: '10000000-0000-4000-8000-000000000001',
+    parentId: null,
+    slugSegment: '',
+    structurePath: '/',
+    depth: 0,
+    isSiteRoot: true,
+  },
+  {
+    id: '10000000-0000-4000-8000-000000000002',
+    parentId: '10000000-0000-4000-8000-000000000001',
+    slugSegment: 'about',
+    structurePath: '/about',
+    depth: 1,
+    isSiteRoot: false,
+  },
+  {
+    id: '10000000-0000-4000-8000-000000000003',
+    parentId: '10000000-0000-4000-8000-000000000002',
+    slugSegment: 'team',
+    structurePath: '/about/team',
+    depth: 2,
+    isSiteRoot: false,
+  },
+  {
+    id: '10000000-0000-4000-8000-000000000004',
+    parentId: '10000000-0000-4000-8000-000000000001',
+    slugSegment: 'contact',
+    structurePath: '/contact',
+    depth: 1,
+    isSiteRoot: false,
+  },
+];
+
+/** Mock menus for the corporate site. */
+export const mockMenus: MenuResponse[] = [
+  {
+    id: '20000000-0000-4000-8000-000000000001',
+    siteId: CORPORATE_SITE_ID,
+    key: 'main',
+    title: 'Main navigation',
+    items: [
+      {
+        id: '21000000-0000-4000-8000-000000000001',
+        label: 'Home',
+        kind: 'Page',
+        pageId: '10000000-0000-4000-8000-000000000001',
+        url: null,
+        anchor: null,
+        isVisible: true,
+        icon: null,
+        cssClass: null,
+        children: [],
+      },
+      {
+        id: '21000000-0000-4000-8000-000000000002',
+        label: 'About',
+        kind: 'Page',
+        pageId: '10000000-0000-4000-8000-000000000002',
+        url: null,
+        anchor: null,
+        isVisible: true,
+        icon: null,
+        cssClass: null,
+        children: [],
+      },
+    ],
+  },
+  {
+    id: '20000000-0000-4000-8000-000000000002',
+    siteId: CORPORATE_SITE_ID,
+    key: 'footer',
+    title: 'Footer links',
+    items: [
+      {
+        id: '22000000-0000-4000-8000-000000000001',
+        label: 'Privacy',
+        kind: 'ExternalUrl',
+        pageId: null,
+        url: 'https://example.com/privacy',
+        anchor: null,
+        isVisible: true,
+        icon: null,
+        cssClass: null,
+        children: [],
+      },
+    ],
+  },
+];
+
+/** Mock releases for the corporate site (one draft, one scheduled). */
+export const mockReleases: ReleaseResponse[] = [
+  {
+    id: '30000000-0000-4000-8000-000000000001',
+    siteId: CORPORATE_SITE_ID,
+    name: 'Spring relaunch',
+    status: 'Draft',
+    schedule: null,
+    tenantId: null,
+    actions: [
+      {
+        id: '31000000-0000-4000-8000-000000000001',
+        contentType: 'cms.page',
+        contentId: '10000000-0000-4000-8000-000000000002',
+        culture: 'en-GB',
+        type: 'Publish',
+        status: 'Pending',
+        error: null,
+      },
+    ],
+    concurrencyStamp: 'stamp-release-1',
+  },
+  {
+    id: '30000000-0000-4000-8000-000000000002',
+    siteId: CORPORATE_SITE_ID,
+    name: 'Q1 scheduled push',
+    status: 'Ready',
+    schedule: {
+      localDateTime: '2026-07-01T09:00:00',
+      timeZoneId: 'Europe/Brussels',
+      scheduledAtUtc: '2026-07-01T07:00:00Z',
+    },
+    tenantId: null,
+    actions: [
+      {
+        id: '31000000-0000-4000-8000-000000000002',
+        contentType: 'cms.page',
+        contentId: '10000000-0000-4000-8000-000000000004',
+        culture: null,
+        type: 'Publish',
+        status: 'Pending',
+        error: null,
+      },
+    ],
+    concurrencyStamp: 'stamp-release-2',
+  },
+];

--- a/packages/@granit/react-cms/src/testing/handlers.ts
+++ b/packages/@granit/react-cms/src/testing/handlers.ts
@@ -1,0 +1,323 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms/testing — MSW handler factories
+//
+// Each factory takes the collection base URL and returns in-memory handlers
+// seeded from the fixtures. Consumers wire the base to their API origin, e.g.
+// `createSitesHandlers(`${apiUrl}/api/cms/sites`)`.
+// ---------------------------------------------------------------------------
+
+import { http, HttpResponse, type RequestHandler } from 'msw';
+
+import { CORPORATE_SITE_ID, mockMenus, mockPageTree, mockReleases, mockSites } from './data';
+
+import type {
+  CreateMenuRequest,
+  CreatePageRequest,
+  CreateReleaseRequest,
+  CreateSiteRequest,
+  MenuItemResponse,
+  MenuResponse,
+  PageResponse,
+  PageTreeNodeResponse,
+  PagedResponse,
+  ReleaseResponse,
+  ScheduleReleaseRequest,
+  SiteResponse,
+  UpdateMenuRequest,
+  UpdatePageRequest,
+  UpdateSiteRequest,
+} from '@granit/cms';
+
+const notFound = () => new HttpResponse(null, { status: 404 });
+
+function paged<T>(items: readonly T[], page: number, pageSize: number): PagedResponse<T> {
+  const start = (page - 1) * pageSize;
+  return { items: items.slice(start, start + pageSize), totalCount: items.length, page, pageSize };
+}
+
+/** Sites handlers (`/api/cms/sites`) — list/detail/create/update/delete. */
+export function createSitesHandlers(baseUrl = '/api/cms/sites'): RequestHandler[] {
+  const sites: SiteResponse[] = mockSites.map((site) => ({ ...site }));
+
+  return [
+    http.get(baseUrl, ({ request }) => {
+      const url = new URL(request.url);
+      const search = url.searchParams.get('search')?.toLowerCase();
+      const page = Number(url.searchParams.get('page') ?? '1');
+      const pageSize = Number(url.searchParams.get('pageSize') ?? '20');
+      const filtered = search
+        ? sites.filter(
+            (site) =>
+              site.slug.toLowerCase().includes(search) ||
+              Object.values(site.displayNames).some((name) => name.toLowerCase().includes(search))
+          )
+        : sites;
+      return HttpResponse.json(paged(filtered, page, pageSize));
+    }),
+
+    http.get(`${baseUrl}/:id`, ({ params }) => {
+      const site = sites.find((candidate) => candidate.id === params.id);
+      return site ? HttpResponse.json(site) : notFound();
+    }),
+
+    http.post(baseUrl, async ({ request }) => {
+      const dto = (await request.json()) as CreateSiteRequest;
+      const site: SiteResponse = {
+        id: crypto.randomUUID(),
+        slug: dto.slug,
+        defaultCulture: dto.defaultCulture,
+        allowedCultures: [...dto.allowedCultures],
+        domains: dto.domains ? [...dto.domains] : [],
+        defaultTheme: dto.defaultTheme ?? 'granit',
+        activated: true,
+        tenantId: null,
+        displayNames: { [dto.defaultCulture]: dto.slug },
+      };
+      sites.push(site);
+      return HttpResponse.json(site, { status: 201 });
+    }),
+
+    http.put(`${baseUrl}/:id`, async ({ params, request }) => {
+      const existing = sites.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      const dto = (await request.json()) as UpdateSiteRequest;
+      const updated: SiteResponse = {
+        ...existing,
+        defaultCulture: dto.defaultCulture,
+        allowedCultures: [...dto.allowedCultures],
+        domains: [...dto.domains],
+        defaultTheme: dto.defaultTheme,
+        activated: dto.activated,
+      };
+      sites[sites.indexOf(existing)] = updated;
+      return HttpResponse.json(updated);
+    }),
+
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const existing = sites.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      sites.splice(sites.indexOf(existing), 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}
+
+type StoredNode = PageTreeNodeResponse & { readonly siteId: string };
+
+/** Pages handlers (`/api/cms/pages`) — tree (bare array)/detail/create/update/delete. */
+export function createPagesHandlers(baseUrl = '/api/cms/pages'): RequestHandler[] {
+  const nodes: StoredNode[] = mockPageTree.map((node) => ({ ...node, siteId: CORPORATE_SITE_ID }));
+
+  const toTreeNode = ({ siteId: _siteId, ...node }: StoredNode): PageTreeNodeResponse => node;
+  const toPageResponse = (node: StoredNode): PageResponse => ({
+    id: node.id,
+    siteId: node.siteId,
+    parentId: node.parentId,
+    slugSegment: node.slugSegment,
+    structurePath: node.structurePath,
+    depth: node.depth,
+    kind: 'content',
+    isSiteRoot: node.isSiteRoot,
+    layoutKey: null,
+    translations: [],
+  });
+
+  return [
+    http.get(`${baseUrl}/tree`, ({ request }) => {
+      const siteId = new URL(request.url).searchParams.get('siteId');
+      const tree = (siteId ? nodes.filter((node) => node.siteId === siteId) : nodes).map(
+        toTreeNode
+      );
+      return HttpResponse.json(tree);
+    }),
+
+    http.get(`${baseUrl}/:id`, ({ params }) => {
+      const node = nodes.find((candidate) => candidate.id === params.id);
+      return node ? HttpResponse.json(toPageResponse(node)) : notFound();
+    }),
+
+    http.post(baseUrl, async ({ request }) => {
+      const dto = (await request.json()) as CreatePageRequest;
+      const parent = nodes.find((node) => node.id === dto.parentId);
+      const created: StoredNode = {
+        id: crypto.randomUUID(),
+        siteId: dto.siteId,
+        parentId: dto.parentId ?? null,
+        slugSegment: dto.slugSegment,
+        structurePath: `${parent && !parent.isSiteRoot ? parent.structurePath : ''}/${dto.slugSegment}`,
+        depth: parent ? parent.depth + 1 : 0,
+        isSiteRoot: false,
+      };
+      nodes.push(created);
+      return HttpResponse.json(toTreeNode(created), { status: 201 });
+    }),
+
+    http.put(`${baseUrl}/:id`, async ({ params, request }) => {
+      const existing = nodes.find((node) => node.id === params.id);
+      if (!existing) return notFound();
+      const dto = (await request.json()) as UpdatePageRequest;
+      const updated: StoredNode = { ...existing, slugSegment: dto.slugSegment };
+      nodes[nodes.indexOf(existing)] = updated;
+      return HttpResponse.json(toTreeNode(updated));
+    }),
+
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const existing = nodes.find((node) => node.id === params.id);
+      if (!existing) return notFound();
+      nodes.splice(nodes.indexOf(existing), 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}
+
+function toMenuItems(
+  items: CreateMenuRequest['items'] | UpdateMenuRequest['items']
+): MenuItemResponse[] {
+  return (items ?? []).map((item) => ({
+    id: crypto.randomUUID(),
+    label: item.label,
+    kind: item.kind,
+    pageId: item.pageId ?? null,
+    url: item.url ?? null,
+    anchor: item.anchor ?? null,
+    isVisible: item.isVisible ?? true,
+    icon: item.icon ?? null,
+    cssClass: item.cssClass ?? null,
+    children: toMenuItems(item.children),
+  }));
+}
+
+/** Menus handlers (`/api/cms/menus`) — list (paged)/detail/create/update/delete. */
+export function createMenusHandlers(baseUrl = '/api/cms/menus'): RequestHandler[] {
+  const menus: MenuResponse[] = mockMenus.map((menu) => ({ ...menu }));
+
+  return [
+    http.get(baseUrl, ({ request }) => {
+      const url = new URL(request.url);
+      const siteId = url.searchParams.get('siteId');
+      const page = Number(url.searchParams.get('page') ?? '1');
+      const pageSize = Number(url.searchParams.get('pageSize') ?? '20');
+      const filtered = siteId ? menus.filter((menu) => menu.siteId === siteId) : menus;
+      return HttpResponse.json(paged(filtered, page, pageSize));
+    }),
+
+    http.get(`${baseUrl}/:id`, ({ params }) => {
+      const menu = menus.find((candidate) => candidate.id === params.id);
+      return menu ? HttpResponse.json(menu) : notFound();
+    }),
+
+    http.post(baseUrl, async ({ request }) => {
+      const dto = (await request.json()) as CreateMenuRequest;
+      const menu: MenuResponse = {
+        id: crypto.randomUUID(),
+        siteId: dto.siteId,
+        key: dto.key,
+        title: dto.title,
+        items: toMenuItems(dto.items),
+      };
+      menus.push(menu);
+      return HttpResponse.json(menu, { status: 201 });
+    }),
+
+    http.put(`${baseUrl}/:id`, async ({ params, request }) => {
+      const existing = menus.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      const dto = (await request.json()) as UpdateMenuRequest;
+      const updated: MenuResponse = {
+        ...existing,
+        title: dto.title,
+        items: toMenuItems(dto.items),
+      };
+      menus[menus.indexOf(existing)] = updated;
+      return HttpResponse.json(updated);
+    }),
+
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const existing = menus.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      menus.splice(menus.indexOf(existing), 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}
+
+/** Releases handlers (`/api/cms/releases`) — list/detail/create/publish/schedule/cancel/delete. */
+export function createReleasesHandlers(baseUrl = '/api/cms/releases'): RequestHandler[] {
+  const releases: ReleaseResponse[] = mockReleases.map((release) => ({ ...release }));
+
+  return [
+    http.get(baseUrl, ({ request }) => {
+      const url = new URL(request.url);
+      const siteId = url.searchParams.get('siteId');
+      const page = Number(url.searchParams.get('page') ?? '1');
+      const pageSize = Number(url.searchParams.get('pageSize') ?? '20');
+      const filtered = siteId ? releases.filter((release) => release.siteId === siteId) : releases;
+      return HttpResponse.json(paged(filtered, page, pageSize));
+    }),
+
+    http.get(`${baseUrl}/:id`, ({ params }) => {
+      const release = releases.find((candidate) => candidate.id === params.id);
+      return release ? HttpResponse.json(release) : notFound();
+    }),
+
+    http.post(baseUrl, async ({ request }) => {
+      const dto = (await request.json()) as CreateReleaseRequest;
+      const release: ReleaseResponse = {
+        id: crypto.randomUUID(),
+        siteId: dto.siteId,
+        name: dto.name,
+        status: 'Draft',
+        schedule: null,
+        tenantId: null,
+        actions: [],
+        concurrencyStamp: crypto.randomUUID(),
+      };
+      releases.push(release);
+      return HttpResponse.json(release, { status: 201 });
+    }),
+
+    http.post(`${baseUrl}/:id/publish`, ({ params }) => {
+      const existing = releases.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      const updated: ReleaseResponse = {
+        ...existing,
+        status: 'Executed',
+        actions: existing.actions.map((action) => ({ ...action, status: 'Succeeded' })),
+      };
+      releases[releases.indexOf(existing)] = updated;
+      return HttpResponse.json(updated);
+    }),
+
+    http.post(`${baseUrl}/:id/schedule`, async ({ params, request }) => {
+      const existing = releases.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      const dto = (await request.json()) as ScheduleReleaseRequest;
+      // Best-effort UTC for the mock — the real backend resolves the IANA zone.
+      const updated: ReleaseResponse = {
+        ...existing,
+        status: 'Ready',
+        schedule: {
+          localDateTime: dto.localDateTime,
+          timeZoneId: dto.timeZoneId,
+          scheduledAtUtc: new Date(dto.localDateTime).toISOString(),
+        },
+      };
+      releases[releases.indexOf(existing)] = updated;
+      return HttpResponse.json(updated);
+    }),
+
+    http.post(`${baseUrl}/:id/cancel`, ({ params }) => {
+      const existing = releases.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      releases[releases.indexOf(existing)] = { ...existing, status: 'Draft', schedule: null };
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const existing = releases.find((candidate) => candidate.id === params.id);
+      if (!existing) return notFound();
+      releases.splice(releases.indexOf(existing), 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}

--- a/packages/@granit/react-cms/src/testing/index.ts
+++ b/packages/@granit/react-cms/src/testing/index.ts
@@ -1,0 +1,11 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cms/testing — mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { CORPORATE_SITE_ID, mockMenus, mockPageTree, mockReleases, mockSites } from './data';
+export {
+  createMenusHandlers,
+  createPagesHandlers,
+  createReleasesHandlers,
+  createSitesHandlers,
+} from './handlers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1388,6 +1388,9 @@ importers:
 
   packages/@granit/react-cms:
     dependencies:
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1419,6 +1422,9 @@ importers:
 
   packages/@granit/react-cms-hostnames:
     dependencies:
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1447,6 +1453,9 @@ importers:
 
   packages/@granit/react-cms-redirects:
     dependencies:
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1472,6 +1481,9 @@ importers:
 
   packages/@granit/react-cms-seo:
     dependencies:
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7


### PR DESCRIPTION
## What

Adds `./testing` subpath exports to the CMS React packages so consumers (granit-showcase) stop hand-writing CMS mocks and instead consume framework-owned factories — consistent with every other `@granit/react-*` module.

| Package | Exports |
| --- | --- |
| `@granit/react-cms/testing` | `createSitesHandlers`, `createPagesHandlers`, `createMenusHandlers`, `createReleasesHandlers` (incl. publish/schedule/cancel) + mock data |
| `@granit/react-cms-seo/testing` | `createCmsSeoHandlers` (defaults / audit / AI inbox + apply/reject) |
| `@granit/react-cms-redirects/testing` | `createCmsRedirectsHandlers` |
| `@granit/react-cms-hostnames/testing` | `createCmsHostnamesHandlers` (site-scoped) |

Each factory takes the collection base URL and returns in-memory MSW handlers seeded from fixtures. `msw` is added as an **optional** peer dependency.

## Why

Mocks live in granit-front (framework), consumed by the showcase. This unblocks the companion granit-showcase PR that completes the CMS admin module.

## Verify

- `tsc --noEmit` per package ✓ (incl. `noUncheckedIndexedAccess`)
- eslint ✓ / prettier ✓
- Consumed by granit-showcase CMS tests (33 passing)