### PR TITLE
fix(localization): align api models with backend localization contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1691,7 +1691,7 @@
         {
           "name": "applyTranslations",
           "kind": "function",
-          "signature": "function applyTranslations(instance: i18n, data: ApplicationLocalizationDto): void"
+          "signature": "function applyTranslations(instance: i18n, data: ApplicationLocalizationResponse): void"
         },
         {
           "name": "unflattenKeys",
@@ -1706,7 +1706,17 @@
         {
           "name": "getApplicationLocalization",
           "kind": "function",
-          "signature": "async function getApplicationLocalization( client: AxiosInstance, basePath: string, cultureName?: string ): Promise<ApplicationLocalizationDto>"
+          "signature": "async function getApplicationLocalization( client: AxiosInstance, basePath: string, cultureName?: string ): Promise<ApplicationLocalizationResponse>"
+        },
+        {
+          "name": "deleteLocalizationOverride",
+          "kind": "function",
+          "signature": "async function deleteLocalizationOverride( client: AxiosInstance, basePath: string, resourceName: string, cultureName: string, key: string ): Promise<void>"
+        },
+        {
+          "name": "setLocalizationOverride",
+          "kind": "function",
+          "signature": "async function setLocalizationOverride( client: AxiosInstance, basePath: string, resourceName: string, cultureName: string, key: string, value: string ): Promise<void>"
         },
         {
           "name": "LocalizationOverridesPermissions",
@@ -5278,7 +5288,7 @@
         {
           "name": "useApplicationLocalization",
           "kind": "function",
-          "signature": "function useApplicationLocalization( options: UseApplicationLocalizationOptions ): UseQueryResult<ApplicationLocalizationDto>"
+          "signature": "function useApplicationLocalization( options: UseApplicationLocalizationOptions ): UseQueryResult<ApplicationLocalizationResponse>"
         },
         {
           "name": "UseApplicationLocalizationOptions",

--- a/packages/@granit/localization/src/__tests__/apply-translations.test.ts
+++ b/packages/@granit/localization/src/__tests__/apply-translations.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { applyTranslations } from '../apply-translations';
 
-import type { ApplicationLocalizationDto } from '../types/index';
+import type { ApplicationLocalizationResponse } from '../types/index';
 
 function createMockI18n(language = 'fr') {
   return {
@@ -12,7 +12,7 @@ function createMockI18n(language = 'fr') {
   };
 }
 
-const localizationData: ApplicationLocalizationDto = {
+const localizationData: ApplicationLocalizationResponse = {
   cultureName: 'fr',
   resources: {
     Granit: {
@@ -65,7 +65,7 @@ describe('applyTranslations', () => {
 
   it('should handle empty resources', () => {
     const i18n = createMockI18n();
-    const data: ApplicationLocalizationDto = {
+    const data: ApplicationLocalizationResponse = {
       cultureName: 'en',
       resources: {},
       languages: [],
@@ -77,7 +77,7 @@ describe('applyTranslations', () => {
 
   it('should let later modules override earlier ones on key collision', () => {
     const i18n = createMockI18n();
-    const data: ApplicationLocalizationDto = {
+    const data: ApplicationLocalizationResponse = {
       cultureName: 'fr',
       resources: {
         Base: { 'App.Title': 'Base Title' },

--- a/packages/@granit/localization/src/__tests__/localization-admin-api.test.ts
+++ b/packages/@granit/localization/src/__tests__/localization-admin-api.test.ts
@@ -1,74 +1,12 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  deleteLocalizationOverride,
-  listLanguages,
-  setLocalizationOverride,
-  updateLanguageStatus,
-} from '../api/localization-admin-api';
+import { deleteLocalizationOverride, setLocalizationOverride } from '../api/localization-admin-api';
+
+const BASE = '/api/v1/localization';
 
 afterEach(() => {
   vi.restoreAllMocks();
-});
-
-// ---------------------------------------------------------------------------
-// listLanguages
-// ---------------------------------------------------------------------------
-
-describe('listLanguages', () => {
-  it('should GET /localization/languages and return data', async () => {
-    const client = createMockClient();
-    const languages = [
-      { cultureName: 'fr', displayName: 'Français', isEnabled: true },
-      { cultureName: 'en', displayName: 'English', isEnabled: false },
-    ];
-    vi.mocked(client.get).mockResolvedValue(axiosResponse(languages));
-
-    const result = await listLanguages(client, '/api');
-
-    expect(client.get).toHaveBeenCalledWith('/api/localization/languages');
-    expect(result).toEqual(languages);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// updateLanguageStatus
-// ---------------------------------------------------------------------------
-
-describe('updateLanguageStatus', () => {
-  it('should PUT to enable a language', async () => {
-    const client = createMockClient();
-    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
-
-    await updateLanguageStatus(client, '/api', 'en', true);
-
-    expect(client.put).toHaveBeenCalledWith('/api/localization/languages/en', {
-      isEnabled: true,
-    });
-  });
-
-  it('should PUT to disable a language', async () => {
-    const client = createMockClient();
-    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
-
-    await updateLanguageStatus(client, '/api', 'de', false);
-
-    expect(client.put).toHaveBeenCalledWith('/api/localization/languages/de', {
-      isEnabled: false,
-    });
-  });
-
-  it('should encode cultureName in the URL', async () => {
-    const client = createMockClient();
-    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
-
-    await updateLanguageStatus(client, '/api', 'zh-Hant', true);
-
-    expect(client.put).toHaveBeenCalledWith('/api/localization/languages/zh-Hant', {
-      isEnabled: true,
-    });
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -76,13 +14,13 @@ describe('updateLanguageStatus', () => {
 // ---------------------------------------------------------------------------
 
 describe('setLocalizationOverride', () => {
-  it('should PUT the override value', async () => {
+  it('should PUT the override value to {basePath}/overrides/{resource}/{culture}/{key}', async () => {
     const client = createMockClient();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
 
-    await setLocalizationOverride(client, '/api', 'Granit', 'fr', 'Common.Save', 'Sauvegarder');
+    await setLocalizationOverride(client, BASE, 'Granit', 'fr', 'Common.Save', 'Sauvegarder');
 
-    expect(client.put).toHaveBeenCalledWith('/api/localization/overrides/Granit/fr/Common.Save', {
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/overrides/Granit/fr/Common.Save`, {
       value: 'Sauvegarder',
     });
   });
@@ -91,12 +29,11 @@ describe('setLocalizationOverride', () => {
     const client = createMockClient();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
 
-    await setLocalizationOverride(client, '/api', 'My Resource', 'fr-BE', 'key/sub', 'val');
+    await setLocalizationOverride(client, BASE, 'My Resource', 'fr-BE', 'key/sub', 'val');
 
-    expect(client.put).toHaveBeenCalledWith(
-      '/api/localization/overrides/My%20Resource/fr-BE/key%2Fsub',
-      { value: 'val' }
-    );
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/overrides/My%20Resource/fr-BE/key%2Fsub`, {
+      value: 'val',
+    });
   });
 });
 
@@ -109,19 +46,17 @@ describe('deleteLocalizationOverride', () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
 
-    await deleteLocalizationOverride(client, '/api', 'Granit', 'fr', 'Common.Save');
+    await deleteLocalizationOverride(client, BASE, 'Granit', 'fr', 'Common.Save');
 
-    expect(client.delete).toHaveBeenCalledWith('/api/localization/overrides/Granit/fr/Common.Save');
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/overrides/Granit/fr/Common.Save`);
   });
 
   it('should encode special characters in path segments', async () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
 
-    await deleteLocalizationOverride(client, '/api', 'My Resource', 'fr-BE', 'key/sub');
+    await deleteLocalizationOverride(client, BASE, 'My Resource', 'fr-BE', 'key/sub');
 
-    expect(client.delete).toHaveBeenCalledWith(
-      '/api/localization/overrides/My%20Resource/fr-BE/key%2Fsub'
-    );
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/overrides/My%20Resource/fr-BE/key%2Fsub`);
   });
 });

--- a/packages/@granit/localization/src/api/localization-admin-api.ts
+++ b/packages/@granit/localization/src/api/localization-admin-api.ts
@@ -1,39 +1,10 @@
-import type { AdminLanguage } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
-
-/**
- * List all languages with admin status.
- *
- * `GET {basePath}/localization/languages`
- */
-export async function listLanguages(
-  client: AxiosInstance,
-  basePath: string
-): Promise<AdminLanguage[]> {
-  const response = await client.get<AdminLanguage[]>(`${basePath}/localization/languages`);
-  return response.data;
-}
-
-/**
- * Enable or disable a language.
- *
- * `PUT {basePath}/localization/languages/{cultureName}`
- */
-export async function updateLanguageStatus(
-  client: AxiosInstance,
-  basePath: string,
-  cultureName: string,
-  isEnabled: boolean
-): Promise<void> {
-  await client.put(`${basePath}/localization/languages/${encodeURIComponent(cultureName)}`, {
-    isEnabled,
-  });
-}
 
 /**
  * Set a localization override (create or update).
  *
- * `PUT {basePath}/localization/overrides/{resourceName}/{cultureName}/{key}`
+ * `PUT {basePath}/overrides/{resourceName}/{cultureName}/{key}` where
+ * `basePath` is the localization module root (e.g. `/api/v1/localization`).
  */
 export async function setLocalizationOverride(
   client: AxiosInstance,
@@ -44,7 +15,7 @@ export async function setLocalizationOverride(
   value: string
 ): Promise<void> {
   await client.put(
-    `${basePath}/localization/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`,
+    `${basePath}/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`,
     { value }
   );
 }
@@ -52,7 +23,8 @@ export async function setLocalizationOverride(
 /**
  * Delete a localization override.
  *
- * `DELETE {basePath}/localization/overrides/{resourceName}/{cultureName}/{key}`
+ * `DELETE {basePath}/overrides/{resourceName}/{cultureName}/{key}` where
+ * `basePath` is the localization module root (e.g. `/api/v1/localization`).
  */
 export async function deleteLocalizationOverride(
   client: AxiosInstance,
@@ -62,6 +34,6 @@ export async function deleteLocalizationOverride(
   key: string
 ): Promise<void> {
   await client.delete(
-    `${basePath}/localization/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`
+    `${basePath}/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`
   );
 }

--- a/packages/@granit/localization/src/api/localization-api.ts
+++ b/packages/@granit/localization/src/api/localization-api.ts
@@ -1,4 +1,4 @@
-import type { ApplicationLocalizationDto } from '../types/index';
+import type { ApplicationLocalizationResponse } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
@@ -13,8 +13,8 @@ export async function getApplicationLocalization(
   client: AxiosInstance,
   basePath: string,
   cultureName?: string
-): Promise<ApplicationLocalizationDto> {
-  const { data } = await client.get<ApplicationLocalizationDto>(basePath, {
+): Promise<ApplicationLocalizationResponse> {
+  const { data } = await client.get<ApplicationLocalizationResponse>(basePath, {
     params: cultureName ? { cultureName } : undefined,
   });
   return data;

--- a/packages/@granit/localization/src/apply-translations.ts
+++ b/packages/@granit/localization/src/apply-translations.ts
@@ -1,4 +1,4 @@
-import type { ApplicationLocalizationDto } from './types/index';
+import type { ApplicationLocalizationResponse } from './types/index';
 import type { i18n } from 'i18next';
 
 /**
@@ -16,7 +16,7 @@ import type { i18n } from 'i18next';
  * }, [data]);
  * ```
  */
-export function applyTranslations(instance: i18n, data: ApplicationLocalizationDto): void {
+export function applyTranslations(instance: i18n, data: ApplicationLocalizationResponse): void {
   if (!data.resources) return;
 
   const merged: Record<string, string> = {};

--- a/packages/@granit/localization/src/index.ts
+++ b/packages/@granit/localization/src/index.ts
@@ -5,8 +5,8 @@ export { unflattenKeys } from './unflatten-keys';
 export { LOCALE_STORAGE_KEY } from './constants';
 
 export type {
-  AdminLanguage,
   ApplicationLocalizationDto,
+  ApplicationLocalizationResponse,
   LanguageInfo,
   LocalizationConfig,
   LocalizationOverride,
@@ -17,10 +17,5 @@ export type {
 export { getApplicationLocalization } from './api/localization-api';
 
 // API — Admin
-export {
-  deleteLocalizationOverride,
-  listLanguages,
-  setLocalizationOverride,
-  updateLanguageStatus,
-} from './api/localization-admin-api';
+export { deleteLocalizationOverride, setLocalizationOverride } from './api/localization-admin-api';
 export { LocalizationOverridesPermissions } from './permissions';

--- a/packages/@granit/localization/src/types/index.ts
+++ b/packages/@granit/localization/src/types/index.ts
@@ -9,35 +9,44 @@ export interface LanguageInfo {
   isDefault: boolean;
 }
 
-/** Matches backend ApplicationLocalizationDto. */
-export interface ApplicationLocalizationDto {
+/** Matches backend Granit.Localization.Endpoints.Dtos.ApplicationLocalizationResponse. */
+export interface ApplicationLocalizationResponse {
   cultureName: string;
   resources: Record<string, Record<string, string>>;
   languages: LanguageInfo[];
 }
 
-// ── Admin types ─────────────────────────────────────────────────────────────
+/**
+ * @deprecated Renamed to {@link ApplicationLocalizationResponse} to mirror the
+ * backend DTO name. Kept as an alias for backward compatibility; will be
+ * removed in a future major version.
+ */
+export type ApplicationLocalizationDto = ApplicationLocalizationResponse;
 
-/** Admin-scoped language with enable/disable capability. */
-export interface AdminLanguage extends LanguageInfo {
-  isEnabled: boolean;
-  parentCulture?: string;
-}
+// ── Admin types ─────────────────────────────────────────────────────────────
 
 /** Branded localization override identifier. */
 export type LocalizationOverrideId = EntityId<'LocalizationOverride'>;
 
-/** Localization override record for admin translation management. */
+/**
+ * Localization override record for admin translation management.
+ *
+ * Mirrors `Granit.Localization.Domain.LocalizationOverride` (an `AuditedEntity`,
+ * `IMultiTenant`). Audit fields are `modifiedAt` / `modifiedBy` (from
+ * `AuditedEntity`), not `lastModified*`.
+ */
 export interface LocalizationOverride {
   readonly id: LocalizationOverrideId;
+  /** Tenant scope. `null` = host-level override (applies to all tenants). */
+  readonly tenantId: string | null;
   readonly resourceName: string;
   readonly cultureName: string;
   readonly key: string;
   readonly value: string;
   readonly createdAt: ISODateString;
   readonly createdBy: string;
-  readonly lastModifiedAt: ISODateString | null;
-  readonly lastModifiedBy: string | null;
+  readonly modifiedAt: ISODateString | null;
+  readonly modifiedBy: string | null;
 }
 
 export interface LocalizationConfig {

--- a/packages/@granit/react-localization/src/__tests__/use-admin-localization.test.tsx
+++ b/packages/@granit/react-localization/src/__tests__/use-admin-localization.test.tsx
@@ -1,31 +1,24 @@
-import {
-  deleteLocalizationOverride,
-  listLanguages,
-  setLocalizationOverride,
-  updateLanguageStatus,
-} from '@granit/localization';
+import { deleteLocalizationOverride, setLocalizationOverride } from '@granit/localization';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
 import { QueryClientProvider } from '@tanstack/react-query';
-import { act, renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   useDeleteLocalizationOverride,
-  useLanguages,
   useSetLocalizationOverride,
-  useToggleLanguage,
 } from '../hooks/use-admin-localization';
 
 import type { ReactNode } from 'react';
 
 vi.mock('@granit/localization', () => ({
-  listLanguages: vi.fn(),
-  updateLanguageStatus: vi.fn(),
   setLocalizationOverride: vi.fn(),
   deleteLocalizationOverride: vi.fn(),
 }));
+
+const BASE = '/api/v1/localization';
 
 function createWrapper() {
   const queryClient = createTestQueryClient();
@@ -40,59 +33,13 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe('useLanguages', () => {
-  it('should fetch languages', async () => {
-    const client = createMockClient();
-    const languages = [
-      { cultureName: 'fr', displayName: 'Français', isDefault: true, isEnabled: true },
-    ];
-    vi.mocked(listLanguages).mockResolvedValue(languages);
-
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useLanguages({ client, basePath: '/api' }), { wrapper });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(listLanguages).toHaveBeenCalledWith(client, '/api');
-    expect(result.current.data).toEqual(languages);
-  });
-
-  it('should use empty string as default basePath', async () => {
-    const client = createMockClient();
-    vi.mocked(listLanguages).mockResolvedValue([]);
-
-    const { wrapper } = createWrapper();
-    renderHook(() => useLanguages({ client }), { wrapper });
-
-    await waitFor(() => expect(listLanguages).toHaveBeenCalledWith(client, ''));
-  });
-});
-
-describe('useToggleLanguage', () => {
-  it('should call updateLanguageStatus', async () => {
-    const client = createMockClient();
-    vi.mocked(updateLanguageStatus).mockResolvedValue(undefined);
-
-    const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useToggleLanguage({ client, basePath: '/api' }), {
-      wrapper,
-    });
-
-    await act(async () => {
-      await result.current.mutateAsync({ cultureName: 'nl', isEnabled: true });
-    });
-
-    expect(updateLanguageStatus).toHaveBeenCalledWith(client, '/api', 'nl', true);
-  });
-});
-
 describe('useSetLocalizationOverride', () => {
   it('should call setLocalizationOverride', async () => {
     const client = createMockClient();
     vi.mocked(setLocalizationOverride).mockResolvedValue(undefined);
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useSetLocalizationOverride({ client, basePath: '/api' }), {
+    const { result } = renderHook(() => useSetLocalizationOverride({ client, basePath: BASE }), {
       wrapper,
     });
 
@@ -107,7 +54,33 @@ describe('useSetLocalizationOverride', () => {
 
     expect(setLocalizationOverride).toHaveBeenCalledWith(
       client,
-      '/api',
+      BASE,
+      'App',
+      'fr',
+      'hello',
+      'Bonjour'
+    );
+  });
+
+  it('should default basePath to /api/v1/localization', async () => {
+    const client = createMockClient();
+    vi.mocked(setLocalizationOverride).mockResolvedValue(undefined);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useSetLocalizationOverride({ client }), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        resourceName: 'App',
+        cultureName: 'fr',
+        key: 'hello',
+        value: 'Bonjour',
+      });
+    });
+
+    expect(setLocalizationOverride).toHaveBeenCalledWith(
+      client,
+      BASE,
       'App',
       'fr',
       'hello',
@@ -122,10 +95,9 @@ describe('useDeleteLocalizationOverride', () => {
     vi.mocked(deleteLocalizationOverride).mockResolvedValue(undefined);
 
     const { wrapper } = createWrapper();
-    const { result } = renderHook(
-      () => useDeleteLocalizationOverride({ client, basePath: '/api' }),
-      { wrapper }
-    );
+    const { result } = renderHook(() => useDeleteLocalizationOverride({ client, basePath: BASE }), {
+      wrapper,
+    });
 
     await act(async () => {
       await result.current.mutateAsync({
@@ -135,6 +107,6 @@ describe('useDeleteLocalizationOverride', () => {
       });
     });
 
-    expect(deleteLocalizationOverride).toHaveBeenCalledWith(client, '/api', 'App', 'fr', 'hello');
+    expect(deleteLocalizationOverride).toHaveBeenCalledWith(client, BASE, 'App', 'fr', 'hello');
   });
 });

--- a/packages/@granit/react-localization/src/__tests__/use-application-localization.test.tsx
+++ b/packages/@granit/react-localization/src/__tests__/use-application-localization.test.tsx
@@ -8,7 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useApplicationLocalization } from '../hooks/use-application-localization';
 
-import type { ApplicationLocalizationDto } from '@granit/localization';
+import type { ApplicationLocalizationResponse } from '@granit/localization';
 import type { ReactNode } from 'react';
 
 vi.mock('@granit/localization', () => ({
@@ -29,7 +29,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-const EMPTY_DTO: ApplicationLocalizationDto = {
+const EMPTY_DTO: ApplicationLocalizationResponse = {
   cultureName: 'fr-BE',
   resources: {},
   languages: [],

--- a/packages/@granit/react-localization/src/hooks/use-admin-localization.ts
+++ b/packages/@granit/react-localization/src/hooks/use-admin-localization.ts
@@ -1,58 +1,18 @@
-import {
-  deleteLocalizationOverride,
-  listLanguages,
-  setLocalizationOverride,
-  updateLanguageStatus,
-} from '@granit/localization';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { deleteLocalizationOverride, setLocalizationOverride } from '@granit/localization';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { DEFAULT_BASE_PATH } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { AdminLanguage } from '@granit/localization';
-import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+import type { UseMutationResult } from '@tanstack/react-query';
 
 export interface LocalizationAdminOptions {
   readonly client: AxiosInstance;
+  /** Localization module root. Default: `/api/v1/localization`. */
   readonly basePath?: string;
 }
 
-const LANGUAGES_KEY = ['localization', 'languages'] as const;
 const OVERRIDES_KEY = ['localization', 'overrides'] as const;
-
-/**
- * List all languages with admin enable/disable status.
- */
-export function useLanguages(options: LocalizationAdminOptions): UseQueryResult<AdminLanguage[]> {
-  const { client, basePath = '' } = options;
-
-  return useQuery({
-    queryKey: [...LANGUAGES_KEY],
-    queryFn: () => listLanguages(client, basePath),
-  });
-}
-
-export type ToggleLanguageVariables = {
-  readonly cultureName: string;
-  readonly isEnabled: boolean;
-};
-
-/**
- * Enable or disable a language.
- * Invalidates language queries on success.
- */
-export function useToggleLanguage(
-  options: LocalizationAdminOptions
-): UseMutationResult<void, Error, ToggleLanguageVariables> {
-  const { client, basePath = '' } = options;
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: ({ cultureName, isEnabled }: ToggleLanguageVariables) =>
-      updateLanguageStatus(client, basePath, cultureName, isEnabled),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [...LANGUAGES_KEY] });
-    },
-  });
-}
 
 export type SetOverrideVariables = {
   readonly resourceName: string;
@@ -68,7 +28,7 @@ export type SetOverrideVariables = {
 export function useSetLocalizationOverride(
   options: LocalizationAdminOptions
 ): UseMutationResult<void, Error, SetOverrideVariables> {
-  const { client, basePath = '' } = options;
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
   const queryClient = useQueryClient();
 
   return useMutation({
@@ -93,7 +53,7 @@ export type DeleteOverrideVariables = {
 export function useDeleteLocalizationOverride(
   options: LocalizationAdminOptions
 ): UseMutationResult<void, Error, DeleteOverrideVariables> {
-  const { client, basePath = '' } = options;
+  const { client, basePath = DEFAULT_BASE_PATH } = options;
   const queryClient = useQueryClient();
 
   return useMutation({

--- a/packages/@granit/react-localization/src/hooks/use-application-localization.ts
+++ b/packages/@granit/react-localization/src/hooks/use-application-localization.ts
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query';
 import { DEFAULT_BASE_PATH } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { ApplicationLocalizationDto } from '@granit/localization';
+import type { ApplicationLocalizationResponse } from '@granit/localization';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /** Options accepted by {@link useApplicationLocalization}. */
@@ -32,7 +32,7 @@ export interface UseApplicationLocalizationOptions {
  */
 export function useApplicationLocalization(
   options: UseApplicationLocalizationOptions
-): UseQueryResult<ApplicationLocalizationDto> {
+): UseQueryResult<ApplicationLocalizationResponse> {
   const { client, basePath = DEFAULT_BASE_PATH, cultureName, enabled } = options;
   return useQuery({
     queryKey: ['localization', 'application', cultureName ?? null],

--- a/packages/@granit/react-localization/src/index.ts
+++ b/packages/@granit/react-localization/src/index.ts
@@ -9,15 +9,12 @@ export type { UseApplicationLocalizationOptions } from './hooks/use-application-
 // Hooks — Admin
 export {
   useDeleteLocalizationOverride,
-  useLanguages,
   useSetLocalizationOverride,
-  useToggleLanguage,
 } from './hooks/use-admin-localization';
 export type {
   DeleteOverrideVariables,
   LocalizationAdminOptions,
   SetOverrideVariables,
-  ToggleLanguageVariables,
 } from './hooks/use-admin-localization';
 
 // Hooks — Date formatting

--- a/packages/@granit/react-localization/src/testing/data.ts
+++ b/packages/@granit/react-localization/src/testing/data.ts
@@ -1,33 +1,30 @@
 import { toEntityId, toISODateString } from '@granit/types';
 
 import type {
-  AdminLanguage,
-  ApplicationLocalizationDto,
+  ApplicationLocalizationResponse,
+  LanguageInfo,
   LocalizationOverride,
 } from '@granit/localization';
 import type { Mutable } from '@granit/testing';
 
-export const mockLanguages: AdminLanguage[] = [
+export const mockLanguages: LanguageInfo[] = [
   {
     cultureName: 'en',
     displayName: 'English',
     flagIcon: '',
     isDefault: true,
-    isEnabled: true,
   },
   {
     cultureName: 'fr',
     displayName: 'Français',
     flagIcon: '',
     isDefault: false,
-    isEnabled: true,
   },
   {
     cultureName: 'nl',
     displayName: 'Nederlands',
     flagIcon: '',
     isDefault: false,
-    isEnabled: true,
   },
 ];
 
@@ -55,7 +52,7 @@ const MOCK_TRANSLATIONS: Record<string, Record<string, string>> = {
 /**
  * Build a mock localization response for a given culture.
  */
-export function buildMockLocalization(cultureName: string): ApplicationLocalizationDto {
+export function buildMockLocalization(cultureName: string): ApplicationLocalizationResponse {
   const resources = MOCK_TRANSLATIONS[cultureName] ?? MOCK_TRANSLATIONS['en'];
   return {
     cultureName,
@@ -67,57 +64,62 @@ export function buildMockLocalization(cultureName: string): ApplicationLocalizat
 export const mockLocalizationOverrides: Mutable<LocalizationOverride>[] = [
   {
     id: toEntityId<'LocalizationOverride'>('1'),
+    tenantId: null,
     resourceName: 'Showcase',
     cultureName: 'fr',
     key: 'common.save',
     value: 'Sauvegarder',
     createdAt: toISODateString('2026-03-01T10:00:00Z'),
     createdBy: 'admin@granit-showcase.local',
-    lastModifiedAt: toISODateString('2026-03-01T10:00:00Z'),
-    lastModifiedBy: 'admin@granit-showcase.local',
+    modifiedAt: toISODateString('2026-03-01T10:00:00Z'),
+    modifiedBy: 'admin@granit-showcase.local',
   },
   {
     id: toEntityId<'LocalizationOverride'>('2'),
+    tenantId: null,
     resourceName: 'Showcase',
     cultureName: 'fr',
     key: 'common.cancel',
     value: 'Abandonner',
     createdAt: toISODateString('2026-03-01T10:00:00Z'),
     createdBy: 'admin@granit-showcase.local',
-    lastModifiedAt: toISODateString('2026-03-01T10:00:00Z'),
-    lastModifiedBy: 'admin@granit-showcase.local',
+    modifiedAt: toISODateString('2026-03-01T10:00:00Z'),
+    modifiedBy: 'admin@granit-showcase.local',
   },
   {
     id: toEntityId<'LocalizationOverride'>('3'),
+    tenantId: null,
     resourceName: 'Showcase',
     cultureName: 'en',
     key: 'common.save',
     value: 'Save changes',
     createdAt: toISODateString('2026-03-02T09:00:00Z'),
     createdBy: 'admin@granit-showcase.local',
-    lastModifiedAt: toISODateString('2026-03-02T09:00:00Z'),
-    lastModifiedBy: 'admin@granit-showcase.local',
+    modifiedAt: toISODateString('2026-03-02T09:00:00Z'),
+    modifiedBy: 'admin@granit-showcase.local',
   },
   {
     id: toEntityId<'LocalizationOverride'>('4'),
+    tenantId: null,
     resourceName: 'Granit',
     cultureName: 'fr',
     key: 'auth.login',
     value: 'Se connecter',
     createdAt: toISODateString('2026-03-05T14:00:00Z'),
     createdBy: 'admin@granit-showcase.local',
-    lastModifiedAt: toISODateString('2026-03-05T14:00:00Z'),
-    lastModifiedBy: 'admin@granit-showcase.local',
+    modifiedAt: toISODateString('2026-03-05T14:00:00Z'),
+    modifiedBy: 'admin@granit-showcase.local',
   },
   {
     id: toEntityId<'LocalizationOverride'>('5'),
+    tenantId: null,
     resourceName: 'Granit',
     cultureName: 'fr',
     key: 'auth.logout',
     value: 'Se déconnecter',
     createdAt: toISODateString('2026-03-05T14:00:00Z'),
     createdBy: 'admin@granit-showcase.local',
-    lastModifiedAt: toISODateString('2026-03-05T14:00:00Z'),
-    lastModifiedBy: 'admin@granit-showcase.local',
+    modifiedAt: toISODateString('2026-03-05T14:00:00Z'),
+    modifiedBy: 'admin@granit-showcase.local',
   },
 ];

--- a/packages/@granit/react-localization/src/testing/handlers.ts
+++ b/packages/@granit/react-localization/src/testing/handlers.ts
@@ -1,11 +1,11 @@
 import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
-import { noContent, notFound, pagedResponse } from '@granit/testing/msw';
+import { noContent, pagedResponse } from '@granit/testing/msw';
 import { toEntityId, toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
-import { buildMockLocalization, mockLanguages, mockLocalizationOverrides } from './data';
+import { buildMockLocalization, mockLocalizationOverrides } from './data';
 
 import type { LocalizationOverride } from '@granit/localization';
 import type { QueryMetadata } from '@granit/query-engine';
@@ -60,7 +60,7 @@ export const localizationOverrideQueryMetadata: QueryMetadata = {
       isVisible: true,
     },
     {
-      name: 'lastModifiedAt',
+      name: 'modifiedAt',
       label: 'Modified at',
       type: 'DateTime',
       order: 5,
@@ -69,7 +69,7 @@ export const localizationOverrideQueryMetadata: QueryMetadata = {
       isVisible: true,
     },
     {
-      name: 'lastModifiedBy',
+      name: 'modifiedBy',
       label: 'Modified by',
       type: 'String',
       order: 6,
@@ -83,14 +83,14 @@ export const localizationOverrideQueryMetadata: QueryMetadata = {
     { name: 'cultureName', type: 'String', operators: ENUM_OPERATORS },
     { name: 'key', type: 'String', operators: STRING_OPERATORS },
     { name: 'value', type: 'String', operators: STRING_OPERATORS },
-    { name: 'lastModifiedAt', type: 'DateTime', operators: DATE_OPERATORS },
-    { name: 'lastModifiedBy', type: 'String', operators: STRING_OPERATORS },
+    { name: 'modifiedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'modifiedBy', type: 'String', operators: STRING_OPERATORS },
   ],
   sortableFields: [
     { name: 'resourceName' },
     { name: 'cultureName' },
     { name: 'key' },
-    { name: 'lastModifiedAt' },
+    { name: 'modifiedAt' },
   ],
   presetFilterGroups: [],
   quickFilters: [],
@@ -115,7 +115,6 @@ export const localizationOverrideQueryMetadata: QueryMetadata = {
  * @param baseUrl - API base path (default: `/api/v1/localization`)
  */
 export function createLocalizationHandlers(baseUrl = DEFAULT_BASE_PATH): RequestHandler[] {
-  const languages = [...mockLanguages];
   let overrides: LocalizationOverride[] = [...mockLocalizationOverrides];
   const overridesBase = `${baseUrl}/overrides`;
 
@@ -127,27 +126,6 @@ export function createLocalizationHandlers(baseUrl = DEFAULT_BASE_PATH): Request
     // different TS variants and the cross-package `RequestHandler` then
     // breaks portable type emission (TS2883).
     http.get(`${overridesBase}/meta`, () => HttpResponse.json(localizationOverrideQueryMetadata)),
-
-    // GET /languages — list all languages
-    http.get(`${baseUrl}/languages`, () => {
-      return HttpResponse.json(languages);
-    }),
-
-    // PUT /languages/:cultureName — toggle language enabled state
-    http.put(`${baseUrl}/languages/:cultureName`, async ({ params, request }) => {
-      const cultureName = decodeURIComponent(params.cultureName as string);
-      const body = (await request.json()) as { isEnabled: boolean };
-
-      const lang = languages.find((l) => l.cultureName === cultureName);
-      if (!lang) return notFound();
-
-      if (lang.isDefault && !body.isEnabled) {
-        return HttpResponse.json({ error: 'Cannot disable the default language' }, { status: 400 });
-      }
-
-      lang.isEnabled = body.isEnabled;
-      return HttpResponse.json(lang);
-    }),
 
     // GET / — get localization bundle for a culture
     http.get(baseUrl, ({ request }) => {
@@ -208,22 +186,23 @@ export function createLocalizationHandlers(baseUrl = DEFAULT_BASE_PATH): Request
         overrides[idx] = {
           ...existing,
           value: body.value,
-          lastModifiedAt: toISODateString(new Date().toISOString()),
-          lastModifiedBy: 'admin@granit-showcase.local',
+          modifiedAt: toISODateString(new Date().toISOString()),
+          modifiedBy: 'admin@granit-showcase.local',
         };
       } else {
         overrides = [
           ...overrides,
           {
             id: toEntityId<'LocalizationOverride'>(String(overrides.length + 1)),
+            tenantId: null,
             resourceName,
             cultureName,
             key,
             value: body.value,
             createdAt: toISODateString(new Date().toISOString()),
             createdBy: 'admin@granit-showcase.local',
-            lastModifiedAt: toISODateString(new Date().toISOString()),
-            lastModifiedBy: 'admin@granit-showcase.local',
+            modifiedAt: toISODateString(new Date().toISOString()),
+            modifiedBy: 'admin@granit-showcase.local',
           },
         ];
       }


### PR DESCRIPTION
## Context

Audit of `@granit/localization` + `@granit/react-localization` against the authoritative `Granit.Localization.Endpoints` contract (vendored OpenAPI snapshot `contracts/openapi/localization.json` + `granit-dotnet` source) surfaced contract drift. This PR reconciles the front-end packages with the backend.

## Backend endpoint inventory (authoritative)

| Method | Route | Front-end |
| --- | --- | --- |
| GET | `/localization` | `getApplicationLocalization` ✅ |
| GET | `/localization/overrides` | generic `useQueryEndpoint` ✅ |
| GET | `/localization/overrides/meta` | generic `useQueryMeta` ✅ |
| PUT | `/localization/overrides/{resourceName}/{cultureName}/{key}` | `setLocalizationOverride` ✅ |
| DELETE | `/localization/overrides/{resourceName}/{cultureName}/{key}` | `deleteLocalizationOverride` ✅ |

There is **no `/localization/languages` route** anywhere in `granit-dotnet`/`granit-business` (verified by source grep + the route builder's own XML docs).

## Changes

- **BREAKING (removed orphan surface):** `listLanguages`, `updateLanguageStatus`, `useLanguages`, `useToggleLanguage`, `AdminLanguage`, and their tests/MSW handlers. These targeted a non-existent `/localization/languages` endpoint. The language list ships embedded in `GET /localization` (`ApplicationLocalizationResponse.languages`); there is no server-side enable/disable capability.
- **BREAKING (field rename):** `LocalizationOverride.lastModifiedAt/lastModifiedBy` → `modifiedAt/modifiedBy` — the backend entity is an `AuditedEntity`, serialized as `modifiedAt`/`modifiedBy`. The old names were always `undefined` at runtime. Added the nullable `tenantId` field (host-level override marker).
- **Rename:** `ApplicationLocalizationDto` → `ApplicationLocalizationResponse` (mirror the backend DTO). Kept `@deprecated ApplicationLocalizationDto` alias so downstream consumers (guava-front) keep compiling. `LanguageInfo` is unchanged — it correctly mirrors the domain type `Granit.Localization.LanguageInfo`.
- **Consistency:** standardized the override API `basePath` to the module root (`{basePath}/overrides/...`), matching `getApplicationLocalization` and the MSW handlers. Admin hooks now default `basePath` to `/api/v1/localization`.

## Verification

- `tsc` (per-package + recursive pre-commit): clean
- `eslint --max-warnings 0`: clean
- `vitest run` (both packages): 72 passed

## Downstream

Showcase consumer changes (read-only `LanguageList`, `ApplicationLocalizationResponse` import, override-dialog basePaths) ship in a paired **granit-showcase-react** MR, opened as Draft until this merges.