### PR TITLE
feat(contract-tests): endpoint (route/verb) conformance + features module

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -864,7 +864,7 @@
     },
     {
       "name": "@granit/authentication-local",
-      "description": "Local credential authentication types and API — headless login + full account self-service (registration, password, email, profile, 2FA, passkeys) — mirrors Granit.Identity.Local.Endpoints .NET contract",
+      "description": "Local credential authentication types and API — headless login, passkey assertion — mirrors Granit.Identity.Local.Endpoints .NET contract",
       "exports": [
         {
           "name": "loginAccount",
@@ -875,56 +875,6 @@
           "name": "verifyTwoFactorLogin",
           "kind": "function",
           "signature": "async function verifyTwoFactorLogin( client: AxiosInstance, basePath: string, request: AccountTwoFactorLoginRequest ): Promise<AccountLoginResponse>"
-        },
-        {
-          "name": "changePassword",
-          "kind": "function",
-          "signature": "async function changePassword( client: AxiosInstance, basePath: string, request: AccountPasswordChangeRequest ): Promise<void>"
-        },
-        {
-          "name": "forgotPassword",
-          "kind": "function",
-          "signature": "async function forgotPassword( client: AxiosInstance, basePath: string, request: AccountForgotPasswordRequest ): Promise<void>"
-        },
-        {
-          "name": "resetPassword",
-          "kind": "function",
-          "signature": "async function resetPassword( client: AxiosInstance, basePath: string, request: AccountPasswordResetRequest ): Promise<void>"
-        },
-        {
-          "name": "changeEmail",
-          "kind": "function",
-          "signature": "async function changeEmail( client: AxiosInstance, basePath: string, request: AccountChangeEmailRequest ): Promise<void>"
-        },
-        {
-          "name": "confirmEmailChange",
-          "kind": "function",
-          "signature": "async function confirmEmailChange( client: AxiosInstance, basePath: string, request: AccountConfirmEmailChangeRequest ): Promise<void>"
-        },
-        {
-          "name": "getProfile",
-          "kind": "function",
-          "signature": "async function getProfile( client: AxiosInstance, basePath: string ): Promise<AccountProfileResponse>"
-        },
-        {
-          "name": "updateProfile",
-          "kind": "function",
-          "signature": "async function updateProfile( client: AxiosInstance, basePath: string, request: AccountProfileUpdateRequest ): Promise<AccountProfileResponse>"
-        },
-        {
-          "name": "deleteAccount",
-          "kind": "function",
-          "signature": "async function deleteAccount( client: AxiosInstance, basePath: string, request: AccountDeleteRequest ): Promise<void>"
-        },
-        {
-          "name": "sendSessionHeartbeat",
-          "kind": "function",
-          "signature": "async function sendSessionHeartbeat(client: AxiosInstance, basePath: string): Promise<void>"
-        },
-        {
-          "name": "getAccountConfig",
-          "kind": "function",
-          "signature": "async function getAccountConfig( client: AxiosInstance, basePath: string ): Promise<IdentityLocalConfigResponse>"
         },
         {
           "name": "extractReturnUrl",
@@ -1222,6 +1172,55 @@
               "name": "components",
               "kind": "property",
               "signature": "components?: { schemas?: Record<string, OpenApiSchema> }"
+            }
+          ]
+        },
+        {
+          "name": "checkEndpointConformance",
+          "kind": "function",
+          "signature": "function checkEndpointConformance( module: string, spec: OpenApiPaths, apiSources: ReadonlyArray<"
+        },
+        {
+          "name": "EndpointViolation",
+          "kind": "interface",
+          "signature": "interface EndpointViolation",
+          "members": [
+            {
+              "name": "rule",
+              "kind": "property",
+              "signature": "rule: string"
+            },
+            {
+              "name": "module",
+              "kind": "property",
+              "signature": "module: string"
+            },
+            {
+              "name": "method",
+              "kind": "property",
+              "signature": "method: string"
+            },
+            {
+              "name": "route",
+              "kind": "property",
+              "signature": "route: string"
+            },
+            {
+              "name": "message",
+              "kind": "property",
+              "signature": "message: string"
+            }
+          ]
+        },
+        {
+          "name": "OpenApiPaths",
+          "kind": "interface",
+          "signature": "interface OpenApiPaths",
+          "members": [
+            {
+              "name": "paths",
+              "kind": "property",
+              "signature": "paths?: Record<string, Record<string, unknown>>"
             }
           ]
         }
