### PR TITLE
chore(contracts): regenerate vendored OpenAPI snapshots

### DIFF
--- a/contracts/openapi/ai.json
+++ b/contracts/openapi/ai.json
@@ -7,7 +7,9 @@
   "paths": {
     "/ai/workspaces": {
       "get": {
-        "tags": ["AI - Workspaces"],
+        "tags": [
+          "AI - Workspaces"
+        ],
         "summary": "Lists all AI workspaces, both system and dynamic.",
         "description": "Returns every registered workspace with its provider, model, and configuration. System workspaces are defined in configuration; dynamic workspaces are user-created.",
         "operationId": "ListAIWorkspaces",
@@ -55,7 +57,9 @@
         }
       },
       "post": {
-        "tags": ["AI - Workspaces"],
+        "tags": [
+          "AI - Workspaces"
+        ],
         "summary": "Creates a new dynamic AI workspace.",
         "description": "Registers a new user-defined workspace with the specified provider and model configuration. Returns 409 if a workspace with the same name already exists.",
         "operationId": "CreateAIWorkspace",
@@ -135,7 +139,9 @@
     },
     "/ai/workspaces/{name}": {
       "get": {
-        "tags": ["AI - Workspaces"],
+        "tags": [
+          "AI - Workspaces"
+        ],
         "summary": "Returns an AI workspace by its name.",
         "description": "Fetches the full configuration of a single workspace including provider, model, system prompt, and active status. Returns 404 if no workspace matches the name.",
         "operationId": "GetAIWorkspace",
@@ -204,7 +210,9 @@
         }
       },
       "put": {
-        "tags": ["AI - Workspaces"],
+        "tags": [
+          "AI - Workspaces"
+        ],
         "summary": "Updates an existing dynamic AI workspace.",
         "description": "Replaces the provider, model, and prompt configuration of a dynamic workspace. System workspaces cannot be modified and return 422. Returns 404 if the workspace does not exist.",
         "operationId": "UpdateAIWorkspace",
@@ -293,7 +301,9 @@
         }
       },
       "delete": {
-        "tags": ["AI - Workspaces"],
+        "tags": [
+          "AI - Workspaces"
+        ],
         "summary": "Deletes a dynamic AI workspace.",
         "description": "Permanently removes a user-created workspace. System workspaces cannot be deleted and return 422. Returns 404 if the workspace does not exist.",
         "operationId": "DeleteAIWorkspace",
@@ -367,7 +377,9 @@
     },
     "/ai/usage": {
       "get": {
-        "tags": ["AI - Usage"],
+        "tags": [
+          "AI - Usage"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of AIUsageRecord entries.",
         "description": "Executes a dynamic query against AIUsageRecord using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryAIUsageRecord",
@@ -378,7 +390,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -389,7 +404,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -398,7 +416,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -406,7 +427,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -414,7 +438,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -422,7 +449,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -430,7 +460,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -438,7 +471,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -448,7 +484,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -461,7 +500,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -532,7 +574,9 @@
     },
     "/ai/usage/meta": {
       "get": {
-        "tags": ["AI - Usage"],
+        "tags": [
+          "AI - Usage"
+        ],
         "summary": "Returns query metadata for AIUsageRecord (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for AIUsageRecord: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetAIUsageRecordMeta",
@@ -582,7 +626,9 @@
     },
     "/ai/providers": {
       "get": {
-        "tags": ["AI - Providers"],
+        "tags": [
+          "AI - Providers"
+        ],
         "summary": "Lists all registered AI providers.",
         "description": "Returns every AI provider registered via dependency injection, along with an indication of whether each provider supports chat and embedding capabilities.",
         "operationId": "ListAIProviders",
@@ -635,7 +681,9 @@
     },
     "/ai/providers/{providerName}/models": {
       "get": {
-        "tags": ["AI - Providers"],
+        "tags": [
+          "AI - Providers"
+        ],
         "summary": "Lists the models available from a specific AI provider.",
         "description": "Returns the models currently available from the specified provider. For cloud providers (OpenAI, AzureOpenAI) this is a static catalog. For local providers (Ollama) this queries the server for installed models. Returns 404 if the provider is not registered, or 502 if the provider's model listing fails.",
         "operationId": "ListAIProviderModels",
@@ -719,7 +767,9 @@
     },
     "/ai/chat/{workspaceName}": {
       "post": {
-        "tags": ["AI - Inference"],
+        "tags": [
+          "AI - Inference"
+        ],
         "summary": "Sends messages to an AI workspace and returns a completion response.",
         "description": "Forwards the conversation to the underlying AI provider configured for the workspace. Returns the assistant's reply, token usage, and response duration. Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.",
         "operationId": "AIChatComplete",
@@ -820,7 +870,9 @@
     },
     "/ai/chat/{workspaceName}/stream": {
       "post": {
-        "tags": ["AI - Inference"],
+        "tags": [
+          "AI - Inference"
+        ],
         "summary": "Streams a chat completion response via Server-Sent Events.",
         "description": "Opens an SSE stream that emits incremental content chunks as they arrive from the provider. The stream ends with a [DONE] sentinel. If the provider returns an error after streaming has started, an SSE 'error' event is emitted before closing. Returns 404 if the workspace does not exist, 422 if the model is not found, or 502/503 if the provider is unavailable.",
         "operationId": "AIChatStream",
@@ -931,7 +983,9 @@
     },
     "/ai/embeddings/{workspaceName}": {
       "post": {
-        "tags": ["AI - Inference"],
+        "tags": [
+          "AI - Inference"
+        ],
         "summary": "Generates vector embeddings for input texts using the specified workspace.",
         "description": "Sends the input texts to the embedding model configured for the workspace and returns float vectors for each input. Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.",
         "operationId": "AIGenerateEmbeddings",
@@ -1034,7 +1088,10 @@
   "components": {
     "schemas": {
       "AIChatMessageRequest": {
-        "required": ["role", "content"],
+        "required": [
+          "role",
+          "content"
+        ],
         "type": "object",
         "properties": {
           "role": {
@@ -1046,7 +1103,9 @@
         }
       },
       "AIChatRequest": {
-        "required": ["messages"],
+        "required": [
+          "messages"
+        ],
         "type": "object",
         "properties": {
           "messages": {
@@ -1058,7 +1117,13 @@
         }
       },
       "AIChatResponse": {
-        "required": ["workspaceName", "model", "content", "usage", "duration"],
+        "required": [
+          "workspaceName",
+          "model",
+          "content",
+          "usage",
+          "duration"
+        ],
         "type": "object",
         "properties": {
           "workspaceName": {
@@ -1087,7 +1152,12 @@
         }
       },
       "AIChatUsageResponse": {
-        "required": ["inputTokens", "outputTokens", "estimatedCost", "costCurrency"],
+        "required": [
+          "inputTokens",
+          "outputTokens",
+          "estimatedCost",
+          "costCurrency"
+        ],
         "type": "object",
         "properties": {
           "inputTokens": {
@@ -1100,16 +1170,26 @@
           },
           "estimatedCost": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-            "type": ["null", "number", "string"],
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
             "format": "double"
           },
           "costCurrency": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AIEmbeddingDataResponse": {
-        "required": ["index", "vector"],
+        "required": [
+          "index",
+          "vector"
+        ],
         "type": "object",
         "properties": {
           "index": {
@@ -1120,14 +1200,19 @@
             "type": "array",
             "items": {
               "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-              "type": ["number", "string"],
+              "type": [
+                "number",
+                "string"
+              ],
               "format": "float"
             }
           }
         }
       },
       "AIEmbeddingRequest": {
-        "required": ["inputs"],
+        "required": [
+          "inputs"
+        ],
         "type": "object",
         "properties": {
           "inputs": {
@@ -1139,7 +1224,12 @@
         }
       },
       "AIEmbeddingResponse": {
-        "required": ["workspaceName", "model", "embeddings", "usage"],
+        "required": [
+          "workspaceName",
+          "model",
+          "embeddings",
+          "usage"
+        ],
         "type": "object",
         "properties": {
           "workspaceName": {
@@ -1167,7 +1257,9 @@
         }
       },
       "AIEmbeddingUsageResponse": {
-        "required": ["inputTokens"],
+        "required": [
+          "inputTokens"
+        ],
         "type": "object",
         "properties": {
           "inputTokens": {
@@ -1212,7 +1304,12 @@
         }
       },
       "AIProviderModelResponse": {
-        "required": ["id", "displayName", "capabilities", "maxContextTokens"],
+        "required": [
+          "id",
+          "displayName",
+          "capabilities",
+          "maxContextTokens"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -1225,13 +1322,20 @@
             "$ref": "#/components/schemas/AIModelCapabilities"
           },
           "maxContextTokens": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           }
         }
       },
       "AIProviderResponse": {
-        "required": ["name", "supportsChat", "supportsEmbeddings"],
+        "required": [
+          "name",
+          "supportsChat",
+          "supportsEmbeddings"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1246,7 +1350,13 @@
         }
       },
       "AIUsageRecord": {
-        "required": ["id", "workspaceName", "provider", "model", "timestamp"],
+        "required": [
+          "id",
+          "workspaceName",
+          "provider",
+          "model",
+          "timestamp"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -1254,11 +1364,17 @@
             "format": "uuid"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "userId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "workspaceName": {
@@ -1280,11 +1396,18 @@
           },
           "estimatedCost": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-            "type": ["null", "number", "string"],
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
             "format": "double"
           },
           "costCurrency": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "timestamp": {
             "type": "string",
@@ -1292,12 +1415,19 @@
           },
           "duration": {
             "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AIWorkspaceCreateRequest": {
-        "required": ["name", "provider", "model", "systemPrompt", "temperature", "maxOutputTokens"],
+        "required": [
+          "name",
+          "provider",
+          "model"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1310,24 +1440,40 @@
             "type": "string"
           },
           "systemPrompt": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "temperature": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
             "format": "float"
           },
           "maxOutputTokens": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           }
         }
       },
       "AIWorkspaceKind": {
-        "enum": ["System", "Dynamic"]
+        "enum": [
+          "System",
+          "Dynamic"
+        ]
       },
       "AIWorkspaceListResponse": {
-        "required": ["workspaces", "totalCount"],
+        "required": [
+          "workspaces",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "workspaces": {
@@ -1366,15 +1512,25 @@
             "type": "string"
           },
           "systemPrompt": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "temperature": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
             "format": "float"
           },
           "maxOutputTokens": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "kind": {
@@ -1399,9 +1555,6 @@
         "required": [
           "provider",
           "model",
-          "systemPrompt",
-          "temperature",
-          "maxOutputTokens",
           "activated"
         ],
         "type": "object",
@@ -1412,20 +1565,30 @@
           "model": {
             "type": "string"
           },
+          "activated": {
+            "type": "boolean"
+          },
           "systemPrompt": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "temperature": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
             "format": "float"
           },
           "maxOutputTokens": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
-          },
-          "activated": {
-            "type": "boolean"
           }
         }
       },
@@ -1465,12 +1628,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1488,10 +1658,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1507,7 +1689,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1525,7 +1710,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1557,7 +1746,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1569,7 +1761,10 @@
         }
       },
       "GroupedResultOfAIUsageRecord": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -1585,13 +1780,18 @@
         }
       },
       "GroupEntryOfAIUsageRecord": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -1600,10 +1800,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/AIUsageRecord"
             }
@@ -1614,20 +1820,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1644,23 +1865,38 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1668,17 +1904,32 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "PagedResultOfAIUsageRecord": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "required": ["id", "workspaceName", "provider", "model", "timestamp"],
+              "required": [
+                "id",
+                "workspaceName",
+                "provider",
+                "model",
+                "timestamp"
+              ],
               "type": "object",
               "properties": {
                 "id": {
@@ -1686,11 +1937,17 @@
                   "format": "uuid"
                 },
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "userId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "workspaceName": {
@@ -1712,11 +1969,18 @@
                 },
                 "estimatedCost": {
                   "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-                  "type": ["null", "number", "string"],
+                  "type": [
+                    "null",
+                    "number",
+                    "string"
+                  ],
                   "format": "double"
                 },
                 "costCurrency": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "timestamp": {
                   "type": "string",
@@ -1724,25 +1988,39 @@
                 },
                 "duration": {
                   "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 }
               }
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1763,7 +2041,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1861,12 +2143,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1881,7 +2170,9 @@
         }
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/api-keys.json
+++ b/contracts/openapi/api-keys.json
@@ -7,7 +7,9 @@
   "paths": {
     "/authentication/api-keys": {
       "get": {
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "summary": "Returns a paginated list of API keys.",
         "description": "Lists all API keys for the current tenant with optional filters on type, environment, search term, and revocation status. The raw secret is never returned — only the prefix and last four characters for identification.",
         "operationId": "ListApiKeys",
@@ -110,7 +112,9 @@
         }
       },
       "post": {
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "summary": "Creates a new API key. The raw secret is returned once.",
         "description": "Generates a new API key with the specified type, environment, permissions, and optional CIDR restrictions. The caller must possess every permission being assigned (privilege escalation prevention). The response includes the full raw secret — this is the only time the secret is available. Store it securely; it cannot be retrieved later. The key is immediately active.",
         "operationId": "CreateApiKey",
@@ -180,7 +184,9 @@
     },
     "/authentication/api-keys/{id}": {
       "get": {
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "summary": "Returns a single API key by ID.",
         "description": "Returns the metadata of a single API key. The raw secret is never exposed after creation. Returns 404 if the key does not exist.",
         "operationId": "GetApiKeyById",
@@ -252,7 +258,9 @@
     },
     "/authentication/api-keys/{id}/revoke": {
       "post": {
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "summary": "Revokes an API key. The key will no longer be accepted for authentication.",
         "description": "Permanently revokes the API key. Any subsequent authentication attempt using this key will be rejected. This operation is irreversible — use rotate instead if you need a replacement key. Returns 404 if the key does not exist.",
         "operationId": "RevokeApiKey",
@@ -317,7 +325,9 @@
     },
     "/authentication/api-keys/{id}/rotate": {
       "post": {
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "summary": "Rotates an API key: revokes the current key and creates a replacement with the same settings.",
         "description": "Atomically revokes the existing key and creates a new one inheriting the same name, type, environment, permissions, CIDR restrictions, and expiration. The response contains the new raw secret (shown once) and both the old and new key IDs. Returns 404 if the key does not exist or is already revoked.",
         "operationId": "RotateApiKey",
@@ -389,7 +399,9 @@
     },
     "/authentication/api-keys/{id}/scopes": {
       "put": {
-        "tags": ["API Keys"],
+        "tags": [
+          "API Keys"
+        ],
         "summary": "Updates the permissions and allowed CIDR ranges for an API key.",
         "description": "Replaces the full list of permissions and allowed CIDR ranges for the specified key. The caller must possess every permission being assigned (privilege escalation prevention). Both fields are replaced entirely (not merged). Returns 404 if the key does not exist.",
         "operationId": "UpdateApiKeyScopes",
@@ -476,7 +488,11 @@
   "components": {
     "schemas": {
       "ApiKeyCreateRequest": {
-        "required": ["name", "type", "environment"],
+        "required": [
+          "name",
+          "type",
+          "environment"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -489,19 +505,28 @@
             "type": "string"
           },
           "permissions": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
           },
           "allowedCidrs": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
           },
           "expiresAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "cacheBehavior": {
@@ -545,7 +570,10 @@
             "type": "string"
           },
           "expiresAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
@@ -600,15 +628,24 @@
             }
           },
           "expiresAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "lastUsedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "revokedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "cacheBehavior": {
@@ -621,7 +658,13 @@
         }
       },
       "ApiKeyRotateResponse": {
-        "required": ["newKeyId", "rawSecret", "prefix", "lastFourChars", "oldKeyId"],
+        "required": [
+          "newKeyId",
+          "rawSecret",
+          "prefix",
+          "lastFourChars",
+          "oldKeyId"
+        ],
         "type": "object",
         "properties": {
           "newKeyId": {
@@ -644,10 +687,18 @@
         }
       },
       "ApiKeyType": {
-        "enum": ["Secret", "Publishable", "Webhook", "Ephemeral"]
+        "enum": [
+          "Secret",
+          "Publishable",
+          "Webhook",
+          "Ephemeral"
+        ]
       },
       "ApiKeyUpdateScopesRequest": {
-        "required": ["permissions", "allowedCidrs"],
+        "required": [
+          "permissions",
+          "allowedCidrs"
+        ],
         "type": "object",
         "properties": {
           "permissions": {
@@ -665,10 +716,17 @@
         }
       },
       "CacheBehavior": {
-        "enum": ["Normal", "NoCache"]
+        "enum": [
+          "Normal",
+          "NoCache"
+        ]
       },
       "PagedResultOfApiKeyResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -678,14 +736,20 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/contracts/openapi/auditing.json
+++ b/contracts/openapi/auditing.json
@@ -7,7 +7,9 @@
   "paths": {
     "/auditing/audit-entries": {
       "get": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of AuditEntryResponse entries projected from AuditEntry.",
         "description": "Executes a dynamic query against AuditEntry using the Granit query engine and projects each row to AuditEntryResponse. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<AuditEntryResponse> by default. When the groupBy query parameter is specified, returns a GroupedResult<AuditEntryResponse> with the same projection applied to the items inside each group.",
         "operationId": "QueryAuditEntry",
@@ -18,7 +20,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -29,7 +34,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -38,7 +46,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -46,7 +57,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -54,7 +68,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -62,7 +79,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -70,7 +90,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -78,7 +101,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -88,7 +114,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -101,7 +130,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -172,7 +204,9 @@
     },
     "/auditing/audit-entries/meta": {
       "get": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Returns query metadata for AuditEntry (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for AuditEntry: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetAuditEntryMeta",
@@ -222,7 +256,9 @@
     },
     "/auditing/audit-entries/{id}": {
       "get": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Returns a single audit log entry with full change details.",
         "description": "Returns the complete audit log entry including all entity changes and property-level diffs (original → new value). Sensitive properties are masked with '***'. Returns 404 if the entry does not exist.",
         "operationId": "GetAuditEntryById",
@@ -294,7 +330,9 @@
     },
     "/auditing/audit-entries/entity/{entityType}/{entityId}": {
       "get": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Returns the audit trail for a specific entity instance.",
         "description": "Returns all audit log entries associated with a specific entity, identified by its CLR type name and primary key. Results are paginated and ordered by timestamp descending. Useful for displaying the full change history of a single record. Path parameters are limited to 256 characters.",
         "operationId": "GetAuditEntriesByEntity",
@@ -392,7 +430,9 @@
     },
     "/auditing/audit-entries/correlation/{correlationId}": {
       "get": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Returns audit entries matching a distributed tracing correlation ID.",
         "description": "Returns all audit log entries that share the given correlation ID, ordered by timestamp descending. This is essential for distributed tracing investigation — correlating audit events across multiple services or operations that belong to the same logical transaction. The correlation ID is limited to 256 characters.",
         "operationId": "GetAuditEntriesByCorrelationId",
@@ -466,7 +506,9 @@
     },
     "/auditing/audit-entries/pseudonymize/{userId}": {
       "post": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Pseudonymize all audit entries for a specific user.",
         "description": "Replaces personal data (UserId, UserName, IpAddress, UserAgent) in all audit entries belonging to the specified user with pseudonymized values (GDPR Art. 17). The UserId is replaced with a SHA-256 hash to preserve audit trail correlation without re-identification. Audit entry integrity is maintained per ISO 27001 A.12.4. Returns 204 No Content on success.",
         "operationId": "PseudonymizeAuditEntries",
@@ -530,7 +572,9 @@
     },
     "/auditing/audit-entity-changes": {
       "get": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of AuditEntityChangeSummaryResponse entries projected from AuditEntityChange.",
         "description": "Executes a dynamic query against AuditEntityChange using the Granit query engine and projects each row to AuditEntityChangeSummaryResponse. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult<AuditEntityChangeSummaryResponse> by default. When the groupBy query parameter is specified, returns a GroupedResult<AuditEntityChangeSummaryResponse> with the same projection applied to the items inside each group.",
         "operationId": "QueryAuditEntityChange",
@@ -541,7 +585,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -552,7 +599,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -561,7 +611,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -569,7 +622,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -577,7 +633,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -585,7 +644,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -593,7 +655,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -601,7 +666,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -611,7 +679,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -624,7 +695,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -695,7 +769,9 @@
     },
     "/auditing/audit-entity-changes/meta": {
       "get": {
-        "tags": ["Audit Log"],
+        "tags": [
+          "Audit Log"
+        ],
         "summary": "Returns query metadata for AuditEntityChange (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for AuditEntityChange: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetAuditEntityChangeMeta",
@@ -756,10 +832,20 @@
         ]
       },
       "AuditChangeType": {
-        "enum": ["Created", "Modified", "Deleted", "SoftDeleted"]
+        "enum": [
+          "Created",
+          "Modified",
+          "Deleted",
+          "SoftDeleted"
+        ]
       },
       "AuditEntityChangeResponse": {
-        "required": ["entityType", "entityId", "changeType", "propertyChanges"],
+        "required": [
+          "entityType",
+          "entityId",
+          "changeType",
+          "propertyChanges"
+        ],
         "type": "object",
         "properties": {
           "entityType": {
@@ -839,20 +925,32 @@
             "type": "string"
           },
           "userName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "category": {
             "type": "string"
           },
           "ipAddress": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "correlationId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "entityChanges": {
             "type": "array",
@@ -888,20 +986,32 @@
             "type": "string"
           },
           "userName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "category": {
             "$ref": "#/components/schemas/AuditCategory"
           },
           "ipAddress": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "correlationId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "entityChangeCount": {
             "type": "integer",
@@ -910,17 +1020,27 @@
         }
       },
       "AuditPropertyChangeResponse": {
-        "required": ["propertyName", "originalValue", "newValue"],
+        "required": [
+          "propertyName",
+          "originalValue",
+          "newValue"
+        ],
         "type": "object",
         "properties": {
           "propertyName": {
             "type": "string"
           },
           "originalValue": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "newValue": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -960,12 +1080,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -983,10 +1110,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1002,7 +1141,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1020,7 +1162,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1052,7 +1198,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1064,7 +1213,10 @@
         }
       },
       "GroupedResultOfAuditEntityChangeSummaryResponse": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -1080,7 +1232,10 @@
         }
       },
       "GroupedResultOfAuditEntryResponse": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -1096,13 +1251,18 @@
         }
       },
       "GroupEntryOfAuditEntityChangeSummaryResponse": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -1111,10 +1271,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/AuditEntityChangeSummaryResponse"
             }
@@ -1122,13 +1288,18 @@
         }
       },
       "GroupEntryOfAuditEntryResponse": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -1137,10 +1308,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/AuditEntryResponse"
             }
@@ -1151,20 +1328,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1181,23 +1373,38 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1205,11 +1412,20 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "PagedResultOfAuditEntityChangeSummaryResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1240,7 +1456,12 @@
                   "type": "string"
                 },
                 "changeType": {
-                  "enum": ["Created", "Modified", "Deleted", "SoftDeleted"]
+                  "enum": [
+                    "Created",
+                    "Modified",
+                    "Deleted",
+                    "SoftDeleted"
+                  ]
                 },
                 "propertyChangeCount": {
                   "type": "integer",
@@ -1250,19 +1471,29 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PagedResultOfAuditEntryResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1293,7 +1524,10 @@
                   "type": "string"
                 },
                 "userName": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "category": {
                   "enum": [
@@ -1305,14 +1539,23 @@
                   ]
                 },
                 "ipAddress": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "correlationId": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "entityChangeCount": {
                   "type": "integer",
@@ -1322,19 +1565,30 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1355,7 +1609,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1453,12 +1711,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1473,7 +1738,9 @@
         }
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/authorization.json
+++ b/contracts/openapi/authorization.json
@@ -7,7 +7,9 @@
   "paths": {
     "/authorization/permissions": {
       "get": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Returns the list of permissions granted to the current user.",
         "description": "Evaluates all registered permission definitions against the current user's claims and roles. Returns the flat list of granted permission names. Useful for front-end UI to conditionally render actions based on the user's effective permissions.",
         "operationId": "GetMyPermissions",
@@ -57,7 +59,9 @@
     },
     "/authorization/permissions/definitions": {
       "get": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Returns all registered permission definitions grouped by category.",
         "description": "Returns the full registry of permission definitions discovered from all loaded modules, organized by permission group. Display names are localized based on the Accept-Language header. This endpoint is intended for admin UIs that manage role-to-permission assignments.",
         "operationId": "GetPermissionDefinitions",
@@ -110,7 +114,9 @@
     },
     "/authorization/roles/{roleName}": {
       "get": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Returns the list of permissions explicitly granted to a role.",
         "description": "Returns only the permissions explicitly assigned to the specified role for the current tenant. Does not include inherited or implicit permissions. The role name is case-sensitive and must match the identity provider's role definition. Returns 404 if the role has a RoleMetadata row that is not visible in the caller's context (host-scope role from a tenant admin, or another tenant's role) — no 403 is returned to avoid disclosing the role's existence.",
         "operationId": "GetRolePermissions",
@@ -191,7 +197,9 @@
     },
     "/authorization/roles/{roleName}/{permissionName}": {
       "put": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Grants a permission to a role. No-op if already granted.",
         "description": "Grants the specified permission to the role for the current tenant. The permission name must match a registered permission definition (returns 422 otherwise). The calling user must hold the permission being granted (privilege escalation prevention). Idempotent — granting an already-granted permission is a no-op. Returns 404 when the role is not visible in the caller's context.",
         "operationId": "GrantPermission",
@@ -272,7 +280,9 @@
         }
       },
       "delete": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Revokes a permission from a role. No-op if not granted.",
         "description": "Revokes the specified permission from the role for the current tenant. The permission name must match a registered permission definition (returns 422 otherwise). The calling user must hold the permission being revoked (privilege escalation prevention). Idempotent — revoking a non-granted permission is a no-op. Returns 404 when the role is not visible in the caller's context.",
         "operationId": "RevokePermission",
