### PR TITLE
feat(authentication-local): complete the account self-service surface

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -864,7 +864,7 @@
     },
     {
       "name": "@granit/authentication-local",
-      "description": "Local credential authentication types and API — headless login, passkey assertion — mirrors Granit.Identity.Local.Endpoints .NET contract",
+      "description": "Local credential authentication types and API — headless login + full account self-service (registration, password, email, profile, 2FA, passkeys) — mirrors Granit.Identity.Local.Endpoints .NET contract",
       "exports": [
         {
           "name": "loginAccount",
@@ -875,6 +875,56 @@
           "name": "verifyTwoFactorLogin",
           "kind": "function",
           "signature": "async function verifyTwoFactorLogin( client: AxiosInstance, basePath: string, request: AccountTwoFactorLoginRequest ): Promise<AccountLoginResponse>"
+        },
+        {
+          "name": "changePassword",
+          "kind": "function",
+          "signature": "async function changePassword( client: AxiosInstance, basePath: string, request: AccountPasswordChangeRequest ): Promise<void>"
+        },
+        {
+          "name": "forgotPassword",
+          "kind": "function",
+          "signature": "async function forgotPassword( client: AxiosInstance, basePath: string, request: AccountForgotPasswordRequest ): Promise<void>"
+        },
+        {
+          "name": "resetPassword",
+          "kind": "function",
+          "signature": "async function resetPassword( client: AxiosInstance, basePath: string, request: AccountPasswordResetRequest ): Promise<void>"
+        },
+        {
+          "name": "changeEmail",
+          "kind": "function",
+          "signature": "async function changeEmail( client: AxiosInstance, basePath: string, request: AccountChangeEmailRequest ): Promise<void>"
+        },
+        {
+          "name": "confirmEmailChange",
+          "kind": "function",
+          "signature": "async function confirmEmailChange( client: AxiosInstance, basePath: string, request: AccountConfirmEmailChangeRequest ): Promise<void>"
+        },
+        {
+          "name": "getProfile",
+          "kind": "function",
+          "signature": "async function getProfile( client: AxiosInstance, basePath: string ): Promise<AccountProfileResponse>"
+        },
+        {
+          "name": "updateProfile",
+          "kind": "function",
+          "signature": "async function updateProfile( client: AxiosInstance, basePath: string, request: AccountProfileUpdateRequest ): Promise<AccountProfileResponse>"
+        },
+        {
+          "name": "deleteAccount",
+          "kind": "function",
+          "signature": "async function deleteAccount( client: AxiosInstance, basePath: string, request: AccountDeleteRequest ): Promise<void>"
+        },
+        {
+          "name": "sendSessionHeartbeat",
+          "kind": "function",
+          "signature": "async function sendSessionHeartbeat(client: AxiosInstance, basePath: string): Promise<void>"
+        },
+        {
+          "name": "getAccountConfig",
+          "kind": "function",
+          "signature": "async function getAccountConfig( client: AxiosInstance, basePath: string ): Promise<IdentityLocalConfigResponse>"
         },
         {
           "name": "extractReturnUrl",
@@ -2892,7 +2942,7 @@
     },
     {
       "name": "@granit/react-authentication-local",
-      "description": "React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion",
+      "description": "React hooks for local credential authentication — login, registration, password, email change, profile, two-factor and passkey management",
       "exports": [
         {
           "name": "LocalAuthProvider",
@@ -2915,6 +2965,11 @@
           "kind": "interface",
           "signature": "interface LocalAuthProviderProps",
           "members": []
+        },
+        {
+          "name": "localAuthKeys",
+          "kind": "const",
+          "signature": "const localAuthKeys"
         },
         {
           "name": "useLogin",
@@ -2940,6 +2995,73 @@
           "name": "useCompletePasskeyAssertion",
           "kind": "function",
           "signature": "function useCompletePasskeyAssertion(): UseMutationResult< AccountLoginResponse, Error, AccountPasskeyLoginRequest >"
+        },
+        {
+          "name": "useChangePassword",
+          "kind": "function",
+          "signature": "function useChangePassword(): UseMutationResult<void, Error, AccountPasswordChangeRequest>"
+        },
+        {
+          "name": "useForgotPassword",
+          "kind": "function",
+          "signature": "function useForgotPassword(): UseMutationResult<void, Error, AccountForgotPasswordRequest>"
+        },
+        {
+          "name": "useResetPassword",
+          "kind": "function",
+          "signature": "function useResetPassword(): UseMutationResult<void, Error, AccountPasswordResetRequest>"
+        },
+        {
+          "name": "useChangeEmail",
+          "kind": "function",
+          "signature": "function useChangeEmail(): UseMutationResult<void, Error, AccountChangeEmailRequest>"
+        },
+        {
+          "name": "useConfirmEmailChange",
+          "kind": "function",
+          "signature": "function useConfirmEmailChange(): UseMutationResult< void, Error, AccountConfirmEmailChangeRequest >"
+        },
+        {
+          "name": "useProfile",
+          "kind": "function",
+          "signature": "function useProfile(): UseQueryResult<AccountProfileResponse>"
+        },
+        {
+          "name": "useUpdateProfile",
+          "kind": "function",
+          "signature": "function useUpdateProfile(): UseMutationResult< AccountProfileResponse, Error, AccountProfileUpdateRequest >"
+        },
+        {
+          "name": "RenamePasskeyVariables",
+          "kind": "interface",
+          "signature": "interface RenamePasskeyVariables",
+          "members": [
+            {
+              "name": "id",
+              "kind": "property",
+              "signature": "id: string"
+            },
+            {
+              "name": "request",
+              "kind": "property",
+              "signature": "request: PasskeyRenameRequest"
+            }
+          ]
+        },
+        {
+          "name": "useDeleteAccount",
+          "kind": "function",
+          "signature": "function useDeleteAccount(): UseMutationResult<void, Error, AccountDeleteRequest>"
+        },
+        {
+          "name": "useSendSessionHeartbeat",
+          "kind": "function",
+          "signature": "function useSendSessionHeartbeat(): UseMutationResult<void, Error, void>"
+        },
+        {
+          "name": "useAccountConfig",
+          "kind": "function",
+          "signature": "function useAccountConfig(): UseQueryResult<IdentityLocalConfigResponse>"
         }
       ]
     },

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ pnpm --filter @granit/utils lint   # Per package
 
 **React package** `@granit/react-{module}` (React-specific):
 
-```
+```text
 react-{module}/src/
 ├── __tests__/
 ├── components/      # Optional — React components
@@ -118,6 +118,24 @@ Full frontend conventions: `../granit-dotnet/docs/guide/conventions/frontend/`
   - `commit-msg`: commitlint (Conventional Commits)
   - `pre-commit`: `gitleaks` → `lint-staged` → `tsc -r --noEmit` →
     regenerate `.mcp-front-index.json` when `packages/@granit/*/src/` changed
+
+### Mirroring DTOs from `contracts/openapi/*.json`
+
+The OpenAPI specs are authoritative for **routes, HTTP methods, status codes,
+and field names** (PascalCase .NET → camelCase JSON). For **field optionality**,
+read the schema's `required` array — NOT the nullability:
+
+- A property's TS optionality (`?`) comes from `required`, never from whether
+  it can be `null`. The .NET generator marks **every** positional-record
+  parameter **without a C# default** as `required`, because System.Text.Json
+  needs the key present to construct the record.
+- `string? Foo` (no default) → `required` + `type: ["null","string"]` →
+  mirror as **`foo: T | null`** (key required, value nullable), **not** `foo?: T`.
+- Only params with a C# default (e.g. `bool X = false`) are absent from
+  `required` → **`foo?: T`** (genuinely optional).
+- Cross-check the record + FluentValidation validator in
+  `granit-dotnet/src/Granit.{Module}.Endpoints/` when in doubt — a missing
+  `NotEmpty()`/`NotNull()` rule constrains the _value_, not key presence.
 
 ## Refactoring — framework-specific
 

--- a/packages/@granit/authentication-local/package.json
+++ b/packages/@granit/authentication-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@granit/authentication-local",
-  "description": "Local credential authentication types and API — headless login, passkey assertion — mirrors Granit.Identity.Local.Endpoints .NET contract",
+  "description": "Local credential authentication types and API — headless login + full account self-service (registration, password, email, profile, 2FA, passkeys) — mirrors Granit.Identity.Local.Endpoints .NET contract",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
@@ -14,11 +14,13 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/authentication-local/src/__tests__/account-management-api.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/account-management-api.test.ts
@@ -1,0 +1,240 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  changeEmail,
+  changePassword,
+  completePasskeyRegistration,
+  confirmEmail,
+  confirmEmailChange,
+  deleteAccount,
+  deletePasskey,
+  disableTwoFactor,
+  enableTwoFactor,
+  forgotPassword,
+  generateRecoveryCodes,
+  getAccountConfig,
+  getAuthenticatorKey,
+  getProfile,
+  getTwoFactorStatus,
+  listPasskeys,
+  registerAccount,
+  renamePasskey,
+  resendConfirmationEmail,
+  resetPassword,
+  sendSessionHeartbeat,
+  updateProfile,
+} from '../index';
+
+const BASE = '/api/account';
+
+describe('authentication-local account management API', () => {
+  describe('registration', () => {
+    it('registerAccount POSTs /register', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await registerAccount(client, BASE, {
+        email: 'a@b.c',
+        password: 'P@ss',
+        firstName: null,
+        lastName: null,
+      });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/register`, {
+        email: 'a@b.c',
+        password: 'P@ss',
+        firstName: null,
+        lastName: null,
+      });
+    });
+
+    it('confirmEmail GETs /confirm-email with userId + token', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: undefined });
+      await confirmEmail(client, BASE, 'u1', 't1');
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/confirm-email`, {
+        params: { userId: 'u1', token: 't1' },
+      });
+    });
+
+    it('resendConfirmationEmail POSTs /resend-confirmation-email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await resendConfirmationEmail(client, BASE);
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/resend-confirmation-email`);
+    });
+  });
+
+  describe('password', () => {
+    it('changePassword POSTs /change-password', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await changePassword(client, BASE, { currentPassword: 'old', newPassword: 'new' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/change-password`, {
+        currentPassword: 'old',
+        newPassword: 'new',
+      });
+    });
+
+    it('forgotPassword POSTs /forgot-password', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await forgotPassword(client, BASE, { email: 'a@b.c' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/forgot-password`, { email: 'a@b.c' });
+    });
+
+    it('resetPassword POSTs /reset-password', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await resetPassword(client, BASE, { userId: 'u1', token: 't1', newPassword: 'new' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/reset-password`, {
+        userId: 'u1',
+        token: 't1',
+        newPassword: 'new',
+      });
+    });
+  });
+
+  describe('email change', () => {
+    it('changeEmail POSTs /change-email', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await changeEmail(client, BASE, { newEmail: 'new@b.c', currentPassword: 'pw' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/change-email`, {
+        newEmail: 'new@b.c',
+        currentPassword: 'pw',
+      });
+    });
+
+    it('confirmEmailChange POSTs /confirm-email-change', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await confirmEmailChange(client, BASE, { userId: 'u1', newEmail: 'new@b.c', token: 't1' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/confirm-email-change`, {
+        userId: 'u1',
+        newEmail: 'new@b.c',
+        token: 't1',
+      });
+    });
+  });
+
+  describe('profile', () => {
+    it('getProfile GETs /profile and returns data', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: { userId: 'u1', email: 'a@b.c' } });
+      const result = await getProfile(client, BASE);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/profile`);
+      expect(result).toEqual({ userId: 'u1', email: 'a@b.c' });
+    });
+
+    it('updateProfile PUTs /profile and returns data', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValueOnce({ data: { firstName: 'Ada' } });
+      const result = await updateProfile(client, BASE, { firstName: 'Ada', lastName: null });
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/profile`, {
+        firstName: 'Ada',
+        lastName: null,
+      });
+      expect(result).toEqual({ firstName: 'Ada' });
+    });
+  });
+
+  describe('two-factor management', () => {
+    it('getTwoFactorStatus GETs /two-factor', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: { isEnabled: false } });
+      await getTwoFactorStatus(client, BASE);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/two-factor`);
+    });
+
+    it('getAuthenticatorKey GETs /two-factor/authenticator-key', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({
+        data: { sharedKey: 'K', qrCodeUri: 'otpauth://' },
+      });
+      await getAuthenticatorKey(client, BASE);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/two-factor/authenticator-key`);
+    });
+
+    it('enableTwoFactor POSTs /two-factor/enable and returns recovery codes', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: { recoveryCodes: ['a'] } });
+      const result = await enableTwoFactor(client, BASE, { code: '123456' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/enable`, { code: '123456' });
+      expect(result.recoveryCodes).toEqual(['a']);
+    });
+
+    it('disableTwoFactor POSTs /two-factor/disable', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await disableTwoFactor(client, BASE, { password: 'pw' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/disable`, { password: 'pw' });
+    });
+
+    it('generateRecoveryCodes POSTs /two-factor/recovery-codes', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: { recoveryCodes: ['a', 'b'] } });
+      const result = await generateRecoveryCodes(client, BASE, { password: 'pw' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/recovery-codes`, {
+        password: 'pw',
+      });
+      expect(result.recoveryCodes).toHaveLength(2);
+    });
+  });
+
+  describe('passkey management', () => {
+    it('listPasskeys GETs /passkeys', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: [] });
+      await listPasskeys(client, BASE);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/passkeys`);
+    });
+
+    it('completePasskeyRegistration POSTs /passkeys/register/complete', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: { id: 'pk-1' } });
+      await completePasskeyRegistration(client, BASE, { credentialJson: '{}', name: 'Laptop' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/passkeys/register/complete`, {
+        credentialJson: '{}',
+        name: 'Laptop',
+      });
+    });
+
+    it('renamePasskey PATCHes /passkeys/{id} with encoded id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValueOnce({ data: undefined });
+      await renamePasskey(client, BASE, 'pk 1', { name: 'New' });
+      expect(client.patch).toHaveBeenCalledWith(`${BASE}/passkeys/pk%201`, { name: 'New' });
+    });
+
+    it('deletePasskey DELETEs /passkeys/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValueOnce({ data: undefined });
+      await deletePasskey(client, BASE, 'pk-1');
+      expect(client.delete).toHaveBeenCalledWith(`${BASE}/passkeys/pk-1`);
+    });
+  });
+
+  describe('deletion, session, config', () => {
+    it('deleteAccount POSTs /delete', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await deleteAccount(client, BASE, { password: 'pw' });
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/delete`, { password: 'pw' });
+    });
+
+    it('sendSessionHeartbeat POSTs /session/heartbeat', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+      await sendSessionHeartbeat(client, BASE);
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/session/heartbeat`);
+    });
+
+    it('getAccountConfig GETs /config', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({ data: { allowSelfRegistration: true } });
+      const result = await getAccountConfig(client, BASE);
+      expect(client.get).toHaveBeenCalledWith(`${BASE}/config`);
+      expect(result.allowSelfRegistration).toBe(true);
+    });
+  });
+});

--- a/packages/@granit/authentication-local/src/api/account-config-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-config-api.ts
@@ -1,0 +1,15 @@
+import type { IdentityLocalConfigResponse } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Get the public local-identity configuration (anonymous).
+ *
+ * `GET {basePath}/config`
+ */
+export async function getAccountConfig(
+  client: AxiosInstance,
+  basePath: string
+): Promise<IdentityLocalConfigResponse> {
+  const { data } = await client.get<IdentityLocalConfigResponse>(`${basePath}/config`);
+  return data;
+}

--- a/packages/@granit/authentication-local/src/api/account-deletion-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-deletion-api.ts
@@ -1,0 +1,17 @@
+import type { AccountDeleteRequest } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Request deletion of the authenticated account (step-up: password).
+ *
+ * Returns 202 Accepted; the account is scheduled for erasure.
+ *
+ * `POST {basePath}/delete`
+ */
+export async function deleteAccount(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountDeleteRequest
+): Promise<void> {
+  await client.post(`${basePath}/delete`, request);
+}

--- a/packages/@granit/authentication-local/src/api/account-email-change-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-email-change-api.ts
@@ -1,0 +1,30 @@
+import type { AccountChangeEmailRequest, AccountConfirmEmailChangeRequest } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Request an email-address change (authenticated, step-up: current password).
+ *
+ * Returns 202 and sends a confirmation link to the new address.
+ *
+ * `POST {basePath}/change-email`
+ */
+export async function changeEmail(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountChangeEmailRequest
+): Promise<void> {
+  await client.post(`${basePath}/change-email`, request);
+}
+
+/**
+ * Confirm an email-address change (anonymous — called from the e-mailed link).
+ *
+ * `POST {basePath}/confirm-email-change`
+ */
+export async function confirmEmailChange(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountConfirmEmailChangeRequest
+): Promise<void> {
+  await client.post(`${basePath}/confirm-email-change`, request);
+}

--- a/packages/@granit/authentication-local/src/api/account-passkey-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-passkey-api.ts
@@ -1,0 +1,80 @@
+import type {
+  PasskeyInfoResponse,
+  PasskeyRegistrationRequest,
+  PasskeyRenameRequest,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List the authenticated user's registered passkeys.
+ *
+ * `GET {basePath}/passkeys`
+ */
+export async function listPasskeys(
+  client: AxiosInstance,
+  basePath: string
+): Promise<PasskeyInfoResponse[]> {
+  const { data } = await client.get<PasskeyInfoResponse[]>(`${basePath}/passkeys`);
+  return data;
+}
+
+/**
+ * Begin a WebAuthn passkey registration ceremony (authenticated).
+ *
+ * Returns raw `PublicKeyCredentialCreationOptions` JSON to pass to
+ * `navigator.credentials.create()`, then submit via {@link completePasskeyRegistration}.
+ *
+ * `POST {basePath}/passkeys/register/begin`
+ */
+export async function beginPasskeyRegistration(
+  client: AxiosInstance,
+  basePath: string
+): Promise<string> {
+  const { data } = await client.post<string>(`${basePath}/passkeys/register/begin`);
+  return data;
+}
+
+/**
+ * Complete a WebAuthn passkey registration ceremony (authenticated).
+ *
+ * `POST {basePath}/passkeys/register/complete`
+ */
+export async function completePasskeyRegistration(
+  client: AxiosInstance,
+  basePath: string,
+  request: PasskeyRegistrationRequest
+): Promise<PasskeyInfoResponse> {
+  const { data } = await client.post<PasskeyInfoResponse>(
+    `${basePath}/passkeys/register/complete`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Rename a registered passkey.
+ *
+ * `PATCH {basePath}/passkeys/{id}`
+ */
+export async function renamePasskey(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: PasskeyRenameRequest
+): Promise<void> {
+  await client.patch(`${basePath}/passkeys/${encodeURIComponent(id)}`, request);
+}
+
+/**
+ * Delete a registered passkey. The server rejects deleting the last credential
+ * when the account has no password (400).
+ *
+ * `DELETE {basePath}/passkeys/{id}`
+ */
+export async function deletePasskey(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(`${basePath}/passkeys/${encodeURIComponent(id)}`);
+}

--- a/packages/@granit/authentication-local/src/api/account-password-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-password-api.ts
@@ -1,0 +1,47 @@
+import type {
+  AccountForgotPasswordRequest,
+  AccountPasswordChangeRequest,
+  AccountPasswordResetRequest,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Change the authenticated user's password (requires the current password).
+ *
+ * `POST {basePath}/change-password`
+ */
+export async function changePassword(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountPasswordChangeRequest
+): Promise<void> {
+  await client.post(`${basePath}/change-password`, request);
+}
+
+/**
+ * Request a password-reset link (anonymous).
+ *
+ * Always returns 202 regardless of whether the email exists (anti-enumeration).
+ *
+ * `POST {basePath}/forgot-password`
+ */
+export async function forgotPassword(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountForgotPasswordRequest
+): Promise<void> {
+  await client.post(`${basePath}/forgot-password`, request);
+}
+
+/**
+ * Reset the password using the token from the forgot-password email (anonymous).
+ *
+ * `POST {basePath}/reset-password`
+ */
+export async function resetPassword(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountPasswordResetRequest
+): Promise<void> {
+  await client.post(`${basePath}/reset-password`, request);
+}

--- a/packages/@granit/authentication-local/src/api/account-profile-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-profile-api.ts
@@ -1,0 +1,29 @@
+import type { AccountProfileResponse, AccountProfileUpdateRequest } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Get the authenticated user's profile.
+ *
+ * `GET {basePath}/profile`
+ */
+export async function getProfile(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountProfileResponse> {
+  const { data } = await client.get<AccountProfileResponse>(`${basePath}/profile`);
+  return data;
+}
+
+/**
+ * Update the authenticated user's profile (first/last name).
+ *
+ * `PUT {basePath}/profile`
+ */
+export async function updateProfile(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountProfileUpdateRequest
+): Promise<AccountProfileResponse> {
+  const { data } = await client.put<AccountProfileResponse>(`${basePath}/profile`, request);
+  return data;
+}

--- a/packages/@granit/authentication-local/src/api/account-registration-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-registration-api.ts
@@ -1,0 +1,46 @@
+import type { AccountRegisterRequest } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Register a new local account.
+ *
+ * Returns 202 Accepted; when email confirmation is enabled the server sends a
+ * confirmation link. Requires self-registration to be enabled.
+ *
+ * `POST {basePath}/register`
+ */
+export async function registerAccount(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountRegisterRequest
+): Promise<void> {
+  await client.post(`${basePath}/register`, request);
+}
+
+/**
+ * Confirm a newly registered account's email address.
+ *
+ * Called from the link the server e-mailed after {@link registerAccount}.
+ *
+ * `GET {basePath}/confirm-email?userId={userId}&token={token}`
+ */
+export async function confirmEmail(
+  client: AxiosInstance,
+  basePath: string,
+  userId: string,
+  token: string
+): Promise<void> {
+  await client.get(`${basePath}/confirm-email`, { params: { userId, token } });
+}
+
+/**
+ * Resend the email-confirmation link for the authenticated account.
+ *
+ * `POST {basePath}/resend-confirmation-email`
+ */
+export async function resendConfirmationEmail(
+  client: AxiosInstance,
+  basePath: string
+): Promise<void> {
+  await client.post(`${basePath}/resend-confirmation-email`);
+}

--- a/packages/@granit/authentication-local/src/api/account-session-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-session-api.ts
@@ -1,0 +1,10 @@
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Send a session keep-alive heartbeat for the authenticated user.
+ *
+ * `POST {basePath}/session/heartbeat`
+ */
+export async function sendSessionHeartbeat(client: AxiosInstance, basePath: string): Promise<void> {
+  await client.post(`${basePath}/session/heartbeat`);
+}

--- a/packages/@granit/authentication-local/src/api/account-two-factor-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-two-factor-api.ts
@@ -1,0 +1,86 @@
+import type {
+  AccountAuthenticatorKeyResponse,
+  AccountGenerateRecoveryCodesRequest,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorDisableRequest,
+  AccountTwoFactorEnableRequest,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Get the authenticated user's two-factor status.
+ *
+ * `GET {basePath}/two-factor`
+ */
+export async function getTwoFactorStatus(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountTwoFactorStatusResponse> {
+  const { data } = await client.get<AccountTwoFactorStatusResponse>(`${basePath}/two-factor`);
+  return data;
+}
+
+/**
+ * Get (or generate) the TOTP shared key and `otpauth://` QR-code URI.
+ *
+ * `GET {basePath}/two-factor/authenticator-key`
+ */
+export async function getAuthenticatorKey(
+  client: AxiosInstance,
+  basePath: string
+): Promise<AccountAuthenticatorKeyResponse> {
+  const { data } = await client.get<AccountAuthenticatorKeyResponse>(
+    `${basePath}/two-factor/authenticator-key`
+  );
+  return data;
+}
+
+/**
+ * Enable two-factor after verifying a TOTP code. Returns recovery codes.
+ *
+ * `POST {basePath}/two-factor/enable`
+ */
+export async function enableTwoFactor(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountTwoFactorEnableRequest
+): Promise<AccountTwoFactorEnableResponse> {
+  const { data } = await client.post<AccountTwoFactorEnableResponse>(
+    `${basePath}/two-factor/enable`,
+    request
+  );
+  return data;
+}
+
+/**
+ * Disable two-factor (step-up: password).
+ *
+ * `POST {basePath}/two-factor/disable`
+ */
+export async function disableTwoFactor(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountTwoFactorDisableRequest
+): Promise<void> {
+  await client.post(`${basePath}/two-factor/disable`, request);
+}
+
+/**
+ * Regenerate the single-use recovery codes (step-up: password). Invalidates
+ * any previously issued codes.
+ *
+ * `POST {basePath}/two-factor/recovery-codes`
+ */
+export async function generateRecoveryCodes(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountGenerateRecoveryCodesRequest
+): Promise<AccountRecoveryCodesResponse> {
+  const { data } = await client.post<AccountRecoveryCodesResponse>(
+    `${basePath}/two-factor/recovery-codes`,
+    request
+  );
+  return data;
+}

--- a/packages/@granit/authentication-local/src/index.ts
+++ b/packages/@granit/authentication-local/src/index.ts
@@ -1,22 +1,62 @@
+// ---------------------------------------------------------------------------
+// @granit/authentication-local — local credential authentication: headless
+// login + full account self-service surface. Mirrors the
+// Granit.Identity.Local.Endpoints .NET contract.
+// ---------------------------------------------------------------------------
+
 // Types
-export type {
-  AccountLoginRequest,
-  AccountLoginResponse,
-  AccountPasskeyLoginRequest,
-  AccountTwoFactorLoginRequest,
-} from './types/index';
+export type * from './types/index';
 
-// API — Login
+// API — Login (anonymous: password, 2FA, passkey assertion)
 export { loginAccount } from './api/account-login-api';
-
-// API — Two-factor login verification
 export { verifyTwoFactorLogin } from './api/account-two-factor-login-api';
-
-// API — Passkey assertion (for login)
 export {
   beginPasskeyAssertion,
   completePasskeyAssertion,
 } from './api/account-passkey-assertion-api';
+
+// API — Registration
+export {
+  confirmEmail,
+  registerAccount,
+  resendConfirmationEmail,
+} from './api/account-registration-api';
+
+// API — Password management
+export { changePassword, forgotPassword, resetPassword } from './api/account-password-api';
+
+// API — Email change
+export { changeEmail, confirmEmailChange } from './api/account-email-change-api';
+
+// API — Profile
+export { getProfile, updateProfile } from './api/account-profile-api';
+
+// API — Two-factor management
+export {
+  disableTwoFactor,
+  enableTwoFactor,
+  generateRecoveryCodes,
+  getAuthenticatorKey,
+  getTwoFactorStatus,
+} from './api/account-two-factor-api';
+
+// API — Passkey management
+export {
+  beginPasskeyRegistration,
+  completePasskeyRegistration,
+  deletePasskey,
+  listPasskeys,
+  renamePasskey,
+} from './api/account-passkey-api';
+
+// API — Account deletion
+export { deleteAccount } from './api/account-deletion-api';
+
+// API — Session
+export { sendSessionHeartbeat } from './api/account-session-api';
+
+// API — Public config
+export { getAccountConfig } from './api/account-config-api';
 
 // Utilities
 export { extractReturnUrl } from './utils/extract-return-url';

--- a/packages/@granit/authentication-local/src/types/account-config.ts
+++ b/packages/@granit/authentication-local/src/types/account-config.ts
@@ -1,0 +1,9 @@
+// ---------------------------------------------------------------------------
+// Public config — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Response from `GET {basePath}/config` (anonymous). */
+export interface IdentityLocalConfigResponse {
+  /** Whether the front should expose a self-registration entry point. */
+  readonly allowSelfRegistration: boolean;
+}

--- a/packages/@granit/authentication-local/src/types/account-deletion.ts
+++ b/packages/@granit/authentication-local/src/types/account-deletion.ts
@@ -1,0 +1,13 @@
+// ---------------------------------------------------------------------------
+// Account deletion — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for `POST {basePath}/delete` (authenticated, step-up: password).
+ *
+ * On success the server returns 202 Accepted and schedules the account for
+ * deletion (GDPR erasure flow).
+ */
+export interface AccountDeleteRequest {
+  readonly password: string;
+}

--- a/packages/@granit/authentication-local/src/types/account-email.ts
+++ b/packages/@granit/authentication-local/src/types/account-email.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// Email change — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for `POST {basePath}/change-email` (authenticated, step-up).
+ *
+ * Requires the current password as step-up authentication. On success the
+ * server returns 202 and sends a confirmation link to the new address.
+ */
+export interface AccountChangeEmailRequest {
+  readonly newEmail: string;
+  readonly currentPassword: string;
+}
+
+/** Request body for `POST {basePath}/confirm-email-change` (anonymous). */
+export interface AccountConfirmEmailChangeRequest {
+  readonly userId: string;
+  readonly newEmail: string;
+  readonly token: string;
+}

--- a/packages/@granit/authentication-local/src/types/account-passkey.ts
+++ b/packages/@granit/authentication-local/src/types/account-passkey.ts
@@ -1,0 +1,27 @@
+// ---------------------------------------------------------------------------
+// Passkey management — mirrors Granit.Identity.Local.Endpoints .NET contract
+// (anonymous login assertion lives in account-login.ts)
+// ---------------------------------------------------------------------------
+
+import type { ISODateString } from '@granit/types';
+
+/** Request body for `POST {basePath}/passkeys/register/complete`. */
+export interface PasskeyRegistrationRequest {
+  /** Serialized `AuthenticatorAttestationResponse` JSON from `navigator.credentials.create()`. */
+  readonly credentialJson: string;
+  /** Friendly name for the credential — required key, may be `null` (max 100 when set). */
+  readonly name: string | null;
+}
+
+/** Request body for `PATCH {basePath}/passkeys/{id}`. */
+export interface PasskeyRenameRequest {
+  readonly name: string;
+}
+
+/** A registered WebAuthn passkey — response item from `GET {basePath}/passkeys`. */
+export interface PasskeyInfoResponse {
+  readonly id: string;
+  readonly name: string | null;
+  readonly createdAt: ISODateString;
+  readonly lastUsedAt: ISODateString | null;
+}

--- a/packages/@granit/authentication-local/src/types/account-password.ts
+++ b/packages/@granit/authentication-local/src/types/account-password.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// Password management — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST {basePath}/forgot-password` (anonymous). */
+export interface AccountForgotPasswordRequest {
+  readonly email: string;
+}
+
+/** Request body for `POST {basePath}/reset-password` (anonymous). */
+export interface AccountPasswordResetRequest {
+  readonly userId: string;
+  readonly token: string;
+  readonly newPassword: string;
+}
+
+/** Request body for `POST {basePath}/change-password` (authenticated). */
+export interface AccountPasswordChangeRequest {
+  readonly currentPassword: string;
+  readonly newPassword: string;
+}

--- a/packages/@granit/authentication-local/src/types/account-profile.ts
+++ b/packages/@granit/authentication-local/src/types/account-profile.ts
@@ -1,0 +1,25 @@
+// ---------------------------------------------------------------------------
+// Account profile — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/** Response from `GET {basePath}/profile` and `PUT {basePath}/profile`. */
+export interface AccountProfileResponse {
+  readonly userId: string;
+  readonly email: string;
+  readonly emailConfirmed: boolean;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+  readonly twoFactorEnabled: boolean;
+  readonly hasPassword: boolean;
+  readonly externalLogins: readonly string[];
+}
+
+/**
+ * Request body for `PUT {basePath}/profile` (authenticated).
+ *
+ * Both keys are required (full replacement); pass `null` to clear a name.
+ */
+export interface AccountProfileUpdateRequest {
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+}

--- a/packages/@granit/authentication-local/src/types/account-registration.ts
+++ b/packages/@granit/authentication-local/src/types/account-registration.ts
@@ -1,0 +1,19 @@
+// ---------------------------------------------------------------------------
+// Account registration — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Request body for `POST {basePath}/register`.
+ *
+ * On success the server returns 202 Accepted and (when email confirmation is
+ * required) sends a confirmation link. Self-registration must be enabled —
+ * see {@link IdentityLocalConfigResponse}.
+ */
+export interface AccountRegisterRequest {
+  readonly email: string;
+  readonly password: string;
+  /** Required key, may be `null` (max 256 when set). */
+  readonly firstName: string | null;
+  /** Required key, may be `null` (max 256 when set). */
+  readonly lastName: string | null;
+}

--- a/packages/@granit/authentication-local/src/types/account-two-factor.ts
+++ b/packages/@granit/authentication-local/src/types/account-two-factor.ts
@@ -1,0 +1,47 @@
+// ---------------------------------------------------------------------------
+// Two-factor management — mirrors Granit.Identity.Local.Endpoints .NET contract
+// (login-time 2FA verification lives in account-login.ts)
+// ---------------------------------------------------------------------------
+
+/** Response from `GET {basePath}/two-factor`. */
+export interface AccountTwoFactorStatusResponse {
+  readonly isEnabled: boolean;
+  readonly hasAuthenticatorApp: boolean;
+  readonly recoveryCodesLeft: number;
+}
+
+/**
+ * Response from `GET {basePath}/two-factor/authenticator-key`.
+ *
+ * `qrCodeUri` is an `otpauth://` URI the frontend can render as a QR code for
+ * authenticator-app enrolment.
+ */
+export interface AccountAuthenticatorKeyResponse {
+  readonly sharedKey: string;
+  readonly qrCodeUri: string;
+}
+
+/** Request body for `POST {basePath}/two-factor/enable`. */
+export interface AccountTwoFactorEnableRequest {
+  readonly code: string;
+}
+
+/** Response from `POST {basePath}/two-factor/enable` — single-use recovery codes. */
+export interface AccountTwoFactorEnableResponse {
+  readonly recoveryCodes: readonly string[];
+}
+
+/** Request body for `POST {basePath}/two-factor/disable` (step-up: password). */
+export interface AccountTwoFactorDisableRequest {
+  readonly password: string;
+}
+
+/** Request body for `POST {basePath}/two-factor/recovery-codes` (step-up: password). */
+export interface AccountGenerateRecoveryCodesRequest {
+  readonly password: string;
+}
+
+/** Response from `POST {basePath}/two-factor/recovery-codes`. */
+export interface AccountRecoveryCodesResponse {
+  readonly recoveryCodes: readonly string[];
+}

--- a/packages/@granit/authentication-local/src/types/index.ts
+++ b/packages/@granit/authentication-local/src/types/index.ts
@@ -1,6 +1,47 @@
+// Login (anonymous: password, 2FA, passkey assertion)
 export type {
   AccountLoginRequest,
   AccountLoginResponse,
   AccountPasskeyLoginRequest,
   AccountTwoFactorLoginRequest,
 } from './account-login';
+
+// Registration
+export type { AccountRegisterRequest } from './account-registration';
+
+// Password management
+export type {
+  AccountForgotPasswordRequest,
+  AccountPasswordChangeRequest,
+  AccountPasswordResetRequest,
+} from './account-password';
+
+// Email change
+export type { AccountChangeEmailRequest, AccountConfirmEmailChangeRequest } from './account-email';
+
+// Profile
+export type { AccountProfileResponse, AccountProfileUpdateRequest } from './account-profile';
+
+// Two-factor management
+export type {
+  AccountAuthenticatorKeyResponse,
+  AccountGenerateRecoveryCodesRequest,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorDisableRequest,
+  AccountTwoFactorEnableRequest,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from './account-two-factor';
+
+// Passkey management
+export type {
+  PasskeyInfoResponse,
+  PasskeyRegistrationRequest,
+  PasskeyRenameRequest,
+} from './account-passkey';
+
+// Account deletion
+export type { AccountDeleteRequest } from './account-deletion';
+
+// Public config
+export type { IdentityLocalConfigResponse } from './account-config';

--- a/packages/@granit/react-authentication-local/package.json
+++ b/packages/@granit/react-authentication-local/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@granit/react-authentication-local",
-  "description": "React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion",
+  "description": "React hooks for local credential authentication — login, registration, password, email change, profile, two-factor and passkey management",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",
@@ -31,7 +31,8 @@
     "@granit/api-client": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
-    "@granit/testing": "workspace:*"
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/react-authentication-local/src/__tests__/account-management-hooks.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/account-management-hooks.test.tsx
@@ -1,0 +1,148 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { usePasskeys, useDeletePasskey } from '../hooks/use-passkeys';
+import { useChangePassword } from '../hooks/use-password';
+import { useProfile, useUpdateProfile } from '../hooks/use-profile';
+import { useEnableTwoFactor, useTwoFactorStatus } from '../hooks/use-two-factor';
+import { LocalAuthProvider } from '../providers/local-auth-provider';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getProfile: vi.fn(),
+    updateProfile: vi.fn(),
+    getTwoFactorStatus: vi.fn(),
+    enableTwoFactor: vi.fn(),
+    listPasskeys: vi.fn(),
+    deletePasskey: vi.fn(),
+    changePassword: vi.fn(),
+  };
+});
+
+const api = await import('@granit/authentication-local');
+
+function createWrapper(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const config: LocalAuthConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+  };
+}
+
+afterEach(() => vi.clearAllMocks());
+
+describe('account-management hooks', () => {
+  it('useProfile fetches the profile at the resolved base path', async () => {
+    const client = createMockClient();
+    vi.mocked(api.getProfile).mockResolvedValue({
+      userId: 'u1',
+      email: 'a@b.c',
+      emailConfirmed: true,
+      firstName: null,
+      lastName: null,
+      twoFactorEnabled: false,
+      hasPassword: true,
+      externalLogins: [],
+    });
+
+    const { result } = renderHook(() => useProfile(), { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.getProfile).toHaveBeenCalledWith(client, '/api/v1/account');
+    expect(result.current.data?.userId).toBe('u1');
+  });
+
+  it('useUpdateProfile primes the profile cache from the response', async () => {
+    const client = createMockClient();
+    const updated = {
+      userId: 'u1',
+      email: 'a@b.c',
+      emailConfirmed: true,
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      twoFactorEnabled: false,
+      hasPassword: true,
+      externalLogins: [],
+    };
+    vi.mocked(api.updateProfile).mockResolvedValue(updated);
+
+    const { result } = renderHook(() => useUpdateProfile(), { wrapper: createWrapper(client) });
+    result.current.mutate({ firstName: 'Ada', lastName: 'Lovelace' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.updateProfile).toHaveBeenCalledWith(client, '/api/v1/account', {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+    });
+  });
+
+  it('useTwoFactorStatus fetches the status', async () => {
+    const client = createMockClient();
+    vi.mocked(api.getTwoFactorStatus).mockResolvedValue({
+      isEnabled: true,
+      hasAuthenticatorApp: true,
+      recoveryCodesLeft: 5,
+    });
+
+    const { result } = renderHook(() => useTwoFactorStatus(), { wrapper: createWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.recoveryCodesLeft).toBe(5);
+  });
+
+  it('useEnableTwoFactor returns recovery codes', async () => {
+    const client = createMockClient();
+    vi.mocked(api.enableTwoFactor).mockResolvedValue({ recoveryCodes: ['a', 'b'] });
+
+    const { result } = renderHook(() => useEnableTwoFactor(), { wrapper: createWrapper(client) });
+    result.current.mutate({ code: '123456' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.recoveryCodes).toHaveLength(2);
+    expect(api.enableTwoFactor).toHaveBeenCalledWith(client, '/api/v1/account', { code: '123456' });
+  });
+
+  it('usePasskeys lists passkeys and useDeletePasskey removes one', async () => {
+    const client = createMockClient();
+    vi.mocked(api.listPasskeys).mockResolvedValue([
+      { id: 'pk-1', name: 'Laptop', createdAt: '2026-01-01T00:00:00Z', lastUsedAt: null },
+    ] as never);
+    vi.mocked(api.deletePasskey).mockResolvedValue(undefined);
+
+    const list = renderHook(() => usePasskeys(), { wrapper: createWrapper(client) });
+    await waitFor(() => expect(list.result.current.isSuccess).toBe(true));
+    expect(list.result.current.data).toHaveLength(1);
+
+    const del = renderHook(() => useDeletePasskey(), { wrapper: createWrapper(client) });
+    del.result.current.mutate('pk-1');
+    await waitFor(() => expect(del.result.current.isSuccess).toBe(true));
+    expect(api.deletePasskey).toHaveBeenCalledWith(client, '/api/v1/account', 'pk-1');
+  });
+
+  it('useChangePassword posts the change', async () => {
+    const client = createMockClient();
+    vi.mocked(api.changePassword).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useChangePassword(), { wrapper: createWrapper(client) });
+    result.current.mutate({ currentPassword: 'old', newPassword: 'new' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(api.changePassword).toHaveBeenCalledWith(client, '/api/v1/account', {
+      currentPassword: 'old',
+      newPassword: 'new',
+    });
+  });
+});

--- a/packages/@granit/react-authentication-local/src/__tests__/use-login-with-redirect.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-login-with-redirect.test.tsx
@@ -49,13 +49,6 @@ const twoFactorResponse: AccountLoginResponse = {
   isNotAllowed: false,
 };
 
-const notAllowedResponse: AccountLoginResponse = {
-  succeeded: false,
-  requiresTwoFactor: false,
-  isLockedOut: false,
-  isNotAllowed: true,
-};
-
 let locationMock: { href: string; search: string };
 
 afterEach(() => {
@@ -148,25 +141,6 @@ describe('useLoginWithRedirect', () => {
     await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
 
     expect(onTwoFactorRequired).toHaveBeenCalledOnce();
-  });
-
-  it('calls onNotAllowed when login is not allowed', async () => {
-    const client = createMockClient();
-    vi.mocked(loginAccount).mockResolvedValue(notAllowedResponse);
-    const onNotAllowed = vi.fn();
-
-    const { result } = renderHook(() => useLoginWithRedirect({ search: '', onNotAllowed }), {
-      wrapper: createWrapper(client),
-    });
-
-    result.current.loginAndRedirect({
-      login: 'user@example.com',
-      password: 'P@ssw0rd!',
-    });
-
-    await waitFor(() => expect(result.current.mutation.isSuccess).toBe(true));
-
-    expect(onNotAllowed).toHaveBeenCalledOnce();
   });
 
   it('exposes the underlying mutation for UI state', async () => {

--- a/packages/@granit/react-authentication-local/src/hooks/query-keys.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/query-keys.ts
@@ -1,0 +1,16 @@
+/**
+ * Query-key factory for local-account self-service queries.
+ *
+ * Mutations invalidate the relevant keys so dependent queries (profile,
+ * two-factor status, passkeys) refetch automatically.
+ */
+const ROOT = ['authentication-local'] as const;
+
+export const localAuthKeys = {
+  all: ROOT,
+  config: () => [...ROOT, 'config'] as const,
+  profile: () => [...ROOT, 'profile'] as const,
+  twoFactorStatus: () => [...ROOT, 'two-factor', 'status'] as const,
+  authenticatorKey: () => [...ROOT, 'two-factor', 'authenticator-key'] as const,
+  passkeys: () => [...ROOT, 'passkeys'] as const,
+};

--- a/packages/@granit/react-authentication-local/src/hooks/use-account-config.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-account-config.ts
@@ -1,0 +1,23 @@
+import { getAccountConfig } from '@granit/authentication-local';
+import { useQuery } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import { localAuthKeys } from './query-keys';
+
+import type { IdentityLocalConfigResponse } from '@granit/authentication-local';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetches the public local-identity config (anonymous), e.g. whether
+ * self-registration is enabled. Cached aggressively — config rarely changes.
+ */
+export function useAccountConfig(): UseQueryResult<IdentityLocalConfigResponse> {
+  const config = useLocalAuthConfig();
+
+  return useQuery({
+    queryKey: localAuthKeys.config(),
+    queryFn: () => getAccountConfig(config.client, config.basePath!),
+    staleTime: Infinity,
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-account-deletion.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-account-deletion.ts
@@ -1,0 +1,17 @@
+import { deleteAccount } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import type { AccountDeleteRequest } from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Requests deletion of the authenticated account (step-up: password). */
+export function useDeleteAccount(): UseMutationResult<void, Error, AccountDeleteRequest> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountDeleteRequest) =>
+      deleteAccount(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-email-change.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-email-change.ts
@@ -1,0 +1,40 @@
+import { changeEmail, confirmEmailChange } from '@granit/authentication-local';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import { localAuthKeys } from './query-keys';
+
+import type {
+  AccountChangeEmailRequest,
+  AccountConfirmEmailChangeRequest,
+} from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Requests an email-address change (authenticated, step-up: current password). */
+export function useChangeEmail(): UseMutationResult<void, Error, AccountChangeEmailRequest> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountChangeEmailRequest) =>
+      changeEmail(config.client, config.basePath!, request),
+  });
+}
+
+/** Confirms an email-address change (anonymous — from the e-mailed link). */
+export function useConfirmEmailChange(): UseMutationResult<
+  void,
+  Error,
+  AccountConfirmEmailChangeRequest
+> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountConfirmEmailChangeRequest) =>
+      confirmEmailChange(config.client, config.basePath!, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.profile() });
+    },
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-login-with-redirect.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-login-with-redirect.ts
@@ -17,9 +17,13 @@ export interface UseLoginWithRedirectOptions {
   readonly fallbackUrl?: string;
   /** Called when the server requires two-factor authentication. */
   readonly onTwoFactorRequired?: () => void;
-  /** Called when login is not allowed (e.g. unconfirmed email). */
-  readonly onNotAllowed?: () => void;
-  /** Called when the login request fails (network error, 401, etc.). */
+  /**
+   * Called when the login request fails. Invalid credentials, locked-out and
+   * not-allowed (e.g. unconfirmed email) all surface here as a 401
+   * `AxiosError<ProblemDetails>` — the backend returns a generic 401 (with a
+   * distinguishing `detail`) for these, never a `200` body, to prevent account
+   * enumeration. Inspect `error` to tailor the message.
+   */
   readonly onError?: (error: Error) => void;
 }
 
@@ -27,8 +31,8 @@ export interface UseLoginWithRedirectResult {
   /**
    * Submit credentials and auto-redirect to `returnUrl` on success.
    *
-   * On non-success responses (`requiresTwoFactor`, `isNotAllowed`),
-   * the corresponding callback from {@link UseLoginWithRedirectOptions} is invoked.
+   * On a `requiresTwoFactor` response `onTwoFactorRequired` is invoked; any
+   * failure (invalid credentials, locked-out, not-allowed) arrives via `onError`.
    */
   readonly loginAndRedirect: (request: AccountLoginRequest) => void;
   /** The underlying React Query mutation for UI state (`isPending`, `error`, etc.). */
@@ -69,10 +73,6 @@ export function useLoginWithRedirect(
           }
           if (data.requiresTwoFactor) {
             optionsRef.current?.onTwoFactorRequired?.();
-            return;
-          }
-          if (data.isNotAllowed) {
-            optionsRef.current?.onNotAllowed?.();
           }
         },
         onError: (error) => {

--- a/packages/@granit/react-authentication-local/src/hooks/use-passkeys.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-passkeys.ts
@@ -1,0 +1,89 @@
+import {
+  beginPasskeyRegistration,
+  completePasskeyRegistration,
+  deletePasskey,
+  listPasskeys,
+  renamePasskey,
+} from '@granit/authentication-local';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import { localAuthKeys } from './query-keys';
+
+import type {
+  PasskeyInfoResponse,
+  PasskeyRegistrationRequest,
+  PasskeyRenameRequest,
+} from '@granit/authentication-local';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Variables for the {@link useRenamePasskey} mutation. */
+export interface RenamePasskeyVariables {
+  id: string;
+  request: PasskeyRenameRequest;
+}
+
+/** Lists the authenticated user's registered passkeys. */
+export function usePasskeys(): UseQueryResult<PasskeyInfoResponse[]> {
+  const config = useLocalAuthConfig();
+
+  return useQuery({
+    queryKey: localAuthKeys.passkeys(),
+    queryFn: () => listPasskeys(config.client, config.basePath!),
+  });
+}
+
+/** Begins a WebAuthn passkey registration ceremony (returns options JSON). */
+export function useBeginPasskeyRegistration(): UseMutationResult<string, Error, void> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: () => beginPasskeyRegistration(config.client, config.basePath!),
+  });
+}
+
+/** Completes a passkey registration and refreshes the passkey list. */
+export function useCompletePasskeyRegistration(): UseMutationResult<
+  PasskeyInfoResponse,
+  Error,
+  PasskeyRegistrationRequest
+> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: PasskeyRegistrationRequest) =>
+      completePasskeyRegistration(config.client, config.basePath!, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.passkeys() });
+    },
+  });
+}
+
+/** Renames a registered passkey and refreshes the passkey list. */
+export function useRenamePasskey(): UseMutationResult<void, Error, RenamePasskeyVariables> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: RenamePasskeyVariables) =>
+      renamePasskey(config.client, config.basePath!, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.passkeys() });
+    },
+  });
+}
+
+/** Deletes a registered passkey and refreshes the passkey list. */
+export function useDeletePasskey(): UseMutationResult<void, Error, string> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deletePasskey(config.client, config.basePath!, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.passkeys() });
+    },
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-password.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-password.ts
@@ -1,0 +1,41 @@
+import { changePassword, forgotPassword, resetPassword } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import type {
+  AccountForgotPasswordRequest,
+  AccountPasswordChangeRequest,
+  AccountPasswordResetRequest,
+} from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Changes the authenticated user's password (requires the current password). */
+export function useChangePassword(): UseMutationResult<void, Error, AccountPasswordChangeRequest> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountPasswordChangeRequest) =>
+      changePassword(config.client, config.basePath!, request),
+  });
+}
+
+/** Requests a password-reset link (anonymous). */
+export function useForgotPassword(): UseMutationResult<void, Error, AccountForgotPasswordRequest> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountForgotPasswordRequest) =>
+      forgotPassword(config.client, config.basePath!, request),
+  });
+}
+
+/** Resets the password using the token from the forgot-password email (anonymous). */
+export function useResetPassword(): UseMutationResult<void, Error, AccountPasswordResetRequest> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountPasswordResetRequest) =>
+      resetPassword(config.client, config.basePath!, request),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-profile.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-profile.ts
@@ -1,0 +1,40 @@
+import { getProfile, updateProfile } from '@granit/authentication-local';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import { localAuthKeys } from './query-keys';
+
+import type {
+  AccountProfileResponse,
+  AccountProfileUpdateRequest,
+} from '@granit/authentication-local';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches the authenticated user's profile. */
+export function useProfile(): UseQueryResult<AccountProfileResponse> {
+  const config = useLocalAuthConfig();
+
+  return useQuery({
+    queryKey: localAuthKeys.profile(),
+    queryFn: () => getProfile(config.client, config.basePath!),
+  });
+}
+
+/** Updates the authenticated user's profile and primes the profile cache. */
+export function useUpdateProfile(): UseMutationResult<
+  AccountProfileResponse,
+  Error,
+  AccountProfileUpdateRequest
+> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountProfileUpdateRequest) =>
+      updateProfile(config.client, config.basePath!, request),
+    onSuccess: (data) => {
+      queryClient.setQueryData(localAuthKeys.profile(), data);
+    },
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-registration.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-registration.ts
@@ -1,0 +1,44 @@
+import {
+  confirmEmail,
+  registerAccount,
+  resendConfirmationEmail,
+} from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import type { AccountRegisterRequest } from '@granit/authentication-local';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Registers a new local account (anonymous). */
+export function useRegisterAccount(): UseMutationResult<void, Error, AccountRegisterRequest> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountRegisterRequest) =>
+      registerAccount(config.client, config.basePath!, request),
+  });
+}
+
+/** Confirms a newly registered account's email via the `userId` + `token` link params. */
+export function useConfirmEmail(): UseMutationResult<
+  void,
+  Error,
+  { userId: string; token: string }
+> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: ({ userId, token }: { userId: string; token: string }) =>
+      confirmEmail(config.client, config.basePath!, userId, token),
+  });
+}
+
+/** Resends the email-confirmation link for the authenticated account. */
+export function useResendConfirmationEmail(): UseMutationResult<void, Error, void> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: () => resendConfirmationEmail(config.client, config.basePath!),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-session-heartbeat.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-session-heartbeat.ts
@@ -1,0 +1,15 @@
+import { sendSessionHeartbeat } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/** Sends a session keep-alive heartbeat for the authenticated user. */
+export function useSendSessionHeartbeat(): UseMutationResult<void, Error, void> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: () => sendSessionHeartbeat(config.client, config.basePath!),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-two-factor.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-two-factor.ts
@@ -1,0 +1,109 @@
+import {
+  disableTwoFactor,
+  enableTwoFactor,
+  generateRecoveryCodes,
+  getAuthenticatorKey,
+  getTwoFactorStatus,
+} from '@granit/authentication-local';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import { localAuthKeys } from './query-keys';
+
+import type {
+  AccountAuthenticatorKeyResponse,
+  AccountGenerateRecoveryCodesRequest,
+  AccountRecoveryCodesResponse,
+  AccountTwoFactorDisableRequest,
+  AccountTwoFactorEnableRequest,
+  AccountTwoFactorEnableResponse,
+  AccountTwoFactorStatusResponse,
+} from '@granit/authentication-local';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches the authenticated user's two-factor status. */
+export function useTwoFactorStatus(): UseQueryResult<AccountTwoFactorStatusResponse> {
+  const config = useLocalAuthConfig();
+
+  return useQuery({
+    queryKey: localAuthKeys.twoFactorStatus(),
+    queryFn: () => getTwoFactorStatus(config.client, config.basePath!),
+  });
+}
+
+/**
+ * Fetches the TOTP shared key + `otpauth://` QR-code URI.
+ *
+ * Generates a key server-side, so it is gated behind `enabled` (default
+ * `false`) — enable it only when the enrolment UI is shown.
+ */
+export function useAuthenticatorKey(options?: {
+  enabled?: boolean;
+}): UseQueryResult<AccountAuthenticatorKeyResponse> {
+  const config = useLocalAuthConfig();
+
+  return useQuery({
+    queryKey: localAuthKeys.authenticatorKey(),
+    queryFn: () => getAuthenticatorKey(config.client, config.basePath!),
+    enabled: options?.enabled ?? false,
+    staleTime: 0,
+    gcTime: 0,
+  });
+}
+
+/** Enables two-factor after verifying a TOTP code; returns recovery codes. */
+export function useEnableTwoFactor(): UseMutationResult<
+  AccountTwoFactorEnableResponse,
+  Error,
+  AccountTwoFactorEnableRequest
+> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountTwoFactorEnableRequest) =>
+      enableTwoFactor(config.client, config.basePath!, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.twoFactorStatus() });
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.profile() });
+    },
+  });
+}
+
+/** Disables two-factor (step-up: password). */
+export function useDisableTwoFactor(): UseMutationResult<
+  void,
+  Error,
+  AccountTwoFactorDisableRequest
+> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountTwoFactorDisableRequest) =>
+      disableTwoFactor(config.client, config.basePath!, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.twoFactorStatus() });
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.profile() });
+    },
+  });
+}
+
+/** Regenerates the single-use recovery codes (step-up: password). */
+export function useGenerateRecoveryCodes(): UseMutationResult<
+  AccountRecoveryCodesResponse,
+  Error,
+  AccountGenerateRecoveryCodesRequest
+> {
+  const config = useLocalAuthConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountGenerateRecoveryCodesRequest) =>
+      generateRecoveryCodes(config.client, config.basePath!, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: localAuthKeys.twoFactorStatus() });
+    },
+  });
+}