@@ -2979,7 +2978,7 @@
     },
     {
       "name": "@granit/react-authentication-local",
-      "description": "React hooks for local credential authentication — login, registration, password, email change, profile, two-factor and passkey management",
+      "description": "React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion",
       "exports": [
         {
           "name": "LocalAuthProvider",
@@ -3002,11 +3001,6 @@
           "kind": "interface",
           "signature": "interface LocalAuthProviderProps",
           "members": []
-        },
-        {
-          "name": "localAuthKeys",
-          "kind": "const",
-          "signature": "const localAuthKeys"
         },
         {
           "name": "useLogin",
@@ -3032,73 +3026,6 @@
           "name": "useCompletePasskeyAssertion",
           "kind": "function",
           "signature": "function useCompletePasskeyAssertion(): UseMutationResult< AccountLoginResponse, Error, AccountPasskeyLoginRequest >"
-        },
-        {
-          "name": "useChangePassword",
-          "kind": "function",
-          "signature": "function useChangePassword(): UseMutationResult<void, Error, AccountPasswordChangeRequest>"
-        },
-        {
-          "name": "useForgotPassword",
-          "kind": "function",
-          "signature": "function useForgotPassword(): UseMutationResult<void, Error, AccountForgotPasswordRequest>"
-        },
-        {
-          "name": "useResetPassword",
-          "kind": "function",
-          "signature": "function useResetPassword(): UseMutationResult<void, Error, AccountPasswordResetRequest>"
-        },
-        {
-          "name": "useChangeEmail",
-          "kind": "function",
-          "signature": "function useChangeEmail(): UseMutationResult<void, Error, AccountChangeEmailRequest>"
-        },
-        {
-          "name": "useConfirmEmailChange",
-          "kind": "function",
-          "signature": "function useConfirmEmailChange(): UseMutationResult< void, Error, AccountConfirmEmailChangeRequest >"
-        },
-        {
-          "name": "useProfile",
-          "kind": "function",
-          "signature": "function useProfile(): UseQueryResult<AccountProfileResponse>"
-        },
-        {
-          "name": "useUpdateProfile",
-          "kind": "function",
-          "signature": "function useUpdateProfile(): UseMutationResult< AccountProfileResponse, Error, AccountProfileUpdateRequest >"
-        },
-        {
-          "name": "RenamePasskeyVariables",
-          "kind": "interface",
-          "signature": "interface RenamePasskeyVariables",
-          "members": [
-            {
-              "name": "id",
-              "kind": "property",
-              "signature": "id: string"
-            },
-            {
-              "name": "request",
-              "kind": "property",
-              "signature": "request: PasskeyRenameRequest"
-            }
-          ]
-        },
-        {
-          "name": "useDeleteAccount",
-          "kind": "function",
-          "signature": "function useDeleteAccount(): UseMutationResult<void, Error, AccountDeleteRequest>"
-        },
-        {
-          "name": "useSendSessionHeartbeat",
-          "kind": "function",
-          "signature": "function useSendSessionHeartbeat(): UseMutationResult<void, Error, void>"
-        },
-        {
-          "name": "useAccountConfig",
-          "kind": "function",
-          "signature": "function useAccountConfig(): UseQueryResult<IdentityLocalConfigResponse>"
         }
       ]
     },

--- a/packages/@granit/contract-tests/README.md
+++ b/packages/@granit/contract-tests/README.md
@@ -18,6 +18,13 @@ type family — while a small **normalization table** absorbs the spec's
 representation warts. Drift (a new backend field, a flipped nullability, a
 removed field) fails the test; representation differences do not.
 
