### PR TITLE
feat(api-keys): query-option overrides + keepPreviousData on hooks

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2688,6 +2688,43 @@
           ]
         },
         {
+          "name": "ApiKeyQueryOptions",
+          "kind": "interface",
+          "signature": "interface ApiKeyQueryOptions",
+          "members": [
+            {
+              "name": "staleTime",
+              "kind": "property",
+              "signature": "staleTime?: number"
+            },
+            {
+              "name": "gcTime",
+              "kind": "property",
+              "signature": "gcTime?: number"
+            },
+            {
+              "name": "enabled",
+              "kind": "property",
+              "signature": "enabled?: boolean"
+            },
+            {
+              "name": "refetchInterval",
+              "kind": "property",
+              "signature": "refetchInterval?: number | false"
+            },
+            {
+              "name": "refetchOnWindowFocus",
+              "kind": "property",
+              "signature": "refetchOnWindowFocus?: boolean"
+            },
+            {
+              "name": "retry",
+              "kind": "property",
+              "signature": "retry?: boolean | number"
+            }
+          ]
+        },
+        {
           "name": "UseApiKeysParams",
           "kind": "type",
           "signature": "type UseApiKeysParams = ListApiKeysParams"
@@ -2700,7 +2737,7 @@
         {
           "name": "useApiKey",
           "kind": "function",
-          "signature": "function useApiKey(id: string, options: ApiKeyHookOptions): UseQueryResult<ApiKeyResponse>"
+          "signature": "function useApiKey( id: string, options: ApiKeyHookOptions, queryOptions?: ApiKeyQueryOptions ): UseQueryResult<ApiKeyResponse>"
         },
         {
           "name": "UpdateApiKeyScopesVariables",

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
@@ -216,6 +216,21 @@ describe('useApiKeys', () => {
     expect(result.current.data?.items).toEqual([]);
     expect(result.current.data?.totalCount).toBe(0);
   });
+
+  it('accepts TanStack query option overrides (staleTime)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: { items: [mockApiKey], totalCount: 1, hasMore: false },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useApiKeys({ client }, {}, { staleTime: 60_000 }), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.items).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-key.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-key.ts
@@ -5,7 +5,7 @@ import { DEFAULT_BASE_PATH } from '../constants';
 
 import { buildApiKeyQueryKey } from './query-keys';
 
-import type { ApiKeyHookOptions } from './use-api-keys';
+import type { ApiKeyHookOptions, ApiKeyQueryOptions } from './use-api-keys';
 import type { ApiKeyResponse } from '@granit/authentication-api-keys';
 import type { UseQueryResult } from '@tanstack/react-query';
 
@@ -16,18 +16,24 @@ import type { UseQueryResult } from '@tanstack/react-query';
  *
  * @param id - The API key ID to fetch.
  * @param options - Axios client and optional base path.
+ * @param queryOptions - Optional TanStack Query overrides (e.g. `staleTime`).
  *
  * @example
  * ```tsx
  * const { data: apiKey, isLoading } = useApiKey('key-123', { client: api });
  * ```
  */
-export function useApiKey(id: string, options: ApiKeyHookOptions): UseQueryResult<ApiKeyResponse> {
+export function useApiKey(
+  id: string,
+  options: ApiKeyHookOptions,
+  queryOptions?: ApiKeyQueryOptions
+): UseQueryResult<ApiKeyResponse> {
   const { client, basePath = DEFAULT_BASE_PATH } = options;
 
   return useQuery({
     queryKey: buildApiKeyQueryKey(options, 'detail', id),
     queryFn: () => getApiKey(client, basePath, id),
-    enabled: Boolean(id),
+    ...queryOptions,
+    enabled: Boolean(id) && queryOptions?.enabled !== false,
   });
 }

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
@@ -1,5 +1,5 @@
 import { listApiKeys } from '@granit/authentication-api-keys';
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
@@ -32,6 +32,20 @@ export interface ApiKeyHookOptions {
  */
 export type UseApiKeysParams = ListApiKeysParams;
 
+/**
+ * TanStack Query options consumers may override on the api-key query hooks
+ * (e.g. `staleTime`, `enabled`, `refetchInterval`). Data-shape options
+ * (`queryKey`, `queryFn`, `placeholderData`) are managed internally.
+ */
+export interface ApiKeyQueryOptions {
+  staleTime?: number;
+  gcTime?: number;
+  enabled?: boolean;
+  refetchInterval?: number | false;
+  refetchOnWindowFocus?: boolean;
+  retry?: boolean | number;
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -41,25 +55,34 @@ export type UseApiKeysParams = ListApiKeysParams;
  *
  * Calls `GET {basePath}` with query parameters derived from `params`.
  *
+ * Keeps the previous page visible while the next one loads (no flash on page
+ * change) and stays integrated with the TanStack Query cache, so the api-key
+ * mutations' `invalidateQueries` refresh this list automatically.
+ *
  * @param options - Axios client and optional base path.
  * @param params - Optional search/filter/pagination parameters.
+ * @param queryOptions - Optional TanStack Query overrides (e.g. `staleTime`).
  *
  * @example
  * ```tsx
  * const { data, isLoading } = useApiKeys(
  *   { client: api },
- *   { environment: 'production', type: ['Secret'] }
+ *   { environment: 'production', type: 'Secret' },
+ *   { staleTime: 60_000 }
  * );
  * ```
  */
 export function useApiKeys(
   options: ApiKeyHookOptions,
-  params: UseApiKeysParams = {}
+  params: UseApiKeysParams = {},
+  queryOptions?: ApiKeyQueryOptions
 ): UseQueryResult<PagedResult<ApiKeyResponse>> {
   const { client, basePath = DEFAULT_BASE_PATH } = options;
 
   return useQuery({
     queryKey: buildApiKeyQueryKey(options, 'list', params),
     queryFn: () => listApiKeys(client, basePath, params),
+    placeholderData: keepPreviousData,
+    ...queryOptions,
   });
 }

--- a/packages/@granit/react-authentication-api-keys/src/index.ts
+++ b/packages/@granit/react-authentication-api-keys/src/index.ts
@@ -1,6 +1,6 @@
 // Hooks — queries
 export { useApiKeys } from './hooks/use-api-keys';
-export type { ApiKeyHookOptions, UseApiKeysParams } from './hooks/use-api-keys';
+export type { ApiKeyHookOptions, ApiKeyQueryOptions, UseApiKeysParams } from './hooks/use-api-keys';
 export { buildApiKeyQueryKey } from './hooks/query-keys';
 export { useApiKey } from './hooks/use-api-key';
 


### PR DESCRIPTION
Follow-up to the authentication audit (#548).

## Changes
- `useApiKeys` / `useApiKey` now accept an optional `queryOptions` arg (`staleTime`, `gcTime`, `enabled`, `refetchInterval`, `refetchOnWindowFocus`, `retry`). Restores the `staleTime` control the showcase lost when it adopted the hook.
- `useApiKeys` defaults to `placeholderData: keepPreviousData` → no empty flash on page change, still TanStack-cache-integrated so mutations' `invalidateQueries` refresh the list.

## Why not `usePagination`?
`@granit/react-query-engine`'s `usePagination` is a standalone `useState`-based hook, **not** TanStack-cache-integrated. Swapping `useApiKeys` to it would break the mutation→list auto-refresh (revoke/rotate/create invalidate the query cache). So the pagination ergonomics were delivered via `keepPreviousData` instead.

## Verification
tsc ✅ · ESLint ✅ · vitest 39 ✅