### PR TITLE
feat(localization): retry-safe idempotent override writes

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1716,12 +1716,12 @@
         {
           "name": "deleteLocalizationOverride",
           "kind": "function",
-          "signature": "async function deleteLocalizationOverride( client: AxiosInstance, basePath: string, resourceName: string, cultureName: string, key: string ): Promise<void>"
+          "signature": "async function deleteLocalizationOverride( client: AxiosInstance, basePath: string, resourceName: string, cultureName: string, key: string, idempotencyKey?: string ): Promise<void>"
         },
         {
           "name": "setLocalizationOverride",
           "kind": "function",
-          "signature": "async function setLocalizationOverride( client: AxiosInstance, basePath: string, resourceName: string, cultureName: string, key: string, value: string ): Promise<void>"
+          "signature": "async function setLocalizationOverride( client: AxiosInstance, basePath: string, resourceName: string, cultureName: string, key: string, value: string, idempotencyKey?: string ): Promise<void>"
         },
         {
           "name": "LocalizationOverridesPermissions",

--- a/packages/@granit/localization/src/__tests__/localization-admin-api.test.ts
+++ b/packages/@granit/localization/src/__tests__/localization-admin-api.test.ts
@@ -35,6 +35,27 @@ describe('setLocalizationOverride', () => {
       value: 'val',
     });
   });