+Two oracles:
+
+- **`checkSchemaConformance`** — DTOs (field presence, nullability, type family).
+- **`checkEndpointConformance`** — routes/verbs: every spec `path`+`method` has a
+  front `client.METHOD()` call at the same route (the module `basePath` is
+  auto-detected). Catches a removed route, a flipped verb, or a stale front call.
+
 ## Usage
 
 ```ts
@@ -45,15 +52,23 @@ with `GRANIT_DOTNET=/path/to/granit-dotnet`).
 ## Extending coverage
 
 1. Vendor the spec: `node scripts/sync-openapi-contracts.mjs <slug>`.
-2. Add a line to [`src/manifest.ts`](src/manifest.ts) — `{ slug, package, types }`,
-   where `types` lists the per-module DTO interfaces (spec schema name === front
-   interface name). Shared schemas (query-engine metadata, `ProblemDetails`,
-   `*Of*` wrapper generics) belong to their owning package and are not listed.
+2. Add a line to [`src/manifest.ts`](src/manifest.ts):
+   - `types` — per-module DTO interfaces (spec schema name === front interface
+     name). Shared schemas (query-engine metadata, `ProblemDetails`, `*Of*`
+     wrapper generics) belong to their owning package and are not listed.
+   - `checkEndpoints: true` — also verify routes/verbs. Leave off for modules
+     served by native `fetch` (BFF) instead of the Axios client.
+   - `endpointIgnore` — routes (relative to the detected `basePath`) served by
+     the query-engine generic surface (`''` list, `'/meta'`), not an `api/` fn.
 
 The suite resolves each interface, brands (`EntityId<…>`, `ISODateString`),
-local string-union aliases and `$ref` enums automatically.
+local string-union aliases, `$ref` enums, and both `interface X {}` and
+`type X = {…}` DTOs automatically.
 
-Covered so far: `background-jobs`, `bff`, `blob-storage`, `api-keys`, `ai`. The
-`Granit.OpenApi.Generator` ships the 30 framework modules; granit-business
-modules (dashboards, parties, …) need an equivalent generator. Endpoint
-(route/verb) conformance is a planned follow-up.
+Covered so far: `background-jobs`, `bff`, `blob-storage`, `api-keys`, `ai`,
+`auditing`, `authorization`, `features` (endpoint conformance on the
+Axios-client ones). Modules whose front DTO names still diverge from the spec
+(e.g. `multi-tenancy` `AdminTenant` vs `TenantResponse`, several `webhooks`
+types) need the same rename treatment as auditing/authorization before wiring.
+The `Granit.OpenApi.Generator` ships the 30 framework modules; granit-business
+modules (dashboards, parties, …) need an equivalent generator.

--- a/packages/@granit/contract-tests/src/__tests__/conformance-suite.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/conformance-suite.test.ts
@@ -5,9 +5,11 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 import { checkSchemaConformance } from '../conformance';
+import { checkEndpointConformance } from '../endpoints';
 import { CONTRACTS } from '../manifest';
 
 import type { OpenApiDocument } from '../conformance';
+import type { OpenApiPaths } from '../endpoints';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(here, '../../../../..');
@@ -35,6 +37,23 @@ function findInterfaceFile(srcDir: string, typeName: string): string | undefined
   return undefined;
 }
 
+/** Read every `api/**\/*.ts` (non-test) file under a package's src. */
+function readApiSources(srcDir: string): { file: string; text: string }[] {
+  const out: { file: string; text: string }[] = [];
+  const walk = (dir: string, underApi: boolean): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      if (['node_modules', 'dist', '__tests__'].includes(entry.name)) continue;
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) walk(full, underApi || entry.name === 'api');
+      else if (underApi && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+        out.push({ file: full, text: readFileSync(full, 'utf8') });
+      }
+    }
+  };
+  walk(srcDir, false);
+  return out;
+}
+
 describe.each(CONTRACTS.map((m) => [m.slug, m] as const))(
   'contract conformance — %s',
   (_slug, mod) => {
@@ -55,5 +74,17 @@ describe.each(CONTRACTS.map((m) => [m.slug, m] as const))(
         expect(violations).toEqual([]);
       }
     );
+
+    if (mod.checkEndpoints) {
+      it(`@granit/${mod.package} api/ routes mirror the backend endpoints`, () => {
+        const violations = checkEndpointConformance(
+          mod.slug,
+          spec as OpenApiPaths,
+          readApiSources(srcDir),
+          { ignore: mod.endpointIgnore }
+        );
+        expect(violations).toEqual([]);
+      });
+    }
   }
 );