@@ -355,7 +365,9 @@
     },
     "/authorization/grants": {
       "get": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of PermissionGrant entries.",
         "description": "Executes a dynamic query against PermissionGrant using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryPermissionGrant",
@@ -366,7 +378,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -377,7 +392,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -386,7 +404,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -394,7 +415,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -402,7 +426,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -410,7 +437,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -418,7 +448,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -426,7 +459,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -436,7 +472,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -449,7 +488,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -520,7 +562,9 @@
     },
     "/authorization/grants/meta": {
       "get": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Returns query metadata for PermissionGrant (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for PermissionGrant: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetPermissionGrantMeta",
@@ -570,7 +614,9 @@
     },
     "/authorization/role-metadata": {
       "get": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of RoleMetadata entries.",
         "description": "Executes a dynamic query against RoleMetadata using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryRoleMetadata",
@@ -581,7 +627,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -592,7 +641,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -601,7 +653,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -609,7 +664,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -617,7 +675,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -625,7 +686,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -633,7 +697,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -641,7 +708,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -651,7 +721,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -664,7 +737,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -735,7 +811,9 @@
     },
     "/authorization/role-metadata/meta": {
       "get": {
-        "tags": ["Authorization"],
+        "tags": [
+          "Authorization"
+        ],
         "summary": "Returns query metadata for RoleMetadata (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for RoleMetadata: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetRoleMetadataMeta",
@@ -822,12 +900,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -845,10 +930,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -864,7 +961,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -882,7 +982,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -914,7 +1018,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -926,7 +1033,10 @@
         }
       },
       "GroupedResultOfPermissionGrant": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -942,7 +1052,10 @@
         }
       },
       "GroupedResultOfRoleMetadata": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -958,13 +1071,18 @@
         }
       },
       "GroupEntryOfPermissionGrant": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -973,10 +1091,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/PermissionGrant"
             }
@@ -984,13 +1108,18 @@
         }
       },
       "GroupEntryOfRoleMetadata": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -999,10 +1128,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/RoleMetadata"
             }
@@ -1013,20 +1148,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1051,23 +1201,38 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1075,7 +1240,12 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "MultiTenancySides": {
@@ -1083,7 +1253,9 @@
         "description": "Scope of an object (permission, BFF frontend, ...) relative to the host/tenant boundary."
       },
       "MyPermissionsResponse": {
-        "required": ["permissions"],
+        "required": [
+          "permissions"
+        ],
         "type": "object",
         "properties": {
           "permissions": {
@@ -1095,7 +1267,11 @@
         }
       },
       "PagedResultOfPermissionGrant": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1113,27 +1289,42 @@
                   "type": "string"
                 },
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "modifiedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "domainEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for domain events."
                   }
                 },
                 "integrationEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for integration events (ETO — Event Transfer Object)."
@@ -1157,19 +1348,29 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PagedResultOfRoleMetadata": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1181,18 +1382,27 @@
                   "type": "string"
                 },
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "clientId": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "multiTenancySides": {
                   "type": "string",
                   "description": "Scope of an object (permission, BFF frontend, ...) relative to the host/tenant boundary."
                 },
                 "description": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "isSystem": {
                   "type": "boolean"
@@ -1201,30 +1411,45 @@
                   "type": "boolean"
                 },
                 "orphanedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "date-time"
                 },
                 "concurrencyStamp": {
                   "type": "string"
                 },
                 "modifiedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "domainEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for domain events."
                   }
                 },
                 "integrationEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for integration events (ETO — Event Transfer Object)."
@@ -1248,19 +1473,30 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1281,14 +1517,21 @@
         }
       },
       "PermissionDefinitionResponse": {
-        "required": ["name", "displayName", "multiTenancySides"],
+        "required": [
+          "name",
+          "displayName",
+          "multiTenancySides"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "multiTenancySides": {
             "$ref": "#/components/schemas/MultiTenancySides"
@@ -1308,26 +1551,41 @@
             "type": "string"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Identifier of the user who last modified the entity."
           },
           "domainEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IDomainEvent"
             }
           },
           "integrationEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IIntegrationEvent"
             }
@@ -1349,7 +1607,10 @@
         }
       },
       "PermissionGrantResponse": {
-        "required": ["roleName", "permissions"],
+        "required": [
+          "roleName",
+          "permissions"
+        ],
         "type": "object",
         "properties": {
           "roleName": {
@@ -1364,14 +1625,21 @@
         }
       },
       "PermissionGroupResponse": {
-        "required": ["name", "displayName", "permissions"],
+        "required": [
+          "name",
+          "displayName",
+          "permissions"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "permissions": {
             "type": "array",
@@ -1382,7 +1650,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1480,12 +1752,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1506,17 +1785,26 @@
             "type": "string"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "clientId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "multiTenancySides": {
             "$ref": "#/components/schemas/MultiTenancySides"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "isSystem": {
             "type": "boolean"
@@ -1525,29 +1813,44 @@
             "type": "boolean"
           },
           "orphanedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "concurrencyStamp": {
             "type": "string"
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Identifier of the user who last modified the entity."
           },
           "domainEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IDomainEvent"
             }
           },
           "integrationEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IIntegrationEvent"
             }
