### PR TITLE
fix(catalog): align front contract with Granit.Catalog backend

### DIFF
--- a/packages/@granit/catalog/src/__tests__/catalog-api.test.ts
+++ b/packages/@granit/catalog/src/__tests__/catalog-api.test.ts
@@ -7,7 +7,7 @@ import {
   createProduct,
   getProductById,
   getProductBySku,
-  listPublishedProducts,
+  listActiveProducts,
   publishProduct,
   removeProductExternalMapping,
   updateProduct,
@@ -56,7 +56,7 @@ const sampleDraftProduct: ProductResponse = {
   sku: 'GOOD-WIDGET-A',
   name: 'Widget A',
   description: null,
-  type: 'Good',
+  type: 'Physical',
   unit: 'each',
   lifecycleStatus: 'Draft',
   metadata: {},
@@ -66,25 +66,25 @@ const sampleDraftProduct: ProductResponse = {
 const basePath = '/api/catalog';
 
 // ---------------------------------------------------------------------------
-// listPublishedProducts
+// listActiveProducts
 // ---------------------------------------------------------------------------
 
-describe('listPublishedProducts', () => {
-  it('should GET {basePath}/products', async () => {
+describe('listActiveProducts', () => {
+  it('should GET {basePath}/products/active', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: [sampleProduct] });
 
-    const result = await listPublishedProducts(client, basePath);
+    const result = await listActiveProducts(client, basePath);
 
-    expect(client.get).toHaveBeenCalledWith(`${basePath}/products`);
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/products/active`);
     expect(result).toEqual([sampleProduct]);
   });
 
-  it('should return an empty array when no products are published', async () => {
+  it('should return an empty array when no products are active', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: [] });
 
-    const result = await listPublishedProducts(client, basePath);
+    const result = await listActiveProducts(client, basePath);
 
     expect(result).toEqual([]);
   });
@@ -93,9 +93,9 @@ describe('listPublishedProducts', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: [sampleProduct] });
 
-    await listPublishedProducts(client, '/v2/shop');
+    await listActiveProducts(client, '/v2/shop');
 
-    expect(client.get).toHaveBeenCalledWith('/v2/shop/products');
+    expect(client.get).toHaveBeenCalledWith('/v2/shop/products/active');
   });
 });
 
@@ -181,7 +181,7 @@ describe('createProduct', () => {
     const request: ProductCreateRequest = {
       sku: 'GOOD-WIDGET-A',
       name: 'Widget A',
-      type: 'Good',
+      type: 'Physical',
       unit: 'each',
     };
 
@@ -203,7 +203,7 @@ describe('createProduct', () => {
     const request: ProductCreateRequest = {
       sku: 'GOOD-WIDGET-A',
       name: 'Widget A',
-      type: 'Good',
+      type: 'Physical',
       unit: 'each',
       description: 'A sturdy widget.',
     };
@@ -312,26 +312,22 @@ describe('updateProductMetadata', () => {
 // ---------------------------------------------------------------------------
 
 describe('publishProduct', () => {
-  it('should POST {basePath}/products/{id}/publish', async () => {
+  it('should POST {basePath}/products/{id}/publish and resolve to void (204)', async () => {
     const client = createMockClient();
-    const publishedProduct: ProductResponse = {
-      ...sampleDraftProduct,
-      lifecycleStatus: 'Published',
-    };
-    vi.mocked(client.post).mockResolvedValue({ data: publishedProduct });
+    vi.mocked(client.post).mockResolvedValue({ data: undefined });
 
     const result = await publishProduct(client, basePath, PRODUCT_ID_2);
 
     expect(client.post).toHaveBeenCalledWith(
       `${basePath}/products/${encodeURIComponent(PRODUCT_ID_2)}/publish`
     );
-    expect(result.lifecycleStatus).toBe('Published');
+    expect(result).toBeUndefined();
   });
 
   it('should URI-encode the product ID', async () => {
     const client = createMockClient();
     const specialId = 'prod/special id' as ProductId;
-    vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+    vi.mocked(client.post).mockResolvedValue({ data: undefined });
 
     await publishProduct(client, basePath, specialId);
 
@@ -346,26 +342,22 @@ describe('publishProduct', () => {
 // ---------------------------------------------------------------------------
 
 describe('archiveProduct', () => {
-  it('should POST {basePath}/products/{id}/archive', async () => {
+  it('should POST {basePath}/products/{id}/archive and resolve to void (204)', async () => {
     const client = createMockClient();
-    const archivedProduct: ProductResponse = {
-      ...sampleProduct,
-      lifecycleStatus: 'Archived',
-    };
-    vi.mocked(client.post).mockResolvedValue({ data: archivedProduct });
+    vi.mocked(client.post).mockResolvedValue({ data: undefined });
 
     const result = await archiveProduct(client, basePath, PRODUCT_ID);
 
     expect(client.post).toHaveBeenCalledWith(
       `${basePath}/products/${encodeURIComponent(PRODUCT_ID)}/archive`
     );
-    expect(result.lifecycleStatus).toBe('Archived');
+    expect(result).toBeUndefined();
   });
 
   it('should URI-encode the product ID', async () => {
     const client = createMockClient();
     const specialId = 'prod/archive&me' as ProductId;
-    vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
+    vi.mocked(client.post).mockResolvedValue({ data: undefined });
 
     await archiveProduct(client, basePath, specialId);
 
@@ -380,9 +372,10 @@ describe('archiveProduct', () => {
 // ---------------------------------------------------------------------------
 
 describe('addProductExternalMapping', () => {
-  it('should POST {basePath}/products/{id}/external-mappings with the request body', async () => {
+  it('should POST {basePath}/products/{id}/external-mappings and return the updated product', async () => {
     const client = createMockClient();
-    vi.mocked(client.post).mockResolvedValue({ data: sampleMapping });
+    // Backend responds 200 with the full updated product (mapping appended).
+    vi.mocked(client.post).mockResolvedValue({ data: sampleProduct });
 
     const request: AddProductExternalMappingRequest = {
       providerName: 'Stripe',
@@ -395,7 +388,8 @@ describe('addProductExternalMapping', () => {
       `${basePath}/products/${encodeURIComponent(PRODUCT_ID)}/external-mappings`,
       request
     );
-    expect(result).toEqual(sampleMapping);
+    expect(result).toEqual(sampleProduct);
+    expect(result.externalMappings).toContainEqual(sampleMapping);
   });
 
   it('should support other provider names (Avalara, Odoo)', async () => {
@@ -405,7 +399,11 @@ describe('addProductExternalMapping', () => {
       providerName: 'Avalara',
       externalId: 'AVA-SERVICE-001',
     };
-    vi.mocked(client.post).mockResolvedValue({ data: avalaraMapping });
+    const updatedProduct: ProductResponse = {
+      ...sampleProduct,
+      externalMappings: [...sampleProduct.externalMappings, avalaraMapping],
+    };
+    vi.mocked(client.post).mockResolvedValue({ data: updatedProduct });
 
     const request: AddProductExternalMappingRequest = {
       providerName: 'Avalara',
@@ -418,7 +416,7 @@ describe('addProductExternalMapping', () => {
       `${basePath}/products/${encodeURIComponent(PRODUCT_ID)}/external-mappings`,
       request
     );
-    expect(result.providerName).toBe('Avalara');
+    expect(result.externalMappings.map((m) => m.providerName)).toContain('Avalara');
   });
 });
 

--- a/packages/@granit/catalog/src/api/products-api.ts
+++ b/packages/@granit/catalog/src/api/products-api.ts
@@ -2,7 +2,6 @@ import type {
   AddProductExternalMappingRequest,
   ProductCreateRequest,
   ProductExternalMappingId,
-  ProductExternalMappingResponse,
   ProductId,
   ProductResponse,
   ProductUpdateRequest,
@@ -11,15 +10,19 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
- * Lists all Published products in the catalog.
+ * Lists the active product catalog (Published status only).
  *
- * `GET {basePath}/products`
+ * `GET {basePath}/products/active`
+ *
+ * The bare `GET {basePath}/products` route is the `Products.Manage`-gated
+ * query-engine admin grid (paginated, full lifecycle) — consume it via
+ * `@granit/react-query-engine`, not this function.
  */
-export async function listPublishedProducts(
+export async function listActiveProducts(
   client: AxiosInstance,
   basePath: string
 ): Promise<readonly ProductResponse[]> {
-  const { data } = await client.get<ProductResponse[]>(`${basePath}/products`);
+  const { data } = await client.get<ProductResponse[]>(`${basePath}/products/active`);
   return data;
 }
 
@@ -109,47 +112,42 @@ export async function updateProductMetadata(
 /**
  * Transitions a Draft product to Published.
  *
- * `POST {basePath}/products/{id}/publish`
+ * `POST {basePath}/products/{id}/publish` — responds `204 No Content`.
  */
 export async function publishProduct(
   client: AxiosInstance,
   basePath: string,
   id: ProductId
-): Promise<ProductResponse> {
-  const { data } = await client.post<ProductResponse>(
-    `${basePath}/products/${encodeURIComponent(id)}/publish`
-  );
-  return data;
+): Promise<void> {
+  await client.post(`${basePath}/products/${encodeURIComponent(id)}/publish`);
 }
 
 /**
  * Archives a Published product.
  *
- * `POST {basePath}/products/{id}/archive`
+ * `POST {basePath}/products/{id}/archive` — responds `204 No Content`.
  */
 export async function archiveProduct(
   client: AxiosInstance,
   basePath: string,
   id: ProductId
-): Promise<ProductResponse> {
-  const { data } = await client.post<ProductResponse>(
-    `${basePath}/products/${encodeURIComponent(id)}/archive`
-  );
-  return data;
+): Promise<void> {
+  await client.post(`${basePath}/products/${encodeURIComponent(id)}/archive`);
 }
 
 /**
  * Adds an external provider mapping (Stripe, Avalara, Odoo, ...) to a product.
  *
- * `POST {basePath}/products/{id}/external-mappings`
+ * `POST {basePath}/products/{id}/external-mappings` — responds `200 OK` with the
+ * full updated product (including the new mapping in `externalMappings`).
  */
 export async function addProductExternalMapping(
   client: AxiosInstance,
   basePath: string,
   id: ProductId,
   request: AddProductExternalMappingRequest
-): Promise<ProductExternalMappingResponse> {
-  const { data } = await client.post<ProductExternalMappingResponse>(
+): Promise<ProductResponse> {
+  const { data } = await client.post<ProductResponse>(
     `${basePath}/products/${encodeURIComponent(id)}/external-mappings`,
     request
   );

--- a/packages/@granit/catalog/src/index.ts
+++ b/packages/@granit/catalog/src/index.ts
@@ -11,6 +11,7 @@ export type {
   ProductId,
   ProductLifecycleStatus,
   ProductResponse,
+  ProductType,
   ProductUpdateRequest,
   UpdateProductMetadataRequest,
 } from './types/index';
@@ -21,7 +22,7 @@ export {
   createProduct,
   getProductById,
   getProductBySku,
-  listPublishedProducts,
+  listActiveProducts,
   publishProduct,
   removeProductExternalMapping,
   updateProduct,

--- a/packages/@granit/catalog/src/types/index.ts
+++ b/packages/@granit/catalog/src/types/index.ts
@@ -7,10 +7,19 @@ export type ProductId = EntityId<'Product'>;
 export type ProductExternalMappingId = EntityId<'ProductExternalMapping'>;
 
 /**
- * Lifecycle status of a catalog product. Mirrors
- * `Granit.Workflow.Domain.WorkflowLifecycleStatus` string values.
+ * Lifecycle status of a catalog product. Mirrors the reachable subset of
+ * `Granit.Workflow.Domain.WorkflowLifecycleStatus` for `Product`: the entity's
+ * state machine is `Draft → Published → Archived` (it never enters
+ * `PendingReview`).
  */
 export type ProductLifecycleStatus = 'Draft' | 'Published' | 'Archived';
+
+/**
+ * Coarse product classification. Mirrors `Granit.Catalog.Domain.ProductType`
+ * (serialized to its string name). Drives downstream behavior (tax, shipping,
+ * metering).
+ */
+export type ProductType = 'Service' | 'Metered' | 'Physical' | 'Digital';
 
 /** Product external provider mapping (Stripe, Avalara, Odoo, ...). */
 export interface ProductExternalMappingResponse {
@@ -25,8 +34,8 @@ export interface ProductResponse {
   readonly sku: string;
   readonly name: string;
   readonly description: string | null;
-  /** Free-form product type (e.g. `Service`, `Good`). Backend string. */
-  readonly type: string;
+  /** Product classification (`Service`, `Metered`, `Physical`, `Digital`). */
+  readonly type: ProductType;
   /** Unit of measure (e.g. `each`, `hour`). */
   readonly unit: string;
   readonly lifecycleStatus: ProductLifecycleStatus;
@@ -38,7 +47,7 @@ export interface ProductResponse {
 export interface ProductCreateRequest {
   readonly sku: string;
   readonly name: string;
-  readonly type: string;
+  readonly type: ProductType;
   readonly unit: string;
   readonly description?: string | null;
 }

--- a/packages/@granit/react-catalog/src/__tests__/use-products.test.tsx
+++ b/packages/@granit/react-catalog/src/__tests__/use-products.test.tsx
@@ -8,10 +8,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 import {
+  useActiveProducts,
   useCreateProduct,
   useProduct,
   useProductBySku,
-  usePublishedProducts,
 } from '../hooks/use-products';
 import {
   CatalogProvider,
@@ -48,7 +48,7 @@ const sampleProduct: ProductResponse = {
   sku: 'SKU-001',
   name: 'Widget Pro',
   description: 'A professional widget',
-  type: 'Good',
+  type: 'Physical',
   unit: 'each',
   lifecycleStatus: 'Published',
   metadata: { category: 'hardware' },
@@ -60,7 +60,7 @@ const sampleDraftProduct: ProductResponse = {
   sku: 'SKU-002',
   name: 'Widget Lite',
   description: null,
-  type: 'Good',
+  type: 'Physical',
   unit: 'each',
   lifecycleStatus: 'Draft',
   metadata: {},
@@ -170,24 +170,24 @@ describe('buildCatalogQueryKey', () => {
 });
 
 // ---------------------------------------------------------------------------
-// usePublishedProducts
+// useActiveProducts
 // ---------------------------------------------------------------------------
 
-describe('usePublishedProducts', () => {
+describe('useActiveProducts', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('fetches all published products', async () => {
+  it('fetches the active (published) products', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: [sampleProduct] });
 
-    const { result } = renderHook(() => usePublishedProducts(), {
+    const { result } = renderHook(() => useActiveProducts(), {
       wrapper: createWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith(`${DEFAULT_BASE_PATH}/products`);
+    expect(client.get).toHaveBeenCalledWith(`${DEFAULT_BASE_PATH}/products/active`);
     expect(result.current.data).toEqual([sampleProduct]);
   });
 
@@ -195,7 +195,7 @@ describe('usePublishedProducts', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: [] });
 
-    const { result } = renderHook(() => usePublishedProducts(), {
+    const { result } = renderHook(() => useActiveProducts(), {
       wrapper: createWrapper(client),
     });
 
@@ -207,12 +207,12 @@ describe('usePublishedProducts', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue({ data: [sampleProduct] });
 
-    const { result } = renderHook(() => usePublishedProducts(), {
+    const { result } = renderHook(() => useActiveProducts(), {
       wrapper: createWrapper(client, '/custom/catalog'),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/custom/catalog/products');
+    expect(client.get).toHaveBeenCalledWith('/custom/catalog/products/active');
   });
 });
 

--- a/packages/@granit/react-catalog/src/hooks/use-products.ts
+++ b/packages/@granit/react-catalog/src/hooks/use-products.ts
@@ -4,7 +4,7 @@ import {
   createProduct,
   getProductById,
   getProductBySku,
-  listPublishedProducts,
+  listActiveProducts,
   publishProduct,
   removeProductExternalMapping,
   updateProduct,
@@ -18,7 +18,6 @@ import type {
   AddProductExternalMappingRequest,
   ProductCreateRequest,
   ProductExternalMappingId,
-  ProductExternalMappingResponse,
   ProductId,
   ProductResponse,
   ProductUpdateRequest,
@@ -30,12 +29,12 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 // Reads
 // ---------------------------------------------------------------------------
 
-/** Lists all Published products in the catalog. */
-export function usePublishedProducts(): UseQueryResult<readonly ProductResponse[]> {
+/** Lists the active product catalog (Published status only). */
+export function useActiveProducts(): UseQueryResult<readonly ProductResponse[]> {
   const config = useCatalogConfig();
   return useQuery({
-    queryKey: buildCatalogQueryKey(config, 'products', 'published'),
-    queryFn: () => listPublishedProducts(config.client, config.basePath),
+    queryKey: buildCatalogQueryKey(config, 'products', 'active'),
+    queryFn: () => listActiveProducts(config.client, config.basePath),
   });
 }
 
@@ -139,8 +138,8 @@ export function useUpdateProductMetadata(): UseMutationResult<
 // Mutations — lifecycle
 // ---------------------------------------------------------------------------
 
-/** Transitions a Draft product to Published. */
-export function usePublishProduct(): UseMutationResult<ProductResponse, Error, ProductId> {
+/** Transitions a Draft product to Published. Resolves with no value (backend returns 204). */
+export function usePublishProduct(): UseMutationResult<void, Error, ProductId> {
   const config = useCatalogConfig();
   const invalidate = useInvalidateProducts();
   return useMutation({
@@ -149,8 +148,8 @@ export function usePublishProduct(): UseMutationResult<ProductResponse, Error, P
   });
 }
 
-/** Archives a Published product. */
-export function useArchiveProduct(): UseMutationResult<ProductResponse, Error, ProductId> {
+/** Archives a Published product. Resolves with no value (backend returns 204). */
+export function useArchiveProduct(): UseMutationResult<void, Error, ProductId> {
   const config = useCatalogConfig();
   const invalidate = useInvalidateProducts();
   return useMutation({
@@ -169,9 +168,12 @@ export interface AddProductExternalMappingVariables {
   readonly request: AddProductExternalMappingRequest;
 }
 
-/** Adds an external provider mapping (Stripe, Avalara, Odoo, ...) to a product. */
+/**
+ * Adds an external provider mapping (Stripe, Avalara, Odoo, ...) to a product.
+ * Resolves with the full updated product (backend returns 200 + ProductResponse).
+ */
 export function useAddProductExternalMapping(): UseMutationResult<
-  ProductExternalMappingResponse,
+  ProductResponse,
   Error,
   AddProductExternalMappingVariables
 > {

--- a/packages/@granit/react-catalog/src/index.ts
+++ b/packages/@granit/react-catalog/src/index.ts
@@ -16,13 +16,13 @@ export type {
 
 // Hooks
 export {
+  useActiveProducts,
   useAddProductExternalMapping,
   useArchiveProduct,
   useCreateProduct,
   useProduct,
   useProductBySku,
   usePublishProduct,
-  usePublishedProducts,
   useRemoveProductExternalMapping,
   useUpdateProduct,
   useUpdateProductMetadata,

--- a/packages/@granit/react-catalog/src/testing/handlers.ts
+++ b/packages/@granit/react-catalog/src/testing/handlers.ts
@@ -39,8 +39,10 @@ function nextProductId(): string {
  */
 export function createCatalogHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
-    // GET /catalog/products → Published only
-    http.get(`${baseUrl}/products`, () => {
+    // GET /catalog/products/active → active catalog (Published only).
+    // The bare GET /catalog/products route is the query-engine admin grid
+    // (paged, full lifecycle) — not mocked here.
+    http.get(`${baseUrl}/products/active`, () => {
       const published = products.filter((p) => p.lifecycleStatus === 'Published');
       return HttpResponse.json(published);
     }),
@@ -108,25 +110,25 @@ export function createCatalogHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(updated);
     }),
 
-    // POST /catalog/products/{id}/publish
+    // POST /catalog/products/{id}/publish → 204 No Content
     http.post(`${baseUrl}/products/:id/publish`, ({ params }) => {
       const product = findProductOrFail(params.id as string);
       if (!product) return new HttpResponse(null, { status: 404 });
       const updated: ProductResponse = { ...product, lifecycleStatus: 'Published' };
       products = products.map((p) => (p.id === updated.id ? updated : p));
-      return HttpResponse.json(updated);
+      return new HttpResponse(null, { status: 204 });
     }),
 
-    // POST /catalog/products/{id}/archive
+    // POST /catalog/products/{id}/archive → 204 No Content
     http.post(`${baseUrl}/products/:id/archive`, ({ params }) => {
       const product = findProductOrFail(params.id as string);
       if (!product) return new HttpResponse(null, { status: 404 });
       const updated: ProductResponse = { ...product, lifecycleStatus: 'Archived' };
       products = products.map((p) => (p.id === updated.id ? updated : p));
-      return HttpResponse.json(updated);
+      return new HttpResponse(null, { status: 204 });
     }),
 
-    // POST /catalog/products/{id}/external-mappings
+    // POST /catalog/products/{id}/external-mappings → 200 OK with the full product
     http.post(`${baseUrl}/products/:id/external-mappings`, async ({ params, request }) => {
       const body = (await request.json()) as AddProductExternalMappingRequest;
       const product = findProductOrFail(params.id as string);
@@ -141,7 +143,7 @@ export function createCatalogHandlers(baseUrl = DEFAULT_BASE_PATH) {
         externalMappings: [...product.externalMappings, mapping],
       };
       products = products.map((p) => (p.id === updated.id ? updated : p));
-      return HttpResponse.json(mapping, { status: 201 });
+      return HttpResponse.json(updated);
     }),
 
     // DELETE /catalog/products/{id}/external-mappings/{mappingId}


### PR DESCRIPTION
## Why

The catalog API functions, hooks, MSW handlers and tests encoded contracts that
diverged from `Granit.Catalog.Endpoints`, so they passed in isolation but would
break against the real backend (wrong auth, wrong response shapes).

## Changes

- **BREAKING** `listActiveProducts` (renamed from `listPublishedProducts` /
  `usePublishedProducts` → `useActiveProducts`) now targets `GET /products/active`
  (Published-only, `Products.Read`). It previously hit `GET /products` — the
  `Products.Manage`-gated query-engine admin grid returning a `PagedResult`
  envelope, not an array.
- **BREAKING** `publishProduct` / `archiveProduct` now return `void` (backend
  responds `204 No Content`); hooks retyped to `UseMutationResult<void, …>`.
- **BREAKING** `addProductExternalMapping` now returns `ProductResponse` (backend
  responds `200` with the full updated product, not the bare mapping).
- `ProductType` modeled as a union (`'Service' | 'Metered' | 'Physical' |
  'Digital'`) instead of free-form `string`, mirroring the .NET enum.
- MSW handlers + tests fixed to the real routes / status codes / shapes so the
  suite guards the actual contract.

## Verification

- `tsc --noEmit` clean (catalog + react-catalog)
- ESLint clean (`--max-warnings 0`)
- 43 tests pass

## Consumer impact

Renames `usePublishedProducts` → `useActiveProducts` (and the underlying
`listPublishedProducts`). Coordinated showcase update:
**granit-showcase-react MR !39** (depends on this PR).