### PR TITLE
fix(testing): align notifications & webhooks MSW handlers with backend contracts

### DIFF
--- a/packages/@granit/react-notifications/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/testing-handlers.test.ts
@@ -1,7 +1,11 @@
 import { setupServer } from 'msw/node';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
-import { createNotificationsHandlers, notificationQueryMetadata } from '../testing/index';
+import {
+  createNotificationsHandlers,
+  mockNotificationDefinitions,
+  notificationQueryMetadata,
+} from '../testing/index';
 
 const BASE = 'http://api.test/api/v1';
 const server = setupServer();
@@ -16,5 +20,18 @@ describe('createNotificationsHandlers /meta', () => {
     const response = await fetch(`${BASE}/notifications/meta`);
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(notificationQueryMetadata);
+  });
+});
+
+describe('createNotificationsHandlers /types', () => {
+  it('responds with the notification definition registry as a bare array', async () => {
+    server.use(...createNotificationsHandlers(BASE));
+    const response = await fetch(`${BASE}/notifications/types`);
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    // Contract: GET /notifications/types returns a bare JSON array, not an
+    // envelope — the preferences panel calls `.filter` on it directly.
+    expect(Array.isArray(body)).toBe(true);
+    expect(body).toEqual(mockNotificationDefinitions);
   });
 });

--- a/packages/@granit/react-notifications/src/__tests__/use-notification-subscriptions.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/use-notification-subscriptions.test.tsx
@@ -39,11 +39,14 @@ function createWrapper(client: AxiosInstance, basePath = '/api/v1') {
 
 const MOCK_TYPES: NotificationDefinition[] = [
   {
-    typeName: 'NewMessage',
-    severity: 'Info',
-    group: 'inbox',
-    defaultChannels: ['inApp'],
-  } as unknown as NotificationDefinition,
+    name: 'NewMessage',
+    defaultSeverity: 'Info',
+    defaultChannels: ['InApp'],
+    displayName: 'New message',
+    description: null,
+    groupName: 'inbox',
+    allowUserOptOut: true,
+  },
 ];
 
 const MOCK_SUBS: NotificationSubscriptionResponse[] = [

--- a/packages/@granit/react-notifications/src/testing/data.ts
+++ b/packages/@granit/react-notifications/src/testing/data.ts
@@ -1,6 +1,10 @@
 import { toEntityId, toISODateString } from '@granit/types';
 
-import type { NotificationPreference, UserNotification } from '@granit/notifications';
+import type {
+  NotificationDefinition,
+  NotificationPreference,
+  UserNotification,
+} from '@granit/notifications';
 import type { Mutable } from '@granit/testing';
 import type { UserId } from '@granit/types';
 
@@ -243,6 +247,92 @@ export const mockNotifications: Mutable<UserNotification>[] = [
     state: 'Read',
     createdAt: toISODateString('2026-03-10T10:00:00Z'),
     readAt: toISODateString('2026-03-10T12:00:00Z'),
+  },
+];
+
+/**
+ * Registry of notification types returned by `GET /notifications/types`.
+ *
+ * Mirrors the bare `NotificationDefinition[]` the .NET endpoint produces. Every
+ * `notificationTypeName` used in {@link mockNotificationPreferences} and
+ * {@link mockNotifications} has a matching entry so the preferences UI lines up
+ * with the seeded preference rows. `security_alert` and `rgpd_request` are
+ * mandatory (`allowUserOptOut: false`) — the preferences panel hides them.
+ */
+export const mockNotificationDefinitions: NotificationDefinition[] = [
+  {
+    name: 'user_registered',
+    defaultSeverity: 'Info',
+    defaultChannels: ['InApp', 'Email'],
+    displayName: 'User registered',
+    description: 'A new user account has been created and is pending approval.',
+    groupName: 'Users',
+    allowUserOptOut: true,
+  },
+  {
+    name: 'user_role_changed',
+    defaultSeverity: 'Info',
+    defaultChannels: ['InApp', 'Email'],
+    displayName: 'User role changed',
+    description: 'A role has been granted to or revoked from a user.',
+    groupName: 'Users',
+    allowUserOptOut: true,
+  },
+  {
+    name: 'country_updated',
+    defaultSeverity: 'Success',
+    defaultChannels: ['InApp'],
+    displayName: 'Country reference updated',
+    description: 'A country in the reference data has been created, updated or deactivated.',
+    groupName: 'Reference data',
+    allowUserOptOut: true,
+  },
+  {
+    name: 'config_changed',
+    defaultSeverity: 'Warning',
+    defaultChannels: ['InApp', 'Email'],
+    displayName: 'Configuration changed',
+    description: 'A feature flag or system configuration value has been changed.',
+    groupName: 'System',
+    allowUserOptOut: true,
+  },
+  {
+    name: 'security_alert',
+    defaultSeverity: 'Error',
+    defaultChannels: ['InApp', 'Email', 'Push'],
+    displayName: 'Security alert',
+    description: 'A security-relevant event was detected (e.g. authentication failure spike).',
+    groupName: 'Security',
+    allowUserOptOut: false,
+  },
+  {
+    name: 'service_health',
+    defaultSeverity: 'Warning',
+    defaultChannels: ['InApp', 'Email'],
+    displayName: 'Service health',
+    description:
+      'Infrastructure or service health status changed (backups, degradation, maintenance).',
+    groupName: 'System',
+    allowUserOptOut: true,
+  },
+  {
+    name: 'audit_export',
+    defaultSeverity: 'Info',
+    defaultChannels: ['InApp', 'Email'],
+    displayName: 'Audit export ready',
+    description: 'A requested audit log export has finished and is ready to download.',
+    groupName: 'Compliance',
+    allowUserOptOut: true,
+  },
+  {
+    name: 'rgpd_request',
+    defaultSeverity: 'Info',
+    defaultChannels: ['InApp', 'Email', 'Push'],
+    displayName: 'RGPD request',
+    description:
+      'A GDPR data subject request (access, erasure) requires action within the legal delay.',
+    groupName: 'Compliance',
+    allowUserOptOut: false,
   },
 ];
 