--- a/packages/@granit/contract-tests/src/__tests__/endpoints.test.ts
+++ b/packages/@granit/contract-tests/src/__tests__/endpoints.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { checkEndpointConformance } from '../endpoints';
+
+import type { OpenApiPaths } from '../endpoints';
+
+const spec: OpenApiPaths = {
+  paths: {
+    '/widgets': { get: {}, post: {} },
+    '/widgets/{id}': { get: {} },
+    '/widgets/{id}/archive': { post: {} },
+  },
+};
+
+const file = '/virtual/widgets-api.ts';
+const check = (src: string) => checkEndpointConformance('widgets', spec, [{ file, text: src }]);
+
+const GREEN = `
+  export async function listWidgets(client, basePath) {
+    return client.get(\`\${basePath}/widgets\`);
+  }
+  export async function createWidget(client, basePath, body) {
+    return client.post(\`\${basePath}/widgets\`, body);
+  }
+  export async function getWidget(client, basePath, id) {
+    return client.get(\`\${basePath}/widgets/\${encodeURIComponent(id)}\`);
+  }
+  export async function archiveWidget(client, basePath, id) {
+    const url = \`\${basePath}/widgets/\${id}/archive\`;
+    return client.post(url);
+  }`;
+
+describe('endpoint conformance — positive & negative controls', () => {
+  it('passes when api/ routes mirror the spec (basePath auto-detected, const url resolved)', () => {
+    expect(check(GREEN)).toEqual([]);
+  });
+
+  it('flags a missing endpoint (spec route with no front call)', () => {
+    const src = GREEN.replace(/export async function archiveWidget[\s\S]*?\n {2}}/, '');
+    expect(check(src)).toContainEqual(
+      expect.objectContaining({
+        rule: 'missing-endpoint',
+        method: 'post',
+        route: '/widgets/{}/archive',
+      })
+    );
+  });
+
+  it('flags an orphan endpoint (front call with no spec route)', () => {
+    const src = `${GREEN}
+      export async function deleteWidget(client, basePath, id) {
+        return client.delete(\`\${basePath}/widgets/\${id}\`);
+      }`;
+    expect(check(src)).toContainEqual(
+      expect.objectContaining({ rule: 'orphan-endpoint', method: 'delete', route: '/widgets/{}' })
+    );
+  });
+
+  it('flags a verb mismatch as both missing and orphan', () => {
+    const src = GREEN.replace('return client.post(url);', 'return client.get(url);');
+    const v = check(src);
+    expect(v).toContainEqual(
+      expect.objectContaining({
+        rule: 'missing-endpoint',
+        method: 'post',
+        route: '/widgets/{}/archive',
+      })
+    );
+    expect(v).toContainEqual(
+      expect.objectContaining({
+        rule: 'orphan-endpoint',
+        method: 'get',
+        route: '/widgets/{}/archive',
+      })
+    );
+  });
+
+  it('respects the ignore list (query-engine surface routes)', () => {
+    const listSpec: OpenApiPaths = {
+      paths: {
+        '/widgets': { get: {} }, // query-engine list — not a front api fn
+        '/widgets/{id}': { get: {} },
+      },
+    };
+    const src = `
+      export async function getWidget(client, basePath, id) {
+        return client.get(\`\${basePath}/widgets/\${encodeURIComponent(id)}\`);
+      }`;
+    expect(
+      checkEndpointConformance('widgets', listSpec, [{ file, text: src }], { ignore: ['/widgets'] })
+    ).toEqual([]);
+  });
+});

