### PR TITLE
feat(authorization): expose grants & role-metadata query surfaces

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -3044,11 +3044,6 @@
           "signature": "function buildPermissionQueryKey( config:"
         },
         {
-          "name": "permissionKeys",
-          "kind": "const",
-          "signature": "const permissionKeys"
-        },
-        {
           "name": "usePermissionDefinitions",
           "kind": "function",
           "signature": "function usePermissionDefinitions( options: UsePermissionDefinitionsOptions ): UseQueryResult<PermissionGroupResponse[]>"
@@ -3062,6 +3057,26 @@
           "name": "usePermissionGrant",
           "kind": "function",
           "signature": "function usePermissionGrant(options: UsePermissionGrantOptions): UsePermissionGrantReturn"
+        },
+        {
+          "name": "usePermissionGrants",
+          "kind": "function",
+          "signature": "function usePermissionGrants( options: UsePermissionGrantsOptions, request: QueryRequest ="
+        },
+        {
+          "name": "usePermissionGrantMeta",
+          "kind": "function",
+          "signature": "function usePermissionGrantMeta( options: UsePermissionGrantsOptions ): UseQueryResult<QueryMetadata>"
+        },
+        {
+          "name": "useRoleMetadata",
+          "kind": "function",
+          "signature": "function useRoleMetadata( options: UseRoleMetadataOptions, request: QueryRequest ="
+        },
+        {
+          "name": "useRoleMetadataMeta",
+          "kind": "function",
+          "signature": "function useRoleMetadataMeta( options: UseRoleMetadataOptions ): UseQueryResult<QueryMetadata>"
         },
         {
           "name": "UsePermissionGrantReturn",

--- a/packages/@granit/authorization/README.md
+++ b/packages/@granit/authorization/README.md
@@ -12,21 +12,26 @@ pnpm add @granit/authorization
 
 ### Types
 
-- `PermissionsResponse` -- server response containing permission grants
-- `PermissionDefinitionDto` -- single permission definition
-- `PermissionGroupDto` -- group of related permissions
-- `PermissionGrantDto` -- granted permission for a role/user
-- `PermissionGrantParams` -- parameters for granting a permission
-- `UsePermissionsOptions` -- options for the permissions hook
-- `UsePermissionsReturn` -- return type of the permissions hook
-- `UsePermissionDefinitionsOptions` -- options for fetching permission definitions
-- `UseRolePermissionsOptions` -- options for fetching role-specific permissions
-- `UsePermissionGrantOptions` -- options for the permission grant hook
+- `MyPermissionsResponse` -- current user's granted permissions (`GET /permissions`)
+- `PermissionDefinitionResponse` -- single permission definition
+- `PermissionGroupResponse` -- group of related permission definitions
+- `PermissionGrantResponse` -- permissions granted to a specific role
+- `PermissionGrantParams` -- parameters for granting/revoking a permission
+- `PermissionMultiTenancySide` -- tenancy scope of a permission (`Host` / `Tenant` / `Both`)
+- `PermissionGrant` -- permission-grant row from the `GET /grants` query surface
+- `RoleMetadata` -- role-metadata row from the `GET /role-metadata` query surface
+
+### Functions
+
+- `getMyPermissions`, `listPermissionDefinitions`, `getRolePermissions`
+- `grantPermission`, `revokePermission`
+- `queryPermissionGrants`, `getPermissionGrantMeta`
+- `queryRoleMetadata`, `getRoleMetadataMeta`
 
 ## Usage
 
 ```ts
-import type { PermissionsResponse, PermissionDefinitionDto } from '@granit/authorization';
+import type { MyPermissionsResponse, PermissionDefinitionResponse } from '@granit/authorization';
 ```
 
 ## License

--- a/packages/@granit/authorization/package.json
+++ b/packages/@granit/authorization/package.json
@@ -14,7 +14,8 @@
     "build": "tsup"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*"
   },
   "publishConfig": {
     "exports": {
@@ -27,6 +28,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*"
   }
 }

