### PR TITLE
feat(idempotency): retry-safe keys + replay detection

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -245,6 +245,11 @@
           "signature": "function readIdempotencyTombstone(error: unknown): IdempotencyTombstoneInfo | undefined"
         },
         {
+          "name": "isIdempotentReplay",
+          "kind": "function",
+          "signature": "function isIdempotentReplay(responseOrError: unknown): boolean"
+        },
+        {
           "name": "IdempotencyTombstoneInfo",
           "kind": "interface",
           "signature": "interface IdempotencyTombstoneInfo",
@@ -1598,19 +1603,14 @@
       "description": "Automatic Idempotency-Key header injection for mutation requests",
       "exports": [
         {
-          "name": "IdempotencyOptions",
+          "name": "IdempotencyClientOptions",
           "kind": "interface",
-          "signature": "interface IdempotencyOptions",
+          "signature": "interface IdempotencyClientOptions",
           "members": [
             {
               "name": "methods",
               "kind": "property",
               "signature": "methods?: string[]"
-            },
-            {
-              "name": "headerName",
-              "kind": "property",
-              "signature": "headerName?: string"
             },
             {
               "name": "keyGenerator",
@@ -1620,9 +1620,14 @@
           ]
         },
         {
+          "name": "IdempotencyOptions",
+          "kind": "type",
+          "signature": "type IdempotencyOptions = IdempotencyClientOptions"
+        },
+        {
           "name": "enableIdempotency",
           "kind": "function",
-          "signature": "function enableIdempotency(options?: IdempotencyOptions): void"
+          "signature": "function enableIdempotency(options?: IdempotencyClientOptions): void"
         },
         {
           "name": "disableIdempotency",

--- a/packages/@granit/api-client/src/__tests__/idempotency.test.ts
+++ b/packages/@granit/api-client/src/__tests__/idempotency.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isIdempotencyTombstoned, readIdempotencyTombstone } from '../idempotency';
+import { isIdempotencyTombstoned, isIdempotentReplay, readIdempotencyTombstone } from '../idempotency';
 
 // Builds an AxiosError-shaped object with the given response headers.
 // We intentionally do NOT use the real `AxiosError` constructor — the
@@ -15,6 +15,12 @@ function errorWithHeaders(headers: Record<string, string>, status = 413): unknow
     },
     message: 'Request failed',
   };
+}
+
+// Builds an AxiosResponse-shaped object exposing `headers` directly (success
+// path), as opposed to the error wrapper above (`response.headers`).
+function responseWithHeaders(headers: Record<string, string>, status = 200): unknown {
+  return { status, statusText: 'OK', headers, data: {} };
 }
 
 describe('readIdempotencyTombstone', () => {
@@ -92,5 +98,47 @@ describe('isIdempotencyTombstoned', () => {
   it('is false for non-error input', () => {
     expect(isIdempotencyTombstoned(null)).toBe(false);
     expect(isIdempotencyTombstoned(new Error('network'))).toBe(false);
+  });
+});
+
+describe('isIdempotentReplay', () => {
+  it('is true when a success response carries the replay header', () => {
+    const res = responseWithHeaders({ 'idempotent-replayed': 'true' });
+
+    expect(isIdempotentReplay(res)).toBe(true);
+  });
+
+  it('is true for the canonical-cased header', () => {
+    // Axios normally lowercases headers, but a proxy or test fixture may not.
+    const res = responseWithHeaders({ 'Idempotent-Replayed': 'true' });
+
+    expect(isIdempotentReplay(res)).toBe(true);
+  });
+
+  it('is true when the replay reproduces a cached error status (error shape)', () => {
+    // Cacheable error statuses (e.g. 409, 422) are replayed too — the helper
+    // must read `error.response.headers`, not just `response.headers`.
+    const err = errorWithHeaders({ 'idempotent-replayed': 'true' }, 409);
+
+    expect(isIdempotentReplay(err)).toBe(true);
+  });
+
+  it('is false when the replay header is absent', () => {
+    const res = responseWithHeaders({ 'content-type': 'application/json' });
+
+    expect(isIdempotentReplay(res)).toBe(false);
+  });
+
+  it('is false when the replay header is not "true"', () => {
+    const res = responseWithHeaders({ 'idempotent-replayed': 'false' });
+
+    expect(isIdempotentReplay(res)).toBe(false);
+  });
+
+  it('is false for non-object input', () => {
+    expect(isIdempotentReplay(null)).toBe(false);
+    expect(isIdempotentReplay(undefined)).toBe(false);
+    expect(isIdempotentReplay('true')).toBe(false);
+    expect(isIdempotentReplay({})).toBe(false);
   });
 });

--- a/packages/@granit/api-client/src/idempotency.ts
+++ b/packages/@granit/api-client/src/idempotency.ts
@@ -15,6 +15,7 @@
 // ---------------------------------------------------------------------------
 
 const TOMBSTONE_HEADER = 'x-idempotency-tombstone';
+const REPLAY_HEADER = 'idempotent-replayed';
 
 /** Reason reported by the backend for the tombstoned response. */
 export interface IdempotencyTombstoneInfo {
@@ -28,24 +29,30 @@ export interface IdempotencyTombstoneInfo {
   readonly reason: string;
 }
 
-// Minimal shape test for an AxiosError-like object without taking a direct
-// dependency on axios's error constructor. This lets the helper accept either
-// a raw AxiosError or a framework-specific error wrapper that preserves
-// `response.headers`.
-interface ErrorWithResponseHeaders {
-  response?: {
-    headers?: Readonly<Record<string, unknown>>;
-  };
-}
+type HeaderBag = Readonly<Record<string, unknown>>;
 
-function hasResponseHeaders(error: unknown): error is ErrorWithResponseHeaders {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'response' in error &&
-    typeof (error as { response?: unknown }).response === 'object' &&
-    (error as { response?: unknown }).response !== null
-  );
+// Extract the response header bag from either an AxiosResponse (`response.headers`)
+// or an AxiosError-like wrapper (`error.response.headers`), without taking a
+// direct dependency on axios's types. This lets the idempotency helpers accept
+// a successful response, a raw AxiosError, or a framework-specific `HttpError`
+// that preserves the original response headers — covering both the tombstone
+// (always an error) and replay (success or cached error) signals.
+function extractResponseHeaders(value: unknown): HeaderBag | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const direct = (value as { headers?: unknown }).headers;
+  if (typeof direct === 'object' && direct !== null) {
+    return direct as HeaderBag;
+  }
+
+  const nested = (value as { response?: { headers?: unknown } }).response?.headers;
+  if (typeof nested === 'object' && nested !== null) {
+    return nested as HeaderBag;
+  }
+
+  return undefined;
 }
 
 /**
@@ -59,11 +66,7 @@ function hasResponseHeaders(error: unknown): error is ErrorWithResponseHeaders {
  * when they preserve the original response headers.
  */
 export function readIdempotencyTombstone(error: unknown): IdempotencyTombstoneInfo | undefined {
-  if (!hasResponseHeaders(error)) {
-    return undefined;
-  }
-
-  const headers = error.response?.headers;
+  const headers = extractResponseHeaders(error);
   if (!headers) {
     return undefined;
   }
@@ -86,4 +89,27 @@ export function readIdempotencyTombstone(error: unknown): IdempotencyTombstoneIn
  */
 export function isIdempotencyTombstoned(error: unknown): boolean {
   return readIdempotencyTombstone(error) !== undefined;
+}
+
+/**
+ * `true` when the response carried the `Idempotent-Replayed: true` header —
+ * the backend served a cached copy of a previously-completed request instead
+ * of re-executing the handler. Useful for telemetry and UX ("already
+ * processed — this was a duplicate submission").
+ *
+ * Accepts either a successful `AxiosResponse` (header read from
+ * `response.headers`) or an `AxiosError` (header read from
+ * `error.response.headers`), since a replay reproduces the original cached
+ * status — which may be a success OR a cached error (e.g. 409, 422).
+ */
+export function isIdempotentReplay(responseOrError: unknown): boolean {
+  const headers = extractResponseHeaders(responseOrError);
+  if (!headers) {
+    return false;
+  }
+
+  // Axios lowercases response headers by default; check the canonical casing
+  // too for adapters/proxies that preserve it.
+  const raw = headers[REPLAY_HEADER] ?? headers['Idempotent-Replayed'];
+  return typeof raw === 'string' && raw.toLowerCase() === 'true';
 }

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -286,8 +286,8 @@ export function buildApiUrl(basePath: string, ...segments: string[]): string {
 export { HttpError, TimeoutError, ValidationError } from './errors';
 export type { ProblemDetailsPayload, ValidationDetails } from './errors';
 
-// Idempotency tombstone helpers — see ./idempotency.ts.
-export { isIdempotencyTombstoned, readIdempotencyTombstone } from './idempotency';
+// Idempotency tombstone + replay helpers — see ./idempotency.ts.
+export { isIdempotencyTombstoned, readIdempotencyTombstone, isIdempotentReplay } from './idempotency';
 export type { IdempotencyTombstoneInfo } from './idempotency';
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/idempotency/package.json
+++ b/packages/@granit/idempotency/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@granit/idempotency",
   "description": "Automatic Idempotency-Key header injection for mutation requests",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "type": "module",
   "exports": {

--- a/packages/@granit/idempotency/src/__tests__/idempotency.test.ts
+++ b/packages/@granit/idempotency/src/__tests__/idempotency.test.ts
@@ -13,7 +13,6 @@ interface ApiClientModule {
 interface IdempotencyModule {
   enableIdempotency: (options?: {
     methods?: string[];
-    headerName?: string;
     keyGenerator?: (config: InternalAxiosRequestConfig) => string | undefined;
   }) => void;
   disableIdempotency: () => void;
@@ -99,6 +98,24 @@ describe('enableIdempotency', () => {
     expect(key1).toBeDefined();
     expect(key2).toBeDefined();
     expect(key1).not.toBe(key2);
+  });
+
+  it('should preserve a caller-provided Idempotency-Key (stable across retries)', async () => {
+    // The default generator must NOT clobber a key the caller already set —
+    // that is the mechanism by which one logical operation keeps the same key
+    // across every retry attempt, so the backend replays instead of re-running.
+    idempotencyMod.enableIdempotency();
+    const client = apiMod.createApiClient({ baseURL: 'https://api.example.com' });
+    client.defaults.adapter = captureAdapter;
+
+    const stableKey = 'stable-operation-key-123';
+    const response = await client.post(
+      '/test',
+      { data: 'value' },
+      { headers: { 'Idempotency-Key': stableKey } }
+    );
+
+    expect(response.config.headers['Idempotency-Key']).toBe(stableKey);
   });
 });
 

--- a/packages/@granit/idempotency/src/index.ts
+++ b/packages/@granit/idempotency/src/index.ts
@@ -2,16 +2,20 @@ import { isIdempotencyTombstoned, setIdempotencyKeyGenerator } from '@granit/api
 
 import type { InternalAxiosRequestConfig } from '@granit/api-client';
 
-// Re-export the tombstone helpers so consumers only need to depend on
+// Re-export the tombstone + replay helpers so consumers only need to depend on
 // `@granit/idempotency` to handle idempotency end-to-end (generation + retry).
-export { isIdempotencyTombstoned, readIdempotencyTombstone } from '@granit/api-client';
+export {
+  isIdempotencyTombstoned,
+  readIdempotencyTombstone,
+  isIdempotentReplay,
+} from '@granit/api-client';
 export type { IdempotencyTombstoneInfo } from '@granit/api-client';
 
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
 
-export interface IdempotencyOptions {
+export interface IdempotencyClientOptions {
   /**
    * HTTP methods that receive an `Idempotency-Key` header.
    * Default: `['post', 'put', 'patch', 'delete']`.
@@ -19,19 +23,25 @@ export interface IdempotencyOptions {
   methods?: string[];
 
   /**
-   * Name of the HTTP header. Default: `'Idempotency-Key'`.
-   * Must match the backend `IdempotencyOptions.HeaderName`.
-   */
-  headerName?: string;
-
-  /**
    * Custom key generator. Receives the Axios request config and returns
    * the idempotency key string, or `undefined` to skip the header.
    *
    * Default: UUID v4 via `crypto.randomUUID()`.
+   *
+   * The backend rejects keys longer than its `MaxKeyLength` (default 256
+   * characters) with HTTP 400 before any processing — keep generated keys
+   * well under that bound (a UUIDv4 is 36 characters).
    */
   keyGenerator?: (config: InternalAxiosRequestConfig) => string | undefined;
 }
+
+/**
+ * @deprecated Renamed to {@link IdempotencyClientOptions} to avoid colliding
+ * with the unrelated server-side `IdempotencyOptions` (.NET middleware config).
+ * This alias is kept for backward compatibility and will be removed in a
+ * future major version.
+ */
+export type IdempotencyOptions = IdempotencyClientOptions;
 
 const DEFAULT_METHODS = ['post', 'put', 'patch', 'delete'];
 
@@ -45,6 +55,15 @@ const DEFAULT_METHODS = ['post', 'put', 'patch', 'delete'];
  * Call once during app initialization (e.g. in `main.ts` or the root component).
  * All subsequent mutation requests will automatically include an `Idempotency-Key` header.
  *
+ * By default the key is a fresh UUIDv4 per request — UNLESS the caller already
+ * set an `Idempotency-Key` header on the request, in which case that value is
+ * preserved. This is what makes retries idempotent: reuse a single key across
+ * every attempt of one logical operation (e.g. carry a stable key in the React
+ * Query mutation variables) so the backend replays the original response
+ * instead of re-executing. Random per-request keys do NOT make automatic
+ * retries safe — each retry would otherwise mint a new key the backend treats
+ * as a distinct operation.
+ *
  * @example
  * ```typescript
  * // src/main.ts
@@ -55,16 +74,12 @@ const DEFAULT_METHODS = ['post', 'put', 'patch', 'delete'];
  *
  * @example
  * ```typescript
- * // Custom key generator (e.g. form-based deduplication)
- * enableIdempotency({
- *   keyGenerator: (config) => {
- *     // Use a stable key derived from the request body for retries
- *     return config.data?.idempotencyKey ?? crypto.randomUUID();
- *   },
- * });
+ * // Retry-safe mutation: the SAME key rides every attempt of one operation,
+ * // so a retry after an ambiguous failure replays instead of double-executing.
+ * api.post('/orders', body, { headers: { 'Idempotency-Key': stableKey } });
  * ```
  */
-export function enableIdempotency(options?: IdempotencyOptions): void {
+export function enableIdempotency(options?: IdempotencyClientOptions): void {
   const methods = new Set((options?.methods ?? DEFAULT_METHODS).map((m) => m.toLowerCase()));
   const generate = options?.keyGenerator ?? defaultKeyGenerator;
 
@@ -89,8 +104,16 @@ export function disableIdempotency(): void {
 // Default key generator
 // ---------------------------------------------------------------------------
 
-function defaultKeyGenerator(_config: InternalAxiosRequestConfig): string {
-  return crypto.randomUUID();
+/**
+ * Reuses a caller-provided `Idempotency-Key` header when present — so the SAME
+ * key can ride every retry attempt of one logical operation (required for the
+ * backend to replay the original response or return a deterministic tombstone
+ * rather than re-executing). Falls back to a fresh UUIDv4 for one-shot
+ * mutations that don't opt in.
+ */
+function defaultKeyGenerator(config: InternalAxiosRequestConfig): string {
+  const existing = config.headers.get('Idempotency-Key');
+  return typeof existing === 'string' && existing.length > 0 ? existing : crypto.randomUUID();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

Audit of `@granit/idempotency` (and its showcase usage). Two coupled issues surfaced:

1. The default key generator minted a **fresh UUID per request**, so React Query mutation retries got a *new* `Idempotency-Key` each attempt → no double-execution guard on ambiguous failures, and `shouldRetryIgnoringTombstone` was effectively inert (a tombstone can only arise from a reused key). The package's own retry helper assumed key stability the default didn't provide.
2. The public `IdempotencyOptions.headerName` option was documented but **never used** — the header name is hardcoded in `@granit/api-client`. A consumer setting it would be silently ignored.

## Changes

- **`@granit/idempotency`** — `defaultKeyGenerator` now **preserves a caller-set `Idempotency-Key` header** (stable across retries), falling back to a fresh UUID for one-shot mutations. This makes a retried mutation *replay* the original response instead of re-executing.
- **`@granit/api-client`** — add `isIdempotentReplay(responseOrError)` to detect the backend's `Idempotent-Replayed: true` header (works on success responses and cached-error replays). Header extraction refactored into a shared, behavior-preserving helper.
- Drop the non-functional `headerName` option; rename `IdempotencyOptions` → `IdempotencyClientOptions` (**deprecated alias kept**, zero blast radius).
- Document the backend `MaxKeyLength` (256) bound on `keyGenerator`.
- Bump `@granit/idempotency` `0.2.0` → `0.3.0`.

## Verification

- `tsc --noEmit` (idempotency + api-client): clean
- Vitest: 80 passed (incl. new stable-key + replay-detection tests)
- ESLint `--max-warnings 0`: clean
- `dist/` regenerated (published package)

## Follow-up

Consuming-side demo (stable key per mutation via a `useIdempotentMutation` hook) lands in a **showcase-react MR that depends on this PR** — it must merge first so the linked `@granit/idempotency` carries the header-preserving generator.