--- a/packages/@granit/contract-tests/src/endpoints.ts
+++ b/packages/@granit/contract-tests/src/endpoints.ts
@@ -1,0 +1,203 @@
+import * as ts from 'typescript';
+
+/** A route/verb mismatch between the backend spec and the front `api/` functions. */
+export interface EndpointViolation {
+  /** `missing-endpoint` (spec route with no front fn) | `orphan-endpoint` (front call with no spec route). */
+  rule: string;
+  module: string;
+  method: string;
+  route: string;
+  message: string;
+}
+
+const HTTP_METHODS = new Set(['get', 'post', 'put', 'patch', 'delete']);
+
+interface Endpoint {
+  method: string;
+  /** Route relative to the module base, with every path param normalized to `{}`. */
+  route: string;
+}
+
+const normalizeRoute = (route: string): string => route.replace(/\{[^}]+\}/g, '{}');
+
+// --- OpenAPI side ----------------------------------------------------------
+
+export interface OpenApiPaths {
+  paths?: Record<string, Record<string, unknown>>;
+}
+
+/**
+ * Candidate module-base prefixes: every segment-aligned prefix shared by all
+ * paths (stopping before any path param), longest-first, plus the empty base.
+ * The front `basePath` may or may not include the resource segment, so we try
+ * each candidate and keep the one that best aligns spec routes with front calls.
+ */
+function candidateBases(paths: readonly string[]): string[] {
+  if (paths.length === 0) return [''];
+  const split = paths.map((p) => p.split('/'));
+  const first = split[0]!;
+  let max = 0;
+  for (; max < first.length; max++) {
+    const seg = first[max]!;
+    if (seg.includes('{')) break;
+    if (!split.every((s) => s[max] === seg)) break;
+  }
+  const out: string[] = [];
+  for (let i = max; i >= 1; i--) out.push(first.slice(0, i).join('/'));
+  out.push('');
+  return [...new Set(out)];
+}
+
+function specEndpoints(spec: OpenApiPaths, base: string): Endpoint[] {
+  const out: Endpoint[] = [];
+  for (const [path, methods] of Object.entries(spec.paths ?? {})) {
+    const route = normalizeRoute(path.startsWith(base) ? path.slice(base.length) : path);
+    for (const method of Object.keys(methods)) {
+      if (HTTP_METHODS.has(method)) out.push({ method, route });
+    }
+  }
+  return out;
+}
+
+// --- TypeScript side -------------------------------------------------------
+
+/** Reconstruct the route a `client.METHOD(url)` call targets, relative to `basePath`. */
+function extractRoute(arg: ts.Expression | undefined): string | undefined {
+  if (!arg) return undefined;
+  if (ts.isIdentifier(arg) && arg.text === 'basePath') return '';
+  if (ts.isTemplateExpression(arg)) {
+    if (arg.head.text !== '') return undefined;
+    const [first, ...rest] = arg.templateSpans;
+    if (!first || !ts.isIdentifier(first.expression) || first.expression.text !== 'basePath') {
+      return undefined;
+    }
+    let route = first.literal.text;
+    for (const span of rest) route += `{}${span.literal.text}`;
+    return normalizeRoute(route);
+  }
+  return undefined;
+}
+
+function frontEndpoints(sources: ReadonlyArray<{ file: string; text: string }>): {
+  endpoints: Endpoint[];
+  unparseable: number;
+} {
+  const endpoints: Endpoint[] = [];
+  let unparseable = 0;
+
+  for (const { file, text } of sources) {
+    const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
+
+    // `const url = \`${basePath}/…\`` then `client.post(url, …)` — resolve the local.
+    const consts = new Map<string, ts.Expression>();
+    const collect = (node: ts.Node): void => {
+      if (ts.isVariableDeclaration(node) && ts.isIdentifier(node.name) && node.initializer) {
+        consts.set(node.name.text, node.initializer);
+      }
+      ts.forEachChild(node, collect);
+    };
+    collect(sf);
+
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isCallExpression(node) &&
+        ts.isPropertyAccessExpression(node.expression) &&
+        ts.isIdentifier(node.expression.expression) &&
+        node.expression.expression.text === 'client'
+      ) {
+        const method = node.expression.name.text.toLowerCase();
+        if (HTTP_METHODS.has(method)) {
+          let arg = node.arguments[0];
+          if (arg && ts.isIdentifier(arg) && arg.text !== 'basePath') {
+            arg = consts.get(arg.text) ?? arg;
+          }
+          const route = extractRoute(arg);
+          if (route === undefined) unparseable++;
+          else endpoints.push({ method, route });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(sf);
+  }
+  return { endpoints, unparseable };
+}
+
+// --- Oracle ----------------------------------------------------------------
+
+const key = (e: Endpoint): string => `${e.method} ${e.route}`;
+
+export interface EndpointOptions {
+  /**
+   * Normalized routes (relative to `basePath`, params as `{}`) served outside
+   * `api/` — e.g. a query-engine list (`''`, `'/meta'`) or a streaming
+   * (`adapter: 'fetch'`) endpoint. Skipped on both sides.
+   */
+  ignore?: readonly string[];
+}
+
+/**
+ * Verify the module's `api/` functions mirror the backend's routes: every spec
+ * `path`+`method` has a front `client.METHOD()` call at the same route, and
+ * every parseable front call maps to a real endpoint. The module base is
+ * auto-detected (the front `basePath` may or may not include the resource
+ * segment). Returns one {@link EndpointViolation} per drift (missing or orphan).
+ */
+export function checkEndpointConformance(
+  module: string,
+  spec: OpenApiPaths,
+  apiSources: ReadonlyArray<{ file: string; text: string }>,
+  options: EndpointOptions = {}
+): EndpointViolation[] {
+  const ignore = new Set(options.ignore ?? []);
+  const { endpoints: frontEps } = frontEndpoints(apiSources);
+  const frontSet = new Set(frontEps.map(key));
+
+  // Pick the base prefix that minimizes the spec/front symmetric difference.
+  const bases = candidateBases(Object.keys(spec.paths ?? {}));
+  let best: { specEps: Endpoint[]; diff: number } | undefined;
+  for (const base of bases) {
+    const specEps = specEndpoints(spec, base).filter((e) => !ignore.has(e.route));
+    const specSet = new Set(specEps.map(key));
+    const diff =
+      specEps.filter((e) => !frontSet.has(key(e))).length +
+      frontEps.filter((e) => !ignore.has(e.route) && !specSet.has(key(e))).length;
+    if (!best || diff < best.diff) best = { specEps, diff };
+    if (diff === 0) break;
+  }
+
+  const specEps = best?.specEps ?? [];
+  const specSet = new Set(specEps.map(key));
+  const seen = new Set<string>();
+  const out: EndpointViolation[] = [];
+  const push = (v: EndpointViolation): void => {
+    const k = `${v.rule} ${v.method} ${v.route}`;
+    if (seen.has(k)) return;
+    seen.add(k);
+    out.push(v);
+  };
+
+  for (const e of specEps) {
+    if (!frontSet.has(key(e))) {
+      push({
+        rule: 'missing-endpoint',
+        module,
+        method: e.method,
+        route: e.route,
+        message: `backend ${e.method.toUpperCase()} {basePath}${e.route} has no matching front api function`,
+      });
+    }
+  }
+  for (const e of frontEps) {
+    if (!ignore.has(e.route) && !specSet.has(key(e))) {
+      push({
+        rule: 'orphan-endpoint',
+        module,
+        method: e.method,
+        route: e.route,
+        message: `front api call ${e.method.toUpperCase()} {basePath}${e.route} has no matching backend endpoint`,
+      });
+    }
+  }
+  return out;
+}

--- a/packages/@granit/contract-tests/src/index.ts
+++ b/packages/@granit/contract-tests/src/index.ts
@@ -1,2 +1,5 @@
 export { checkSchemaConformance } from './conformance';
 export type { CheckSchemaOptions, ConformanceViolation, OpenApiDocument } from './conformance';
+
+export { checkEndpointConformance } from './endpoints';
+export type { EndpointViolation, OpenApiPaths } from './endpoints';

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -14,10 +14,27 @@ export interface ModuleContract {
   readonly package: string;
   /** DTO interfaces to check (spec schema name === front interface name). */
   readonly types: readonly string[];
+  /**
+   * Also verify route/verb conformance: every spec `path`+`method` has a front
+   * `client.METHOD()` call at the same route. Opt-in — leave off for modules
+   * whose routes are served by native `fetch` (BFF) instead of the Axios client.
+   */
+  readonly checkEndpoints?: boolean;
+  /**
+   * Routes (relative to `basePath`, params as `{}`) to skip in the endpoint
+   * check — served by the query-engine generic surface (`''` list, `'/meta'`)
+   * rather than a module `api/` function.
+   */
+  readonly endpointIgnore?: readonly string[];
 }
 
 export const CONTRACTS: readonly ModuleContract[] = [
-  { slug: 'background-jobs', package: 'background-jobs', types: ['BackgroundJobStatus'] },
+  {
+    slug: 'background-jobs',
+    package: 'background-jobs',
+    types: ['BackgroundJobStatus'],
+    checkEndpoints: true,
+  },
   { slug: 'bff', package: 'bff', types: ['BffCsrfTokenResponse'] },
   {
     slug: 'blob-storage',
@@ -33,6 +50,8 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'BlobDescriptorResponse',
       'BlobCleanupOrphansResponse',
     ],
+    checkEndpoints: true,
+    endpointIgnore: ['', '/meta'],
   },
   {
     slug: 'api-keys',
@@ -44,6 +63,7 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'ApiKeyRotateResponse',
       'ApiKeyUpdateScopesRequest',
     ],
+    checkEndpoints: true,
   },
   {
     slug: 'ai',
@@ -66,6 +86,8 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'AIModelCapabilities',
       'AIUsageRecord',
     ],
