### PR TITLE
fix(observability): wire error-context enrichment + OTLP fidelity (audit)

### DIFF
--- a/packages/@granit/error-boundary/src/types/index.ts
+++ b/packages/@granit/error-boundary/src/types/index.ts
@@ -20,8 +20,9 @@ export type Breadcrumb = {
 export type ErrorContextConfig = {
   /** Returns the current route path for error enrichment. */
   getRouteInfo?: () => string;
-  /** Returns the current user identity for error enrichment. */
-  getUserInfo?: () => { id: string };
+  /** Returns the current user identity for error enrichment, or `undefined`
+   * when no user is authenticated. */
+  getUserInfo?: () => { id: string } | undefined;
   /** Maximum number of breadcrumbs to retain (FIFO). Default: `20`. */
   maxBreadcrumbs?: number;
 };

--- a/packages/@granit/logger-otlp/src/__tests__/otlp-transport.test.ts
+++ b/packages/@granit/logger-otlp/src/__tests__/otlp-transport.test.ts
@@ -311,4 +311,38 @@ describe('createOtlpTransport', () => {
     // Should not throw
     await expect(transport.flush!()).resolves.toBeUndefined();
   });
+
+  it('serializes object and array context values as JSON (not "[object Object]")', async () => {
+    const transport = createOtlpTransport({
+      endpoint: '/v1/logs',
+      serviceName: 'test',
+      batchSize: 100,
+      redact: (s) => s,
+    });
+    transport.send(makeEntry({ context: { user: { id: 7 }, tags: ['a', 'b'] } }));
+    await transport.flush!();
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]!.body as string);
+    const attrs = body.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+    expect(attrs).toContainEqual({ key: 'user', value: { stringValue: '{"id":7}' } });
+    expect(attrs).toContainEqual({ key: 'tags', value: { stringValue: '["a","b"]' } });
+  });
+
+  it('records non-Error reasons as exception.message instead of dropping them', async () => {
+    const transport = createOtlpTransport({
+      endpoint: '/v1/logs',
+      serviceName: 'test',
+      batchSize: 100,
+      redact: (s) => s,
+    });
+    transport.send(makeEntry({ level: 'ERROR', error: 'plain string failure' }));
+    await transport.flush!();
+
+    const body = JSON.parse(vi.mocked(fetch).mock.calls[0]![1]!.body as string);
+    const attrs = body.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+    expect(attrs).toContainEqual({
+      key: 'exception.message',
+      value: { stringValue: 'plain string failure' },
+    });
+  });
 });

--- a/packages/@granit/logger-otlp/src/otlp-transport.ts
+++ b/packages/@granit/logger-otlp/src/otlp-transport.ts
@@ -68,20 +68,39 @@ function toStringAttribute(key: string, value: string): OtlpAttribute {
   return { key, value: { stringValue: value } };
 }
 
+/**
+ * OTLP attribute values are strings. Primitives stringify directly; objects and
+ * arrays are JSON-serialized so structured context survives the transport with
+ * the same fidelity as the console transport (instead of `"[object Object]"`).
+ */
+function toAttributeValue(value: unknown): string {
+  if (typeof value !== 'object' || value === null) return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
 function contextToAttributes(context: LogContext): OtlpAttribute[] {
-  return Object.entries(context).map(([key, val]) => toStringAttribute(key, String(val)));
+  return Object.entries(context).map(([key, val]) => toStringAttribute(key, toAttributeValue(val)));
 }
 
 function errorToAttributes(error: unknown): OtlpAttribute[] {
-  if (!(error instanceof Error)) return [];
-  const attrs: OtlpAttribute[] = [
-    toStringAttribute('exception.type', error.name),
-    toStringAttribute('exception.message', error.message),
-  ];
-  if (error.stack) {
-    attrs.push(toStringAttribute('exception.stacktrace', error.stack));
+  if (error instanceof Error) {
+    const attrs: OtlpAttribute[] = [
+      toStringAttribute('exception.type', error.name),
+      toStringAttribute('exception.message', error.message),
+    ];
+    if (error.stack) {
+      attrs.push(toStringAttribute('exception.stacktrace', error.stack));
+    }
+    return attrs;
   }
-  return attrs;
+
+  // Non-Error reason (string, plain object, …): preserve it instead of dropping
+  // it silently — the console transport keeps it, so OTLP should too.
+  return [toStringAttribute('exception.message', toAttributeValue(error))];
 }
 
 function buildLogRecord(

--- a/packages/@granit/react-error-boundary/package.json
+++ b/packages/@granit/react-error-boundary/package.json
@@ -24,6 +24,7 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
       }
-    }
+    },
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/@granit/react-error-boundary/src/__tests__/global-error-capture.test.tsx
+++ b/packages/@granit/react-error-boundary/src/__tests__/global-error-capture.test.tsx
@@ -2,6 +2,7 @@ import { render } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { GlobalErrorCapture } from '../components/global-error-capture';
+import { ErrorContextProvider } from '../providers/error-context-provider';
 
 import type { Logger } from '@granit/logger';
 