--- a/packages/@granit/react-notifications/src/testing/handlers.ts
+++ b/packages/@granit/react-notifications/src/testing/handlers.ts
@@ -6,7 +6,11 @@ import { http, HttpResponse } from 'msw';
 
 import { API_BASE_PATH } from '../constants';
 
-import { mockNotificationPreferences, mockNotifications } from './data';
+import {
+  mockNotificationDefinitions,
+  mockNotificationPreferences,
+  mockNotifications,
+} from './data';
 
 import type {
   NotificationPreference,
@@ -228,6 +232,11 @@ export function createNotificationsHandlers(baseUrl = API_BASE_PATH) {
         n.state === 'Unread' ? { ...n, state: 'Read' as const, readAt: now } : n
       );
       return noContent();
+    }),
+
+    // GET notification type registry — drives the preferences UI
+    http.get(`${baseUrl}/notifications/types`, () => {
+      return HttpResponse.json(mockNotificationDefinitions);
     }),
 
     // GET notification preferences

--- a/packages/@granit/react-notifications/src/testing/index.ts
+++ b/packages/@granit/react-notifications/src/testing/index.ts
@@ -2,5 +2,9 @@
 // @granit/react-notifications/testing — Mock data & MSW handlers
 // ---------------------------------------------------------------------------
 
-export { mockNotificationPreferences, mockNotifications } from './data';
+export {
+  mockNotificationDefinitions,
+  mockNotificationPreferences,
+  mockNotifications,
+} from './data';
 export { createNotificationsHandlers, notificationQueryMetadata } from './handlers';

--- a/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
@@ -3,7 +3,10 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { createWebhooksHandlers, webhookSubscriptionQueryMetadata } from '../testing/index';
 
-import type { WebhookSubscriptionResponse } from '@granit/webhooks';
+import type {
+  WebhookSubscriptionResponse,
+  WebhookSubscriptionStatsResponse,
+} from '@granit/webhooks';
 
 const BASE = 'http://api.test/api/v1/webhooks';
 const server = setupServer();
@@ -21,6 +24,23 @@ describe('createWebhooksHandlers /meta', () => {
     const response = await fetch(`${BASE}/subscriptions/meta`);
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(webhookSubscriptionQueryMetadata);
+  });
+});
+
+describe('createWebhooksHandlers /stats', () => {
+  // Regression: the handler must sit at `${baseUrl}/stats` — the path getStats
+  // hits — not under `/subscriptions`. A mismatch lets the request fall through
+  // (server uses onUnhandledRequest: 'error'), so the dashboard receives a
+  // body without `successRateLast24h` and crashes on `.toFixed`.
+  it('responds with stats at /stats and carries every required field', async () => {
+    server.use(...createWebhooksHandlers(BASE));
+    const response = await fetch(`${BASE}/stats`);
+    expect(response.status).toBe(200);
+
+    const stats = (await response.json()) as WebhookSubscriptionStatsResponse;
+    expect(typeof stats.successRateLast24h).toBe('number');
+    expect(typeof stats.avgResponseTimeMsLast24h).toBe('number');
+    expect(typeof stats.totalSubscriptions).toBe('number');
   });
 });
 

--- a/packages/@granit/react-webhooks/src/testing/handlers.ts
+++ b/packages/@granit/react-webhooks/src/testing/handlers.ts
@@ -236,8 +236,9 @@ export function createWebhooksHandlers(baseUrl = DEFAULT_WEBHOOKS_BASE_PATH) {
       return HttpResponse.json(mockWebhookConfig);
     }),
 
-    // Stats
-    http.get(`${baseUrl}/subscriptions/stats`, () => {
+    // Stats — lives directly under the webhooks root, NOT under /subscriptions
+    // (see getStats: `GET {basePath}/stats` and OpenAPI route `/webhooks/stats`).
+    http.get(`${baseUrl}/stats`, () => {
       return HttpResponse.json(mockWebhookStats);
     }),
 


### PR DESCRIPTION
## Summary

Two test-fixture/MSW handler corrections so the `@granit/*/testing` utilities (consumed by apps for their MSW setup) match the real backend contracts.

### `@granit/react-notifications`
- Add `mockNotificationDefinitions` registry + a `GET /notifications/types` handler returning a **bare array** (mirrors the .NET endpoint that drives the preferences panel — the UI calls `.filter` on it directly). Exported from `testing/`.
- Fix `NotificationDefinition` fixtures to the real DTO shape (`name` / `defaultSeverity` / `defaultChannels` / `displayName` / `groupName` / `allowUserOptOut`), removing the unsafe `as unknown as NotificationDefinition` casts.

### `@granit/react-webhooks`
- Move the stats handler from `/subscriptions/stats` to `/stats` — the path `getStats` actually hits (OpenAPI `/webhooks/stats`). The old mismatch let the request fall through (`onUnhandledRequest: 'error'`) so the dashboard received a body without `successRateLast24h` and crashed on `.toFixed`.
- Add a regression test asserting `/stats` responds with the required fields.

## Testing
- `eslint` clean (`--max-warnings 0`)
- `tsc --noEmit` clean
- `vitest run` — 142 tests passing across both packages