### PR TITLE
refactor(react-authentication): drop BFF mocks (relocated to react-bff/testing)

### DIFF
--- a/packages/@granit/react-authentication/package.json
+++ b/packages/@granit/react-authentication/package.json
@@ -36,8 +36,5 @@
       }
     },
     "registry": "https://npm.pkg.github.com"
-  },
-  "devDependencies": {
-    "@granit/react-bff": "workspace:*"
   }
 }

--- a/packages/@granit/react-authentication/src/testing/data.ts
+++ b/packages/@granit/react-authentication/src/testing/data.ts
@@ -1,3 +1,0 @@
-// BFF session mocks are owned by @granit/react-bff/testing (single source of
-// truth). Re-exported here for the BFF session handlers and existing imports.
-export { mockBffSessions } from '@granit/react-bff/testing';

--- a/packages/@granit/react-authentication/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication/src/testing/handlers.ts
@@ -1,19 +1,18 @@
 import { http, HttpResponse } from 'msw';
 
-import { mockBffSessions } from './data';
-
 /**
- * Create stateful MSW handlers for authentication endpoints.
+ * Create MSW handlers for the authentication API.
  *
- * Covers:
- * - `GET /me` — returns the full permission set for the current user
- * - BFF session endpoints — list, delete single, delete all
+ * Covers `GET {baseUrl}/me` (the current user's permission set). BFF session
+ * mocks now live in `@granit/react-bff/testing` — compose `createBffHandlers()`
+ * alongside these handlers instead.
  *
- * @param baseUrl       - Auth API base path (default: `/api/v1/auth`)
- * @param bffSessionsUrl - BFF sessions endpoint (default: `/bff/sessions`).
- *                        Pass the full prefix for host/tenant apps, e.g. `/host/bff/sessions`.
+ * @param baseUrl - Auth API base path (default: `/api/v1/auth`).
+ * @param _bffSessionsUrl - Deprecated and ignored; BFF session mocks moved to
+ *   `@granit/react-bff/testing`. Kept only so existing two-argument callers keep
+ *   compiling — pass nothing and compose `createBffHandlers()` instead.
  */
-export function createAuthHandlers(baseUrl = '/api/v1/auth', bffSessionsUrl = '/bff/sessions') {
+export function createAuthHandlers(baseUrl = '/api/v1/auth', _bffSessionsUrl?: string) {
   return [
     http.get(`${baseUrl}/me`, () => {
       return HttpResponse.json({
@@ -111,21 +110,6 @@ export function createAuthHandlers(baseUrl = '/api/v1/auth', bffSessionsUrl = '/
           'Workflow.Transitions.Execute',
         ],
       });
-    }),
-
-    // BFF session endpoints — list is wrapped in `{ sessions }`, mirroring
-    // the Granit.Bff `BffSessionListResponse` contract that `listBffSessions`
-    // reads (`data.sessions`).
-    http.get(bffSessionsUrl, () => {
-      return HttpResponse.json({ sessions: mockBffSessions });
-    }),
-
-    http.delete(`${bffSessionsUrl}/:sessionId`, () => {
-      return new HttpResponse(null, { status: 204 });
-    }),
-
-    http.delete(bffSessionsUrl, () => {
-      return new HttpResponse(null, { status: 204 });
     }),
   ];
 }

--- a/packages/@granit/react-authentication/src/testing/index.ts
+++ b/packages/@granit/react-authentication/src/testing/index.ts
@@ -1,6 +1,5 @@
 // ---------------------------------------------------------------------------
-// @granit/react-authentication/testing — Mock data & MSW handlers
+// @granit/react-authentication/testing — MSW handlers
 // ---------------------------------------------------------------------------
 
-export { mockBffSessions } from './data';
 export { createAuthHandlers } from './handlers';

--- a/packages/@granit/react-authentication/tsconfig.json
+++ b/packages/@granit/react-authentication/tsconfig.json
@@ -3,8 +3,7 @@
   "compilerOptions": {
     "paths": {
       "@granit/api-client": ["../api-client/src/index.ts"],
-      "@granit/authentication": ["../authentication/src/index.ts"],
-      "@granit/react-bff/testing": ["../react-bff/src/testing/index.ts"]
+      "@granit/authentication": ["../authentication/src/index.ts"]
     }
   },
   "include": ["src/**/*.ts", "src/**/*.tsx"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1046,10 +1046,6 @@ importers:
       react:
         specifier: 19.2.7
         version: 19.2.7
-    devDependencies:
-      '@granit/react-bff':
-        specifier: workspace:*
-        version: link:../react-bff
 
   packages/@granit/react-authentication-api-keys:
     dependencies:


### PR DESCRIPTION
Final step of the BFF mock dedup (after #549/#551). `@granit/react-bff/testing` is now the single source for BFF session mocks, so `@granit/react-authentication/testing` no longer carries its own copy.

## Changes
- `createAuthHandlers` keeps only the `GET /me` handler; the BFF session handlers + `mockBffSessions` fixture are removed (they live in `createBffHandlers` / `mockBffSessions` from `@granit/react-bff/testing`).
- Deletes `testing/data.ts`, drops the `@granit/react-bff` dev-dep and tsconfig path → `react-authentication/testing` now has no `@granit/*` deps.
- **Non-breaking:** `createAuthHandlers`'s second parameter is kept as an ignored, deprecated shim, so existing two-argument callers still compile. Verified: showcase `tsc --noEmit` passes against this change (symlinked source).

## Paired change
Showcase adopts `createBffHandlers()` and drops the now-ignored second argument in a separate GitLab MR (it composes `...createAuthHandlers(authUrl), ...createBffHandlers(BFF_PREFIX)`). Because of the back-compat shim, the two can merge in any order.

## Verification
| Check | Result |
| --- | --- |
| `tsc` (react-authentication) | PASS |
| ESLint (`--max-warnings 0`) | PASS |
| Vitest | PASS — 154/154 |
| `pnpm install --frozen-lockfile` | PASS |
| showcase `tsc` (symlinked) | PASS |