### PR TITLE
feat(authentication-api-keys)!: migrate api-keys listing to QueryEngine

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -666,6 +666,11 @@
       "description": "API key types — TypeScript mirror of Granit.Authentication.ApiKeys .NET",
       "exports": [
         {
+          "name": "ApiKeyQuickFilters",
+          "kind": "const",
+          "signature": "const ApiKeyQuickFilters"
+        },
+        {
           "name": "ApiKeyPermissions",
           "kind": "const",
           "signature": "const ApiKeyPermissions"
@@ -2749,6 +2754,11 @@
           "name": "useApiKeys",
           "kind": "function",
           "signature": "function useApiKeys( options: ApiKeyHookOptions, params: UseApiKeysParams ="
+        },
+        {
+          "name": "useApiKeysQueryMeta",
+          "kind": "function",
+          "signature": "function useApiKeysQueryMeta( options: ApiKeyHookOptions, queryOptions?: ApiKeyQueryOptions ): UseQueryResult<QueryMetadata>"
         },
         {
           "name": "ApiKeyHookOptions",

--- a/packages/@granit/authentication-api-keys/src/__tests__/api-keys-api.test.ts
+++ b/packages/@granit/authentication-api-keys/src/__tests__/api-keys-api.test.ts
@@ -1,0 +1,74 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getApiKeysQueryMeta, listApiKeys } from '../api/api-keys-api';
+
+import type { ApiKeyListPage } from '../types/index';
+
+const basePath = '/api/v1/authentication';
+
+const emptyPage: ApiKeyListPage = { items: [], totalCount: 0, hasMore: false, nextCursor: null };
+
+/** The single URL string `getPage`/`getQueryMeta` forwarded to `client.get`. */
+function calledUrl(client: ReturnType<typeof createMockClient>): string {
+  return decodeURIComponent(vi.mocked(client.get).mock.calls[0]![0] as string);
+}
+
+describe('listApiKeys', () => {
+  it('GETs the api-keys sub-path with no query string when params are empty', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(emptyPage));
+
+    const result = await listApiKeys(client, basePath);
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/api-keys`, undefined);
+    expect(result.items).toEqual([]);
+  });
+
+  it('serializes the QueryEngine grammar (search, filter, quickFilters, sort, page)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(emptyPage));
+
+    await listApiKeys(client, basePath, {
+      page: 1,
+      pageSize: 20,
+      search: 'labo',
+      filters: [
+        { field: 'type', operator: 'Eq', value: 'Secret' },
+        { field: 'environment', operator: 'Eq', value: 'live' },
+      ],
+      quickFilters: ['includeRevoked'],
+      sort: [{ field: 'createdAt', direction: 'desc' }],
+    });
+
+    const url = calledUrl(client);
+    expect(url.startsWith(`${basePath}/api-keys?`)).toBe(true);
+    expect(url).toContain('search=labo');
+    expect(url).toContain('filter[type.Eq]=Secret');
+    expect(url).toContain('filter[environment.Eq]=live');
+    expect(url).toContain('quickFilters=includeRevoked');
+    expect(url).toContain('sort=-createdAt');
+    expect(url).toContain('page=1');
+  });
+
+  it('forwards the abort signal to the request', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(emptyPage));
+    const signal = new AbortController().signal;
+
+    await listApiKeys(client, basePath, {}, { signal });
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/api-keys`, { signal });
+  });
+});
+
+describe('getApiKeysQueryMeta', () => {
+  it('GETs the api-keys /meta sub-path', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ columns: [], filterableFields: [] }));
+
+    await getApiKeysQueryMeta(client, basePath);
+
+    expect(client.get).toHaveBeenCalledWith(`${basePath}/api-keys/meta`, undefined);
+  });
+});

--- a/packages/@granit/authentication-api-keys/src/__tests__/api-keys-types.test.ts
+++ b/packages/@granit/authentication-api-keys/src/__tests__/api-keys-types.test.ts
@@ -1,14 +1,19 @@
-import { describe, expectTypeOf, it } from 'vitest';
+import { describe, expect, expectTypeOf, it } from 'vitest';
+
+import { ApiKeyQuickFilters } from '../index';
 
 import type {
   ApiKeyCreateRequest,
   ApiKeyCreateResponse,
+  ApiKeyListItemResponse,
   ApiKeyResponse,
   ApiKeyRotateResponse,
   ApiKeyType,
   ApiKeyUpdateScopesRequest,
   CacheBehavior,
+  ListApiKeysParams,
 } from '../index';
