### PR TITLE
fix(blob-storage): cover cancel-pending, fix list invalidation, align mocks to backend

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3018,21 +3018,6 @@
           "signature": "function useBlob(id: string, containerName: string): UseQueryResult<BlobDescriptorResponse>"
         },
         {
-          "name": "useConfirmUpload",
-          "kind": "function",
-          "signature": "function useConfirmUpload(): UseMutationResult< BlobConfirmUploadResponse, Error,"
-        },
-        {
-          "name": "useDeleteBlob",
-          "kind": "function",
-          "signature": "function useDeleteBlob(): UseMutationResult< void, Error,"
-        },
-        {
-          "name": "useInitiateUpload",
-          "kind": "function",
-          "signature": "function useInitiateUpload(): UseMutationResult< BlobUploadInitiateResponse, Error, BlobUploadInitiateRequest >"
-        },
-        {
           "name": "useDownloadUrl",
           "kind": "function",
           "signature": "function useDownloadUrl(): UseMutationResult< BlobDownloadUrlResponse, Error,"
@@ -3063,6 +3048,11 @@
           "kind": "interface",
           "signature": "interface BlobUploadState",
           "members": []
+        },
+        {
+          "name": "blobListQueryKey",
+          "kind": "function",
+          "signature": "function blobListQueryKey(config:"
         },
         {
           "name": "blobStorageKeys",

--- a/packages/@granit/blob-storage/src/__tests__/blob-storage-api.test.ts
+++ b/packages/@granit/blob-storage/src/__tests__/blob-storage-api.test.ts
@@ -2,6 +2,7 @@ import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  cancelPendingUpload,
   cleanupOrphans,
   confirmUpload,
   deleteBlob,
@@ -192,6 +193,39 @@ describe('blob-storage-api', () => {
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/cleanup-orphans`);
       expect(result).toEqual(response);
+    });
+  });
+
+  describe('cancelPendingUpload', () => {
+    it('sends DELETE to /{id}/pending with body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await cancelPendingUpload(client, BASE, 'abc-123', {
+        containerName: 'docs',
+        reason: 'Pre-signed PUT failed: 403 SignatureDoesNotMatch',
+      });
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/abc-123/pending`, {
+        data: {
+          containerName: 'docs',
+          reason: 'Pre-signed PUT failed: 403 SignatureDoesNotMatch',
+        },
+      });
+    });
+
+    it('encodes blob ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+      await cancelPendingUpload(client, BASE, 'id/slash', {
+        containerName: 'docs',
+        reason: 'aborted',
+      });
+
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/id%2Fslash/pending`, {
+        data: { containerName: 'docs', reason: 'aborted' },
+      });
     });
   });
 });

--- a/packages/@granit/blob-storage/src/api/blob-storage-api.ts
+++ b/packages/@granit/blob-storage/src/api/blob-storage-api.ts
@@ -1,4 +1,5 @@
 import type {
+  BlobCancelPendingRequest,
   BlobCleanupOrphansResponse,
   BlobConfirmUploadRequest,
   BlobConfirmUploadResponse,
@@ -73,6 +74,23 @@ export async function deleteBlob(
   request: BlobDeleteRequest
 ): Promise<void> {
   await client.delete(`${basePath}/${encodeURIComponent(id)}`, { data: request });
+}
+
+/**
+ * Cancel a `Pending` upload whose pre-signed PUT failed client-side.
+ *
+ * Short-circuits the orphan-cleanup window by transitioning the blob straight
+ * to `Rejected`. Returns 409 Conflict if the blob has already left `Pending`.
+ *
+ * `DELETE {basePath}/{id}/pending`
+ */
+export async function cancelPendingUpload(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: BlobCancelPendingRequest
+): Promise<void> {
+  await client.delete(`${basePath}/${encodeURIComponent(id)}/pending`, { data: request });
 }
 
 /**

--- a/packages/@granit/blob-storage/src/index.ts
+++ b/packages/@granit/blob-storage/src/index.ts
@@ -2,10 +2,12 @@
 export { BlobStatus } from './types/index';
 
 export type {
+  BlobCancelPendingRequest,
   BlobCleanupOrphansResponse,
   BlobConfirmUploadRequest,
   BlobConfirmUploadResponse,
   BlobDeleteRequest,
+  BlobDescriptorListItem,
   BlobDescriptorResponse,
   BlobDownloadUrlRequest,
   BlobDownloadUrlResponse,
@@ -13,10 +15,9 @@ export type {
   BlobUploadInitiateResponse,
 } from './types/index';
 
-// Query keys
-
 // API
 export {
+  cancelPendingUpload,
   cleanupOrphans,
   confirmUpload,
   deleteBlob,

--- a/packages/@granit/blob-storage/src/types/index.ts
+++ b/packages/@granit/blob-storage/src/types/index.ts
@@ -76,6 +76,21 @@ export interface BlobDeleteRequest {
   readonly deletionReason?: string;
 }
 
+// ── Cancel pending upload ─────────────────────────────────────────────────────
+
+/**
+ * Request body for `DELETE /{id}/pending`.
+ *
+ * Cancels a `Pending` upload whose pre-signed PUT failed client-side,
+ * transitioning the blob straight to `Rejected` instead of waiting for the
+ * orphan-cleanup window. Mirrors `Granit.BlobStorage.Endpoints.Dtos.BlobCancelPendingRequest`.
+ */
+export interface BlobCancelPendingRequest {
+  readonly containerName: string;
+  /** Human-readable cancellation reason for the audit trail (required, max 512). */
+  readonly reason: string;
+}
+
 // ── Descriptor ──────────────────────────────────────────────────────────────
 
 /** Full blob descriptor. Mirrors `BlobDescriptorResponse` (.NET). */
@@ -91,6 +106,37 @@ export interface BlobDescriptorResponse {
   readonly rejectionReason: string | null;
   readonly deletionReason: string | null;
   readonly createdAt: string;
+  readonly validatedAt: string | null;
+  readonly deletedAt: string | null;
+}
+
+// ── Query / list row ──────────────────────────────────────────────────────────
+
+/**
+ * Row shape returned by the blob query/list endpoint
+ * (`GET {basePath}/blobs` → `QueryBlobDescriptor`, paged as `PagedResult<T>`).
+ *
+ * Mirrors the **domain** `Granit.BlobStorage.Domain.BlobDescriptor` projection,
+ * which differs from {@link BlobDescriptorResponse} (the `getBlob` DTO): the
+ * actual validated size is a single `sizeBytes` (null until `Valid`) rather than
+ * the DTO's `declaredSizeBytes` / `actualSizeBytes` split, and it carries the
+ * tenant / storage-key audit fields.
+ */
+export interface BlobDescriptorListItem {
+  readonly id: string;
+  readonly tenantId: string | null;
+  readonly containerName: string;
+  readonly objectKey: string;
+  readonly originalFileName: string;
+  readonly declaredContentType: string;
+  readonly maxAllowedBytes: number;
+  readonly verifiedContentType: string | null;
+  readonly sizeBytes: number | null;
+  readonly status: BlobStatus;
+  readonly rejectionReason: string | null;
+  readonly deletionReason: string | null;
+  readonly createdAt: string;
+  readonly createdBy: string;
   readonly validatedAt: string | null;
   readonly deletedAt: string | null;
 }

--- a/packages/@granit/react-blob-storage/package.json
+++ b/packages/@granit/react-blob-storage/package.json
@@ -25,9 +25,6 @@
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
-    "@granit/query-engine": {
-      "optional": true
-    },
     "@granit/react-query-engine": {
       "optional": true
     },

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-mutations.test.tsx
@@ -6,8 +6,13 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { blobStorageKeys } from '../hooks/query-keys';
-import { useConfirmUpload, useDeleteBlob, useInitiateUpload } from '../hooks/use-blob-mutations';
+import { blobListQueryKey, blobStorageKeys } from '../hooks/query-keys';
+import {
+  useCancelPendingUpload,
+  useConfirmUpload,
+  useDeleteBlob,
+  useInitiateUpload,
+} from '../hooks/use-blob-mutations';
 import { BlobStorageProvider } from '../providers/blob-storage-provider';
 
 import type { AxiosInstance } from '@granit/api-client';
@@ -128,6 +133,10 @@ describe('useConfirmUpload', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: blobStorageKeys.blobs(),
     });
+    // Also refreshes the query-engine list (admin table) — the keys are disjoint.
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: blobListQueryKey({ basePath: '/api/v1/blob-storage' }),
+    });
   });
 
   it('should handle confirmation error', async () => {
@@ -168,6 +177,9 @@ describe('useDeleteBlob', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: blobStorageKeys.blobs(),
     });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: blobListQueryKey({ basePath: '/api/v1/blob-storage' }),
+    });
   });
 
   it('should handle delete error', async () => {
@@ -178,6 +190,49 @@ describe('useDeleteBlob', () => {
     const { result } = renderHook(() => useDeleteBlob(), { wrapper });
 
     result.current.mutate({ id: 'abc-123', request: { containerName: 'docs' } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useCancelPendingUpload', () => {
+  it('should send DELETE to /{id}/pending and invalidate on success', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper, queryClient } = createWrapper(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCancelPendingUpload(), { wrapper });
+
+    result.current.mutate({
+      id: 'abc-123',
+      request: { containerName: 'docs', reason: 'User aborted' },
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/blob-storage/blobs/abc-123/pending', {
+      data: { containerName: 'docs', reason: 'User aborted' },
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: blobListQueryKey({ basePath: '/api/v1/blob-storage' }),
+    });
+  });
+
+  it('should handle cancel error', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockRejectedValueOnce(new Error('Conflict'));
+
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useCancelPendingUpload(), { wrapper });
+
+    result.current.mutate({
+      id: 'abc-123',
+      request: { containerName: 'docs', reason: 'User aborted' },
+    });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 

--- a/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
+++ b/packages/@granit/react-blob-storage/src/__tests__/use-blob-upload.test.tsx
@@ -180,6 +180,57 @@ describe('useBlobUpload', () => {
     expect(result.current.state.phase).toBe('error');
   });
 
+  it('should cancel the pending blob when the pre-signed PUT fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValueOnce({ data: mockTicket });
+    vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBlobUpload(), { wrapper });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+
+    let uploadPromise: Promise<BlobConfirmUploadResponse>;
+
+    await act(async () => {
+      uploadPromise = result.current.upload({ file, containerName: 'docs' });
+      await waitFor(() => expect(xhrInstances).toHaveLength(1));
+    });
+
+    await act(async () => {
+      xhrInstances[0]!.simulateError();
+      await expect(uploadPromise!).rejects.toThrow('network error');
+    });
+
+    // The freshly-initiated (still Pending) blob is cancelled best-effort so it
+    // does not linger until the orphan-cleanup window.
+    expect(client.delete).toHaveBeenCalledWith(
+      '/api/v1/blob-storage/blobs/blob-456/pending',
+      expect.objectContaining({
+        data: expect.objectContaining({ containerName: 'docs' }),
+      })
+    );
+  });
+
+  it('should not cancel anything when initiation itself fails', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockRejectedValueOnce(new Error('Unauthorized'));
+
+    const { wrapper } = createWrapper(client);
+    const { result } = renderHook(() => useBlobUpload(), { wrapper });
+
+    const file = new File(['content'], 'test.txt', { type: 'text/plain' });
+
+    await act(async () => {
+      await expect(result.current.upload({ file, containerName: 'docs' })).rejects.toThrow(
+        'Unauthorized'
+      );
+    });
+
+    // No blob was created, so there is nothing to cancel.
+    expect(client.delete).not.toHaveBeenCalled();
+  });
+
   it('should reset state', async () => {
     const client = createMockClient();
     vi.mocked(client.post).mockRejectedValueOnce(new Error('fail'));

--- a/packages/@granit/react-blob-storage/src/hooks/query-keys.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/query-keys.ts
@@ -1,3 +1,5 @@
+import { buildQueryKey } from '@granit/query-engine';
+
 /** Query key factory for blob storage queries. */
 export const blobStorageKeys = {
   all: ['blob-storage'] as const,
@@ -5,3 +7,22 @@ export const blobStorageKeys = {
   blob: (id: string, containerName: string) =>
     [...blobStorageKeys.blobs(), id, containerName] as const,
 };
+
+/**
+ * Query key of the blob **list** (`GET {basePath}/blobs`), as built by the
+ * query-engine (`@granit/react-query-engine`'s `useQueryEndpoint`). Mutation
+ * hooks invalidate this so the admin list refreshes — it does NOT overlap with
+ * {@link blobStorageKeys}, which only covers single-descriptor `useBlob` reads.
+ *
+ * The key mirrors `buildQueryKey({ basePath: \`${basePath}/blobs\` }, 'list')`,
+ * matching a `QueryProvider`/`useQueryEndpoint` configured at `{basePath}/blobs`.
+ */
+export function blobListQueryKey(config: {
+  readonly basePath: string;
+  readonly queryKeyPrefix?: readonly string[];
+}): readonly unknown[] {
+  return buildQueryKey(
+    { basePath: `${config.basePath}/blobs`, queryKeyPrefix: config.queryKeyPrefix },
+    'list'
+  );
+}

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-cleanup.ts
@@ -1,7 +1,9 @@
 import { cleanupOrphans } from '@granit/blob-storage';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
+
+import { blobListQueryKey, blobStorageKeys } from './query-keys';
 
 import type { BlobCleanupOrphansResponse } from '@granit/blob-storage';
 import type { UseMutationResult } from '@tanstack/react-query';
@@ -18,9 +20,16 @@ import type { UseMutationResult } from '@tanstack/react-query';
  * ```
  */
 export function useCleanupOrphans(): UseMutationResult<BlobCleanupOrphansResponse, Error, void> {
-  const { client, basePath } = useBlobStorageConfig();
+  const config = useBlobStorageConfig();
+  const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => cleanupOrphans(client, `${basePath}/blobs`),
+    mutationFn: () => cleanupOrphans(config.client, `${config.basePath}/blobs`),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
+      ]);
+    },
   });
 }

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-mutations.ts
@@ -1,11 +1,17 @@
-import { confirmUpload, deleteBlob, initiateUpload } from '@granit/blob-storage';
+import {
+  cancelPendingUpload,
+  confirmUpload,
+  deleteBlob,
+  initiateUpload,
+} from '@granit/blob-storage';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 
-import { blobStorageKeys } from './query-keys';
+import { blobListQueryKey, blobStorageKeys } from './query-keys';
 
 import type {
+  BlobCancelPendingRequest,
   BlobConfirmUploadRequest,
   BlobConfirmUploadResponse,
   BlobDeleteRequest,
@@ -55,13 +61,17 @@ export function useConfirmUpload(): UseMutationResult<
   Error,
   { id: string; request: BlobConfirmUploadRequest }
 > {
-  const { client, basePath } = useBlobStorageConfig();
+  const config = useBlobStorageConfig();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, request }) => confirmUpload(client, `${basePath}/blobs`, id, request),
+    mutationFn: ({ id, request }) =>
+      confirmUpload(config.client, `${config.basePath}/blobs`, id, request),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
+      ]);
     },
   });
 }
@@ -83,13 +93,53 @@ export function useDeleteBlob(): UseMutationResult<
   Error,
   { id: string; request: BlobDeleteRequest }
 > {
-  const { client, basePath } = useBlobStorageConfig();
+  const config = useBlobStorageConfig();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ id, request }) => deleteBlob(client, `${basePath}/blobs`, id, request),
+    mutationFn: ({ id, request }) =>
+      deleteBlob(config.client, `${config.basePath}/blobs`, id, request),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
+      ]);
+    },
+  });
+}
+
+/**
+ * Mutation hook to cancel a `Pending` upload whose pre-signed PUT failed
+ * client-side.
+ *
+ * Sends `DELETE {basePath}/{id}/pending`, transitioning the blob straight to
+ * `Rejected` (short-circuiting the orphan-cleanup window). Invalidates blob
+ * queries on success. {@link useBlobUpload} calls this automatically when the
+ * direct-to-cloud PUT fails — use this hook for manual cancellation flows
+ * (e.g. a user aborting a stuck upload).
+ *
+ * @example
+ * ```tsx
+ * const { mutate: cancel } = useCancelPendingUpload();
+ * cancel({ id: 'abc-123', request: { containerName: 'docs', reason: 'User aborted' } });
+ * ```
+ */
+export function useCancelPendingUpload(): UseMutationResult<
+  void,
+  Error,
+  { id: string; request: BlobCancelPendingRequest }
+> {
+  const config = useBlobStorageConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }) =>
+      cancelPendingUpload(config.client, `${config.basePath}/blobs`, id, request),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+        queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
+      ]);
     },
   });
 }

--- a/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
+++ b/packages/@granit/react-blob-storage/src/hooks/use-blob-upload.ts
@@ -1,10 +1,10 @@
-import { confirmUpload, initiateUpload } from '@granit/blob-storage';
+import { cancelPendingUpload, confirmUpload, initiateUpload } from '@granit/blob-storage';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useRef, useState } from 'react';
 
 import { useBlobStorageConfig } from '../providers/blob-storage-provider';
 
-import { blobStorageKeys } from './query-keys';
+import { blobListQueryKey, blobStorageKeys } from './query-keys';
 
 import type { BlobConfirmUploadResponse } from '@granit/blob-storage';
 
@@ -127,7 +127,8 @@ const IDLE_STATE: BlobUploadState = {
  * ```
  */
 export function useBlobUpload(): UseBlobUploadReturn {
-  const { client, basePath } = useBlobStorageConfig();
+  const config = useBlobStorageConfig();
+  const { client, basePath } = config;
   const queryClient = useQueryClient();
   const [state, setState] = useState<BlobUploadState>(IDLE_STATE);
   const abortRef = useRef<XMLHttpRequest | null>(null);
@@ -163,20 +164,35 @@ export function useBlobUpload(): UseBlobUploadReturn {
 
         setState((prev) => ({ ...prev, phase: 'uploading', blobId: ticket.blobId }));
 
-        // Step 2: Upload file to pre-signed URL via XMLHttpRequest (for progress)
-        await uploadViaXhr(
-          {
-            url: ticket.uploadUrl,
-            method: ticket.httpMethod,
-            headers: ticket.requiredHeaders,
-            body: file,
-            onProgress: (percent) => {
-              setState((prev) => ({ ...prev, progress: percent }));
-              onProgress?.(percent);
+        // Step 2: Upload file to pre-signed URL via XMLHttpRequest (for progress).
+        // If the pre-signed PUT fails, the blob is still `Pending` server-side —
+        // cancel it (best-effort) so it transitions straight to `Rejected`
+        // instead of lingering visible until the orphan-cleanup window elapses.
+        try {
+          await uploadViaXhr(
+            {
+              url: ticket.uploadUrl,
+              method: ticket.httpMethod,
+              headers: ticket.requiredHeaders,
+              body: file,
+              onProgress: (percent) => {
+                setState((prev) => ({ ...prev, progress: percent }));
+                onProgress?.(percent);
+              },
             },
-          },
-          abortRef
-        );
+            abortRef
+          );
+        } catch (putError) {
+          const reason = putError instanceof Error ? putError.message : String(putError);
+          await cancelPendingUpload(client, `${basePath}/blobs`, ticket.blobId, {
+            containerName,
+            reason: `Pre-signed PUT failed: ${reason}`.slice(0, 512),
+          }).catch(() => {
+            // Best-effort: orphan cleanup is the backstop if the cancel call
+            // itself fails (offline, already left Pending, …).
+          });
+          throw putError;
+        }
 
         // Step 3: Confirm upload
         setState((prev) => ({ ...prev, phase: 'confirming', progress: 100 }));
@@ -193,7 +209,10 @@ export function useBlobUpload(): UseBlobUploadReturn {
           error: null,
         });
 
-        await queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() });
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: blobStorageKeys.blobs() }),
+          queryClient.invalidateQueries({ queryKey: blobListQueryKey(config) }),
+        ]);
 
         return confirmation;
       } catch (err) {
@@ -202,7 +221,7 @@ export function useBlobUpload(): UseBlobUploadReturn {
         throw error;
       }
     },