+
+  it('should forward an Idempotency-Key header when supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+    await setLocalizationOverride(
+      client,
+      BASE,
+      'Granit',
+      'fr',
+      'Common.Save',
+      'Sauvegarder',
+      'idem-1'
+    );
+
+    expect(client.put).toHaveBeenCalledWith(
+      `${BASE}/overrides/Granit/fr/Common.Save`,
+      { value: 'Sauvegarder' },
+      { headers: { 'Idempotency-Key': 'idem-1' } }
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -58,5 +79,16 @@ describe('deleteLocalizationOverride', () => {
     await deleteLocalizationOverride(client, BASE, 'My Resource', 'fr-BE', 'key/sub');
 
     expect(client.delete).toHaveBeenCalledWith(`${BASE}/overrides/My%20Resource/fr-BE/key%2Fsub`);
+  });
+
+  it('should forward an Idempotency-Key header when supplied', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    await deleteLocalizationOverride(client, BASE, 'Granit', 'fr', 'Common.Save', 'idem-2');
+
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/overrides/Granit/fr/Common.Save`, {
+      headers: { 'Idempotency-Key': 'idem-2' },
+    });
   });
 });

--- a/packages/@granit/localization/src/api/localization-admin-api.ts
+++ b/packages/@granit/localization/src/api/localization-admin-api.ts
@@ -1,10 +1,23 @@
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
+ * Build the optional Axios config carrying a retry-stable `Idempotency-Key`
+ * header. Returns `undefined` when no key is supplied so the call signature
+ * stays `(url, body)` — the shared `@granit/api-client` idempotency interceptor
+ * still mints a per-request key, this only pins ONE key across retries.
+ */
+function idempotencyConfig(idempotencyKey?: string) {
+  return idempotencyKey ? { headers: { 'Idempotency-Key': idempotencyKey } } : undefined;
+}
+
+/**
  * Set a localization override (create or update).
  *
  * `PUT {basePath}/overrides/{resourceName}/{cultureName}/{key}` where
  * `basePath` is the localization module root (e.g. `/api/v1/localization`).
+ *
+ * Pass `idempotencyKey` to make a retried write (after an ambiguous failure)
+ * replay the original instead of re-applying it.
  */
 export async function setLocalizationOverride(
   client: AxiosInstance,
@@ -12,12 +25,15 @@ export async function setLocalizationOverride(
   resourceName: string,
   cultureName: string,
   key: string,
-  value: string
+  value: string,
+  idempotencyKey?: string
 ): Promise<void> {
-  await client.put(
-    `${basePath}/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`,
-    { value }
-  );
+  const url = `${basePath}/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`;
+  if (idempotencyKey) {
+    await client.put(url, { value }, idempotencyConfig(idempotencyKey));
+  } else {
+    await client.put(url, { value });
+  }
 }
 
 /**
@@ -25,15 +41,21 @@ export async function setLocalizationOverride(
  *
  * `DELETE {basePath}/overrides/{resourceName}/{cultureName}/{key}` where
  * `basePath` is the localization module root (e.g. `/api/v1/localization`).
+ *
+ * Pass `idempotencyKey` to make a retried delete replay the original.
  */
 export async function deleteLocalizationOverride(
   client: AxiosInstance,
   basePath: string,
   resourceName: string,
   cultureName: string,
-  key: string
+  key: string,
+  idempotencyKey?: string
 ): Promise<void> {
-  await client.delete(
-    `${basePath}/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`
-  );
+  const url = `${basePath}/overrides/${encodeURIComponent(resourceName)}/${encodeURIComponent(cultureName)}/${encodeURIComponent(key)}`;
+  if (idempotencyKey) {
+    await client.delete(url, idempotencyConfig(idempotencyKey));
+  } else {
+    await client.delete(url);
+  }
 }

--- a/packages/@granit/react-localization/src/__tests__/use-admin-localization.test.tsx
+++ b/packages/@granit/react-localization/src/__tests__/use-admin-localization.test.tsx
@@ -58,7 +58,8 @@ describe('useSetLocalizationOverride', () => {
       'App',
       'fr',
       'hello',
-      'Bonjour'
+      'Bonjour',
+      expect.any(String)
     );
   });
 
@@ -84,7 +85,8 @@ describe('useSetLocalizationOverride', () => {
       'App',
       'fr',
       'hello',
-      'Bonjour'
+      'Bonjour',
+      expect.any(String)
     );
   });
 });
@@ -107,6 +109,13 @@ describe('useDeleteLocalizationOverride', () => {
       });
     });
 
-    expect(deleteLocalizationOverride).toHaveBeenCalledWith(client, BASE, 'App', 'fr', 'hello');
+    expect(deleteLocalizationOverride).toHaveBeenCalledWith(
+      client,
+      BASE,
+      'App',
+      'fr',
+      'hello',
+      expect.any(String)
+    );
   });
 });

--- a/packages/@granit/react-localization/src/hooks/use-admin-localization.ts
+++ b/packages/@granit/react-localization/src/hooks/use-admin-localization.ts
@@ -1,5 +1,6 @@
 import { deleteLocalizationOverride, setLocalizationOverride } from '@granit/localization';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
 
 import { DEFAULT_BASE_PATH } from '../constants';
 
@@ -14,6 +15,26 @@ export interface LocalizationAdminOptions {
 
 const OVERRIDES_KEY = ['localization', 'overrides'] as const;
 
+/**
+ * Mints ONE idempotency key per logical mutation and reuses it across every
+ * retry of that operation. TanStack Query passes the same `variables` reference
+ * on each retry, so keying by that reference yields a stable `Idempotency-Key`
+ * — a retry after an ambiguous failure replays the original write instead of
+ * re-applying it. A fresh `mutate()` call gets a new key.
+ */
+function useIdempotencyKeyFor<V extends object>(): (variables: V) => string {
+  const mapRef = useRef<WeakMap<V, string> | null>(null);
+  return (variables: V) => {
+    const map = (mapRef.current ??= new WeakMap<V, string>());
+    let key = map.get(variables);
+    if (key === undefined) {
+      key = crypto.randomUUID();
+      map.set(variables, key);
+    }
+    return key;
+  };
+}
+
 export type SetOverrideVariables = {
   readonly resourceName: string;
   readonly cultureName: string;
@@ -22,7 +43,7 @@ export type SetOverrideVariables = {
 };
 
 /**
- * Create or update a localization override.
+ * Create or update a localization override (idempotent, retry-safe).
  * Invalidates override queries on success.
  */
 export function useSetLocalizationOverride(
@@ -30,10 +51,19 @@ export function useSetLocalizationOverride(
 ): UseMutationResult<void, Error, SetOverrideVariables> {
   const { client, basePath = DEFAULT_BASE_PATH } = options;
   const queryClient = useQueryClient();
+  const idempotencyKeyFor = useIdempotencyKeyFor<SetOverrideVariables>();
 
   return useMutation({
-    mutationFn: ({ resourceName, cultureName, key, value }: SetOverrideVariables) =>
-      setLocalizationOverride(client, basePath, resourceName, cultureName, key, value),
+    mutationFn: (variables: SetOverrideVariables) =>
+      setLocalizationOverride(
+        client,
+        basePath,
+        variables.resourceName,
+        variables.cultureName,
+        variables.key,
+        variables.value,
+        idempotencyKeyFor(variables)
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...OVERRIDES_KEY] });
     },
@@ -47,7 +77,7 @@ export type DeleteOverrideVariables = {
 };
 
 /**
- * Delete a localization override.
+ * Delete a localization override (idempotent, retry-safe).
  * Invalidates override queries on success.
  */
 export function useDeleteLocalizationOverride(
@@ -55,10 +85,18 @@ export function useDeleteLocalizationOverride(
 ): UseMutationResult<void, Error, DeleteOverrideVariables> {
   const { client, basePath = DEFAULT_BASE_PATH } = options;
   const queryClient = useQueryClient();
+  const idempotencyKeyFor = useIdempotencyKeyFor<DeleteOverrideVariables>();
 
   return useMutation({
-    mutationFn: ({ resourceName, cultureName, key }: DeleteOverrideVariables) =>
-      deleteLocalizationOverride(client, basePath, resourceName, cultureName, key),
+    mutationFn: (variables: DeleteOverrideVariables) =>
+      deleteLocalizationOverride(
+        client,
+        basePath,
+        variables.resourceName,
+        variables.cultureName,
+        variables.key,
+        idempotencyKeyFor(variables)
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [...OVERRIDES_KEY] });
     },


### PR DESCRIPTION
## Context

Follow-up to #573 (localization contract conformance). The override write path was not retry-safe: the showcase had built an idempotent wrapper but never wired it in, and the framework hooks sent no stable `Idempotency-Key`. This makes idempotency a first-class framework concern so every consumer gets it for free.

## Changes

- `setLocalizationOverride` / `deleteLocalizationOverride` accept an optional `idempotencyKey`, forwarded as an `Idempotency-Key` header (no key → unchanged `(url, body)` call; the shared `@granit/api-client` interceptor still mints a per-request key).
- `useSetLocalizationOverride` / `useDeleteLocalizationOverride` mint **one** key per logical mutation and reuse it across retries (WeakMap keyed by the `variables` reference, the same pattern the showcase proved with `useIdempotentMutation`). A retry after an ambiguous failure now replays the original write instead of re-applying it.

## Verification

- `tsc` clean · `eslint --max-warnings 0` clean · `vitest` **74 passed** (adds key-forwarding coverage)

## Downstream

Lets granit-showcase-react drop its dead local `use-override-mutation.ts` duplicate and rely on the (now idempotent) framework hooks — shipped in MR !52.