--- a/packages/@granit/authorization/src/api/query-api.ts
+++ b/packages/@granit/authorization/src/api/query-api.ts
@@ -1,0 +1,61 @@
+import { getPage, getQueryMeta } from '@granit/query-engine';
+
+import type { PermissionGrant, RoleMetadata } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+import type { PagedResult, QueryMetadata, QueryRequest } from '@granit/query-engine';
+
+/**
+ * Queries the paginated / filterable list of permission grants.
+ *
+ * `GET {basePath}/grants` → `PagedResult<PermissionGrant>`
+ * (backend policy: `Authorization.Grants.Manage`)
+ */
+export async function queryPermissionGrants(
+  client: AxiosInstance,
+  basePath: string,
+  request: QueryRequest = {},
+  options?: { readonly signal?: AbortSignal }
+): Promise<PagedResult<PermissionGrant>> {
+  return getPage<PermissionGrant>(client, `${basePath}/grants`, request, options);
+}
+
+/**
+ * Fetches the query metadata (columns, filterable fields, presets) for permission grants.
+ *
+ * `GET {basePath}/grants/meta` → `QueryMetadata`
+ */
+export async function getPermissionGrantMeta(
+  client: AxiosInstance,
+  basePath: string,
+  options?: { readonly signal?: AbortSignal }
+): Promise<QueryMetadata> {
+  return getQueryMeta(client, `${basePath}/grants`, options);
+}
+
+/**
+ * Queries the paginated / filterable list of role metadata.
+ *
+ * `GET {basePath}/role-metadata` → `PagedResult<RoleMetadata>`
+ * (backend policy: `Authorization.Definitions.Read`)
+ */
+export async function queryRoleMetadata(
+  client: AxiosInstance,
+  basePath: string,
+  request: QueryRequest = {},
+  options?: { readonly signal?: AbortSignal }
+): Promise<PagedResult<RoleMetadata>> {
+  return getPage<RoleMetadata>(client, `${basePath}/role-metadata`, request, options);
+}
+
+/**
+ * Fetches the query metadata (columns, filterable fields, presets) for role metadata.
+ *
+ * `GET {basePath}/role-metadata/meta` → `QueryMetadata`
+ */
+export async function getRoleMetadataMeta(
+  client: AxiosInstance,
+  basePath: string,
+  options?: { readonly signal?: AbortSignal }
+): Promise<QueryMetadata> {
+  return getQueryMeta(client, `${basePath}/role-metadata`, options);
+}

--- a/packages/@granit/authorization/src/index.ts
+++ b/packages/@granit/authorization/src/index.ts
@@ -1,10 +1,12 @@
 export type {
   PermissionDefinitionResponse,
+  PermissionGrant,
   PermissionGrantResponse,
   PermissionGrantParams,
   PermissionGroupResponse,
   PermissionMultiTenancySide,
   MyPermissionsResponse,
+  RoleMetadata,
 } from './types/index';
 export { AuthorizationEndpointsPermissions } from './permissions';
 export {
@@ -14,3 +16,9 @@ export {
   listPermissionDefinitions,
   revokePermission,
 } from './api/permissions-api';
+export {
+  getPermissionGrantMeta,
+  getRoleMetadataMeta,
+  queryPermissionGrants,
+  queryRoleMetadata,
+} from './api/query-api';

--- a/packages/@granit/authorization/src/types/index.ts
+++ b/packages/@granit/authorization/src/types/index.ts
@@ -1,8 +1,8 @@
 // ---------------------------------------------------------------------------
-// Permissions (GET /auth/me response DTO)
+// Permissions (GET {basePath}/permissions response DTO)
 // ---------------------------------------------------------------------------
 
-/** Response from the `GET /auth/me` backend endpoint — mirrors `MyPermissionsResponse`. */
+/** Response from the `GET {basePath}/permissions` backend endpoint — mirrors `MyPermissionsResponse`. */
 export type MyPermissionsResponse = {
   permissions: readonly string[];
 };
@@ -48,4 +48,46 @@ export type PermissionGrantResponse = {
 export type PermissionGrantParams = {
   roleName: string;
   permissionName: string;
+};
+
+// ---------------------------------------------------------------------------
+// Admin query surfaces (MapGranitQuery entities — read-only)
+// ---------------------------------------------------------------------------
+//
+// `GET {basePath}/grants` and `GET {basePath}/role-metadata` expose the raw
+// audited aggregates via the query engine (paginated / filterable / groupable).
+// The `domainEvents` / `integrationEvents` marker collections present in the
+// .NET aggregates are persistence/eventing internals — never populated on the
+// HTTP contract — and are intentionally not mirrored here.
+
+/** A single permission grant row — mirrors the `PermissionGrant` aggregate exposed by `GET {basePath}/grants`. */
+export type PermissionGrant = {
+  readonly id: string;
+  readonly name: string;
+  readonly providerName: string;
+  readonly providerKey: string;
+  readonly tenantId: string | null;
+  readonly createdAt: string;
+  readonly createdBy: string;
+  readonly modifiedAt: string | null;
+  readonly modifiedBy: string | null;
+};
+
+/** Role metadata row — mirrors the `RoleMetadata` aggregate exposed by `GET {basePath}/role-metadata`. */
+export type RoleMetadata = {
+  readonly id: string;
+  readonly name: string;
+  readonly tenantId: string | null;
+  readonly clientId: string | null;
+  /** Tenancy sides where this role is valid. */
+  readonly multiTenancySides: PermissionMultiTenancySide;
+  readonly description: string | null;
+  readonly isSystem: boolean;
+  readonly isOrphaned: boolean;
+  readonly orphanedAt: string | null;
+  readonly concurrencyStamp: string;
+  readonly createdAt: string;
+  readonly createdBy: string;
+  readonly modifiedAt: string | null;
+  readonly modifiedBy: string | null;
 };

--- a/packages/@granit/react-authorization/README.md
+++ b/packages/@granit/react-authorization/README.md
@@ -16,10 +16,14 @@ pnpm add @granit/react-authorization
 - `usePermissionDefinitions(options?)` -- fetch all permission definitions
 - `useRolePermissions(options?)` -- fetch permissions for a specific role
 - `usePermissionGrant(options?)` -- grant or revoke a permission
+- `usePermissionGrants(options, request?)` -- paginated permission-grants query surface (`GET /grants`)
+- `usePermissionGrantMeta(options)` -- query metadata for permission grants (`GET /grants/meta`)
+- `useRoleMetadata(options, request?)` -- paginated role-metadata query surface (`GET /role-metadata`)
+- `useRoleMetadataMeta(options)` -- query metadata for role metadata (`GET /role-metadata/meta`)
 
 ### Utilities
 
-- `permissionKeys` -- React Query key factory
+- `buildPermissionQueryKey(config, ...segments)` -- React Query key factory
 
 ### Types
 

--- a/packages/@granit/react-authorization/package.json
+++ b/packages/@granit/react-authorization/package.json
@@ -17,6 +17,7 @@
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/authorization": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "axios": "^1.6.0",
     "msw": "^2.12.0",
@@ -42,6 +43,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/react-testing": "workspace:*"
   }

--- a/packages/@granit/react-authorization/src/__tests__/use-permission-grant.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-permission-grant.test.tsx
@@ -93,7 +93,7 @@ describe('usePermissionGrant', () => {
     await waitFor(() => expect(result.current.grant.isSuccess).toBe(true));
 
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: ['auth', 'permissions', 'roles', 'editor'],
+      queryKey: ['authorization', 'permissions', 'roles', 'editor'],
     });
   });
 