+import type { QueryRequest } from '@granit/query-engine';
 
 describe('@granit/authentication-api-keys types', () => {
   describe('ApiKeyType', () => {
@@ -47,6 +52,34 @@ describe('@granit/authentication-api-keys types', () => {
       expectTypeOf<ApiKeyResponse>().toHaveProperty('expiresAt');
       expectTypeOf<ApiKeyResponse>().toHaveProperty('lastUsedAt');
       expectTypeOf<ApiKeyResponse>().toHaveProperty('revokedAt');
+    });
+  });
+
+  describe('ApiKeyListItemResponse', () => {
+    it('should be a summary projection without permissions/allowedCidrs', () => {
+      expectTypeOf<ApiKeyListItemResponse>().toHaveProperty('id');
+      expectTypeOf<ApiKeyListItemResponse>().toHaveProperty('lastFourChars');
+      expectTypeOf<ApiKeyListItemResponse>().toHaveProperty('cacheBehavior');
+      expectTypeOf<ApiKeyListItemResponse>().not.toHaveProperty('permissions');
+      expectTypeOf<ApiKeyListItemResponse>().not.toHaveProperty('allowedCidrs');
+    });
+
+    it('should keep nullable timestamp fields', () => {
+      expectTypeOf<ApiKeyListItemResponse['expiresAt']>().toMatchTypeOf<string | null>();
+      expectTypeOf<ApiKeyListItemResponse['revokedAt']>().toMatchTypeOf<string | null>();
+    });
+  });
+
+  describe('ListApiKeysParams', () => {
+    it('should be the generic QueryEngine request shape', () => {
+      expectTypeOf<ListApiKeysParams>().toEqualTypeOf<QueryRequest>();
+    });
+  });
+
+  describe('ApiKeyQuickFilters', () => {
+    it('should expose the active/includeRevoked quick-filter names', () => {
+      expect(ApiKeyQuickFilters.Active).toBe('active');
+      expect(ApiKeyQuickFilters.IncludeRevoked).toBe('includeRevoked');
     });
   });
 

--- a/packages/@granit/authentication-api-keys/src/api/api-keys-api.ts
+++ b/packages/@granit/authentication-api-keys/src/api/api-keys-api.ts
@@ -1,35 +1,54 @@
+import { getPage, getQueryMeta } from '@granit/query-engine';
+
 import type {
   ApiKeyCreateRequest,
   ApiKeyCreateResponse,
+  ApiKeyListItemResponse,
+  ApiKeyListPage,
   ApiKeyResponse,
   ApiKeyRotateResponse,
   ApiKeyUpdateScopesRequest,
   ListApiKeysParams,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
-import type { PagedResult } from '@granit/query-engine';
+import type { QueryMetadata } from '@granit/query-engine';
+
+/** Sub-path of the QueryEngine listing surface, relative to the module base. */
+const API_KEYS_PATH = 'api-keys';
+
+function apiKeysQueryPath(basePath: string): string {
+  return `${basePath}/${API_KEYS_PATH}`;
+}
 
 /**
- * Lists API keys filtered by the given parameters.
+ * Lists API keys via the generic QueryEngine surface.
  *
- * `GET {basePath}/api-keys` → `PagedResult<ApiKeyResponse>`
+ * `GET {basePath}/api-keys` → `PagedResult<ApiKeyListItemResponse>` — a summary
+ * projection without `permissions`/`allowedCidrs`. Pass the QueryEngine grammar
+ * via {@link ListApiKeysParams} (`page`, `pageSize`, `sort`, `search`,
+ * `filters`, `quickFilters`); by default only active keys are returned.
  */
 export async function listApiKeys(
   client: AxiosInstance,
   basePath: string,
-  params: ListApiKeysParams = {}
-): Promise<PagedResult<ApiKeyResponse>> {
-  const response = await client.get<PagedResult<ApiKeyResponse>>(`${basePath}/api-keys`, {
-    params: {
-      search: params.search,
-      type: params.type,
-      environment: params.environment,
-      includeRevoked: params.includeRevoked,
-      page: params.page,
-      pageSize: params.pageSize,
-    },
-  });
-  return response.data;
+  params: ListApiKeysParams = {},
+  options?: { readonly signal?: AbortSignal }
+): Promise<ApiKeyListPage> {
+  return getPage<ApiKeyListItemResponse>(client, apiKeysQueryPath(basePath), params, options);
+}
+
+/**
+ * Gets the QueryEngine metadata (columns, filterable/sortable fields, quick
+ * filters, default sort, page size) for the api-keys grid.
+ *
+ * `GET {basePath}/api-keys/meta`
+ */
+export async function getApiKeysQueryMeta(
+  client: AxiosInstance,
+  basePath: string,
+  options?: { readonly signal?: AbortSignal }
+): Promise<QueryMetadata> {
+  return getQueryMeta(client, apiKeysQueryPath(basePath), options);
 }
 
 /**

--- a/packages/@granit/authentication-api-keys/src/index.ts
+++ b/packages/@granit/authentication-api-keys/src/index.ts
@@ -1,18 +1,23 @@
 export type {
   ApiKeyId,
   ApiKeyType,
+  ApiKeyQuickFilter,
   CacheBehavior,
   ApiKeyResponse,
+  ApiKeyListItemResponse,
+  ApiKeyListPage,
   ApiKeyCreateRequest,
   ApiKeyCreateResponse,
   ApiKeyRotateResponse,
   ApiKeyUpdateScopesRequest,
   ListApiKeysParams,
 } from './types/index';
+export { ApiKeyQuickFilters } from './types/index';
 export { ApiKeyPermissions } from './permissions';
 export {
   createApiKey,
   getApiKey,
+  getApiKeysQueryMeta,
   listApiKeys,
   revokeApiKey,
   rotateApiKey,

--- a/packages/@granit/authentication-api-keys/src/types/index.ts
+++ b/packages/@granit/authentication-api-keys/src/types/index.ts
@@ -1,3 +1,4 @@
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
 import type { EntityId, ISODateString } from '@granit/types';
 
 /** API key type. Mirrors Granit.Authentication.ApiKeys.ApiKeyType .NET. */
@@ -9,7 +10,13 @@ export type CacheBehavior = 'Normal' | 'NoCache';
 /** Branded API key identifier. */
 export type ApiKeyId = EntityId<'ApiKey'>;
 
-/** API key response DTO. */
+/**
+ * Full API key response DTO — returned by `GET /api-keys/{id}` (detail).
+ *
+ * Includes the heavyweight `permissions` and `allowedCidrs` collections. Since
+ * the listing endpoint migrated to the QueryEngine these are no longer part of
+ * the list rows — see {@link ApiKeyListItemResponse}.
+ */
 export interface ApiKeyResponse {
   readonly id: ApiKeyId;
   readonly name: string;
@@ -19,6 +26,29 @@ export interface ApiKeyResponse {
   readonly lastFourChars: string;
   readonly permissions: readonly string[];
   readonly allowedCidrs: readonly string[];
+  readonly expiresAt: ISODateString | null;
+  readonly lastUsedAt: ISODateString | null;
+  readonly revokedAt: ISODateString | null;
+  readonly cacheBehavior: CacheBehavior;
+  readonly createdAt: ISODateString;
+}
+
+/**
+ * Summary API key row returned by the QueryEngine listing
+ * (`GET /api-keys` → `PagedResult<ApiKeyListItemResponse>`).
+ *
+ * A lighter projection of {@link ApiKeyResponse}: it intentionally drops
+ * `permissions` and `allowedCidrs`, which are only available on the detail
+ * endpoint (`GET /api-keys/{id}`). Load the detail on demand when a grid row
+ * needs them.
+ */
+export interface ApiKeyListItemResponse {
+  readonly id: ApiKeyId;
+  readonly name: string;
+  readonly type: ApiKeyType;
+  readonly environment: string;
+  readonly prefix: string;
+  readonly lastFourChars: string;
   readonly expiresAt: ISODateString | null;
   readonly lastUsedAt: ISODateString | null;
   readonly revokedAt: ISODateString | null;
@@ -64,13 +94,40 @@ export interface ApiKeyUpdateScopesRequest {
   readonly allowedCidrs: readonly string[];
 }
 
-/** Query parameters accepted by {@link listApiKeys}. */
-export interface ListApiKeysParams {
-  search?: string;
-  /** Filter by a single key type — mirrors the backend `ApiKeyType?` query parameter. */
-  type?: ApiKeyType;
-  environment?: string;
-  includeRevoked?: boolean;
-  page?: number;
-  pageSize?: number;
-}
+/**
+ * Quick-filter names recognized by the api-keys listing endpoint.
+ *
+ * Quick-filters are independent, server-defined predicates combined with AND
+ * semantics. When none is supplied the backend applies its default
+ * ({@link ApiKeyQuickFilters.Active}), so only active keys are returned; pass
+ * {@link ApiKeyQuickFilters.IncludeRevoked} to also surface revoked keys.
+ */
+export type ApiKeyQuickFilter = 'active' | 'includeRevoked';
+
+export const ApiKeyQuickFilters = {
+  /** Default — only active (non-revoked) keys. */
+  Active: 'active',
+  /** Include revoked keys in the results. */
+  IncludeRevoked: 'includeRevoked',
+} as const satisfies Record<string, ApiKeyQuickFilter>;
+
+/**
+ * Query parameters accepted by {@link listApiKeys} — the generic QueryEngine
+ * grammar (`page`, `pageSize`, `sort`, `search`, `filters`, `quickFilters`).
+ *
+ * Mapping from the legacy bespoke filters:
+ * - `type=Secret` → `{ filters: [{ field: 'type', operator: 'Eq', value: 'Secret' }] }`
+ * - `environment=live` → `{ filters: [{ field: 'environment', operator: 'Eq', value: 'live' }] }`
+ * - `search=foo` → `{ search: 'foo' }` (now matches the name only)
+ * - `includeRevoked=true` → `{ quickFilters: [ApiKeyQuickFilters.IncludeRevoked] }`
+ * - `includeRevoked=false` (default) → omit `quickFilters` entirely
+ *
+ * Filterable fields: `name`, `type`, `environment`, `prefix`, `tenantId`,
+ * `createdAt`, `expiresAt`, `lastUsedAt`, `revokedAt`.
+ * Sortable fields: `name`, `type`, `environment`, `expiresAt`, `lastUsedAt`,
+ * `revokedAt`, `createdAt` (server default `-createdAt`).
+ */
+export type ListApiKeysParams = QueryRequest;
+
+/** Page of summary rows returned by {@link listApiKeys}. */
+export type ApiKeyListPage = PagedResult<ApiKeyListItemResponse>;

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -64,6 +64,10 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'ApiKeyUpdateScopesRequest',
     ],
     checkEndpoints: true,
+    // The list (`/api-keys`) and `/api-keys/meta` are served by the query-engine
+    // generic surface (getPage/getQueryMeta), not by a `client.METHOD` call in
+    // this module's api/. The module base auto-detects to `/authentication`.
+    endpointIgnore: ['/api-keys', '/api-keys/meta'],
   },
   {
     slug: 'ai',

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
@@ -11,28 +11,83 @@ afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
 
 describe('createApiKeyHandlers', () => {
-  it('returns a PagedResult shape (items + totalCount) from the list endpoint', async () => {
+  it('returns a PagedResult shape (items + totalCount + hasMore) from the list endpoint', async () => {
     server.use(...createApiKeyHandlers(BASE));
     const response = await fetch(BASE);
 
     expect(response.status).toBe(200);
-    const body = (await response.json()) as { items: unknown[]; totalCount: number };
+    const body = (await response.json()) as {
+      items: unknown[];
+      totalCount: number;
+      hasMore: boolean;
+    };
     expect(Array.isArray(body.items)).toBe(true);
     expect(typeof body.totalCount).toBe('number');
+    expect(typeof body.hasMore).toBe('boolean');
     expect(body.items.length).toBeGreaterThan(0);
   });
 
-  it('filters by a single type value', async () => {
+  it('returns summary rows without permissions/allowedCidrs', async () => {
     server.use(...createApiKeyHandlers(BASE));
-    const response = await fetch(`${BASE}?type=Secret`);
+    const body = (await (await fetch(BASE)).json()) as {
+      items: Record<string, unknown>[];
+    };
+
+    const row = body.items[0]!;
+    expect(row).toHaveProperty('lastFourChars');
+    expect(row).not.toHaveProperty('permissions');
+    expect(row).not.toHaveProperty('allowedCidrs');
+  });
+
+  it('hides revoked keys by default and surfaces them with quickFilters=includeRevoked', async () => {
+    server.use(...createApiKeyHandlers(BASE));
+
+    const active = (await (await fetch(BASE)).json()) as { items: { revokedAt: string | null }[] };
+    expect(active.items.every((k) => k.revokedAt === null)).toBe(true);
+
+    const withRevoked = (await (await fetch(`${BASE}?quickFilters=includeRevoked`)).json()) as {
+      items: { revokedAt: string | null }[];
+    };
+    expect(withRevoked.items.some((k) => k.revokedAt !== null)).toBe(true);
+  });
+
+  it('filters by a single type via filter[type.eq]', async () => {
+    server.use(...createApiKeyHandlers(BASE));
+    const response = await fetch(
+      `${BASE}?${new URLSearchParams({ 'filter[type.Eq]': 'Secret' }).toString()}`
+    );
     const body = (await response.json()) as { items: { type: string }[] };
 
+    expect(body.items.length).toBeGreaterThan(0);
     expect(body.items.every((k) => k.type === 'Secret')).toBe(true);
+  });
+
+  it('searches on the name only', async () => {
+    server.use(...createApiKeyHandlers(BASE));
+    const body = (await (await fetch(`${BASE}?search=Patient`)).json()) as {
+      items: { name: string }[];
+    };
+
+    expect(body.items.length).toBeGreaterThan(0);
+    expect(body.items.every((k) => k.name.toLowerCase().includes('patient'))).toBe(true);
+  });
+
+  it('exposes QueryEngine metadata at /meta', async () => {
+    server.use(...createApiKeyHandlers(BASE));
+    const response = await fetch(`${BASE}/meta`);
+
+    expect(response.status).toBe(200);
+    const meta = (await response.json()) as {
+      quickFilters: { name: string }[];
+      defaultSort: string;
+    };
+    expect(meta.quickFilters.map((q) => q.name)).toContain('includeRevoked');
+    expect(meta.defaultSort).toBe('-createdAt');
   });
 
   it('revoke returns 204 No Content', async () => {
     server.use(...createApiKeyHandlers(BASE));
-    const list = (await (await fetch(`${BASE}?includeRevoked=false`)).json()) as {
+    const list = (await (await fetch(BASE)).json()) as {
       items: { id: string }[];
     };
     const id = list.items[0]!.id;

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/use-api-keys.test.tsx
@@ -8,9 +8,13 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { buildApiKeyQueryKey } from '../hooks/query-keys';
 import { useApiKey } from '../hooks/use-api-key';
-import { useApiKeys } from '../hooks/use-api-keys';
+import { useApiKeys, useApiKeysQueryMeta } from '../hooks/use-api-keys';
 
-import type { ApiKeyResponse } from '@granit/authentication-api-keys';
+import type {
+  ApiKeyListItemResponse,
+  ApiKeyListPage,
+  ApiKeyResponse,
+} from '@granit/authentication-api-keys';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -42,7 +46,31 @@ const mockApiKey: ApiKeyResponse = {
   createdAt: toISODateString('2026-01-01T00:00:00Z'),
 };
 
-const emptyPage = { items: [] as ApiKeyResponse[], totalCount: 0, hasMore: false };
+const mockListItem: ApiKeyListItemResponse = {
+  id: 'key-1',
+  name: 'Test Key',
+  type: 'Secret',
+  environment: 'production',
+  prefix: 'test',
+  lastFourChars: 'xYzW',
+  expiresAt: null,
+  lastUsedAt: null,
+  revokedAt: null,
+  cacheBehavior: 'Normal',
+  createdAt: toISODateString('2026-01-01T00:00:00Z'),
+};
+
+const emptyPage: ApiKeyListPage = {
+  items: [],
+  totalCount: 0,
+  hasMore: false,
+  nextCursor: null,
+};
+
+/** Decode the URL string the QueryEngine layer forwarded to `client.get`. */
+function calledUrl(client: ReturnType<typeof createMockClient>, callIndex = 0): string {
+  return decodeURIComponent(vi.mocked(client.get).mock.calls[callIndex]![0] as string);
+}
 
 // ---------------------------------------------------------------------------
 // buildApiKeyQueryKey
@@ -80,7 +108,7 @@ describe('useApiKeys', () => {
   it('should fetch the paginated API key list with default base path', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({
-      data: { items: [mockApiKey], totalCount: 1, hasMore: false },
+      data: { items: [mockListItem], totalCount: 1, hasMore: false, nextCursor: null },
     });
 
     const { wrapper } = createWrapper();
@@ -88,16 +116,28 @@ describe('useApiKeys', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/authentication/api-keys',
-      expect.objectContaining({})
-    );
+    expect(calledUrl(client)).toBe('/api/v1/authentication/api-keys');
     expect(result.current.data?.items).toHaveLength(1);
     expect(result.current.data?.items[0].id).toBe('key-1');
     expect(result.current.data?.totalCount).toBe(1);
   });
 
-  it('should pass search param to the request', async () => {
+  it('should forward the abort signal to the request', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
+
+    const { wrapper } = createWrapper();
+    renderHook(() => useApiKeys({ client }), { wrapper });
+
+    await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/authentication/api-keys',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it('should serialize the search term into the query string', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
@@ -106,64 +146,57 @@ describe('useApiKeys', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/authentication/api-keys',
-      expect.objectContaining({ params: expect.objectContaining({ search: 'prod' }) })
-    );
+    expect(calledUrl(client)).toContain('search=prod');
   });
 
-  it('should pass the single type filter to the request', async () => {
+  it('should map a type filter to filter[type.Eq]', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
-    renderHook(() => useApiKeys({ client }, { type: 'Secret' }), { wrapper });
+    renderHook(
+      () =>
+        useApiKeys({ client }, { filters: [{ field: 'type', operator: 'Eq', value: 'Secret' }] }),
+      { wrapper }
+    );
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/authentication/api-keys',
-      expect.objectContaining({
-        params: expect.objectContaining({ type: 'Secret' }),
-      })
-    );
+    expect(calledUrl(client)).toContain('filter[type.Eq]=Secret');
   });
 
-  it('should pass environment filter to the request', async () => {
+  it('should map an environment filter to filter[environment.Eq]', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
-    renderHook(() => useApiKeys({ client }, { environment: 'staging' }), { wrapper });
+    renderHook(
+      () =>
+        useApiKeys(
+          { client },
+          { filters: [{ field: 'environment', operator: 'Eq', value: 'staging' }] }
+        ),
+      { wrapper }
+    );
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/authentication/api-keys',
-      expect.objectContaining({
-        params: expect.objectContaining({ environment: 'staging' }),
-      })
-    );
+    expect(calledUrl(client)).toContain('filter[environment.Eq]=staging');
   });
 
-  it('should pass includeRevoked param to the request', async () => {
+  it('should map the "show revoked" toggle to quickFilters=includeRevoked', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
     const { wrapper } = createWrapper();
-    renderHook(() => useApiKeys({ client }, { includeRevoked: true }), { wrapper });
+    renderHook(() => useApiKeys({ client }, { quickFilters: ['includeRevoked'] }), { wrapper });
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/authentication/api-keys',
-      expect.objectContaining({
-        params: expect.objectContaining({ includeRevoked: true }),
-      })
-    );
+    expect(calledUrl(client)).toContain('quickFilters=includeRevoked');
   });
 
-  it('should pass pagination params to the request', async () => {
+  it('should serialize pagination params into the query string', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({ data: emptyPage });
 
@@ -172,12 +205,9 @@ describe('useApiKeys', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/authentication/api-keys',
-      expect.objectContaining({
-        params: expect.objectContaining({ page: 2, pageSize: 25 }),
-      })
-    );
+    const url = calledUrl(client);
+    expect(url).toContain('page=2');
+    expect(url).toContain('pageSize=25');
   });
 
   it('should use custom basePath when provided', async () => {
@@ -189,7 +219,7 @@ describe('useApiKeys', () => {
 
     await waitFor(() => expect(client.get).toHaveBeenCalledOnce());
 
-    expect(client.get).toHaveBeenCalledWith('/api/v2/authentication/api-keys', expect.any(Object));
+    expect(calledUrl(client)).toBe('/api/v2/authentication/api-keys');
   });
 
   it('should surface errors from the API', async () => {
@@ -220,7 +250,7 @@ describe('useApiKeys', () => {
   it('accepts TanStack query option overrides (staleTime)', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValueOnce({
-      data: { items: [mockApiKey], totalCount: 1, hasMore: false },
+      data: { items: [mockListItem], totalCount: 1, hasMore: false, nextCursor: null },
     });
 
     const { wrapper } = createWrapper();
@@ -230,6 +260,33 @@ describe('useApiKeys', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data?.items).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useApiKeysQueryMeta
+// ---------------------------------------------------------------------------
+
+describe('useApiKeysQueryMeta', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should GET the api-keys /meta sub-path', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValueOnce({
+      data: { columns: [], filterableFields: [], quickFilters: [] },
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useApiKeysQueryMeta({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/authentication/api-keys/meta',
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 });
 

--- a/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
+++ b/packages/@granit/react-authentication-api-keys/src/hooks/use-api-keys.ts
@@ -1,4 +1,4 @@
-import { listApiKeys } from '@granit/authentication-api-keys';
+import { getApiKeysQueryMeta, listApiKeys } from '@granit/authentication-api-keys';
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -6,8 +6,8 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import { buildApiKeyQueryKey } from './query-keys';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ApiKeyResponse, ListApiKeysParams } from '@granit/authentication-api-keys';
-import type { PagedResult } from '@granit/query-engine';
+import type { ApiKeyListPage, ListApiKeysParams } from '@granit/authentication-api-keys';
+import type { QueryMetadata } from '@granit/query-engine';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 // ---------------------------------------------------------------------------
@@ -27,8 +27,8 @@ export interface ApiKeyHookOptions {
 /**
  * Query parameters for the paginated API key list.
  *
- * Alias of the core {@link ListApiKeysParams} — exported under this name for
- * consumers that import `UseApiKeysParams`.
+ * Alias of the core {@link ListApiKeysParams} (the QueryEngine grammar) —
+ * exported under this name for consumers that import `UseApiKeysParams`.
  */
 export type UseApiKeysParams = ListApiKeysParams;
 
@@ -51,23 +51,36 @@ export interface ApiKeyQueryOptions {
 // ---------------------------------------------------------------------------
 
 /**
- * Fetches a paginated, filterable list of API keys.
+ * Fetches a paginated, filterable list of API keys (QueryEngine-backed).
  *
- * Calls `GET {basePath}` with query parameters derived from `params`.
+ * Calls `GET {basePath}/api-keys` with the QueryEngine grammar derived from
+ * `params`. Rows are {@link ApiKeyListItemResponse} summaries — they no longer
+ * carry `permissions`/`allowedCidrs`; use {@link useApiKey} to load those for a
+ * selected row.
  *
  * Keeps the previous page visible while the next one loads (no flash on page
  * change) and stays integrated with the TanStack Query cache, so the api-key
- * mutations' `invalidateQueries` refresh this list automatically.
+ * mutations' `invalidateQueries` refresh this list automatically. The fetch is
+ * cancelled when the query is superseded (the request's `AbortSignal` is
+ * forwarded to Axios).
  *
  * @param options - Axios client and optional base path.
- * @param params - Optional search/filter/pagination parameters.
+ * @param params - Optional QueryEngine parameters (`search`, `filters`,
+ *   `quickFilters`, `sort`, `page`, `pageSize`). By default only active keys
+ *   are returned.
  * @param queryOptions - Optional TanStack Query overrides (e.g. `staleTime`).
  *
  * @example
  * ```tsx
+ * // Secret keys, including revoked ones, newest first.
  * const { data, isLoading } = useApiKeys(
  *   { client: api },
- *   { environment: 'production', type: 'Secret' },
+ *   {
+ *     search: 'labo',
+ *     filters: [{ field: 'type', operator: 'Eq', value: 'Secret' }],
+ *     quickFilters: [ApiKeyQuickFilters.IncludeRevoked],
+ *     sort: [{ field: 'createdAt', direction: 'desc' }],
+ *   },
  *   { staleTime: 60_000 }
  * );
  * ```
@@ -76,13 +89,37 @@ export function useApiKeys(
   options: ApiKeyHookOptions,
   params: UseApiKeysParams = {},
   queryOptions?: ApiKeyQueryOptions
-): UseQueryResult<PagedResult<ApiKeyResponse>> {
+): UseQueryResult<ApiKeyListPage> {
   const { client, basePath = DEFAULT_BASE_PATH } = options;
 
   return useQuery({
     queryKey: buildApiKeyQueryKey(options, 'list', params),
-    queryFn: () => listApiKeys(client, basePath, params),
+    queryFn: ({ signal }) => listApiKeys(client, basePath, params, { signal }),
     placeholderData: keepPreviousData,
+    ...queryOptions,
+  });
+}
+
+/**
+ * Fetches the QueryEngine metadata for the api-keys grid (columns, filterable
+ * and sortable fields, quick filters, default sort, page size).
+ *
+ * Calls `GET {basePath}/api-keys/meta`. Useful to drive a generic, dynamically
+ * configured DataGrid. Metadata is static, so it defaults to a long `staleTime`.
+ *
+ * @param options - Axios client and optional base path.
+ * @param queryOptions - Optional TanStack Query overrides.
+ */
+export function useApiKeysQueryMeta(
+  options: ApiKeyHookOptions,
+  queryOptions?: ApiKeyQueryOptions
+): UseQueryResult<QueryMetadata> {
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
+
+  return useQuery({
+    queryKey: buildApiKeyQueryKey(options, 'meta'),
+    queryFn: ({ signal }) => getApiKeysQueryMeta(client, basePath, { signal }),
+    staleTime: Infinity,
     ...queryOptions,
   });
 }

--- a/packages/@granit/react-authentication-api-keys/src/index.ts
+++ b/packages/@granit/react-authentication-api-keys/src/index.ts
@@ -1,5 +1,5 @@
 // Hooks — queries
-export { useApiKeys } from './hooks/use-api-keys';
+export { useApiKeys, useApiKeysQueryMeta } from './hooks/use-api-keys';
 export type { ApiKeyHookOptions, ApiKeyQueryOptions, UseApiKeysParams } from './hooks/use-api-keys';
 export { buildApiKeyQueryKey } from './hooks/query-keys';
 export { useApiKey } from './hooks/use-api-key';

--- a/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-api-keys/src/testing/handlers.ts
@@ -1,4 +1,5 @@
-import { notFound, pagedResponse } from '@granit/testing/msw';
+import { parseQueryRequest } from '@granit/query-engine';
+import { notFound } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
@@ -8,11 +9,219 @@ import { mockApiKeys } from './data';
 
 import type {
   ApiKeyCreateRequest,
+  ApiKeyListItemResponse,
   ApiKeyResponse,
   ApiKeyUpdateScopesRequest,
 } from '@granit/authentication-api-keys';
+import type { FilterEntry, QueryMetadata } from '@granit/query-engine';
 
 type MutableApiKey = { -readonly [K in keyof ApiKeyResponse]: ApiKeyResponse[K] };
+
+/**
+ * QueryEngine metadata describing the api-keys grid — returned by
+ * `GET {baseUrl}/meta`. Mirrors the columns, filterable/sortable fields, quick
+ * filters and defaults exposed by `Granit.Authentication.ApiKeys`.
+ */
+const API_KEY_QUERY_META: QueryMetadata = {
+  columns: [
+    {
+      name: 'name',
+      label: 'Name',
+      type: 'String',
+      order: 0,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'type',
+      label: 'Type',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'environment',
+      label: 'Environment',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'prefix',
+      label: 'Prefix',
+      type: 'String',
+      order: 3,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastFourChars',
+      label: 'Last 4',
+      type: 'String',
+      order: 4,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: true,
+    },
+    {
+      name: 'expiresAt',
+      label: 'Expires',
+      type: 'DateTime',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'lastUsedAt',
+      label: 'Last used',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'revokedAt',
+      label: 'Revoked',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created',
+      type: 'DateTime',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'name', type: 'String', operators: ['Eq', 'Contains', 'StartsWith', 'EndsWith', 'In'] },
+    {
+      name: 'type',
+      type: 'String',
+      operators: ['Eq', 'In'],
+      enumValues: ['Secret', 'Publishable', 'Webhook', 'Ephemeral'],
+    },
+    { name: 'environment', type: 'String', operators: ['Eq', 'In'] },
+    { name: 'prefix', type: 'String', operators: ['Eq', 'StartsWith'] },
+    { name: 'tenantId', type: 'String', operators: ['Eq', 'In'] },
+    { name: 'createdAt', type: 'DateTime', operators: ['Eq', 'Gt', 'Gte', 'Lt', 'Lte', 'Between'] },
+    { name: 'expiresAt', type: 'DateTime', operators: ['Eq', 'Gt', 'Gte', 'Lt', 'Lte', 'Between'] },
+    {
+      name: 'lastUsedAt',
+      type: 'DateTime',
+      operators: ['Eq', 'Gt', 'Gte', 'Lt', 'Lte', 'Between'],
+    },
+    { name: 'revokedAt', type: 'DateTime', operators: ['Eq', 'Gt', 'Gte', 'Lt', 'Lte', 'Between'] },
+  ],
+  sortableFields: [
+    { name: 'name' },
+    { name: 'type' },
+    { name: 'environment' },
+    { name: 'expiresAt' },
+    { name: 'lastUsedAt' },
+    { name: 'revokedAt' },
+    { name: 'createdAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active only', isDefault: true },
+    { name: 'includeRevoked', label: 'Include revoked', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: {
+    defaultPageSize: 20,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
+
+/** Read a filterable/sortable column off a key as a comparable string (or null). */
+function fieldValue(key: MutableApiKey, field: string): string | null {
+  switch (field.toLowerCase()) {
+    case 'name':
+      return key.name;
+    case 'type':
+      return key.type;
+    case 'environment':
+      return key.environment;
+    case 'prefix':
+      return key.prefix;
+    case 'createdat':
+      return key.createdAt;
+    case 'expiresat':
+      return key.expiresAt;
+    case 'lastusedat':
+      return key.lastUsedAt;
+    case 'revokedat':
+      return key.revokedAt;
+    default:
+      return null;
+  }
+}
+
+/** Apply a single `filter[field.op]=value` predicate (operator names case-insensitive). */
+function matchesFilter(key: MutableApiKey, filter: FilterEntry): boolean {
+  const actual = fieldValue(key, filter.field);
+  if (actual === null) return false;
+  const value = filter.value;
+  switch (filter.operator.toLowerCase()) {
+    case 'eq':
+      return actual === value;
+    case 'ne':
+      return actual !== value;
+    case 'contains':
+      return actual.toLowerCase().includes(value.toLowerCase());
+    case 'startswith':
+      return actual.toLowerCase().startsWith(value.toLowerCase());
+    case 'endswith':
+      return actual.toLowerCase().endsWith(value.toLowerCase());
+    case 'in':
+      return value.split(',').includes(actual);
+    case 'gt':
+      return actual > value;
+    case 'gte':
+      return actual >= value;
+    case 'lt':
+      return actual < value;
+    case 'lte':
+      return actual <= value;
+    default:
+      return true;
+  }
+}
+
+/** Project a full key down to the summary row shape returned by the listing. */
+function toListItem(key: MutableApiKey): ApiKeyListItemResponse {
+  return {
+    id: key.id,
+    name: key.name,
+    type: key.type,
+    environment: key.environment,
+    prefix: key.prefix,
+    lastFourChars: key.lastFourChars,
+    expiresAt: key.expiresAt,
+    lastUsedAt: key.lastUsedAt,
+    revokedAt: key.revokedAt,
+    cacheBehavior: key.cacheBehavior,
+    createdAt: key.createdAt,
+  };
+}
 
 function generateSecret(type: string, environment: string): string {
   const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';
@@ -32,9 +241,13 @@ function generateSecret(type: string, environment: string): string {
 /**
  * Create stateful MSW handlers for API key endpoints.
  *
- * Mirrors `Granit.Authentication.ApiKeys.Endpoints`: the list endpoint returns a
- * `PagedResult<ApiKeyResponse>` and filters on `search`, a single `type`,
- * `environment`, and `includeRevoked` — there is no `/meta` endpoint.
+ * Mirrors `Granit.Authentication.ApiKeys.Endpoints`: the list endpoint is backed
+ * by the generic QueryEngine — it returns a `PagedResult<ApiKeyListItemResponse>`
+ * (summary rows without `permissions`/`allowedCidrs`) and understands the
+ * QueryEngine grammar (`page`, `pageSize`, `sort`, `search` on the name,
+ * `filter[field.op]=value`, `quickFilters`). A companion `GET /meta` endpoint
+ * exposes the grid metadata. Revoked keys are hidden unless
+ * `quickFilters=includeRevoked` is supplied.
  *
  * @param baseUrl - API base path (default: `/api/v1/authentication/api-keys`)
  */
@@ -42,42 +255,59 @@ export function createApiKeyHandlers(baseUrl = `${DEFAULT_BASE_PATH}/api-keys`) 
   const apiKeys: MutableApiKey[] = mockApiKeys.map((k) => ({ ...k }));
 
   return [
-    // GET list — paginated with filters
+    // GET meta — QueryEngine grid metadata
+    http.get(`${baseUrl}/meta`, () => HttpResponse.json(API_KEY_QUERY_META)),
+
+    // GET list — QueryEngine-backed (paginated, filterable, sortable)
     http.get(baseUrl, ({ request }) => {
       const url = new URL(request.url);
-      const search = url.searchParams.get('search');
-      const type = url.searchParams.get('type');
-      const environment = url.searchParams.get('environment');
-      const includeRevoked = url.searchParams.get('includeRevoked') === 'true';
-      const page = Number(url.searchParams.get('page') ?? '1');
-      const pageSize = Number(url.searchParams.get('pageSize') ?? '20');
+      const query = parseQueryRequest(url.search);
 
       let filtered = [...apiKeys];
 
-      if (search) {
-        const q = search.toLowerCase();
-        filtered = filtered.filter(
-          (k) => k.name.toLowerCase().includes(q) || k.prefix.toLowerCase().includes(q)
-        );
+      // Full-text search now matches the name only.
+      if (query.search) {
+        const q = query.search.toLowerCase();
+        filtered = filtered.filter((k) => k.name.toLowerCase().includes(q));
       }
 
-      if (type) {
-        filtered = filtered.filter((k) => k.type === type);
+      // Column filters: filter[field.op]=value (AND semantics).
+      for (const filter of query.filters ?? []) {
+        filtered = filtered.filter((k) => matchesFilter(k, filter));
       }
 
-      if (environment) {
-        filtered = filtered.filter((k) => k.environment === environment);
-      }
-
+      // Quick filters: hide revoked keys unless `includeRevoked` is active.
+      const includeRevoked = (query.quickFilters ?? []).some(
+        (name) => name.toLowerCase() === 'includerevoked'
+      );
       if (!includeRevoked) {
         filtered = filtered.filter((k) => k.revokedAt === null);
       }
 
+      // Sort — explicit `sort` entries, else the server default `-createdAt`.
+      const sort = query.sort?.length
+        ? query.sort
+        : [{ field: 'createdAt', direction: 'desc' as const }];
+      for (const entry of [...sort].reverse()) {
+        filtered.sort((a, b) => {
+          const av = fieldValue(a, entry.field) ?? '';
+          const bv = fieldValue(b, entry.field) ?? '';
+          const cmp = av < bv ? -1 : av > bv ? 1 : 0;
+          return entry.direction === 'desc' ? -cmp : cmp;
+        });
+      }
+
+      const page = query.page ?? 1;
+      const pageSize = query.pageSize ?? 20;
       const start = (page - 1) * pageSize;
-      return pagedResponse<ApiKeyResponse>(
-        filtered.slice(start, start + pageSize) as ApiKeyResponse[],
-        filtered.length
-      );
+      const items = filtered.slice(start, start + pageSize).map(toListItem);
+
+      return HttpResponse.json({
+        items,
+        totalCount: filtered.length,
+        hasMore: start + pageSize < filtered.length,
+        nextCursor: null,
+      });
     }),
 
     // GET single


### PR DESCRIPTION
Aligns the front with **granit-dotnet PR #2554**, which moved the admin `GET /api-keys` listing onto the generic **QueryEngine**. This is a breaking contract change for consumers of the listing surface.

## What changed

**Core — `@granit/authentication-api-keys`**
- Added `ApiKeyListItemResponse` (summary row, **without** `permissions`/`allowedCidrs` — those are detail-only) and `ApiKeyListPage = PagedResult<ApiKeyListItemResponse>`.
- `ListApiKeysParams` is now the generic `QueryRequest` (`page`/`pageSize`/`sort`/`search`/`filters`/`quickFilters`). Legacy→QueryEngine mapping is documented in JSDoc.
- Added `ApiKeyQuickFilters` constant (`active` default / `includeRevoked`).
- `listApiKeys` now delegates to `getPage<ApiKeyListItemResponse>` and forwards an `AbortSignal`; added `getApiKeysQueryMeta` → `GET /api-keys/meta`.
- Detail / create / revoke / rotate / update-scopes endpoints **unchanged**.

**React — `@granit/react-authentication-api-keys`**
- `useApiKeys` returns `ApiKeyListPage`, accepts a `QueryRequest`, and cancels superseded fetches via `signal`. Added `useApiKeysQueryMeta`.
- Testing MSW handlers rewritten to parse the QueryEngine grammar (name-only `search`, `filter[field.op]`, `quickFilters` with default-active / include-revoked, `sort`, pagination), return summary rows + `hasMore`/`nextCursor`, and serve `GET /meta`.

**`@granit/contract-tests`**
- `endpointIgnore: ['/api-keys', '/api-keys/meta']` — both are served by the query-engine generic surface, not a `client.METHOD` call in the module's `api/`.

## Legacy → QueryEngine mapping
| Before | After |
| --- | --- |
| `type=Secret` | `filters: [{ field: 'type', operator: 'Eq', value: 'Secret' }]` |
| `environment=live` | `filters: [{ field: 'environment', operator: 'Eq', value: 'live' }]` |
| `search=foo` | `search: 'foo'` (now name-only) |
| `includeRevoked=true` | `quickFilters: [ApiKeyQuickFilters.IncludeRevoked]` |
| `includeRevoked=false` (default) | omit `quickFilters` (server applies `active`) |

## Notes
- The vendored OpenAPI snapshot (`contracts/openapi/api-keys.json`) is **not** touched here — it is a backend build artifact updated only by the dedicated `chore(contracts): regenerate vendored OpenAPI snapshots` sync. Once it is re-synced against #2554, add `ApiKeyListItemResponse` to the `contract-tests` manifest `types` (one line) to bring it under the conformance oracle.

## Verification
- `pnpm tsc` (workspace) ✅
- ESLint `--max-warnings 0` ✅ · Prettier ✅
- Vitest: 190 passed across the 3 affected packages ✅

> [!WARNING]
> **BREAKING CHANGE:** `GET /api-keys` now returns `PagedResult<ApiKeyListItemResponse>` (summary rows without `permissions`/`allowedCidrs`) and accepts the QueryEngine query grammar instead of the `type`/`environment`/`includeRevoked` params. Use `GET /api-keys/{id}` for the full key, and `quickFilters=includeRevoked` to surface revoked keys. showcase-admin-react must be updated in lockstep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)