@@ -85,7 +86,8 @@ describe('GlobalErrorCapture', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       'Unhandled promise rejection',
-      expect.objectContaining({ message: 'Rejected!' })
+      expect.objectContaining({ message: 'Rejected!' }),
+      expect.objectContaining({})
     );
   });
 
@@ -132,7 +134,8 @@ describe('GlobalErrorCapture', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       'Unhandled promise rejection',
-      expect.objectContaining({ message: 'string error' })
+      expect.objectContaining({ message: 'string error' }),
+      expect.objectContaining({})
     );
   });
 
@@ -182,7 +185,8 @@ describe('GlobalErrorCapture', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       'Unhandled promise rejection',
-      expect.objectContaining({ message: 'Unhandled promise rejection' })
+      expect.objectContaining({ message: 'Unhandled promise rejection' }),
+      expect.objectContaining({})
     );
   });
 
@@ -198,7 +202,29 @@ describe('GlobalErrorCapture', () => {
 
     expect(logger.error).toHaveBeenCalledWith(
       'Unhandled promise rejection',
-      expect.objectContaining({ message: 'Unhandled promise rejection' })
+      expect.objectContaining({ message: 'Unhandled promise rejection' }),
+      expect.objectContaining({})
+    );
+  });
+
+  it('enriches captured errors with route and user from ErrorContextProvider', () => {
+    const logger = createMockLogger();
+    render(
+      <ErrorContextProvider
+        config={{ getRouteInfo: () => '/dashboard', getUserInfo: () => ({ id: 'user-1' }) }}
+      >
+        <GlobalErrorCapture logger={logger} />
+      </ErrorContextProvider>
+    );
+
+    globalThis.dispatchEvent(
+      new ErrorEvent('error', { error: new Error('Boom'), message: 'Boom' })
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Uncaught error',
+      expect.objectContaining({ message: 'Boom' }),
+      expect.objectContaining({ route: '/dashboard', userId: 'user-1' })
     );
   });
 });

--- a/packages/@granit/react-error-boundary/src/__tests__/granit-error-boundary.test.tsx
+++ b/packages/@granit/react-error-boundary/src/__tests__/granit-error-boundary.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { GranitErrorBoundary } from '../components/granit-error-boundary';
+import { ErrorContextProvider } from '../providers/error-context-provider';
 
 import type { Logger } from '@granit/logger';
 