+    checkEndpoints: true,
+    endpointIgnore: ['/usage', '/usage/meta'],
   },
   {
     slug: 'auditing',
@@ -87,5 +109,17 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'PermissionGroupResponse',
       'PermissionGrantResponse',
     ],
+  },
+  {
+    slug: 'features',
+    package: 'features',
+    types: [
+      'FeatureDefinitionResponse',
+      'FeatureGroupResponse',
+      'FeatureNumericConstraintResponse',
+      'FeatureValueResponse',
+      'SetFeatureOverrideRequest',
+    ],
+    checkEndpoints: true,
   },
 ];


### PR DESCRIPTION
Phase 2 of the conformance oracle (builds on #555, merged).

## What
- **`checkEndpointConformance`** — every spec `path`+`method` has a front `client.METHOD()` call at the same route. The module `basePath` is auto-detected, local `const url = …` is resolved, and `endpointIgnore` skips query-engine-surface routes (`''` list, `/meta`).
- Endpoint conformance enabled for **background-jobs, api-keys, blob-storage, ai** (bff left off — native `fetch` bootstrap, not the Axios client).
- Oracle now also checks `type X = {…}` object-literal DTOs.
- New module wired: **features** (5 DTOs + endpoints, fully clean).
- 5 positive/negative controls for the endpoint oracle.

## Verification
tsc, lint, markdownlint, vitest (contract-tests **61**, arch-tests **2119**) — green against develop's committed specs.

## Notes
Modules whose front DTO names still diverge from the spec (multi-tenancy `AdminTenant`, several `webhooks` types) need the auditing/authorization rename treatment before wiring.