@@ -1569,7 +1872,9 @@
         }
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/background-jobs.json
+++ b/contracts/openapi/background-jobs.json
@@ -7,7 +7,9 @@
   "paths": {
     "/background-jobs/jobs": {
       "get": {
-        "tags": ["Background Jobs"],
+        "tags": [
+          "Background Jobs"
+        ],
         "summary": "Returns the current status of all registered background jobs with pagination.",
         "description": "Lists all background jobs registered in the application with their current execution state, schedule, last run time, and next occurrence. Supports pagination via page and pageSize query parameters.",
         "operationId": "GetAllBackgroundJobs",
@@ -79,7 +81,9 @@
     },
     "/background-jobs/jobs/{name}": {
       "get": {
-        "tags": ["Background Jobs"],
+        "tags": [
+          "Background Jobs"
+        ],
         "summary": "Returns the status of a specific background job.",
         "description": "Returns the detailed status of a single background job identified by its registered name. Includes execution state, last run time, next scheduled occurrence, and error information if the last run failed. Returns 404 if no job with the given name is registered.",
         "operationId": "GetBackgroundJobByName",
@@ -150,7 +154,9 @@
     },
     "/background-jobs/jobs/{name}/pause": {
       "post": {
-        "tags": ["Background Jobs"],
+        "tags": [
+          "Background Jobs"
+        ],
         "summary": "Pauses a recurring background job. The current execution completes normally.",
         "description": "Pauses the job's recurring schedule. If the job is currently executing, the in-flight execution will complete — only future occurrences are suppressed. Use the resume endpoint to re-enable scheduling. Returns 404 if the job name is not registered.",
         "operationId": "PauseBackgroundJob",
@@ -214,7 +220,9 @@
     },
     "/background-jobs/jobs/{name}/resume": {
       "post": {
-        "tags": ["Background Jobs"],
+        "tags": [
+          "Background Jobs"
+        ],
         "summary": "Resumes a paused background job and schedules its next occurrence.",
         "description": "Re-enables the recurring schedule of a previously paused job and computes the next occurrence. No-op if the job is not paused. Returns 404 if the job name is not registered.",
         "operationId": "ResumeBackgroundJob",
@@ -278,7 +286,9 @@
     },
     "/background-jobs/jobs/{name}/trigger": {
       "post": {
-        "tags": ["Background Jobs"],
+        "tags": [
+          "Background Jobs"
+        ],
         "summary": "Triggers an immediate execution of the job, independent of its schedule.",
         "description": "Enqueues the job for immediate execution regardless of its cron schedule or paused state. The response is 202 Accepted — the actual execution is asynchronous. Does not affect the regular schedule. Returns 404 if the job name is not registered.",
         "operationId": "TriggerBackgroundJob",
@@ -366,11 +376,17 @@
             "type": "boolean"
           },
           "lastExecutedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "nextExecutionAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "consecutiveFailures": {
@@ -379,16 +395,26 @@
           },
           "deadLetterCount": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "lastError": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PagedResultOfBackgroundJobStatus": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -398,14 +424,20 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/contracts/openapi/bff.json
+++ b/contracts/openapi/bff.json
@@ -7,7 +7,9 @@
   "paths": {
     "/bff/user": {
       "get": {
-        "tags": ["BFF - App"],
+        "tags": [
+          "BFF - App"
+        ],
         "summary": "Returns the current user's claims for the SPA.",
         "description": "Reads the session cookie, loads the ID token from the token store, decodes the JWT payload, and returns a filtered set of claims: sub, name, email, roles, tenantId, isHost, and sessionExpiresAt. isHost is server-emitted (true when the id_token carries no tenant_id claim) so the SPA never has to infer Host status from the absence of TenantId. Returns { authenticated: false } if no valid session exists. Tokens are never exposed to the browser.",
         "operationId": "BffGetUserApp",
@@ -37,7 +39,9 @@
     },
     "/bff/csrf-token": {
       "post": {
-        "tags": ["BFF - App"],
+        "tags": [
+          "BFF - App"
+        ],
         "summary": "Generates a CSRF token for the current BFF session.",
         "description": "Reads the session cookie to identify the session, generates an HMAC-SHA256 based CSRF token, and returns it in the response body. The SPA must include this token in the X-CSRF-Token header on all POST/PUT/DELETE/PATCH requests. Returns 401 if no valid session exists.",
         "operationId": "BffGenerateCsrfTokenApp",
@@ -79,7 +83,9 @@
   "components": {
     "schemas": {
       "BffCsrfTokenResponse": {
-        "required": ["csrfToken"],
+        "required": [
+          "csrfToken"
+        ],
         "type": "object",
         "properties": {
           "csrfToken": {

--- a/contracts/openapi/blob-storage.json
+++ b/contracts/openapi/blob-storage.json
@@ -7,7 +7,9 @@
   "paths": {
     "/blob-storage/blobs/{id}": {
       "get": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Returns a blob descriptor by its unique identifier.",
         "description": "Fetches the full metadata of a blob including its status, content type, size, and validation results. The containerName query parameter is required. Returns 404 if the blob does not exist in the specified container.",
         "operationId": "GetBlobDescriptor",
@@ -86,7 +88,9 @@
         }
       },
       "delete": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Deletes a blob using crypto-shredding.",
         "description": "Permanently removes the blob content from storage via crypto-shredding. The blob descriptor and audit trail are retained with the provided deletion reason. A containerName and deletionReason must be supplied in the request body.",
         "operationId": "DeleteBlob",
@@ -181,7 +185,9 @@
     },
     "/blob-storage/blobs/upload": {
       "post": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Initiates a direct-to-cloud upload and returns a pre-signed URL.",
         "description": "Creates a new blob descriptor and generates a pre-signed URL for direct client-side upload. The response includes the upload URL, required HTTP headers, and expiration time. After uploading, call the confirm endpoint to trigger the validation pipeline.",
         "operationId": "InitiateBlobUpload",
@@ -261,7 +267,9 @@
     },
     "/blob-storage/blobs/{id}/confirm": {
       "post": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Confirms a client-side upload and runs the validation pipeline.",
         "description": "Triggers content-type verification and size validation on an uploaded blob. The response includes the validation result: verified content type, actual size, and an optional rejection reason if the blob failed validation.",
         "operationId": "ConfirmBlobUpload",
@@ -363,7 +371,9 @@
     },
     "/blob-storage/blobs/{id}/download-url": {
       "post": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Generates a time-limited pre-signed download URL.",
         "description": "Creates a pre-signed URL for direct client-side download of the blob content. An optional custom file name can be specified to override the Content-Disposition header. The URL expires after the provider-configured duration.",
         "operationId": "GenerateBlobDownloadUrl",
@@ -465,7 +475,9 @@
     },
     "/blob-storage/blobs/{id}/pending": {
       "delete": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Cancels a Pending upload whose presigned PUT failed client-side.",
         "description": "Short-circuits the orphan-cleanup window by transitioning a Pending blob directly to Rejected. Intended to be called by the client when its PUT to the presigned URL returns 4xx/5xx, so the descriptor does not linger visible for up to BlobStorageOptions.OrphanCleanupAge. Returns 409 Conflict if the blob has already left Pending state.",
         "operationId": "CancelPendingBlobUpload",
@@ -570,7 +582,9 @@
     },
     "/blob-storage/blobs/cleanup-orphans": {
       "post": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Cleans up orphaned blobs stuck in Pending or Uploading state.",
         "description": "Scans for blobs that never completed the upload/confirm cycle and deletes them. Returns the number of orphaned blobs removed. Typically called on a schedule or via the admin dashboard.",
         "operationId": "CleanupOrphanedBlobs",
@@ -630,7 +644,9 @@
     },
     "/blob-storage/blobs": {
       "get": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of BlobDescriptor entries.",
         "description": "Executes a dynamic query against BlobDescriptor using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryBlobDescriptor",
@@ -641,7 +657,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -652,7 +671,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -661,7 +683,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -669,7 +694,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -677,7 +705,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -685,7 +716,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -693,7 +727,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -701,7 +738,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -711,7 +751,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -724,7 +767,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -795,7 +841,9 @@
     },
     "/blob-storage/blobs/meta": {
       "get": {
-        "tags": ["Blob Storage"],
+        "tags": [
+          "Blob Storage"
+        ],
         "summary": "Returns query metadata for BlobDescriptor (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for BlobDescriptor: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetBlobDescriptorMeta",
@@ -847,7 +895,10 @@
   "components": {
     "schemas": {
       "BlobCancelPendingRequest": {
-        "required": ["containerName", "reason"],
+        "required": [
+          "containerName",
+          "reason"
+        ],
         "type": "object",
         "properties": {
           "containerName": {
@@ -863,7 +914,9 @@
         }
       },
       "BlobCleanupOrphansResponse": {
-        "required": ["cleanedCount"],
+        "required": [
+          "cleanedCount"
+        ],
         "type": "object",
         "properties": {
           "cleanedCount": {
@@ -873,7 +926,9 @@
         }
       },
       "BlobConfirmUploadRequest": {
-        "required": ["containerName"],
+        "required": [
+          "containerName"
+        ],
         "type": "object",
         "properties": {
           "containerName": {
@@ -906,27 +961,42 @@
             "$ref": "#/components/schemas/BlobStatus"
           },
           "verifiedContentType": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "sizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["null", "integer", "string"],
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "rejectionReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "BlobDeleteRequest": {
-        "required": ["containerName"],
+        "required": [
+          "containerName"
+        ],
         "type": "object",
         "properties": {
           "containerName": {
             "type": "string"
           },
           "deletionReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         },
         "example": {
@@ -938,7 +1008,10 @@
         "type": "object",
         "properties": {
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "containerName": {
@@ -955,42 +1028,70 @@
           },
           "maxAllowedBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "verifiedContentType": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "sizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["null", "integer", "string"],
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "status": {
             "$ref": "#/components/schemas/BlobStatus"
           },
           "validatedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "deletedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "rejectionReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "deletionReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "domainEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IDomainEvent"
             }
           },
           "integrationEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IIntegrationEvent"
             }
@@ -1043,37 +1144,59 @@
             "type": "string"
           },
           "verifiedContentType": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "declaredSizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "actualSizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["null", "integer", "string"],
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "status": {
             "$ref": "#/components/schemas/BlobStatus"
           },
           "rejectionReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "deletionReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "createdAt": {
             "type": "string",
             "format": "date-time"
           },
           "validatedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "deletedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         },
@@ -1094,14 +1217,19 @@
         }
       },
       "BlobDownloadUrlRequest": {
-        "required": ["containerName"],
+        "required": [
+          "containerName"
+        ],
         "type": "object",
         "properties": {
           "containerName": {
             "type": "string"
           },
           "fileName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         },
         "example": {
@@ -1110,7 +1238,10 @@
         }
       },
       "BlobDownloadUrlResponse": {
-        "required": ["downloadUrl", "expiresAt"],
+        "required": [
+          "downloadUrl",
+          "expiresAt"
+        ],
         "type": "object",
         "properties": {
           "downloadUrl": {
@@ -1123,10 +1254,21 @@
         }
       },
       "BlobStatus": {
-        "enum": ["Pending", "Uploading", "Valid", "Rejected", "Deleted"]
+        "enum": [
+          "Pending",
+          "Uploading",
+          "Valid",
+          "Rejected",
+          "Deleted"
+        ]
       },
       "BlobUploadInitiateRequest": {
-        "required": ["containerName", "fileName", "contentType", "sizeBytes"],
+        "required": [
+          "containerName",
+          "fileName",
+          "contentType",
+          "sizeBytes"
+        ],
         "type": "object",
         "properties": {
           "containerName": {
@@ -1140,7 +1282,10 @@
           },
           "sizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           }
         },
@@ -1152,7 +1297,13 @@
         }
       },
       "BlobUploadInitiateResponse": {
-        "required": ["blobId", "uploadUrl", "httpMethod", "expiresAt", "requiredHeaders"],
+        "required": [
+          "blobId",
+          "uploadUrl",
+          "httpMethod",
+          "expiresAt",
+          "requiredHeaders"
+        ],
         "type": "object",
         "properties": {
           "blobId": {
@@ -1223,12 +1374,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1246,10 +1404,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1265,7 +1435,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1283,7 +1456,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1315,7 +1492,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1327,7 +1507,10 @@
         }
       },
       "GroupedResultOfBlobDescriptor": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -1343,13 +1526,18 @@
         }
       },
       "GroupEntryOfBlobDescriptor": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -1358,10 +1546,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/BlobDescriptor"
             }
@@ -1372,20 +1566,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1410,23 +1619,38 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1434,11 +1658,20 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "PagedResultOfBlobDescriptor": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1447,7 +1680,10 @@
               "type": "object",
               "properties": {
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "containerName": {
@@ -1464,43 +1700,77 @@
                 },
                 "maxAllowedBytes": {
                   "pattern": "^-?(?:0|[1-9]\\d*)$",
-                  "type": ["integer", "string"],
+                  "type": [
+                    "integer",
+                    "string"
+                  ],
                   "format": "int64"
                 },
                 "verifiedContentType": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "sizeBytes": {
                   "pattern": "^-?(?:0|[1-9]\\d*)$",
-                  "type": ["null", "integer", "string"],
+                  "type": [
+                    "null",
+                    "integer",
+                    "string"
+                  ],
                   "format": "int64"
                 },
                 "status": {
-                  "enum": ["Pending", "Uploading", "Valid", "Rejected", "Deleted"]
+                  "enum": [
+                    "Pending",
+                    "Uploading",
+                    "Valid",
+                    "Rejected",
+                    "Deleted"
+                  ]
                 },
                 "validatedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "date-time"
                 },
                 "deletedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "date-time"
                 },
                 "rejectionReason": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "deletionReason": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "domainEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for domain events."
                   }
                 },
                 "integrationEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for integration events (ETO — Event Transfer Object)."
@@ -1524,19 +1794,30 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1557,7 +1838,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1655,12 +1940,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1675,7 +1967,9 @@
         }
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/cookies.json
+++ b/contracts/openapi/cookies.json
@@ -7,7 +7,9 @@
   "paths": {
     "/cookies/config": {
       "get": {
-        "tags": ["Cookie Consent"],
+        "tags": [
+          "Cookie Consent"
+        ],
         "summary": "Returns the cookie consent configuration for CMP setup.",
         "description": "Returns the full list of internal cookies and third-party services registered in the application, categorized for GDPR consent management. The front-end CMP (Consent Management Platform) uses this response to render the cookie banner. Response is cached for 1 hour (Cache-Control: public, max-age=3600). Anonymous — no authentication required.",
         "operationId": "GetCookieConsentConfig",
@@ -33,14 +35,19 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     }
   },
   "components": {
     "schemas": {
       "CookieConsentConfigResponse": {
-        "required": ["cookies", "services"],
+        "required": [
+          "cookies",
+          "services"
+        ],
         "type": "object",
         "properties": {
           "cookies": {
@@ -58,7 +65,12 @@
         }
       },
       "CookieDefinitionResponse": {
-        "required": ["name", "category", "retentionDays", "purpose"],
+        "required": [
+          "name",
+          "category",
+          "retentionDays",
+          "purpose"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -102,7 +114,11 @@
         }
       },
       "ThirdPartyServiceResponse": {
-        "required": ["name", "category", "cookiePatterns"],
+        "required": [
+          "name",
+          "category",
+          "cookiePatterns"
+        ],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/data-exchange.json
+++ b/contracts/openapi/data-exchange.json
@@ -7,7 +7,9 @@
   "paths": {
     "/data-exchange/import/jobs": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Lists import jobs with optional status filter and pagination.",
         "description": "Returns a paginated list of import jobs ordered by creation date descending. Supports filtering by job status. Intended for admin dashboards monitoring import activity.",
         "operationId": "ListImportJobs",
@@ -85,7 +87,9 @@
         }
       },
       "post": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Uploads a file and creates an import job.",
         "description": "Accepts a multipart/form-data upload with the file and a definitionName field. Validates MIME type and file size against the import definition's constraints. Creates an import job in 'Created' status. The next step is to call the preview endpoint to inspect headers and mapping suggestions.",
         "operationId": "UploadImportFile",
@@ -93,7 +97,10 @@
           "content": {
             "multipart/form-data": {
               "schema": {
-                "required": ["file", "definitionName"],
+                "required": [
+                  "file",
+                  "definitionName"
+                ],
                 "type": "object",
                 "allOf": [
                   {
@@ -184,7 +191,9 @@
     },
     "/data-exchange/import/{jobId}/preview": {
       "post": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Extracts headers, preview rows, and mapping suggestions for an import job.",
         "description": "Parses the uploaded file to extract column headers, a preview of the first rows, available target field metadata, and AI-assisted mapping suggestions. Transitions the job to 'Previewed' status. Returns 404 if the job does not exist.",
         "operationId": "PreviewImportJob",
@@ -256,7 +265,9 @@
     },
     "/data-exchange/import/{jobId}/mappings": {
       "put": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Confirms the column-to-property mappings for an import job.",
         "description": "Saves the user-confirmed column-to-property mappings and transitions the job to 'Mapped' status, making it eligible for execution or dry-run. At least one mapping is required. Returns 404 if the job does not exist. Returns 409 if the concurrency stamp does not match the stored value.",
         "operationId": "ConfirmImportMappings",
@@ -361,7 +372,9 @@
     },
     "/data-exchange/import/{jobId}/execute": {
       "post": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Dispatches the import job for asynchronous background execution.",
         "description": "Enqueues the import job for background processing. Returns 202 Accepted — poll the status endpoint to track progress. The job must be in 'Mapped' status (mappings confirmed). Returns 400 if the job is in an invalid state, or 404 if not found.",
         "operationId": "ExecuteImportJob",
@@ -436,7 +449,9 @@
     },
     "/data-exchange/import/{jobId}/dry-run": {
       "post": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Executes a dry-run of the import (validates without persisting data).",
         "description": "Runs the full import pipeline (parsing, mapping, validation) without persisting any data. Returns a detailed report with row-level validation results. Use this to preview errors before committing. The job must be in 'Mapped' status.",
         "operationId": "DryRunImportJob",
@@ -518,7 +533,9 @@
     },
     "/data-exchange/import/{jobId}": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Returns the current status of an import job.",
         "description": "Returns the current state of the import job including status (Created, Previewed, Mapped, Executing, Completed, PartiallyCompleted, Failed, Cancelled), original file name, row counts, and timing information. Returns 404 if not found.",
         "operationId": "GetImportJobStatus",
@@ -588,7 +605,9 @@
         }
       },
       "delete": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Cancels an import job that has not yet started execution.",
         "description": "Cancels the import job and deletes the uploaded file from blob storage. Only jobs that have not yet started execution (Executing, Completed, PartiallyCompleted, Failed) can be cancelled. Returns 400 if the job is in a non-cancellable state.",
         "operationId": "CancelImportJob",
@@ -663,7 +682,9 @@
     },
     "/data-exchange/import/{jobId}/report": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Returns the import execution report for a completed job.",
         "description": "Returns the detailed execution report including total rows processed, success/failure counts, and per-row error details. Available after execution or dry-run completes. Returns 404 if the job does not exist or no report has been generated yet.",
         "operationId": "GetImportReport",
@@ -735,7 +756,9 @@
     },
     "/data-exchange/import/{jobId}/correction-file": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Downloads a correction file containing only the failed rows with error annotations.",
         "description": "Generates and streams a file containing only the rows that failed validation or import, annotated with error messages. The file format matches the original upload. Users can fix the errors and re-upload. Returns 204 if there are no failed rows, or 404 if the job or report does not exist.",
         "operationId": "GetImportCorrectionFile",
@@ -803,7 +826,9 @@
     },
     "/data-exchange/export/jobs": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Lists export jobs with optional status filter and pagination.",
         "description": "Returns a paginated list of export jobs ordered by creation date descending. Supports filtering by job status (Created, Processing, Completed, Failed). Intended for admin dashboards monitoring export activity.",
         "operationId": "ListExportJobs",
@@ -881,7 +906,9 @@
         }
       },
       "post": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Creates and dispatches an export job (sync or background).",
         "description": "Creates an export job for the given definition, format, and field selection. Small datasets may complete synchronously; larger ones are dispatched for background processing. Poll the status endpoint to track progress. Returns 400 if the definition name or format is invalid.",
         "operationId": "CreateExportJob",
@@ -961,7 +988,9 @@
     },
     "/data-exchange/export/jobs/{jobId}": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Returns the current status of an export job.",
         "description": "Returns the current status of the export job (Created, Processing, Completed, Failed). Once the status is Completed, the download endpoint becomes available. Returns 404 if the job ID is not found.",
         "operationId": "GetExportJobStatus",
@@ -1033,7 +1062,9 @@
     },
     "/data-exchange/export/jobs/{jobId}/download": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Downloads the generated export file for a completed job.",
         "description": "Streams the generated export file (xlsx, csv, etc.) as a binary download. The Content-Type and Content-Disposition headers are set according to the export format. Returns 404 if the job does not exist, or 400 if the job has not completed yet.",
         "operationId": "DownloadExportFile",
@@ -1108,7 +1139,9 @@
     },
     "/data-exchange/metadata/definitions": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Lists all registered export definitions.",
         "description": "Returns all export definitions registered by application modules. Each definition describes an exportable dataset, its supported output formats, and metadata. Use the fields endpoint to discover selectable columns for a specific definition.",
         "operationId": "ListExportDefinitions",
@@ -1161,7 +1194,9 @@
     },
     "/data-exchange/metadata/definitions/{name}/fields": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Returns the available fields for a given export definition.",
         "description": "Returns the list of selectable fields for the named export definition — each with its property name, display label, and data type. Use this to populate a field picker UI before creating an export job. Returns 404 if the definition name is not registered.",
         "operationId": "GetExportDefinitionFields",
@@ -1235,7 +1270,9 @@
     },
     "/data-exchange/metadata/presets/{definitionName}": {
       "get": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Lists saved export presets for a given definition.",
         "description": "Returns all saved export presets for the given export definition. Presets store a reusable field selection, output format, and sorting configuration so users can quickly re-export without reconfiguring.",
         "operationId": "ListExportPresets",
@@ -1299,7 +1336,9 @@
     },
     "/data-exchange/metadata/presets": {
       "post": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Saves or updates an export preset.",
         "description": "Creates or updates a named preset for the given export definition. If a preset with the same definition and name already exists, it is overwritten. The definition name must reference a registered export definition. At least one selected field is required.",
         "operationId": "SaveExportPreset",
@@ -1372,7 +1411,9 @@
     },
     "/data-exchange/metadata/presets/{definitionName}/{presetName}": {
       "delete": {
-        "tags": ["Data Exchange"],
+        "tags": [
+          "Data Exchange"
+        ],
         "summary": "Deletes a saved export preset.",
         "description": "Permanently removes the named export preset. Returns 404 if the preset does not exist.",
         "operationId": "DeleteExportPreset",
@@ -1447,7 +1488,10 @@
   "components": {
     "schemas": {
       "ConfirmMappingsRequest": {
-        "required": ["mappings", "concurrencyStamp"],
+        "required": [
+          "mappings",
+          "concurrencyStamp"
+        ],
         "type": "object",
         "properties": {
           "mappings": {
@@ -1465,12 +1509,7 @@
         "required": [
           "definitionName",
           "format",
-          "selectedFields",
-          "includeIdForImport",
-          "sort",
-          "filter",
-          "presets",
-          "search"
+          "includeIdForImport"
         ],
         "type": "object",
         "properties": {
@@ -1480,37 +1519,57 @@
           "format": {
             "type": "string"
           },
+          "includeIdForImport": {
+            "type": "boolean"
+          },
           "selectedFields": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
           },
-          "includeIdForImport": {
-            "type": "boolean"
-          },
           "sort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "filter": {
-            "type": ["null", "object"],
+            "type": [
+              "null",
+              "object"
+            ],
             "additionalProperties": {
               "type": "string"
             }
           },
           "presets": {
-            "type": ["null", "object"],
+            "type": [
+              "null",
+              "object"
+            ],
             "additionalProperties": {
               "type": "string"
             }
           },
           "search": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "ExportDefinitionResponse": {
-        "required": ["name", "entityType", "supportedFormats", "isAutoGenerated"],
+        "required": [
+          "name",
+          "entityType",
+          "supportedFormats",
+          "isAutoGenerated"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1531,7 +1590,14 @@
         }
       },
       "ExportFieldResponse": {
-        "required": ["propertyPath", "clrTypeName", "header", "format", "order", "isNavigation"],
+        "required": [
+          "propertyPath",
+          "clrTypeName",
+          "header",
+          "format",
+          "order",
+          "isNavigation"
+        ],
         "type": "object",
         "properties": {
           "propertyPath": {
@@ -1541,10 +1607,16 @@
             "type": "string"
           },
           "header": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "order": {
             "type": "integer",
@@ -1583,27 +1655,44 @@
             "$ref": "#/components/schemas/ExportJobStatus"
           },
           "rowCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "fileName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errorMessage": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "createdAt": {
             "type": "string",
             "format": "date-time"
           },
           "completedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
       },
       "ExportJobStatus": {
-        "enum": ["Queued", "Exporting", "Completed", "Failed"]
+        "enum": [
+          "Queued",
+          "Exporting",
+          "Completed",
+          "Failed"
+        ]
       },
       "ExportPresetResponse": {
         "required": [
@@ -1640,14 +1729,21 @@
         "format": "binary"
       },
       "ImportColumnMapping": {
-        "required": ["sourceColumn", "targetProperty", "confidence"],
+        "required": [
+          "sourceColumn",
+          "targetProperty",
+          "confidence"
+        ],
         "type": "object",
         "properties": {
           "sourceColumn": {
             "type": "string"
           },
           "targetProperty": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "confidence": {
             "$ref": "#/components/schemas/MappingConfidence"
@@ -1655,7 +1751,13 @@
         }
       },
       "ImportFieldMetadata": {
-        "required": ["propertyPath", "clrTypeName", "displayName", "description", "isRequired"],
+        "required": [
+          "propertyPath",
+          "clrTypeName",
+          "displayName",
+          "description",
+          "isRequired"
+        ],
         "type": "object",
         "properties": {
           "propertyPath": {
@@ -1665,10 +1767,16 @@
             "type": "string"
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "isRequired": {
             "type": "boolean"
@@ -1704,7 +1812,10 @@
           },
           "fileSizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "status": {
@@ -1715,7 +1826,10 @@
             "format": "date-time"
           },
           "completedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "concurrencyStamp": {
@@ -1736,7 +1850,12 @@
         ]
       },
       "ImportPreviewResponse": {
-        "required": ["headers", "previewRows", "suggestions", "fieldMetadata"],
+        "required": [
+          "headers",
+          "previewRows",
+          "suggestions",
+          "fieldMetadata"
+        ],
         "type": "object",
         "properties": {
           "headers": {
@@ -1827,7 +1946,12 @@
         }
       },
       "ImportRowError": {
-        "required": ["rowNumber", "kind", "errorCodes", "message"],
+        "required": [
+          "rowNumber",
+          "kind",
+          "errorCodes",
+          "message"
+        ],
         "type": "object",
         "properties": {
           "rowNumber": {
@@ -1849,13 +1973,28 @@
         }
       },
       "ImportRowErrorKind": {
-        "enum": ["Conversion", "Validation", "Persistence", "Identity"]
+        "enum": [
+          "Conversion",
+          "Validation",
+          "Persistence",
+          "Identity"
+        ]
       },
       "MappingConfidence": {
-        "enum": ["Manual", "Saved", "Exact", "Fuzzy", "Semantic"]
+        "enum": [
+          "Manual",
+          "Saved",
+          "Exact",
+          "Fuzzy",
+          "Semantic"
+        ]
       },
       "PagedResultOfExportJobResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1865,19 +2004,29 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PagedResultOfImportJobResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1887,14 +2036,20 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/contracts/openapi/data-lookup.json
+++ b/contracts/openapi/data-lookup.json
@@ -7,7 +7,9 @@
   "paths": {
     "/lookups": {
       "get": {
-        "tags": ["Data Lookup"],
+        "tags": [
+          "Data Lookup"
+        ],
         "summary": "Returns the manifest of every registered lookup source.",
         "description": "Lists all lookups exposed by the host with their name, kind, required permission, and scope keys. Frontend tooling uses this endpoint to populate pickers and to hide lookups the user is not authorized to call.",
         "operationId": "GetDataLookupManifest",
@@ -57,7 +59,9 @@
     },
     "/lookups/{name}": {
       "get": {
-        "tags": ["Data Lookup"],
+        "tags": [
+          "Data Lookup"
+        ],
         "summary": "Searches a lookup source for matching items.",
         "description": "Performs a paginated typeahead search against the lookup source identified by the route parameter. Honors the Accept-Language header, the ambient tenant context and any scope parameters declared by the source (scope.* query string).",
         "operationId": "SearchDataLookup",
@@ -173,7 +177,9 @@
     },
     "/lookups/{name}/resolve": {
       "get": {
-        "tags": ["Data Lookup"],
+        "tags": [
+          "Data Lookup"
+        ],
         "summary": "Resolves a single lookup item by its value.",
         "description": "Used by clients to rehydrate a previously selected value into a human-readable label. Returns 404 if the value is not present in the source.",
         "operationId": "ResolveDataLookup",
@@ -263,23 +269,40 @@
   "components": {
     "schemas": {
       "LookupItemResponse": {
-        "required": ["value", "label", "extra"],
+        "required": [
+          "value",
+          "label",
+          "extra"
+        ],
         "type": "object",
         "properties": {
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
           "extra": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           }
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"]
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ]
       },
       "LookupManifestEntryResponse": {
-        "required": ["name", "kind", "requiredPermission", "scopeKeys"],
+        "required": [
+          "name",
+          "kind",
+          "requiredPermission",
+          "scopeKeys"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -289,7 +312,10 @@
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "scopeKeys": {
             "type": "array",
@@ -300,7 +326,9 @@
         }
       },
       "LookupManifestResponse": {
-        "required": ["lookups"],
+        "required": [
+          "lookups"
+        ],
         "type": "object",
         "properties": {
           "lookups": {
@@ -312,7 +340,11 @@
         }
       },
       "LookupResultResponse": {
-        "required": ["items", "totalCount", "continuationToken"],
+        "required": [
+          "items",
+          "totalCount",
+          "continuationToken"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -322,11 +354,17 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "continuationToken": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/contracts/openapi/diagnostics.json
+++ b/contracts/openapi/diagnostics.json
@@ -7,7 +7,9 @@
   "paths": {
     "/diagnostics/health": {
       "get": {
-        "tags": ["Diagnostics"],
+        "tags": [
+          "Diagnostics"
+        ],
         "summary": "Returns the aggregated health status of all registered services.",
         "description": "Returns the current health status, response time, and description for every registered health check. Results are cached for the configured monitoring cache duration (default 30 seconds).",
         "operationId": "GetMonitoringHealth",
@@ -59,7 +61,10 @@
   "components": {
     "schemas": {
       "MonitoringHealthResponse": {
-        "required": ["services", "checkedAt"],
+        "required": [
+          "services",
+          "checkedAt"
+        ],
         "type": "object",
         "properties": {
           "services": {
@@ -100,7 +105,14 @@
         }
       },
       "ServiceHealthResponse": {
-        "required": ["id", "name", "status", "responseTimeMs", "description", "tags"],
+        "required": [
+          "id",
+          "name",
+          "status",
+          "responseTimeMs",
+          "description",
+          "tags"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -114,11 +126,18 @@
           },
           "responseTimeMs": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
+            "type": [
+              "null",
+              "number",
+              "string"
+            ],
             "format": "double"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "tags": {
             "type": "array",

--- a/contracts/openapi/features.json
+++ b/contracts/openapi/features.json
@@ -7,7 +7,9 @@
   "paths": {
     "/features/definitions": {
       "get": {
-        "tags": ["Features"],
+        "tags": [
+          "Features"
+        ],
         "summary": "Returns all feature definitions grouped by name prefix.",
         "description": "Returns all declared feature definitions, grouped by name prefix (the segment before the first dot in the feature name, e.g. 'Acme' for 'Acme.VideoConference'). Each group contains the features, their value types, defaults, and constraints. Requires the Features.Read permission.",
         "operationId": "GetFeatureDefinitions",
@@ -60,7 +62,9 @@
     },
     "/features/values": {
       "get": {
-        "tags": ["Features"],
+        "tags": [
+          "Features"
+        ],
         "summary": "Returns all resolved feature values for the current context.",
         "description": "Returns a dictionary of all feature values resolved through the Tenant → Plan → Default cascade for the current request context. Any authenticated user can read the features that apply to them.",
         "operationId": "GetAllFeatureValues",
@@ -117,7 +121,9 @@
     },
     "/features/values/{name}": {
       "get": {
-        "tags": ["Features"],
+        "tags": [
+          "Features"
+        ],
         "summary": "Returns the resolved value for a single feature.",
         "description": "Returns the resolved value for the specified feature in the current context. Returns 404 if the feature is not declared in any definition provider.",
         "operationId": "GetFeatureValue",
@@ -188,7 +194,9 @@
     },
     "/features/overrides/{name}": {
       "put": {
-        "tags": ["Features"],
+        "tags": [
+          "Features"
+        ],
         "summary": "Sets a tenant-level feature override.",
         "description": "Creates or updates a tenant-level override for the specified feature. The value is validated against the feature's value type (Toggle: true/false, Numeric: min/max bounds, Selection: allowed values). Returns 404 if the feature is not declared. Requires the Features.Manage permission.",
         "operationId": "SetFeatureOverride",
@@ -270,7 +278,9 @@
         }
       },
       "delete": {
-        "tags": ["Features"],
+        "tags": [
+          "Features"
+        ],
         "summary": "Deletes a tenant-level feature override.",
         "description": "Removes the tenant-level override for the specified feature, reverting to the Plan → Default cascade. Returns 404 if the feature is not declared. Requires the Features.Manage permission.",
         "operationId": "DeleteFeatureOverride",
@@ -367,28 +377,44 @@
             ]
           },
           "selectionValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "FeatureGroupResponse": {
-        "required": ["name", "displayName", "features"],
+        "required": [
+          "name",
+          "displayName",
+          "features"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "features": {
             "type": "array",
@@ -399,23 +425,35 @@
         }
       },
       "FeatureNumericConstraintResponse": {
-        "required": ["min", "max"],
+        "required": [
+          "min",
+          "max"
+        ],
         "type": "object",
         "properties": {
           "min": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "max": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           }
         }
       },
       "FeatureValueResponse": {
-        "required": ["name", "value"],
+        "required": [
+          "name",
+          "value"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -452,7 +490,9 @@
         }
       },
       "SetFeatureOverrideRequest": {
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "type": "object",
         "properties": {
           "value": {

--- a/contracts/openapi/hostnames.json
+++ b/contracts/openapi/hostnames.json
@@ -7,7 +7,9 @@
   "paths": {
     "/hostnames": {
       "get": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Lists the hostnames registered for an owning resource.",
         "description": "Returns hostnames registered for the specified owner (ownerType + ownerId pair), ordered by host name. At most maxResults entries are returned (capped at 500). An empty list is returned when the owner has no registered hostnames. Requires the Hostnames.Read permission.",
         "operationId": "ListManagedHostnames",
@@ -86,7 +88,9 @@
         }
       },
       "post": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Registers a new managed hostname.",
         "description": "Registers a fully-qualified hostname against an owning resource. The hostname must be globally unique — a second registration for the same host, regardless of owner, is rejected with 409. Returns the created hostname record with a 201 status. Requires the Hostnames.Manage permission.",
         "operationId": "CreateManagedHostname",
@@ -176,7 +180,9 @@
     },
     "/hostnames/availability": {
       "get": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Checks whether a hostname is available for registration.",
         "description": "Pre-flight check: returns whether the given fully-qualified hostname is free. A hostname is unavailable when it is already registered by any owner (globally unique constraint). Use before CreateManagedHostname to give immediate feedback. Requires the Hostnames.Read permission.",
         "operationId": "CheckHostnameAvailability",
@@ -246,7 +252,9 @@
     },
     "/hostnames/{id}": {
       "get": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Returns a managed hostname by id.",
         "description": "Returns the full hostname record for the given id. Returns 404 when no hostname with that id exists. Requires the Hostnames.Read permission.",
         "operationId": "GetManagedHostname",
@@ -316,7 +324,9 @@
         }
       },
       "delete": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Deletes a managed hostname.",
         "description": "Removes a hostname registration, freeing the host for re-registration by any owner. Returns 204 on success, 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "DeleteManagedHostname",
@@ -381,7 +391,9 @@
     },
     "/hostnames/{id}/primary": {
       "post": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Marks a hostname as the owner's canonical hostname.",
         "description": "Sets the IsPrimary flag on the specified hostname. This does not automatically clear the flag on other hostnames owned by the same resource — manage that explicitly. Returns 204 on success, 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "SetPrimaryHostname",
@@ -444,7 +456,9 @@
         }
       },
       "delete": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Clears the canonical hostname flag.",
         "description": "Removes the IsPrimary flag from the specified hostname. Returns 204 on success, 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "ClearPrimaryHostname",
@@ -509,7 +523,9 @@
     },
     "/hostnames/{id}/verify-now": {
       "post": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Manually triggers DNS verification for a hostname.",
         "description": "For Verifying, Error, or Active hostnames: resets exponential backoff and re-queues the DNS check (transitions to Verifying). For Pending hostnames: initializes verification by minting the challenge token and expected DNS records, then transitions to Verifying. Returns 409 when the hostname is Pending and the platform ingress target is not configured. Returns 202 Accepted with the updated hostname record. Returns 404 when not found. Requires the Hostnames.Manage permission.",
         "operationId": "VerifyHostnameNow",
@@ -591,7 +607,9 @@
     },
     "/hostnames/{id}/certificate-status": {
       "post": {
-        "tags": ["Hostnames"],
+        "tags": [
+          "Hostnames"
+        ],
         "summary": "Reports the SSL/TLS certificate status from the edge provider.",
         "description": "Webhook endpoint called by the edge provider (e.g. Cloudflare, AWS) when the certificate state changes. The request must carry a valid HMAC-SHA-256 signature in the configured header when Hostnames:CertificateWebhookSecret is set. Stores the new CertificateStatus and expiry date, and dispatches the appropriate integration event (HostnameCertificateSecuredEto or HostnameCertificateFailedEto). Idempotent: repeated delivery of the same status does not re-raise events. Returns 204 on success, 404 when not found. Requires the Hostnames.Certificates.Report permission.",
         "operationId": "ReportHostnameCertificateStatus",
@@ -678,10 +696,19 @@
   "components": {
     "schemas": {
       "CertificateStatus": {
-        "enum": ["Unprovisioned", "Provisioning", "Secured", "Error"]
+        "enum": [
+          "Unprovisioned",
+          "Provisioning",
+          "Secured",
+          "Error"
+        ]
       },
       "CreateManagedHostnameRequest": {
-        "required": ["host", "ownerType", "ownerId"],
+        "required": [
+          "host",
+          "ownerType",
+          "ownerId"
+        ],
         "type": "object",
         "properties": {
           "host": {
@@ -695,7 +722,10 @@
             "format": "uuid"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "isPrimary": {
@@ -705,7 +735,10 @@
         }
       },
       "DnsConflict": {
-        "required": ["conflictType", "details"],
+        "required": [
+          "conflictType",
+          "details"
+        ],
         "type": "object",
         "properties": {
           "conflictType": {
@@ -727,10 +760,19 @@
         ]
       },
       "DnsRecordType": {
-        "enum": ["A", "Aaaa", "Cname", "Txt"]
+        "enum": [
+          "A",
+          "Aaaa",
+          "Cname",
+          "Txt"
+        ]
       },
       "ExpectedDnsRecord": {
-        "required": ["recordType", "name", "value"],
+        "required": [
+          "recordType",
+          "name",
+          "value"
+        ],
         "type": "object",
         "properties": {
           "recordType": {
@@ -745,7 +787,10 @@
         }
       },
       "HostnameAvailabilityResponse": {
-        "required": ["host", "isAvailable"],
+        "required": [
+          "host",
+          "isAvailable"
+        ],
         "type": "object",
         "properties": {
           "host": {
@@ -760,20 +805,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -826,7 +886,10 @@
             "format": "uuid"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "isPrimary": {
@@ -836,7 +899,10 @@
             "type": "string"
           },
           "verificationToken": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "expectedDnsRecords": {
             "type": "array",
@@ -845,7 +911,10 @@
             }
           },
           "lastCheckedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "conflicts": {
@@ -859,14 +928,20 @@
             "format": "int32"
           },
           "nextCheckAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "certificateStatus": {
             "type": "string"
           },
           "certExpiresAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "createdAt": {
@@ -877,11 +952,17 @@
             "type": "string"
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "concurrencyStamp": {
             "type": "string"
@@ -914,14 +995,19 @@
         }
       },
       "ReportCertificateStatusRequest": {
-        "required": ["status"],
+        "required": [
+          "status"
+        ],
         "type": "object",
         "properties": {
           "status": {
             "$ref": "#/components/schemas/CertificateStatus"
           },
           "expiresAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }

--- a/contracts/openapi/identity-local.json
+++ b/contracts/openapi/identity-local.json
@@ -7,7 +7,9 @@
   "paths": {
     "/account/login": {
       "post": {
-        "tags": ["Account - Login"],
+        "tags": [
+          "Account - Login"
+        ],
         "summary": "Authenticates a user and sets the Identity session cookie.",
         "description": "Validates credentials (email or username + password) against ASP.NET Core Identity. On success, sets the Identity authentication cookie and returns 200. On failure, returns 401 with a generic message to prevent account enumeration. Locked-out users are notified exclusively via email with a password reset link. This endpoint is designed for headless/BFF architectures where the SPA handles the login UI and redirects back to /connect/authorize after successful authentication.",
         "operationId": "AccountLogin",
@@ -63,12 +65,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/login/two-factor": {
       "post": {
-        "tags": ["Account - Login"],
+        "tags": [
+          "Account - Login"
+        ],
         "summary": "Completes login with a TOTP code or recovery code.",
         "description": "Finalizes the two-factor authentication challenge after a successful password-based login returned requiresTwoFactor: true. The Identity.TwoFactorUserId cookie (set by the initial login) identifies the user. Accepts either a 6-digit TOTP code from an authenticator app or a single-use recovery code (when useRecoveryCode is true). On success, sets the Identity authentication cookie and returns 200. Returns 401 if the code is invalid or the 2FA session has expired.",
         "operationId": "AccountTwoFactorLogin",
@@ -134,12 +140,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/register": {
       "post": {
-        "tags": ["Account - Registration"],
+        "tags": [
+          "Account - Registration"
+        ],
         "summary": "Registers a new user account.",
         "description": "Creates a new user with the provided email and password. Returns 403 if self-registration is disabled for the current tenant. Always returns 202 to prevent email enumeration. Sends a confirmation email if the account is new, or a notification if the email is already taken. Returns 422 if the password does not meet policy requirements.",
         "operationId": "RegisterAccount",
@@ -198,12 +208,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/confirm-email": {
       "get": {
-        "tags": ["Account - Registration"],
+        "tags": [
+          "Account - Registration"
+        ],
         "summary": "Confirms a user's email address.",
         "description": "Validates the email confirmation token sent via email. Returns 204 on success, 400 if the token is invalid or expired.",
         "operationId": "ConfirmEmail",
@@ -252,12 +266,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/resend-confirmation-email": {
       "post": {
-        "tags": ["Account - Registration"],
+        "tags": [
+          "Account - Registration"
+        ],
         "summary": "Resends the email confirmation link.",
         "description": "Resends the confirmation email to the authenticated user. Always returns 202 to prevent email enumeration.",
         "operationId": "ResendConfirmationEmail",
@@ -300,7 +318,9 @@
     },
     "/account/profile": {
       "get": {
-        "tags": ["Account - Profile"],
+        "tags": [
+          "Account - Profile"
+        ],
         "summary": "Returns the current user's profile.",
         "description": "Fetches the authenticated user's profile including email, name, 2FA status, and linked external logins.",
         "operationId": "GetAccountProfile",
@@ -348,7 +368,9 @@
         }
       },
       "put": {
-        "tags": ["Account - Profile"],
+        "tags": [
+          "Account - Profile"
+        ],
         "summary": "Updates the current user's profile.",
         "description": "Updates the authenticated user's first name and last name. Returns the updated profile.",
         "operationId": "UpdateAccountProfile",
@@ -428,7 +450,9 @@
     },
     "/account/change-email": {
       "post": {
-        "tags": ["Account - Email Change"],
+        "tags": [
+          "Account - Email Change"
+        ],
         "summary": "Requests an email address change.",
         "description": "Requires password confirmation as step-up authentication (OWASP ASVS V2.8.1) so a stolen session cookie alone cannot pivot a compromised account into a permanent take-over via email change followed by password reset. Generates a change-email token and publishes an EmailChangeRequestedEto event. A security alert is sent to the current email and a confirmation link to the new email. Returns 400 if the current password is incorrect; otherwise always returns 202 to prevent email enumeration.",
         "operationId": "ChangeEmail",
@@ -501,7 +525,9 @@
     },
     "/account/confirm-email-change": {
       "post": {
-        "tags": ["Account - Email Change"],
+        "tags": [
+          "Account - Email Change"
+        ],
         "summary": "Confirms an email address change using a token.",
         "description": "Validates the email change token from the confirmation link, applies the new email, and updates the username to match. Returns 400 if the token is invalid or expired.",
         "operationId": "ConfirmEmailChange",
@@ -550,12 +576,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/change-password": {
       "post": {
-        "tags": ["Account - Password"],
+        "tags": [
+          "Account - Password"
+        ],
         "summary": "Changes the authenticated user's password.",
         "description": "Validates the current password, then sets the new password. Returns 400 if the current password is incorrect or the new password is too weak.",
         "operationId": "ChangePassword",
@@ -628,7 +658,9 @@
     },
     "/account/forgot-password": {
       "post": {
-        "tags": ["Account - Password"],
+        "tags": [
+          "Account - Password"
+        ],
         "summary": "Sends a password reset email.",
         "description": "Sends a password reset link to the specified email if the account exists. Always returns 202 to prevent user enumeration.",
         "operationId": "ForgotPassword",
@@ -667,12 +699,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/reset-password": {
       "post": {
-        "tags": ["Account - Password"],
+        "tags": [
+          "Account - Password"
+        ],
         "summary": "Resets a user's password using a reset token.",
         "description": "Validates the reset token from the email link and sets the new password. Returns 400 if the token is invalid or expired.",
         "operationId": "ResetPassword",
@@ -721,12 +757,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/two-factor": {
       "get": {
-        "tags": ["Account - Two-Factor"],
+        "tags": [
+          "Account - Two-Factor"
+        ],
         "summary": "Returns the current 2FA status.",
         "description": "Returns whether 2FA is enabled, whether an authenticator app is configured, and the number of unused recovery codes.",
         "operationId": "GetTwoFactorStatus",
@@ -776,7 +816,9 @@
     },
     "/account/two-factor/authenticator-key": {
       "get": {
-        "tags": ["Account - Two-Factor"],
+        "tags": [
+          "Account - Two-Factor"
+        ],
         "summary": "Returns the TOTP shared key and QR code URI.",
         "description": "Generates or returns the existing TOTP shared key for the user. The QR code URI can be rendered by the frontend for authenticator app scanning.",
         "operationId": "GetAuthenticatorKey",
@@ -826,7 +868,9 @@
     },
     "/account/two-factor/enable": {
       "post": {
-        "tags": ["Account - Two-Factor"],
+        "tags": [
+          "Account - Two-Factor"
+        ],
         "summary": "Enables 2FA after TOTP code verification.",
         "description": "Validates the provided TOTP code against the shared key. On success, enables 2FA and returns single-use recovery codes. Returns 400 if the code is invalid.",
         "operationId": "EnableTwoFactor",
@@ -906,7 +950,9 @@
     },
     "/account/two-factor/disable": {
       "post": {
-        "tags": ["Account - Two-Factor"],
+        "tags": [
+          "Account - Two-Factor"
+        ],
         "summary": "Disables 2FA for the authenticated user.",
         "description": "Disables TOTP-based two-factor authentication. Requires password confirmation as step-up authentication (OWASP ASVS V2.8.1).",
         "operationId": "DisableTwoFactor",
@@ -979,7 +1025,9 @@
     },
     "/account/two-factor/recovery-codes": {
       "post": {
-        "tags": ["Account - Two-Factor"],
+        "tags": [
+          "Account - Two-Factor"
+        ],
         "summary": "Generates new recovery codes.",
         "description": "Generates 10 new single-use recovery codes. Previously generated codes are invalidated. Requires password confirmation as step-up authentication. Recovery codes can be used instead of a TOTP code during login.",
         "operationId": "GenerateRecoveryCodes",
@@ -1059,7 +1107,9 @@
     },
     "/account/external-logins": {
       "get": {
-        "tags": ["Account - External Logins"],
+        "tags": [
+          "Account - External Logins"
+        ],
         "summary": "Lists linked external login providers.",
         "description": "Returns the list of external providers (Google, Microsoft, GitHub) currently linked to the authenticated user's account.",
         "operationId": "ListExternalLogins",
@@ -1112,7 +1162,9 @@
     },
     "/account/external-logins/challenge/{provider}": {
       "post": {
-        "tags": ["Account - External Logins"],
+        "tags": [
+          "Account - External Logins"
+        ],
         "summary": "Initiates an OAuth flow with an external provider.",
         "description": "Validates that the specified provider is registered in IExternalProviderRegistry and returns 200 with metadata for the frontend to initiate the redirect via the standard OAuth client flow. Returns 400 if the provider is not configured.",
         "operationId": "ChallengeExternalLogin",
@@ -1151,12 +1203,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/external-logins/callback": {
       "get": {
-        "tags": ["Account - External Logins"],
+        "tags": [
+          "Account - External Logins"
+        ],
         "summary": "Processes the OAuth callback from an external provider.",
         "description": "Handles the redirect from the external provider. Links the external account to an existing user or creates a new one if AutoRegisterExternalUsers is enabled. Returns 400 if the provider query parameter is missing. Returns 409 if the email is taken by another account. Returns 403 if auto-registration is disabled and no account exists.",
         "operationId": "ExternalLoginCallback",
@@ -1212,12 +1268,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/external-logins/{provider}": {
       "delete": {
-        "tags": ["Account - External Logins"],
+        "tags": [
+          "Account - External Logins"
+        ],
         "summary": "Unlinks an external login provider.",
         "description": "Removes the association between the authenticated user and the specified provider. Returns 400 if it's the last login method and no password is set.",
         "operationId": "UnlinkExternalLogin",
@@ -1280,7 +1340,9 @@
     },
     "/account/passkeys": {
       "get": {
-        "tags": ["Account - Passkeys"],
+        "tags": [
+          "Account - Passkeys"
+        ],
         "summary": "Lists registered passkeys.",
         "description": "Returns the list of WebAuthn passkeys registered for the authenticated user.",
         "operationId": "ListPasskeys",
@@ -1333,7 +1395,9 @@
     },
     "/account/passkeys/register/begin": {
       "post": {
-        "tags": ["Account - Passkeys"],
+        "tags": [
+          "Account - Passkeys"
+        ],
         "summary": "Begins a WebAuthn passkey registration ceremony.",
         "description": "Returns PublicKeyCredentialCreationOptions with mediation: conditional for browser-native passkey autofill support.",
         "operationId": "BeginPasskeyRegistration",
@@ -1383,7 +1447,9 @@
     },
     "/account/passkeys/register/complete": {
       "post": {
-        "tags": ["Account - Passkeys"],
+        "tags": [
+          "Account - Passkeys"
+        ],
         "summary": "Completes a WebAuthn passkey registration ceremony.",
         "description": "Validates and stores the credential via ASP.NET Identity's built-in WebAuthn support.",
         "operationId": "CompletePasskeyRegistration",
@@ -1463,7 +1529,9 @@
     },
     "/account/passkeys/assertion/begin": {
       "post": {
-        "tags": ["Account - Passkeys"],
+        "tags": [
+          "Account - Passkeys"
+        ],
         "summary": "Begins a WebAuthn passkey assertion ceremony (login).",
         "description": "Returns PublicKeyCredentialRequestOptions with mediation: conditional and empty allowCredentials for Conditional UI autofill.",
         "operationId": "BeginPasskeyAssertion",
@@ -1489,12 +1557,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/passkeys/assertion/complete": {
       "post": {
-        "tags": ["Account - Passkeys"],
+        "tags": [
+          "Account - Passkeys"
+        ],
         "summary": "Completes a WebAuthn passkey assertion ceremony (login).",
         "description": "Validates the AuthenticatorAssertionResponse from the browser against stored public keys. On success, signs in the user via ASP.NET Core Identity and returns the login response. Returns 401 if the credential is invalid or no matching user is found.",
         "operationId": "CompletePasskeyAssertion",
@@ -1560,12 +1632,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/account/passkeys/{id}": {
       "patch": {
-        "tags": ["Account - Passkeys"],
+        "tags": [
+          "Account - Passkeys"
+        ],
         "summary": "Renames a passkey.",
         "description": "Updates the friendly name of a registered passkey.",
         "operationId": "RenamePasskey",
@@ -1648,7 +1724,9 @@
         }
       },
       "delete": {
-        "tags": ["Account - Passkeys"],
+        "tags": [
+          "Account - Passkeys"
+        ],
         "summary": "Deletes a passkey.",
         "description": "Removes a registered passkey. Returns 400 if this is the last credential and no password is set on the account.",
         "operationId": "DeletePasskey",
@@ -1723,7 +1801,9 @@
     },
     "/account/delete": {
       "post": {
-        "tags": ["Account - Deletion"],
+        "tags": [
+          "Account - Deletion"
+        ],
         "summary": "Deletes the authenticated user's account.",
         "description": "Initiates account deletion (GDPR Article 17 — right to erasure). Requires password confirmation. Triggers soft-delete, token revocation, and publishes AccountDeletedEto for downstream cleanup. Returns 202 as deletion is asynchronous.",
         "operationId": "DeleteAccount",
@@ -1796,7 +1876,9 @@
     },
     "/account/session/heartbeat": {
       "post": {
-        "tags": ["Account - Session"],
+        "tags": [
+          "Account - Session"
+        ],
         "summary": "Resets the idle session timer.",
         "description": "Updates LastActivityAt in the distributed cache. Returns 204 if the session is still active. No-op for sessions with remember_me claim.",
         "operationId": "SessionHeartbeat",
@@ -1839,7 +1921,9 @@
     },
     "/account/session/back-to-impersonator": {
       "post": {
-        "tags": ["Impersonation"],
+        "tags": [
+          "Impersonation"
+        ],
         "summary": "Ends an impersonation session and returns to the admin account.",
         "description": "Reads the impersonator_id claim from the current (impersonated) token and issues a fresh token set for the original admin user. Returns 400 if the current token is not an impersonation token.",
         "operationId": "BackToImpersonator",
@@ -1899,7 +1983,9 @@
     },
     "/account/config": {
       "get": {
-        "tags": ["Account - Config"],
+        "tags": [
+          "Account - Config"
+        ],
         "summary": "Returns the current Account - Config module configuration.",
         "description": "Returns the runtime configuration of the Account - Config module — the same shape used by SPAs to render module-specific UI without hardcoding values. The payload is module-defined and stable; clients should not assume new fields are absent.",
         "operationId": "GetAccountConfig",
@@ -1925,12 +2011,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/admin/users/{userId}/impersonate": {
       "post": {
-        "tags": ["Impersonation"],
+        "tags": [
+          "Impersonation"
+        ],
         "summary": "Impersonates a user.",
         "description": "Issues a short-lived token (max 1h) with impersonator_id claim. Writes audit log and sends transparency notification.",
         "operationId": "ImpersonateUser",
@@ -2002,7 +2092,9 @@
     },
     "/admin/roles": {
       "get": {
-        "tags": ["Identity - Roles"],
+        "tags": [
+          "Identity - Roles"
+        ],
         "summary": "Lists roles visible in the caller's context.",
         "description": "Host admins see every role (CRUD on Host / Both, read-only on tenant roles). Tenant admins see Both roles (read-only) plus their own tenant roles (CRUD).",
         "operationId": "ListRoles",
@@ -2053,7 +2145,9 @@
         }
       },
       "post": {
-        "tags": ["Identity - Roles"],
+        "tags": [
+          "Identity - Roles"
+        ],
         "summary": "Creates a new local role and its RoleMetadata row.",
         "description": "Invariants: Host / Both ⇒ TenantId must be null; Tenant ⇒ TenantId required. Tenant admins may only create Tenant-scope roles in their own tenant. Set RoleEndpointsOptions.AllowTenantRoles = false to disable Tenant-scope creation entirely.",
         "operationId": "CreateRole",
@@ -2133,7 +2227,9 @@
     },
     "/admin/roles/{id}": {
       "get": {
-        "tags": ["Identity - Roles"],
+        "tags": [
+          "Identity - Roles"
+        ],
         "summary": "Returns a single role by identifier.",
         "description": "Returns 404 when the role is not visible in the caller's context (no 403 to prevent leak).",
         "operationId": "GetRole",
@@ -2203,7 +2299,9 @@
         }
       },
       "put": {
-        "tags": ["Identity - Roles"],
+        "tags": [
+          "Identity - Roles"
+        ],
         "summary": "Renames a role and updates its description.",
         "description": "Side and tenant scope are immutable. System roles and non-visible roles cannot be renamed.",
         "operationId": "RenameRole",
@@ -2303,7 +2401,9 @@
         }
       },
       "delete": {
-        "tags": ["Identity - Roles"],
+        "tags": [
+          "Identity - Roles"
+        ],
         "summary": "Hard-deletes a non-system role.",
         "description": "System roles (SuperAdmin, TenantAdministrator, User) and non-visible roles cannot be deleted.",
         "operationId": "DeleteRole",
@@ -2370,7 +2470,10 @@
   "components": {
     "schemas": {
       "AccountAuthenticatorKeyResponse": {
-        "required": ["sharedKey", "qrCodeUri"],
+        "required": [
+          "sharedKey",
+          "qrCodeUri"
+        ],
         "type": "object",
         "properties": {
           "sharedKey": {
@@ -2382,7 +2485,10 @@
         }
       },
       "AccountChangeEmailRequest": {
-        "required": ["newEmail", "currentPassword"],
+        "required": [
+          "newEmail",
+          "currentPassword"
+        ],
         "type": "object",
         "properties": {
           "newEmail": {
@@ -2394,7 +2500,11 @@
         }
       },
       "AccountConfirmEmailChangeRequest": {
-        "required": ["userId", "newEmail", "token"],
+        "required": [
+          "userId",
+          "newEmail",
+          "token"
+        ],
         "type": "object",
         "properties": {
           "userId": {
@@ -2409,7 +2519,9 @@
         }
       },
       "AccountDeleteRequest": {
-        "required": ["password"],
+        "required": [
+          "password"
+        ],
         "type": "object",
         "properties": {
           "password": {
@@ -2418,7 +2530,9 @@
         }
       },
       "AccountForgotPasswordRequest": {
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "type": "object",
         "properties": {
           "email": {
@@ -2427,7 +2541,9 @@
         }
       },
       "AccountGenerateRecoveryCodesRequest": {
-        "required": ["password"],
+        "required": [
+          "password"
+        ],
         "type": "object",
         "properties": {
           "password": {
@@ -2436,7 +2552,10 @@
         }
       },
       "AccountLoginRequest": {
-        "required": ["login", "password"],
+        "required": [
+          "login",
+          "password"
+        ],
         "type": "object",
         "properties": {
           "login": {
@@ -2452,7 +2571,9 @@
         }
       },
       "AccountLoginResponse": {
-        "required": ["succeeded"],
+        "required": [
+          "succeeded"
+        ],
         "type": "object",
         "properties": {
           "succeeded": {
@@ -2473,7 +2594,9 @@
         }
       },
       "AccountPasskeyLoginRequest": {
-        "required": ["credentialJson"],
+        "required": [
+          "credentialJson"
+        ],
         "type": "object",
         "properties": {
           "credentialJson": {
@@ -2482,7 +2605,10 @@
         }
       },
       "AccountPasswordChangeRequest": {
-        "required": ["currentPassword", "newPassword"],
+        "required": [
+          "currentPassword",
+          "newPassword"
+        ],
         "type": "object",
         "properties": {
           "currentPassword": {
@@ -2494,7 +2620,11 @@
         }
       },
       "AccountPasswordResetRequest": {
-        "required": ["userId", "token", "newPassword"],
+        "required": [
+          "userId",
+          "token",
+          "newPassword"
+        ],
         "type": "object",
         "properties": {
           "userId": {
@@ -2532,10 +2662,16 @@
             "type": "boolean"
           },
           "firstName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "lastName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "twoFactorEnabled": {
             "type": "boolean"
@@ -2552,19 +2688,26 @@
         }
       },
       "AccountProfileUpdateRequest": {
-        "required": ["firstName", "lastName"],
         "type": "object",
         "properties": {
           "firstName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "lastName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AccountRecoveryCodesResponse": {
-        "required": ["recoveryCodes"],
+        "required": [
+          "recoveryCodes"
+        ],
         "type": "object",
         "properties": {
           "recoveryCodes": {
@@ -2576,7 +2719,10 @@
         }
       },
       "AccountRegisterRequest": {
-        "required": ["email", "password", "firstName", "lastName"],
+        "required": [
+          "email",
+          "password"
+        ],
         "type": "object",
         "properties": {
           "email": {
@@ -2586,15 +2732,23 @@
             "type": "string"
           },
           "firstName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "lastName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AccountTwoFactorDisableRequest": {
-        "required": ["password"],
+        "required": [
+          "password"
+        ],
         "type": "object",
         "properties": {
           "password": {
@@ -2603,7 +2757,9 @@
         }
       },
       "AccountTwoFactorEnableRequest": {
-        "required": ["code"],
+        "required": [
+          "code"
+        ],
         "type": "object",
         "properties": {
           "code": {
@@ -2612,7 +2768,9 @@
         }
       },
       "AccountTwoFactorEnableResponse": {
-        "required": ["recoveryCodes"],
+        "required": [
+          "recoveryCodes"
+        ],
         "type": "object",
         "properties": {
           "recoveryCodes": {
@@ -2624,7 +2782,9 @@
         }
       },
       "AccountTwoFactorLoginRequest": {
-        "required": ["code"],
+        "required": [
+          "code"
+        ],
         "type": "object",
         "properties": {
           "code": {
@@ -2641,7 +2801,11 @@
         }
       },
       "AccountTwoFactorStatusResponse": {
-        "required": ["isEnabled", "hasAuthenticatorApp", "recoveryCodesLeft"],
+        "required": [
+          "isEnabled",
+          "hasAuthenticatorApp",
+          "recoveryCodesLeft"
+        ],
         "type": "object",
         "properties": {
           "isEnabled": {
@@ -2657,7 +2821,11 @@
         }
       },
       "ExternalLoginInfoResponse": {
-        "required": ["loginProvider", "providerKey", "providerDisplayName"],
+        "required": [
+          "loginProvider",
+          "providerKey",
+          "providerDisplayName"
+        ],
         "type": "object",
         "properties": {
           "loginProvider": {
@@ -2667,7 +2835,10 @@
             "type": "string"
           },
           "providerDisplayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2675,20 +2846,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -2702,7 +2888,9 @@
         }
       },
       "IdentityLocalConfigResponse": {
-        "required": ["allowSelfRegistration"],
+        "required": [
+          "allowSelfRegistration"
+        ],
         "type": "object",
         "properties": {
           "allowSelfRegistration": {
@@ -2711,7 +2899,11 @@
         }
       },
       "ImpersonationResponse": {
-        "required": ["accessToken", "refreshToken", "expiresIn"],
+        "required": [
+          "accessToken",
+          "refreshToken",
+          "expiresIn"
+        ],
         "type": "object",
         "properties": {
           "accessToken": {
@@ -2731,7 +2923,12 @@
         "description": "Scope of an object (permission, BFF frontend, ...) relative to the host/tenant boundary."
       },
       "PasskeyInfoResponse": {
-        "required": ["id", "name", "createdAt", "lastUsedAt"],
+        "required": [
+          "id",
+          "name",
+          "createdAt",
+          "lastUsedAt"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -2739,32 +2936,45 @@
             "format": "uuid"
           },
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "createdAt": {
             "type": "string",
             "format": "date-time"
           },
           "lastUsedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
       },
       "PasskeyRegistrationRequest": {
-        "required": ["credentialJson", "name"],
+        "required": [
+          "credentialJson"
+        ],
         "type": "object",
         "properties": {
           "credentialJson": {
             "type": "string"
           },
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PasskeyRenameRequest": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2798,7 +3008,10 @@
         }
       },
       "ProcessCallbackResult": {
-        "required": ["userId", "isNewUser"],
+        "required": [
+          "userId",
+          "isNewUser"
+        ],
         "type": "object",
         "properties": {
           "userId": {
@@ -2811,7 +3024,11 @@
         }
       },
       "RoleCreateRequest": {
-        "required": ["name", "multiTenancySides", "tenantId", "description"],
+        "required": [
+          "name",
+          "multiTenancySides",
+          "tenantId"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2821,11 +3038,17 @@
             "$ref": "#/components/schemas/MultiTenancySides"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2854,14 +3077,23 @@
             "$ref": "#/components/schemas/MultiTenancySides"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "clientId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "isSystem": {
             "type": "boolean"
@@ -2871,20 +3103,28 @@
             "format": "date-time"
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
       },
       "RoleUpdateRequest": {
-        "required": ["name", "description"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       }

--- a/contracts/openapi/identity.json
+++ b/contracts/openapi/identity.json
@@ -7,7 +7,9 @@
   "paths": {
     "/identity/users/capabilities": {
       "get": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Returns the capabilities of the active identity provider.",
         "description": "Returns the feature flags of the currently active identity provider (Keycloak, Azure AD, etc.): session termination support, native password reset, group hierarchy, custom attributes, credential verification, and user creation. The front-end uses this to conditionally render identity management features.",
         "operationId": "GetIdentityProviderCapabilities",
@@ -57,7 +59,9 @@
     },
     "/identity/users": {
       "get": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Searches the user cache by free-text term with pagination.",
         "description": "Performs a free-text search across cached user fields (name, email, etc.) with pagination and sorting. Only searches the local cache — does not query the identity provider. Use sync endpoints to refresh stale data.",
         "operationId": "SearchIdentityUserCache",
@@ -107,7 +111,9 @@
     },
     "/identity/users/{userId}": {
       "get": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Resolves a single user by external ID (cache-aside: fetches from provider if stale/missing).",
         "description": "Looks up the user in the local cache first. If the entry is missing or stale, transparently fetches from the identity provider and updates the cache before returning. Returns 404 if the user does not exist in either the cache or the provider.",
         "operationId": "GetIdentityUserById",
@@ -176,7 +182,9 @@
         }
       },
       "delete": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "GDPR Art. 17 — permanently deletes the cached entry for a user.",
         "description": "Implements the GDPR right to erasure (Article 17). Permanently removes the user's cached identity data. This does not affect the upstream identity provider — the data will be re-cached if the user is looked up again. For full erasure, also delete in the identity provider.",
         "operationId": "EraseIdentityUserCache",
@@ -230,7 +238,9 @@
     },
     "/identity/users/batch": {
       "post": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Resolves multiple user IDs to identity information in batch.",
         "description": "Resolves a list of user IDs in a single request, using the cache-aside pattern. Unknown IDs are silently omitted from the result. Useful for enriching lists of entities with user display names without N+1 calls.",
         "operationId": "BatchResolveIdentityUsers",
@@ -303,7 +313,9 @@
     },
     "/identity/users/stats": {
       "get": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Returns cache statistics: total entries, stale count, oldest/newest sync timestamps.",
         "description": "Returns aggregate statistics about the identity user cache: total number of cached entries, count of stale entries needing refresh, and the timestamp range of the oldest and newest synchronization. Useful for monitoring cache health and scheduling sync operations.",
         "operationId": "GetIdentityUserCacheStats",
@@ -353,7 +365,9 @@
     },
     "/identity/users/sync": {
       "post": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Forces refresh of specific users from the identity provider.",
         "description": "Fetches the latest data for the specified user IDs from the identity provider and updates the cache. Returns the refreshed user records. Users not found in the provider are silently skipped.",
         "operationId": "SyncIdentityUsers",
@@ -426,7 +440,9 @@
     },
     "/identity/users/sync-all": {
       "post": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Full sync — fetches all users from the identity provider and upserts the cache.",
         "description": "Fetches every user from the identity provider and upserts the entire cache. This is an expensive operation — use sparingly (e.g., nightly scheduled job or initial setup). Returns the count of synchronized entries.",
         "operationId": "SyncAllIdentityUsers",
@@ -476,7 +492,9 @@
     },
     "/identity/users/sync-stale": {
       "post": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "Incremental sync — refreshes only stale cache entries.",
         "description": "Refreshes only cache entries whose last sync timestamp exceeds the configured staleness threshold. More efficient than a full sync for routine maintenance. Returns the count of refreshed entries.",
         "operationId": "SyncStaleIdentityUsers",
@@ -526,7 +544,9 @@
     },
     "/identity/users/{userId}/pseudonymize": {
       "patch": {
-        "tags": ["Identity - User Cache"],
+        "tags": [
+          "Identity - User Cache"
+        ],
         "summary": "GDPR Art. 18 — replaces PII with anonymized data in the cached entry.",
         "description": "Implements the GDPR right to restriction of processing (Article 18). Replaces all personally identifiable information (name, email, etc.) with anonymized placeholders while preserving the entry for referential integrity. Irreversible.",
         "operationId": "PseudonymizeIdentityUserCache",
@@ -580,7 +600,9 @@
     },
     "/identity/webhook": {
       "post": {
-        "tags": ["Identity - Webhook"],
+        "tags": [
+          "Identity - Webhook"
+        ],
         "summary": "Receives identity provider webhook events (user created/updated/deleted).",
         "description": "Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries. No bearer authentication — security relies on HMAC signature validation in the handler.",
         "operationId": "IdentityWebhook",
@@ -629,7 +651,9 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     }
   },
@@ -680,7 +704,9 @@
         }
       },
       "IdentityUserCacheBatchRequest": {
-        "required": ["userIds"],
+        "required": [
+          "userIds"
+        ],
         "type": "object",
         "properties": {
           "userIds": {
@@ -692,7 +718,12 @@
         }
       },
       "IdentityUserCacheStatsResponse": {
-        "required": ["totalEntries", "staleEntries", "oldestSyncAt", "newestSyncAt"],
+        "required": [
+          "totalEntries",
+          "staleEntries",
+          "oldestSyncAt",
+          "newestSyncAt"
+        ],
         "type": "object",
         "properties": {
           "totalEntries": {
@@ -704,17 +735,25 @@
             "format": "int32"
           },
           "oldestSyncAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "newestSyncAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
       },
       "IdentityUserCacheSyncAllResponse": {
-        "required": ["syncedCount"],
+        "required": [
+          "syncedCount"
+        ],
         "type": "object",
         "properties": {
           "syncedCount": {
@@ -724,7 +763,9 @@
         }
       },
       "IdentityUserCacheSyncRequest": {
-        "required": ["userIds"],
+        "required": [
+          "userIds"
+        ],
         "type": "object",
         "properties": {
           "userIds": {
@@ -736,7 +777,9 @@
         }
       },
       "IdentityUserCacheSyncStaleResponse": {
-        "required": ["refreshedCount"],
+        "required": [
+          "refreshedCount"
+        ],
         "type": "object",
         "properties": {
           "refreshedCount": {
@@ -746,23 +789,43 @@
         }
       },
       "IdentityUserResponse": {
-        "required": ["userId", "username", "email", "firstName", "lastName", "enabled", "metadata"],
+        "required": [
+          "userId",
+          "username",
+          "email",
+          "firstName",
+          "lastName",
+          "enabled",
+          "metadata"
+        ],
         "type": "object",
         "properties": {
           "userId": {
             "type": "string"
           },
           "username": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "email": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "firstName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "lastName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "enabled": {
             "type": "boolean"
@@ -776,7 +839,11 @@
         }
       },
       "PagedResultOfIdentityUserResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -786,14 +853,20 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },

--- a/contracts/openapi/localization.json
+++ b/contracts/openapi/localization.json
@@ -7,7 +7,9 @@
   "paths": {
     "/localization": {
       "get": {
-        "tags": ["Localization"],
+        "tags": [
+          "Localization"
+        ],
         "summary": "Returns all localization resources for the requested culture.",
         "description": "Returns all localization resources (key-value pairs) for the requested culture, grouped by resource name. Accepts an optional cultureName query parameter (BCP 47 format); defaults to the Accept-Language header culture. Also returns the list of supported languages. Response is cached for 1 hour (Cache-Control: public, max-age=3600, Vary: Accept-Language). Anonymous — no authentication required.",
         "operationId": "GetLocalization",
@@ -55,12 +57,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/localization/overrides": {
       "get": {
-        "tags": ["Localization"],
+        "tags": [
+          "Localization"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of LocalizationOverride entries.",
         "description": "Executes a dynamic query against LocalizationOverride using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryLocalizationOverride",
@@ -71,7 +77,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -82,7 +91,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -91,7 +103,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -99,7 +114,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -107,7 +125,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -115,7 +136,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -123,7 +147,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -131,7 +158,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -141,7 +171,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -154,7 +187,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -225,7 +261,9 @@
     },
     "/localization/overrides/meta": {
       "get": {
-        "tags": ["Localization"],
+        "tags": [
+          "Localization"
+        ],
         "summary": "Returns query metadata for LocalizationOverride (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for LocalizationOverride: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetLocalizationOverrideMeta",
@@ -275,7 +313,9 @@
     },
     "/localization/overrides/{resourceName}/{cultureName}/{key}": {
       "put": {
-        "tags": ["Localization"],
+        "tags": [
+          "Localization"
+        ],
         "summary": "Creates or updates a translation override.",
         "description": "Sets a translation override for a specific resource, culture, and key. If an override already exists, it is replaced. The culture name must be a valid BCP 47 tag. Returns 501 if no override store is registered.",
         "operationId": "PutLocalizationOverride",
@@ -385,7 +425,9 @@
         }
       },
       "delete": {
-        "tags": ["Localization"],
+        "tags": [
+          "Localization"
+        ],
         "summary": "Removes a translation override.",
         "description": "Removes the translation override for the specified resource, culture, and key. The original value from the resource file becomes effective again. No-op if the override does not exist. Returns 501 if no override store is registered.",
         "operationId": "DeleteLocalizationOverride",
@@ -479,7 +521,11 @@
   "components": {
     "schemas": {
       "ApplicationLocalizationResponse": {
-        "required": ["cultureName", "resources", "languages"],
+        "required": [
+          "cultureName",
+          "resources",
+          "languages"
+        ],
         "type": "object",
         "properties": {
           "cultureName": {
@@ -538,12 +584,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -561,10 +614,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -580,7 +645,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -598,7 +666,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -630,7 +702,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -642,7 +717,10 @@
         }
       },
       "GroupedResultOfLocalizationOverride": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -658,13 +736,18 @@
         }
       },
       "GroupEntryOfLocalizationOverride": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -673,10 +756,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/LocalizationOverride"
             }
@@ -687,20 +776,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -714,7 +818,12 @@
         }
       },
       "LanguageInfoResponse": {
-        "required": ["cultureName", "displayName", "flagIcon", "isDefault"],
+        "required": [
+          "cultureName",
+          "displayName",
+          "flagIcon",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "cultureName": {
@@ -724,7 +833,10 @@
             "type": "string"
           },
           "flagIcon": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "isDefault": {
             "type": "boolean"
@@ -735,7 +847,10 @@
         "type": "object",
         "properties": {
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "resourceName": {
@@ -751,12 +866,18 @@
             "type": "string"
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Identifier of the user who last modified the entity."
           },
           "createdAt": {
@@ -779,23 +900,38 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -803,11 +939,20 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "PagedResultOfLocalizationOverride": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -816,7 +961,10 @@
               "type": "object",
               "properties": {
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "resourceName": {
@@ -832,12 +980,18 @@
                   "type": "string"
                 },
                 "modifiedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "createdAt": {
@@ -858,19 +1012,30 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -891,7 +1056,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -989,12 +1158,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1009,7 +1185,9 @@
         }
       },
       "SetLocalizationOverrideRequest": {
-        "required": ["value"],
+        "required": [
+          "value"
+        ],
         "type": "object",
         "properties": {
           "value": {
@@ -1018,7 +1196,9 @@
         }
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/multi-tenancy.json
+++ b/contracts/openapi/multi-tenancy.json
@@ -7,7 +7,9 @@
   "paths": {
     "/multi-tenancy/tenants/{id}": {
       "get": {
-        "tags": ["Platform - Tenants"],
+        "tags": [
+          "Platform - Tenants"
+        ],
         "summary": "Returns a tenant by ID.",
         "description": "Fetches the full tenant details by unique identifier. Returns 404 if the tenant does not exist. Requires the MultiTenancy.Tenants.Read permission.",
         "operationId": "GetTenant",
@@ -77,7 +79,9 @@
         }
       },
       "put": {
-        "tags": ["Platform - Tenants"],
+        "tags": [
+          "Platform - Tenants"
+        ],
         "summary": "Updates a tenant's details.",
         "description": "Updates the display name and contact email of an existing tenant. Returns 404 if the tenant does not exist. Returns 409 if the concurrency stamp does not match the stored value. Requires the MultiTenancy.Tenants.Update permission.",
         "operationId": "UpdateTenant",
@@ -182,7 +186,9 @@
     },
     "/multi-tenancy/tenants": {
       "post": {
-        "tags": ["Platform - Tenants"],
+        "tags": [
+          "Platform - Tenants"
+        ],
         "summary": "Creates a new tenant.",
         "description": "Creates a new active tenant with the specified name and identifier. The identifier must be unique, lowercase alphanumeric with hyphens (slug format). Returns the created tenant. Requires the MultiTenancy.Tenants.Create permission.",
         "operationId": "CreateTenant",
@@ -262,7 +268,9 @@
     },
     "/multi-tenancy/tenants/{id}/activate": {
       "post": {
-        "tags": ["Platform - Tenants"],
+        "tags": [
+          "Platform - Tenants"
+        ],
         "summary": "Activates a tenant.",
         "description": "Activates a previously deactivated tenant, allowing it to be resolved by the tenant resolution middleware. Returns 404 if the tenant does not exist. Requires the MultiTenancy.Tenants.Manage permission.",
         "operationId": "ActivateTenant",
@@ -327,7 +335,9 @@
     },
     "/multi-tenancy/tenants/{id}/deactivate": {
       "post": {
-        "tags": ["Platform - Tenants"],
+        "tags": [
+          "Platform - Tenants"
+        ],
         "summary": "Deactivates a tenant.",
         "description": "Deactivates a tenant, preventing it from being resolved by the tenant resolution middleware. Raises a TenantDeactivatedEvent that can trigger session invalidation. Returns 404 if the tenant does not exist. Requires the MultiTenancy.Tenants.Manage permission.",
         "operationId": "DeactivateTenant",
@@ -394,7 +404,10 @@
   "components": {
     "schemas": {
       "CreateTenantRequest": {
-        "required": ["name", "identifier", "contactEmail", "jurisdiction"],
+        "required": [
+          "name",
+          "identifier"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -404,10 +417,16 @@
             "type": "string"
           },
           "contactEmail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "jurisdiction": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -415,20 +434,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -490,13 +524,19 @@
             "type": "string"
           },
           "contactEmail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "activated": {
             "type": "boolean"
           },
           "jurisdiction": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -508,20 +548,29 @@
         }
       },
       "UpdateTenantRequest": {
-        "required": ["name", "contactEmail", "jurisdiction", "concurrencyStamp"],
+        "required": [
+          "name",
+          "concurrencyStamp"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
-          "contactEmail": {
-            "type": ["null", "string"]
-          },
-          "jurisdiction": {
-            "type": ["null", "string"]
-          },
           "concurrencyStamp": {
             "type": "string"
+          },
+          "contactEmail": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "jurisdiction": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       }

--- a/contracts/openapi/notifications.json
+++ b/contracts/openapi/notifications.json
@@ -7,7 +7,9 @@
   "paths": {
     "/notifications": {
       "get": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Returns the user's notification inbox, newest first.",
         "description": "Returns a paginated list of the current user's notifications. Supports filtering by read/unread status. Results are sorted by creation date, newest first.",
         "operationId": "GetNotifications",
@@ -79,7 +81,9 @@
     },
     "/notifications/unread/count": {
       "get": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Returns the number of unread notifications for the current user.",
         "description": "Returns the total count of unread notifications for the authenticated user within the current tenant. Use this to display a badge count in the UI.",
         "operationId": "GetUnreadCount",
@@ -129,7 +133,9 @@
     },
     "/notifications/{id}/read": {
       "post": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Marks a single notification as read.",
         "description": "Marks the specified notification as read by setting its read timestamp. Idempotent — marking an already-read notification is a no-op.",
         "operationId": "MarkAsRead",
@@ -184,7 +190,9 @@
     },
     "/notifications/read-all": {
       "post": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Marks all notifications as read for the current user.",
         "description": "Marks all unread notifications as read for the authenticated user within the current tenant. Useful for a 'mark all as read' bulk action.",
         "operationId": "MarkAllAsRead",
@@ -227,7 +235,9 @@
     },
     "/notifications/entity/{entityType}/{entityId}": {
       "get": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Returns the activity feed for a specific entity.",
         "description": "Returns a paginated list of notifications related to a specific entity. Useful for displaying an activity log on an entity detail page. Results are sorted by creation date, newest first.",
         "operationId": "GetEntityActivityFeed",
@@ -317,7 +327,9 @@
     },
     "/notifications/preferences": {
       "get": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Returns notification delivery preferences for the current user.",
         "description": "Returns all notification delivery preferences for the authenticated user within the current tenant. Each preference indicates whether a specific notification type is enabled or disabled for a given channel.",
         "operationId": "GetPreferences",
@@ -368,7 +380,9 @@
         }
       },
       "put": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Creates or updates a notification delivery preference.",
         "description": "Creates or updates a delivery preference for a specific notification type and channel. If a preference already exists for the same type and channel, it is replaced (upsert).",
         "operationId": "UpdatePreference",
@@ -441,7 +455,9 @@
     },
     "/notifications/types": {
       "get": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Returns all registered notification type definitions.",
         "description": "Returns all notification types registered in the system with their metadata. Use this to build the preferences UI, showing which notification types are available and their supported channels.",
         "operationId": "GetNotificationTypes",
@@ -494,7 +510,9 @@
     },
     "/notifications/subscriptions": {
       "get": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Returns all notification subscriptions for the current user.",
         "description": "Returns all notification type subscriptions for the authenticated user within the current tenant. Each subscription indicates a notification type the user has opted into.",
         "operationId": "GetSubscriptions",
@@ -547,7 +565,9 @@
     },
     "/notifications/subscriptions/{typeName}": {
       "post": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Subscribes the current user to a notification type.",
         "description": "Subscribes the authenticated user to the specified notification type within the current tenant. Idempotent — subscribing to an already-subscribed type is a no-op.",
         "operationId": "Subscribe",
@@ -599,7 +619,9 @@
         }
       },
       "delete": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Unsubscribes the current user from a notification type.",
         "description": "Removes the authenticated user's subscription to the specified notification type within the current tenant. Idempotent — unsubscribing from a non-subscribed type is a no-op.",
         "operationId": "Unsubscribe",
@@ -653,7 +675,9 @@
     },
     "/notifications/entity/{entityType}/{entityId}/follow": {
       "post": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Subscribes the current user as a follower of an entity.",
         "description": "Adds the authenticated user as a follower of the specified entity within the current tenant. Followers receive notifications when activity occurs on the entity. Idempotent.",
         "operationId": "FollowEntity",
@@ -714,7 +738,9 @@
         }
       },
       "delete": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Unsubscribes the current user from an entity.",
         "description": "Removes the authenticated user from the follower list of the specified entity within the current tenant. The user will no longer receive entity-level notifications. Idempotent.",
         "operationId": "UnfollowEntity",
@@ -777,7 +803,9 @@
     },
     "/notifications/entity/{entityType}/{entityId}/followers": {
       "get": {
-        "tags": ["Notifications"],
+        "tags": [
+          "Notifications"
+        ],
         "summary": "Returns all followers of a specific entity.",
         "description": "Returns all users following the specified entity within the current tenant. Each entry includes the user ID and subscription metadata.",
         "operationId": "GetEntityFollowers",
@@ -855,20 +883,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -882,7 +925,9 @@
         }
       },
       "NotificationDefinition": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -898,13 +943,22 @@
             }
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "groupName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "allowUserOptOut": {
             "type": "boolean"
@@ -913,15 +967,27 @@
             "type": "boolean"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "requiredFeature": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "NotificationPreferenceResponse": {
-        "required": ["id", "userId", "notificationTypeName", "channelName", "isEnabled"],
+        "required": [
+          "id",
+          "userId",
+          "notificationTypeName",
+          "channelName",
+          "isEnabled"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -943,7 +1009,11 @@
         }
       },
       "NotificationPreferenceUpdateRequest": {
-        "required": ["notificationTypeName", "channelName", "isEnabled"],
+        "required": [
+          "notificationTypeName",
+          "channelName",
+          "isEnabled"
+        ],
         "type": "object",
         "properties": {
           "notificationTypeName": {
@@ -958,10 +1028,22 @@
         }
       },
       "NotificationSeverity": {
-        "enum": ["Info", "Success", "Warning", "Error", "Fatal"]
+        "enum": [
+          "Info",
+          "Success",
+          "Warning",
+          "Error",
+          "Fatal"
+        ]
       },
       "NotificationSubscriptionResponse": {
-        "required": ["id", "userId", "notificationTypeName", "entityType", "entityId"],
+        "required": [
+          "id",
+          "userId",
+          "notificationTypeName",
+          "entityType",
+          "entityId"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -975,15 +1057,25 @@
             "type": "string"
           },
           "entityType": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "entityId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PagedResultOfUserNotificationResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -993,14 +1085,20 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -1030,7 +1128,9 @@
         }
       },
       "UnreadCountResponse": {
-        "required": ["count"],
+        "required": [
+          "count"
+        ],
         "type": "object",
         "properties": {
           "count": {
@@ -1072,7 +1172,7 @@
           "recipientUserId": {
             "type": "string"
           },
-          "data": {},
+          "data": { },
           "state": {
             "$ref": "#/components/schemas/UserNotificationState"
           },
@@ -1081,19 +1181,31 @@
             "format": "date-time"
           },
           "readAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "relatedEntityType": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "relatedEntityId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "UserNotificationState": {
-        "enum": ["Unread", "Read"]
+        "enum": [
+          "Unread",
+          "Read"
+        ]
       }
     }
   },

--- a/contracts/openapi/openiddict.json
+++ b/contracts/openapi/openiddict.json
@@ -7,7 +7,9 @@
   "paths": {
     "/admin/oidc/applications": {
       "get": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Returns all OIDC applications.",
         "description": "Returns all registered OIDC client applications with their client ID, display name, type, and tenant association. Applications are either public (SPA, mobile) or confidential (server-side). Use this list to manage the registered clients in the admin panel.",
         "operationId": "ListOidcApplications",
@@ -58,7 +60,9 @@
         }
       },
       "post": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Creates a new OIDC application.",
         "description": "Registers a new OIDC client with the specified permissions and redirect URIs. For confidential clients, a client secret is generated and returned once in the response. Returns 409 Conflict if a client with the same client ID already exists.",
         "operationId": "CreateOidcApplication",
@@ -138,7 +142,9 @@
     },
     "/admin/oidc/applications/{clientId}": {
       "delete": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Deletes an OIDC application.",
         "description": "Removes the OIDC client and all associated authorizations and tokens.",
         "operationId": "DeleteOidcApplication",
@@ -202,7 +208,9 @@
     },
     "/admin/oidc/applications/{clientId}/rotate-secret": {
       "post": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Rotates an OIDC application's client secret.",
         "description": "Generates a new client secret, invalidating the old one immediately. The new plaintext secret is returned once in the response (never stored in plaintext).",
         "operationId": "RotateOidcApplicationSecret",
@@ -273,7 +281,9 @@
     },
     "/admin/oidc/scopes": {
       "get": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Returns all OIDC scopes.",
         "description": "Returns all registered OIDC scopes with their name, display name, and associated resources. Scopes define the claims and resources that tokens can grant access to. Use this endpoint to audit which scopes are available for client configuration.",
         "operationId": "ListOidcScopes",
@@ -324,7 +334,9 @@
         }
       },
       "post": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Creates a new OIDC scope.",
         "description": "Registers a new OIDC scope with the specified name, display name, and associated resources. The scope name must be unique. Returns 409 Conflict if a scope with the same name already exists.",
         "operationId": "CreateOidcScope",
@@ -404,7 +416,9 @@
     },
     "/admin/oidc/scopes/{scopeName}": {
       "delete": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Deletes an OIDC scope.",
         "description": "Removes the scope. Existing authorizations using this scope are not affected.",
         "operationId": "DeleteOidcScope",
@@ -468,7 +482,9 @@
     },
     "/admin/oidc/authorizations": {
       "get": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Returns OIDC authorizations.",
         "description": "Returns OIDC authorizations filterable by user ID and client ID. Each authorization represents a user's consent grant to an application. Includes the authorization status (valid, revoked) and type (permanent, ad-hoc).",
         "operationId": "ListOidcAuthorizations",
@@ -521,7 +537,9 @@
     },
     "/admin/oidc/authorizations/{authorizationId}": {
       "delete": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Revokes an OIDC authorization.",
         "description": "Revokes the authorization and all associated tokens. The user will need to re-authorize on next login. Returns 404 if the authorization does not exist.",
         "operationId": "RevokeOidcAuthorization",
@@ -586,7 +604,9 @@
     },
     "/admin/oidc/authorizations/user/{userId}": {
       "delete": {
-        "tags": ["OIDC Admin"],
+        "tags": [
+          "OIDC Admin"
+        ],
         "summary": "Revokes all OIDC authorizations for a user.",
         "description": "Revokes all authorizations and tokens for the specified user. Used for GDPR erasure and security incidents.",
         "operationId": "RevokeUserOidcAuthorizations",
@@ -643,26 +663,49 @@
   "components": {
     "schemas": {
       "AdminOidcApplicationResponse": {
-        "required": ["clientId", "displayName", "type", "tenantId"],
+        "required": [
+          "clientId",
+          "displayName",
+          "type",
+          "tenantId"
+        ],
         "type": "object",
         "properties": {
           "clientId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           }
         }
       },
       "AdminOidcAuthorizationResponse": {
-        "required": ["id", "subject", "clientId", "status", "type"],
+        "required": [
+          "id",
+          "subject",
+          "clientId",
+          "status",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -670,61 +713,102 @@
             "format": "uuid"
           },
           "subject": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "clientId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AdminOidcCreateApplicationRequest": {
-        "required": ["clientId", "displayName", "clientSecret", "type"],
+        "required": [
+          "clientId"
+        ],
         "type": "object",
         "properties": {
           "clientId": {
             "type": "string"
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "clientSecret": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AdminOidcCreateScopeRequest": {
-        "required": ["name", "displayName", "description"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "AdminOidcRotateSecretResponse": {
-        "required": ["clientId", "displayName", "newClientSecret"],
+        "required": [
+          "clientId",
+          "displayName",
+          "newClientSecret"
+        ],
         "type": "object",
         "properties": {
           "clientId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "newClientSecret": {
             "type": "string"
@@ -732,17 +816,30 @@
         }
       },
       "AdminOidcScopeResponse": {
-        "required": ["name", "displayName", "description"],
+        "required": [
+          "name",
+          "displayName",
+          "description"
+        ],
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -750,20 +847,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",

--- a/contracts/openapi/presence.json
+++ b/contracts/openapi/presence.json
@@ -7,7 +7,9 @@
   "paths": {
     "/presence/my": {
       "get": {
-        "tags": ["Presence"],
+        "tags": [
+          "Presence"
+        ],
         "summary": "Returns the caller's current presence snapshot.",
         "description": "Computes the effective presence status for the authenticated user by blending their manual override (if any) with their last reported heartbeat.",
         "operationId": "GetMyPresence",
@@ -55,7 +57,9 @@
         }
       },
       "put": {
-        "tags": ["Presence"],
+        "tags": [
+          "Presence"
+        ],
         "summary": "Sets or clears the caller's manual presence override.",
         "description": "Replaces the caller's manual override. Passing ManualStatus=Available clears the override. UntilUtc is optional and bounded by Presence:MaxOverrideDuration.",
         "operationId": "SetMyPresence",
@@ -145,7 +149,9 @@
     },
     "/presence/my/override": {
       "delete": {
-        "tags": ["Presence"],
+        "tags": [
+          "Presence"
+        ],
         "summary": "Clears the caller's manual presence override.",
         "description": "Removes any active manual override so the effective status is derived from the heartbeat alone.",
         "operationId": "ClearMyPresenceOverride",
@@ -205,7 +211,9 @@
     },
     "/presence/my/poll": {
       "post": {
-        "tags": ["Presence"],
+        "tags": [
+          "Presence"
+        ],
         "summary": "Records a heartbeat and returns the caller's presence snapshot.",
         "description": "Clients should call this every 30-60 seconds with the user's local idle duration (in seconds). The server reconstructs the LastActivityUtc using its own clock to avoid client clock-skew issues, and applies a MAX merge across concurrent tabs.",
         "operationId": "PollMyPresence",
@@ -295,7 +303,9 @@
     },
     "/presence/users/{userId}": {
       "get": {
-        "tags": ["Presence"],
+        "tags": [
+          "Presence"
+        ],
         "summary": "Returns the presence snapshot of one user.",
         "description": "Computes the effective presence status for the specified user. Always returns 200 OK — unknown, never-seen, and policy-denied targets are canonicalized to Offline with a null LastSeenUtc so the response shape cannot be used as an enumeration oracle. Visibility is decided by IPresenceVisibilityPolicy (default: allow-all; multi-tenant apps MUST register a tenant-aware policy).",
         "operationId": "GetUserPresence",
@@ -367,7 +377,9 @@
     },
     "/presence/users/batch": {
       "post": {
-        "tags": ["Presence"],
+        "tags": [
+          "Presence"
+        ],
         "summary": "Returns presence snapshots for a batch of users.",
         "description": "Returns a dictionary keyed by user id. POST is used because UUID lists exceed practical URL length around 50 entries. Targets the caller is not allowed to read (per IPresenceVisibilityPolicy) are silently omitted from the response — not 403'd — to avoid leaking an enumeration channel.",
         "operationId": "GetBatchPresence",
@@ -457,7 +469,9 @@
     },
     "/presence/rooms/{kind}/{id}/heartbeat": {
       "post": {
-        "tags": ["Presence - Rooms"],
+        "tags": [
+          "Presence - Rooms"
+        ],
         "summary": "Joins or refreshes the caller's heartbeat in a resource room.",
         "description": "Acts as both join and refresh — clients should call this every 30-60 s while the user remains in the room. Returns the full room snapshot to save a round-trip; participants are filtered through IResourcePresenceVisibilityPolicy.",
         "operationId": "HeartbeatPresenceRoom",
@@ -582,7 +596,9 @@
     },
     "/presence/rooms/{kind}/{id}": {
       "get": {
-        "tags": ["Presence - Rooms"],
+        "tags": [
+          "Presence - Rooms"
+        ],
         "summary": "Returns the participants currently active in a resource room.",
         "description": "Filters stale entries (older than Presence:OfflineThreshold) and consults IResourcePresenceVisibilityPolicy. Policy denial surfaces as 404 to avoid leaking room existence — same anti-enumeration contract as user presence reads.",
         "operationId": "GetPresenceRoom",
@@ -679,7 +695,9 @@
         }
       },
       "delete": {
-        "tags": ["Presence - Rooms"],
+        "tags": [
+          "Presence - Rooms"
+        ],
         "summary": "Removes the caller from a resource room.",
         "description": "Idempotent — returns 204 whether or not the caller was present. The room cache entry is evicted entirely when the last participant leaves.",
         "operationId": "LeavePresenceRoom",
@@ -763,7 +781,9 @@
   "components": {
     "schemas": {
       "BatchPresenceRequest": {
-        "required": ["userIds"],
+        "required": [
+          "userIds"
+        ],
         "type": "object",
         "properties": {
           "userIds": {
@@ -776,7 +796,9 @@
         }
       },
       "BatchPresenceResponse": {
-        "required": ["presences"],
+        "required": [
+          "presences"
+        ],
         "type": "object",
         "properties": {
           "presences": {
@@ -788,7 +810,9 @@
         }
       },
       "HeartbeatRequest": {
-        "required": ["idleSeconds"],
+        "required": [
+          "idleSeconds"
+        ],
         "type": "object",
         "properties": {
           "idleSeconds": {
@@ -801,7 +825,10 @@
         "type": "object",
         "properties": {
           "metadata": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -809,20 +836,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -836,7 +878,13 @@
         }
       },
       "ManualPresenceStatus": {
-        "enum": ["Available", "Busy", "DoNotDisturb", "AppearOffline", null]
+        "enum": [
+          "Available",
+          "Busy",
+          "DoNotDisturb",
+          "AppearOffline",
+          null
+        ]
       },
       "PresenceResponse": {
         "required": [
@@ -866,17 +914,29 @@
             ]
           },
           "overrideUntilUtc": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "lastSeenUtc": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
       },
       "PresenceStatus": {
-        "enum": ["Online", "Away", "Offline", "Busy", "DoNotDisturb"]
+        "enum": [
+          "Online",
+          "Away",
+          "Offline",
+          "Busy",
+          "DoNotDisturb"
+        ]
       },
       "ProblemDetails": {
         "type": "object",
@@ -904,7 +964,11 @@
         }
       },
       "ResourcePresenceParticipantResponse": {
-        "required": ["userId", "lastSeenUtc", "metadata"],
+        "required": [
+          "userId",
+          "lastSeenUtc",
+          "metadata"
+        ],
         "type": "object",
         "properties": {
           "userId": {
@@ -916,12 +980,19 @@
             "format": "date-time"
           },
           "metadata": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "ResourceRoomResponse": {
-        "required": ["kind", "id", "participants"],
+        "required": [
+          "kind",
+          "id",
+          "participants"
+        ],
         "type": "object",
         "properties": {
           "kind": {
@@ -939,14 +1010,19 @@
         }
       },
       "SetPresenceRequest": {
-        "required": ["manualStatus", "untilUtc"],
+        "required": [
+          "manualStatus"
+        ],
         "type": "object",
         "properties": {
           "manualStatus": {
             "$ref": "#/components/schemas/ManualPresenceStatus"
           },
           "untilUtc": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }

--- a/contracts/openapi/privacy.json
+++ b/contracts/openapi/privacy.json
@@ -7,7 +7,9 @@
   "paths": {
     "/privacy/regulation": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns the privacy regulation profile applicable to the current tenant.",
         "description": "Resolves the privacy regulation for the current tenant context via IPrivacyRegulationResolver. Returns the full regulation profile including consent model, response timelines, breach notification deadlines, age thresholds, cookie consent rules, and cross-border transfer requirements.",
         "operationId": "GetApplicableRegulation",
@@ -57,7 +59,9 @@
     },
     "/privacy/purposes": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns all registered processing purposes with their legal bases.",
         "description": "Lists all processing purposes declared at application startup via RegisterProcessingPurpose(). Each purpose includes its legal basis, whether explicit consent is required, and an optional data category.",
         "operationId": "ListProcessingPurposes",
@@ -110,7 +114,9 @@
     },
     "/privacy/opt-out": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Opts out of data sale/sharing (CCPA).",
         "description": "Records a 'Do Not Sell or Share My Personal Information' request. Supports both authenticated users and anonymous visitors (CCPA compliance). For anonymous visitors, a _optout_id HTTP-Only cookie is set to track the opt-out. Anonymous opt-outs are stored tenant-less by default (PrivacyEndpointsOptions.BindAnonymousOptOutToCurrentTenant) to prevent tenant injection via a spoofable resolver. Rate-limited via the `privacy-optout-create` policy.",
         "operationId": "RequestOptOut",
@@ -156,12 +162,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/privacy/opt-out/status": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns the current opt-out status.",
         "description": "Checks whether the requesting user or visitor has an active opt-out. For authenticated users, checks by UserId. For anonymous visitors, checks the _optout_id cookie.",
         "operationId": "GetOptOutStatus",
@@ -187,12 +197,16 @@
             }
           }
         },
-        "security": [{}]
+        "security": [
+          { }
+        ]
       }
     },
     "/privacy/exports/scopes": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Lists the export scopes visible to the current user.",
         "description": "Returns one entry per IPrivacyDataProvider the subject can include in an export, after applying the framework visibility gates: module loaded, HasDataAsync probe (Takeout-style \"if you never used it, it doesn't appear\"), and the host IPrivacyScopeVisibilityPolicy. Use the returned ProviderName values to populate the POST /privacy/exports `Scopes` field; unknown / hidden scopes in that POST are silently skipped.",
         "operationId": "ListPrivacyExportScopes",
@@ -245,7 +259,9 @@
     },
     "/privacy/exports/on-behalf-of": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Requests a personal data export on behalf of another data subject (admin DSR).",
         "description": "Admin-driven counterpart to POST /privacy/exports — gated by the dedicated Privacy.Exports.ExecuteOnBehalfOf permission so RBAC can hand it to a narrow operator role without unlocking it for every authenticated user. The body's SubjectUserId identifies the data subject; the authenticated caller is recorded separately on the audit row so the substitution is fully reconstructable for GDPR Art. 30 ROPA. Uses the dedicated `privacy-export-create-on-behalf-of` rate-limit policy (distinct from the self-service `privacy-export-create`). The subject id is validated against the caller's tenant via IPrivacySubjectValidator — a subject absent from the tenant returns 404 (same status as a non-existent request id, so cross-tenant existence cannot be probed).",
         "operationId": "RequestPrivacyExportOnBehalfOf",
@@ -325,7 +341,9 @@
     },
     "/privacy/exports": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Requests a personal data export for the current user.",
         "description": "Triggers the scatter-gather export saga (GDPR Art. 15/20). Each registered data provider prepares its fragment asynchronously. The saga assembles fragments into a downloadable archive. The optional `Scopes` array narrows the export to a subset of provider scopes (see GET /privacy/exports/scopes); omitting it exports everything visible to the subject. Poll GET /exports/{requestId} for status, or wire a Granit.Notifications handler on ExportCompletedEto to notify the user when the archive is ready. Rate-limited via the `privacy-export-create` policy (hosts configure quotas in `RateLimiting:Policies` — defaults to 1 export per subject per 24 hours). Honours an optional `Idempotency-Key` header (Granit.Http.Idempotency) so accidental double-clicks don't spawn two scatter-gather sagas.",
         "operationId": "RequestPrivacyExport",
@@ -409,7 +427,9 @@
         }
       },
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Lists all export requests for the current user.",
         "description": "Returns all export requests submitted by the current user, ordered by most recent first. Each entry includes the request state, timestamps, and archive reference when available.",
         "operationId": "ListPrivacyExports",
@@ -462,7 +482,9 @@
     },
     "/privacy/exports/{requestId}": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns the status of a personal data export request.",
         "description": "Queries the export request tracker for the specified request ID. Only the user who created the request can view its status. Returns the current state (Pending, Completed, PartiallyCompleted, TimedOut), the archive blob reference when available, and any missing providers. Returns 404 if the request ID is not found or belongs to another user.",
         "operationId": "GetPrivacyExportStatus",
@@ -534,7 +556,9 @@
     },
     "/privacy/exports/{requestId}/download": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Downloads the personal data export archive (compat — single-shard or manifest).",
         "description": "Convenience route that resolves to shard 0 when the export produced a single archive, or to the manifest sidecar when sharded into multiple ZIPs. For deterministic multi-shard downloads, use GET /exports/{requestId}/download/{shardIndex} per shard plus GET /exports/{requestId}/download/manifest to discover the shard count. Step-up authentication required when DownloadStepUpRequired is enabled (default).",
         "operationId": "DownloadPrivacyExport",
@@ -609,7 +633,9 @@
     },
     "/privacy/exports/{requestId}/download/manifest": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Downloads the manifest sidecar describing the export's shards.",
         "description": "Returns the signed JSON manifest produced by the assembly job. Clients use it to discover the shard count and per-shard sha256/integrity tag before pulling each ZIP. Step-up authentication required when DownloadStepUpRequired is enabled (default).",
         "operationId": "DownloadPrivacyExportManifest",
@@ -684,7 +710,9 @@
     },
     "/privacy/exports/{requestId}/download/{shardIndex}": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Downloads a single shard of a sharded personal data export.",
         "description": "Streams the shard ZIP indexed by 0..(ShardCount-1) from the export's archive set. Shard indices outside the manifest's bounds return 404. Step-up authentication required when DownloadStepUpRequired is enabled (default).",
         "operationId": "DownloadPrivacyExportShard",
@@ -770,7 +798,9 @@
     },
     "/privacy/deletions": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Requests personal data deletion for the current user.",
         "description": "Publishes a distributed deletion event (GDPR Art. 17 — right to erasure). When Defer is false, deletion is immediate. When Defer is true, a cooling-off period starts — the user receives a reminder email before the deadline and can cancel via POST /deletion/{requestId}/cancel. A confirmation email is sent in both cases after deletion is executed. Do not include personally identifiable information in the Reason field.",
         "operationId": "RequestPrivacyDeletion",
@@ -858,7 +888,9 @@
         }
       },
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Lists all deletion requests for the current user.",
         "description": "Returns all deferred deletion requests submitted by the current user, ordered by most recent first. Immediate deletions are not tracked.",
         "operationId": "ListPrivacyDeletions",
@@ -911,7 +943,9 @@
     },
     "/privacy/deletions/{requestId}/cancel": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Cancels a deferred deletion request during the grace period.",
         "description": "Cancels a deferred deletion request. Only requests in Deferred state can be cancelled. Returns 404 if the request is not found, 409 if already executed or cancelled.",
         "operationId": "CancelPrivacyDeletion",
@@ -986,7 +1020,9 @@
     },
     "/privacy/deletions/{requestId}": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns the status of a deferred deletion request.",
         "description": "Queries the deletion request tracker for the specified request ID. Only the user who created the request can view its status. Returns the current state (Deferred, Executed, Cancelled), scheduled deletion date, and timestamps. Returns 404 if the request is not found or belongs to another user.",
         "operationId": "GetPrivacyDeletionStatus",
@@ -1058,7 +1094,9 @@
     },
     "/privacy/agreements/documents": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns all registered legal documents.",
         "description": "Returns all legal documents registered in the consent registry (GDPR Art. 7). Each document includes its identifier, current version, and display name. Use GET /agreements/status to check the user's consent per document.",
         "operationId": "ListPrivacyLegalDocuments",
@@ -1111,7 +1149,9 @@
     },
     "/privacy/agreements/status": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns the consent status for all legal documents.",
         "description": "For each registered legal document, returns whether the current user has accepted the latest version and when the last acceptance occurred. Documents where HasAcceptedLatest is false require re-consent.",
         "operationId": "GetPrivacyConsentStatus",
@@ -1164,7 +1204,9 @@
     },
     "/privacy/agreements/history": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns the consent history for the current user.",
         "description": "Returns all consent records for the current user, ordered by most recent first. Each record includes the document ID, accepted version, timestamp, and whether it matches the current document version.",
         "operationId": "ListPrivacyAgreementHistory",
@@ -1217,7 +1259,9 @@
     },
     "/privacy/agreements/accept": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Records acceptance of a legal agreement.",
         "description": "Records the user's consent for a specific legal document version (GDPR Art. 7). The version must match the current version — stale consent is rejected (422). If the user has already accepted the latest version, returns 409. The client IP address is captured and pseudonymized for the audit trail. Ensure ForwardedHeadersMiddleware is enabled when running behind a reverse proxy.",
         "operationId": "AcceptPrivacyAgreement",
@@ -1300,7 +1344,9 @@
     },
     "/privacy/legal-documents": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Creates a new legal document draft.",
         "description": "Creates a new legal document version in Draft status. The document can be edited and then published to become the active version. Publishing auto-archives the previous active version.",
         "operationId": "CreateLegalDocument",
@@ -1378,7 +1424,9 @@
         }
       },
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Lists all versions of a legal document.",
         "description": "Returns the version history for the specified document ID, ordered by version descending. Includes drafts, published, and archived versions.",
         "operationId": "ListLegalDocumentVersions",
@@ -1441,7 +1489,9 @@
     },
     "/privacy/legal-documents/{id}": {
       "get": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Returns a legal document by ID, including drafts and archived versions.",
         "description": "Returns the full detail of a legal document version, regardless of its lifecycle status. Requires admin read permission.",
         "operationId": "GetLegalDocument",
@@ -1511,7 +1561,9 @@
         }
       },
       "put": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Updates a legal document draft.",
         "description": "Updates metadata of a legal document in Draft status. Returns 400 if the document is not in Draft status. Returns 409 if the concurrency stamp does not match the stored value.",
         "operationId": "UpdateLegalDocument",
@@ -1623,7 +1675,9 @@
     },
     "/privacy/legal-documents/{id}/publish": {
       "post": {
-        "tags": ["Privacy"],
+        "tags": [
+          "Privacy"
+        ],
         "summary": "Publishes a legal document draft, auto-archiving the previous published version.",
         "description": "Promotes the draft to Published status. If a published version already exists for the same document ID, it is archived in the same transaction and LegalAgreementObsoleteEto is dispatched to trigger re-consent flows.",
         "operationId": "PublishLegalDocument",
@@ -1713,20 +1767,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1740,7 +1809,10 @@
         }
       },
       "LegalDocumentCreateRequest": {
-        "required": ["documentId", "displayName", "description", "templateName"],
+        "required": [
+          "documentId",
+          "displayName"
+        ],
         "type": "object",
         "properties": {
           "documentId": {
@@ -1750,10 +1822,16 @@
             "type": "string"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "templateName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -1791,13 +1869,22 @@
             "type": "string"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "templateName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "documentBlobId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "createdAt": {
@@ -1816,9 +1903,6 @@
       "LegalDocumentUpdateRequest": {
         "required": [
           "displayName",
-          "description",
-          "templateName",
-          "documentBlobId",
           "concurrencyStamp"
         ],
         "type": "object",
@@ -1826,23 +1910,35 @@
           "displayName": {
             "type": "string"
           },
-          "description": {
-            "type": ["null", "string"]
-          },
-          "templateName": {
-            "type": ["null", "string"]
-          },
-          "documentBlobId": {
-            "type": ["null", "string"],
-            "format": "uuid"
-          },
           "concurrencyStamp": {
             "type": "string"
+          },
+          "description": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "templateName": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "documentBlobId": {
+            "type": [
+              "null",
+              "string"
+            ],
+            "format": "uuid"
           }
         }
       },
       "PrivacyAcceptAgreementRequest": {
-        "required": ["documentId", "version"],
+        "required": [
+          "documentId",
+          "version"
+        ],
         "type": "object",
         "properties": {
           "documentId": {
@@ -1854,7 +1950,12 @@
         }
       },
       "PrivacyConsentStatusResponse": {
-        "required": ["documentId", "currentVersion", "hasAcceptedLatest", "lastAcceptedAt"],
+        "required": [
+          "documentId",
+          "currentVersion",
+          "hasAcceptedLatest",
+          "lastAcceptedAt"
+        ],
         "type": "object",
         "properties": {
           "documentId": {
@@ -1867,13 +1968,18 @@
             "type": "boolean"
           },
           "lastAcceptedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
       },
       "PrivacyDeletionRequest": {
-        "required": ["reason"],
+        "required": [
+          "reason"
+        ],
         "type": "object",
         "properties": {
           "reason": {
@@ -1886,7 +1992,10 @@
         }
       },
       "PrivacyDeletionRequestResponse": {
-        "required": ["requestId", "scheduledDeletionAt"],
+        "required": [
+          "requestId",
+          "scheduledDeletionAt"
+        ],
         "type": "object",
         "properties": {
           "requestId": {
@@ -1930,17 +2039,25 @@
             "format": "date-time"
           },
           "cancelledAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "executedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           }
         }
       },
       "PrivacyExportOnBehalfOfRequest": {
-        "required": ["subjectUserId"],
+        "required": [
+          "subjectUserId"
+        ],
         "type": "object",
         "properties": {
           "subjectUserId": {
@@ -1948,7 +2065,10 @@
             "format": "uuid"
           },
           "scopes": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1959,7 +2079,10 @@
         "type": "object",
         "properties": {
           "scopes": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1967,7 +2090,10 @@
         }
       },
       "PrivacyExportRequestResponse": {
-        "required": ["requestId", "requestedAt"],
+        "required": [
+          "requestId",
+          "requestedAt"
+        ],
         "type": "object",
         "properties": {
           "requestId": {
@@ -1997,14 +2123,21 @@
             "type": "string"
           },
           "featureName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "defaultSelected": {
             "type": "boolean"
           },
           "estimatedSizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["null", "integer", "string"],
+            "type": [
+              "null",
+              "integer",
+              "string"
+            ],
             "format": "int64"
           }
         }
@@ -2032,7 +2165,10 @@
             "format": "date-time"
           },
           "completedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "archiveBlobReferenceId": {
@@ -2054,7 +2190,11 @@
         }
       },
       "PrivacyLegalDocumentResponse": {
-        "required": ["documentId", "currentVersion", "displayName"],
+        "required": [
+          "documentId",
+          "currentVersion",
+          "displayName"
+        ],
         "type": "object",
         "properties": {
           "documentId": {
@@ -2069,18 +2209,28 @@
         }
       },
       "PrivacyOptOutStatusResponse": {
-        "required": ["isOptedOut", "optedOutAt", "regulation"],
+        "required": [
+          "isOptedOut",
+          "optedOutAt",
+          "regulation"
+        ],
         "type": "object",
         "properties": {
           "isOptedOut": {
             "type": "boolean"
           },
           "optedOutAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "regulation": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2111,7 +2261,10 @@
             "type": "boolean"
           },
           "dataCategory": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2164,11 +2317,17 @@
             "format": "int32"
           },
           "subjectAccessRequestExtensionDays": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "deletionRequestDays": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "defaultDeletionGracePeriodDays": {
@@ -2180,11 +2339,17 @@
             "format": "int32"
           },
           "breachNotifyAuthorityHours": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "breachNotifyIndividualsHours": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "minimumConsentAge": {
@@ -2224,7 +2389,13 @@
         }
       },
       "PrivacyUserAgreementResponse": {
-        "required": ["id", "documentId", "version", "acceptedAt", "isLatest"],
+        "required": [
+          "id",
+          "documentId",
+          "version",
+          "acceptedAt",
+          "isLatest"
+        ],
         "type": "object",
         "properties": {
           "id": {

--- a/contracts/openapi/scheduling.json
+++ b/contracts/openapi/scheduling.json
@@ -7,7 +7,9 @@
   "paths": {
     "/scheduling/scheduled-actions/{id}": {
       "get": {
-        "tags": ["Scheduling"],
+        "tags": [
+          "Scheduling"
+        ],
         "summary": "Returns a scheduled action by ID.",
         "description": "Returns the full details of a single scheduled action identified by its GUID. Returns 404 if the action does not exist or belongs to a different tenant.",
         "operationId": "GetScheduledActionById",
@@ -77,7 +79,9 @@
         }
       },
       "delete": {
-        "tags": ["Scheduling"],
+        "tags": [
+          "Scheduling"
+        ],
         "summary": "Cancels a pending scheduled action.",
         "description": "Cancels a scheduled action that has not yet been executed. Returns 204 on success. Returns 404 if the action does not exist, or 409 if the action is no longer in Pending status.",
         "operationId": "CancelScheduledAction",
@@ -152,7 +156,9 @@
     },
     "/scheduling/scheduled-actions/{id}/reschedule": {
       "put": {
-        "tags": ["Scheduling"],
+        "tags": [
+          "Scheduling"
+        ],
         "summary": "Reschedules a pending action to a new date.",
         "description": "Changes the execution date of a pending scheduled action. Returns 200 on success. Returns 404 if the action does not exist, or 409 if the action is no longer in Pending status.",
         "operationId": "RescheduleScheduledAction",
@@ -257,7 +263,9 @@
     },
     "/scheduling/scheduled-actions": {
       "get": {
-        "tags": ["Scheduling"],
+        "tags": [
+          "Scheduling"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of ScheduledAction entries.",
         "description": "Executes a dynamic query against ScheduledAction using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryScheduledAction",
@@ -268,7 +276,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -279,7 +290,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -288,7 +302,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -296,7 +313,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -304,7 +324,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -312,7 +335,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -320,7 +346,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -328,7 +357,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -338,7 +370,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -351,7 +386,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -422,7 +460,9 @@
     },
     "/scheduling/scheduled-actions/meta": {
       "get": {
-        "tags": ["Scheduling"],
+        "tags": [
+          "Scheduling"
+        ],
         "summary": "Returns query metadata for ScheduledAction (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for ScheduledAction: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetScheduledActionMeta",
@@ -509,12 +549,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -532,10 +579,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -551,7 +610,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -569,7 +631,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -601,7 +667,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -613,7 +682,10 @@
         }
       },
       "GroupedResultOfScheduledAction": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -629,13 +701,18 @@
         }
       },
       "GroupEntryOfScheduledAction": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -644,10 +721,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/ScheduledAction"
             }
@@ -658,20 +741,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -696,23 +794,38 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -720,11 +833,20 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "PagedResultOfScheduledAction": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -743,43 +865,76 @@
                   "format": "date-time"
                 },
                 "correlationId": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "status": {
-                  "enum": ["Pending", "Executed", "Cancelled", "Failed", "Processing"]
+                  "enum": [
+                    "Pending",
+                    "Executed",
+                    "Cancelled",
+                    "Failed",
+                    "Processing"
+                  ]
                 },
                 "executedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "date-time"
                 },
                 "cancelledBy": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "failureReason": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "modifiedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "domainEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for domain events."
                   }
                 },
                 "integrationEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for integration events (ETO — Event Transfer Object)."
@@ -803,19 +958,30 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -836,7 +1002,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -934,12 +1104,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -954,7 +1131,9 @@
         }
       },
       "RescheduleActionRequest": {
-        "required": ["newExecuteAt"],
+        "required": [
+          "newExecuteAt"
+        ],
         "type": "object",
         "properties": {
           "newExecuteAt": {
@@ -977,42 +1156,69 @@
             "format": "date-time"
           },
           "correlationId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/ScheduledActionStatus"
           },
           "executedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "cancelledBy": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "failureReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Identifier of the user who last modified the entity."
           },
           "domainEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IDomainEvent"
             }
           },
           "integrationEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IIntegrationEvent"
             }
@@ -1059,20 +1265,32 @@
             "format": "date-time"
           },
           "correlationId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
             "$ref": "#/components/schemas/ScheduledActionStatus"
           },
           "executedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "cancelledBy": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "failureReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "createdAt": {
             "type": "string",
@@ -1081,10 +1299,18 @@
         }
       },
       "ScheduledActionStatus": {
-        "enum": ["Pending", "Executed", "Cancelled", "Failed", "Processing"]
+        "enum": [
+          "Pending",
+          "Executed",
+          "Cancelled",
+          "Failed",
+          "Processing"
+        ]
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {

--- a/contracts/openapi/security-headers.json
+++ b/contracts/openapi/security-headers.json
@@ -7,7 +7,9 @@
   "paths": {
     "/security-headers/csp": {
       "get": {
-        "tags": ["Security Headers"],
+        "tags": [
+          "Security Headers"
+        ],
         "summary": "Returns the effective Content-Security-Policy per endpoint.",
         "description": "Returns a snapshot of the composed CSP for every registered endpoint, plus the base directives and the list of registered ICspContributor implementations. Contributors that branch on request-scoped state beyond endpoint metadata (e.g. authenticated user, tenant) will under-report — the audit synthesises requests carrying only the matched endpoint.",
         "operationId": "GetCspAudit",
@@ -59,7 +61,13 @@
   "components": {
     "schemas": {
       "CspAuditResponse": {
-        "required": ["baseDirectives", "rawOverride", "reportOnly", "contributors", "endpoints"],
+        "required": [
+          "baseDirectives",
+          "rawOverride",
+          "reportOnly",
+          "contributors",
+          "endpoints"
+        ],
         "type": "object",
         "properties": {
           "baseDirectives": {
@@ -72,7 +80,10 @@
             }
           },
           "rawOverride": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "reportOnly": {
             "type": "boolean"
@@ -92,7 +103,10 @@
         }
       },
       "CspContributorInfo": {
-        "required": ["name", "fullTypeName"],
+        "required": [
+          "name",
+          "fullTypeName"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -104,7 +118,13 @@
         }
       },
       "CspEndpointAudit": {
-        "required": ["httpMethods", "pattern", "displayName", "headerName", "composedCsp"],
+        "required": [
+          "httpMethods",
+          "pattern",
+          "displayName",
+          "headerName",
+          "composedCsp"
+        ],
         "type": "object",
         "properties": {
           "httpMethods": {

--- a/contracts/openapi/settings.json
+++ b/contracts/openapi/settings.json
@@ -7,7 +7,9 @@
   "paths": {
     "/settings/user": {
       "get": {
-        "tags": ["Settings - User"],
+        "tags": [
+          "Settings - User"
+        ],
         "summary": "Returns all client-visible settings resolved for the current user.",
         "description": "Returns all settings marked as client-visible, resolved through the cascading chain (User → Tenant → Global). Only settings with the ClientVisible flag are included. The values reflect the effective configuration for the authenticated user.",
         "operationId": "GetAllUserSettings",
@@ -64,7 +66,9 @@
     },
     "/settings/user/{name}": {
       "get": {
-        "tags": ["Settings - User"],
+        "tags": [
+          "Settings - User"
+        ],
         "summary": "Returns a single setting resolved for the current user.",
         "description": "Returns the effective value of a single setting resolved through the cascading chain (User → Tenant → Global). Returns 404 if the setting name does not match any registered setting definition.",
         "operationId": "GetUserSetting",
@@ -133,7 +137,9 @@
         }
       },
       "put": {
-        "tags": ["Settings - User"],
+        "tags": [
+          "Settings - User"
+        ],
         "summary": "Sets a user-level setting value.",
         "description": "Sets a user-level override for the specified setting. This value takes precedence over tenant and global values for this user. Pass null to clear. Returns 404 if the setting name is not defined. Returns 400 if the User provider is not allowed for this setting.",
         "operationId": "UpdateUserSetting",
@@ -225,7 +231,9 @@
         }
       },
       "delete": {
-        "tags": ["Settings - User"],
+        "tags": [
+          "Settings - User"
+        ],
         "summary": "Clears the user-level setting value (falls back to tenant/global).",
         "description": "Removes the user-level override for the specified setting. The effective value reverts to the tenant or global value. Returns 404 if the setting name is not defined.",
         "operationId": "DeleteUserSetting",
@@ -289,7 +297,9 @@
     },
     "/settings/global": {
       "get": {
-        "tags": ["Settings - Global"],
+        "tags": [
+          "Settings - Global"
+        ],
         "summary": "Returns all settings at the global scope.",
         "description": "Returns all settings defined at the global (application-wide) scope as a key-value dictionary. Global settings serve as the base layer in the cascading resolution chain (User → Tenant → Global). Requires the Settings.Global.Read permission.",
         "operationId": "GetAllGlobalSettings",
@@ -346,7 +356,9 @@
     },
     "/settings/global/definitions": {
       "get": {
-        "tags": ["Settings - Global"],
+        "tags": [
+          "Settings - Global"
+        ],
         "summary": "Returns all global settings enriched with their definition metadata.",
         "description": "Returns every declared setting alongside its metadata (display label, description, default value, value kind, optional allow-list) and the current resolved value at the global scope. Intended for admin UIs that need to render a typed form per setting without guessing value types. The IsVisibleToClients flag is ignored — admins see all settings. Encrypted values are returned masked as '***'. Requires the Settings.Global.Read permission.",
         "operationId": "GetAllGlobalSettingDefinitions",
@@ -399,7 +411,9 @@
     },
     "/settings/global/{name}": {
       "put": {
-        "tags": ["Settings - Global"],
+        "tags": [
+          "Settings - Global"
+        ],
         "summary": "Sets a global-level setting value.",
         "description": "Sets or clears a global-level setting value. Pass null to remove the override and revert to the definition's default. The setting name must match a registered setting definition (returns 404 otherwise). Returns 400 if the Global provider is not allowed for this setting. Requires the Settings.Global.Manage permission.",
         "operationId": "UpdateGlobalSetting",
@@ -493,7 +507,9 @@
     },
     "/settings/global/bulk": {
       "put": {
-        "tags": ["Settings - Global"],
+        "tags": [
+          "Settings - Global"
+        ],
         "summary": "Applies multiple global setting updates in a single request.",
         "description": "Applies every entry individually — a failure on one entry (unknown key, disallowed provider, invalid value) does not roll back the others. Returns HTTP 200 with a per-entry outcome envelope; clients inspect each BulkSettingResult to determine success. Pass null in Value to clear an override. Malformed request bodies (empty list, too many entries) return 400. Requires the Settings.Global.Manage permission.",
         "operationId": "BulkUpdateGlobalSettings",
@@ -573,7 +589,9 @@
     },
     "/settings/tenant": {
       "get": {
-        "tags": ["Settings - Tenant"],
+        "tags": [
+          "Settings - Tenant"
+        ],
         "summary": "Returns all settings at the current tenant scope.",
         "description": "Returns all settings defined at the tenant scope for the current tenant. Tenant settings override global values in the cascading resolution chain. Requires the Settings.Tenant.Read permission. Returns 400 if no tenant context is available.",
         "operationId": "GetAllTenantSettings",
@@ -640,7 +658,9 @@
     },
     "/settings/tenant/definitions": {
       "get": {
-        "tags": ["Settings - Tenant"],
+        "tags": [
+          "Settings - Tenant"
+        ],
         "summary": "Returns all tenant settings enriched with their definition metadata.",
         "description": "Returns every declared setting alongside its metadata (display label, description, default value, value kind, optional allow-list) and the current resolved value for the current tenant. Intended for tenant-admin UIs that need to render a typed form per setting. The IsVisibleToClients flag is ignored — tenant admins see all settings. Encrypted values are returned masked as '***'. Returns 400 if no tenant context is available. Requires the Settings.Tenant.Read permission.",
         "operationId": "GetAllTenantSettingDefinitions",
@@ -703,7 +723,9 @@
     },
     "/settings/tenant/{name}": {
       "put": {
-        "tags": ["Settings - Tenant"],
+        "tags": [
+          "Settings - Tenant"
+        ],
         "summary": "Sets a tenant-level setting value.",
         "description": "Sets or clears a tenant-level setting value for the current tenant. Pass null to remove the tenant override and fall back to the global value. The setting name must match a registered setting definition (returns 404 otherwise). Returns 400 if no tenant context is available or if the Tenant provider is not allowed for this setting. Requires the Settings.Tenant.Manage permission.",
         "operationId": "UpdateTenantSetting",
@@ -797,7 +819,9 @@
     },
     "/settings/tenant/bulk": {
       "put": {
-        "tags": ["Settings - Tenant"],
+        "tags": [
+          "Settings - Tenant"
+        ],
         "summary": "Applies multiple tenant setting updates in a single request.",
         "description": "Applies every entry individually for the current tenant — a failure on one entry (unknown key, disallowed provider, invalid value) does not roll back the others. Returns HTTP 200 with a per-entry outcome envelope; clients inspect each BulkSettingResult to determine success. Pass null in Value to clear an override. Returns 400 if no tenant context is available or if the request body is malformed. Requires the Settings.Tenant.Manage permission.",
         "operationId": "BulkUpdateTenantSettings",
@@ -895,22 +919,37 @@
             "type": "string"
           },
           "label": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "defaultValue": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "value": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "valueKind": {
             "$ref": "#/components/schemas/ValueKind"
           },
           "allowedValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -921,22 +960,37 @@
         }
       },
       "BulkSettingEntry": {
-        "required": ["key", "value"],
+        "required": [
+          "key",
+          "value"
+        ],
         "type": "object",
         "properties": {
           "key": {
             "type": "string"
           },
           "value": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "BulkSettingOutcome": {
-        "enum": ["Updated", "NotFound", "ProviderNotAllowed", "ValidationFailed"]
+        "enum": [
+          "Updated",
+          "NotFound",
+          "ProviderNotAllowed",
+          "ValidationFailed"
+        ]
       },
       "BulkSettingResult": {
-        "required": ["key", "outcome", "errorCode"],
+        "required": [
+          "key",
+          "outcome",
+          "errorCode"
+        ],
         "type": "object",
         "properties": {
           "key": {
@@ -946,12 +1000,17 @@
             "$ref": "#/components/schemas/BulkSettingOutcome"
           },
           "errorCode": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "BulkUpdateSettingsRequest": {
-        "required": ["settings"],
+        "required": [
+          "settings"
+        ],
         "type": "object",
         "properties": {
           "settings": {
@@ -963,7 +1022,9 @@
         }
       },
       "BulkUpdateSettingsResponse": {
-        "required": ["results"],
+        "required": [
+          "results"
+        ],
         "type": "object",
         "properties": {
           "results": {
@@ -978,20 +1039,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1030,28 +1106,42 @@
         }
       },
       "SettingValueResponse": {
-        "required": ["name", "value"],
+        "required": [
+          "name",
+          "value"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "value": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "UpdateSettingValueRequest": {
-        "required": ["value"],
         "type": "object",
         "properties": {
           "value": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "ValueKind": {
-        "enum": ["String", "Bool", "Int", "Double", "Json"]
+        "enum": [
+          "String",
+          "Bool",
+          "Int",
+          "Double",
+          "Json"
+        ]
       }
     }
   },

--- a/contracts/openapi/templating.json
+++ b/contracts/openapi/templating.json
@@ -7,7 +7,9 @@
   "paths": {
     "/templating/templates": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of TemplateSummary entries.",
         "description": "Executes a dynamic query against TemplateSummary using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryTemplateSummary",
@@ -18,7 +20,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -29,7 +34,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -38,7 +46,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -46,7 +57,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -54,7 +68,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -62,7 +79,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -70,7 +90,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -78,7 +101,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -88,7 +114,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -101,7 +130,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -170,7 +202,9 @@
         }
       },
       "post": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Creates a new template draft.",
         "description": "Creates a new template with an initial draft revision. The template name must be unique. The draft can be previewed and edited before publishing. Returns 201 Created with the template detail.",
         "operationId": "CreateTemplateDraft",
@@ -260,7 +294,9 @@
     },
     "/templating/templates/meta": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns query metadata for TemplateSummary (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for TemplateSummary: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetTemplateSummaryMeta",
@@ -310,7 +346,9 @@
     },
     "/templating/templates/{name}": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns detail of a template (current draft and published revision).",
         "description": "Returns the full detail of a template including both the current draft revision (if any) and the published revision (if any). Includes content, metadata, category, and variable bindings. Returns 404 if the template name does not exist.",
         "operationId": "GetTemplateDetail",
@@ -406,7 +444,9 @@
         }
       },
       "put": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Updates an existing template draft.",
         "description": "Replaces the draft revision content and metadata. Only the draft revision is affected — published and archived revisions are immutable. Creates a new draft if none exists. Returns 409 if the concurrency stamp does not match the stored draft. Returns 404 if the template does not exist.",
         "operationId": "UpdateTemplateDraft",
@@ -517,7 +557,9 @@
     },
     "/templating/templates/{name}/draft": {
       "delete": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Deletes the draft revision of a template (published/archived are preserved).",
         "description": "Removes only the draft revision. Published and archived revisions remain unaffected. Returns 404 if the template does not exist or has no draft revision.",
         "operationId": "DeleteTemplateDraft",
@@ -598,7 +640,9 @@
     },
     "/templating/templates/{name}/lifecycle": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns lifecycle status, workflow state, and available transitions.",
         "description": "Returns the current lifecycle state of the template (draft, published, archived), the workflow state if workflow integration is enabled, and the list of available state transitions for the current user.",
         "operationId": "GetTemplateLifecycle",
@@ -696,7 +740,9 @@
     },
     "/templating/templates/{name}/publish": {
       "post": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Publishes the current draft, archiving any previous published revision.",
         "description": "Promotes the current draft to published status. If a published revision already exists, it is archived first. The draft is consumed — a new draft must be created for further edits. Returns 404 if the template or draft does not exist.",
         "operationId": "PublishTemplate",
@@ -794,7 +840,9 @@
     },
     "/templating/templates/{name}/unpublish": {
       "post": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Unpublishes the template (archives the published revision).",
         "description": "Archives the currently published revision. The template will no longer be available for rendering until a new revision is published. Returns 404 if the template has no published revision.",
         "operationId": "UnpublishTemplate",
@@ -875,7 +923,9 @@
     },
     "/templating/templates/{name}/preview": {
       "post": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Renders the current draft with optional test data and returns the HTML output.",
         "description": "Renders the template's current draft content using the configured template engine (Liquid, Razor, etc.) with optional test data. Returns the rendered HTML. Useful for live preview in the template editor. Returns 404 if the template or draft does not exist.",
         "operationId": "PreviewTemplate",
@@ -986,7 +1036,9 @@
     },
     "/templating/templates/{name}/variables": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns all available template variables (global, model, enriched) for autocompletion.",
         "description": "Returns all variables available for use in the template: global variables (application-wide), model variables (bound to the template's entity type), and enriched variables (computed at render time). Used to power autocompletion in the template editor.",
         "operationId": "GetTemplateVariables",
@@ -1057,7 +1109,9 @@
     },
     "/templating/templates/{name}/history": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns a paginated revision history for the template (without content).",
         "description": "Returns a paginated list of all revisions for the template, ordered by creation date descending. Each entry includes revision ID, status, author, and timestamp — but not the content. Use the revision detail endpoint to retrieve content.",
         "operationId": "GetTemplateHistory",
@@ -1165,7 +1219,9 @@
     },
     "/templating/templates/{name}/history/{revisionId}": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns the full detail of a specific template revision (including content).",
         "description": "Returns the complete content and metadata of a specific historical revision, identified by its GUID. Useful for comparing versions or restoring a previous revision. Returns 404 if the revision does not exist.",
         "operationId": "GetTemplateRevisionDetail",
@@ -1273,7 +1329,9 @@
     },
     "/templating/layouts": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns all available layout template names.",
         "description": "Returns a deduplicated list of layout template names from both the code-level ILayoutRegistry and database-assigned LayoutName values. Used by the admin UI to populate layout dropdowns.",
         "operationId": "ListAvailableLayouts",
@@ -1326,7 +1384,9 @@
     },
     "/templating/categories": {
       "get": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Returns all template categories ordered by sort order then name.",
         "description": "Returns all template categories for organizing templates. Categories are sorted by their sort order, then alphabetically by name. Each category includes its ID, name, and template count.",
         "operationId": "ListTemplateCategories",
@@ -1387,7 +1447,9 @@
         }
       },
       "post": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Creates a new template category.",
         "description": "Creates a new template category with the given name and sort order. The name must be unique.",
         "operationId": "CreateTemplateCategory",
@@ -1487,7 +1549,9 @@
     },
     "/templating/categories/{id}": {
       "put": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Updates an existing template category.",
         "description": "Updates the name and sort order of an existing category. Returns 404 if the category does not exist.",
         "operationId": "UpdateTemplateCategory",
@@ -1607,7 +1671,9 @@
         }
       },
       "delete": {
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "summary": "Deletes a template category (409 if templates are still associated).",
         "description": "Deletes the template category. Returns 409 Conflict if templates are still associated with this category — reassign or delete them first. Returns 404 if the category does not exist.",
         "operationId": "DeleteTemplateCategory",
@@ -1729,12 +1795,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1752,10 +1825,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1771,7 +1856,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1789,7 +1877,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1821,7 +1913,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1833,7 +1928,10 @@
         }
       },
       "GroupedResultOfTemplateSummary": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -1849,13 +1947,18 @@
         }
       },
       "GroupEntryOfTemplateSummary": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -1864,10 +1967,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/TemplateSummary"
             }
@@ -1878,20 +1987,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1904,31 +2028,42 @@
           }
         }
       },
-      "JsonElement": {
-        "type": ["null", "boolean", "number", "string", "object", "array"],
-        "description": "Arbitrary JSON value (object, array, string, number, boolean, or null)."
-      },
       "LookupDescriptor": {
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1936,11 +2071,20 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "PagedResultOfTemplateSummary": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1958,20 +2102,31 @@
               "type": "object",
               "properties": {
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "name": {
                   "type": "string"
                 },
                 "culture": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "mimeType": {
                   "type": "string"
                 },
                 "currentStatus": {
-                  "enum": ["Draft", "PendingReview", "Published", "Archived"]
+                  "enum": [
+                    "Draft",
+                    "PendingReview",
+                    "Published",
+                    "Archived"
+                  ]
                 },
                 "lastModifiedAt": {
                   "type": "string",
@@ -1984,29 +2139,46 @@
                   "type": "boolean"
                 },
                 "layoutName": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "categoryId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 }
               }
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -2027,7 +2199,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2125,12 +2301,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2145,17 +2328,25 @@
         }
       },
       "SaveTemplateCategoryRequest": {
-        "required": ["name", "description", "icon"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "icon": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "sortOrder": {
             "type": "integer",
@@ -2165,32 +2356,48 @@
         }
       },
       "SaveTemplateRequest": {
-        "required": ["name", "culture", "content"],
+        "required": [
+          "content"
+        ],
         "type": "object",
         "properties": {
-          "name": {
-            "type": ["null", "string"]
-          },
-          "culture": {
-            "type": ["null", "string"]
-          },
           "content": {
             "type": "string"
+          },
+          "name": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "culture": {
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "mimeType": {
             "type": "string",
             "default": "text/html"
           },
           "layoutName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "concurrencyStamp": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2199,7 +2406,14 @@
         }
       },
       "TemplateCategoryResponse": {
-        "required": ["id", "name", "description", "icon", "sortOrder", "templateCount"],
+        "required": [
+          "id",
+          "name",
+          "description",
+          "icon",
+          "sortOrder",
+          "templateCount"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -2210,10 +2424,16 @@
             "type": "string"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "icon": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "sortOrder": {
             "type": "integer",
@@ -2226,14 +2446,23 @@
         }
       },
       "TemplateDetailResponse": {
-        "required": ["name", "culture", "draft", "published", "layoutName"],
+        "required": [
+          "name",
+          "culture",
+          "draft",
+          "published",
+          "layoutName"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "culture": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "draft": {
             "oneOf": [
@@ -2256,12 +2485,20 @@
             ]
           },
           "layoutName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "TemplateHistoryResponse": {
-        "required": ["revisions", "totalCount", "page", "pageSize"],
+        "required": [
+          "revisions",
+          "totalCount",
+          "page",
+          "pageSize"
+        ],
         "type": "object",
         "properties": {
           "revisions": {
@@ -2285,14 +2522,23 @@
         }
       },
       "TemplateLifecycleResponse": {
-        "required": ["name", "culture", "currentStatus", "workflowEnabled", "availableTransitions"],
+        "required": [
+          "name",
+          "culture",
+          "currentStatus",
+          "workflowEnabled",
+          "availableTransitions"
+        ],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "culture": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "currentStatus": {
             "$ref": "#/components/schemas/WorkflowLifecycleStatus"
@@ -2309,38 +2555,51 @@
         }
       },
       "TemplatePreviewRequest": {
-        "required": ["culture", "data"],
         "type": "object",
         "properties": {
           "culture": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "data": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/JsonElement"
-              }
-            ]
+            "type": [
+              "null",
+              "boolean",
+              "number",
+              "string",
+              "object",
+              "array"
+            ],
+            "description": "Arbitrary JSON value (object, array, string, number, boolean, or null)."
           }
         }
       },
       "TemplatePreviewResponse": {
-        "required": ["html", "revisionId", "renderTimeMs"],
+        "required": [
+          "html",
+          "revisionId",
+          "renderTimeMs"
+        ],
         "type": "object",
         "properties": {
           "html": {
             "type": "string"
           },
           "revisionId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "renderTimeMs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           }
         }
@@ -2381,14 +2640,23 @@
             "type": "string"
           },
           "publishedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "publishedBy": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "layoutName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "concurrencyStamp": {
             "type": "string"
@@ -2422,11 +2690,17 @@
             "type": "string"
           },
           "publishedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "publishedBy": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "contentLength": {
             "type": "integer",
@@ -2447,14 +2721,20 @@
         "type": "object",
         "properties": {
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "name": {
             "type": "string"
           },
           "culture": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "mimeType": {
             "type": "string"
@@ -2473,16 +2753,26 @@
             "type": "boolean"
           },
           "layoutName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "categoryId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           }
         }
       },
       "TemplateVariableItemResponse": {
-        "required": ["name", "type", "description"],
+        "required": [
+          "name",
+          "type",
+          "description"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2492,12 +2782,19 @@
             "type": "string"
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "TemplateVariablesResponse": {
-        "required": ["globalVariables", "modelVariables", "enrichedVariables"],
+        "required": [
+          "globalVariables",
+          "modelVariables",
+          "enrichedVariables"
+        ],
         "type": "object",
         "properties": {
           "globalVariables": {
@@ -2521,7 +2818,12 @@
         }
       },
       "WorkflowLifecycleStatus": {
-        "enum": ["Draft", "PendingReview", "Published", "Archived"]
+        "enum": [
+          "Draft",
+          "PendingReview",
+          "Published",
+          "Archived"
+        ]
       }
     }
   },

--- a/contracts/openapi/timeline.json
+++ b/contracts/openapi/timeline.json
@@ -7,7 +7,9 @@
   "paths": {
     "/timeline/{entityType}/{entityId}": {
       "get": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Returns the paginated activity stream for an entity, newest first.",
         "description": "Returns comments, internal notes (staff-only, requires Timeline.InternalNotes.Read), and system log entries. Supports pagination. Soft-deleted entries are excluded.",
         "operationId": "GetTimelineStream",
@@ -107,7 +109,9 @@
     },
     "/timeline/{entityType}/{entityId}/entries": {
       "post": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Posts a new comment, internal note, or system log entry.",
         "description": "Creates a new timeline entry for the specified entity. Supports Comment and InternalNote types (SystemLog is system-only). The body supports Markdown. @mentions in the body trigger one-time mention notifications (max 10 per entry). Supports threaded replies via parentEntryId.",
         "operationId": "PostTimelineEntry",
@@ -207,7 +211,9 @@
     },
     "/timeline/{entityType}/{entityId}/anchor": {
       "post": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Materializes (or returns) the shadow row for an external timeline source entry.",
         "description": "Idempotent: returns the deterministic v5 GUID of the native anchor row so subsequent reactions/replies can target a stable id. The endpoint snapshots the source's body/author/occurred-at at anchor time; if the source later evolves, the shadow keeps its snapshot (audit retention independence).",
         "operationId": "AnchorExternalTimelineEntry",
@@ -307,7 +313,9 @@
     },
     "/timeline/{entityType}/{entityId}/entries/{entryId}": {
       "patch": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Edits the body of an entry the caller authored within the edit window.",
         "description": "Replaces the Markdown body of a Comment or InternalNote authored by the current user, provided the configured edit window (TimelineOptions.EditWindow, default 15 min) has not elapsed. Origin must be Native; SystemLog and external-origin entries are immutable. Returns 403 with reason in extensions when a gate rejects the request.",
         "operationId": "UpdateTimelineEntryBody",
@@ -408,7 +416,9 @@
         }
       },
       "delete": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Soft-deletes a comment or internal note (GDPR right to erasure).",
         "description": "Performs a soft-delete on the timeline entry. Only the author or users with Timeline.Entries.Manage permission can delete. SystemLog entries are immutable (ISO 27001). Returns 404 if the entry does not exist.",
         "operationId": "DeleteTimelineEntry",
@@ -491,7 +501,9 @@
     },
     "/timeline/{entityType}/{entityId}/follow": {
       "post": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Subscribes the current user as a follower of an entity.",
         "description": "Adds the authenticated user to the follower list for the specified entity. Followers receive notifications when new timeline entries are posted. Idempotent.",
         "operationId": "FollowTimelineEntity",
@@ -552,7 +564,9 @@
         }
       },
       "delete": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Unsubscribes the current user from an entity.",
         "description": "Removes the authenticated user from the follower list. Idempotent.",
         "operationId": "UnfollowTimelineEntity",
@@ -615,7 +629,9 @@
     },
     "/timeline/{entityType}/{entityId}/followers": {
       "get": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Returns the user IDs of all followers of an entity.",
         "description": "Returns the list of user IDs currently following the specified entity.",
         "operationId": "GetTimelineFollowers",
@@ -688,7 +704,9 @@
     },
     "/timeline/entries/{entryId}/reactions/{emoji}": {
       "post": {
-        "tags": ["Timeline"],
+        "tags": [
+          "Timeline"
+        ],
         "summary": "Toggles a reaction on a timeline entry by the calling user.",
         "description": "Idempotent toggle — adds the reaction if absent, removes if present. Accepts any well-formed Unicode emoji sequence (see EmojiValidator); rejects malformed input with 400 and Granit:Timeline:InvalidEmoji. Emits ReactionToggledEvent on the local bus on success. Concurrent double-POST is collapsed by the unique (EntryId, UserId, Emoji) DB index.",
         "operationId": "ToggleTimelineReaction",
@@ -770,7 +788,10 @@
   "components": {
     "schemas": {
       "AnchorTimelineEntryRequest": {
-        "required": ["sourceKey", "sourceId"],
+        "required": [
+          "sourceKey",
+          "sourceId"
+        ],
         "type": "object",
         "properties": {
           "sourceKey": {
@@ -782,7 +803,9 @@
         }
       },
       "AnchorTimelineEntryResponse": {
-        "required": ["entryId"],
+        "required": [
+          "entryId"
+        ],
         "type": "object",
         "properties": {
           "entryId": {
@@ -795,20 +818,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -822,7 +860,11 @@
         }
       },
       "PagedResultOfTimelineStreamEntryResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -832,19 +874,28 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PostTimelineEntryRequest": {
-        "required": ["entryType", "body"],
+        "required": [
+          "entryType",
+          "body"
+        ],
         "type": "object",
         "properties": {
           "entryType": {
@@ -854,11 +905,17 @@
             "type": "string"
           },
           "parentEntryId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "attachmentBlobIds": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string",
               "format": "uuid"
@@ -892,7 +949,11 @@
         }
       },
       "ReactionAggregateResponse": {
-        "required": ["count", "byCurrentUser", "displayEmoji"],
+        "required": [
+          "count",
+          "byCurrentUser",
+          "displayEmoji"
+        ],
         "type": "object",
         "properties": {
           "count": {
@@ -908,7 +969,12 @@
         }
       },
       "ReactionToggleResponse": {
-        "required": ["entryId", "emoji", "count", "currentUserHasReacted"],
+        "required": [
+          "entryId",
+          "emoji",
+          "count",
+          "currentUserHasReacted"
+        ],
         "type": "object",
         "properties": {
           "entryId": {
@@ -928,7 +994,13 @@
         }
       },
       "TimelineAttachmentInfoResponse": {
-        "required": ["id", "blobId", "fileName", "contentType", "sizeBytes"],
+        "required": [
+          "id",
+          "blobId",
+          "fileName",
+          "contentType",
+          "sizeBytes"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -947,13 +1019,20 @@
           },
           "sizeBytes": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           }
         }
       },
       "TimelineEntryType": {
-        "enum": ["Comment", "SystemLog", "InternalNote"]
+        "enum": [
+          "Comment",
+          "SystemLog",
+          "InternalNote"
+        ]
       },
       "TimelineStreamEntryResponse": {
         "required": [
@@ -980,10 +1059,16 @@
             "$ref": "#/components/schemas/TimelineStreamEntryType"
           },
           "authorId": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "authorName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "body": {
             "type": "string"
@@ -995,11 +1080,17 @@
             }
           },
           "parentEntryId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "reactions": {
-            "type": ["null", "object"],
+            "type": [
+              "null",
+              "object"
+            ],
             "additionalProperties": {
               "$ref": "#/components/schemas/ReactionAggregateResponse"
             }
@@ -1007,10 +1098,16 @@
         }
       },
       "TimelineStreamEntryType": {
-        "enum": ["Comment", "SystemLog", "InternalNote"]
+        "enum": [
+          "Comment",
+          "SystemLog",
+          "InternalNote"
+        ]
       },
       "UpdateTimelineEntryBodyRequest": {
-        "required": ["body"],
+        "required": [
+          "body"
+        ],
         "type": "object",
         "properties": {
           "body": {

--- a/contracts/openapi/validation.json
+++ b/contracts/openapi/validation.json
@@ -7,7 +7,9 @@
   "paths": {
     "/validation/validate": {
       "post": {
-        "tags": ["Validation"],
+        "tags": [
+          "Validation"
+        ],
         "summary": "Validates a single field value against a registered server-side validator.",
         "description": "Looks up the validator by error code and returns the validation result. Returns 404 if no validator is registered for the specified error code. Use the GET /validators endpoint to discover available validators.",
         "operationId": "ValidateField",
@@ -67,7 +69,9 @@
     },
     "/validation/validate-batch": {
       "post": {
-        "tags": ["Validation"],
+        "tags": [
+          "Validation"
+        ],
         "summary": "Validates multiple field values in a single round-trip (max 20).",
         "description": "For each field, looks up the validator by error code and returns the result. Unknown error codes return ValidatorNotFound status instead of failing the entire batch.",
         "operationId": "ValidateFieldBatch",
@@ -127,7 +131,9 @@
     },
     "/validation/validators": {
       "get": {
-        "tags": ["Validation"],
+        "tags": [
+          "Validation"
+        ],
         "summary": "Lists all registered server-side validator error codes.",
         "description": "Returns the list of error codes that can be used with the validate and validate-batch endpoints. Useful for frontend discovery: only error codes listed here can be validated in real-time.",
         "operationId": "GetRegisteredValidators",
@@ -165,20 +171,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -217,10 +238,16 @@
         }
       },
       "ValidationFieldStatus": {
-        "enum": ["Valid", "Invalid", "ValidatorNotFound"]
+        "enum": [
+          "Valid",
+          "Invalid",
+          "ValidatorNotFound"
+        ]
       },
       "ValidationFieldValidateBatchRequest": {
-        "required": ["fields"],
+        "required": [
+          "fields"
+        ],
         "type": "object",
         "properties": {
           "fields": {
@@ -232,7 +259,9 @@
         }
       },
       "ValidationFieldValidateBatchResponse": {
-        "required": ["results"],
+        "required": [
+          "results"
+        ],
         "type": "object",
         "properties": {
           "results": {
@@ -244,19 +273,27 @@
         }
       },
       "ValidationFieldValidateRequest": {
-        "required": ["errorCode", "value"],
+        "required": [
+          "errorCode"
+        ],
         "type": "object",
         "properties": {
           "errorCode": {
             "type": "string"
           },
           "value": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "ValidationFieldValidateResponse": {
-        "required": ["errorCode", "status"],
+        "required": [
+          "errorCode",
+          "status"
+        ],
         "type": "object",
         "properties": {
           "errorCode": {

--- a/contracts/openapi/webhooks.json
+++ b/contracts/openapi/webhooks.json
@@ -7,7 +7,9 @@
   "paths": {
     "/webhooks/event-types": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Returns all registered webhook event types.",
         "description": "Returns the full list of webhook event types declared by application modules at startup. Each entry includes the event type name, localized display name, description, and category for UI grouping. Labels are resolved based on the Accept-Language header. Use these values when creating webhook subscriptions to ensure the event type is valid. Returns an empty list if no event type providers are registered.",
         "operationId": "GetWebhookEventTypes",
@@ -60,7 +62,9 @@
     },
     "/webhooks/subscriptions/{id}": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Returns a webhook subscription by its unique identifier.",
         "description": "Fetches the full details of a single webhook subscription including its current status, target URL, event type, and delivery statistics. Returns 404 if the subscription does not exist.",
         "operationId": "GetWebhookSubscription",
@@ -130,7 +134,9 @@
         }
       },
       "put": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Updates a webhook subscription's target URL.",
         "description": "Replaces the target URL of an existing subscription. The subscription keeps its current status, secret, and event type. Returns 404 if the subscription does not exist.",
         "operationId": "UpdateWebhookSubscription",
@@ -230,7 +236,9 @@
         }
       },
       "delete": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Deletes a webhook subscription.",
         "description": "Permanently removes a webhook subscription and all its associated delivery history. This action is irreversible.",
         "operationId": "DeleteWebhookSubscription",
@@ -285,7 +293,9 @@
     },
     "/webhooks/subscriptions/{id}/keys": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Lists the signing keys associated with a subscription.",
         "description": "Returns all signing keys for the subscription, including Active, Retired (within the rotation grace period), and Revoked entries. The protected secret value is never disclosed; rotate the key to obtain a new plain-text secret.",
         "operationId": "ListWebhookSigningKeys",
@@ -358,7 +368,9 @@
         }
       },
       "post": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Rotates the subscription's signing key with overlap semantics.",
         "description": "Generates a new Active signing key and moves the previous Active key to Retired for a configurable grace period (default 24 hours, controlled by WebhooksOptions.RetiredKeyGracePeriod). Verification accepts both keys until the Retired key expires. The new plain-text secret is returned exactly once.",
         "operationId": "RotateWebhookSigningKey",
@@ -430,7 +442,9 @@
     },
     "/webhooks/subscriptions": {
       "post": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Creates a new webhook subscription.",
         "description": "Registers a new webhook subscription for the specified event type. The response includes the plain-text signing secret which is only returned once. The subscription starts in the Active status.",
         "operationId": "CreateWebhookSubscription",
@@ -508,7 +522,9 @@
         }
       },
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of WebhookSubscription entries.",
         "description": "Executes a dynamic query against WebhookSubscription using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryWebhookSubscription",
@@ -519,7 +535,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -530,7 +549,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -539,7 +561,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -547,7 +572,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -555,7 +583,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -563,7 +594,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -571,7 +605,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -579,7 +616,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -589,7 +629,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -602,7 +645,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -673,7 +719,9 @@
     },
     "/webhooks/subscriptions/{id}/activate": {
       "post": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Activates a suspended webhook subscription.",
         "description": "Transitions a subscription from Suspended to Active status. Deliveries will resume for matching events. The consecutive failure counter is reset to zero.",
         "operationId": "ActivateWebhookSubscription",
@@ -745,7 +793,9 @@
     },
     "/webhooks/subscriptions/{id}/suspend": {
       "post": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Suspends an active webhook subscription.",
         "description": "Temporarily pauses event delivery for the subscription. The caller's identity is recorded alongside the suspension reason. Use the activate endpoint to resume deliveries.",
         "operationId": "SuspendWebhookSubscription",
@@ -817,7 +867,9 @@
     },
     "/webhooks/subscriptions/{id}/deactivate": {
       "post": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Permanently deactivates a webhook subscription.",
         "description": "Moves the subscription to the Deactivated terminal status. No further deliveries will be attempted. A deactivation reason must be provided. This action cannot be reversed — create a new subscription instead.",
         "operationId": "DeactivateWebhookSubscription",
@@ -909,7 +961,9 @@
     },
     "/webhooks/subscriptions/{id}/test-ping": {
       "post": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Sends a test ping to the subscription's target URL.",
         "description": "Dispatches a synthetic test event to the subscription endpoint and reports the HTTP status code and round-trip duration. Does not affect delivery statistics or the consecutive failure counter.",
         "operationId": "TestWebhookPing",
@@ -981,7 +1035,9 @@
     },
     "/webhooks/stats": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Returns aggregate webhook delivery statistics.",
         "description": "Provides a summary of all webhook subscriptions: total count by status, number of deliveries in the last 24 hours, success rate, and average response time.",
         "operationId": "GetWebhookStats",
@@ -1031,7 +1087,9 @@
     },
     "/webhooks/subscriptions/{id}/keys/{keyId}": {
       "delete": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Revokes a specific signing key.",
         "description": "Marks the targeted key as Revoked. Verification will reject signatures produced with this key from now on. The last Active key cannot be revoked — rotate first to introduce a new Active key, then revoke the old one.",
         "operationId": "RevokeWebhookSigningKey",
@@ -1116,7 +1174,9 @@
     },
     "/webhooks/subscriptions/meta": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Returns query metadata for WebhookSubscription (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for WebhookSubscription: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetWebhookSubscriptionMeta",
@@ -1166,7 +1226,9 @@
     },
     "/webhooks/deliveries": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Returns a filtered, sorted, and paginated list of WebhookDeliveryAttempt entries.",
         "description": "Executes a dynamic query against WebhookDeliveryAttempt using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
         "operationId": "QueryWebhookDeliveryAttempt",
@@ -1177,7 +1239,10 @@
             "description": "1-based page index. Ignored when cursor is supplied.",
             "schema": {
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -1188,7 +1253,10 @@
             "schema": {
               "maximum": 500,
               "minimum": 1,
-              "type": ["null", "integer"],
+              "type": [
+                "null",
+                "integer"
+              ],
               "format": "int32"
             }
           },
@@ -1197,7 +1265,10 @@
             "in": "query",
             "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -1205,7 +1276,10 @@
             "in": "query",
             "description": "Free-text search across searchable columns declared in the query definition.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -1213,7 +1287,10 @@
             "in": "query",
             "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -1221,7 +1298,10 @@
             "in": "query",
             "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -1229,7 +1309,10 @@
             "in": "query",
             "description": "Comma-separated quick-filter names (declared in the query definition).",
             "schema": {
-              "type": ["null", "string"]
+              "type": [
+                "null",
+                "string"
+              ]
             }
           },
           {
@@ -1237,7 +1320,10 @@
             "in": "query",
             "description": "Skip the total row count for faster pagination when the client doesn't need it.",
             "schema": {
-              "type": ["null", "boolean"]
+              "type": [
+                "null",
+                "boolean"
+              ]
             }
           },
           {
@@ -1247,7 +1333,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -1260,7 +1349,10 @@
             "style": "deepObject",
             "explode": true,
             "schema": {
-              "type": ["null", "object"],
+              "type": [
+                "null",
+                "object"
+              ],
               "additionalProperties": {
                 "type": "string"
               }
@@ -1331,7 +1423,9 @@
     },
     "/webhooks/deliveries/meta": {
       "get": {
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "summary": "Returns query metadata for WebhookDeliveryAttempt (columns, filters, sorts, presets).",
         "description": "Returns the query definition metadata for WebhookDeliveryAttempt: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
         "operationId": "GetWebhookDeliveryAttemptMeta",
@@ -1418,12 +1512,19 @@
             "type": "boolean"
           },
           "format": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "DateFilterMeta": {
-        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "required": [
+          "name",
+          "defaultPeriod",
+          "availablePeriods"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1441,10 +1542,22 @@
         }
       },
       "DatePeriod": {
-        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+        "enum": [
+          "Today",
+          "ThisWeek",
+          "ThisMonth",
+          "LastMonth",
+          "ThisQuarter",
+          "ThisYear",
+          "Custom"
+        ]
       },
       "FilterableField": {
-        "required": ["name", "type", "operators"],
+        "required": [
+          "name",
+          "type",
+          "operators"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1460,7 +1573,10 @@
             }
           },
           "enumValues": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1478,7 +1594,11 @@
         }
       },
       "FilterGroupMeta": {
-        "required": ["name", "label", "presets"],
+        "required": [
+          "name",
+          "label",
+          "presets"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1510,7 +1630,10 @@
         ]
       },
       "GroupByField": {
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1522,7 +1645,10 @@
         }
       },
       "GroupedResultOfWebhookDeliveryAttempt": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -1538,7 +1664,10 @@
         }
       },
       "GroupedResultOfWebhookSubscription": {
-        "required": ["groups", "totalCount"],
+        "required": [
+          "groups",
+          "totalCount"
+        ],
         "type": "object",
         "properties": {
           "groups": {
@@ -1554,13 +1683,18 @@
         }
       },
       "GroupEntryOfWebhookDeliveryAttempt": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -1569,10 +1703,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/WebhookDeliveryAttempt"
             }
@@ -1580,13 +1720,18 @@
         }
       },
       "GroupEntryOfWebhookSubscription": {
-        "required": ["field", "value", "label", "count"],
+        "required": [
+          "field",
+          "value",
+          "label",
+          "count"
+        ],
         "type": "object",
         "properties": {
           "field": {
             "type": "string"
           },
-          "value": {},
+          "value": { },
           "label": {
             "type": "string"
           },
@@ -1595,10 +1740,16 @@
             "format": "int32"
           },
           "aggregates": {
-            "type": ["null", "object"]
+            "type": [
+              "null",
+              "object"
+            ]
           },
           "items": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/WebhookSubscription"
             }
@@ -1612,20 +1763,35 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "title": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "status": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "detail": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "instance": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "errors": {
             "type": "object",
@@ -1650,23 +1816,38 @@
         "type": "object",
         "properties": {
           "name": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "endpoint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "kind": {
             "$ref": "#/components/schemas/LookupKind"
           },
           "requiredPermission": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "searchParam": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "default": "search"
           },
           "scopeKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "type": "string"
             }
@@ -1674,11 +1855,20 @@
         }
       },
       "LookupKind": {
-        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "enum": [
+          "QueryEngine",
+          "Simple",
+          "ReferenceData",
+          "Enum"
+        ],
         "default": "QueryEngine"
       },
       "PagedResultOfWebhookDeliveryAttempt": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1695,7 +1885,10 @@
                   "format": "uuid"
                 },
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "eventType": {
@@ -1705,7 +1898,10 @@
                   "type": "string"
                 },
                 "httpStatusCode": {
-                  "type": ["null", "integer"],
+                  "type": [
+                    "null",
+                    "integer"
+                  ],
                   "format": "int32"
                 },
                 "payloadHash": {
@@ -1717,17 +1913,26 @@
                 },
                 "durationMs": {
                   "pattern": "^-?(?:0|[1-9]\\d*)$",
-                  "type": ["integer", "string"],
+                  "type": [
+                    "integer",
+                    "string"
+                  ],
                   "format": "int64"
                 },
                 "errorMessage": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "isSuccess": {
                   "type": "boolean"
                 },
                 "payload": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "id": {
                   "type": "string",
@@ -1738,19 +1943,29 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PagedResultOfWebhookSubscription": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -1765,7 +1980,10 @@
                   "type": "string"
                 },
                 "signingKeys": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "properties": {
@@ -1781,19 +1999,32 @@
                         "format": "date-time"
                       },
                       "expiresAt": {
-                        "type": ["null", "string"],
+                        "type": [
+                          "null",
+                          "string"
+                        ],
                         "format": "date-time"
                       },
                       "revokedAt": {
-                        "type": ["null", "string"],
+                        "type": [
+                          "null",
+                          "string"
+                        ],
                         "format": "date-time"
                       },
                       "lastRotationNotificationAt": {
-                        "type": ["null", "string"],
+                        "type": [
+                          "null",
+                          "string"
+                        ],
                         "format": "date-time"
                       },
                       "status": {
-                        "enum": ["Active", "Retired", "Revoked"]
+                        "enum": [
+                          "Active",
+                          "Retired",
+                          "Revoked"
+                        ]
                       },
                       "id": {
                         "type": "string",
@@ -1804,51 +2035,85 @@
                   }
                 },
                 "tenantId": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "uuid"
                 },
                 "status": {
-                  "enum": ["Active", "Suspended", "Deactivated"]
+                  "enum": [
+                    "Active",
+                    "Suspended",
+                    "Deactivated"
+                  ]
                 },
                 "signingSecretHint": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "deactivationReason": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "consecutiveFailureCount": {
                   "type": "integer",
                   "format": "int32"
                 },
                 "lastSuccessAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "date-time"
                 },
                 "suspendedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "format": "date-time"
                 },
                 "suspendedBy": {
-                  "type": ["null", "string"]
+                  "type": [
+                    "null",
+                    "string"
+                  ]
                 },
                 "modifiedAt": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
                 "modifiedBy": {
-                  "type": ["null", "string"],
+                  "type": [
+                    "null",
+                    "string"
+                  ],
                   "description": "Identifier of the user who last modified the entity."
                 },
                 "domainEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for domain events."
                   }
                 },
                 "integrationEvents": {
-                  "type": ["null", "array"],
+                  "type": [
+                    "null",
+                    "array"
+                  ],
                   "items": {
                     "type": "object",
                     "description": "Marker interface for integration events (ETO — Event Transfer Object)."
@@ -1872,19 +2137,30 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "PaginationMeta": {
-        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "required": [
+          "defaultPageSize",
+          "maxPageSize",
+          "maxStreamSize",
+          "supportsCursor"
+        ],
         "type": "object",
         "properties": {
           "defaultPageSize": {
@@ -1905,7 +2181,11 @@
         }
       },
       "PresetMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2003,12 +2283,19 @@
             "$ref": "#/components/schemas/PaginationMeta"
           },
           "defaultSort": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
       "QuickFilterMeta": {
-        "required": ["name", "label", "isDefault"],
+        "required": [
+          "name",
+          "label",
+          "isDefault"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2023,7 +2310,9 @@
         }
       },
       "SortableField": {
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -2043,7 +2332,10 @@
             "format": "uuid"
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "eventType": {
@@ -2053,7 +2345,10 @@
             "type": "string"
           },
           "httpStatusCode": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "payloadHash": {
@@ -2065,17 +2360,26 @@
           },
           "durationMs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           },
           "errorMessage": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "isSuccess": {
             "type": "boolean"
           },
           "payload": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "id": {
             "type": "string",
@@ -2085,20 +2389,34 @@
         }
       },
       "WebhookEventTypeResponse": {
-        "required": ["eventType", "displayName", "description", "category"],
+        "required": [
+          "eventType",
+          "displayName",
+          "description",
+          "category"
+        ],
         "type": "object",
         "properties": {
           "eventType": {
             "type": "string"
           },
           "displayName": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "description": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "category": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2117,15 +2435,24 @@
             "format": "date-time"
           },
           "expiresAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "revokedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "lastRotationNotificationAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "status": {
@@ -2139,7 +2466,12 @@
         }
       },
       "WebhookSigningKeyCreatedResponse": {
-        "required": ["id", "subscriptionId", "createdAt", "plainSecret"],
+        "required": [
+          "id",
+          "subscriptionId",
+          "createdAt",
+          "plainSecret"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -2184,15 +2516,24 @@
             "format": "date-time"
           },
           "expiresAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "revokedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "lastRotationNotificationAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "status": {
@@ -2201,7 +2542,11 @@
         }
       },
       "WebhookSigningKeyStatus": {
-        "enum": ["Active", "Retired", "Revoked"]
+        "enum": [
+          "Active",
+          "Retired",
+          "Revoked"
+        ]
       },
       "WebhookSubscription": {
         "type": "object",
@@ -2213,56 +2558,89 @@
             "type": "string"
           },
           "signingKeys": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/WebhookSigningKey"
             }
           },
           "tenantId": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "uuid"
           },
           "status": {
             "$ref": "#/components/schemas/WebhookSubscriptionStatus"
           },
           "signingSecretHint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "deactivationReason": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "consecutiveFailureCount": {
             "type": "integer",
             "format": "int32"
           },
           "lastSuccessAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "suspendedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "suspendedBy": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Last modification timestamp (UTC).",
             "format": "date-time"
           },
           "modifiedBy": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "description": "Identifier of the user who last modified the entity."
           },
           "domainEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IDomainEvent"
             }
           },
           "integrationEvents": {
-            "type": ["null", "array"],
+            "type": [
+              "null",
+              "array"
+            ],
             "items": {
               "$ref": "#/components/schemas/IIntegrationEvent"
             }
@@ -2284,7 +2662,13 @@
         }
       },
       "WebhookSubscriptionCreatedResponse": {
-        "required": ["id", "targetUrl", "eventType", "status", "signingSecret"],
+        "required": [
+          "id",
+          "targetUrl",
+          "eventType",
+          "status",
+          "signingSecret"
+        ],
         "type": "object",
         "properties": {
           "id": {
@@ -2306,7 +2690,10 @@
         }
       },
       "WebhookSubscriptionCreateRequest": {
-        "required": ["targetUrl", "eventType"],
+        "required": [
+          "targetUrl",
+          "eventType"
+        ],
         "type": "object",
         "properties": {
           "targetUrl": {
@@ -2318,7 +2705,9 @@
         }
       },
       "WebhookSubscriptionDeactivateRequest": {
-        "required": ["reason"],
+        "required": [
+          "reason"
+        ],
         "type": "object",
         "properties": {
           "reason": {
@@ -2358,7 +2747,10 @@
             "format": "int32"
           },
           "lastSuccessAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "createdAt": {
@@ -2366,11 +2758,17 @@
             "format": "date-time"
           },
           "modifiedAt": {
-            "type": ["null", "string"],
+            "type": [
+              "null",
+              "string"
+            ],
             "format": "date-time"
           },
           "signingSecretHint": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -2408,21 +2806,35 @@
           },
           "successRateLast24h": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["number", "string"],
+            "type": [
+              "number",
+              "string"
+            ],
             "format": "double"
           },
           "avgResponseTimeMsLast24h": {
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["number", "string"],
+            "type": [
+              "number",
+              "string"
+            ],
             "format": "double"
           }
         }
       },
       "WebhookSubscriptionStatus": {
-        "enum": ["Active", "Suspended", "Deactivated"]
+        "enum": [
+          "Active",
+          "Suspended",
+          "Deactivated"
+        ]
       },
       "WebhookSubscriptionTestPingResponse": {
-        "required": ["success", "httpStatusCode", "durationMs"],
+        "required": [
+          "success",
+          "httpStatusCode",
+          "durationMs"
+        ],
         "type": "object",
         "properties": {
           "success": {
@@ -2434,13 +2846,18 @@
           },
           "durationMs": {
             "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
+            "type": [
+              "integer",
+              "string"
+            ],
             "format": "int64"
           }
         }
       },
       "WebhookSubscriptionUpdateRequest": {
-        "required": ["targetUrl"],
+        "required": [
+          "targetUrl"
+        ],
         "type": "object",
         "properties": {
           "targetUrl": {

--- a/contracts/openapi/workflow.json
+++ b/contracts/openapi/workflow.json
@@ -7,7 +7,9 @@
   "paths": {
     "/workflow/{entityType}/{entityId}/history": {
       "get": {
-        "tags": ["Workflow"],
+        "tags": [
+          "Workflow"
+        ],
         "summary": "Returns the ISO 27001-compliant audit trail of workflow transitions for an entity.",
         "description": "Returns a paginated list of all state transitions for the specified entity, ordered by timestamp descending. Each entry includes the source and target state, the actor, an optional comment, and the transition timestamp. This history is immutable and serves as the ISO 27001 A.12.4 audit trail for workflow changes.",
         "operationId": "GetWorkflowTransitionHistory",
@@ -109,7 +111,11 @@
   "components": {
     "schemas": {
       "PagedResultOfWorkflowTransitionHistoryResponse": {
-        "required": ["items", "totalCount", "hasMore"],
+        "required": [
+          "items",
+          "totalCount",
+          "hasMore"
+        ],
         "type": "object",
         "properties": {
           "items": {
@@ -119,14 +125,20 @@
             }
           },
           "totalCount": {
-            "type": ["null", "integer"],
+            "type": [
+              "null",
+              "integer"
+            ],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -156,7 +168,13 @@
         }
       },
       "WorkflowTransitionHistoryResponse": {
-        "required": ["previousState", "newState", "transitionedAt", "transitionedBy", "comment"],
+        "required": [
+          "previousState",
+          "newState",
+          "transitionedAt",
+          "transitionedBy",
+          "comment"
+        ],
         "type": "object",
         "properties": {
           "previousState": {
@@ -173,7 +191,10 @@
             "type": "string"
           },
           "comment": {
-            "type": ["null", "string"]
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       }


### PR DESCRIPTION
## What

Regenerates all 29 vendored backend OpenAPI contract snapshots under `contracts/openapi/` by re-running `Granit.OpenApi.Generator` (granit-dotnet) and re-vendoring via `scripts/sync-openapi-contracts.mjs`.

## Why

The snapshots had drifted from the backend. This refresh picks up the backend change that **defaults optional nullable params on Request DTOs** so they are no longer `required` in the generated OpenAPI — e.g. `AccountProfileUpdateRequest` `firstName`/`lastName` move from required+nullable to genuinely optional. The bulk of the line count is the generator now serializing `required` arrays multi-line; the rest is the real optionality deltas across modules.

## Verification

- `@granit/contract-tests` conformance oracle: **46 tests green** against the regenerated snapshots.
- All 29 files validated as well-formed JSON.

## ⚠️ Backend dependency

These snapshots mirror the backend branch carrying the Request-DTO optional-default change (granit-dotnet `1d62bc63`, prep in #2547/#2548 *on granit-dotnet*). **Confirm that backend change is merged to the backend base before relying on / merging these contracts**, otherwise the front would pin an unmerged backend state.

> Generated artifacts — do not hand-edit; re-run `node scripts/sync-openapi-contracts.mjs`.