@@ -114,7 +114,7 @@ describe('usePermissionGrant', () => {
     await waitFor(() => expect(result.current.revoke.isSuccess).toBe(true));
 
     expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: ['auth', 'permissions', 'roles', 'admin'],
+      queryKey: ['authorization', 'permissions', 'roles', 'admin'],
     });
   });
 

--- a/packages/@granit/react-authorization/src/__tests__/use-permissions.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-permissions.test.tsx
@@ -45,7 +45,7 @@ function createWrapper() {
 
 describe('buildPermissionQueryKey', () => {
   it('should use default prefix when no queryKeyPrefix is provided', () => {
-    expect(buildPermissionQueryKey({}, 'me')).toEqual(['auth', 'permissions', 'me']);
+    expect(buildPermissionQueryKey({}, 'me')).toEqual(['authorization', 'permissions', 'me']);
   });
 
   it('should use custom prefix when queryKeyPrefix is provided', () => {
@@ -54,12 +54,12 @@ describe('buildPermissionQueryKey', () => {
   });
 
   it('should return only the prefix when no segments are provided', () => {
-    expect(buildPermissionQueryKey({})).toEqual(['auth', 'permissions']);
+    expect(buildPermissionQueryKey({})).toEqual(['authorization', 'permissions']);
   });
 
   it('should handle multiple segments', () => {
     expect(buildPermissionQueryKey({}, 'roles', 'admin')).toEqual([
-      'auth',
+      'authorization',
       'permissions',
       'roles',
       'admin',

--- a/packages/@granit/react-authorization/src/hooks/query-keys.ts
+++ b/packages/@granit/react-authorization/src/hooks/query-keys.ts
@@ -2,7 +2,7 @@
 // Query key builder
 // ---------------------------------------------------------------------------
 
-export const DEFAULT_QUERY_KEY_PREFIX = ['auth', 'permissions'] as const;
+export const DEFAULT_QUERY_KEY_PREFIX = ['authorization', 'permissions'] as const;
 
 /**
  * Builds a query key for permission / authorization queries.
@@ -16,15 +16,3 @@ export function buildPermissionQueryKey(
 ): readonly unknown[] {
   return [...(config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX), ...segments];
 }
-
-// ---------------------------------------------------------------------------
-// Legacy query key factory (delegates to default prefix)
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use {@link buildPermissionQueryKey} instead. */
-export const permissionKeys = {
-  all: DEFAULT_QUERY_KEY_PREFIX as readonly string[],
-  me: (userId?: string) => [...DEFAULT_QUERY_KEY_PREFIX, 'me', userId] as const,
-  definitions: () => [...DEFAULT_QUERY_KEY_PREFIX, 'definitions'] as const,
-  role: (roleName: string) => [...DEFAULT_QUERY_KEY_PREFIX, 'roles', roleName] as const,
-};

--- a/packages/@granit/react-authorization/src/hooks/use-permission-grant.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permission-grant.ts
@@ -40,10 +40,15 @@ export function usePermissionGrant(options: UsePermissionGrantOptions): UsePermi
   const { client, basePath = DEFAULT_BASE_PATH } = options;
   const queryClient = useQueryClient();
 
-  const invalidateRole = (params: PermissionGrantParams) =>
-    queryClient.invalidateQueries({
+  const invalidateRole = (params: PermissionGrantParams) => {
+    // Refresh the role's own grant list and the admin grants query surface.
+    void queryClient.invalidateQueries({
       queryKey: buildPermissionQueryKey(options, 'roles', params.roleName),
     });
+    void queryClient.invalidateQueries({
+      queryKey: buildPermissionQueryKey(options, 'grants'),
+    });
+  };
 
   const grant = useMutation({
     mutationFn: (params: PermissionGrantParams) => grantPermission(client, basePath, params),

--- a/packages/@granit/react-authorization/src/hooks/use-permission-grants.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permission-grants.ts
@@ -1,0 +1,62 @@
+import { getPermissionGrantMeta, queryPermissionGrants } from '@granit/authorization';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { buildPermissionQueryKey } from './query-keys';
+
+import type { UsePermissionGrantsOptions } from '../types';
+import type { PermissionGrant } from '@granit/authorization';
+import type { PagedResult, QueryMetadata, QueryRequest } from '@granit/query-engine';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetches the paginated / filterable list of permission grants.
+ *
+ * Calls `GET {basePath}/grants` (default `/api/v1/authorization/grants`).
+ * Keeps the previous page visible while the next one loads.
+ *
+ * @param options - Axios client instance and optional configuration.
+ * @param request - Optional query request (pagination, filters, sort, search).
+ * @returns Standard React Query result with a `PagedResult<PermissionGrant>`.
+ *
+ * @example
+ * ```tsx
+ * const { data } = usePermissionGrants({ client: api }, { search: 'admin' });
+ * // data.items, data.totalCount, data.hasMore
+ * ```
+ */
+export function usePermissionGrants(
+  options: UsePermissionGrantsOptions,
+  request: QueryRequest = {}
+): UseQueryResult<PagedResult<PermissionGrant>> {
+  const { client, basePath = DEFAULT_BASE_PATH, enabled } = options;
+
+  return useQuery({
+    queryKey: buildPermissionQueryKey(options, 'grants', request),
+    queryFn: ({ signal }) => queryPermissionGrants(client, basePath, request, { signal }),
+    enabled: enabled ?? true,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * Fetches the query metadata (columns, filterable fields, presets) for permission grants.
+ *
+ * Calls `GET {basePath}/grants/meta` (default `/api/v1/authorization/grants/meta`).
+ *
+ * @param options - Axios client instance and optional configuration.
+ * @returns Standard React Query result with the query metadata.
+ */
+export function usePermissionGrantMeta(
+  options: UsePermissionGrantsOptions
+): UseQueryResult<QueryMetadata> {
+  const { client, basePath = DEFAULT_BASE_PATH, enabled } = options;
+
+  return useQuery({
+    queryKey: buildPermissionQueryKey(options, 'grants', 'meta'),
+    queryFn: ({ signal }) => getPermissionGrantMeta(client, basePath, { signal }),
+    enabled: enabled ?? true,
+    staleTime: Infinity,
+  });
+}

--- a/packages/@granit/react-authorization/src/hooks/use-permissions.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-permissions.ts
@@ -4,7 +4,7 @@ import * as React from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-export { buildPermissionQueryKey, permissionKeys } from './query-keys';
+export { buildPermissionQueryKey } from './query-keys';
 import { buildPermissionQueryKey } from './query-keys';
 
 import type { UsePermissionsOptions, UsePermissionsReturn } from '../types';

--- a/packages/@granit/react-authorization/src/hooks/use-role-metadata.ts
+++ b/packages/@granit/react-authorization/src/hooks/use-role-metadata.ts
@@ -1,0 +1,62 @@
+import { getRoleMetadataMeta, queryRoleMetadata } from '@granit/authorization';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { buildPermissionQueryKey } from './query-keys';
+
+import type { UseRoleMetadataOptions } from '../types';
+import type { RoleMetadata } from '@granit/authorization';
+import type { PagedResult, QueryMetadata, QueryRequest } from '@granit/query-engine';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetches the paginated / filterable list of role metadata.
+ *
+ * Calls `GET {basePath}/role-metadata` (default `/api/v1/authorization/role-metadata`).
+ * Keeps the previous page visible while the next one loads.
+ *
+ * @param options - Axios client instance and optional configuration.
+ * @param request - Optional query request (pagination, filters, sort, search).
+ * @returns Standard React Query result with a `PagedResult<RoleMetadata>`.
+ *
+ * @example
+ * ```tsx
+ * const { data } = useRoleMetadata({ client: api }, { sort: [{ field: 'name', direction: 'asc' }] });
+ * // data.items, data.totalCount, data.hasMore
+ * ```
+ */
+export function useRoleMetadata(
+  options: UseRoleMetadataOptions,
+  request: QueryRequest = {}
+): UseQueryResult<PagedResult<RoleMetadata>> {
+  const { client, basePath = DEFAULT_BASE_PATH, enabled } = options;
+
+  return useQuery({
+    queryKey: buildPermissionQueryKey(options, 'role-metadata', request),
+    queryFn: ({ signal }) => queryRoleMetadata(client, basePath, request, { signal }),
+    enabled: enabled ?? true,
+    placeholderData: keepPreviousData,
+  });
+}
+
+/**
+ * Fetches the query metadata (columns, filterable fields, presets) for role metadata.
+ *
+ * Calls `GET {basePath}/role-metadata/meta` (default `/api/v1/authorization/role-metadata/meta`).
+ *
+ * @param options - Axios client instance and optional configuration.
+ * @returns Standard React Query result with the query metadata.
+ */
+export function useRoleMetadataMeta(
+  options: UseRoleMetadataOptions
+): UseQueryResult<QueryMetadata> {
+  const { client, basePath = DEFAULT_BASE_PATH, enabled } = options;
+
+  return useQuery({
+    queryKey: buildPermissionQueryKey(options, 'role-metadata', 'meta'),
+    queryFn: ({ signal }) => getRoleMetadataMeta(client, basePath, { signal }),
+    enabled: enabled ?? true,
+    staleTime: Infinity,
+  });
+}

--- a/packages/@granit/react-authorization/src/index.ts
+++ b/packages/@granit/react-authorization/src/index.ts
@@ -1,13 +1,17 @@
 export { usePermissions } from './hooks/use-permissions';
-export { buildPermissionQueryKey, permissionKeys } from './hooks/query-keys';
+export { buildPermissionQueryKey } from './hooks/query-keys';
 export { usePermissionDefinitions } from './hooks/use-permission-definitions';
 export { useRolePermissions } from './hooks/use-role-permissions';
 export { usePermissionGrant } from './hooks/use-permission-grant';
+export { usePermissionGrants, usePermissionGrantMeta } from './hooks/use-permission-grants';
+export { useRoleMetadata, useRoleMetadataMeta } from './hooks/use-role-metadata';
 export type { UsePermissionGrantReturn } from './hooks/use-permission-grant';
 export type {
   UsePermissionDefinitionsOptions,
   UsePermissionGrantOptions,
+  UsePermissionGrantsOptions,
   UsePermissionsOptions,
   UsePermissionsReturn,
+  UseRoleMetadataOptions,
   UseRolePermissionsOptions,
 } from './types';

--- a/packages/@granit/react-authorization/src/testing/data.ts
+++ b/packages/@granit/react-authorization/src/testing/data.ts
@@ -1,84 +1,99 @@
-import type { PermissionDefinitionResponse, PermissionGroupResponse } from '@granit/authorization';
+import type {
+  PermissionDefinitionResponse,
+  PermissionGrant,
+  PermissionGroupResponse,
+  RoleMetadata,
+} from '@granit/authorization';
+
+/**
+ * Builds a {@link PermissionDefinitionResponse}. `multiTenancySides` defaults to
+ * `'Both'` (the backend's default for legacy declarations) so every mock
+ * permission carries the field the real API always returns.
+ */
+function def(
+  name: string,
+  displayName: string,
+  multiTenancySides: PermissionDefinitionResponse['multiTenancySides'] = 'Both'
+): PermissionDefinitionResponse {
+  return { name, displayName, multiTenancySides };
+}
 
 export const mockPermissionGroups: PermissionGroupResponse[] = [
   {
     name: 'Showcase',
     displayName: 'Showcase Application',
     permissions: [
-      { name: 'Showcase.Users.Read', displayName: 'View users' },
-      { name: 'Showcase.Users.Manage', displayName: 'Create, edit, disable users' },
-      { name: 'Showcase.Countries.Read', displayName: 'View countries' },
-      { name: 'Showcase.Countries.Manage', displayName: 'Create, edit, deactivate countries' },
-    ] as PermissionDefinitionResponse[],
+      def('Showcase.Users.Read', 'View users'),
+      def('Showcase.Users.Manage', 'Create, edit, disable users'),
+      def('Showcase.Countries.Read', 'View countries'),
+      def('Showcase.Countries.Manage', 'Create, edit, deactivate countries'),
+    ],
   },
   {
     name: 'AI',
     displayName: 'AI Management',
     permissions: [
-      { name: 'AI.Workspaces.Read', displayName: 'View AI workspaces' },
-      { name: 'AI.Workspaces.Manage', displayName: 'Create, edit, delete AI workspaces' },
-      { name: 'AI.Usage.Read', displayName: 'View AI usage statistics' },
-      { name: 'AI.Chat.Execute', displayName: 'Execute AI chat completions' },
-      { name: 'AI.Embeddings.Execute', displayName: 'Execute AI embeddings' },
-    ] as PermissionDefinitionResponse[],
+      def('AI.Workspaces.Read', 'View AI workspaces'),
+      def('AI.Workspaces.Manage', 'Create, edit, delete AI workspaces'),
+      def('AI.Usage.Read', 'View AI usage statistics'),
+      def('AI.Chat.Execute', 'Execute AI chat completions'),
+      def('AI.Embeddings.Execute', 'Execute AI embeddings'),
+    ],
   },
   {
     name: 'AuthenticationApiKeys',
     displayName: 'API Key Management',
     permissions: [
-      { name: 'AuthenticationApiKeys.Keys.Read', displayName: 'View API keys' },
-      { name: 'AuthenticationApiKeys.Keys.Create', displayName: 'Create API keys' },
-      { name: 'AuthenticationApiKeys.Keys.Revoke', displayName: 'Revoke API keys' },
-      { name: 'AuthenticationApiKeys.Keys.Rotate', displayName: 'Rotate API keys' },
-      {
-        name: 'AuthenticationApiKeys.Keys.UpdateScopes',
-        displayName: 'Update API key scopes and CIDR',
-      },
-    ] as PermissionDefinitionResponse[],
+      def('AuthenticationApiKeys.Keys.Read', 'View API keys'),
+      def('AuthenticationApiKeys.Keys.Create', 'Create API keys'),
+      def('AuthenticationApiKeys.Keys.Revoke', 'Revoke API keys'),
+      def('AuthenticationApiKeys.Keys.Rotate', 'Rotate API keys'),
+      def('AuthenticationApiKeys.Keys.UpdateScopes', 'Update API key scopes and CIDR'),
+    ],
   },
   {
     name: 'Authorization',
     displayName: 'Authorization',
     permissions: [
-      { name: 'Authorization.Definitions.Read', displayName: 'View permission definitions' },
-      { name: 'Authorization.Grants.Manage', displayName: 'Manage permission grants' },
-    ] as PermissionDefinitionResponse[],
+      def('Authorization.Definitions.Read', 'View permission definitions'),
+      def('Authorization.Grants.Manage', 'Manage permission grants'),
+    ],
   },
   {
     name: 'BackgroundJobs',
     displayName: 'Background Jobs',
     permissions: [
-      { name: 'BackgroundJobs.Jobs.Read', displayName: 'View background jobs' },
-      { name: 'BackgroundJobs.Jobs.Manage', displayName: 'Manage jobs (pause, resume, trigger)' },
-    ] as PermissionDefinitionResponse[],
+      def('BackgroundJobs.Jobs.Read', 'View background jobs'),
+      def('BackgroundJobs.Jobs.Manage', 'Manage jobs (pause, resume, trigger)'),
+    ],
   },
   {
     name: 'Features',
     displayName: 'Feature Flags',
     permissions: [
-      { name: 'Features.Flags.Read', displayName: 'View feature flags' },
-      { name: 'Features.Flags.Manage', displayName: 'Manage feature flags' },
-    ] as PermissionDefinitionResponse[],
+      def('Features.Flags.Read', 'View feature flags'),
+      def('Features.Flags.Manage', 'Manage feature flags'),
+    ],
   },
   {
     name: 'Identity',
     displayName: 'Identity',
     permissions: [
-      { name: 'Identity.Users.Read', displayName: 'View identity users' },
-      { name: 'Identity.Users.Manage', displayName: 'Manage identity users' },
-      { name: 'Identity.Roles.Read', displayName: 'View identity roles' },
-      { name: 'Identity.Roles.Manage', displayName: 'Manage identity roles' },
-    ] as PermissionDefinitionResponse[],
+      def('Identity.Users.Read', 'View identity users'),
+      def('Identity.Users.Manage', 'Manage identity users'),
+      def('Identity.Roles.Read', 'View identity roles'),
+      def('Identity.Roles.Manage', 'Manage identity roles'),
+    ],
   },
   {
     name: 'Settings',
     displayName: 'Application Settings',
     permissions: [
-      { name: 'Settings.Global.Read', displayName: 'View global settings' },
-      { name: 'Settings.Global.Manage', displayName: 'Modify global settings' },
-      { name: 'Settings.Tenant.Read', displayName: 'View tenant settings' },
-      { name: 'Settings.Tenant.Manage', displayName: 'Modify tenant settings' },
-    ] as PermissionDefinitionResponse[],
+      def('Settings.Global.Read', 'View global settings', 'Host'),
+      def('Settings.Global.Manage', 'Modify global settings', 'Host'),
+      def('Settings.Tenant.Read', 'View tenant settings', 'Tenant'),
+      def('Settings.Tenant.Manage', 'Modify tenant settings', 'Tenant'),
+    ],
   },
 ];
 
@@ -129,3 +144,65 @@ export const mockRoleGrants: Record<string, string[]> = {
     'Settings.Tenant.Read',
   ],
 };
+
+/** Mock rows for the `GET /grants` query surface. */
+export const mockPermissionGrants: PermissionGrant[] = [
+  {
+    id: '00000000-0000-0000-0000-000000000001',
+    name: 'Showcase.Users.Manage',
+    providerName: 'R',
+    providerKey: 'admin',
+    tenantId: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    createdBy: 'system',
+    modifiedAt: null,
+    modifiedBy: null,
+  },
+  {
+    id: '00000000-0000-0000-0000-000000000002',
+    name: 'Showcase.Users.Read',
+    providerName: 'R',
+    providerKey: 'viewer',
+    tenantId: null,
+    createdAt: '2026-01-01T00:00:00Z',
+    createdBy: 'system',
+    modifiedAt: null,
+    modifiedBy: null,
+  },
+];
+
+/** Mock rows for the `GET /role-metadata` query surface. */
+export const mockRoleMetadata: RoleMetadata[] = [
+  {
+    id: '00000000-0000-0000-0000-0000000000a1',
+    name: 'admin',
+    tenantId: null,
+    clientId: null,
+    multiTenancySides: 'Both',
+    description: 'Full administrative access',
+    isSystem: true,
+    isOrphaned: false,
+    orphanedAt: null,
+    concurrencyStamp: 'stamp-admin',
+    createdAt: '2026-01-01T00:00:00Z',
+    createdBy: 'system',
+    modifiedAt: null,
+    modifiedBy: null,
+  },
+  {
+    id: '00000000-0000-0000-0000-0000000000a2',
+    name: 'viewer',
+    tenantId: null,
+    clientId: null,
+    multiTenancySides: 'Tenant',
+    description: 'Read-only access',
+    isSystem: false,
+    isOrphaned: false,
+    orphanedAt: null,
+    concurrencyStamp: 'stamp-viewer',
+    createdAt: '2026-01-01T00:00:00Z',
+    createdBy: 'system',
+    modifiedAt: null,
+    modifiedBy: null,
+  },
+];

--- a/packages/@granit/react-authorization/src/testing/handlers.ts
+++ b/packages/@granit/react-authorization/src/testing/handlers.ts
@@ -3,7 +3,12 @@ import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import { mockPermissionGroups, mockRoleGrants } from './data';
+import {
+  mockPermissionGrants,
+  mockPermissionGroups,
+  mockRoleGrants,
+  mockRoleMetadata,
+} from './data';
 
 /**
  * Create stateful MSW handlers for authorization endpoints (permission
@@ -25,8 +30,8 @@ export function createAuthorizationHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json({ roleName, permissions });
     }),
 
-    // PUT /roles/:roleName/permissions/:permissionName — grant permission to role
-    http.put(`${baseUrl}/roles/:roleName/permissions/:permissionName`, ({ params }) => {
+    // PUT /roles/:roleName/:permissionName — grant permission to role
+    http.put(`${baseUrl}/roles/:roleName/:permissionName`, ({ params }) => {
       const roleName = params.roleName as string;
       const permissionName = params.permissionName as string;
       mockRoleGrants[roleName] ??= [];
@@ -36,13 +41,57 @@ export function createAuthorizationHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return noContent();
     }),
 
-    // DELETE /roles/:roleName/permissions/:permissionName — revoke permission from role
-    http.delete(`${baseUrl}/roles/:roleName/permissions/:permissionName`, ({ params }) => {
+    // DELETE /roles/:roleName/:permissionName — revoke permission from role
+    http.delete(`${baseUrl}/roles/:roleName/:permissionName`, ({ params }) => {
       const roleName = params.roleName as string;
       const permissionName = params.permissionName as string;
       if (!mockRoleGrants[roleName]) return notFound();
       mockRoleGrants[roleName] = mockRoleGrants[roleName].filter((p) => p !== permissionName);
       return noContent();
     }),
+
+    // GET /grants — paginated permission grants query surface
+    http.get(`${baseUrl}/grants`, () => {
+      return HttpResponse.json({
+        items: mockPermissionGrants,
+        totalCount: mockPermissionGrants.length,
+        hasMore: false,
+        nextCursor: null,
+      });
+    }),
+
+    // GET /grants/meta — query metadata for the permission grants surface
+    http.get(`${baseUrl}/grants/meta`, () => {
+      return HttpResponse.json(emptyQueryMetadata());
+    }),
+
+    // GET /role-metadata — paginated role metadata query surface
+    http.get(`${baseUrl}/role-metadata`, () => {
+      return HttpResponse.json({
+        items: mockRoleMetadata,
+        totalCount: mockRoleMetadata.length,
+        hasMore: false,
+        nextCursor: null,
+      });
+    }),
+
+    // GET /role-metadata/meta — query metadata for the role metadata surface
+    http.get(`${baseUrl}/role-metadata/meta`, () => {
+      return HttpResponse.json(emptyQueryMetadata());
+    }),
   ];
+}
+
+/** Minimal, structurally-valid {@link QueryMetadata} placeholder for mock query surfaces. */
+function emptyQueryMetadata() {
+  return {
+    columns: [],
+    filterableFields: [],
+    sortableFields: [],
+    presetFilterGroups: [],
+    quickFilters: [],
+    dateFilters: [],
+    groupByFields: [],
+    pagination: { defaultPageSize: 20, maxPageSize: 100, pageSizeOptions: [20, 50, 100] },
+  };
 }

--- a/packages/@granit/react-authorization/src/testing/index.ts
+++ b/packages/@granit/react-authorization/src/testing/index.ts
@@ -2,5 +2,10 @@
 // @granit/react-authorization/testing — Mock data & MSW handlers
 // ---------------------------------------------------------------------------
 
-export { mockPermissionGroups, mockRoleGrants } from './data';
+export {
+  mockPermissionGrants,
+  mockPermissionGroups,
+  mockRoleGrants,
+  mockRoleMetadata,
+} from './data';
 export { createAuthorizationHandlers } from './handlers';

--- a/packages/@granit/react-authorization/src/types/index.ts
+++ b/packages/@granit/react-authorization/src/types/index.ts
@@ -8,7 +8,7 @@ import type { AxiosInstance } from '@granit/api-client';
 export type UsePermissionsOptions = {
   /** Axios instance to use for the API call. */
   client: AxiosInstance;
-  /** Base path for the authorization API. Default: `'/auth'`. */
+  /** Base path for the authorization API. Default: `'/api/v1/authorization'`. */
   basePath?: string;
   /** Override the enabled state. Default: `true` when authenticated. */
   enabled?: boolean;
@@ -61,6 +61,24 @@ export type UseRolePermissionsOptions = {
 export type UsePermissionGrantOptions = {
   client: AxiosInstance;
   basePath?: string;
+  /** Custom prefix for all query keys produced by this module. */
+  queryKeyPrefix?: readonly string[];
+};
+
+/** Options for the {@link usePermissionGrants} / {@link usePermissionGrantMeta} hooks. */
+export type UsePermissionGrantsOptions = {
+  client: AxiosInstance;
+  basePath?: string;
+  enabled?: boolean;
+  /** Custom prefix for all query keys produced by this module. */
+  queryKeyPrefix?: readonly string[];
+};
+
+/** Options for the {@link useRoleMetadata} / {@link useRoleMetadataMeta} hooks. */
+export type UseRoleMetadataOptions = {
+  client: AxiosInstance;
+  basePath?: string;
+  enabled?: boolean;
   /** Custom prefix for all query keys produced by this module. */
   queryKeyPrefix?: readonly string[];
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -340,6 +340,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
@@ -1227,6 +1230,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/react-testing':
         specifier: workspace:*
         version: link:../react-testing


### PR DESCRIPTION
## Contexte

Audit des modules `@granit/authorization` / `@granit/react-authorization` contre `contracts/openapi/authorization.json` et `granit-dotnet`. Couverture d'endpoints portée de **5/9 → 9/9**.

## Ajouts (GAP — endpoints query-engine non mirrorés)

Les deux surfaces `MapGranitQuery` admin n'avaient aucun équivalent frontend :

- **types** : `PermissionGrant`, `RoleMetadata`
- **api** : `queryPermissionGrants`, `getPermissionGrantMeta`, `queryRoleMetadata`, `getRoleMetadataMeta` (via `@granit/query-engine`)
- **hooks** : `usePermissionGrants` (+`Meta`), `useRoleMetadata` (+`Meta`)
- **testing** : handlers MSW + fixtures pour `/grants` et `/role-metadata`
- **deps** : `@granit/query-engine` ajouté en peer/dev des 2 packages

## Corrections d'audit

- **BREAKING** : route MSW grant/revoke avait un segment `/permissions/` parasite (ne matchait ni le backend ni le client Axios)
- docs obsolètes (`MyPermissionsResponse` → `/auth/me`, `basePath` défaut `'/auth'`)
- préfixe de query-key `['auth']` → `['authorization']`
- suppression de la factory dépréciée `permissionKeys`
- invalidation de la liste `grants` lors d'un grant/revoke
- fixtures : suppression du cast `as` non sûr, `multiTenancySides` désormais peuplé

## Vérification

- `tsc` (authorization + react-authorization) : PASS
- Tests : 41 passed
- ESLint (`--max-warnings 0`) : 0

> ⚠️ PR liée côté consommateur : l'UI showcase qui consomme ces surfaces est dans une PR séparée sur `granit-showcase-react`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)