-    [client, basePath, queryClient]
+    [config, client, basePath, queryClient]
   );
 
   return { upload, state, reset };

--- a/packages/@granit/react-blob-storage/src/index.ts
+++ b/packages/@granit/react-blob-storage/src/index.ts
@@ -14,7 +14,12 @@ export type { BlobUploadFieldProps } from './components/blob-upload-field';
 
 // Hooks
 export { useBlob } from './hooks/use-blob';
-export { useConfirmUpload, useDeleteBlob, useInitiateUpload } from './hooks/use-blob-mutations';
+export {
+  useCancelPendingUpload,
+  useConfirmUpload,
+  useDeleteBlob,
+  useInitiateUpload,
+} from './hooks/use-blob-mutations';
 export { useDownloadUrl } from './hooks/use-blob-download';
 export { useCleanupOrphans } from './hooks/use-blob-cleanup';
 export { useBlobUpload } from './hooks/use-blob-upload';
@@ -23,4 +28,4 @@ export { useBlobUpload } from './hooks/use-blob-upload';
 export type { BlobUploadParams, BlobUploadPhase, BlobUploadState } from './hooks/use-blob-upload';
 
 // Query keys
-export { blobStorageKeys } from './hooks/query-keys';
+export { blobListQueryKey, blobStorageKeys } from './hooks/query-keys';