--- a/packages/@granit/react-authentication-local/src/index.ts
+++ b/packages/@granit/react-authentication-local/src/index.ts
@@ -2,7 +2,10 @@
 export { LocalAuthProvider, useLocalAuthConfig } from './providers/local-auth-provider';
 export type { LocalAuthConfig, LocalAuthProviderProps } from './providers/local-auth-provider';
 
-// Hooks
+// Query keys
+export { localAuthKeys } from './hooks/query-keys';
+
+// Hooks — login (anonymous: password, 2FA, passkey assertion)
 export { useLogin } from './hooks/use-login';
 export { useLoginWithRedirect } from './hooks/use-login-with-redirect';
 export type {
@@ -12,3 +15,47 @@ export type {
 export { useVerifyTwoFactorLogin } from './hooks/use-verify-two-factor-login';
 export { useBeginPasskeyAssertion } from './hooks/use-begin-passkey-assertion';
 export { useCompletePasskeyAssertion } from './hooks/use-complete-passkey-assertion';
+
+// Hooks — registration
+export {
+  useConfirmEmail,
+  useRegisterAccount,
+  useResendConfirmationEmail,
+} from './hooks/use-registration';
+
+// Hooks — password management
+export { useChangePassword, useForgotPassword, useResetPassword } from './hooks/use-password';
+
+// Hooks — email change
+export { useChangeEmail, useConfirmEmailChange } from './hooks/use-email-change';
+
+// Hooks — profile
+export { useProfile, useUpdateProfile } from './hooks/use-profile';
+
+// Hooks — two-factor management
+export {
+  useAuthenticatorKey,
+  useDisableTwoFactor,
+  useEnableTwoFactor,
+  useGenerateRecoveryCodes,
+  useTwoFactorStatus,
+} from './hooks/use-two-factor';
+
+// Hooks — passkey management
+export {
+  useBeginPasskeyRegistration,
+  useCompletePasskeyRegistration,
+  useDeletePasskey,
+  usePasskeys,
+  useRenamePasskey,
+} from './hooks/use-passkeys';
+export type { RenamePasskeyVariables } from './hooks/use-passkeys';
+
+// Hooks — account deletion
+export { useDeleteAccount } from './hooks/use-account-deletion';
+
+// Hooks — session
+export { useSendSessionHeartbeat } from './hooks/use-session-heartbeat';
+
+// Hooks — public config
+export { useAccountConfig } from './hooks/use-account-config';

--- a/packages/@granit/react-authentication-local/src/testing/data.ts
+++ b/packages/@granit/react-authentication-local/src/testing/data.ts
@@ -1,4 +1,13 @@
-import type { AccountLoginResponse } from '@granit/authentication-local';
+import { toISODateString } from '@granit/types';
+
+import type {
+  AccountAuthenticatorKeyResponse,
+  AccountLoginResponse,
+  AccountProfileResponse,
+  AccountTwoFactorStatusResponse,
+  IdentityLocalConfigResponse,
+  PasskeyInfoResponse,
+} from '@granit/authentication-local';
 
 export const mockLoginSuccess: AccountLoginResponse = {
   succeeded: true,
@@ -28,3 +37,53 @@ export const MOCK_CREDENTIALS = {
 
 export const MOCK_TOTP_CODE = '123456';
 export const MOCK_RECOVERY_CODE = 'XXXX-XXXX-XXXX';
+
+export const mockProfile: AccountProfileResponse = {
+  userId: 'd2c47314-4d08-4952-98b1-a1b8a6e22ef1',
+  email: 'admin@granit-showcase.local',
+  emailConfirmed: true,
+  firstName: 'Ada',
+  lastName: 'Lovelace',
+  twoFactorEnabled: false,
+  hasPassword: true,
+  externalLogins: [],
+};
+
+export const mockTwoFactorStatus: AccountTwoFactorStatusResponse = {
+  isEnabled: false,
+  hasAuthenticatorApp: false,
+  recoveryCodesLeft: 0,
+};
+
+export const mockAuthenticatorKey: AccountAuthenticatorKeyResponse = {
+  sharedKey: 'JBSWY3DPEHPK3PXP',
+  qrCodeUri:
+    'otpauth://totp/Granit:admin@granit-showcase.local?secret=JBSWY3DPEHPK3PXP&issuer=Granit',
+};
+
+export const mockRecoveryCodes: readonly string[] = [
+  'AAAA-1111',
+  'BBBB-2222',
+  'CCCC-3333',
+  'DDDD-4444',
+  'EEEE-5555',
+];
+
+export const mockPasskeys: PasskeyInfoResponse[] = [
+  {
+    id: 'pk-1',
+    name: 'MacBook Touch ID',
+    createdAt: toISODateString('2026-02-01T10:00:00Z'),
+    lastUsedAt: toISODateString('2026-03-09T08:30:00Z'),
+  },
+  {
+    id: 'pk-2',
+    name: null,
+    createdAt: toISODateString('2026-01-15T09:00:00Z'),
+    lastUsedAt: null,
+  },
+];
+
+export const mockAccountConfig: IdentityLocalConfigResponse = {
+  allowSelfRegistration: true,
+};

--- a/packages/@granit/react-authentication-local/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-local/src/testing/handlers.ts
@@ -1,3 +1,4 @@
+import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -5,124 +6,170 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import {
   MOCK_CREDENTIALS,
   MOCK_TOTP_CODE,
+  mockAccountConfig,
+  mockAuthenticatorKey,
   mockLoginRequiresTwoFactor,
   mockLoginSuccess,
+  mockPasskeys,
+  mockProfile,
+  mockRecoveryCodes,
+  mockTwoFactorStatus,
 } from './data';
 
+import type { AccountProfileResponse, PasskeyInfoResponse } from '@granit/authentication-local';
+
+type MutablePasskey = { -readonly [K in keyof PasskeyInfoResponse]: PasskeyInfoResponse[K] };
+
+const problem = (status: number, title: string, section: string) =>
+  HttpResponse.json(
+    { type: `https://tools.ietf.org/html/rfc9110#section-${section}`, title, status },
+    { status }
+  );
+
+const unauthorized = () => problem(401, 'Unauthorized', '15.5.2');
+
 /**
- * Create MSW handlers for local authentication endpoints (login, 2FA,
- * passkeys, password reset, registration, email confirmation).
+ * Create MSW handlers for the full local-account surface — login, 2FA,
+ * passkeys (login + management), registration, email confirmation/change,
+ * password, profile, two-factor management, account deletion, session and
+ * public config. Status codes mirror `Granit.Identity.Local.Endpoints`.
+ *
+ * Profile and passkey state is mutated in-memory per factory instance.
  *
  * @param baseUrl - API base path (default: `/api/v1/account`)
  */
 export function createLocalAuthHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  let profile: AccountProfileResponse = { ...mockProfile };
+  const passkeys: MutablePasskey[] = mockPasskeys.map((p) => ({ ...p }));
+
   return [
-    // POST /login
+    // ── Login (anonymous) ───────────────────────────────────────────────
     http.post(`${baseUrl}/login`, async ({ request }) => {
       const body = (await request.json()) as { login: string; password: string };
-
       if (body.login === MOCK_CREDENTIALS.login && body.password === MOCK_CREDENTIALS.password) {
         return HttpResponse.json(mockLoginSuccess);
       }
-
       if (body.login === '2fa@granit-showcase.local') {
         return HttpResponse.json(mockLoginRequiresTwoFactor);
       }
-
-      return HttpResponse.json(
-        {
-          type: 'https://tools.ietf.org/html/rfc9110#section-15.5.2',
-          title: 'Unauthorized',
-          status: 401,
-        },
-        { status: 401 }
-      );
+      return unauthorized();
     }),
 
-    // POST /login/two-factor
     http.post(`${baseUrl}/login/two-factor`, async ({ request }) => {
       const body = (await request.json()) as { code: string; useRecoveryCode?: boolean };
-
       if (body.code === MOCK_TOTP_CODE || body.useRecoveryCode) {
         return HttpResponse.json(mockLoginSuccess);
       }
-
-      return HttpResponse.json(
-        {
-          type: 'https://tools.ietf.org/html/rfc9110#section-15.5.2',
-          title: 'Unauthorized',
-          status: 401,
-        },
-        { status: 401 }
-      );
+      return unauthorized();
     }),
 
-    // POST /passkeys/assertion/begin
-    http.post(`${baseUrl}/passkeys/assertion/begin`, () => {
-      return HttpResponse.json(
+    // ── Passkey login (assertion) ───────────────────────────────────────
+    http.post(`${baseUrl}/passkeys/assertion/begin`, () =>
+      HttpResponse.json(
         JSON.stringify({
           challenge: btoa('mock-challenge'),
           timeout: 60000,
           rpId: 'localhost',
           allowCredentials: [],
         })
-      );
-    }),
+      )
+    ),
+    http.post(`${baseUrl}/passkeys/assertion/complete`, () => HttpResponse.json(mockLoginSuccess)),
 
-    // POST /passkeys/assertion/complete
-    http.post(`${baseUrl}/passkeys/assertion/complete`, () => {
-      return HttpResponse.json(mockLoginSuccess);
-    }),
-
-    // POST /forgot-password
-    http.post(`${baseUrl}/forgot-password`, () => {
-      return new HttpResponse(null, { status: 200 });
-    }),
-
-    // POST /reset-password
-    http.post(`${baseUrl}/reset-password`, () => {
-      return new HttpResponse(null, { status: 200 });
-    }),
-
-    // POST /register
+    // ── Registration ────────────────────────────────────────────────────
     http.post(`${baseUrl}/register`, async ({ request }) => {
       const body = (await request.json()) as { email: string };
-
       if (body.email === 'existing@granit-showcase.local') {
-        return HttpResponse.json(
-          {
-            type: 'https://tools.ietf.org/html/rfc9110#section-15.5.10',
-            title: 'Conflict',
-            status: 409,
-          },
-          { status: 409 }
-        );
+        return problem(409, 'Conflict', '15.5.10');
       }
-
-      return HttpResponse.json({
-        userId: 'd2c47314-4d08-4952-98b1-a1b8a6e22ef1',
-        requiresEmailConfirmation: true,
-      });
+      return new HttpResponse(null, { status: 202 });
     }),
-
-    // GET /confirm-email
     http.get(`${baseUrl}/confirm-email`, ({ request }) => {
       const url = new URL(request.url);
-      const userId = url.searchParams.get('userId');
-      const token = url.searchParams.get('token');
-
-      if (userId && token) {
-        return new HttpResponse(null, { status: 200 });
+      if (url.searchParams.get('userId') && url.searchParams.get('token')) {
+        return new HttpResponse(null, { status: 204 });
       }
-
-      return HttpResponse.json(
-        {
-          type: 'https://tools.ietf.org/html/rfc9110#section-15.5.1',
-          title: 'Bad Request',
-          status: 400,
-        },
-        { status: 400 }
-      );
+      return problem(400, 'Bad Request', '15.5.1');
     }),
+    http.post(
+      `${baseUrl}/resend-confirmation-email`,
+      () => new HttpResponse(null, { status: 202 })
+    ),
+
+    // ── Password ────────────────────────────────────────────────────────
+    http.post(`${baseUrl}/change-password`, () => new HttpResponse(null, { status: 204 })),
+    http.post(`${baseUrl}/forgot-password`, () => new HttpResponse(null, { status: 202 })),
+    http.post(`${baseUrl}/reset-password`, () => new HttpResponse(null, { status: 204 })),
+
+    // ── Email change ────────────────────────────────────────────────────
+    http.post(`${baseUrl}/change-email`, () => new HttpResponse(null, { status: 202 })),
+    http.post(`${baseUrl}/confirm-email-change`, () => new HttpResponse(null, { status: 204 })),
+
+    // ── Profile ─────────────────────────────────────────────────────────
+    http.get(`${baseUrl}/profile`, () => HttpResponse.json(profile)),
+    http.put(`${baseUrl}/profile`, async ({ request }) => {
+      const body = (await request.json()) as {
+        firstName?: string | null;
+        lastName?: string | null;
+      };
+      profile = { ...profile, firstName: body.firstName ?? null, lastName: body.lastName ?? null };
+      return HttpResponse.json(profile);
+    }),
+
+    // ── Two-factor management ───────────────────────────────────────────
+    http.get(`${baseUrl}/two-factor`, () => HttpResponse.json(mockTwoFactorStatus)),
+    http.get(`${baseUrl}/two-factor/authenticator-key`, () =>
+      HttpResponse.json(mockAuthenticatorKey)
+    ),
+    http.post(`${baseUrl}/two-factor/enable`, async ({ request }) => {
+      const body = (await request.json()) as { code: string };
+      if (body.code !== MOCK_TOTP_CODE) return problem(400, 'Bad Request', '15.5.1');
+      return HttpResponse.json({ recoveryCodes: mockRecoveryCodes });
+    }),
+    http.post(`${baseUrl}/two-factor/disable`, () => new HttpResponse(null, { status: 204 })),
+    http.post(`${baseUrl}/two-factor/recovery-codes`, () =>
+      HttpResponse.json({ recoveryCodes: mockRecoveryCodes })
+    ),
+
+    // ── Passkey management ──────────────────────────────────────────────
+    http.get(`${baseUrl}/passkeys`, () => HttpResponse.json(passkeys)),
+    http.post(`${baseUrl}/passkeys/register/begin`, () =>
+      HttpResponse.json(
+        JSON.stringify({ challenge: btoa('mock-reg-challenge'), rp: { id: 'localhost' } })
+      )
+    ),
+    http.post(`${baseUrl}/passkeys/register/complete`, async ({ request }) => {
+      const body = (await request.json()) as { name?: string | null };
+      const created: MutablePasskey = {
+        id: `pk-${passkeys.length + 1}`,
+        name: body.name ?? null,
+        createdAt: toISODateString(new Date().toISOString()),
+        lastUsedAt: null,
+      };
+      passkeys.push(created);
+      return HttpResponse.json(created, { status: 201 });
+    }),
+    http.patch(`${baseUrl}/passkeys/:id`, async ({ params, request }) => {
+      const body = (await request.json()) as { name: string };
+      const pk = passkeys.find((p) => p.id === params.id);
+      if (!pk) return problem(404, 'Not Found', '15.5.5');
+      pk.name = body.name;
+      return new HttpResponse(null, { status: 204 });
+    }),
+    http.delete(`${baseUrl}/passkeys/:id`, ({ params }) => {
+      const idx = passkeys.findIndex((p) => p.id === params.id);
+      if (idx === -1) return problem(404, 'Not Found', '15.5.5');
+      passkeys.splice(idx, 1);
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    // ── Account deletion ────────────────────────────────────────────────
+    http.post(`${baseUrl}/delete`, () => new HttpResponse(null, { status: 202 })),
+
+    // ── Session ─────────────────────────────────────────────────────────
+    http.post(`${baseUrl}/session/heartbeat`, () => new HttpResponse(null, { status: 204 })),
+
+    // ── Public config (anonymous) ───────────────────────────────────────
+    http.get(`${baseUrl}/config`, () => HttpResponse.json(mockAccountConfig)),
   ];
 }

--- a/packages/@granit/react-authentication-local/src/testing/index.ts
+++ b/packages/@granit/react-authentication-local/src/testing/index.ts
@@ -6,8 +6,14 @@ export {
   MOCK_CREDENTIALS,
   MOCK_RECOVERY_CODE,
   MOCK_TOTP_CODE,
+  mockAccountConfig,
+  mockAuthenticatorKey,
   mockLoginNotAllowed,
   mockLoginRequiresTwoFactor,
   mockLoginSuccess,
+  mockPasskeys,
+  mockProfile,
+  mockRecoveryCodes,
+  mockTwoFactorStatus,
 } from './data';
 export { createLocalAuthHandlers } from './handlers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/authorization:
     devDependencies:
@@ -1205,6 +1208,9 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
 
   packages/@granit/react-authorization:
     dependencies:


### PR DESCRIPTION
Follow-up to the authentication audit. Mirrors the full `Granit.Identity.Local.Endpoints` account contract beyond headless login — closing the GAP where the package only exposed login/2FA/passkey-assertion while the backend offers the whole self-service surface (the showcase had pages calling these endpoints directly).

## New surface (core API fns + React hooks)
| Feature | Endpoints |
| --- | --- |
| Registration | register, confirm-email, resend-confirmation |
| Password | change, forgot, reset |
| Email change | change, confirm |
| Profile | get, update |
| Two-factor mgmt | status, authenticator-key, enable, disable, recovery-codes |
| Passkey mgmt | list, register begin/complete, rename, delete |
| Other | account deletion, session heartbeat, public config |

Query hooks (`useProfile`, `useTwoFactorStatus`, `usePasskeys`, `useAccountConfig`, `useAuthenticatorKey`) + mutation hooks with cache invalidation. Re-introduces a `localAuthKeys` query-key factory (now that the package has real queries).

## Also
- **Removes the dead `onNotAllowed`/`isNotAllowed` branch** in `useLoginWithRedirect` — the backend returns a generic **401** for not-allowed/locked-out (never a 200 body, anti-enumeration), so it surfaces via `onError`. ⚠️ **Needs a small showcase follow-up** (drop the `onNotAllowed` prop in `credential-form.tsx`).
- Extends the MSW `createLocalAuthHandlers` to the full surface, aligned to backend status codes (202/204/etc.).
- Declares the `@granit/types` peer (ISODateString).
- Documents OpenAPI `required`/nullable DTO-mirroring in CLAUDE.md (a `string?` no-default param is required-key + nullable-value → `field: T | null`).

## Contract verification
Cross-checked every route, method, status code, field name & nullability against `contracts/openapi/identity-local.json` **and** the granit-dotnet records + validators.

## Deferred (separate concerns, can follow up)
External logins (federated), admin impersonation, role CRUD — different bounded contexts; the `IdentityLocalPermissions.{Roles,Users}` constants remain for gating.

## Verification
tsc ✅ · ESLint ✅ · vitest **62** ✅ · markdownlint ✅