### PR TITLE
fix(react-cookies): restore /testing MSW handlers dropped in #566 squash

### DIFF
--- a/packages/@granit/react-cookies/package.json
+++ b/packages/@granit/react-cookies/package.json
@@ -5,7 +5,8 @@
   "license": "Apache-2.0",
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
   },
   "files": [
     "dist"
@@ -16,16 +17,27 @@
   "peerDependencies": {
     "@granit/cookies": "workspace:*",
     "@granit/logger": "workspace:*",
+    "msw": "^2.0.0",
     "react": "^19.0.0"
   },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
+  },
   "devDependencies": {
-    "@granit/logger": "workspace:*"
+    "@granit/logger": "workspace:*",
+    "msw": "^2.14.6"
   },
   "publishConfig": {
     "exports": {
       ".": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
       }
     },
     "registry": "https://npm.pkg.github.com"

--- a/packages/@granit/react-cookies/src/testing/data.ts
+++ b/packages/@granit/react-cookies/src/testing/data.ts
@@ -1,0 +1,46 @@
+import type { CookieConsentConfigResponse } from '@granit/cookies';
+
+/**
+ * Mock cookie consent configuration mirroring `CookieConsentConfigResponse`
+ * from `Granit.Http.Cookies.Endpoints`. Covers every CMP category so a
+ * consent banner has representative content to render.
+ */
+export const mockCookieConsentConfig: CookieConsentConfigResponse = {
+  cookies: [
+    {
+      name: 'cc_cookie',
+      category: 'strictly_necessary',
+      retentionDays: 182,
+      purpose: 'Stores the cookie consent preferences.',
+    },
+    {
+      name: '.AspNetCore.Antiforgery',
+      category: 'strictly_necessary',
+      retentionDays: 1,
+      purpose: 'CSRF protection token.',
+    },
+    {
+      name: 'theme',
+      category: 'preferences',
+      retentionDays: 365,
+      purpose: 'Remembers the selected colour theme.',
+    },
+    {
+      name: '_ga',
+      category: 'analytics',
+      retentionDays: 730,
+      purpose: 'Distinguishes anonymous visitors (analytics).',
+    },
+    {
+      name: '_fbp',
+      category: 'marketing',
+      retentionDays: 90,
+      purpose: 'Delivers and measures advertising.',
+    },
+  ],
+  services: [
+    { name: 'theme', category: 'preferences', cookiePatterns: ['^theme$'] },
+    { name: 'google-analytics', category: 'analytics', cookiePatterns: ['^_ga', '^_gid'] },
+    { name: 'meta-pixel', category: 'marketing', cookiePatterns: ['^_fbp$'] },
+  ],
+};

--- a/packages/@granit/react-cookies/src/testing/handlers.ts
+++ b/packages/@granit/react-cookies/src/testing/handlers.ts
@@ -1,0 +1,17 @@
+import { http, HttpResponse } from 'msw';
+
+import { mockCookieConsentConfig } from './data';
+
+/**
+ * Create MSW handlers for the cookie consent endpoints.
+ *
+ * Mirrors `Granit.Http.Cookies.Endpoints` — `GET {baseUrl}/cookies/config`
+ * (anonymous, cached 1h server-side). Returns {@link mockCookieConsentConfig}.
+ *
+ * @param baseUrl - API base path (default: `/api/v1`)
+ */
+export function createCookieConsentHandlers(baseUrl = '/api/v1') {
+  return [
+    http.get(`${baseUrl}/cookies/config`, () => HttpResponse.json(mockCookieConsentConfig)),
+  ];
+}

--- a/packages/@granit/react-cookies/src/testing/index.ts
+++ b/packages/@granit/react-cookies/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-cookies/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockCookieConsentConfig } from './data';
+export { createCookieConsentHandlers } from './handlers';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1537,6 +1537,9 @@ importers:
       '@granit/logger':
         specifier: workspace:*
         version: link:../logger
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.1)(typescript@6.0.3)
 
   packages/@granit/react-customer-balance:
     dependencies:


### PR DESCRIPTION
## Problem

PR #566 was **squash-merged from an earlier commit**, so its second commit — the `@granit/react-cookies/testing` subpath — never reached `develop`. Any consumer importing it (the showcase) now fails to build:

```
src/mocks/handlers/index.ts: error TS2307: Cannot find module '@granit/react-cookies/testing'
```

## Fix

Re-add what was dropped:
- `src/testing/{data,handlers,index}.ts` — `createCookieConsentHandlers(baseUrl)` + `mockCookieConsentConfig`, mirroring the other `@granit/react-*/testing` modules (MSW handler for `GET {baseUrl}/cookies/config`).
- `./testing` subpath in `exports` + `publishConfig.exports`.
- `msw` as an **optional** peer dependency (only the `/testing` entry needs it).

## Verification

- `tsc --noEmit` (react-cookies): PASS
- ESLint (`--max-warnings 0`) on `src/testing`: PASS

Unblocks the showcase cookie-consent build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)