--- a/packages/@granit/react-blob-storage/src/testing/handlers.ts
+++ b/packages/@granit/react-blob-storage/src/testing/handlers.ts
@@ -1,7 +1,6 @@
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import {
   applyStringFilter,
-  groupBy as groupByField,
   paginate,
   parseFilters,
   parseSort,
@@ -17,23 +16,31 @@ import type {
   BlobConfirmUploadRequest,
   BlobConfirmUploadResponse,
   BlobDescriptorResponse,
-  BlobStatus,
   BlobUploadInitiateRequest,
   BlobUploadInitiateResponse,
 } from '@granit/blob-storage';
 import type { QueryMetadata } from '@granit/query-engine';
 
-/** Mock /meta payload for the blobs resource. */
+/**
+ * Mock `/meta` payload for the blobs resource — mirrors the backend
+ * `Granit.BlobStorage.Queries.BlobDescriptorQueryDefinition`:
+ *
+ * - rows are the domain `BlobDescriptor` projection (note `sizeBytes`, not the
+ *   DTO's `declaredSizeBytes`/`actualSizeBytes`),
+ * - a single `ValidOnly` **quick filter** is the default (no status preset group),
+ * - a `createdAt` date filter, default sort `-createdAt`, default page size 25,
+ * - no group-by fields.
+ */
 export const blobQueryMetadata: QueryMetadata = {
   columns: [
     {
-      name: 'originalFileName',
-      label: 'File name',
-      type: 'String',
+      name: 'tenantId',
+      label: 'Tenant',
+      type: 'Guid',
       order: 1,
       isSortable: true,
       isFilterable: true,
-      isVisible: true,
+      isVisible: false,
     },
     {
       name: 'containerName',
@@ -45,86 +52,136 @@ export const blobQueryMetadata: QueryMetadata = {
       isVisible: true,
     },
     {
-      name: 'declaredContentType',
-      label: 'Content type',
+      name: 'originalFileName',
+      label: 'File Name',
       type: 'String',
       order: 3,
-      isSortable: false,
+      isSortable: true,
       isFilterable: true,
       isVisible: true,
     },
     {
-      name: 'declaredSizeBytes',
-      label: 'Size',
-      type: 'Int64',
+      name: 'declaredContentType',
+      label: 'Content Type',
+      type: 'String',
       order: 4,
       isSortable: true,
-      isFilterable: false,
+      isFilterable: true,
       isVisible: true,
     },
     {
-      name: 'status',
-      label: 'Status',
+      name: 'verifiedContentType',
+      label: 'Verified Content Type',
       type: 'String',
       order: 5,
-      isSortable: true,
-      isFilterable: false,
-      isVisible: true,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
     },
     {
-      name: 'createdAt',
-      label: 'Created at',
-      type: 'DateTime',
+      name: 'sizeBytes',
+      label: 'Size (bytes)',
+      type: 'Int64',
       order: 6,
       isSortable: true,
       isFilterable: false,
       isVisible: true,
     },
-  ],
-  filterableFields: [
-    { name: 'originalFileName', type: 'String', operators: ['Eq', 'Contains', 'StartsWith'] },
-    { name: 'containerName', type: 'String', operators: ['Eq'] },
-    { name: 'declaredContentType', type: 'String', operators: ['Eq', 'Contains'] },
-  ],
-  sortableFields: [
-    { name: 'originalFileName' },
-    { name: 'containerName' },
-    { name: 'declaredSizeBytes' },
-    { name: 'createdAt' },
-    { name: 'status' },
-  ],
-  presetFilterGroups: [
     {
       name: 'status',
       label: 'Status',
-      presets: [
-        { name: 'valid', label: 'Valid', isDefault: false },
-        { name: 'pending', label: 'Pending', isDefault: false },
-        { name: 'rejected', label: 'Rejected', isDefault: false },
-        { name: 'deleted', label: 'Deleted', isDefault: false },
+      type: 'String',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created At',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'validatedAt',
+      label: 'Validated At',
+      type: 'DateTime',
+      order: 9,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'deletedAt',
+      label: 'Deleted At',
+      type: 'DateTime',
+      order: 10,
+      isSortable: true,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'rejectionReason',
+      label: 'Rejection Reason',
+      type: 'String',
+      order: 11,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'tenantId', type: 'Guid', operators: ['Eq'] },
+    { name: 'containerName', type: 'String', operators: ['Eq', 'Contains', 'StartsWith'] },
+    { name: 'originalFileName', type: 'String', operators: ['Eq', 'Contains', 'StartsWith'] },
+    { name: 'declaredContentType', type: 'String', operators: ['Eq', 'Contains'] },
+    { name: 'verifiedContentType', type: 'String', operators: ['Eq', 'Contains'] },
+    {
+      name: 'status',
+      type: 'String',
+      operators: ['Eq'],
+      enumValues: ['Pending', 'Uploading', 'Valid', 'Rejected', 'Deleted'],
+    },
+  ],
+  sortableFields: [
+    { name: 'tenantId' },
+    { name: 'containerName' },
+    { name: 'originalFileName' },
+    { name: 'declaredContentType' },
+    { name: 'sizeBytes' },
+    { name: 'status' },
+    { name: 'createdAt' },
+    { name: 'validatedAt' },
+    { name: 'deletedAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [{ name: 'ValidOnly', label: 'Valid uploads only', isDefault: true }],
+  dateFilters: [
+    {
+      name: 'createdAt',
+      defaultPeriod: 'ThisMonth',
+      availablePeriods: [
+        'Today',
+        'ThisWeek',
+        'ThisMonth',
+        'LastMonth',
+        'ThisQuarter',
+        'ThisYear',
+        'Custom',
       ],
     },
   ],
-  quickFilters: [],
-  dateFilters: [],
-  groupByFields: [
-    { name: 'containerName', type: 'String' },
-    { name: 'status', type: 'String' },
-  ],
+  groupByFields: [],
   pagination: {
-    defaultPageSize: 20,
-    maxPageSize: 50,
+    defaultPageSize: 25,
+    maxPageSize: 100,
     maxStreamSize: 1000,
     supportsCursor: false,
   },
-};
-
-const STATUS_LABELS: Record<BlobStatus, string> = {
-  Pending: 'Pending',
-  Uploading: 'Uploading',
-  Valid: 'Valid',
-  Rejected: 'Rejected',
-  Deleted: 'Deleted',
+  defaultSort: '-createdAt',
 };
 
 /**
@@ -142,32 +199,32 @@ export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const search = url.searchParams.get('search') ?? '';
       const filters = parseFilters(url);
       const sortEntries = parseSort(url);
-      const presetStatus = url.searchParams.get('presets[status]');
 
-      let filtered = [...mockBlobs];
+      // The query endpoint (`MapGranitQuery<BlobDescriptor>`) returns the domain
+      // projection, where the actual size lives in `sizeBytes` (null until
+      // validated) — not the descriptor DTO's `declaredSizeBytes`/`actualSizeBytes`.
+      let filtered = mockBlobs.map((b) => ({ ...b, sizeBytes: b.actualSizeBytes }));
 
-      // Preset filters
-      if (presetStatus) {
-        const presetNames = new Set(presetStatus.split(','));
-        filtered = filtered.filter((b) => {
-          if (presetNames.has('valid') && b.status === S.Valid) return true;
-          if (presetNames.has('pending') && (b.status === S.Pending || b.status === S.Uploading))
-            return true;
-          if (presetNames.has('rejected') && b.status === S.Rejected) return true;
-          if (presetNames.has('deleted') && b.status === S.Deleted) return true;
-          return false;
-        });
+      // Quick filters — `ValidOnly` is the backend default (isDefault: true),
+      // applied server-side when the client sends no `quickFilters` param.
+      const quickFiltersParam = url.searchParams.get('quickFilters');
+      const activeQuickFilters =
+        quickFiltersParam !== null
+          ? new Set(quickFiltersParam.split(',').filter(Boolean))
+          : new Set(['ValidOnly']);
+      if (activeQuickFilters.has('ValidOnly')) {
+        filtered = filtered.filter((b) => b.status === S.Valid);
       }
 
       // Advanced filters
       for (const f of filters) {
         filtered = filtered.filter((b) => {
-          const fieldValue = b[f.field as keyof BlobDescriptorResponse];
+          const fieldValue = b[f.field as keyof typeof b];
           return applyStringFilter(String(fieldValue ?? ''), f.operator, f.value);
         });
       }
 
-      // Full-text search
+      // Full-text search (OriginalFileName, ContainerName)
       if (search) {
         const q = search.toLowerCase();
         filtered = filtered.filter(
@@ -177,21 +234,11 @@ export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
         );
       }
 
-      // Sort — fall back to createdAt desc when no explicit sort is given
+      // Sort — fall back to createdAt desc (the backend default sort) when none given
       if (sortEntries.length > 0) {
         sortItems(filtered as unknown as Record<string, unknown>[], sortEntries);
       } else {
         filtered.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
-      }
-
-      // GroupBy
-      const groupByParam = url.searchParams.get('groupBy');
-      if (groupByParam) {
-        const labelFn = (key: string): string =>
-          groupByParam === 'status' ? (STATUS_LABELS[key as BlobStatus] ?? key) : key;
-        return HttpResponse.json(
-          groupByField(filtered as unknown as Record<string, unknown>[], groupByParam, labelFn)
-        );
       }
 
       return HttpResponse.json(paginate(filtered, url));
@@ -269,6 +316,18 @@ export function createBlobStorageHandlers(baseUrl = DEFAULT_BASE_PATH) {
         return HttpResponse.json(response);
       }
     ),
+
+    // Cancel a Pending upload (presigned PUT failed client-side). Drops the
+    // tracked upload so it no longer lingers — mirrors the backend transition
+    // Pending → Rejected. 404 when the blob is unknown / no longer Pending.
+    http.delete(`${baseUrl}/blobs/:id/pending`, ({ params }) => {
+      const blobId = decodeURIComponent(params.id as string);
+      if (!pendingUploads.has(blobId)) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      pendingUploads.delete(blobId);
+      return new HttpResponse(null, { status: 204 });
+    }),
   ];
 }
 


### PR DESCRIPTION
## Context

Framework audit of `@granit/blob-storage` + `@granit/react-blob-storage` against the `Granit.BlobStorage` backend contract (validated against the generated OpenAPI spec and the `.Endpoints` source). All findings below are evidence-backed.

## Findings fixed

### GAP — `cancel-pending` endpoint was uncovered (backend #2214)
- Add `BlobCancelPendingRequest` type (`{ containerName, reason }`, both required — matches the spec), `cancelPendingUpload()` API fn (`DELETE {basePath}/{id}/pending`), and `useCancelPendingUpload()` hook.

### GAP — `useBlobUpload` leaked orphaned blobs
- When the pre-signed PUT fails, the still-`Pending` blob is now cancelled best-effort (→ `Rejected`) instead of lingering until the orphan-cleanup window — the exact scenario the backend endpoint was built for.

### INCONSISTENCY — mutation hooks invalidated a key the list never consumes
- `useDeleteBlob` / `useConfirmUpload` / `useCleanupOrphans` / `useBlobUpload` invalidated only `blobStorageKeys.blobs()`, which is disjoint from the query-engine list key the admin table uses → the table never refreshed after a mutation.
- They now also invalidate `blobListQueryKey(config)` (new helper, derived from `{basePath}/blobs`). `@granit/query-engine` promoted from optional → required peer (now imported by the main entry).

### INCONSISTENCY — `/testing` mock drifted from the backend
- `blobQueryMetadata` is realigned with `BlobDescriptorQueryDefinition`: single `ValidOnly` quick filter (default-on), `createdAt` date filter, **no** fabricated status-preset group / group-by, 11 real columns, page size 25, default sort `-createdAt`.
- The list handler applies the `ValidOnly` server-default and projects `sizeBytes` (the domain field the table reads). Added a `DELETE …/pending` mock handler.

### Type fidelity — list/query row was unmodeled
- Add `BlobDescriptorListItem` for the query row (domain `BlobDescriptor` projection with `sizeBytes`), distinct from the `getBlob` DTO (`declaredSizeBytes`/`actualSizeBytes`).

### Cleanup
- Removed a stale empty `// Query keys` comment.

## Deliberately not changed
- **`BlobImage` default `/download` route** — targets a route the framework backend doesn't expose (the docstring frames it as host/BFF-supplied). Changing the default risks breaking consumers; needs a backend decision, not a unilateral front change.

## Verification
- `tsc` ✅ · ESLint (`--max-warnings 0`) ✅ · `tsup` build (ESM + DTS) ✅
- **67 tests pass** (+6 new: cancel-pending api/hook, auto-cancel paths, list-key invalidation assertions)

## Follow-up (separate)
- Consumer (`granit-showcase-react`): retype the blob list table to `BlobDescriptorListItem`, and surface the `ValidOnly` quick filter on the blob page (its bespoke filter row replaced the fabricated status presets that never existed on the real backend). A dependent MR will reference this PR.