@@ -124,6 +125,30 @@ describe('GranitErrorBoundary', () => {
 
     expect(screen.getByText('Test render error')).toBeInTheDocument();
     expect(logger.error).toHaveBeenCalled();
+  });
+
+  it('enriches the logged error with route and user from ErrorContextProvider', () => {
+    const logger = createMockLogger();
+
+    render(
+      <ErrorContextProvider
+        config={{ getRouteInfo: () => '/settings', getUserInfo: () => ({ id: 'user-9' }) }}
+      >
+        <GranitErrorBoundary logger={logger} renderFallback={(error) => <p>{error.message}</p>}>
+          <ThrowingComponent shouldThrow />
+        </GranitErrorBoundary>
+      </ErrorContextProvider>
+    );
+
+    expect(logger.error).toHaveBeenCalledWith(
+      'Uncaught render error',
+      expect.objectContaining({ message: 'Test render error' }),
+      expect.objectContaining({
+        componentStack: expect.any(String),
+        route: '/settings',
+        userId: 'user-9',
+      })
+    );
   });
 
   it('should reset the error boundary and re-render children', async () => {

--- a/packages/@granit/react-error-boundary/src/components/global-error-capture.tsx
+++ b/packages/@granit/react-error-boundary/src/components/global-error-capture.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { collectErrorContext, ErrorContext } from '../providers/error-context-provider';
+
 import type { GlobalErrorCaptureProps } from '../types/index';
 
 /**
@@ -15,6 +17,15 @@ import type { GlobalErrorCaptureProps } from '../types/index';
  * ```
  */
 export function GlobalErrorCapture({ logger, onError }: GlobalErrorCaptureProps) {
+  // Track the latest error context in a ref so the listener effect below stays
+  // subscribed across breadcrumb updates (the context value changes on every
+  // `addBreadcrumb`) instead of tearing down and re-adding the global listeners.
+  const errorContext = React.useContext(ErrorContext);
+  const contextRef = React.useRef(errorContext);
+  React.useEffect(() => {
+    contextRef.current = errorContext;
+  }, [errorContext]);
+
   React.useEffect(() => {
     const recentErrors = new Set<string>();
 
@@ -35,6 +46,7 @@ export function GlobalErrorCapture({ logger, onError }: GlobalErrorCaptureProps)
         filename: event.filename,
         lineno: event.lineno,
         colno: event.colno,
+        ...collectErrorContext(contextRef.current),
       });
 
       onError?.(error);
@@ -48,7 +60,7 @@ export function GlobalErrorCapture({ logger, onError }: GlobalErrorCaptureProps)
 
       if (isDuplicate(error.message)) return;
 
-      logger.error('Unhandled promise rejection', error);
+      logger.error('Unhandled promise rejection', error, collectErrorContext(contextRef.current));
 
       onError?.(error);
     }

--- a/packages/@granit/react-error-boundary/src/components/granit-error-boundary.tsx
+++ b/packages/@granit/react-error-boundary/src/components/granit-error-boundary.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react';
 
+import { collectErrorContext, ErrorContext } from '../providers/error-context-provider';
+
 import type { ErrorBoundaryProps } from '../types/index';
 import type { Logger } from '@granit/logger';
 
@@ -35,6 +37,9 @@ type ErrorBoundaryState = {
  * ```
  */
 export class GranitErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  static contextType = ErrorContext;
+  declare context: React.ContextType<typeof ErrorContext>;
+
   private readonly logger: Logger;
 
   constructor(props: ErrorBoundaryProps) {
@@ -50,6 +55,7 @@ export class GranitErrorBoundary extends React.Component<ErrorBoundaryProps, Err
   override componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
     this.logger.error('Uncaught render error', error, {
       componentStack: errorInfo.componentStack ?? undefined,
+      ...collectErrorContext(this.context),
     });
 
     this.props.onError?.(error, errorInfo);

--- a/packages/@granit/react-error-boundary/src/providers/error-context-provider.tsx
+++ b/packages/@granit/react-error-boundary/src/providers/error-context-provider.tsx
@@ -1,12 +1,19 @@
 import * as React from 'react';
 
 import type { Breadcrumb, ErrorContextConfig, ErrorContextValue } from '@granit/error-boundary';
+import type { LogContext } from '@granit/logger';
 
 // ---------------------------------------------------------------------------
 // Context
 // ---------------------------------------------------------------------------
 
-const ErrorContext = React.createContext<ErrorContextValue | null>(null);
+/**
+ * Error context shared with `GranitErrorBoundary` and `GlobalErrorCapture` so
+ * caught errors are enriched with the current route, user, and breadcrumb
+ * trail. Package-internal — consumers read it through `useErrorBoundaryConfig`
+ * / `useBreadcrumb`, never the raw context object.
+ */
+export const ErrorContext = React.createContext<ErrorContextValue | null>(null);
 
 /**
  * Returns the error context value from the nearest `ErrorContextProvider`.
@@ -23,6 +30,28 @@ export function useErrorBoundaryConfig(): ErrorContextValue {
 
 /** @deprecated Use useErrorBoundaryConfig instead */
 export const useErrorContext = useErrorBoundaryConfig;
+
+/**
+ * Projects the error context into a flat {@link LogContext} attached to every
+ * error logged by `GranitErrorBoundary` / `GlobalErrorCapture`. Returns an
+ * empty object when no `ErrorContextProvider` is mounted, so both components
+ * remain usable standalone.
+ */
+export function collectErrorContext(context: ErrorContextValue | null): LogContext {
+  if (!context) return {};
+
+  const enrichment: LogContext = {};
+
+  const route = context.getRouteInfo();
+  if (route !== undefined) enrichment.route = route;
+
+  const user = context.getUserInfo();
+  if (user !== undefined) enrichment.userId = user.id;
+
+  if (context.breadcrumbs.length > 0) enrichment.breadcrumbs = context.breadcrumbs;
+
+  return enrichment;
+}
 
 // ---------------------------------------------------------------------------
 // Provider


### PR DESCRIPTION
Audit remediation for the logger / error-boundary stack (`/audit logger logger-otlp react-error-boundary`).

## Changes

**`@granit/react-error-boundary` — enrichment was collected but never used**
`ErrorContextProvider` gathered route / user / breadcrumbs, but neither `GranitErrorBoundary` nor `GlobalErrorCapture` read the context, so its documented enrichment never reached the logs. They now consume `ErrorContext` (class `contextType` / `useContext` + ref) and merge `route`, `userId`, and the `breadcrumbs` trail into every logged error.

**`@granit/logger-otlp` — transport fidelity**
- Object/array context values were stringified to `"[object Object]"` → now JSON-serialized (parity with the console transport).
- Non-`Error` log reasons were dropped → now recorded as `exception.message`.

**`@granit/error-boundary` — type**
`ErrorContextConfig.getUserInfo` may now return `undefined` (no authenticated user), matching `ErrorContextValue.getUserInfo`.

**`@granit/react-error-boundary` — packaging**
`publishConfig.registry` added (GitHub Packages), aligning with every sibling observability package.

## Tests
+4 tests (enrichment in both components, OTLP object/non-Error fidelity). `tsc`, ESLint (`--max-warnings 0`), and the full suites pass for the four packages (114 + 37 green).

## Consumer
A follow-up **Draft** MR on `granit-showcase-react` wires `getUserInfo` + navigation breadcrumbs and depends on the `getUserInfo` type loosening here — it should merge after this PR lands on `develop`.