### PR TITLE
fix(features)!: align GET /values with backend dictionary contract

### DIFF
--- a/packages/@granit/features/src/__tests__/features-api.test.ts
+++ b/packages/@granit/features/src/__tests__/features-api.test.ts
@@ -75,14 +75,15 @@ describe('features-api', () => {
   });
 
   describe('getAllFeatureValues', () => {
-    it('should GET {basePath}/values', async () => {
+    it('should GET {basePath}/values and return a dictionary', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue(axiosResponse([sampleValue]));
+      const values = { 'ui.dark-mode': 'true', 'ui.max-items': '50' };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(values));
 
       const result = await getAllFeatureValues(client, basePath);
 
       expect(client.get).toHaveBeenCalledWith(`${basePath}/values`);
-      expect(result).toEqual([sampleValue]);
+      expect(result).toEqual(values);
     });
   });
 

--- a/packages/@granit/features/src/api/features-api.ts
+++ b/packages/@granit/features/src/api/features-api.ts
@@ -21,13 +21,16 @@ export async function getFeatureDefinitions(
 /**
  * Fetch all resolved feature values for the current tenant.
  *
+ * Returns a dictionary keyed by feature name, mirroring the backend
+ * `IReadOnlyDictionary<string, string>` contract.
+ *
  * `GET {basePath}/values`
  */
 export async function getAllFeatureValues(
   client: AxiosInstance,
   basePath: string
-): Promise<readonly FeatureValueResponse[]> {
-  const response = await client.get<readonly FeatureValueResponse[]>(`${basePath}/values`);
+): Promise<Readonly<Record<string, string>>> {
+  const response = await client.get<Record<string, string>>(`${basePath}/values`);
   return response.data;
 }
 

--- a/packages/@granit/react-features/src/__tests__/use-features.test.tsx
+++ b/packages/@granit/react-features/src/__tests__/use-features.test.tsx
@@ -97,9 +97,10 @@ describe('use-features', () => {
   });
 
   describe('useFeatureValues', () => {
-    it('fetches all feature values', async () => {
+    it('fetches all feature values as a dictionary', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleValue] });
+      const values = { 'ui.dark-mode': 'true' };
+      vi.mocked(client.get).mockResolvedValue({ data: values });
 
       const { result } = renderHook(() => useFeatureValues(), {
         wrapper: createWrapper(client),
@@ -107,7 +108,7 @@ describe('use-features', () => {
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(client.get).toHaveBeenCalledWith('/api/v1/features/values');
-      expect(result.current.data).toEqual([sampleValue]);
+      expect(result.current.data).toEqual(values);
     });
   });
 

--- a/packages/@granit/react-features/src/hooks/use-features.ts
+++ b/packages/@granit/react-features/src/hooks/use-features.ts
@@ -37,12 +37,15 @@ export function useFeatureDefinitions(): UseQueryResult<readonly FeatureGroupRes
 /**
  * Fetch all resolved feature values for the current tenant.
  *
+ * Resolves to a dictionary keyed by feature name.
+ *
  * @example
  * ```tsx
  * const { data: values } = useFeatureValues();
+ * const darkMode = values?.['ui.dark-mode'];
  * ```
  */
-export function useFeatureValues(): UseQueryResult<readonly FeatureValueResponse[]> {
+export function useFeatureValues(): UseQueryResult<Readonly<Record<string, string>>> {
   const config = useFeaturesConfig();
   const basePath = config.basePath!;
 

--- a/packages/@granit/react-features/src/testing/data.ts
+++ b/packages/@granit/react-features/src/testing/data.ts
@@ -1,8 +1,4 @@
-import type {
-  FeatureDefinitionResponse,
-  FeatureGroupResponse,
-  FeatureValueResponse,
-} from '@granit/features';
+import type { FeatureDefinitionResponse, FeatureGroupResponse } from '@granit/features';
 
 export const mockFeatureGroups: FeatureGroupResponse[] = [
   {
@@ -59,9 +55,13 @@ export const mockFeatureDefinitions: FeatureDefinitionResponse[] = mockFeatureGr
   (g) => g.features
 );
 
-export const mockFeatureValues: FeatureValueResponse[] = [
-  { name: 'billing.auto-invoicing', value: 'true' },
-  { name: 'billing.max-retry-attempts', value: '3' },
-  { name: 'ui.dark-mode', value: 'true' },
-  { name: 'ui.theme', value: 'compact' },
-];
+/**
+ * Resolved feature values keyed by feature name — mirrors the backend
+ * `GET /values` `IReadOnlyDictionary<string, string>` contract.
+ */
+export const mockFeatureValues: Record<string, string> = {
+  'billing.auto-invoicing': 'true',
+  'billing.max-retry-attempts': '3',
+  'ui.dark-mode': 'true',
+  'ui.theme': 'compact',
+};

--- a/packages/@granit/react-features/src/testing/handlers.ts
+++ b/packages/@granit/react-features/src/testing/handlers.ts
@@ -1,25 +1,56 @@
-import { noContent, notFound } from '@granit/testing/msw';
+import { noContent, notFound, unprocessableEntity } from '@granit/testing/msw';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
 import { mockFeatureGroups, mockFeatureValues } from './data';
 
-import type { FeatureValueResponse } from '@granit/features';
+import type { FeatureDefinitionResponse } from '@granit/features';
 
-type Mutable<T> = { -readonly [K in keyof T]: T[K] };
+const allDefinitions: readonly FeatureDefinitionResponse[] = mockFeatureGroups.flatMap(
+  (g) => g.features
+);
+
+/**
+ * Validate an override value against a feature definition's value type,
+ * mirroring the backend rules (Toggle: true/false, Numeric: min/max bounds,
+ * Selection: allowed values). Returns an error message, or `null` if valid.
+ */
+function validateValue(definition: FeatureDefinitionResponse, value: string): string | null {
+  switch (definition.valueType) {
+    case 'Toggle':
+      return value === 'true' || value === 'false'
+        ? null
+        : `Value '${value}' is not a valid toggle (expected 'true' or 'false').`;
+    case 'Numeric': {
+      const parsed = Number(value);
+      if (!Number.isInteger(parsed)) {
+        return `Value '${value}' is not a valid integer.`;
+      }
+      const constraint = definition.numericConstraint;
+      if (constraint && (parsed < constraint.min || parsed > constraint.max)) {
+        return `Value ${parsed} is out of range [${constraint.min}, ${constraint.max}].`;
+      }
+      return null;
+    }
+    case 'Selection':
+      return definition.selectionValues?.includes(value)
+        ? null
+        : `Value '${value}' is not an allowed selection value.`;
+    default:
+      return null;
+  }
+}
 
 /**
  * Create stateful MSW handlers for feature flag endpoints.
- * The `featureValues` array is a mutable copy — override/delete calls
+ * The `featureValues` dictionary is a mutable copy — override/delete calls
  * update state that subsequent GET calls reflect.
  *
  * @param baseUrl - API base path (default: `/api/v1/features`)
  */
 export function createFeaturesHandlers(baseUrl = DEFAULT_BASE_PATH) {
-  const featureValues: Mutable<FeatureValueResponse>[] = structuredClone(
-    mockFeatureValues
-  ) as Mutable<FeatureValueResponse>[];
+  const featureValues: Record<string, string> = structuredClone(mockFeatureValues);
 
   return [
     // GET definitions — returns groups with nested feature definitions
@@ -27,7 +58,7 @@ export function createFeaturesHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return HttpResponse.json(mockFeatureGroups);
     }),
 
-    // GET all values
+    // GET all values — dictionary keyed by feature name
     http.get(`${baseUrl}/values`, () => {
       return HttpResponse.json(featureValues);
     }),
@@ -35,32 +66,30 @@ export function createFeaturesHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // GET single value by name
     http.get(`${baseUrl}/values/:name`, ({ params }) => {
       const name = decodeURIComponent(params.name as string);
-      const value = featureValues.find((v) => v.name === name);
-      if (!value) return notFound();
-      return HttpResponse.json(value);
+      if (!(name in featureValues)) return notFound();
+      return HttpResponse.json({ name, value: featureValues[name] });
     }),
 
-    // POST override
-    http.post(`${baseUrl}/overrides/:name`, async ({ params, request }) => {
+    // PUT override — validate against the definition, then upsert state (204)
+    http.put(`${baseUrl}/overrides/:name`, async ({ params, request }) => {
       const name = decodeURIComponent(params.name as string);
+      const definition = allDefinitions.find((f) => f.name === name);
+      if (!definition) return notFound();
+
       const body = (await request.json()) as { value: string };
-      const existing = featureValues.find((v) => v.name === name);
-      if (existing) {
-        existing.value = body.value;
-        return HttpResponse.json(existing);
-      }
-      const created: Mutable<FeatureValueResponse> = { name, value: body.value };
-      featureValues.push(created);
-      return HttpResponse.json(created);
+      const error = validateValue(definition, body.value);
+      if (error) return unprocessableEntity(error);
+
+      featureValues[name] = body.value;
+      return noContent();
     }),
 
-    // DELETE override — reset value to definition default
+    // DELETE override — reset value to definition default (204)
     http.delete(`${baseUrl}/overrides/:name`, ({ params }) => {
       const name = decodeURIComponent(params.name as string);
-      const existing = featureValues.find((v) => v.name === name);
-      if (!existing) return notFound();
-      const definition = mockFeatureGroups.flatMap((g) => g.features).find((f) => f.name === name);
-      existing.value = definition?.defaultValue ?? existing.value;
+      const definition = allDefinitions.find((f) => f.name === name);
+      if (!definition) return notFound();
+      featureValues[name] = definition.defaultValue;
       return noContent();
     }),
   ];

--- a/packages/@granit/testing/src/msw-helpers.ts
+++ b/packages/@granit/testing/src/msw-helpers.ts
@@ -52,6 +52,11 @@ export function accepted() {
   return new HttpResponse(null, { status: 202 });
 }
 
+/** 422 Unprocessable Entity — for validation failures, as a `ProblemDetails` body. */
+export function unprocessableEntity(detail?: string) {
+  return HttpResponse.json({ title: 'Unprocessable Entity', status: 422, detail }, { status: 422 });
+}
+
 // ---------------------------------------------------------------------------
 // Query-engine param parsing — mirrors @granit/query-engine serialization
 // ---------------------------------------------------------------------------

--- a/packages/@granit/testing/src/msw.ts
+++ b/packages/@granit/testing/src/msw.ts
@@ -16,6 +16,7 @@ export {
   parseFilters,
   parseSort,
   sortItems,
+  unprocessableEntity,
 } from './msw-helpers';
 
 export type { FilterEntry, SortEntry } from './msw-helpers';


### PR DESCRIPTION
## Contexte

Audit de conformité des modules `@granit/features` + `@granit/react-features` contre le contrat backend `Granit.Features.Endpoints` (`contracts/openapi/features.json`).

L'audit a confirmé une couverture d'endpoints complète (5/5), un mapping de verbes correct et un alignement des permissions (`Features.Flags.Read/Manage`). Une seule cause racine de désalignement, à fort impact runtime.

## Cause racine

Le backend `GET /features/values` renvoie `IReadOnlyDictionary<string, string>` (map `nom de feature → valeur`), mais le frontend modélisait la réponse comme `FeatureValueResponse[]`. Tout consommateur faisant `.map`/`.find`/`.length` sur le résultat casse à l'exécution.

## Changements

- **BREAKING** — `getAllFeatureValues` / `useFeatureValues` renvoient désormais `Readonly<Record<string, string>>` au lieu de `readonly FeatureValueResponse[]`.
- `@granit/react-features/testing` :
  - handler `GET /values` renvoie le dictionnaire ;
  - handler d'override `POST` → **`PUT`** (route backend + client réel) renvoyant `204` ;
  - validation value-type → `422` (Toggle / Numeric / Selection), en miroir du backend.
- `mockFeatureValues` converti en `Record<string, string>`.
- Nouveau helper `unprocessableEntity()` (422 / `ProblemDetails`) dans `@granit/testing/msw`.
- Tests mis à jour (`features-api.test.ts`, `use-features.test.tsx`).

`FeatureValueResponse` reste le contrat de `GET /values/{name}` (inchangé).

## Vérification

| Check | Résultat |
| --- | --- |
| `tsc` (features, react-features, testing) | ✅ |
| Tests (5 fichiers) | ✅ 34/34 |
| ESLint `--max-warnings 0` | ✅ |

## Blast radius

`useFeatureValues` / `getAllFeatureValues` n'étaient consommés par aucune app — bug latent corrigé avant qu'un consommateur ne soit écrit contre la mauvaise forme. La PR consommateur côté showcase (qui exploite désormais l'endpoint dictionnaire) dépend de cette PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)