### PR TITLE
chore(openapi): add granit-iot and granit-business to contract sync

### DIFF
--- a/contracts/openapi/activities.json
+++ b/contracts/openapi/activities.json
@@ -1,0 +1,1075 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "activities",
+    "version": "1"
+  },
+  "paths": {
+    "/activities": {
+      "get": {
+        "tags": ["Activities"],
+        "summary": "Returns a paginated list of activities matching the query filter.",
+        "description": "Filter by entity (entityType + entityId), assignee (assignedToUserId or 'me'), status (open / done / cancelled), or due-date window (dueAtFrom / dueAtTo, half-open). Ordered by DueAt ascending. Caps page size at ActivitiesEndpointsOptions.MaxPageSize (default 100). Activities pinned to hosts the caller cannot read are filtered out (IActivityHostAuthorizationProvider). Listing peers' activities (assignedToUserId != caller) requires Activities.Activities.ReadOthers.",
+        "operationId": "ListActivities",
+        "parameters": [
+          {
+            "name": "EntityType",
+            "in": "query",
+            "description": "Fully qualified entity type (e.g. 'Acme.Patients').",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "EntityId",
+            "in": "query",
+            "description": "Entity identifier (primary key).",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "AssignedToUserId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Status",
+            "in": "query",
+            "description": "Filter by status value.",
+            "schema": {
+              "$ref": "#/components/schemas/ActivityStatusFilter"
+            }
+          },
+          {
+            "name": "DueAtFrom",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "DueAtTo",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "Page",
+            "in": "query",
+            "description": "1-based page index.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "PageSize",
+            "in": "query",
+            "description": "Number of items per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Activities"],
+        "summary": "Creates a new activity in Open state.",
+        "description": "Validates the activity type against IActivityRegistry — types from unloaded providers are rejected with 400. The created-by user id is resolved from the authenticated principal — clients cannot impersonate. Emits ActivityAssignedEvent (local) and ActivityAssignedEto (distributed) on success.",
+        "operationId": "CreateActivity",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateActivityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/{id}": {
+      "get": {
+        "tags": ["Activities"],
+        "summary": "Returns a single activity by id.",
+        "description": "Returns 404 if the activity does not exist, is in a different tenant, or its host entity is not readable by the caller.",
+        "operationId": "GetActivityById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/{id}/complete": {
+      "post": {
+        "tags": ["Activities"],
+        "summary": "Marks the activity as Done.",
+        "description": "Idempotent within a single transition — completing an already-terminal activity (Done or Cancelled) returns 409. The completion timestamp is derived server-side from IClock; the actor is resolved from the authenticated principal. Emits ActivityCompletedEvent (local) and ActivityCompletedEto (distributed).",
+        "operationId": "CompleteActivity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CompleteActivityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/{id}/cancel": {
+      "post": {
+        "tags": ["Activities"],
+        "summary": "Marks the activity as Cancelled.",
+        "description": "Append-only — cancelling an already-terminal activity returns 409. The cancellation timestamp is derived server-side from IClock; the actor is resolved from the authenticated principal.",
+        "operationId": "CancelActivity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CancelActivityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/{id}/assignee": {
+      "put": {
+        "tags": ["Activities"],
+        "summary": "Changes the assignee of an open activity.",
+        "description": "Allowed only while the activity is Open. Requires the dedicated Reassign permission (separate from Manage so least-privilege roles cannot move work to other users). Emits ActivityReassignedEvent (local) and ActivityReassignedEto (distributed). Setting the same assignee is a no-op (no event raised).",
+        "operationId": "ReassignActivity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReassignActivityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/{id}/due-date": {
+      "put": {
+        "tags": ["Activities"],
+        "summary": "Updates the due date of an open activity.",
+        "description": "Allowed only while the activity is Open. The new due date must lie within ActivitiesEndpointsOptions.MaxFutureRescheduleDays of the server clock. Emits ActivityRescheduledEvent (local) and ActivityRescheduledEto (distributed). Setting the same due date is a no-op (no event raised).",
+        "operationId": "RescheduleActivity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RescheduleActivityRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/activities/calendar": {
+      "get": {
+        "tags": ["Activities"],
+        "summary": "Returns activities positioned on the cross-entity calendar within a time window.",
+        "description": "Spans every entity type the caller can read. The window must be <= ActivitiesEndpointsOptions.MaxCalendarRangeDays (default 90 days) and (To > From) — otherwise 400. Filter by assignee ('me' resolves from the JWT 'sub' claim or any string-form Guid), entityType (polymorphic FK), type (comma-separated), or status (defaults to OpenOrOverdue). FusionCache TTL is 1 minute by default; the cache key includes the resolved tenant id, the user permission hash, the window, and every filter. Per-tenant eviction tags drop every cached calendar window when an Activity row changes (handler in this same package). Returns 304 on If-None-Match match.",
+        "operationId": "GetActivityCalendar",
+        "parameters": [
+          {
+            "name": "From",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "To",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "Assignee",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "EntityType",
+            "in": "query",
+            "description": "Fully qualified entity type (e.g. 'Acme.Patients').",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Type",
+            "in": "query",
+            "description": "Filter by type discriminator value.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "Status",
+            "in": "query",
+            "description": "Filter by status value.",
+            "schema": {
+              "$ref": "#/components/schemas/ActivityStatusFilter"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ActivityCalendarItemResponse"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ActivityCalendarItemResponse": {
+        "required": [
+          "id",
+          "start",
+          "end",
+          "title",
+          "color",
+          "type",
+          "status",
+          "entityType",
+          "entityId",
+          "assignedToUserId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "end": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ActivityStatus"
+          },
+          "entityType": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedToUserId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "ActivityListResponse": {
+        "required": ["items", "totalCount", "page", "pageSize"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ActivityResponse"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ActivityResponse": {
+        "required": [
+          "id",
+          "entityType",
+          "entityId",
+          "type",
+          "assignedToUserId",
+          "createdByUserId",
+          "dueAt",
+          "description",
+          "status",
+          "completedAt",
+          "completedByUserId",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "entityType": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string"
+          },
+          "assignedToUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdByUserId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "dueAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "$ref": "#/components/schemas/ActivityStatus"
+          },
+          "completedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "completedByUserId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ActivityStatus": {
+        "enum": ["Open", "Done", "Cancelled"]
+      },
+      "ActivityStatusFilter": {
+        "enum": ["OpenOrOverdue", "Done", "Cancelled", null]
+      },
+      "CancelActivityRequest": {
+        "type": "object"
+      },
+      "CompleteActivityRequest": {
+        "type": "object"
+      },
+      "CreateActivityRequest": {
+        "required": ["entityType", "entityId", "type", "assignedToUserId", "dueAt"],
+        "type": "object",
+        "properties": {
+          "entityType": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string"
+          },
+          "assignedToUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "dueAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "description": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "ReassignActivityRequest": {
+        "required": ["newAssigneeUserId"],
+        "type": "object",
+        "properties": {
+          "newAssigneeUserId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "RescheduleActivityRequest": {
+        "required": ["newDueAt"],
+        "type": "object",
+        "properties": {
+          "newDueAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Activities"
+    }
+  ]
+}

--- a/contracts/openapi/analytics.json
+++ b/contracts/openapi/analytics.json
@@ -1,0 +1,1443 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "analytics",
+    "version": "1"
+  },
+  "paths": {
+    "/analytics/metrics/{name}": {
+      "post": {
+        "tags": ["Analytics"],
+        "summary": "Evaluates a registered Granit.Analytics MetricDefinition.",
+        "description": "Resolves the metric by name, applies the period (and optional comparison window) through the same filter pipeline grids use, runs the aggregation through the EF Core executor, caches the result via FusionCache (key includes tenant id), and returns the { snapshot, sequence, emittedAt, refreshHint } envelope. Returns 404 when the metric name is unknown, 422 when the period spec is invalid or comparison is requested on a metric without a PeriodSelector.",
+        "operationId": "EvaluateMetric",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Unique registered name of the background job.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MetricRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MetricResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/widgets/kpi/render": {
+      "post": {
+        "tags": ["Analytics"],
+        "summary": "Renders a single KPI widget definition.",
+        "description": "Used by the dashboard composer / catalogue / preview paths to fetch a KPI snapshot without persisting the widget. Body carries the typed KpiWidgetDefinition (with its embedded Datasource — MetricDatasource or QueryAggregateDatasource) plus an optional render context. Returns the same DashboardRenderedWidgetResponse shape the bundle path emits.",
+        "operationId": "RenderKpiWidget",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/KpiWidgetRenderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardRenderedWidgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/widgets/chart/render": {
+      "post": {
+        "tags": ["Analytics"],
+        "summary": "Renders a single chart widget definition.",
+        "description": "Used by the dashboard composer / catalogue / preview paths to fetch a chart snapshot without persisting the widget. Body carries the typed ChartWidgetDefinition plus an optional render context. Returns the same DashboardRenderedWidgetResponse shape the bundle path emits.",
+        "operationId": "RenderChartWidget",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChartWidgetRenderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardRenderedWidgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/widgets/table/render": {
+      "post": {
+        "tags": ["Analytics"],
+        "summary": "Renders a single table widget definition.",
+        "description": "Used by the dashboard composer / catalogue / preview paths to fetch a table snapshot without persisting the widget. Body carries the typed TableWidgetDefinition plus an optional render context.",
+        "operationId": "RenderTableWidget",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TableWidgetRenderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardRenderedWidgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/widgets/pivot/render": {
+      "post": {
+        "tags": ["Analytics"],
+        "summary": "Renders a single pivot widget definition.",
+        "description": "Used by the dashboard composer / catalogue / preview paths to fetch a pivot snapshot without persisting the widget. Body carries the typed PivotWidgetDefinition plus an optional render context.",
+        "operationId": "RenderPivotWidget",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PivotWidgetRenderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardRenderedWidgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/analytics/widgets/map/render": {
+      "post": {
+        "tags": ["Analytics"],
+        "summary": "Renders a single map widget definition.",
+        "description": "Used by the dashboard composer / catalogue / preview paths to fetch a map snapshot without persisting the widget. Body carries the typed MapWidgetDefinition plus an optional render context.",
+        "operationId": "RenderMapWidget",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MapWidgetRenderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardRenderedWidgetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AggregateFunction": {
+        "enum": ["Count", "Sum", "Avg", "Min", "Max"]
+      },
+      "ChartType": {
+        "enum": ["Bar", "HorizontalBar", "Line", "Area", "Pie", "Donut"]
+      },
+      "ChartWidgetDefinition": {
+        "required": [
+          "queryName",
+          "groupBy",
+          "aggregation",
+          "field",
+          "chartType",
+          "slug",
+          "position"
+        ],
+        "type": "object",
+        "properties": {
+          "queryName": {
+            "type": "string"
+          },
+          "groupBy": {
+            "type": "string"
+          },
+          "aggregation": {
+            "$ref": "#/components/schemas/AggregateFunction"
+          },
+          "field": {
+            "type": ["null", "string"]
+          },
+          "chartType": {
+            "$ref": "#/components/schemas/ChartType"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "$ref": "#/components/schemas/WidgetSize"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "timeWindowOverride": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardTimeWindow"
+              }
+            ]
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/WidgetAction"
+            }
+          }
+        }
+      },
+      "ChartWidgetRenderRequest": {
+        "required": ["definition"],
+        "type": "object",
+        "properties": {
+          "definition": {
+            "$ref": "#/components/schemas/ChartWidgetDefinition"
+          },
+          "context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WidgetRenderContextRequest"
+              }
+            ]
+          }
+        }
+      },
+      "DashboardRenderedWidgetResponse": {
+        "required": [
+          "id",
+          "widgetType",
+          "slug",
+          "position",
+          "width",
+          "height",
+          "titleLocalizationKey",
+          "actions",
+          "requiredPermission",
+          "status",
+          "sequence",
+          "emittedAt",
+          "refreshHint",
+          "transport",
+          "snapshot"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "widgetType": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "titleLocalizationKey": {
+            "type": "string"
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/WidgetAction"
+            }
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "$ref": "#/components/schemas/WidgetSnapshotStatus"
+          },
+          "sequence": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "emittedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "refreshHint": {
+            "$ref": "#/components/schemas/RefreshHint"
+          },
+          "transport": {
+            "$ref": "#/components/schemas/WidgetTransport"
+          },
+          "snapshot": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/JsonElement"
+              }
+            ]
+          },
+          "reasonLocalizationKey": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DashboardTimeWindow": {
+        "required": ["period"],
+        "type": "object",
+        "properties": {
+          "period": {
+            "$ref": "#/components/schemas/PeriodSpec"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/TimeWindowKind"
+          },
+          "compareTo": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PeriodSpec"
+              }
+            ]
+          },
+          "aggregation": {
+            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DataKeyFormat": {
+        "required": ["key"],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "labelLocalizationKey": {
+            "type": ["null", "string"]
+          },
+          "color": {
+            "type": ["null", "string"]
+          },
+          "unit": {
+            "type": ["null", "string"]
+          },
+          "decimals": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          }
+        }
+      },
+      "Datasource": {
+        "required": ["kind"],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/DatasourceMetricDatasource"
+          },
+          {
+            "$ref": "#/components/schemas/DatasourceQueryAggregateDatasource"
+          },
+          {
+            "$ref": "#/components/schemas/DatasourceTelemetryDatasource"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "metric": "#/components/schemas/DatasourceMetricDatasource",
+            "query-aggregate": "#/components/schemas/DatasourceQueryAggregateDatasource",
+            "iot-telemetry": "#/components/schemas/DatasourceTelemetryDatasource"
+          }
+        }
+      },
+      "DatasourceMetricDatasource": {
+        "required": ["metricName"],
+        "properties": {
+          "kind": {
+            "enum": ["metric"],
+            "type": "string"
+          },
+          "metricName": {
+            "type": "string"
+          }
+        }
+      },
+      "DatasourceQueryAggregateDatasource": {
+        "required": ["queryName", "aggregation"],
+        "properties": {
+          "kind": {
+            "enum": ["query-aggregate"],
+            "type": "string"
+          },
+          "queryName": {
+            "type": "string"
+          },
+          "aggregation": {
+            "$ref": "#/components/schemas/AggregateFunction"
+          },
+          "field": {
+            "type": ["null", "string"]
+          },
+          "keyFormats": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/DataKeyFormat"
+            }
+          }
+        }
+      },
+      "DatasourceTelemetryDatasource": {
+        "required": ["entityAlias", "telemetryKey"],
+        "properties": {
+          "kind": {
+            "enum": ["iot-telemetry"],
+            "type": "string"
+          },
+          "entityAlias": {
+            "type": "string"
+          },
+          "telemetryKey": {
+            "type": "string"
+          },
+          "aggregation": {
+            "$ref": "#/components/schemas/TelemetryAggregation"
+          },
+          "keyFormats": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/DataKeyFormat"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "JsonElement": {
+        "type": ["null", "boolean", "number", "string", "object", "array"],
+        "description": "Arbitrary JSON value (object, array, string, number, boolean, or null)."
+      },
+      "KpiWidgetDefinition": {
+        "required": ["datasource", "slug", "position"],
+        "type": "object",
+        "properties": {
+          "datasource": {
+            "$ref": "#/components/schemas/Datasource"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "$ref": "#/components/schemas/WidgetSize"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "timeWindowOverride": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardTimeWindow"
+              }
+            ]
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/WidgetAction"
+            }
+          }
+        }
+      },
+      "KpiWidgetRenderRequest": {
+        "required": ["definition"],
+        "type": "object",
+        "properties": {
+          "definition": {
+            "$ref": "#/components/schemas/KpiWidgetDefinition"
+          },
+          "context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WidgetRenderContextRequest"
+              }
+            ]
+          }
+        }
+      },
+      "MapCenter": {
+        "required": ["latitude", "longitude"],
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          }
+        }
+      },
+      "MapPointSource": {
+        "required": ["kind"],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/MapPointSourceLatLng"
+          },
+          {
+            "$ref": "#/components/schemas/MapPointSourceGeography"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "kind",
+          "mapping": {
+            "lat-lng": "#/components/schemas/MapPointSourceLatLng",
+            "geography": "#/components/schemas/MapPointSourceGeography"
+          }
+        }
+      },
+      "MapPointSourceGeography": {
+        "required": ["geographyColumn"],
+        "properties": {
+          "kind": {
+            "enum": ["geography"],
+            "type": "string"
+          },
+          "geographyColumn": {
+            "type": "string"
+          }
+        }
+      },
+      "MapPointSourceLatLng": {
+        "required": ["latitudeColumn", "longitudeColumn"],
+        "properties": {
+          "kind": {
+            "enum": ["lat-lng"],
+            "type": "string"
+          },
+          "latitudeColumn": {
+            "type": "string"
+          },
+          "longitudeColumn": {
+            "type": "string"
+          }
+        }
+      },
+      "MapTileLayerKind": {
+        "enum": ["Plan", "Satellite", "Hybrid", "Topo", "Custom", null]
+      },
+      "MapWidgetDefinition": {
+        "required": ["queryName", "pointSource", "popupColumns", "slug", "position"],
+        "type": "object",
+        "properties": {
+          "queryName": {
+            "type": "string"
+          },
+          "pointSource": {
+            "$ref": "#/components/schemas/MapPointSource"
+          },
+          "popupColumns": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "defaultZoom": {
+            "type": "integer",
+            "format": "int32",
+            "default": 5
+          },
+          "defaultCenter": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MapCenter"
+              }
+            ]
+          },
+          "clusterThreshold": {
+            "type": "integer",
+            "format": "int32",
+            "default": 200
+          },
+          "detailRoute": {
+            "type": ["null", "string"]
+          },
+          "tileUrlTemplate": {
+            "type": ["null", "string"]
+          },
+          "defaultLayerKind": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MapTileLayerKind"
+              }
+            ]
+          },
+          "slug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "$ref": "#/components/schemas/WidgetSize"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "timeWindowOverride": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardTimeWindow"
+              }
+            ]
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/WidgetAction"
+            }
+          }
+        }
+      },
+      "MapWidgetRenderRequest": {
+        "required": ["definition"],
+        "type": "object",
+        "properties": {
+          "definition": {
+            "$ref": "#/components/schemas/MapWidgetDefinition"
+          },
+          "context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WidgetRenderContextRequest"
+              }
+            ]
+          }
+        }
+      },
+      "MetricPreviousPayload": {
+        "required": ["value", "deltaRatio", "trend", "isFavorable"],
+        "type": "object",
+        "properties": {
+          "value": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "deltaRatio": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "trend": {
+            "type": "string"
+          },
+          "isFavorable": {
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "MetricRequest": {
+        "required": ["period"],
+        "type": "object",
+        "properties": {
+          "period": {
+            "$ref": "#/components/schemas/PeriodSpec"
+          },
+          "compareTo": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PeriodSpec"
+              }
+            ]
+          }
+        }
+      },
+      "MetricResponse": {
+        "required": ["name", "snapshot", "sequence", "emittedAt", "refreshHint"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "snapshot": {
+            "$ref": "#/components/schemas/MetricSnapshotPayload"
+          },
+          "sequence": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "emittedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "refreshHint": {
+            "$ref": "#/components/schemas/RefreshHint"
+          }
+        }
+      },
+      "MetricSnapshotPayload": {
+        "required": ["value", "valueKind", "currency", "isHigherBetter", "noData", "previous"],
+        "type": "object",
+        "properties": {
+          "value": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "valueKind": {
+            "$ref": "#/components/schemas/MetricValueKind"
+          },
+          "currency": {
+            "type": ["null", "string"]
+          },
+          "isHigherBetter": {
+            "type": "boolean"
+          },
+          "noData": {
+            "type": "boolean"
+          },
+          "previous": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/MetricPreviousPayload"
+              }
+            ]
+          }
+        }
+      },
+      "MetricValueKind": {
+        "enum": ["Count", "Number", "Currency", "Percentage", "Duration", "Date"]
+      },
+      "PeriodSpec": {
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "to": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "token": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PivotWidgetDefinition": {
+        "required": [
+          "queryName",
+          "rowFields",
+          "columnFields",
+          "valueField",
+          "valueAggregation",
+          "slug",
+          "position"
+        ],
+        "type": "object",
+        "properties": {
+          "queryName": {
+            "type": "string"
+          },
+          "rowFields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "columnFields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "valueField": {
+            "type": ["null", "string"]
+          },
+          "valueAggregation": {
+            "$ref": "#/components/schemas/AggregateFunction"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "$ref": "#/components/schemas/WidgetSize"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "timeWindowOverride": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardTimeWindow"
+              }
+            ]
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/WidgetAction"
+            }
+          }
+        }
+      },
+      "PivotWidgetRenderRequest": {
+        "required": ["definition"],
+        "type": "object",
+        "properties": {
+          "definition": {
+            "$ref": "#/components/schemas/PivotWidgetDefinition"
+          },
+          "context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WidgetRenderContextRequest"
+              }
+            ]
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "RefreshHint": {
+        "enum": ["Static", "Dynamic", "Realtime"]
+      },
+      "TableWidgetDefinition": {
+        "required": ["queryName", "visibleColumns", "pageSize", "slug", "position"],
+        "type": "object",
+        "properties": {
+          "queryName": {
+            "type": "string"
+          },
+          "visibleColumns": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "size": {
+            "$ref": "#/components/schemas/WidgetSize"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "timeWindowOverride": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardTimeWindow"
+              }
+            ]
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/WidgetAction"
+            }
+          }
+        }
+      },
+      "TableWidgetRenderRequest": {
+        "required": ["definition"],
+        "type": "object",
+        "properties": {
+          "definition": {
+            "$ref": "#/components/schemas/TableWidgetDefinition"
+          },
+          "context": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/WidgetRenderContextRequest"
+              }
+            ]
+          }
+        }
+      },
+      "TelemetryAggregation": {
+        "enum": ["Last", "Avg", "Sum", "Min", "Max", "Count"],
+        "default": "Last"
+      },
+      "TimeWindowKind": {
+        "enum": ["History", "Realtime"],
+        "default": "History"
+      },
+      "WidgetAction": {
+        "required": ["trigger", "kind", "target"],
+        "type": "object",
+        "properties": {
+          "trigger": {
+            "$ref": "#/components/schemas/WidgetActionTrigger"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/WidgetActionKind"
+          },
+          "target": {
+            "type": "string"
+          },
+          "params": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "WidgetActionKind": {
+        "enum": ["Navigate", "OpenDashboardView", "OpenDashboard", "ExportData", "OpenDetail"]
+      },
+      "WidgetActionTrigger": {
+        "enum": ["Click", "RowClick", "SeriesClick", "LegendClick"]
+      },
+      "WidgetRenderContextRequest": {
+        "type": "object",
+        "properties": {
+          "periodFrom": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodTo": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodToken": {
+            "type": ["null", "string"]
+          },
+          "locale": {
+            "type": ["null", "string"]
+          },
+          "filters": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "WidgetSize": {
+        "required": ["width", "height"],
+        "type": "object",
+        "properties": {
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "WidgetSnapshotStatus": {
+        "enum": ["Snapshot", "Unavailable", "Error"]
+      },
+      "WidgetTransport": {
+        "enum": ["Pull", "Push"]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Analytics"
+    }
+  ]
+}

--- a/contracts/openapi/catalog.json
+++ b/contracts/openapi/catalog.json
@@ -1,23 +1,26 @@
 {
   "openapi": "3.1.1",
   "info": {
-    "title": "ai",
+    "title": "catalog",
     "version": "1"
   },
   "paths": {
-    "/ai/workspaces": {
+    "/catalog/products/active": {
       "get": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Lists all AI workspaces, both system and dynamic.",
-        "description": "Returns every registered workspace with its provider, model, and configuration. System workspaces are defined in configuration; dynamic workspaces are user-created.",
-        "operationId": "ListAIWorkspaces",
+        "tags": ["Catalog - Products"],
+        "summary": "Returns the active product catalog (Published only).",
+        "description": "Catalog surface for tenant users — lists products available for use by Subscriptions and Metering (Published status). Draft and Archived products are excluded. For the admin grid with full lifecycle visibility (Draft / Published / Archived), use GET /products which requires Products.Manage.",
+        "operationId": "ListActiveProducts",
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceListResponse"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ProductResponse"
+                  }
                 }
               }
             }
@@ -34,84 +37,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Creates a new dynamic AI workspace.",
-        "description": "Registers a new user-defined workspace with the specified provider and model configuration. Returns 409 if a workspace with the same name already exists.",
-        "operationId": "CreateAIWorkspace",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIWorkspaceCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceResponse"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -133,20 +58,21 @@
         }
       }
     },
-    "/ai/workspaces/{name}": {
+    "/catalog/products/{id}": {
       "get": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Returns an AI workspace by its name.",
-        "description": "Fetches the full configuration of a single workspace including provider, model, system prompt, and active status. Returns 404 if no workspace matches the name.",
-        "operationId": "GetAIWorkspace",
+        "tags": ["Catalog - Products"],
+        "summary": "Returns a product by ID (any lifecycle status).",
+        "description": "Returns the full product details including external mappings and metadata.",
+        "operationId": "GetCatalogProductById",
         "parameters": [
           {
-            "name": "name",
+            "name": "id",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -156,7 +82,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceResponse"
+                  "$ref": "#/components/schemas/ProductResponse"
                 }
               }
             }
@@ -204,18 +130,19 @@
         }
       },
       "put": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Updates an existing dynamic AI workspace.",
-        "description": "Replaces the provider, model, and prompt configuration of a dynamic workspace. System workspaces cannot be modified and return 422. Returns 404 if the workspace does not exist.",
-        "operationId": "UpdateAIWorkspace",
+        "tags": ["Catalog - Products"],
+        "summary": "Updates editable fields of a Draft product.",
+        "description": "Only Draft products can be updated. SKU and Type are immutable post-creation — to change them, archive the product and create a new one.",
+        "operationId": "UpdateCatalogProduct",
         "parameters": [
           {
-            "name": "name",
+            "name": "id",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -223,7 +150,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/AIWorkspaceUpdateRequest"
+                "$ref": "#/components/schemas/ProductUpdateRequest"
               }
             }
           },
@@ -235,7 +162,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceResponse"
+                  "$ref": "#/components/schemas/ProductResponse"
                 }
               }
             }
@@ -246,6 +173,176 @@
               "application/problem+json": {
                 "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/products/by-sku/{sku}": {
+      "get": {
+        "tags": ["Catalog - Products"],
+        "summary": "Returns a product by SKU (any lifecycle status).",
+        "description": "Useful for SKU-based reverse lookups during Stripe / Avalara / Odoo integration syncs.",
+        "operationId": "GetCatalogProductBySku",
+        "parameters": [
+          {
+            "name": "sku",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/products": {
+      "post": {
+        "tags": ["Catalog - Products"],
+        "summary": "Creates a new product in Draft status.",
+        "description": "Creates a product that can be configured (metadata, external mappings) before publishing.",
+        "operationId": "CreateCatalogProduct",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProductCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -292,85 +389,11 @@
           }
         }
       },
-      "delete": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Deletes a dynamic AI workspace.",
-        "description": "Permanently removes a user-created workspace. System workspaces cannot be deleted and return 422. Returns 404 if the workspace does not exist.",
-        "operationId": "DeleteAIWorkspace",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Unique registered name of the background job.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/usage": {
       "get": {
-        "tags": ["AI - Usage"],
-        "summary": "Returns a filtered, sorted, and paginated list of AIUsageRecord entries.",
-        "description": "Executes a dynamic query against AIUsageRecord using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
-        "operationId": "QueryAIUsageRecord",
+        "tags": ["Granit.Business.OpenApi.Generator"],
+        "summary": "Returns a filtered, sorted, and paginated list of Product entries.",
+        "description": "Executes a dynamic query against Product using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryProduct",
         "parameters": [
           {
             "name": "page",
@@ -476,10 +499,10 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedResultOfAIUsageRecord"
+                      "$ref": "#/components/schemas/PagedResultOfProduct"
                     },
                     {
-                      "$ref": "#/components/schemas/GroupedResultOfAIUsageRecord"
+                      "$ref": "#/components/schemas/GroupedResultOfProduct"
                     }
                   ],
                   "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
@@ -530,12 +553,451 @@
         }
       }
     },
-    "/ai/usage/meta": {
+    "/catalog/products/{id}/metadata": {
+      "put": {
+        "tags": ["Catalog - Products"],
+        "summary": "Replaces the product metadata dictionary.",
+        "description": "Allowed in any lifecycle state — metadata may need to flow even for Published products (e.g., adjusting Stripe sync attributes). MUST NOT contain PII.",
+        "operationId": "UpdateCatalogProductMetadata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateProductMetadataRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/products/{id}/publish": {
+      "post": {
+        "tags": ["Catalog - Products"],
+        "summary": "Publishes a Draft product, making it available for use.",
+        "description": "Transitions Draft → Published. This unlocks the product for MeterDefinition.ProductId and PlanPrice.ProductId references.",
+        "operationId": "PublishCatalogProduct",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/products/{id}/archive": {
+      "post": {
+        "tags": ["Catalog - Products"],
+        "summary": "Archives a Published product.",
+        "description": "Existing references (meters, plan prices) are unaffected; the product becomes unavailable for new attachments.",
+        "operationId": "ArchiveCatalogProduct",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/products/{id}/external-mappings": {
+      "post": {
+        "tags": ["Catalog - Products"],
+        "summary": "Adds an external provider mapping (Stripe / Avalara / Odoo / ...) to a product.",
+        "description": "Allowed in any lifecycle state. Each (provider, externalId) pair must be globally unique (one external identifier maps to exactly one product).",
+        "operationId": "AddCatalogProductExternalMapping",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddProductExternalMappingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProductResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/products/{id}/external-mappings/{mappingId}": {
+      "delete": {
+        "tags": ["Catalog - Products"],
+        "summary": "Removes an external provider mapping from a product.",
+        "description": "Returns 404 if either the product or the mapping does not exist.",
+        "operationId": "RemoveCatalogProductExternalMapping",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "mappingId",
+            "in": "path",
+            "description": "Unique identifier of the mapping.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/catalog/products/meta": {
       "get": {
-        "tags": ["AI - Usage"],
-        "summary": "Returns query metadata for AIUsageRecord (columns, filters, sorts, presets).",
-        "description": "Returns the query definition metadata for AIUsageRecord: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
-        "operationId": "GetAIUsageRecordMeta",
+        "tags": ["Granit.Business.OpenApi.Generator"],
+        "summary": "Returns query metadata for Product (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Product: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetProductMeta",
         "responses": {
           "200": {
             "description": "OK",
@@ -579,847 +1041,19 @@
           }
         }
       }
-    },
-    "/ai/providers": {
-      "get": {
-        "tags": ["AI - Providers"],
-        "summary": "Lists all registered AI providers.",
-        "description": "Returns every AI provider registered via dependency injection, along with an indication of whether each provider supports chat and embedding capabilities.",
-        "operationId": "ListAIProviders",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AIProviderResponse"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/providers/{providerName}/models": {
-      "get": {
-        "tags": ["AI - Providers"],
-        "summary": "Lists the models available from a specific AI provider.",
-        "description": "Returns the models currently available from the specified provider. For cloud providers (OpenAI, AzureOpenAI) this is a static catalog. For local providers (Ollama) this queries the server for installed models. Returns 404 if the provider is not registered, or 502 if the provider's model listing fails.",
-        "operationId": "ListAIProviderModels",
-        "parameters": [
-          {
-            "name": "providerName",
-            "in": "path",
-            "description": "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AIProviderModelResponse"
-                  }
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/chat/{workspaceName}": {
-      "post": {
-        "tags": ["AI - Inference"],
-        "summary": "Sends messages to an AI workspace and returns a completion response.",
-        "description": "Forwards the conversation to the underlying AI provider configured for the workspace. Returns the assistant's reply, token usage, and response duration. Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.",
-        "operationId": "AIChatComplete",
-        "parameters": [
-          {
-            "name": "workspaceName",
-            "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIChatRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIChatResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/chat/{workspaceName}/stream": {
-      "post": {
-        "tags": ["AI - Inference"],
-        "summary": "Streams a chat completion response via Server-Sent Events.",
-        "description": "Opens an SSE stream that emits incremental content chunks as they arrive from the provider. The stream ends with a [DONE] sentinel. If the provider returns an error after streaming has started, an SSE 'error' event is emitted before closing. Returns 404 if the workspace does not exist, 422 if the model is not found, or 502/503 if the provider is unavailable.",
-        "operationId": "AIChatStream",
-        "parameters": [
-          {
-            "name": "workspaceName",
-            "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIChatRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Service Unavailable",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/embeddings/{workspaceName}": {
-      "post": {
-        "tags": ["AI - Inference"],
-        "summary": "Generates vector embeddings for input texts using the specified workspace.",
-        "description": "Sends the input texts to the embedding model configured for the workspace and returns float vectors for each input. Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.",
-        "operationId": "AIGenerateEmbeddings",
-        "parameters": [
-          {
-            "name": "workspaceName",
-            "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIEmbeddingRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIEmbeddingResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
     }
   },
   "components": {
     "schemas": {
-      "AIChatMessageRequest": {
-        "required": ["role", "content"],
+      "AddProductExternalMappingRequest": {
+        "required": ["providerName", "externalId"],
         "type": "object",
         "properties": {
-          "role": {
+          "providerName": {
             "type": "string"
           },
-          "content": {
+          "externalId": {
             "type": "string"
-          }
-        }
-      },
-      "AIChatRequest": {
-        "required": ["messages"],
-        "type": "object",
-        "properties": {
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AIChatMessageRequest"
-            }
-          }
-        }
-      },
-      "AIChatResponse": {
-        "required": ["workspaceName", "model", "content", "usage", "duration"],
-        "type": "object",
-        "properties": {
-          "workspaceName": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "usage": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/AIChatUsageResponse"
-              }
-            ]
-          },
-          "duration": {
-            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-            "type": "string"
-          }
-        }
-      },
-      "AIChatUsageResponse": {
-        "required": ["inputTokens", "outputTokens", "estimatedCost", "costCurrency"],
-        "type": "object",
-        "properties": {
-          "inputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "outputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "estimatedCost": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "double"
-          },
-          "costCurrency": {
-            "type": ["null", "string"]
-          }
-        }
-      },
-      "AIEmbeddingDataResponse": {
-        "required": ["index", "vector"],
-        "type": "object",
-        "properties": {
-          "index": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "vector": {
-            "type": "array",
-            "items": {
-              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-              "type": ["number", "string"],
-              "format": "float"
-            }
-          }
-        }
-      },
-      "AIEmbeddingRequest": {
-        "required": ["inputs"],
-        "type": "object",
-        "properties": {
-          "inputs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "AIEmbeddingResponse": {
-        "required": ["workspaceName", "model", "embeddings", "usage"],
-        "type": "object",
-        "properties": {
-          "workspaceName": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "embeddings": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AIEmbeddingDataResponse"
-            }
-          },
-          "usage": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/AIEmbeddingUsageResponse"
-              }
-            ]
-          }
-        }
-      },
-      "AIEmbeddingUsageResponse": {
-        "required": ["inputTokens"],
-        "type": "object",
-        "properties": {
-          "inputTokens": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "AIModelCapabilities": {
-        "type": "object",
-        "properties": {
-          "chat": {
-            "type": "boolean"
-          },
-          "embeddings": {
-            "type": "boolean"
-          },
-          "vision": {
-            "type": "boolean"
-          },
-          "imageGeneration": {
-            "type": "boolean"
-          },
-          "audio": {
-            "type": "boolean"
-          },
-          "toolUse": {
-            "type": "boolean"
-          },
-          "streaming": {
-            "type": "boolean"
-          },
-          "structuredOutput": {
-            "type": "boolean"
-          },
-          "extensions": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "AIProviderModelResponse": {
-        "required": ["id", "displayName", "capabilities", "maxContextTokens"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "displayName": {
-            "type": "string"
-          },
-          "capabilities": {
-            "$ref": "#/components/schemas/AIModelCapabilities"
-          },
-          "maxContextTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          }
-        }
-      },
-      "AIProviderResponse": {
-        "required": ["name", "supportsChat", "supportsEmbeddings"],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "supportsChat": {
-            "type": "boolean"
-          },
-          "supportsEmbeddings": {
-            "type": "boolean"
-          }
-        }
-      },
-      "AIUsageRecord": {
-        "required": ["id", "workspaceName", "provider", "model", "timestamp"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "tenantId": {
-            "type": ["null", "string"],
-            "format": "uuid"
-          },
-          "userId": {
-            "type": ["null", "string"],
-            "format": "uuid"
-          },
-          "workspaceName": {
-            "type": "string"
-          },
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "inputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "outputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "estimatedCost": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "double"
-          },
-          "costCurrency": {
-            "type": ["null", "string"]
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "duration": {
-            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-            "type": ["null", "string"]
-          }
-        }
-      },
-      "AIWorkspaceCreateRequest": {
-        "required": ["name", "provider", "model"],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "systemPrompt": {
-            "type": ["null", "string"]
-          },
-          "temperature": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "float"
-          },
-          "maxOutputTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          }
-        }
-      },
-      "AIWorkspaceKind": {
-        "enum": ["System", "Dynamic"]
-      },
-      "AIWorkspaceListResponse": {
-        "required": ["workspaces", "totalCount"],
-        "type": "object",
-        "properties": {
-          "workspaces": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AIWorkspaceResponse"
-            }
-          },
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "AIWorkspaceResponse": {
-        "required": [
-          "name",
-          "provider",
-          "model",
-          "systemPrompt",
-          "temperature",
-          "maxOutputTokens",
-          "kind",
-          "activated",
-          "capabilities"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "systemPrompt": {
-            "type": ["null", "string"]
-          },
-          "temperature": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "float"
-          },
-          "maxOutputTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          },
-          "kind": {
-            "$ref": "#/components/schemas/AIWorkspaceKind"
-          },
-          "activated": {
-            "type": "boolean"
-          },
-          "capabilities": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/AIModelCapabilities"
-              }
-            ]
-          }
-        }
-      },
-      "AIWorkspaceUpdateRequest": {
-        "required": ["provider", "model"],
-        "type": "object",
-        "properties": {
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "systemPrompt": {
-            "type": ["null", "string"]
-          },
-          "temperature": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "float"
-          },
-          "maxOutputTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          },
-          "activated": {
-            "type": "boolean",
-            "default": false
           }
         }
       },
@@ -1562,14 +1196,14 @@
           }
         }
       },
-      "GroupedResultOfAIUsageRecord": {
+      "GroupedResultOfProduct": {
         "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/GroupEntryOfAIUsageRecord"
+              "$ref": "#/components/schemas/GroupEntryOfProduct"
             }
           },
           "totalCount": {
@@ -1578,7 +1212,7 @@
           }
         }
       },
-      "GroupEntryOfAIUsageRecord": {
+      "GroupEntryOfProduct": {
         "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
@@ -1599,7 +1233,7 @@
           "items": {
             "type": ["null", "array"],
             "items": {
-              "$ref": "#/components/schemas/AIUsageRecord"
+              "$ref": "#/components/schemas/Product"
             }
           }
         }
@@ -1634,6 +1268,14 @@
           }
         }
       },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
       "LookupDescriptor": {
         "type": "object",
         "properties": {
@@ -1665,60 +1307,91 @@
         "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
         "default": "QueryEngine"
       },
-      "PagedResultOfAIUsageRecord": {
+      "PagedResultOfProduct": {
         "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "required": ["id", "workspaceName", "provider", "model", "timestamp"],
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "string",
-                  "format": "uuid"
-                },
-                "tenantId": {
-                  "type": ["null", "string"],
-                  "format": "uuid"
-                },
-                "userId": {
-                  "type": ["null", "string"],
-                  "format": "uuid"
-                },
-                "workspaceName": {
+                "sku": {
                   "type": "string"
                 },
-                "provider": {
+                "name": {
                   "type": "string"
                 },
-                "model": {
-                  "type": "string"
-                },
-                "inputTokens": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "outputTokens": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "estimatedCost": {
-                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-                  "type": ["null", "number", "string"],
-                  "format": "double"
-                },
-                "costCurrency": {
+                "description": {
                   "type": ["null", "string"]
                 },
-                "timestamp": {
-                  "type": "string",
+                "type": {
+                  "enum": ["Service", "Metered", "Physical", "Digital"]
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "lifecycleStatus": {
+                  "enum": ["Draft", "PendingReview", "Published", "Archived"]
+                },
+                "metadataJson": {
+                  "type": ["null", "string"]
+                },
+                "externalMappings": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "providerName": {
+                        "type": "string"
+                      },
+                      "externalId": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
                   "format": "date-time"
                 },
-                "duration": {
-                  "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-                  "type": ["null", "string"]
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
                 }
               }
             }
@@ -1793,6 +1466,194 @@
           "instance": {
             "type": "string",
             "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "Product": {
+        "type": "object",
+        "properties": {
+          "sku": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "type": {
+            "$ref": "#/components/schemas/ProductType"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "lifecycleStatus": {
+            "$ref": "#/components/schemas/WorkflowLifecycleStatus"
+          },
+          "metadataJson": {
+            "type": ["null", "string"]
+          },
+          "externalMappings": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/ProductExternalMapping"
+            }
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "ProductCreateRequest": {
+        "required": ["sku", "name", "type", "unit"],
+        "type": "object",
+        "properties": {
+          "sku": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "ProductExternalMapping": {
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "ProductExternalMappingResponse": {
+        "required": ["id", "providerName", "externalId"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          }
+        }
+      },
+      "ProductResponse": {
+        "required": [
+          "id",
+          "sku",
+          "name",
+          "description",
+          "type",
+          "unit",
+          "lifecycleStatus",
+          "metadata",
+          "externalMappings"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sku": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "type": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "lifecycleStatus": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "externalMappings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ProductExternalMappingResponse"
+            }
+          }
+        }
+      },
+      "ProductType": {
+        "enum": ["Service", "Metered", "Physical", "Digital"]
+      },
+      "ProductUpdateRequest": {
+        "required": ["name", "description", "unit"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "unit": {
+            "type": "string"
           }
         }
       },
@@ -1882,21 +1743,30 @@
             "type": "string"
           }
         }
+      },
+      "UpdateProductMetadataRequest": {
+        "required": ["metadata"],
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "WorkflowLifecycleStatus": {
+        "enum": ["Draft", "PendingReview", "Published", "Archived"]
       }
     }
   },
   "tags": [
     {
-      "name": "AI - Inference"
+      "name": "Catalog - Products"
     },
     {
-      "name": "AI - Providers"
-    },
-    {
-      "name": "AI - Usage"
-    },
-    {
-      "name": "AI - Workspaces"
+      "name": "Granit.Business.OpenApi.Generator"
     }
   ]
 }

--- a/contracts/openapi/customer-balance.json
+++ b/contracts/openapi/customer-balance.json
@@ -1,0 +1,525 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "customer-balance",
+    "version": "1"
+  },
+  "paths": {
+    "/customer-balance/balance": {
+      "get": {
+        "tags": ["Customer Balance"],
+        "summary": "Returns the balance for the current tenant and currency.",
+        "description": "Returns the current credit balance for the authenticated tenant in the specified currency. Returns zero balance if no account exists for that currency.",
+        "operationId": "GetCustomerBalance",
+        "parameters": [
+          {
+            "name": "currency",
+            "in": "query",
+            "description": "ISO 4217 three-letter currency code (e.g. 'EUR', 'USD').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerBalanceResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/customer-balance/transactions": {
+      "get": {
+        "tags": ["Customer Balance"],
+        "summary": "Returns paginated transaction history for the current tenant.",
+        "description": "Returns the append-only transaction ledger for the specified currency. Ordered by creation date descending (most recent first). Each entry shows the transaction type, amount, source, and optional reference.",
+        "operationId": "ListBalanceTransactions",
+        "parameters": [
+          {
+            "name": "currency",
+            "in": "query",
+            "description": "ISO 4217 three-letter currency code (e.g. 'EUR', 'USD').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page.",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BalanceTransactionResponse"
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/customer-balance/balance/credit": {
+      "post": {
+        "tags": ["Customer Balance"],
+        "summary": "Adds a manual credit to the tenant's balance.",
+        "description": "Creates a credit transaction on the tenant's balance account. The account is created automatically if it does not exist for the specified currency. Supports optional expiration date for promotional credits.",
+        "operationId": "AddAdminCredit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminCreditRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerBalanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/customer-balance/balance/debit": {
+      "post": {
+        "tags": ["Customer Balance"],
+        "summary": "Debits the tenant's balance manually (admin tooling).",
+        "description": "Creates a ManualAdjustment debit transaction on the tenant's balance account — for corrections, scheduled drawdowns, and non-invoice adjustments. Returns 404 when no account exists for the (tenant, currency); 422 when the balance is insufficient or tenant context is missing. Idempotent at the application level when the same ReferenceId is supplied — replays return the original outcome without double-debiting.",
+        "operationId": "ApplyAdminDebit",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminDebitRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerBalanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AdminCreditRequest": {
+        "required": ["partyId", "amount", "currency", "source", "reason", "expiresAt"],
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "AdminDebitRequest": {
+        "required": ["partyId", "amount", "currency", "reason"],
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "referenceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "referenceType": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "BalanceTransactionResponse": {
+        "required": [
+          "id",
+          "type",
+          "amount",
+          "source",
+          "reason",
+          "referenceId",
+          "referenceType",
+          "expiresAt",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "source": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "referenceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "referenceType": {
+            "type": ["null", "string"]
+          },
+          "expiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CustomerBalanceResponse": {
+        "required": ["balanceAccountId", "currency", "balance", "updatedAt"],
+        "type": "object",
+        "properties": {
+          "balanceAccountId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "balance": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "updatedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Customer Balance"
+    }
+  ]
+}

--- a/contracts/openapi/dashboards.json
+++ b/contracts/openapi/dashboards.json
@@ -1,0 +1,1806 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "dashboards",
+    "version": "1"
+  },
+  "paths": {
+    "/dashboards/catalog": {
+      "get": {
+        "tags": ["Dashboards - Catalogue"],
+        "summary": "Lists every registered DashboardDefinition.",
+        "description": "Returns the full dashboard catalogue surfaced by IDashboardDefinitionRegistry. Each entry carries the wire identifier, category, version, widget count and feature flags (HasViews / HasAliases / HasFilters) that the frontend uses to decide how to render the import dialog. Optionally filters by ?category=... to narrow to a specific section.",
+        "operationId": "ListDashboardCatalog",
+        "parameters": [
+          {
+            "name": "category",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/DashboardCategory"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/DashboardCatalogEntryResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/from-definition/{name}": {
+      "post": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Imports a registered DashboardDefinition into a persisted Dashboard.",
+        "description": "Deep-copies the named DashboardDefinition into a fresh tenant-scoped Dashboard aggregate (status: Draft, sourceDefinitionVersion captured at import time). Multi-view definitions yield a Dashboard whose widgets are the entry view's pool (DefaultView, or the first view when DefaultView is null). Returns 201 with the new dashboard's identifying fields, or 404 when the definition name is not registered.",
+        "operationId": "ImportDashboardFromDefinition",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Unique registered name of the background job.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardImportResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}/resync": {
+      "post": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Resyncs a persisted dashboard with its currently-registered DashboardDefinition.",
+        "description": "Replaces the widget pool with the descriptor's current entry-view widgets, refreshes the structural metadata (layout, isSystem, sourceDefinitionVersion), and best-effort preserves per-instance overrides via Widget:{Name}.{slug} match. The dashboard's user-renamable Name and lifecycle Status are intentionally preserved. Returns 200 with a change-summary, 404 when the dashboard is not found in the current tenant scope, or 409 when resync is not applicable (ad-hoc dashboard, or source definition no longer registered in the host).",
+        "operationId": "ResyncDashboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardResyncResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards": {
+      "get": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Lists the current tenant's persisted dashboards (paged).",
+        "description": "Returns the tenant's dashboards as a paged summary list, optionally filtered by ?status= (Draft / Published / Archived). Results are ordered by Name ascending. Pagination defaults: page=0, pageSize=50; pageSize is capped at 200. Multi-tenant filter is applied by the DbContext — cross-tenant rows are never reachable.",
+        "operationId": "ListDashboards",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status value.",
+            "schema": {
+              "$ref": "#/components/schemas/DashboardStatus"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 0
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page.",
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "default": 50
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PagedResponseOfDashboardSummaryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}": {
+      "get": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Reads a single persisted dashboard with its widget tree.",
+        "description": "Returns the full dashboard payload including the layout values and the ordered widget pool. Multi-tenant filtered — returns 404 when the id is not found in the current tenant's scope (avoids leaking the existence of cross-tenant dashboards).",
+        "operationId": "ReadDashboardById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardDetailResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Updates the dashboard's name and grid layout.",
+        "description": "Full replacement of the editable metadata: Name, LayoutColumns and LayoutRowHeight. FluentValidation runs first (Name not empty, layout values > 0); the domain guards are kept as defense-in-depth and surface as 422 if hit. Returns the updated dashboard summary so callers refresh without a follow-up GET.",
+        "operationId": "UpdateDashboardMetadata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DashboardMetadataUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSummaryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}/publish": {
+      "post": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Transitions the dashboard from Draft to Published.",
+        "description": "Publishes a Draft dashboard, making it visible to consumers. Idempotent — already-Published dashboards return the current state. An Archived dashboard must be Restored before it can be Published (returns 409 Conflict).",
+        "operationId": "PublishDashboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSummaryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}/archive": {
+      "post": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Archives the dashboard.",
+        "description": "Archives the dashboard regardless of its current status. Idempotent — already-Archived dashboards return the current state. Use POST /{id}/restore to bring it back to Draft.",
+        "operationId": "ArchiveDashboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSummaryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}/restore": {
+      "post": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Restores an archived dashboard to Draft.",
+        "description": "Transitions an Archived dashboard back to Draft. Returns 409 Conflict when the dashboard is not Archived (the domain rejects spurious transitions to keep the state machine deterministic).",
+        "operationId": "RestoreDashboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardSummaryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}/render": {
+      "post": {
+        "tags": ["Dashboards - Instances"],
+        "summary": "Renders a dashboard's widget pool into one bundle response.",
+        "description": "Loads the persisted dashboard, builds the per-render context (tenant, principal, period, locale, dashboard filters, resolved entity aliases) and dispatches every widget through its registered IWidgetInstanceRenderer. Each widget surfaces independently as Snapshot / Unavailable / Error — one bad widget cannot 500 the whole render. Multi-tenant filtered through the DbContext (404 for cross-tenant ids — never leaks existence).",
+        "operationId": "RenderDashboard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/DashboardRenderRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DashboardRenderResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}/widgets": {
+      "post": {
+        "tags": ["Dashboards - Widgets"],
+        "summary": "Adds a widget instance to the dashboard.",
+        "description": "Pins a new widget into the dashboard's widget pool. The widget id is allocated server-side. FluentValidation runs first (non-empty type / title / config; non-negative position; positive width and height); the domain guards stay as defense-in-depth and surface as 422 if hit. Returns 201 with the new widget payload, or 404 when the parent dashboard is not in the current tenant's scope.",
+        "operationId": "AddDashboardWidget",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddWidgetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WidgetInstanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/dashboards/{id}/widgets/{widgetId}": {
+      "put": {
+        "tags": ["Dashboards - Widgets"],
+        "summary": "Updates a widget's layout, title and config.",
+        "description": "Full replacement of the widget's editable fields: Position, Width, Height, TitleLocalizationKey, ConfigJson. WidgetType, MetricName, QueryName and RequiredPermission stay immutable — switching widget kind or rebinding to a different metric/query is delete + add, not edit. Returns 200 with the updated widget, 404 when the dashboard or the widget id is not in scope, or 422 when the domain guards reject the input.",
+        "operationId": "UpdateDashboardWidget",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "widgetId",
+            "in": "path",
+            "description": "Unique identifier of the widget.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateWidgetRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WidgetInstanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Dashboards - Widgets"],
+        "summary": "Removes a widget instance from the dashboard.",
+        "description": "Removes the named widget from the dashboard's pool. Returns 204 on successful removal, 404 when the dashboard is not in the current tenant's scope, or when the widget id does not belong to that dashboard. Idempotent retries on a removed widget therefore receive a 404 — callers treat this as benign.",
+        "operationId": "RemoveDashboardWidget",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "widgetId",
+            "in": "path",
+            "description": "Unique identifier of the widget.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AddWidgetRequest": {
+        "required": [
+          "widgetType",
+          "position",
+          "width",
+          "height",
+          "titleLocalizationKey",
+          "configJson"
+        ],
+        "type": "object",
+        "properties": {
+          "widgetType": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "titleLocalizationKey": {
+            "type": "string"
+          },
+          "configJson": {
+            "type": "string"
+          },
+          "metricName": {
+            "type": ["null", "string"]
+          },
+          "queryName": {
+            "type": ["null", "string"]
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DashboardCatalogEntryResponse": {
+        "required": [
+          "name",
+          "category",
+          "isSystem",
+          "version",
+          "widgetCount",
+          "hasViews",
+          "hasAliases",
+          "hasFilters"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/DashboardCategory"
+          },
+          "isSystem": {
+            "type": "boolean"
+          },
+          "version": {
+            "type": "string"
+          },
+          "widgetCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "hasViews": {
+            "type": "boolean"
+          },
+          "hasAliases": {
+            "type": "boolean"
+          },
+          "hasFilters": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DashboardCategory": {
+        "enum": ["General", "Finance", "Operations", "Security", "Compliance", "Platform", "Iot"]
+      },
+      "DashboardDetailResponse": {
+        "required": [
+          "id",
+          "name",
+          "category",
+          "status",
+          "isSystem",
+          "sourceDefinitionName",
+          "sourceDefinitionVersion",
+          "layoutColumns",
+          "layoutRowHeight",
+          "widgets"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/DashboardCategory"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DashboardStatus"
+          },
+          "isSystem": {
+            "type": "boolean"
+          },
+          "sourceDefinitionName": {
+            "type": ["null", "string"]
+          },
+          "sourceDefinitionVersion": {
+            "type": ["null", "string"]
+          },
+          "layoutColumns": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "layoutRowHeight": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "widgets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WidgetInstanceResponse"
+            }
+          }
+        }
+      },
+      "DashboardDriftStatus": {
+        "enum": ["NotApplicable", "Aligned", "Behind", "Ahead", "Unknown", "SourceUnregistered"]
+      },
+      "DashboardImportResponse": {
+        "required": [
+          "id",
+          "name",
+          "category",
+          "status",
+          "sourceDefinitionName",
+          "sourceDefinitionVersion",
+          "widgetCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/DashboardCategory"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DashboardStatus"
+          },
+          "sourceDefinitionName": {
+            "type": "string"
+          },
+          "sourceDefinitionVersion": {
+            "type": "string"
+          },
+          "widgetCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "DashboardMetadataUpdateRequest": {
+        "required": ["name", "layoutColumns", "layoutRowHeight"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "layoutColumns": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "layoutRowHeight": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "DashboardRenderedWidgetResponse": {
+        "required": [
+          "id",
+          "widgetType",
+          "slug",
+          "position",
+          "width",
+          "height",
+          "titleLocalizationKey",
+          "actions",
+          "requiredPermission",
+          "status",
+          "sequence",
+          "emittedAt",
+          "refreshHint",
+          "transport",
+          "snapshot"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "widgetType": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "titleLocalizationKey": {
+            "type": "string"
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/WidgetAction"
+            }
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "$ref": "#/components/schemas/WidgetSnapshotStatus"
+          },
+          "sequence": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "emittedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "refreshHint": {
+            "$ref": "#/components/schemas/RefreshHint"
+          },
+          "transport": {
+            "$ref": "#/components/schemas/WidgetTransport"
+          },
+          "snapshot": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/JsonElement"
+              }
+            ]
+          },
+          "reasonLocalizationKey": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DashboardRenderPeriodResponse": {
+        "required": ["from", "to"],
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "to": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "token": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DashboardRenderRequest": {
+        "type": "object",
+        "properties": {
+          "periodFrom": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodTo": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodToken": {
+            "type": ["null", "string"]
+          },
+          "locale": {
+            "type": ["null", "string"]
+          },
+          "filters": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "viewName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DashboardRenderResponse": {
+        "required": [
+          "dashboardId",
+          "renderedAt",
+          "period",
+          "activeViewName",
+          "driftStatus",
+          "sourceDefinitionVersion",
+          "registeredVersion",
+          "widgets"
+        ],
+        "type": "object",
+        "properties": {
+          "dashboardId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "renderedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "period": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DashboardRenderPeriodResponse"
+              }
+            ]
+          },
+          "activeViewName": {
+            "type": ["null", "string"]
+          },
+          "driftStatus": {
+            "$ref": "#/components/schemas/DashboardDriftStatus"
+          },
+          "sourceDefinitionVersion": {
+            "type": ["null", "string"]
+          },
+          "registeredVersion": {
+            "type": ["null", "string"]
+          },
+          "widgets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardRenderedWidgetResponse"
+            }
+          }
+        }
+      },
+      "DashboardResyncResponse": {
+        "required": [
+          "id",
+          "name",
+          "status",
+          "sourceDefinitionName",
+          "previousSourceDefinitionVersion",
+          "sourceDefinitionVersion",
+          "widgetsAdded",
+          "widgetsRemoved",
+          "overridesCarriedOver"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DashboardStatus"
+          },
+          "sourceDefinitionName": {
+            "type": "string"
+          },
+          "previousSourceDefinitionVersion": {
+            "type": ["null", "string"]
+          },
+          "sourceDefinitionVersion": {
+            "type": "string"
+          },
+          "widgetsAdded": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "widgetsRemoved": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "overridesCarriedOver": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "DashboardStatus": {
+        "enum": ["Draft", "Published", "Archived"]
+      },
+      "DashboardSummaryResponse": {
+        "required": [
+          "id",
+          "name",
+          "category",
+          "status",
+          "isSystem",
+          "sourceDefinitionName",
+          "sourceDefinitionVersion",
+          "widgetCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/DashboardCategory"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DashboardStatus"
+          },
+          "isSystem": {
+            "type": "boolean"
+          },
+          "sourceDefinitionName": {
+            "type": ["null", "string"]
+          },
+          "sourceDefinitionVersion": {
+            "type": ["null", "string"]
+          },
+          "widgetCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "JsonElement": {
+        "type": ["null", "boolean", "number", "string", "object", "array"],
+        "description": "Arbitrary JSON value (object, array, string, number, boolean, or null)."
+      },
+      "PagedResponseOfDashboardSummaryResponse": {
+        "required": ["items", "totalCount", "page", "pageSize"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DashboardSummaryResponse"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "page": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "pageSize": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "RefreshHint": {
+        "enum": ["Static", "Dynamic", "Realtime"]
+      },
+      "UpdateWidgetRequest": {
+        "required": ["position", "width", "height", "titleLocalizationKey", "configJson"],
+        "type": "object",
+        "properties": {
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "titleLocalizationKey": {
+            "type": "string"
+          },
+          "configJson": {
+            "type": "string"
+          }
+        }
+      },
+      "WidgetAction": {
+        "required": ["trigger", "kind", "target"],
+        "type": "object",
+        "properties": {
+          "trigger": {
+            "$ref": "#/components/schemas/WidgetActionTrigger"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/WidgetActionKind"
+          },
+          "target": {
+            "type": "string"
+          },
+          "params": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "WidgetActionKind": {
+        "enum": ["Navigate", "OpenDashboardView", "OpenDashboard", "ExportData", "OpenDetail"]
+      },
+      "WidgetActionTrigger": {
+        "enum": ["Click", "RowClick", "SeriesClick", "LegendClick"]
+      },
+      "WidgetInstanceResponse": {
+        "required": [
+          "id",
+          "widgetType",
+          "position",
+          "width",
+          "height",
+          "titleLocalizationKey",
+          "metricName",
+          "queryName",
+          "configJson",
+          "requiredPermission"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "widgetType": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "height": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "titleLocalizationKey": {
+            "type": "string"
+          },
+          "metricName": {
+            "type": ["null", "string"]
+          },
+          "queryName": {
+            "type": ["null", "string"]
+          },
+          "configJson": {
+            "type": "string"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "WidgetSnapshotStatus": {
+        "enum": ["Snapshot", "Unavailable", "Error"]
+      },
+      "WidgetTransport": {
+        "enum": ["Pull", "Push"]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Dashboards - Catalogue"
+    },
+    {
+      "name": "Dashboards - Instances"
+    },
+    {
+      "name": "Dashboards - Widgets"
+    }
+  ]
+}

--- a/contracts/openapi/documents-properties.json
+++ b/contracts/openapi/documents-properties.json
@@ -1,0 +1,384 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "documents-properties",
+    "version": "1"
+  },
+  "paths": {
+    "/documents/documents/{id}/metadata": {
+      "get": {
+        "tags": ["Documents - Properties"],
+        "summary": "Returns extracted metadata for the document's current version.",
+        "description": "Surfaces the typed projection (camera, dimensions, page count, audio track …) plus the verbatim extractor payload under `rawMetadata`. Returns 404 when the document is missing, excluded by the tenant filter, or extraction has not yet completed for the current version.",
+        "operationId": "GetDocumentProperties",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentPropertiesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/versions/{versionId}/metadata": {
+      "get": {
+        "tags": ["Documents - Properties"],
+        "summary": "Returns extracted metadata for a specific version of the document.",
+        "description": "Same shape as the current-version endpoint, addressed by an explicit version identifier. Useful for audit trails or comparing metadata between revisions. Returns 404 when the document or version is missing, the version does not belong to the supplied document, or no metadata row has been produced yet.",
+        "operationId": "GetDocumentVersionProperties",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "versionId",
+            "in": "path",
+            "description": "Unique identifier of the version.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentPropertiesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DocumentPropertiesResponse": {
+        "required": [
+          "id",
+          "documentId",
+          "documentVersionId",
+          "sourceContentType",
+          "status",
+          "createdAt",
+          "completedAt",
+          "failureReason",
+          "extractorCount",
+          "width",
+          "height",
+          "cameraMake",
+          "cameraModel",
+          "lensModel",
+          "iso",
+          "fNumber",
+          "exposureTimeMs",
+          "takenAt",
+          "gpsLatitude",
+          "gpsLongitude",
+          "gpsAltitude",
+          "pageCount",
+          "title",
+          "author",
+          "subject",
+          "keywords",
+          "producer",
+          "revision",
+          "lastModifiedBy",
+          "durationMs",
+          "codec",
+          "bitrate",
+          "artist",
+          "album",
+          "trackNumber",
+          "genre",
+          "rawMetadata"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentVersionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sourceContentType": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DocumentPropertiesStatus"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "failureReason": {
+            "type": ["null", "string"]
+          },
+          "extractorCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "width": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "height": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "cameraMake": {
+            "type": ["null", "string"]
+          },
+          "cameraModel": {
+            "type": ["null", "string"]
+          },
+          "lensModel": {
+            "type": ["null", "string"]
+          },
+          "iso": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "fNumber": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "exposureTimeMs": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "takenAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "gpsLatitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "gpsLongitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "gpsAltitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "pageCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "author": {
+            "type": ["null", "string"]
+          },
+          "subject": {
+            "type": ["null", "string"]
+          },
+          "keywords": {
+            "type": ["null", "string"]
+          },
+          "producer": {
+            "type": ["null", "string"]
+          },
+          "revision": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "lastModifiedBy": {
+            "type": ["null", "string"]
+          },
+          "durationMs": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["null", "integer", "string"],
+            "format": "int64"
+          },
+          "codec": {
+            "type": ["null", "string"]
+          },
+          "bitrate": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "artist": {
+            "type": ["null", "string"]
+          },
+          "album": {
+            "type": ["null", "string"]
+          },
+          "trackNumber": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "genre": {
+            "type": ["null", "string"]
+          },
+          "rawMetadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "DocumentPropertiesStatus": {
+        "enum": ["Pending", "Extracting", "Ready", "Failed"]
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Documents - Properties"
+    }
+  ]
+}

--- a/contracts/openapi/documents-public-links.json
+++ b/contracts/openapi/documents-public-links.json
@@ -1,0 +1,529 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "documents-public-links",
+    "version": "1"
+  },
+  "paths": {
+    "/documents/documents/{id}/public-links": {
+      "post": {
+        "tags": ["Documents - Public Links"],
+        "summary": "Mints a fresh public link for a document.",
+        "description": "Generates a 32-byte random bearer token, persists only its HMAC-SHA256 digest, and returns the raw token together with the fully-qualified redemption URL. The token is shown exactly once and is never recoverable after this response. `ttlDays` is clamped down to the configured maximum; `maxUses` falls back to the configured default when omitted. Returns 422 when the document is missing or excluded by the tenant filter.",
+        "operationId": "CreateDocumentPublicLink",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePublicLinkRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreatePublicLinkResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Documents - Public Links"],
+        "summary": "Lists every public link issued against a document.",
+        "description": "Newest-first listing. The raw token and its HMAC digest are deliberately omitted — the bearer is only ever shown at creation time. Returns an empty array when the document has no links (or does not exist for the current tenant).",
+        "operationId": "ListDocumentPublicLinks",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PublicLinkResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/public-links/{id}": {
+      "delete": {
+        "tags": ["Documents - Public Links"],
+        "summary": "Revokes an existing public link.",
+        "description": "Idempotency is not enforced: revoking an already-revoked link returns 422. The optional `reason` is persisted on the aggregate and surfaced on the audit trail (DocumentPublicLinkRevokedEvent / Eto).",
+        "operationId": "RevokeDocumentPublicLink",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/RevokePublicLinkRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/p/{token}": {
+      "get": {
+        "tags": ["Documents - Public Links"],
+        "summary": "Resolves a bearer token and serves the document as an attachment.",
+        "description": "Anonymous endpoint — no authentication is required. The token is hashed with the host's signing key, looked up bypassing the tenant filter, and validated (not revoked, not expired, MaxUses not exhausted). On success the response is a 302 redirect to a short-lived presigned blob URL with `Content-Disposition: attachment`. EVERY failure path returns 404 with no body — invalid, expired, revoked, exhausted and not-yet-finalised links are indistinguishable on the wire.",
+        "operationId": "RedeemDocumentPublicLinkDownload",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "Single-use token from a confirmation/reset email link.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Found"
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [{}]
+      }
+    },
+    "/p/{token}/preview": {
+      "get": {
+        "tags": ["Documents - Public Links"],
+        "summary": "Resolves a bearer token and serves the document inline.",
+        "description": "Anonymous endpoint — no authentication is required. Same resolution path as the download endpoint, but the presigned URL is issued without a forced `Content-Disposition: attachment` header so the browser may preview the bytes inline. EVERY failure path returns 404 with no body.",
+        "operationId": "RedeemDocumentPublicLinkPreview",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "Single-use token from a confirmation/reset email link.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Found"
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [{}]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreatePublicLinkRequest": {
+        "required": ["scope", "ttlDays", "maxUses"],
+        "type": "object",
+        "properties": {
+          "scope": {
+            "$ref": "#/components/schemas/PublicLinkScope"
+          },
+          "ttlDays": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxUses": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          }
+        }
+      },
+      "CreatePublicLinkResponse": {
+        "required": ["id", "documentId", "token", "url", "scope", "expiresAt", "maxUses"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "token": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/PublicLinkScope"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "maxUses": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "PublicLinkResponse": {
+        "required": [
+          "id",
+          "documentId",
+          "scope",
+          "expiresAt",
+          "maxUses",
+          "currentUses",
+          "revokedAt",
+          "revocationReason",
+          "createdAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "scope": {
+            "$ref": "#/components/schemas/PublicLinkScope"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "maxUses": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "currentUses": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "revokedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "revocationReason": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PublicLinkScope": {
+        "enum": ["Download", "View"]
+      },
+      "RevokePublicLinkRequest": {
+        "required": ["reason"],
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Documents - Public Links"
+    }
+  ]
+}

--- a/contracts/openapi/documents-renditions.json
+++ b/contracts/openapi/documents-renditions.json
@@ -1,0 +1,307 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "documents-renditions",
+    "version": "1"
+  },
+  "paths": {
+    "/documents/documents/{id}/renditions": {
+      "get": {
+        "tags": ["Documents - Renditions"],
+        "summary": "Lists every rendition for a document's current version.",
+        "description": "Returns each rendition row (any status — including Pending and Failed) so the UI can render placeholders or surface errors. Ordered by Type then Format. Returns 404 when the document is not found or has no current version.",
+        "operationId": "ListDocumentRenditions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListRenditionsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/renditions/{type}/download": {
+      "get": {
+        "tags": ["Documents - Renditions"],
+        "summary": "Issues a presigned download URL for a Ready rendition.",
+        "description": "Returns a short-lived presigned URL the client can use to download the rendition bytes directly from blob storage. Pass `?format=image/webp` to pick a specific MIME when several renditions of the requested Type are Ready; otherwise the first Ready row wins. Returns 404 when the document is missing or no rendition of the requested Type / Format is yet in Ready status — on-demand synchronous generation is deferred to a follow-up; until then callers retry once the F16.4 background job completes.",
+        "operationId": "RequestRenditionDownloadUrl",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "type",
+            "in": "path",
+            "description": "Filter by type discriminator value.",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/RenditionType"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RenditionDownloadUrlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ListRenditionsResponse": {
+        "required": ["documentId", "documentVersionId", "renditions"],
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentVersionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "renditions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RenditionResponse"
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "RenditionDownloadUrlResponse": {
+        "required": ["url", "expiresAt"],
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "RenditionResponse": {
+        "required": [
+          "id",
+          "documentId",
+          "documentVersionId",
+          "type",
+          "format",
+          "status",
+          "sizeBytes",
+          "width",
+          "height",
+          "createdAt",
+          "completedAt",
+          "failureReason"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentVersionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "$ref": "#/components/schemas/RenditionType"
+          },
+          "format": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/RenditionStatus"
+          },
+          "sizeBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["null", "integer", "string"],
+            "format": "int64"
+          },
+          "width": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "height": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "failureReason": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "RenditionStatus": {
+        "enum": ["Pending", "Generating", "Ready", "Failed"]
+      },
+      "RenditionType": {
+        "enum": ["Thumbnail", "Web", "Print", "Poster"]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Documents - Renditions"
+    }
+  ]
+}

--- a/contracts/openapi/documents-resolution.json
+++ b/contracts/openapi/documents-resolution.json
@@ -1,0 +1,303 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "documents-resolution",
+    "version": "1"
+  },
+  "paths": {
+    "/documents/resolution/resolve": {
+      "post": {
+        "tags": ["Documents - Resolution"],
+        "summary": "Resolves a batch of document assets into stable render-ready descriptors.",
+        "description": "Each item in the request array is resolved to a stable URL backed by a long-TTL DocumentPublicLink, with dimensions and MIME type from the best available source (Ready rendition when found, original document otherwise). A null slot in the response indicates a missing or revoked document — partial success is intentional. Maximum 100 items per request.",
+        "operationId": "BatchResolveDocumentAssets",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchResolveRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ResolvedDocumentResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/r/{token}": {
+      "get": {
+        "tags": ["Documents - Resolution"],
+        "summary": "Resolves a public-link token and serves the document or rendition inline.",
+        "description": "Anonymous endpoint — no authentication required. Validates the bearer token, then tries to redirect to the requested rendition if `renditionType` is provided and a Ready rendition exists; falls back to the original document inline preview. Every failure path returns 404 with no body (no info disclosure).",
+        "operationId": "ServeResolvedDocument",
+        "parameters": [
+          {
+            "name": "token",
+            "in": "path",
+            "description": "Single-use token from a confirmation/reset email link.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "renditionType",
+            "in": "query",
+            "schema": {
+              "$ref": "#/components/schemas/RenditionType"
+            }
+          },
+          {
+            "name": "renditionFormat",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "302": {
+            "description": "Found"
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [{}]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BatchResolveRequest": {
+        "required": ["requests"],
+        "type": "object",
+        "properties": {
+          "requests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ResolveItemRequest"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "RenditionType": {
+        "enum": ["Thumbnail", "Web", "Print", "Poster", null]
+      },
+      "ResolvedDocumentResponse": {
+        "required": [
+          "documentId",
+          "versionId",
+          "url",
+          "width",
+          "height",
+          "mimeType",
+          "sizeBytes",
+          "lastModified"
+        ],
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "versionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "height": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "mimeType": {
+            "type": ["null", "string"]
+          },
+          "sizeBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["null", "integer", "string"],
+            "format": "int64"
+          },
+          "lastModified": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "ResolveItemRequest": {
+        "required": ["documentId"],
+        "type": "object",
+        "properties": {
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "versionId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "renditionType": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/RenditionType"
+              }
+            ]
+          },
+          "renditionFormat": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Documents - Resolution"
+    }
+  ]
+}

--- a/contracts/openapi/documents.json
+++ b/contracts/openapi/documents.json
@@ -1,0 +1,4017 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "documents",
+    "version": "1"
+  },
+  "paths": {
+    "/documents/folders": {
+      "get": {
+        "tags": ["Documents - Folders"],
+        "summary": "Lists child folders under a parent (defaults to the tenant root).",
+        "description": "Returns the children of the folder identified by the optional `parentId` query parameter. When `parentId` is omitted, the children of the invisible tenant root are returned. The tenant root itself is always filtered out of the result set. Pass `?status=Trashed` to read the trash listing for the same parent (F8.1); the default is `Active`.",
+        "operationId": "ListFolders",
+        "parameters": [
+          {
+            "name": "parentId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by status value.",
+            "schema": {
+              "$ref": "#/components/schemas/FolderStatus"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListFoldersResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Documents - Folders"],
+        "summary": "Creates a folder under the given parent (or under the tenant root).",
+        "description": "Creates a new folder under `parentFolderId`. When `parentFolderId` is omitted the folder is created directly under the invisible tenant root, which is auto-bootstrapped on first access for the tenant. The folder name is validated against length, the reserved path separator '/', and parent-scoped uniqueness.",
+        "operationId": "CreateFolder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateFolderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/folders/{id}": {
+      "get": {
+        "tags": ["Documents - Folders"],
+        "summary": "Returns a folder by id.",
+        "description": "Returns the folder identified by `id`, including the materialised path and depth. Returns 404 when the folder does not exist or when the caller's tenant filter excludes it. The tenant root itself is also returned as 404 because it is not user-visible.",
+        "operationId": "GetFolder",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Documents - Folders"],
+        "summary": "Renames a folder.",
+        "description": "Renames the folder identified by `id`. The materialised path is recomputed atomically. Descendant paths are updated by the move-folder endpoint (F2.4) — rename does not modify descendants. The tenant root cannot be renamed.",
+        "operationId": "RenameFolder",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameFolderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Documents - Folders"],
+        "summary": "Sends a folder to the trash (soft-delete).",
+        "description": "Moves the folder identified by `id` to the trash. Cascade-trashes every active descendant folder and document in a single transaction (F8.1). Permanent deletion happens after the configured retention period via the empty-trash background job (F8/F9.2). The tenant root cannot be trashed.",
+        "operationId": "TrashFolder",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/folders/{id}/breadcrumb": {
+      "get": {
+        "tags": ["Documents - Folders"],
+        "summary": "Returns the chain of ancestors plus the folder itself.",
+        "description": "Returns the chain of folders from the first user-visible ancestor (closest to the tenant root) down to and including the folder identified by `id`. The invisible tenant root is excluded from the chain so the client never has to know about it. Returns 404 when the folder does not exist or is the tenant root.",
+        "operationId": "GetFolderBreadcrumb",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderBreadcrumbResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/folders/{id}/move": {
+      "post": {
+        "tags": ["Documents - Folders"],
+        "summary": "Moves a folder under a new parent.",
+        "description": "Moves the folder identified by `id` under `newParentFolderId` (or under the invisible tenant root when omitted). The materialised path and depth of the moved folder AND every descendant are re-materialised in a single SQL UPDATE within the same transaction. Cycles, cross-tenant moves, and moves under a trashed or descendant target are rejected. The tenant root cannot be moved.",
+        "operationId": "MoveFolder",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveFolderRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/folders/{id}/owner": {
+      "put": {
+        "tags": ["Documents - Folders"],
+        "summary": "Transfers folder ownership to another user.",
+        "description": "Replaces `OwnerId` with the user identified by `newOwnerId`. The previous owner loses any owner-based access derived from `OwnedByCurrentUserHandler`; explicit share grants on this folder survive the transfer. Emits a `FolderOwnerChangedEvent` for the ISO 27001 audit trail. The tenant root cannot be transferred (422). Returns 422 when `newOwnerId` is empty or when the folder is trashed; 404 when the folder is missing.",
+        "operationId": "TransferFolderOwnership",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferFolderOwnershipRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/folders/{id}/restore": {
+      "post": {
+        "tags": ["Documents - Folders"],
+        "summary": "Restores a trashed folder.",
+        "description": "Sets the folder identified by `id` back to `Active`. Descendants stay trashed unless restored individually (per F8.1 — restore is non-cascading by design). Returns 404 when the folder is missing or not currently trashed; 409 when the parent folder is itself trashed (callers must restore the parent first).",
+        "operationId": "RestoreFolder",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FolderResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/upload-ticket": {
+      "post": {
+        "tags": ["Documents"],
+        "summary": "Issues a presigned upload ticket for direct client-to-cloud transfer.",
+        "description": "Issues a presigned PUT URL backed by Granit.BlobStorage. The client uploads the bytes directly to the configured cloud provider (no proxying through the API), then calls POST /documents/finalize with the returned blobId. Tickets expire after the BlobStorage-configured TTL (default 15 minutes).",
+        "operationId": "RequestDocumentUploadTicket",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadTicketRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UploadTicketResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/finalize": {
+      "post": {
+        "tags": ["Documents"],
+        "summary": "Confirms the upload and creates the Document + initial version.",
+        "description": "Confirms with BlobStorage that the bytes have arrived and pass validation, then atomically creates the Document aggregate plus its initial v1 DocumentVersion under the requested folder (or the tenant root when folderId is omitted). Returns 422 when the blob fails validation, 404 when the target folder is missing.",
+        "operationId": "FinalizeDocumentUpload",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinalizeUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/versions": {
+      "post": {
+        "tags": ["Documents"],
+        "summary": "Appends a new version to an existing document.",
+        "description": "Confirms with BlobStorage that the bytes have arrived and pass validation, then atomically appends a new DocumentVersion under the parent document with VersionNumber = max + 1 and updates Document.CurrentVersionId. Optimistic concurrency on Document.ConcurrencyStamp plus the unique index on (DocumentId, VersionNumber) protect concurrent uploaders. Returns 422 when the blob fails validation or the document is trashed; 404 when the document is missing or excluded by the tenant filter.",
+        "operationId": "AppendDocumentVersion",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AppendVersionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentVersionResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Documents"],
+        "summary": "Lists the version history of a document.",
+        "description": "Returns a paged slice of the document's version history ordered by VersionNumber descending (latest first). The currently-active version is flagged via `isCurrent: true`. Use `?skip=` and `?take=` to page; defaults are skip=0, take=50 (max 200). Returns 404 when the document is missing or excluded by the tenant filter.",
+        "operationId": "ListDocumentVersions",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDocumentVersionsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/trash": {
+      "get": {
+        "tags": ["Documents"],
+        "summary": "Lists trashed documents for the current tenant (F8.2).",
+        "description": "Returns a paged slice of trashed documents ordered by `TrashedAt` descending. Each row carries `daysUntilPermanentDeletion`, derived from the trash retention window (`GranitDocumentsOptions.TrashRetentionDays`, default 30 days). Defaults are `skip=0` and `take=50` (max 200).",
+        "operationId": "ListTrashedDocuments",
+        "parameters": [
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListTrashedDocumentsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}": {
+      "get": {
+        "tags": ["Documents"],
+        "summary": "Returns a document by id.",
+        "description": "Returns the document identified by `id`, including its current version pointer and folder placement. 404 when the document is not found or excluded by the tenant filter.",
+        "operationId": "GetDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Documents"],
+        "summary": "Renames a document and / or updates its description.",
+        "description": "Partial update — fields left null are unchanged. Send `clearDescription: true` to drop the description (sending an empty string sets a non-null empty value, which is rarely what callers want). 404 when the document is missing; 409 when the document is trashed.",
+        "operationId": "RenameDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Documents"],
+        "summary": "Sends a document to the trash (soft-delete).",
+        "description": "Moves the document identified by `id` to the trash. Permanent deletion happens after the configured retention period via the empty-trash background job (F8 / F9.2). Already-trashed documents surface as 409.",
+        "operationId": "TrashDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/move": {
+      "post": {
+        "tags": ["Documents"],
+        "summary": "Moves a document under a different folder.",
+        "description": "Moves the document identified by `id` under `newFolderId` (or under the tenant root when omitted). Cross-tenant moves and moves into trashed or missing folders surface as 409 Conflict.",
+        "operationId": "MoveDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveDocumentRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/owner": {
+      "put": {
+        "tags": ["Documents"],
+        "summary": "Transfers document ownership to another user.",
+        "description": "Replaces `OwnerId` with the user identified by `newOwnerId`. The previous owner loses any owner-based access derived from `OwnedByCurrentUserHandler`; explicit share grants on this document survive the transfer. Emits a `DocumentOwnerChangedEvent` for the ISO 27001 audit trail. Returns 422 when `newOwnerId` is empty or when the document is trashed / permanently deleted; 404 when the document is missing.",
+        "operationId": "TransferDocumentOwnership",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransferOwnershipRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/restore": {
+      "post": {
+        "tags": ["Documents"],
+        "summary": "Restores a trashed document.",
+        "description": "Sets the document identified by `id` back to `Active`. Returns 404 when the document is missing or not currently trashed; 409 when the parent folder is itself trashed (callers must restore the folder first).",
+        "operationId": "RestoreDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/permanent": {
+      "delete": {
+        "tags": ["Documents"],
+        "summary": "Permanently deletes a trashed document (F8.2).",
+        "description": "Soft-deletes every version's `BlobDescriptor` (the bytes are removed; the audit row is retained per `Granit.BlobStorage`'s 3-year retention), decrements the tenant's storage quota by the released bytes, and promotes the document to `Status = PermanentlyDeleted` (tombstone for the GDPR / ISO 27001 audit trail). Emits `DocumentPermanentlyDeletedEvent`. Returns 204 on success, 404 when the document is missing or not currently trashed.",
+        "operationId": "PermanentlyDeleteDocument",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/download": {
+      "get": {
+        "tags": ["Documents"],
+        "summary": "Issues a presigned download URL for a document version.",
+        "description": "Returns a JSON response carrying a short-lived presigned URL the client can use to download the bytes directly from the configured cloud provider. Defaults to the document's CurrentVersionId; pass `?versionId={guid}` to download a specific historical version. Emits a DocumentDownloadedEvent for the ISO 27001 audit trail and increments granit.documents.download.count. Returns 404 when the document or version is not found, 409 when the document is trashed or has no current version yet.",
+        "operationId": "RequestDocumentDownloadUrl",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "versionId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DownloadUrlResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/tags": {
+      "get": {
+        "tags": ["Documents"],
+        "summary": "Lists every tag currently assigned to a document.",
+        "description": "Proxy over Granit.Taxonomy: returns the tags assigned to the document with TargetType = Granit.Documents.Domain.Document. The canonical store lives in Taxonomy; this endpoint is purely a UX shortcut on the Documents surface. Permission: Documents.Documents.Read.",
+        "operationId": "ListDocumentTags",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListDocumentTagsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{id}/tags/{tagId}": {
+      "post": {
+        "tags": ["Documents"],
+        "summary": "Assigns a tag to a document.",
+        "description": "Idempotent assignment: re-posting the same (document, tag) pair returns the existing row instead of creating a duplicate. Delegates to Granit.Taxonomy's TagAssignmentService. Permission: Documents.Documents.Manage.",
+        "operationId": "AssignDocumentTag",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "tagId",
+            "in": "path",
+            "description": "Unique identifier of the tag.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentTagAssignmentResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DocumentTagAssignmentResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Documents"],
+        "summary": "Removes a tag assignment from a document.",
+        "description": "Deletes the (document, tag) assignment row. Returns 404 when no row matches (typically because the tag was never assigned, or has already been removed). Permission: Documents.Documents.Manage.",
+        "operationId": "UnassignDocumentTag",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "tagId",
+            "in": "path",
+            "description": "Unique identifier of the tag.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/folders/{folderId}/shares": {
+      "get": {
+        "tags": ["Documents - Shares"],
+        "summary": "Lists active share grants on a folder.",
+        "description": "Returns the share grants on the folder identified by `folderId`, ordered by creation time. Expired grants are excluded. The path-based inheritance (F6.4) is not flattened in this listing — callers see only grants directly attached to this folder.",
+        "operationId": "ListFolderShares",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Unique identifier of the folder.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSharesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Documents - Shares"],
+        "summary": "Grants a share on a folder.",
+        "description": "Creates a `DocumentShare` row targeting the folder identified by `folderId`. When `isDefault` is true (the default), the grant inherits to descendants via the path-based effective-permission resolver introduced by F6.4 — F6.1 only persists the flag.",
+        "operationId": "GrantFolderShare",
+        "parameters": [
+          {
+            "name": "folderId",
+            "in": "path",
+            "description": "Unique identifier of the folder.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantShareRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/{documentId}/shares": {
+      "get": {
+        "tags": ["Documents - Shares"],
+        "summary": "Lists active share grants on a document.",
+        "description": "Returns the share grants on the document identified by `documentId`, ordered by creation time. Expired grants are excluded. Inherited grants from the document's parent folder are not included — see the F6.5 effective ACL field on document list responses for the resolved view.",
+        "operationId": "ListDocumentShares",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "Unique identifier of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListSharesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Documents - Shares"],
+        "summary": "Grants a share on a document.",
+        "description": "Creates a `DocumentShare` row targeting the document identified by `documentId`. The `isDefault` flag is ignored for document shares.",
+        "operationId": "GrantDocumentShare",
+        "parameters": [
+          {
+            "name": "documentId",
+            "in": "path",
+            "description": "Unique identifier of the document.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GrantShareRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ShareResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/shares/{id}": {
+      "delete": {
+        "tags": ["Documents - Shares"],
+        "summary": "Revokes a share grant.",
+        "description": "Deletes the share row identified by `id` and emits `DocumentShareRevokedEvent` for downstream cache invalidation (F6.3). Returns 404 when the share does not exist or is excluded by the tenant filter.",
+        "operationId": "RevokeShare",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/quota": {
+      "get": {
+        "tags": ["Documents - Quotas"],
+        "summary": "Returns the current tenant's storage quota usage.",
+        "description": "Returns the active `LimitBytes` / `UsageBytes` pair for the calling tenant plus a precomputed `percentUsed` ratio. The quota row is lazy-created on first call (mirrors the F2.2 tenant-root bootstrap), so a brand-new tenant always sees `UsageBytes = 0` instead of a 404. Returns 401 when the request carries no tenant context.",
+        "operationId": "GetTenantStorageQuota",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TenantStorageQuotaResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents": {
+      "get": {
+        "tags": ["Documents"],
+        "summary": "Returns a filtered, sorted, and paginated list of Document entries.",
+        "description": "Executes a dynamic query against Document using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryDocument",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfDocument"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfDocument"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/documents/documents/meta": {
+      "get": {
+        "tags": ["Documents"],
+        "summary": "Returns query metadata for Document (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Document: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetDocumentMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AppendVersionRequest": {
+        "required": ["blobId", "commitMessage"],
+        "type": "object",
+        "properties": {
+          "blobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "commitMessage": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "CreateFolderRequest": {
+        "required": ["parentFolderId", "name"],
+        "type": "object",
+        "properties": {
+          "parentFolderId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "Document": {
+        "type": "object",
+        "properties": {
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "folderId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "currentVersionId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "currentVersionSizeBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["null", "integer", "string"],
+            "format": "int64"
+          },
+          "currentVersionContentType": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "$ref": "#/components/schemas/DocumentStatus"
+          },
+          "trashedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "concurrencyStamp": {
+            "type": "string"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "DocumentResponse": {
+        "required": [
+          "id",
+          "folderId",
+          "name",
+          "description",
+          "ownerId",
+          "currentVersionId",
+          "status",
+          "trashedAt",
+          "sizeBytes",
+          "contentType",
+          "createdAt",
+          "modifiedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "folderId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "currentVersionId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "trashedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sizeBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["null", "integer", "string"],
+            "format": "int64"
+          },
+          "contentType": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "permission": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DocumentStatus": {
+        "enum": ["Active", "Trashed", "PermanentlyDeleted"]
+      },
+      "DocumentTagAssignmentResponse": {
+        "required": ["id", "tenantId", "tagId", "documentId", "assignedAt", "assignedByUserId"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "tagId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "assignedByUserId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "DocumentTagResponse": {
+        "required": ["id", "tenantId", "scope", "name", "color", "hideOnEntityCard"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "hideOnEntityCard": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DocumentVersionResponse": {
+        "required": [
+          "id",
+          "documentId",
+          "versionNumber",
+          "blobDescriptorId",
+          "sizeBytes",
+          "contentType",
+          "contentHash",
+          "uploadedByUserId",
+          "uploadedAt",
+          "commitMessage",
+          "isCurrent"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "versionNumber": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "blobDescriptorId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sizeBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "contentHash": {
+            "type": ["null", "string"]
+          },
+          "uploadedByUserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "uploadedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "commitMessage": {
+            "type": ["null", "string"]
+          },
+          "isCurrent": {
+            "type": "boolean"
+          }
+        }
+      },
+      "DownloadUrlResponse": {
+        "required": ["url", "expiresAt"],
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "FinalizeUploadRequest": {
+        "required": ["blobId", "folderId", "name", "description", "commitMessage"],
+        "type": "object",
+        "properties": {
+          "blobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "folderId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "commitMessage": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "FolderBreadcrumbResponse": {
+        "required": ["folders"],
+        "type": "object",
+        "properties": {
+          "folders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FolderResponse"
+            }
+          }
+        }
+      },
+      "FolderResponse": {
+        "required": [
+          "id",
+          "parentFolderId",
+          "name",
+          "path",
+          "depth",
+          "ownerId",
+          "status",
+          "trashedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "parentFolderId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "path": {
+            "type": "string"
+          },
+          "depth": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "trashedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "permission": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "FolderStatus": {
+        "enum": ["Active", "Trashed", null]
+      },
+      "GrantShareRequest": {
+        "required": ["granteeType", "granteeId", "permission"],
+        "type": "object",
+        "properties": {
+          "granteeType": {
+            "$ref": "#/components/schemas/ShareGranteeType"
+          },
+          "granteeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/SharePermissionLevel"
+          },
+          "isDefault": {
+            "type": "boolean",
+            "default": true
+          },
+          "expiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfDocument": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfDocument"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfDocument": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Document"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "ListDocumentTagsResponse": {
+        "required": ["items"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentTagResponse"
+            }
+          }
+        }
+      },
+      "ListDocumentVersionsResponse": {
+        "required": ["versions", "totalCount", "skip", "take"],
+        "type": "object",
+        "properties": {
+          "versions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DocumentVersionResponse"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "skip": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "take": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ListFoldersResponse": {
+        "required": ["folders"],
+        "type": "object",
+        "properties": {
+          "folders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FolderResponse"
+            }
+          }
+        }
+      },
+      "ListSharesResponse": {
+        "required": ["items"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ShareResponse"
+            }
+          }
+        }
+      },
+      "ListTrashedDocumentsResponse": {
+        "required": ["documents", "totalCount", "skip", "take"],
+        "type": "object",
+        "properties": {
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TrashedDocumentResponse"
+            }
+          },
+          "totalCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "skip": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "take": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "MoveDocumentRequest": {
+        "required": ["newFolderId"],
+        "type": "object",
+        "properties": {
+          "newFolderId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "MoveFolderRequest": {
+        "required": ["newParentFolderId"],
+        "type": "object",
+        "properties": {
+          "newParentFolderId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "PagedResultOfDocument": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "folderId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "ownerId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": ["null", "string"]
+                },
+                "currentVersionId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "currentVersionSizeBytes": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)$",
+                  "type": ["null", "integer", "string"],
+                  "format": "int64"
+                },
+                "currentVersionContentType": {
+                  "type": ["null", "string"]
+                },
+                "status": {
+                  "enum": ["Active", "Trashed", "PermanentlyDeleted"]
+                },
+                "trashedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "concurrencyStamp": {
+                  "type": "string"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "RenameDocumentRequest": {
+        "required": ["name", "description"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "clearDescription": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "RenameFolderRequest": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ShareGranteeType": {
+        "enum": ["User", "Role", "Group"]
+      },
+      "SharePermissionLevel": {
+        "enum": ["Read", "Edit", "Manage"]
+      },
+      "ShareResponse": {
+        "required": [
+          "id",
+          "targetType",
+          "folderId",
+          "documentId",
+          "granteeType",
+          "granteeId",
+          "permission",
+          "isDefault",
+          "expiresAt",
+          "createdAt",
+          "createdBy"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "targetType": {
+            "$ref": "#/components/schemas/ShareTargetType"
+          },
+          "folderId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "documentId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "granteeType": {
+            "$ref": "#/components/schemas/ShareGranteeType"
+          },
+          "granteeId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "permission": {
+            "$ref": "#/components/schemas/SharePermissionLevel"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "expiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string"
+          }
+        }
+      },
+      "ShareTargetType": {
+        "enum": ["Folder", "Document"]
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "TenantStorageQuotaResponse": {
+        "required": ["limitBytes", "usageBytes", "percentUsed", "updatedAt"],
+        "type": "object",
+        "properties": {
+          "limitBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "usageBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "percentUsed": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TransferFolderOwnershipRequest": {
+        "required": ["newOwnerId"],
+        "type": "object",
+        "properties": {
+          "newOwnerId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "TransferOwnershipRequest": {
+        "required": ["newOwnerId"],
+        "type": "object",
+        "properties": {
+          "newOwnerId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "TrashedDocumentResponse": {
+        "required": [
+          "id",
+          "folderId",
+          "name",
+          "ownerId",
+          "trashedAt",
+          "daysUntilPermanentDeletion"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "folderId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "trashedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "daysUntilPermanentDeletion": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "UploadTicketRequest": {
+        "required": ["fileName", "contentType", "maxAllowedBytes"],
+        "type": "object",
+        "properties": {
+          "fileName": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "maxAllowedBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          }
+        }
+      },
+      "UploadTicketResponse": {
+        "required": ["blobId", "uploadUrl", "httpMethod", "expiresAt", "requiredHeaders"],
+        "type": "object",
+        "properties": {
+          "blobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "uploadUrl": {
+            "type": "string",
+            "format": "uri"
+          },
+          "httpMethod": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "requiredHeaders": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Documents"
+    },
+    {
+      "name": "Documents - Folders"
+    },
+    {
+      "name": "Documents - Quotas"
+    },
+    {
+      "name": "Documents - Shares"
+    }
+  ]
+}

--- a/contracts/openapi/entities-customization.json
+++ b/contracts/openapi/entities-customization.json
@@ -1,0 +1,427 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "entities-customization",
+    "version": "1"
+  },
+  "paths": {
+    "/entities/{entityName}/customization/{layoutKind}": {
+      "get": {
+        "tags": ["Entities - Customization"],
+        "summary": "Returns the tenant's customization for the given (entity, layout) pair.",
+        "description": "Returns 200 with the persisted deltas, or 404 when the tenant has not customized that layout (compiled defaults apply).",
+        "operationId": "GetEntityCustomization",
+        "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "layoutKind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LayoutKind"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityCustomizationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Entities - Customization"],
+        "summary": "Replaces the tenant's customization for the given (entity, layout) pair.",
+        "description": "Full-replace semantics — the previous delta list is discarded. Validates each FieldName + group key against the compiled descriptor; rejects unknown names with 400. ISO 27001 audit entry written via IAuditingWriter on success.",
+        "operationId": "PutEntityCustomization",
+        "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "layoutKind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LayoutKind"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityCustomizationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityCustomizationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Entities - Customization"],
+        "summary": "Reverts the tenant to the compiled defaults for the given (entity, layout) pair.",
+        "description": "Hard-deletes the persisted customization row. Idempotent — deleting a non-existent customization returns 204. ISO 27001 audit entry written on actual deletion only.",
+        "operationId": "DeleteEntityCustomization",
+        "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "layoutKind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/LayoutKind"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "EntityCustomizationRequest": {
+        "required": ["deltas"],
+        "type": "object",
+        "properties": {
+          "deltas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LayoutDelta"
+            }
+          }
+        }
+      },
+      "EntityCustomizationResponse": {
+        "required": ["id", "entityName", "layoutKind", "deltas"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "entityName": {
+            "type": "string"
+          },
+          "layoutKind": {
+            "$ref": "#/components/schemas/LayoutKind"
+          },
+          "deltas": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LayoutDelta"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "LayoutDelta": {
+        "required": ["$type"],
+        "type": "object",
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/LayoutDeltaReorderDelta"
+          },
+          {
+            "$ref": "#/components/schemas/LayoutDeltaRegroupDelta"
+          },
+          {
+            "$ref": "#/components/schemas/LayoutDeltaHideDelta"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "$type",
+          "mapping": {
+            "reorder": "#/components/schemas/LayoutDeltaReorderDelta",
+            "regroup": "#/components/schemas/LayoutDeltaRegroupDelta",
+            "hide": "#/components/schemas/LayoutDeltaHideDelta"
+          }
+        }
+      },
+      "LayoutDeltaHideDelta": {
+        "required": ["fieldName"],
+        "properties": {
+          "$type": {
+            "enum": ["hide"],
+            "type": "string"
+          },
+          "fieldName": {
+            "type": "string"
+          }
+        }
+      },
+      "LayoutDeltaRegroupDelta": {
+        "required": ["groupKey", "fieldName"],
+        "properties": {
+          "$type": {
+            "enum": ["regroup"],
+            "type": "string"
+          },
+          "groupKey": {
+            "type": "string"
+          },
+          "fieldName": {
+            "type": "string"
+          }
+        }
+      },
+      "LayoutDeltaReorderDelta": {
+        "required": ["beforeFieldName", "afterFieldName", "fieldName"],
+        "properties": {
+          "$type": {
+            "enum": ["reorder"],
+            "type": "string"
+          },
+          "beforeFieldName": {
+            "type": ["null", "string"]
+          },
+          "afterFieldName": {
+            "type": ["null", "string"]
+          },
+          "isAnchorWellFormed": {
+            "type": "boolean"
+          },
+          "fieldName": {
+            "type": "string"
+          }
+        }
+      },
+      "LayoutKind": {
+        "enum": ["FormDefault", "DetailDefault", "List", "Calendar", "Gallery"]
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Entities - Customization"
+    }
+  ]
+}

--- a/contracts/openapi/entities-views.json
+++ b/contracts/openapi/entities-views.json
@@ -1,0 +1,1084 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "entities-views",
+    "version": "1"
+  },
+  "paths": {
+    "/entities/{entityName}/views": {
+      "get": {
+        "tags": ["Entities - Views"],
+        "summary": "Lists every saved view accessible to the current user for the given entity.",
+        "description": "Returns Personal views owned by the user, Shared views whose audience targets the user (by role or user id), and every Tenant view in the current tenant. Sorted by SortOrder ascending then Name.",
+        "operationId": "ListEntityViews",
+        "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EntityViewResponse"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Entities - Views"],
+        "summary": "Creates a Personal saved view for the current user.",
+        "description": "Requires the Entities.Views.Create permission. The created view is owned by the caller and bound to the supplied compiled collection (BasedOn) and kind. Returns 201 with the created descriptor.",
+        "operationId": "CreateEntityView",
+        "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityViewCreateBodyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{entityName}/views/{id}": {
+      "get": {
+        "tags": ["Entities - Views"],
+        "summary": "Gets one saved view by id.",
+        "description": "Returns 404 when the view does not exist or is not accessible to the current user (defense-in-depth: same response shape, no scope leakage).",
+        "operationId": "GetEntityView",
+        "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Entities - Views"],
+        "summary": "Updates the name / description / icon / state of a saved view.",
+        "description": "Requires ownership for Personal / Shared views, or Entities.Views.Manage for Tenant views. BasedOn and Kind are immutable post-creation and rejected if changed.",
+        "operationId": "UpdateEntityView",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityViewUpdateBodyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Entities - Views"],
+        "summary": "Deletes a saved view.",
+        "description": "The owner can delete their own views; moderation deletes require Entities.Views.DeleteAny. Returns 204 on success.",
+        "operationId": "DeleteEntityView",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{entityName}/views/_default": {
+      "get": {
+        "tags": ["Entities - Views"],
+        "summary": "Resolves the user's effective default saved view for the entity.",
+        "description": "Precedence per ADR-047 §4: IsPersonalDefault > IsDefault > compiled fallback. Returns 204 when no saved or pinned view exists — the renderer falls back to the compiled default collection.",
+        "operationId": "GetEntityDefaultView",
+        "parameters": [
+          {
+            "name": "entityName",
+            "in": "path",
+            "description": "Entity definition name (matches the registered Granit.Entities entity).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{entityName}/views/{id}/pin": {
+      "post": {
+        "tags": ["Entities - Views"],
+        "summary": "Pins or unpins a saved view in the workspace tab strip.",
+        "description": "Requires Entities.Views.Manage. The pinned flag is independent from IsDefault / IsPersonalDefault.",
+        "operationId": "ToggleEntityViewPinned",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityViewToggleFlagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{entityName}/views/{id}/set-default": {
+      "post": {
+        "tags": ["Entities - Views"],
+        "summary": "Sets or clears the tenant-default flag.",
+        "description": "Requires Entities.Views.Manage. At most one IsDefault view per (entity, tenant) — setting one clears any existing tenant default.",
+        "operationId": "ToggleEntityViewTenantDefault",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityViewToggleFlagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{entityName}/views/{id}/star": {
+      "post": {
+        "tags": ["Entities - Views"],
+        "summary": "Sets or clears the personal-default flag for the current user.",
+        "description": "Requires the caller to own the view (group-level Read permission suffices — ownership is enforced in the writer). At most one IsPersonalDefault view per (entity, user) — setting one clears any existing personal default.",
+        "operationId": "ToggleEntityViewPersonalDefault",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityViewToggleFlagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{entityName}/views/{id}/share": {
+      "post": {
+        "tags": ["Entities - Views"],
+        "summary": "Promotes a Personal view to Shared with the given audience.",
+        "description": "Requires Entities.Views.Share. The audience must include at least one role or user — empty audiences are rejected.",
+        "operationId": "ShareEntityView",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EntityViewShareBodyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityViewResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "EntityViewCreateBodyRequest": {
+        "required": ["basedOn", "kind", "name", "description", "icon", "state"],
+        "type": "object",
+        "properties": {
+          "basedOn": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "state": {
+            "$ref": "#/components/schemas/JsonObject"
+          }
+        }
+      },
+      "EntityViewResponse": {
+        "required": [
+          "id",
+          "entityName",
+          "basedOn",
+          "kind",
+          "name",
+          "description",
+          "icon",
+          "state",
+          "visibility",
+          "ownerId",
+          "sharedWith",
+          "isPinned",
+          "isDefault",
+          "isPersonalDefault",
+          "sortOrder"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "entityName": {
+            "type": "string"
+          },
+          "basedOn": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "state": {
+            "$ref": "#/components/schemas/JsonObject"
+          },
+          "visibility": {
+            "$ref": "#/components/schemas/EntityViewVisibility"
+          },
+          "ownerId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "sharedWith": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityViewSharedWithResponse"
+              }
+            ]
+          },
+          "isPinned": {
+            "type": "boolean"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "isPersonalDefault": {
+            "type": "boolean"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "EntityViewShareBodyRequest": {
+        "required": ["roles", "users"],
+        "type": "object",
+        "properties": {
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "EntityViewSharedWithResponse": {
+        "required": ["roles", "users"],
+        "type": "object",
+        "properties": {
+          "roles": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "users": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "EntityViewToggleFlagRequest": {
+        "required": ["value"],
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "boolean"
+          }
+        }
+      },
+      "EntityViewUpdateBodyRequest": {
+        "required": ["name", "description", "icon", "state"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "state": {
+            "$ref": "#/components/schemas/JsonObject"
+          }
+        }
+      },
+      "EntityViewVisibility": {
+        "enum": ["Personal", "Shared", "Tenant"]
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "JsonObject": {
+        "type": "object"
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Entities - Views"
+    }
+  ]
+}

--- a/contracts/openapi/entities.json
+++ b/contracts/openapi/entities.json
@@ -1,0 +1,1644 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "entities",
+    "version": "1"
+  },
+  "paths": {
+    "/entities": {
+      "get": {
+        "tags": ["Entities"],
+        "summary": "Returns the discovery tree of registered entities, grouped by module.",
+        "description": "Lists every EntityDefinition the requesting user has Read permission on (or that has no PermissionGroup declared), grouped by module. Each item carries a Manifest link plus a List link when the entity exposes a query collection. Empty modules are omitted. Cached 5 minutes per (user-perms-hash, culture).",
+        "operationId": "GetEntitiesDiscovery",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityDiscoveryResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{name}": {
+      "get": {
+        "tags": ["Entities"],
+        "summary": "Returns the per-entity manifest for the requesting user.",
+        "description": "Aggregates identity, permission flags, form variants, detail variants, and collection references (query / export / metric / dashboard / default view) for the addressed entity. Defense-in-depth: fields, sections, side panels gated by a permission the user does NOT hold are absent from the payload, never just hidden. Use ?facets=... to slim the response. Carries a strong ETag and the Granit-Entities-Schema-Version header; honours If-None-Match to short-circuit with 304.",
+        "operationId": "GetEntityManifest",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Unique registered name of the background job.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "facets",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityManifestResponse"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{name}/{id}/relations/aggregates": {
+      "post": {
+        "tags": ["Entities"],
+        "summary": "Returns the aggregate values for the relations of a single source row, in one round-trip.",
+        "description": "Computes count / sum / avg / min / max per relation declared on the source EntityDefinition. Pass `relations: []` (or omit the body) to get every relation the caller can read; pass an explicit list to slim the response. Each relation is computed in parallel by the registered IRelationAggregateService — the framework default returns an empty dictionary; hosts plug in an EF Core implementation. Defense-in-depth: relations gated by a permission the caller does not hold are absent from the request set and the response. FusionCache 30-second sliding per (sourceEntity, sourceId, relation, perms-hash, culture).",
+        "operationId": "PostEntityRelationAggregates",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Unique registered name of the background job.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/RelationAggregatesRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RelationAggregatesResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{name}/calendar": {
+      "get": {
+        "tags": ["Entities"],
+        "summary": "Returns calendar items for one entity within a time window.",
+        "description": "Reads the entity's CalendarLayoutDescriptor (selected by the optional ?calendar= name when an entity exposes more than one) and returns the events whose Start/End falls inside [from, to]. The range is enforced server-side: a window wider than 366 days or with To < From is rejected with 400. Permission gate inherited from the underlying entity's Read permission — same defense-in-depth as the manifest endpoint (no calendar-specific permission, rationale: the calendar exposes an aggregate of data the user could already see via the list endpoint). FusionCache TTL is 1 minute by default; the cache key includes the resolved user permission hash plus the From/To window, and the response carries a strong ETag so callers can short-circuit unchanged windows with If-None-Match → 304. Per-entity eviction tags allow the EF Core companion package's CalendarRangeCacheInvalidator<T> to drop every cached window for the entity in one call when one of its rows is created, updated, or deleted (story #1691). Returns an empty list when the entity declares no calendar layout, no item matches, or the host has not yet wired a real ICalendarRangeService implementation.",
+        "operationId": "GetEntityCalendarRange",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Unique registered name of the background job.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "From",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "To",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "Calendar",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CalendarItemResponse"
+                  }
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "Not Modified"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/entities/{name}/bulk/{action}": {
+      "post": {
+        "tags": ["Entities"],
+        "summary": "Executes a registered entity action against the supplied rows in one round-trip.",
+        "description": "Resolves the entity definition and the named action, gates the call through the action's RequiresPermission (defense in depth), then dispatches the run via the framework's BulkActionExecutionOrchestrator. Hosts wire a scoped IEntityActionExecutor<TEntity> per action; an optional IBulkActionExecutor<TEntity> shortcut lets the executor batch the work (one UPDATE … WHERE Id IN (…) call). Per-row failures are returned in the response payload; the call itself returns HTTP 200 whenever the bulk surface accepted the request. One EntityBulkUpdatedEvent<TEntity> is emitted via ILocalEventBus when at least one row succeeded and the entity implements IEmitEntityLifecycleEvents.",
+        "operationId": "PostEntityBulkAction",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Unique registered name of the background job.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "action",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkActionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkActionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BulkActionFailure": {
+        "required": ["id", "reason"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "BulkActionRequest": {
+        "required": ["ids", "payload"],
+        "type": "object",
+        "properties": {
+          "ids": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "payload": {
+            "$ref": "#/components/schemas/JsonElement"
+          }
+        }
+      },
+      "BulkActionResponse": {
+        "required": ["affected", "failures"],
+        "type": "object",
+        "properties": {
+          "affected": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "failures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/BulkActionFailure"
+            }
+          }
+        }
+      },
+      "CalendarItemResponse": {
+        "required": ["id", "start", "end", "title", "color"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "start": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "end": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "title": {
+            "type": "string"
+          },
+          "color": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityActionKind": {
+        "enum": ["ApiCall", "Download", "Navigate", "WorkflowTransition", "OpenDrawer", "OpenModal"]
+      },
+      "EntityActionManifest": {
+        "required": [
+          "name",
+          "kind",
+          "displayKey",
+          "icon",
+          "order",
+          "urlTemplate",
+          "httpMethod",
+          "confirmationKey",
+          "workflowTransitionName",
+          "contributorAssemblyName"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/EntityActionKind"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "urlTemplate": {
+            "type": ["null", "string"]
+          },
+          "httpMethod": {
+            "type": ["null", "string"]
+          },
+          "confirmationKey": {
+            "type": ["null", "string"]
+          },
+          "workflowTransitionName": {
+            "type": ["null", "string"]
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityActivitiesManifest": {
+        "required": ["allowedTypes", "defaultAssignee"],
+        "type": "object",
+        "properties": {
+          "allowedTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "defaultAssignee": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityCalendarLayoutManifest": {
+        "required": [
+          "startPropertyName",
+          "endPropertyName",
+          "titlePropertyName",
+          "colorByPropertyName",
+          "actions"
+        ],
+        "type": "object",
+        "properties": {
+          "startPropertyName": {
+            "type": "string"
+          },
+          "endPropertyName": {
+            "type": ["null", "string"]
+          },
+          "titlePropertyName": {
+            "type": ["null", "string"]
+          },
+          "colorByPropertyName": {
+            "type": ["null", "string"]
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityCalendarTileActionManifest"
+            }
+          }
+        }
+      },
+      "EntityCalendarTileActionManifest": {
+        "required": ["name", "displayKey", "icon", "contributorAssemblyName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityCollectionReference": {
+        "required": ["name", "clrTypeName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "clrTypeName": {
+            "type": "string"
+          }
+        }
+      },
+      "EntityCollectionsSection": {
+        "required": [
+          "query",
+          "export",
+          "metrics",
+          "dashboards",
+          "defaultViewId",
+          "listLayouts",
+          "headerActions",
+          "selectionActions"
+        ],
+        "type": "object",
+        "properties": {
+          "query": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityCollectionReference"
+              }
+            ]
+          },
+          "export": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityCollectionReference"
+              }
+            ]
+          },
+          "metrics": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityCollectionReference"
+            }
+          },
+          "dashboards": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityCollectionReference"
+            }
+          },
+          "defaultViewId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "listLayouts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityListLayoutManifest"
+            }
+          },
+          "headerActions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityHeaderActionManifest"
+            }
+          },
+          "selectionActions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntitySelectionActionManifest"
+            }
+          }
+        }
+      },
+      "EntityDetailManifest": {
+        "required": ["name", "sections", "sidePanels"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityDetailSectionManifest"
+            }
+          },
+          "sidePanels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityDetailSidePanelManifest"
+            }
+          }
+        }
+      },
+      "EntityDetailSectionManifest": {
+        "required": ["key", "labelKey", "order", "inheritsFromFormVariant", "fields"],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "labelKey": {
+            "type": ["null", "string"]
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "inheritsFromFormVariant": {
+            "type": ["null", "string"]
+          },
+          "fields": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "EntityDetailSidePanelManifest": {
+        "required": ["kind", "order"],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/SidePanelKind"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "EntityDiscoveryItemResponse": {
+        "required": ["name", "displayKey", "icon", "permissionGroup", "links"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "permissionGroup": {
+            "type": ["null", "string"]
+          },
+          "links": {
+            "$ref": "#/components/schemas/EntityDiscoveryLinks"
+          }
+        }
+      },
+      "EntityDiscoveryLinks": {
+        "required": ["manifest", "list"],
+        "type": "object",
+        "properties": {
+          "manifest": {
+            "type": "string"
+          },
+          "list": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityDiscoveryResponse": {
+        "required": ["schemaVersion", "modules"],
+        "type": "object",
+        "properties": {
+          "schemaVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "modules": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityModuleGroupResponse"
+            }
+          }
+        }
+      },
+      "EntityFormFieldManifest": {
+        "required": [
+          "propertyName",
+          "clrTypeName",
+          "component",
+          "config",
+          "labelKey",
+          "helpKey",
+          "order",
+          "readOnly",
+          "visibleIf"
+        ],
+        "type": "object",
+        "properties": {
+          "propertyName": {
+            "type": "string"
+          },
+          "clrTypeName": {
+            "type": "string"
+          },
+          "component": {
+            "type": "string"
+          },
+          "config": {
+            "type": ["null", "object"]
+          },
+          "labelKey": {
+            "type": ["null", "string"]
+          },
+          "helpKey": {
+            "type": ["null", "string"]
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "readOnly": {
+            "type": "boolean"
+          },
+          "visibleIf": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/VisibilityCondition"
+              }
+            ]
+          },
+          "provenance": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityProvenance"
+              }
+            ]
+          }
+        }
+      },
+      "EntityFormManifest": {
+        "required": ["name", "customizable", "sections"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "customizable": {
+            "type": "boolean"
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityFormSectionManifest"
+            }
+          },
+          "hiddenByOverride": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "EntityFormOwnedCollectionManifest": {
+        "required": [
+          "propertyName",
+          "itemTypeName",
+          "itemFields",
+          "itemDisplayProperty",
+          "maxRendered"
+        ],
+        "type": "object",
+        "properties": {
+          "propertyName": {
+            "type": "string"
+          },
+          "itemTypeName": {
+            "type": "string"
+          },
+          "itemFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityFormFieldManifest"
+            }
+          },
+          "itemDisplayProperty": {
+            "type": ["null", "string"]
+          },
+          "maxRendered": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          }
+        }
+      },
+      "EntityFormSectionManifest": {
+        "required": ["key", "labelKey", "order", "collapsedByDefault", "fields"],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "labelKey": {
+            "type": ["null", "string"]
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "collapsedByDefault": {
+            "type": "boolean"
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityFormFieldManifest"
+            }
+          },
+          "ownedCollection": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityFormOwnedCollectionManifest"
+              }
+            ]
+          }
+        }
+      },
+      "EntityGalleryCardActionManifest": {
+        "required": ["name", "displayKey", "icon", "contributorAssemblyName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityGalleryLayoutManifest": {
+        "required": [
+          "imagePropertyName",
+          "titlePropertyName",
+          "subtitlePropertyName",
+          "groupByPropertyName",
+          "cardSize",
+          "actions"
+        ],
+        "type": "object",
+        "properties": {
+          "imagePropertyName": {
+            "type": "string"
+          },
+          "titlePropertyName": {
+            "type": ["null", "string"]
+          },
+          "subtitlePropertyName": {
+            "type": ["null", "string"]
+          },
+          "groupByPropertyName": {
+            "type": ["null", "string"]
+          },
+          "cardSize": {
+            "$ref": "#/components/schemas/GalleryCardSize"
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityGalleryCardActionManifest"
+            }
+          }
+        }
+      },
+      "EntityHeaderActionManifest": {
+        "required": ["name", "displayKey", "icon", "contributorAssemblyName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityIdentitySection": {
+        "required": [
+          "name",
+          "entityClrType",
+          "displayKey",
+          "icon",
+          "permissionGroup",
+          "displayProperty",
+          "subtitleProperty"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "entityClrType": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "permissionGroup": {
+            "type": ["null", "string"]
+          },
+          "displayProperty": {
+            "type": ["null", "string"]
+          },
+          "subtitleProperty": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityKanbanCardActionManifest": {
+        "required": ["name", "displayKey", "icon", "contributorAssemblyName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityKanbanCardManifest": {
+        "required": ["titleProperty", "fields", "relations", "actions"],
+        "type": "object",
+        "properties": {
+          "titleProperty": {
+            "type": ["null", "string"]
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityFormFieldManifest"
+            }
+          },
+          "relations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityKanbanCardRelationManifest"
+            }
+          },
+          "actions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityKanbanCardActionManifest"
+            }
+          }
+        }
+      },
+      "EntityKanbanCardRelationManifest": {
+        "required": ["name", "displayKey", "icon", "contributorAssemblyName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityKanbanColumnManifest": {
+        "required": ["value", "color", "defaultState"],
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          },
+          "color": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/KanbanColor"
+              }
+            ]
+          },
+          "defaultState": {
+            "$ref": "#/components/schemas/KanbanColumnState"
+          }
+        }
+      },
+      "EntityKanbanLayoutManifest": {
+        "required": ["groupByPropertyName", "groupByClrTypeName", "card", "columns"],
+        "type": "object",
+        "properties": {
+          "groupByPropertyName": {
+            "type": "string"
+          },
+          "groupByClrTypeName": {
+            "type": "string"
+          },
+          "card": {
+            "$ref": "#/components/schemas/EntityKanbanCardManifest"
+          },
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityKanbanColumnManifest"
+            }
+          }
+        }
+      },
+      "EntityListLayoutKind": {
+        "enum": ["List", "Kanban", "Calendar", "Gallery"]
+      },
+      "EntityListLayoutManifest": {
+        "required": ["kind", "isDefault", "kanban", "calendar", "gallery"],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/EntityListLayoutKind"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "kanban": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityKanbanLayoutManifest"
+              }
+            ]
+          },
+          "calendar": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityCalendarLayoutManifest"
+              }
+            ]
+          },
+          "gallery": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityGalleryLayoutManifest"
+              }
+            ]
+          }
+        }
+      },
+      "EntityManifestResponse": {
+        "required": [
+          "schemaVersion",
+          "identity",
+          "permissions",
+          "forms",
+          "details",
+          "collections",
+          "relations"
+        ],
+        "type": "object",
+        "properties": {
+          "schemaVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "identity": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityIdentitySection"
+              }
+            ]
+          },
+          "permissions": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityPermissionsSection"
+              }
+            ]
+          },
+          "forms": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/EntityFormManifest"
+            }
+          },
+          "details": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/EntityDetailManifest"
+            }
+          },
+          "collections": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityCollectionsSection"
+              }
+            ]
+          },
+          "relations": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/EntityRelationManifest"
+            }
+          },
+          "actions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/EntityActionManifest"
+            }
+          },
+          "activities": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/EntityActivitiesManifest"
+              }
+            ]
+          }
+        }
+      },
+      "EntityModuleGroupResponse": {
+        "required": ["module", "items"],
+        "type": "object",
+        "properties": {
+          "module": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityDiscoveryItemResponse"
+            }
+          }
+        }
+      },
+      "EntityPermissionsSection": {
+        "required": ["canRead", "canCreate", "canUpdate", "canDelete", "canManage", "canExecute"],
+        "type": "object",
+        "properties": {
+          "canRead": {
+            "type": "boolean"
+          },
+          "canCreate": {
+            "type": "boolean"
+          },
+          "canUpdate": {
+            "type": "boolean"
+          },
+          "canDelete": {
+            "type": "boolean"
+          },
+          "canManage": {
+            "type": "boolean"
+          },
+          "canExecute": {
+            "type": "boolean"
+          }
+        }
+      },
+      "EntityProvenance": {
+        "required": ["layer", "overrideId"],
+        "type": "object",
+        "properties": {
+          "layer": {
+            "type": "string"
+          },
+          "overrideId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "EntityRelationAggregateManifest": {
+        "required": ["kind", "propertyName", "labelKey", "format"],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/RelationAggregateKind"
+          },
+          "propertyName": {
+            "type": ["null", "string"]
+          },
+          "labelKey": {
+            "type": ["null", "string"]
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntityRelationManifest": {
+        "required": [
+          "name",
+          "cardinality",
+          "display",
+          "targetEntityName",
+          "displayKey",
+          "icon",
+          "order",
+          "queryDefinitionName",
+          "aggregates",
+          "contributorAssemblyName"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "cardinality": {
+            "$ref": "#/components/schemas/RelationCardinality"
+          },
+          "display": {
+            "$ref": "#/components/schemas/RelationDisplay"
+          },
+          "targetEntityName": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "queryDefinitionName": {
+            "type": ["null", "string"]
+          },
+          "aggregates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/EntityRelationAggregateManifest"
+            }
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "EntitySelectionActionManifest": {
+        "required": ["name", "displayKey", "icon", "confirmationKey", "contributorAssemblyName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "confirmationKey": {
+            "type": ["null", "string"]
+          },
+          "contributorAssemblyName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "FieldOp": {
+        "enum": ["Eq", "NotEq", "In", "NotIn", "Gt", "Lt", "IsNull", "IsNotNull"]
+      },
+      "GalleryCardSize": {
+        "enum": ["Small", "Medium", "Large"]
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "JsonElement": {
+        "type": ["null", "boolean", "number", "string", "object", "array"],
+        "description": "Arbitrary JSON value (object, array, string, number, boolean, or null)."
+      },
+      "KanbanColor": {
+        "enum": [
+          "Neutral",
+          "Gray",
+          "Blue",
+          "Green",
+          "Orange",
+          "Red",
+          "Yellow",
+          "Purple",
+          "Cyan",
+          null
+        ]
+      },
+      "KanbanColumnState": {
+        "enum": ["Open", "Collapsed", "Hidden"]
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "RelationAggregateKind": {
+        "enum": ["Count", "Sum", "Avg", "Min", "Max"]
+      },
+      "RelationAggregatesRequest": {
+        "required": ["relations"],
+        "type": "object",
+        "properties": {
+          "relations": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RelationAggregatesResponse": {
+        "required": ["aggregates"],
+        "type": "object",
+        "properties": {
+          "aggregates": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/RelationAggregateValue"
+            }
+          }
+        }
+      },
+      "RelationAggregateValue": {
+        "required": ["count", "sum", "avg", "min", "max"],
+        "type": "object",
+        "properties": {
+          "count": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["null", "integer", "string"],
+            "format": "int64"
+          },
+          "sum": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "avg": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "min": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "max": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "RelationCardinality": {
+        "enum": ["Many", "One"]
+      },
+      "RelationDisplay": {
+        "enum": ["Tab", "SmartButton", "Sidebar", "InlineChips"]
+      },
+      "SidePanelKind": {
+        "enum": ["Audit", "Timeline", "Comments", "Documents", "Activities"]
+      },
+      "VisibilityCondition": {
+        "required": ["field", "op", "value"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "op": {
+            "$ref": "#/components/schemas/FieldOp"
+          },
+          "value": {}
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Entities"
+    }
+  ]
+}

--- a/contracts/openapi/invoicing.json
+++ b/contracts/openapi/invoicing.json
@@ -1,0 +1,2284 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "invoicing",
+    "version": "1"
+  },
+  "paths": {
+    "/invoicing/invoices/{id}": {
+      "get": {
+        "tags": ["Invoicing"],
+        "summary": "Returns an invoice by ID.",
+        "description": "Returns the full invoice details including line items, amounts, and status. Returns 404 if the invoice does not exist.",
+        "operationId": "GetInvoiceById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoicing/invoices/{id}/pdf": {
+      "get": {
+        "tags": ["Invoicing"],
+        "summary": "Downloads the invoice as a PDF document.",
+        "description": "Generates a PDF for the specified invoice using the configured document generator. Returns 404 if the invoice does not exist.",
+        "operationId": "DownloadInvoicePdf",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoicing/invoices": {
+      "post": {
+        "tags": ["Invoicing"],
+        "summary": "Creates a new invoice or credit note.",
+        "description": "Creates a draft invoice or credit note for the current tenant. Credit notes must reference a parent invoice via parentInvoiceId. Line items can be added after creation. Requires tenant context.",
+        "operationId": "CreateInvoice",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvoiceCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Invoicing"],
+        "summary": "Returns a filtered, sorted, and paginated list of Invoice entries.",
+        "description": "Executes a dynamic query against Invoice using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryInvoice",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfInvoice"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfInvoice"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoicing/invoices/{id}/finalize": {
+      "post": {
+        "tags": ["Invoicing"],
+        "summary": "Finalizes a Draft invoice, assigning a document number and issuing it.",
+        "description": "Transitions a Draft invoice to Open via IWorkflowManager. Generates the next document number via IInvoiceNumberGenerator and snapshots the issuance metadata. Returns 404 if missing, 403 if forbidden, 409 if the invoice is not in Draft.",
+        "operationId": "FinalizeInvoice",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FinalizeInvoiceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoicing/invoices/{id}/cancel": {
+      "post": {
+        "tags": ["Invoicing"],
+        "summary": "Cancels an Open or Uncollectible invoice.",
+        "description": "Transitions an invoice to Cancelled via IWorkflowManager. The optional Reason is persisted on the workflow transition record (ISO 27001 audit). Returns 404 if missing, 403 if forbidden, 409 if the invoice cannot be cancelled from its current state.",
+        "operationId": "CancelInvoice",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/CancelInvoiceRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoicing/invoices/{id}/mark-uncollectible": {
+      "post": {
+        "tags": ["Invoicing"],
+        "summary": "Marks an Open invoice as Uncollectible (bad debt).",
+        "description": "Transitions an Open invoice to Uncollectible via IWorkflowManager. The optional Reason is persisted on the workflow transition record. Returns 404 if missing, 403 if forbidden, 409 if the invoice is not in Open state.",
+        "operationId": "MarkInvoiceUncollectible",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/MarkInvoiceUncollectibleRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InvoiceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoicing/invoices/meta": {
+      "get": {
+        "tags": ["Invoicing"],
+        "summary": "Returns query metadata for Invoice (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Invoice: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetInvoiceMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/invoicing/invoices/transitions": {
+      "get": {
+        "tags": ["Invoicing"],
+        "summary": "Returns the transitions available from the given state for the current user.",
+        "description": "Returns the list of transitions available from the specified current state for the current user, considering their permissions. Transitions where the user lacks the required permission but approval routing is enabled are included with RequiresApproval = true.",
+        "operationId": "GetAvailableInvoiceStatusTransitions",
+        "parameters": [
+          {
+            "name": "currentState",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Invoicing"],
+        "summary": "Evaluates a workflow transition with permission checking and approval routing.",
+        "description": "Attempts to transition from the current state to the target state. Returns the outcome: Completed (direct transition), ApprovalRequested (routed to pending review), Denied (no permission and no approval path), or InvalidTransition (no such transition defined). The caller is responsible for persisting the resulting state on the entity.",
+        "operationId": "ExecuteInvoiceStatusTransition",
+        "parameters": [
+          {
+            "name": "currentState",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkflowTransitionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkflowTransitionResultResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BillingAddress": {
+        "type": "object",
+        "properties": {
+          "companyName": {
+            "type": ["null", "string"]
+          },
+          "line1": {
+            "type": "string"
+          },
+          "line2": {
+            "type": ["null", "string"]
+          },
+          "city": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "state": {
+            "type": ["null", "string"]
+          },
+          "country": {
+            "type": "string"
+          },
+          "vatNumber": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "BillingReason": {
+        "enum": ["SubscriptionCreate", "SubscriptionCycle", "SubscriptionUpdate", "Manual"]
+      },
+      "CancelInvoiceRequest": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "CollectionMethod": {
+        "enum": ["Auto", "SendInvoice"]
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "FinalizeInvoiceRequest": {
+        "required": ["issuedAt", "dueAt"],
+        "type": "object",
+        "properties": {
+          "issuedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "dueAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "comment": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfInvoice": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfInvoice"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfInvoice": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Invoice"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "Invoice": {
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "$ref": "#/components/schemas/PartyId"
+          },
+          "documentType": {
+            "$ref": "#/components/schemas/InvoiceDocumentType"
+          },
+          "invoiceNumber": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "$ref": "#/components/schemas/InvoiceStatus"
+          },
+          "collectionMethod": {
+            "$ref": "#/components/schemas/CollectionMethod"
+          },
+          "billingReason": {
+            "$ref": "#/components/schemas/BillingReason"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "issuedBillingAddressSnapshot": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BillingAddress"
+              }
+            ]
+          },
+          "parentInvoiceId": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/InvoiceId"
+              }
+            ]
+          },
+          "creditNoteReason": {
+            "type": ["null", "string"]
+          },
+          "subtotal": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "taxTotal": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "total": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amountPaid": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amountCredited": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amountRemaining": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "overpayment": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "issuedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "dueAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "paidAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodStart": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "lineItems": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/InvoiceLineItem"
+            }
+          },
+          "externalReferences": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/InvoiceExternalReference"
+            }
+          },
+          "documents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/InvoiceDocument"
+            }
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "isCreditNote": {
+            "type": "boolean"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "InvoiceCreateRequest": {
+        "required": ["partyId", "documentType", "currency", "collectionMethod", "billingReason"],
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentType": {
+            "$ref": "#/components/schemas/InvoiceDocumentType"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "collectionMethod": {
+            "$ref": "#/components/schemas/CollectionMethod"
+          },
+          "billingReason": {
+            "$ref": "#/components/schemas/BillingReason"
+          },
+          "parentInvoiceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "creditNoteReason": {
+            "type": ["null", "string"]
+          },
+          "periodStart": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        },
+        "example": {
+          "partyId": "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+          "documentType": "Invoice",
+          "currency": "EUR",
+          "collectionMethod": "ChargeAutomatically",
+          "billingReason": "Subscription",
+          "parentInvoiceId": null,
+          "creditNoteReason": null,
+          "periodStart": "2026-04-01T00:00:00+00:00",
+          "periodEnd": "2026-04-30T23:59:59+00:00"
+        }
+      },
+      "InvoiceDocument": {
+        "type": "object",
+        "properties": {
+          "blobId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "generatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "InvoiceDocumentType": {
+        "enum": ["Invoice", "CreditNote"]
+      },
+      "InvoiceExternalReference": {
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "InvoiceId": {},
+      "InvoiceLineItem": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "quantity": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "unitPrice": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "taxRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "taxAmount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "sourceType": {
+            "$ref": "#/components/schemas/InvoiceSourceType"
+          },
+          "sourceId": {
+            "type": ["null", "string"]
+          },
+          "periodStart": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "productId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "InvoiceLineItemResponse": {
+        "required": [
+          "id",
+          "description",
+          "quantity",
+          "unitPrice",
+          "amount",
+          "taxRate",
+          "taxAmount",
+          "sourceType",
+          "sourceId",
+          "periodStart",
+          "periodEnd"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "description": {
+            "type": "string"
+          },
+          "quantity": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "unitPrice": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "taxRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "taxAmount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "sourceType": {
+            "type": "string"
+          },
+          "sourceId": {
+            "type": ["null", "string"]
+          },
+          "periodStart": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "InvoiceResponse": {
+        "required": [
+          "id",
+          "partyId",
+          "documentType",
+          "invoiceNumber",
+          "status",
+          "collectionMethod",
+          "billingReason",
+          "currency",
+          "subtotal",
+          "taxTotal",
+          "total",
+          "amountPaid",
+          "amountCredited",
+          "amountRemaining",
+          "parentInvoiceId",
+          "creditNoteReason",
+          "issuedAt",
+          "dueAt",
+          "paidAt",
+          "periodStart",
+          "periodEnd",
+          "lineItems"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "documentType": {
+            "type": "string"
+          },
+          "invoiceNumber": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": "string"
+          },
+          "collectionMethod": {
+            "type": "string"
+          },
+          "billingReason": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "subtotal": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "taxTotal": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "total": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amountPaid": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amountCredited": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "amountRemaining": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "parentInvoiceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "creditNoteReason": {
+            "type": ["null", "string"]
+          },
+          "issuedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "dueAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "paidAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodStart": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "lineItems": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/InvoiceLineItemResponse"
+            }
+          }
+        },
+        "example": {
+          "id": "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+          "partyId": "01960f3a-5c9e-7c3b-b4a2-abc123def456",
+          "documentType": "Invoice",
+          "invoiceNumber": "INV-2026-00042",
+          "status": "Open",
+          "collectionMethod": "ChargeAutomatically",
+          "billingReason": "Subscription",
+          "currency": "EUR",
+          "subtotal": 99.0,
+          "taxTotal": 20.79,
+          "total": 119.79,
+          "amountPaid": 0.0,
+          "amountCredited": 0.0,
+          "amountRemaining": 119.79,
+          "parentInvoiceId": null,
+          "creditNoteReason": null,
+          "issuedAt": "2026-04-20T10:00:00+00:00",
+          "dueAt": "2026-05-20T10:00:00+00:00",
+          "paidAt": null,
+          "periodStart": "2026-04-01T00:00:00+00:00",
+          "periodEnd": "2026-04-30T23:59:59+00:00",
+          "lineItems": [
+            {
+              "id": "01960f3a-5c9e-7c3b-b4a2-000000000001",
+              "description": "Pro plan — April 2026",
+              "quantity": 1,
+              "unitPrice": 99.0,
+              "amount": 99.0,
+              "taxRate": 0.21,
+              "taxAmount": 20.79,
+              "sourceType": "Subscription",
+              "sourceId": "01960f3a-5c9e-7c3b-b4a2-abc111222333",
+              "periodStart": "2026-04-01T00:00:00+00:00",
+              "periodEnd": "2026-04-30T23:59:59+00:00"
+            }
+          ]
+        }
+      },
+      "InvoiceSourceType": {
+        "enum": ["Subscription", "Usage", "OneShot", "Credit"]
+      },
+      "InvoiceStatus": {
+        "enum": ["Draft", "Open", "Paid", "Cancelled", "Uncollectible"]
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "MarkInvoiceUncollectibleRequest": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfInvoice": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "partyId": {},
+                "documentType": {
+                  "enum": ["Invoice", "CreditNote"]
+                },
+                "invoiceNumber": {
+                  "type": ["null", "string"]
+                },
+                "status": {
+                  "enum": ["Draft", "Open", "Paid", "Cancelled", "Uncollectible"]
+                },
+                "collectionMethod": {
+                  "enum": ["Auto", "SendInvoice"]
+                },
+                "billingReason": {
+                  "enum": [
+                    "SubscriptionCreate",
+                    "SubscriptionCycle",
+                    "SubscriptionUpdate",
+                    "Manual"
+                  ]
+                },
+                "currency": {
+                  "type": "string"
+                },
+                "issuedBillingAddressSnapshot": {
+                  "type": "object",
+                  "properties": {
+                    "companyName": {
+                      "type": ["null", "string"]
+                    },
+                    "line1": {
+                      "type": "string"
+                    },
+                    "line2": {
+                      "type": ["null", "string"]
+                    },
+                    "city": {
+                      "type": "string"
+                    },
+                    "postalCode": {
+                      "type": "string"
+                    },
+                    "state": {
+                      "type": ["null", "string"]
+                    },
+                    "country": {
+                      "type": "string"
+                    },
+                    "vatNumber": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "parentInvoiceId": {},
+                "creditNoteReason": {
+                  "type": ["null", "string"]
+                },
+                "subtotal": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "taxTotal": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "total": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "amountPaid": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "amountCredited": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "amountRemaining": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "overpayment": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "issuedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "dueAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "paidAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "periodStart": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "periodEnd": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "lineItems": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "description": {
+                        "type": "string"
+                      },
+                      "quantity": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "unitPrice": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "amount": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "taxRate": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["null", "number", "string"],
+                        "format": "double"
+                      },
+                      "taxAmount": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "sourceType": {
+                        "enum": ["Subscription", "Usage", "OneShot", "Credit"]
+                      },
+                      "sourceId": {
+                        "type": ["null", "string"]
+                      },
+                      "periodStart": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "periodEnd": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "productId": {
+                        "type": ["null", "string"],
+                        "format": "uuid"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "externalReferences": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "providerName": {
+                        "type": "string"
+                      },
+                      "externalId": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "documents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "blobId": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "fileName": {
+                        "type": "string"
+                      },
+                      "contentType": {
+                        "type": "string"
+                      },
+                      "generatedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "isCreditNote": {
+                  "type": "boolean"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PartyId": {},
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "WorkflowStatusResponse": {
+        "required": ["currentState", "availableTransitions"],
+        "type": "object",
+        "properties": {
+          "currentState": {
+            "type": "string"
+          },
+          "availableTransitions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkflowTransitionResponse"
+            }
+          }
+        }
+      },
+      "WorkflowTransitionRequest": {
+        "required": ["targetState"],
+        "type": "object",
+        "properties": {
+          "targetState": {
+            "type": "string"
+          },
+          "comment": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "WorkflowTransitionResponse": {
+        "required": ["targetState", "name", "allowed", "requiresApproval"],
+        "type": "object",
+        "properties": {
+          "targetState": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "allowed": {
+            "type": "boolean"
+          },
+          "requiresApproval": {
+            "type": "boolean"
+          }
+        }
+      },
+      "WorkflowTransitionResultResponse": {
+        "required": ["succeeded", "resultingState", "outcome"],
+        "type": "object",
+        "properties": {
+          "succeeded": {
+            "type": "boolean"
+          },
+          "resultingState": {
+            "type": "string"
+          },
+          "outcome": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Invoicing"
+    }
+  ]
+}

--- a/contracts/openapi/iot-fleet-provisioning.json
+++ b/contracts/openapi/iot-fleet-provisioning.json
@@ -1,0 +1,290 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "iot-fleet-provisioning",
+    "version": "1"
+  },
+  "paths": {
+    "/api/iot/fleet-provisioning/verify": {
+      "post": {
+        "tags": ["AWS IoT Fleet Provisioning"],
+        "summary": "Pre-provisioning hook called by the customer's AWS Lambda before AWS IoT issues an operational certificate.",
+        "description": "Returns allowProvisioning=false when the serial belongs to a decommissioned device, otherwise allowProvisioning=true. The customer's Lambda forwards this verdict to AWS IoT, which aborts the JITP flow on a deny.",
+        "operationId": "FleetProvisioningVerify",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FleetProvisioningVerifyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetProvisioningVerifyResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/iot/fleet-provisioning/registered": {
+      "post": {
+        "tags": ["AWS IoT Fleet Provisioning"],
+        "summary": "Post-provisioning hook called once AWS IoT has created the Thing and the operational certificate.",
+        "description": "Atomically materialises the cloud-agnostic Device aggregate and the AwsThingBinding (already in Active status, ProvisionedViaJitp=true). Idempotent on the device serial number — a retried JITP flow returns the existing DeviceId without duplicate writes.",
+        "operationId": "FleetProvisioningRegister",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FleetProvisioningRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FleetProvisioningRegisterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "FleetProvisioningRegisterRequest": {
+        "required": [
+          "serialNumber",
+          "tenantId",
+          "thingName",
+          "thingArn",
+          "certificateArn",
+          "certificateSecretArn",
+          "model",
+          "firmwareVersion",
+          "label",
+          "claimCertificateExpiresAt"
+        ],
+        "type": "object",
+        "properties": {
+          "serialNumber": {
+            "type": "string"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "thingName": {
+            "type": "string"
+          },
+          "thingArn": {
+            "type": "string"
+          },
+          "certificateArn": {
+            "type": "string"
+          },
+          "certificateSecretArn": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "firmwareVersion": {
+            "type": "string"
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "claimCertificateExpiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "FleetProvisioningRegisterResponse": {
+        "required": ["deviceId", "alreadyProvisioned"],
+        "type": "object",
+        "properties": {
+          "deviceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "alreadyProvisioned": {
+            "type": "boolean"
+          }
+        }
+      },
+      "FleetProvisioningVerifyRequest": {
+        "required": ["serialNumber", "tenantId"],
+        "type": "object",
+        "properties": {
+          "serialNumber": {
+            "type": "string"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "FleetProvisioningVerifyResponse": {
+        "required": ["allowProvisioning", "reason"],
+        "type": "object",
+        "properties": {
+          "allowProvisioning": {
+            "type": "boolean"
+          },
+          "reason": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "AWS IoT Fleet Provisioning"
+    }
+  ]
+}

--- a/contracts/openapi/iot-ingestion.json
+++ b/contracts/openapi/iot-ingestion.json
@@ -1,0 +1,154 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "iot-ingestion",
+    "version": "1"
+  },
+  "paths": {
+    "/iot/ingest/{source}": {
+      "post": {
+        "tags": ["IoT Ingestion"],
+        "summary": "Receives a signed telemetry webhook from an IoT hub provider.",
+        "description": "Validates the provider signature, deduplicates by transport message id, resolves the device, and dispatches to the Wolverine outbox. Returns 202 Accepted with no synchronous DB write.",
+        "operationId": "IngestTelemetry",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Payload Too Large",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too Many Requests",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "IoT Ingestion"
+    }
+  ]
+}

--- a/contracts/openapi/iot.json
+++ b/contracts/openapi/iot.json
@@ -1,376 +1,16 @@
 {
   "openapi": "3.1.1",
   "info": {
-    "title": "ai",
+    "title": "iot",
     "version": "1"
   },
   "paths": {
-    "/ai/workspaces": {
+    "/iot/devices": {
       "get": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Lists all AI workspaces, both system and dynamic.",
-        "description": "Returns every registered workspace with its provider, model, and configuration. System workspaces are defined in configuration; dynamic workspaces are user-created.",
-        "operationId": "ListAIWorkspaces",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceListResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Creates a new dynamic AI workspace.",
-        "description": "Registers a new user-defined workspace with the specified provider and model configuration. Returns 409 if a workspace with the same name already exists.",
-        "operationId": "CreateAIWorkspace",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIWorkspaceCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceResponse"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/workspaces/{name}": {
-      "get": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Returns an AI workspace by its name.",
-        "description": "Fetches the full configuration of a single workspace including provider, model, system prompt, and active status. Returns 404 if no workspace matches the name.",
-        "operationId": "GetAIWorkspace",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Unique registered name of the background job.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Updates an existing dynamic AI workspace.",
-        "description": "Replaces the provider, model, and prompt configuration of a dynamic workspace. System workspaces cannot be modified and return 422. Returns 404 if the workspace does not exist.",
-        "operationId": "UpdateAIWorkspace",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Unique registered name of the background job.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIWorkspaceUpdateRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIWorkspaceResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "tags": ["AI - Workspaces"],
-        "summary": "Deletes a dynamic AI workspace.",
-        "description": "Permanently removes a user-created workspace. System workspaces cannot be deleted and return 422. Returns 404 if the workspace does not exist.",
-        "operationId": "DeleteAIWorkspace",
-        "parameters": [
-          {
-            "name": "name",
-            "in": "path",
-            "description": "Unique registered name of the background job.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/usage": {
-      "get": {
-        "tags": ["AI - Usage"],
-        "summary": "Returns a filtered, sorted, and paginated list of AIUsageRecord entries.",
-        "description": "Executes a dynamic query against AIUsageRecord using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
-        "operationId": "QueryAIUsageRecord",
+        "tags": ["IoT Devices"],
+        "summary": "Returns a filtered, sorted, and paginated list of Device entries.",
+        "description": "Executes a dynamic query against Device using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryDevice",
         "parameters": [
           {
             "name": "page",
@@ -476,10 +116,558 @@
                 "schema": {
                   "oneOf": [
                     {
-                      "$ref": "#/components/schemas/PagedResultOfAIUsageRecord"
+                      "$ref": "#/components/schemas/PagedResultOfDevice"
                     },
                     {
-                      "$ref": "#/components/schemas/GroupedResultOfAIUsageRecord"
+                      "$ref": "#/components/schemas/GroupedResultOfDevice"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["IoT Devices"],
+        "summary": "Provisions a new IoT device.",
+        "description": "Creates a new device in Provisioning status. Returns 409 if the serial number already exists.",
+        "operationId": "ProvisionDevice",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceProvisionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/iot/devices/meta": {
+      "get": {
+        "tags": ["IoT Devices"],
+        "summary": "Returns query metadata for Device (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Device: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetDeviceMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/iot/devices/{id}": {
+      "get": {
+        "tags": ["IoT Devices"],
+        "summary": "Gets a device by ID.",
+        "description": "Returns the device details or 404 if not found in the current tenant.",
+        "operationId": "GetDeviceById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["IoT Devices"],
+        "summary": "Updates a device.",
+        "description": "Updates firmware version or label of an existing device.",
+        "operationId": "UpdateDevice",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeviceUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeviceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["IoT Devices"],
+        "summary": "Decommissions a device.",
+        "description": "Soft-deletes a device. The device must be in Suspended or Provisioning status — active devices must be suspended first.",
+        "operationId": "DecommissionDevice",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/iot/telemetry": {
+      "get": {
+        "tags": ["IoT Telemetry"],
+        "summary": "Returns a filtered, sorted, and paginated list of TelemetryPoint entries.",
+        "description": "Executes a dynamic query against TelemetryPoint using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryTelemetryPoint",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfTelemetryPoint"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfTelemetryPoint"
                     }
                   ],
                   "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
@@ -530,12 +718,12 @@
         }
       }
     },
-    "/ai/usage/meta": {
+    "/iot/telemetry/meta": {
       "get": {
-        "tags": ["AI - Usage"],
-        "summary": "Returns query metadata for AIUsageRecord (columns, filters, sorts, presets).",
-        "description": "Returns the query definition metadata for AIUsageRecord: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
-        "operationId": "GetAIUsageRecordMeta",
+        "tags": ["IoT Telemetry"],
+        "summary": "Returns query metadata for TelemetryPoint (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for TelemetryPoint: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetTelemetryPointMeta",
         "responses": {
           "200": {
             "description": "OK",
@@ -580,22 +768,41 @@
         }
       }
     },
-    "/ai/providers": {
+    "/iot/telemetry/{deviceId}/latest": {
       "get": {
-        "tags": ["AI - Providers"],
-        "summary": "Lists all registered AI providers.",
-        "description": "Returns every AI provider registered via dependency injection, along with an indication of whether each provider supports chat and embedding capabilities.",
-        "operationId": "ListAIProviders",
+        "tags": ["IoT Telemetry"],
+        "summary": "Gets the latest telemetry point for a device.",
+        "description": "Returns the most recent telemetry point or 404 if no data exists.",
+        "operationId": "GetLatestTelemetry",
+        "parameters": [
+          {
+            "name": "deviceId",
+            "in": "path",
+            "description": "Unique identifier of the device.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AIProviderResponse"
-                  }
+                  "$ref": "#/components/schemas/TelemetryPointResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -633,20 +840,53 @@
         }
       }
     },
-    "/ai/providers/{providerName}/models": {
+    "/iot/telemetry/{deviceId}/aggregate": {
       "get": {
-        "tags": ["AI - Providers"],
-        "summary": "Lists the models available from a specific AI provider.",
-        "description": "Returns the models currently available from the specified provider. For cloud providers (OpenAI, AzureOpenAI) this is a static catalog. For local providers (Ollama) this queries the server for installed models. Returns 404 if the provider is not registered, or 502 if the provider's model listing fails.",
-        "operationId": "ListAIProviderModels",
+        "tags": ["IoT Telemetry"],
+        "summary": "Computes an aggregate over telemetry data.",
+        "description": "Computes Avg, Min, Max, or Count for a specific metric over a time range. The computation is pushed to the database.",
+        "operationId": "GetTelemetryAggregate",
         "parameters": [
           {
-            "name": "providerName",
+            "name": "deviceId",
             "in": "path",
-            "description": "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
+            "description": "Unique identifier of the device.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "metric",
+            "in": "query",
             "required": true,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "aggregation",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/TelemetryAggregation"
+            }
+          },
+          {
+            "name": "rangeStart",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "rangeEnd",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
             }
           }
         ],
@@ -656,26 +896,13 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AIProviderModelResponse"
-                  }
+                  "$ref": "#/components/schemas/TelemetryAggregateResponse"
                 }
               }
             }
           },
           "404": {
             "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -696,319 +923,6 @@
           },
           "403": {
             "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/chat/{workspaceName}": {
-      "post": {
-        "tags": ["AI - Inference"],
-        "summary": "Sends messages to an AI workspace and returns a completion response.",
-        "description": "Forwards the conversation to the underlying AI provider configured for the workspace. Returns the assistant's reply, token usage, and response duration. Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.",
-        "operationId": "AIChatComplete",
-        "parameters": [
-          {
-            "name": "workspaceName",
-            "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIChatRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIChatResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/chat/{workspaceName}/stream": {
-      "post": {
-        "tags": ["AI - Inference"],
-        "summary": "Streams a chat completion response via Server-Sent Events.",
-        "description": "Opens an SSE stream that emits incremental content chunks as they arrive from the provider. The stream ends with a [DONE] sentinel. If the provider returns an error after streaming has started, an SSE 'error' event is emitted before closing. Returns 404 if the workspace does not exist, 422 if the model is not found, or 502/503 if the provider is unavailable.",
-        "operationId": "AIChatStream",
-        "parameters": [
-          {
-            "name": "workspaceName",
-            "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIChatRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "text/event-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "Service Unavailable",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/ai/embeddings/{workspaceName}": {
-      "post": {
-        "tags": ["AI - Inference"],
-        "summary": "Generates vector embeddings for input texts using the specified workspace.",
-        "description": "Sends the input texts to the embedding model configured for the workspace and returns float vectors for each input. Returns 404 if the workspace does not exist, or 502 if the provider is unavailable.",
-        "operationId": "AIGenerateEmbeddings",
-        "parameters": [
-          {
-            "name": "workspaceName",
-            "in": "path",
-            "description": "Workspace identifier — isolates configuration and routing per AI workspace.",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AIEmbeddingRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AIEmbeddingResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -1033,396 +947,6 @@
   },
   "components": {
     "schemas": {
-      "AIChatMessageRequest": {
-        "required": ["role", "content"],
-        "type": "object",
-        "properties": {
-          "role": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          }
-        }
-      },
-      "AIChatRequest": {
-        "required": ["messages"],
-        "type": "object",
-        "properties": {
-          "messages": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AIChatMessageRequest"
-            }
-          }
-        }
-      },
-      "AIChatResponse": {
-        "required": ["workspaceName", "model", "content", "usage", "duration"],
-        "type": "object",
-        "properties": {
-          "workspaceName": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "content": {
-            "type": "string"
-          },
-          "usage": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/AIChatUsageResponse"
-              }
-            ]
-          },
-          "duration": {
-            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-            "type": "string"
-          }
-        }
-      },
-      "AIChatUsageResponse": {
-        "required": ["inputTokens", "outputTokens", "estimatedCost", "costCurrency"],
-        "type": "object",
-        "properties": {
-          "inputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "outputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "estimatedCost": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "double"
-          },
-          "costCurrency": {
-            "type": ["null", "string"]
-          }
-        }
-      },
-      "AIEmbeddingDataResponse": {
-        "required": ["index", "vector"],
-        "type": "object",
-        "properties": {
-          "index": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "vector": {
-            "type": "array",
-            "items": {
-              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-              "type": ["number", "string"],
-              "format": "float"
-            }
-          }
-        }
-      },
-      "AIEmbeddingRequest": {
-        "required": ["inputs"],
-        "type": "object",
-        "properties": {
-          "inputs": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "AIEmbeddingResponse": {
-        "required": ["workspaceName", "model", "embeddings", "usage"],
-        "type": "object",
-        "properties": {
-          "workspaceName": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "embeddings": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AIEmbeddingDataResponse"
-            }
-          },
-          "usage": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/AIEmbeddingUsageResponse"
-              }
-            ]
-          }
-        }
-      },
-      "AIEmbeddingUsageResponse": {
-        "required": ["inputTokens"],
-        "type": "object",
-        "properties": {
-          "inputTokens": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "AIModelCapabilities": {
-        "type": "object",
-        "properties": {
-          "chat": {
-            "type": "boolean"
-          },
-          "embeddings": {
-            "type": "boolean"
-          },
-          "vision": {
-            "type": "boolean"
-          },
-          "imageGeneration": {
-            "type": "boolean"
-          },
-          "audio": {
-            "type": "boolean"
-          },
-          "toolUse": {
-            "type": "boolean"
-          },
-          "streaming": {
-            "type": "boolean"
-          },
-          "structuredOutput": {
-            "type": "boolean"
-          },
-          "extensions": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "AIProviderModelResponse": {
-        "required": ["id", "displayName", "capabilities", "maxContextTokens"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "displayName": {
-            "type": "string"
-          },
-          "capabilities": {
-            "$ref": "#/components/schemas/AIModelCapabilities"
-          },
-          "maxContextTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          }
-        }
-      },
-      "AIProviderResponse": {
-        "required": ["name", "supportsChat", "supportsEmbeddings"],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "supportsChat": {
-            "type": "boolean"
-          },
-          "supportsEmbeddings": {
-            "type": "boolean"
-          }
-        }
-      },
-      "AIUsageRecord": {
-        "required": ["id", "workspaceName", "provider", "model", "timestamp"],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "tenantId": {
-            "type": ["null", "string"],
-            "format": "uuid"
-          },
-          "userId": {
-            "type": ["null", "string"],
-            "format": "uuid"
-          },
-          "workspaceName": {
-            "type": "string"
-          },
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "inputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "outputTokens": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "estimatedCost": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "double"
-          },
-          "costCurrency": {
-            "type": ["null", "string"]
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "duration": {
-            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-            "type": ["null", "string"]
-          }
-        }
-      },
-      "AIWorkspaceCreateRequest": {
-        "required": ["name", "provider", "model"],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "systemPrompt": {
-            "type": ["null", "string"]
-          },
-          "temperature": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "float"
-          },
-          "maxOutputTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          }
-        }
-      },
-      "AIWorkspaceKind": {
-        "enum": ["System", "Dynamic"]
-      },
-      "AIWorkspaceListResponse": {
-        "required": ["workspaces", "totalCount"],
-        "type": "object",
-        "properties": {
-          "workspaces": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/AIWorkspaceResponse"
-            }
-          },
-          "totalCount": {
-            "type": "integer",
-            "format": "int32"
-          }
-        }
-      },
-      "AIWorkspaceResponse": {
-        "required": [
-          "name",
-          "provider",
-          "model",
-          "systemPrompt",
-          "temperature",
-          "maxOutputTokens",
-          "kind",
-          "activated",
-          "capabilities"
-        ],
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "systemPrompt": {
-            "type": ["null", "string"]
-          },
-          "temperature": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "float"
-          },
-          "maxOutputTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          },
-          "kind": {
-            "$ref": "#/components/schemas/AIWorkspaceKind"
-          },
-          "activated": {
-            "type": "boolean"
-          },
-          "capabilities": {
-            "oneOf": [
-              {
-                "type": "null"
-              },
-              {
-                "$ref": "#/components/schemas/AIModelCapabilities"
-              }
-            ]
-          }
-        }
-      },
-      "AIWorkspaceUpdateRequest": {
-        "required": ["provider", "model"],
-        "type": "object",
-        "properties": {
-          "provider": {
-            "type": "string"
-          },
-          "model": {
-            "type": "string"
-          },
-          "systemPrompt": {
-            "type": ["null", "string"]
-          },
-          "temperature": {
-            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
-            "type": ["null", "number", "string"],
-            "format": "float"
-          },
-          "maxOutputTokens": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          },
-          "activated": {
-            "type": "boolean",
-            "default": false
-          }
-        }
-      },
       "ColumnDefinition": {
         "required": [
           "name",
@@ -1483,6 +1007,192 @@
       },
       "DatePeriod": {
         "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "Device": {
+        "type": "object",
+        "properties": {
+          "serialNumber": {
+            "$ref": "#/components/schemas/DeviceSerialNumber"
+          },
+          "model": {
+            "$ref": "#/components/schemas/HardwareModel"
+          },
+          "firmware": {
+            "$ref": "#/components/schemas/FirmwareVersion"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DeviceStatus"
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "credential": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DeviceCredential"
+              }
+            ]
+          },
+          "lastHeartbeatAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "suspensionReason": {
+            "type": ["null", "string"]
+          },
+          "tags": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "isDeleted": {
+            "type": "boolean",
+            "description": "Indicates whether the entity has been soft-deleted."
+          },
+          "deletedAt": {
+            "type": ["null", "string"],
+            "description": "Soft deletion timestamp (UTC).",
+            "format": "date-time"
+          },
+          "deletedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who deleted the entity."
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "DeviceCredential": {
+        "type": "object",
+        "properties": {
+          "credentialType": {
+            "type": "string"
+          },
+          "protectedSecret": {
+            "type": "string"
+          }
+        }
+      },
+      "DeviceProvisionRequest": {
+        "required": ["serialNumber", "hardwareModel", "firmwareVersion"],
+        "type": "object",
+        "properties": {
+          "serialNumber": {
+            "type": "string"
+          },
+          "hardwareModel": {
+            "type": "string"
+          },
+          "firmwareVersion": {
+            "type": "string"
+          },
+          "label": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DeviceResponse": {
+        "required": [
+          "id",
+          "serialNumber",
+          "hardwareModel",
+          "firmwareVersion",
+          "status",
+          "label",
+          "lastHeartbeatAt",
+          "createdAt",
+          "modifiedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "serialNumber": {
+            "type": "string"
+          },
+          "hardwareModel": {
+            "type": "string"
+          },
+          "firmwareVersion": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "lastHeartbeatAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "DeviceSerialNumber": {},
+      "DeviceStatus": {
+        "enum": ["Provisioning", "Active", "Suspended", "Decommissioned"]
+      },
+      "DeviceUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "firmwareVersion": {
+            "type": ["null", "string"]
+          },
+          "label": {
+            "type": ["null", "string"]
+          }
+        }
       },
       "FilterableField": {
         "required": ["name", "type", "operators"],
@@ -1550,6 +1260,7 @@
           "Between"
         ]
       },
+      "FirmwareVersion": {},
       "GroupByField": {
         "required": ["name", "type"],
         "type": "object",
@@ -1562,14 +1273,14 @@
           }
         }
       },
-      "GroupedResultOfAIUsageRecord": {
+      "GroupedResultOfDevice": {
         "required": ["groups", "totalCount"],
         "type": "object",
         "properties": {
           "groups": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/GroupEntryOfAIUsageRecord"
+              "$ref": "#/components/schemas/GroupEntryOfDevice"
             }
           },
           "totalCount": {
@@ -1578,7 +1289,23 @@
           }
         }
       },
-      "GroupEntryOfAIUsageRecord": {
+      "GroupedResultOfTelemetryPoint": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfTelemetryPoint"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfDevice": {
         "required": ["field", "value", "label", "count"],
         "type": "object",
         "properties": {
@@ -1599,11 +1326,38 @@
           "items": {
             "type": ["null", "array"],
             "items": {
-              "$ref": "#/components/schemas/AIUsageRecord"
+              "$ref": "#/components/schemas/Device"
             }
           }
         }
       },
+      "GroupEntryOfTelemetryPoint": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/TelemetryPoint"
+            }
+          }
+        }
+      },
+      "HardwareModel": {},
       "HttpValidationProblemDetails": {
         "type": "object",
         "properties": {
@@ -1633,6 +1387,14 @@
             }
           }
         }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
       },
       "LookupDescriptor": {
         "type": "object",
@@ -1665,60 +1427,165 @@
         "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
         "default": "QueryEngine"
       },
-      "PagedResultOfAIUsageRecord": {
+      "PagedResultOfDevice": {
         "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
             "type": "array",
             "items": {
-              "required": ["id", "workspaceName", "provider", "model", "timestamp"],
               "type": "object",
               "properties": {
-                "id": {
-                  "type": "string",
-                  "format": "uuid"
+                "serialNumber": {},
+                "model": {},
+                "firmware": {},
+                "status": {
+                  "enum": ["Provisioning", "Active", "Suspended", "Decommissioned"]
+                },
+                "label": {
+                  "type": ["null", "string"]
+                },
+                "credential": {
+                  "type": "object",
+                  "properties": {
+                    "credentialType": {
+                      "type": "string"
+                    },
+                    "protectedSecret": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "lastHeartbeatAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "suspensionReason": {
+                  "type": ["null", "string"]
+                },
+                "tags": {
+                  "type": ["null", "object"],
+                  "additionalProperties": {
+                    "type": "string"
+                  }
                 },
                 "tenantId": {
                   "type": ["null", "string"],
                   "format": "uuid"
                 },
-                "userId": {
+                "isDeleted": {
+                  "type": "boolean",
+                  "description": "Indicates whether the entity has been soft-deleted."
+                },
+                "deletedAt": {
                   "type": ["null", "string"],
+                  "description": "Soft deletion timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "deletedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who deleted the entity."
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfTelemetryPoint": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "deviceId": {
+                  "type": "string",
                   "format": "uuid"
                 },
-                "workspaceName": {
-                  "type": "string"
-                },
-                "provider": {
-                  "type": "string"
-                },
-                "model": {
-                  "type": "string"
-                },
-                "inputTokens": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "outputTokens": {
-                  "type": "integer",
-                  "format": "int32"
-                },
-                "estimatedCost": {
-                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
-                  "type": ["null", "number", "string"],
-                  "format": "double"
-                },
-                "costCurrency": {
-                  "type": ["null", "string"]
-                },
-                "timestamp": {
+                "recordedAt": {
                   "type": "string",
                   "format": "date-time"
                 },
-                "duration": {
-                  "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
+                "metrics": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+                    "type": ["number", "string"],
+                    "format": "double"
+                  }
+                },
+                "messageId": {
                   "type": ["null", "string"]
+                },
+                "source": {
+                  "type": ["null", "string"]
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
                 }
               }
             }
@@ -1882,21 +1749,122 @@
             "type": "string"
           }
         }
+      },
+      "TelemetryAggregateResponse": {
+        "required": ["value", "count", "metricName", "aggregation", "rangeStart", "rangeEnd"],
+        "type": "object",
+        "properties": {
+          "value": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "count": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "metricName": {
+            "type": "string"
+          },
+          "aggregation": {
+            "type": "string"
+          },
+          "rangeStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "rangeEnd": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "TelemetryAggregation": {
+        "enum": ["Avg", "Min", "Max", "Count"]
+      },
+      "TelemetryPoint": {
+        "type": "object",
+        "properties": {
+          "deviceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "recordedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+              "type": ["number", "string"],
+              "format": "double"
+            }
+          },
+          "messageId": {
+            "type": ["null", "string"]
+          },
+          "source": {
+            "type": ["null", "string"]
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "TelemetryPointResponse": {
+        "required": ["id", "deviceId", "recordedAt", "metrics", "source"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deviceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "recordedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "metrics": {
+            "type": "object",
+            "additionalProperties": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+              "type": ["number", "string"],
+              "format": "double"
+            }
+          },
+          "source": {
+            "type": ["null", "string"]
+          }
+        }
       }
     }
   },
   "tags": [
     {
-      "name": "AI - Inference"
+      "name": "IoT Devices"
     },
     {
-      "name": "AI - Providers"
-    },
-    {
-      "name": "AI - Usage"
-    },
-    {
-      "name": "AI - Workspaces"
+      "name": "IoT Telemetry"
     }
   ]
 }

--- a/contracts/openapi/metering.json
+++ b/contracts/openapi/metering.json
@@ -1,0 +1,2440 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "metering",
+    "version": "1"
+  },
+  "paths": {
+    "/metering/meters/active": {
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns the active meter catalog (Published only).",
+        "description": "Catalog surface for tenant users — lists meter definitions currently accepting ingestion (Published status). Draft and Archived meters are excluded. For the admin grid with full lifecycle visibility (Draft / Published / Archived), use GET /meters which requires Meters.Manage.",
+        "operationId": "ListActiveMeters",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/MeterDefinitionResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/meters/{id}": {
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns a meter definition by its unique identifier.",
+        "description": "Fetches the full metadata of a meter definition including its aggregation type, unit, and lifecycle status. Returns 404 if the meter does not exist.",
+        "operationId": "GetMeterDefinition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeterDefinitionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Metering"],
+        "summary": "Updates a Draft meter definition.",
+        "description": "Updates the name, unit, and description of a meter definition in Draft status. The aggregation type cannot be changed after creation to preserve data consistency. Returns 404 if the meter does not exist, or 409 if the meter is not in Draft status.",
+        "operationId": "UpdateMeterDefinition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeterDefinitionUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeterDefinitionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/meters": {
+      "post": {
+        "tags": ["Metering"],
+        "summary": "Creates a new meter definition.",
+        "description": "Creates a meter definition with the specified name, unit, and aggregation type. The meter starts in Draft status; it must be Published before it accepts events. Names must be unique within the tenant scope.",
+        "operationId": "CreateMeterDefinition",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MeterDefinitionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeterDefinitionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns a filtered, sorted, and paginated list of MeterDefinition entries.",
+        "description": "Executes a dynamic query against MeterDefinition using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryMeterDefinition",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfMeterDefinition"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfMeterDefinition"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/meters/{id}/publish": {
+      "post": {
+        "tags": ["Metering"],
+        "summary": "Publishes a Draft meter definition.",
+        "description": "Transitions a Draft meter to Published status. Only Published meters accept ingestion. Returns 404 if the meter does not exist, or 409 if the meter is not in Draft status.",
+        "operationId": "PublishMeterDefinition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/meters/{id}/archive": {
+      "post": {
+        "tags": ["Metering"],
+        "summary": "Archives a Published meter definition.",
+        "description": "Transitions a Published meter to Archived status. Existing aggregates and history are preserved; ingestion of new events is rejected. Returns 404 if the meter does not exist, or 409 if the meter is not in Published status.",
+        "operationId": "ArchiveMeterDefinition",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/meters/{id}/recompute": {
+      "post": {
+        "tags": ["Metering"],
+        "summary": "Recomputes UsageAggregate rows for a meter over a chosen window.",
+        "description": "Re-runs the aggregation pipeline over the requested [from, to) window, rebuilding hourly UsageAggregate rows from the raw MeterEvent data. Window edges are snapped to hourly buckets server-side. The global ingestion watermark is never rewound — concurrent ingestion past the upper bound is unaffected. Mutually-excludes with the hourly aggregation job on the same (meter, tenant) via a transaction-scoped database lock. Returns 422 when the window is empty/inverted/in the future, when the meter is unknown, or when the meter is Archived.",
+        "operationId": "RecomputeMeterUsage",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecomputeUsageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecomputeUsageResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/usage": {
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns aggregated usage for a meter over a specific period.",
+        "description": "Queries pre-computed usage aggregates for the specified meter and time range. The meterId, periodStart, and periodEnd query parameters are required. Returns 404 if no aggregate exists for the given parameters.",
+        "operationId": "GetUsageForPeriod",
+        "parameters": [
+          {
+            "name": "meterId",
+            "in": "query",
+            "description": "Metering meter identifier.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "periodStart",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "periodEnd",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UsageAggregateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/quota/{meterId}": {
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns the quota status for a specific meter.",
+        "description": "Checks the current usage against the plan-defined quota for the specified meter. Returns the current usage, limit, percentage used, and whether the quota is exceeded. Meters without a defined quota are reported as unlimited.",
+        "operationId": "CheckMeteringQuota",
+        "parameters": [
+          {
+            "name": "meterId",
+            "in": "path",
+            "description": "Metering meter identifier.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeteringQuotaStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/events": {
+      "post": {
+        "tags": ["Metering"],
+        "summary": "Records one or more usage events.",
+        "description": "Accepts a batch of usage events and records them against their respective meter definitions. Idempotency is enforced at two complementary layers: (1) the HTTP `Idempotency-Key` header (required, RFC 8700) protects against network-level replay of the entire batch — duplicate sends with the same header value return the cached response with `Idempotent-Replayed: true`, and reuse with a different payload returns 422; (2) per-event `IdempotencyKey` payload field is unique within a tenant — duplicate events across different batches are silently ignored (allows partial-overlap retries to safely add only new events). Requests without the `Idempotency-Key` header are rejected 422. All events must have a positive quantity and a non-empty idempotency key.",
+        "operationId": "RecordUsageEvents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RecordUsageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/events/backfill": {
+      "post": {
+        "tags": ["Metering"],
+        "summary": "Inserts historical usage events older than the standard 7-day ingestion window.",
+        "description": "Accepts a batch of historical usage events with timestamps up to 365 days in the past (future timestamps are still rejected). Events are deduplicated via the per-tenant unique (TenantId, IdempotencyKey) index — duplicates are silently ignored. After insertion, the service groups events by meter and triggers an automatic recompute over each meter's spanning window so existing UsageAggregate rows immediately reflect the backfilled data. Idempotent at the HTTP layer via the standard Idempotency-Key header.",
+        "operationId": "BackfillUsageEvents",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BackfillUsageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BackfillUsageResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/events/{id}/deprecate": {
+      "post": {
+        "tags": ["Metering"],
+        "summary": "Soft-deprecates a single meter event so it stops contributing to aggregates.",
+        "description": "Marks the event as deprecated (audit-safe alternative to DELETE; ISO 27001 A.12.4 keeps the row for the audit trail) and triggers an automatic recompute on the affected hourly bucket so the UsageAggregate immediately reflects the change. Returns 404 if the event does not exist; 409 if the event is already deprecated. The original IdempotencyKey remains reserved by the unique index — re-ingestion is rejected, preventing accidental resurrection of the deprecated event.",
+        "operationId": "DeprecateMeterEvent",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeprecateEventRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeprecateEventResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/meters/meta": {
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns query metadata for MeterDefinition (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for MeterDefinition: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetMeterDefinitionMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/usage-aggregates": {
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns a filtered, sorted, and paginated list of UsageAggregate entries.",
+        "description": "Executes a dynamic query against UsageAggregate using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryUsageAggregate",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfUsageAggregate"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfUsageAggregate"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/metering/usage-aggregates/meta": {
+      "get": {
+        "tags": ["Metering"],
+        "summary": "Returns query metadata for UsageAggregate (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for UsageAggregate: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetUsageAggregateMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AggregationPeriod": {
+        "enum": ["Hourly", "Daily", "BillingPeriod"]
+      },
+      "AggregationType": {
+        "enum": ["Sum", "Max", "Count", "Last", "CountDistinct"]
+      },
+      "BackfillUsageRequest": {
+        "required": ["events"],
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MeterEventRequest"
+            }
+          }
+        }
+      },
+      "BackfillUsageResponse": {
+        "required": ["eventsAccepted", "metersAffected", "aggregatesRebuilt"],
+        "type": "object",
+        "properties": {
+          "eventsAccepted": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "metersAffected": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregatesRebuilt": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "DeprecateEventRequest": {
+        "required": ["reason"],
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          }
+        }
+      },
+      "DeprecateEventResponse": {
+        "required": ["eventId", "meterDefinitionId", "deprecatedAt", "aggregatesRebuilt"],
+        "type": "object",
+        "properties": {
+          "eventId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "meterDefinitionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deprecatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "aggregatesRebuilt": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfMeterDefinition": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfMeterDefinition"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupedResultOfUsageAggregate": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfUsageAggregate"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfMeterDefinition": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/MeterDefinition"
+            }
+          }
+        }
+      },
+      "GroupEntryOfUsageAggregate": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/UsageAggregate"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "MeterDefinition": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "aggregationType": {
+            "$ref": "#/components/schemas/AggregationType"
+          },
+          "distinctProperty": {
+            "type": ["null", "string"]
+          },
+          "lifecycleStatus": {
+            "$ref": "#/components/schemas/WorkflowLifecycleStatus"
+          },
+          "productId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "MeterDefinitionCreateRequest": {
+        "required": ["name", "unit", "aggregationType"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "aggregationType": {
+            "$ref": "#/components/schemas/AggregationType"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "productId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "distinctProperty": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "MeterDefinitionResponse": {
+        "required": [
+          "id",
+          "name",
+          "unit",
+          "description",
+          "aggregationType",
+          "productId",
+          "lifecycleStatus",
+          "distinctProperty"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "aggregationType": {
+            "$ref": "#/components/schemas/AggregationType"
+          },
+          "productId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "lifecycleStatus": {
+            "$ref": "#/components/schemas/WorkflowLifecycleStatus"
+          },
+          "distinctProperty": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "MeterDefinitionUpdateRequest": {
+        "required": ["name", "unit"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "unit": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "MeterEventRequest": {
+        "required": ["meterDefinitionId", "idempotencyKey", "quantity", "timestamp"],
+        "type": "object",
+        "properties": {
+          "meterDefinitionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "idempotencyKey": {
+            "type": "string"
+          },
+          "quantity": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "MeteringQuotaStatusResponse": {
+        "required": ["meterName", "currentUsage", "limit", "percentUsed", "isExceeded"],
+        "type": "object",
+        "properties": {
+          "meterName": {
+            "type": "string"
+          },
+          "currentUsage": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "limit": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "percentUsed": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "isExceeded": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PagedResultOfMeterDefinition": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "unit": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": ["null", "string"]
+                },
+                "aggregationType": {
+                  "enum": ["Sum", "Max", "Count", "Last", "CountDistinct"]
+                },
+                "distinctProperty": {
+                  "type": ["null", "string"]
+                },
+                "lifecycleStatus": {
+                  "enum": ["Draft", "PendingReview", "Published", "Archived"]
+                },
+                "productId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfUsageAggregate": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "meterDefinitionId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "period": {
+                  "enum": ["Hourly", "Daily", "BillingPeriod"]
+                },
+                "periodStart": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "periodEnd": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "aggregatedValue": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "eventCount": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)$",
+                  "type": ["integer", "string"],
+                  "format": "int64"
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "RecomputeUsageRequest": {
+        "required": ["from", "to"],
+        "type": "object",
+        "properties": {
+          "from": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "to": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "RecomputeUsageResponse": {
+        "required": [
+          "meterDefinitionId",
+          "windowStart",
+          "windowEnd",
+          "eventsScanned",
+          "aggregatesRebuilt",
+          "durationMilliseconds"
+        ],
+        "type": "object",
+        "properties": {
+          "meterDefinitionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "windowStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "windowEnd": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "eventsScanned": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregatesRebuilt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "durationMilliseconds": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          }
+        }
+      },
+      "RecordUsageRequest": {
+        "required": ["events"],
+        "type": "object",
+        "properties": {
+          "events": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MeterEventRequest"
+            }
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "UsageAggregate": {
+        "type": "object",
+        "properties": {
+          "meterDefinitionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "period": {
+            "$ref": "#/components/schemas/AggregationPeriod"
+          },
+          "periodStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "aggregatedValue": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "eventCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "UsageAggregateResponse": {
+        "required": [
+          "id",
+          "meterDefinitionId",
+          "period",
+          "periodStart",
+          "periodEnd",
+          "aggregatedValue",
+          "eventCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "meterDefinitionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "period": {
+            "$ref": "#/components/schemas/AggregationPeriod"
+          },
+          "periodStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "periodEnd": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "aggregatedValue": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "eventCount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          }
+        }
+      },
+      "WorkflowLifecycleStatus": {
+        "enum": ["Draft", "PendingReview", "Published", "Archived"]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Metering"
+    }
+  ]
+}

--- a/contracts/openapi/parties.json
+++ b/contracts/openapi/parties.json
@@ -1,0 +1,4564 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "parties",
+    "version": "1"
+  },
+  "paths": {
+    "/parties": {
+      "get": {
+        "tags": ["Parties"],
+        "summary": "Returns a filtered, sorted, and paginated list of Party entries.",
+        "description": "Executes a dynamic query against Party using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryParty",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfParty"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfParty"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Parties"],
+        "summary": "Creates a new party in the active scope.",
+        "description": "Creates an Active party in the active scope (host or tenant context). The default role set is Customer. Identity, address, email, and phone collections are populated through dedicated child endpoints after creation. Online duplicate detection (#1302) intercepts before INSERT — a Tier-1 deterministic match (TaxId at create time) returns 409 with the candidates list, letting the admin choose to merge or to confirm-create with ?force=true. Bulk migrations bypass the check via the X-Skip-Duplicate-Check: true header. Tier-2 / Tier-3 fuzzy matches do NOT block at create time — they surface via the recurring scan + the duplicate-candidates inbox.",
+        "operationId": "CreateParty",
+        "parameters": [
+          {
+            "name": "force",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "X-Skip-Duplicate-Check",
+            "in": "header",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyCreateConflictResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/meta": {
+      "get": {
+        "tags": ["Parties"],
+        "summary": "Returns query metadata for Party (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Party: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetPartyMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}": {
+      "get": {
+        "tags": ["Parties"],
+        "summary": "Returns a single party by id.",
+        "description": "Returns the party aggregate including all its addresses, emails, phones, and external mappings. Returns 404 if no party with that id exists in the active scope.",
+        "operationId": "GetPartyById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Parties"],
+        "summary": "Updates the party's identity (name, website, locale, timezone).",
+        "description": "Updates the party's display fields. Emails / phones / addresses live in their own child collections — see the dedicated /emails, /phones, /addresses endpoints. Currency is intentionally not editable here. Returns 404 if the party does not exist; 400 on validation failure.",
+        "operationId": "UpdateIdentity",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/suspend": {
+      "post": {
+        "tags": ["Parties"],
+        "summary": "Suspends a party (idempotent; throws on Archived).",
+        "description": "Sets the party's status to Suspended. The aggregate is idempotent: re-suspending an already-suspended party is a no-op. Suspending an Archived party returns 409 Conflict.",
+        "operationId": "SuspendParty",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "$ref": "#/components/schemas/PartySuspendRequest"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/activate": {
+      "post": {
+        "tags": ["Parties"],
+        "summary": "Reactivates a suspended party (idempotent; throws on Archived).",
+        "description": "Sets the party's status back to Active. No-op if already active. Returns 409 Conflict on Archived parties.",
+        "operationId": "ActivateParty",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/archive": {
+      "post": {
+        "tags": ["Parties"],
+        "summary": "Archives a party (terminal state).",
+        "description": "Sets the party's status to Archived. Archived parties are immutable and can no longer be edited. Idempotent.",
+        "operationId": "ArchiveParty",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/addresses": {
+      "post": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Adds a typed address to a party.",
+        "description": "Adds a typed address. The first address of a kind is auto-promoted to default. Pass IsDefault=true to demote any existing default of the same kind.",
+        "operationId": "AddPartyAddress",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyAddressRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/addresses/{addressId}": {
+      "delete": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Removes an address from a party.",
+        "description": "Removes an address by id. If the removed address was the default for its kind, another address of the same kind (if any) is promoted to default. Idempotent.",
+        "operationId": "RemovePartyAddress",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "addressId",
+            "in": "path",
+            "description": "Address identifier within the parent aggregate.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/emails": {
+      "post": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Adds an email to a party.",
+        "description": "Adds an email. The first email is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary email.",
+        "operationId": "AddPartyEmail",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyEmailRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/emails/{emailId}": {
+      "delete": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Removes an email from a party.",
+        "description": "Removes an email by id. If the removed email was primary, another email (if any) is promoted to primary. Idempotent.",
+        "operationId": "RemovePartyEmail",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "emailId",
+            "in": "path",
+            "description": "Email identifier within the parent aggregate.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/phones": {
+      "post": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Adds a phone number to a party.",
+        "description": "Adds a typed phone (Mobile / Office / Home / Other). The first phone is auto-promoted to primary. Pass IsPrimary=true to demote any existing primary phone.",
+        "operationId": "AddPartyPhone",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyPhoneRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/phones/{phoneId}": {
+      "delete": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Removes a phone number from a party.",
+        "description": "Removes a phone by id. If the removed phone was primary, another phone (if any) is promoted to primary. Idempotent.",
+        "operationId": "RemovePartyPhone",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "phoneId",
+            "in": "path",
+            "description": "Phone identifier within the parent aggregate.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/external-mappings": {
+      "post": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Registers an external provider identifier (Stripe / Mollie / Odoo / …).",
+        "description": "Registers a polyglot external mapping. Returns 409 Conflict if a mapping for the same provider already exists — remove the existing one first.",
+        "operationId": "AddPartyExternalMapping",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyExternalMappingRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/external-mappings/{providerName}": {
+      "delete": {
+        "tags": ["Parties - Contact Info"],
+        "summary": "Removes an external mapping.",
+        "description": "Removes the party's external mapping for the given provider. Idempotent — returns 204 even if no mapping existed.",
+        "operationId": "RemovePartyExternalMapping",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "providerName",
+            "in": "path",
+            "description": "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/roles": {
+      "post": {
+        "tags": ["Parties - Classification"],
+        "summary": "Adds a role flag to a party.",
+        "description": "Adds the requested role flag(s) to the party's Roles set. Idempotent. The standard pattern is for downstream modules to push role flags via event handlers (e.g., Invoicing adds Customer on first invoice) — this endpoint covers manual administrative overrides.",
+        "operationId": "AddPartyRole",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyRoleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/roles/{role}": {
+      "delete": {
+        "tags": ["Parties - Classification"],
+        "summary": "Removes a role flag from a party.",
+        "description": "Removes the requested role flag from the party's Roles set. Idempotent.",
+        "operationId": "RemovePartyRole",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "role",
+            "in": "path",
+            "description": "Role name (e.g. 'owner', 'member').",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/PartyRoles"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/tax-status": {
+      "put": {
+        "tags": ["Parties - Classification"],
+        "summary": "Sets the party's customer-specific tax status.",
+        "description": "Applies VAT-exempt or B2B intra-EU reverse-charge classification to the party. Read by Granit.Tax when computing rates: parties with IsExempt=true or ReverseCharge=true yield 0% on every line. Reverse-charge requires a buyer-side VAT identification number. Returns 422 when the request violates a domain invariant (e.g., reverse-charge without VAT number).",
+        "operationId": "SetPartyTaxStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyTaxStatusRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Parties - Classification"],
+        "summary": "Resets the party's tax status to the default (no special classification).",
+        "description": "Clears any customer-specific tax classification. Subsequent tax calculations fall back to the country / standard rate. Idempotent.",
+        "operationId": "ClearPartyTaxStatus",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/metadata": {
+      "put": {
+        "tags": ["Parties - Classification"],
+        "summary": "Bulk-replaces the party's metadata dictionary.",
+        "description": "Stripe-style customer.metadata: free-form key/value extensibility. Pass an empty object to clear. Capped at 50 entries (key ≤ 40 chars, value ≤ 500 chars). NEVER store PII here — metadata surfaces in audit logs and GDPR exports.",
+        "operationId": "ReplacePartyMetadata",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyMetadataRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{survivorId}/merge/preview": {
+      "get": {
+        "tags": ["Parties - Merge"],
+        "summary": "Previews a party merge in dry-run mode.",
+        "description": "Computes per-field conflicts (with the recommended winner pre-populated) and per-rewriter row counts (Invoice.PartyId, Subscription.PartyId, BalanceAccount.PartyId, ...) without committing anything. Powers the admin merge wizard's side-by-side view. Returns 422 when a hard invariant is violated (tenant / kind / currency mismatch, archived loser).",
+        "operationId": "PreviewPartyMerge",
+        "parameters": [
+          {
+            "name": "survivorId",
+            "in": "path",
+            "description": "Identifier of the surviving record in a merge operation (the duplicate is merged into this one).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "loserId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyMergeResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{survivorId}/merge": {
+      "post": {
+        "tags": ["Parties - Merge"],
+        "summary": "Merges a loser party into the survivor.",
+        "description": "Survivor absorbs the loser: scalar fields resolved per the supplied choices (defaults applied to missing keys), child collections rewritten via SQL bulk-update, cross-module references (Invoice.PartyId, Subscription.PartyId, BalanceAccount.PartyId) redirected onto the survivor, loser tombstoned with MergedIntoId pointing at the survivor. Atomic — any failure rolls the whole transaction back. Stripe-style idempotency via the optional Idempotency-Key header (24h replay window). Returns 422 on invariant violation, 409 on concurrent merge or idempotency-key conflict, 404 when survivor or loser does not exist.",
+        "operationId": "MergeParty",
+        "parameters": [
+          {
+            "name": "survivorId",
+            "in": "path",
+            "description": "Identifier of the surviving record in a merge operation (the duplicate is merged into this one).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyMergeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyMergeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/duplicate-candidates": {
+      "get": {
+        "tags": ["Parties - Duplicates"],
+        "summary": "Lists pending duplicate candidates that involve the given party.",
+        "description": "Returns every non-dismissed pair where the party is either end of the ordered (PartyId, CandidateId) tuple. Powers the per-Party detail-page warning and the create-time online detection (#1302).",
+        "operationId": "ListPartyDuplicateCandidatesForParty",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PartyDuplicateCandidateResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/{id}/vcard": {
+      "get": {
+        "tags": ["Parties"],
+        "summary": "Downloads the party as a vCard 4.0 (text/vcard) file.",
+        "description": "Returns the party's identity, addresses, emails, phones, website, language, and timezone in vCard 4.0 format (RFC 6350). Suitable for import into address-book apps (Outlook, Apple Contacts, Google Contacts, etc.). Filename is suggested as <party-name>.vcf.",
+        "operationId": "DownloadPartyVCard",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/duplicates": {
+      "get": {
+        "tags": ["Parties - Duplicates"],
+        "summary": "Returns a filtered, sorted, and paginated list of PartyDuplicateCandidate entries.",
+        "description": "Executes a dynamic query against PartyDuplicateCandidate using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryPartyDuplicateCandidate",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfPartyDuplicateCandidate"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfPartyDuplicateCandidate"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/duplicates/meta": {
+      "get": {
+        "tags": ["Parties - Duplicates"],
+        "summary": "Returns query metadata for PartyDuplicateCandidate (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for PartyDuplicateCandidate: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetPartyDuplicateCandidateMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/duplicates/{id}/dismiss": {
+      "post": {
+        "tags": ["Parties - Duplicates"],
+        "summary": "Marks a candidate pair as 'not a duplicate'.",
+        "description": "Sets DismissedAt = now on the row. Idempotent — repeated dismisses are a no-op (still 204). Dismissed pairs are durably skipped on every subsequent scan, so the admin's decision sticks. Returns 404 only when the row truly does not exist in the current tenant.",
+        "operationId": "DismissPartyDuplicateCandidate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/parties/duplicates/{id}/merge": {
+      "post": {
+        "tags": ["Parties - Duplicates"],
+        "summary": "One-click merge from a candidate row.",
+        "description": "Forwards to the generic merge orchestrator. Body specifies which end of the ordered candidate pair survives (the other becomes the loser); 422 when the supplied survivorId is not part of the pair. Same Idempotency-Key + audit-write semantics as POST /parties/{survivorId}/merge.",
+        "operationId": "MergePartyFromDuplicateCandidate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PartyDuplicateMergeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PartyMergeResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Address": {
+        "type": "object",
+        "properties": {
+          "companyName": {
+            "type": ["null", "string"]
+          },
+          "line1": {
+            "type": "string"
+          },
+          "line2": {
+            "type": ["null", "string"]
+          },
+          "city": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "state": {
+            "type": ["null", "string"]
+          },
+          "country": {
+            "type": "string"
+          }
+        }
+      },
+      "AddressKind": {
+        "enum": ["Billing", "Shipping", "Other"]
+      },
+      "BlobReference": {
+        "description": "An opaque identifier for a blob produced by a `Granit.BlobStorage`\nprovider (S3 key, Azure Blob name, file-system path, …). Carried across\nmodule boundaries — domain aggregates, distributed events, HTTP DTOs — as\na typed value rather than a bare string so the contract is\nself-documenting and primitive-obsession is avoided."
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "DuplicateMatchSignalResponse": {
+        "required": ["kind", "score"],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "type": "string"
+          },
+          "score": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          }
+        }
+      },
+      "FieldConflictResponse": {
+        "required": ["fieldPath", "survivorValue", "loserValue", "default"],
+        "type": "object",
+        "properties": {
+          "fieldPath": {
+            "type": "string"
+          },
+          "survivorValue": {
+            "type": ["null", "string"]
+          },
+          "loserValue": {
+            "type": ["null", "string"]
+          },
+          "default": {
+            "type": "string"
+          }
+        }
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfParty": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfParty"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupedResultOfPartyDuplicateCandidate": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfPartyDuplicateCandidate"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfParty": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Party"
+            }
+          }
+        }
+      },
+      "GroupEntryOfPartyDuplicateCandidate": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PartyDuplicateCandidate"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "PagedResultOfParty": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "enum": ["Individual", "Company", "Department"]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "emails": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "address": {
+                        "type": "string"
+                      },
+                      "canonicalEmail": {
+                        "type": ["null", "string"]
+                      },
+                      "canonicalEmailHash": {
+                        "type": ["null", "string"]
+                      },
+                      "isPrimary": {
+                        "type": "boolean"
+                      },
+                      "label": {
+                        "type": ["null", "string"]
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "primaryEmail": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "canonicalEmail": {
+                      "type": ["null", "string"]
+                    },
+                    "canonicalEmailHash": {
+                      "type": ["null", "string"]
+                    },
+                    "isPrimary": {
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": ["null", "string"]
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier of the entity.",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "phones": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "enum": ["Mobile", "Work", "Home", "Other"]
+                      },
+                      "number": {
+                        "type": "string"
+                      },
+                      "canonicalNumber": {
+                        "type": ["null", "string"]
+                      },
+                      "canonicalNumberHash": {
+                        "type": ["null", "string"]
+                      },
+                      "isPrimary": {
+                        "type": "boolean"
+                      },
+                      "label": {
+                        "type": ["null", "string"]
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "primaryPhone": {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "enum": ["Mobile", "Work", "Home", "Other"]
+                    },
+                    "number": {
+                      "type": "string"
+                    },
+                    "canonicalNumber": {
+                      "type": ["null", "string"]
+                    },
+                    "canonicalNumberHash": {
+                      "type": ["null", "string"]
+                    },
+                    "isPrimary": {
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": ["null", "string"]
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier of the entity.",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "website": {
+                  "type": ["null", "string"]
+                },
+                "language": {
+                  "type": ["null", "string"]
+                },
+                "timezone": {
+                  "type": "string"
+                },
+                "defaultCurrency": {
+                  "type": "string"
+                },
+                "taxId": {
+                  "type": ["null", "string"]
+                },
+                "registrationNumber": {
+                  "type": ["null", "string"]
+                },
+                "taxStatus": {
+                  "type": "object",
+                  "properties": {
+                    "isExempt": {
+                      "type": "boolean"
+                    },
+                    "reverseCharge": {
+                      "type": "boolean"
+                    },
+                    "vatin": {
+                      "type": ["null", "string"]
+                    },
+                    "evidenceBlobId": {
+                      "type": ["null", "string"],
+                      "format": "uuid"
+                    },
+                    "yieldsZeroRate": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "metadataJson": {
+                  "type": ["null", "string"]
+                },
+                "internalNotes": {
+                  "type": ["null", "string"]
+                },
+                "mergedIntoId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "mergedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "addresses": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "kind": {
+                        "enum": ["Billing", "Shipping", "Other"]
+                      },
+                      "value": {
+                        "type": "object",
+                        "properties": {
+                          "companyName": {
+                            "type": ["null", "string"]
+                          },
+                          "line1": {
+                            "type": "string"
+                          },
+                          "line2": {
+                            "type": ["null", "string"]
+                          },
+                          "city": {
+                            "type": "string"
+                          },
+                          "postalCode": {
+                            "type": "string"
+                          },
+                          "state": {
+                            "type": ["null", "string"]
+                          },
+                          "country": {
+                            "type": "string"
+                          }
+                        }
+                      },
+                      "isDefault": {
+                        "type": "boolean"
+                      },
+                      "label": {
+                        "type": ["null", "string"]
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "defaultBillingAddress": {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "enum": ["Billing", "Shipping", "Other"]
+                    },
+                    "value": {
+                      "type": "object",
+                      "properties": {
+                        "companyName": {
+                          "type": ["null", "string"]
+                        },
+                        "line1": {
+                          "type": "string"
+                        },
+                        "line2": {
+                          "type": ["null", "string"]
+                        },
+                        "city": {
+                          "type": "string"
+                        },
+                        "postalCode": {
+                          "type": "string"
+                        },
+                        "state": {
+                          "type": ["null", "string"]
+                        },
+                        "country": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "isDefault": {
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": ["null", "string"]
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier of the entity.",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "defaultShippingAddress": {
+                  "type": "object",
+                  "properties": {
+                    "kind": {
+                      "enum": ["Billing", "Shipping", "Other"]
+                    },
+                    "value": {
+                      "type": "object",
+                      "properties": {
+                        "companyName": {
+                          "type": ["null", "string"]
+                        },
+                        "line1": {
+                          "type": "string"
+                        },
+                        "line2": {
+                          "type": ["null", "string"]
+                        },
+                        "city": {
+                          "type": "string"
+                        },
+                        "postalCode": {
+                          "type": "string"
+                        },
+                        "state": {
+                          "type": ["null", "string"]
+                        },
+                        "country": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "isDefault": {
+                      "type": "boolean"
+                    },
+                    "label": {
+                      "type": ["null", "string"]
+                    },
+                    "id": {
+                      "type": "string",
+                      "description": "Unique identifier of the entity.",
+                      "format": "uuid"
+                    }
+                  }
+                },
+                "avatar": {
+                  "description": "An opaque identifier for a blob produced by a `Granit.BlobStorage`\nprovider (S3 key, Azure Blob name, file-system path, …). Carried across\nmodule boundaries — domain aggregates, distributed events, HTTP DTOs — as\na typed value rather than a bare string so the contract is\nself-documenting and primitive-obsession is avoided."
+                },
+                "parentPartyId": {},
+                "userId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "roles": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": ["Active", "Suspended", "Archived"]
+                },
+                "externalMappings": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "providerName": {
+                        "type": "string"
+                      },
+                      "externalId": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfPartyDuplicateCandidate": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "partyId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "candidateId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "tier": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "score": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "signalsJson": {
+                  "type": "string"
+                },
+                "dismissedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "updatedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Party": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/PartyKind"
+          },
+          "name": {
+            "type": "string"
+          },
+          "emails": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PartyEmail"
+            }
+          },
+          "primaryEmail": {
+            "$ref": "#/components/schemas/PartyEmail"
+          },
+          "phones": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PartyPhone"
+            }
+          },
+          "primaryPhone": {
+            "$ref": "#/components/schemas/PartyPhone"
+          },
+          "website": {
+            "type": ["null", "string"]
+          },
+          "language": {
+            "type": ["null", "string"]
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "defaultCurrency": {
+            "type": "string"
+          },
+          "taxId": {
+            "type": ["null", "string"]
+          },
+          "registrationNumber": {
+            "type": ["null", "string"]
+          },
+          "taxStatus": {
+            "$ref": "#/components/schemas/TaxStatus"
+          },
+          "metadataJson": {
+            "type": ["null", "string"]
+          },
+          "internalNotes": {
+            "type": ["null", "string"]
+          },
+          "mergedIntoId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "mergedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "addresses": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PartyAddress"
+            }
+          },
+          "defaultBillingAddress": {
+            "$ref": "#/components/schemas/PartyAddress"
+          },
+          "defaultShippingAddress": {
+            "$ref": "#/components/schemas/PartyAddress"
+          },
+          "avatar": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/BlobReference"
+              }
+            ]
+          },
+          "parentPartyId": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PartyId"
+              }
+            ]
+          },
+          "userId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "roles": {
+            "$ref": "#/components/schemas/PartyRoles"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PartyStatus"
+          },
+          "externalMappings": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PartyExternalMapping"
+            }
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyAddress": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/AddressKind"
+          },
+          "value": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyAddressRequest": {
+        "required": ["kind", "line1", "city", "postalCode", "country"],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/AddressKind"
+          },
+          "line1": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": ["null", "string"]
+          },
+          "line2": {
+            "type": ["null", "string"]
+          },
+          "state": {
+            "type": ["null", "string"]
+          },
+          "isDefault": {
+            "type": "boolean",
+            "default": false
+          },
+          "label": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyAddressResponse": {
+        "required": [
+          "id",
+          "kind",
+          "isDefault",
+          "label",
+          "line1",
+          "city",
+          "postalCode",
+          "country",
+          "companyName",
+          "line2",
+          "state"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/AddressKind"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "line1": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "companyName": {
+            "type": ["null", "string"]
+          },
+          "line2": {
+            "type": ["null", "string"]
+          },
+          "state": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyCreateConflictResponse": {
+        "required": ["reason", "candidates"],
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "candidates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PartyCreateDuplicateCandidate"
+            }
+          }
+        }
+      },
+      "PartyCreateDuplicateCandidate": {
+        "required": ["candidateId", "score", "tier", "signals"],
+        "type": "object",
+        "properties": {
+          "candidateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "score": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DuplicateMatchSignalResponse"
+            }
+          }
+        }
+      },
+      "PartyCreateRequest": {
+        "required": ["kind", "name", "defaultCurrency"],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/PartyKind"
+          },
+          "name": {
+            "type": "string"
+          },
+          "defaultCurrency": {
+            "type": "string"
+          },
+          "roles": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PartyRoles"
+              }
+            ]
+          },
+          "website": {
+            "type": ["null", "string"]
+          },
+          "language": {
+            "type": ["null", "string"]
+          },
+          "timezone": {
+            "type": ["null", "string"]
+          },
+          "taxId": {
+            "type": ["null", "string"]
+          },
+          "registrationNumber": {
+            "type": ["null", "string"]
+          },
+          "internalNotes": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyDuplicateCandidate": {
+        "type": "object",
+        "properties": {
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "candidateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tier": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "score": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "signalsJson": {
+            "type": "string"
+          },
+          "dismissedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyDuplicateCandidateResponse": {
+        "required": [
+          "id",
+          "partyId",
+          "candidateId",
+          "score",
+          "tier",
+          "signals",
+          "dismissedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "candidateId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "score": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "signals": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DuplicateMatchSignalResponse"
+            }
+          },
+          "dismissedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "PartyDuplicateMergeRequest": {
+        "required": ["survivorId"],
+        "type": "object",
+        "properties": {
+          "survivorId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "choices": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "reason": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyEmail": {
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "canonicalEmail": {
+            "type": ["null", "string"]
+          },
+          "canonicalEmailHash": {
+            "type": ["null", "string"]
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyEmailRequest": {
+        "required": ["address"],
+        "type": "object",
+        "properties": {
+          "address": {
+            "type": "string"
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "default": false
+          },
+          "label": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyEmailResponse": {
+        "required": ["id", "address", "isPrimary", "label"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "address": {
+            "type": "string"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyExternalMapping": {
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyExternalMappingRequest": {
+        "required": ["providerName", "externalId"],
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          }
+        }
+      },
+      "PartyExternalMappingResponse": {
+        "required": ["id", "providerName", "externalId"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          }
+        }
+      },
+      "PartyId": {},
+      "PartyKind": {
+        "enum": ["Individual", "Company", "Department"]
+      },
+      "PartyMergeRequest": {
+        "required": ["loserId"],
+        "type": "object",
+        "properties": {
+          "loserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "choices": {
+            "type": ["null", "object"],
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "reason": {
+            "type": ["null", "string"]
+          },
+          "dryRun": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "PartyMergeResponse": {
+        "required": ["survivorId", "loserId", "conflicts", "rewriteCounts", "dryRun"],
+        "type": "object",
+        "properties": {
+          "survivorId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "loserId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "conflicts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FieldConflictResponse"
+            }
+          },
+          "rewriteCounts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "dryRun": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PartyMetadataRequest": {
+        "required": ["metadata"],
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "PartyPhone": {
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/PhoneKind"
+          },
+          "number": {
+            "type": "string"
+          },
+          "canonicalNumber": {
+            "type": ["null", "string"]
+          },
+          "canonicalNumberHash": {
+            "type": ["null", "string"]
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": ["null", "string"]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyPhoneRequest": {
+        "required": ["kind", "number"],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/PhoneKind"
+          },
+          "number": {
+            "type": "string"
+          },
+          "isPrimary": {
+            "type": "boolean",
+            "default": false
+          },
+          "label": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyPhoneResponse": {
+        "required": ["id", "kind", "number", "isPrimary", "label"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/PhoneKind"
+          },
+          "number": {
+            "type": "string"
+          },
+          "isPrimary": {
+            "type": "boolean"
+          },
+          "label": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyResponse": {
+        "required": [
+          "id",
+          "tenantId",
+          "kind",
+          "name",
+          "defaultCurrency",
+          "timezone",
+          "language",
+          "website",
+          "taxId",
+          "registrationNumber",
+          "parentPartyId",
+          "userId",
+          "avatar",
+          "roles",
+          "status",
+          "addresses",
+          "emails",
+          "phones",
+          "externalMappings",
+          "taxStatus",
+          "metadata",
+          "internalNotes"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/PartyKind"
+          },
+          "name": {
+            "type": "string"
+          },
+          "defaultCurrency": {
+            "type": "string"
+          },
+          "timezone": {
+            "type": "string"
+          },
+          "language": {
+            "type": ["null", "string"]
+          },
+          "website": {
+            "type": ["null", "string"]
+          },
+          "taxId": {
+            "type": ["null", "string"]
+          },
+          "registrationNumber": {
+            "type": ["null", "string"]
+          },
+          "parentPartyId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "userId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "avatar": {
+            "type": ["null", "string"]
+          },
+          "roles": {
+            "$ref": "#/components/schemas/PartyRoles"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PartyStatus"
+          },
+          "addresses": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PartyAddressResponse"
+            }
+          },
+          "emails": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PartyEmailResponse"
+            }
+          },
+          "phones": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PartyPhoneResponse"
+            }
+          },
+          "externalMappings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PartyExternalMappingResponse"
+            }
+          },
+          "taxStatus": {
+            "$ref": "#/components/schemas/PartyTaxStatusResponse"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "internalNotes": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyRoleRequest": {
+        "required": ["role"],
+        "type": "object",
+        "properties": {
+          "role": {
+            "$ref": "#/components/schemas/PartyRoles"
+          }
+        }
+      },
+      "PartyRoles": {
+        "type": "string"
+      },
+      "PartyStatus": {
+        "enum": ["Active", "Suspended", "Archived"]
+      },
+      "PartySuspendRequest": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PartyTaxStatusRequest": {
+        "required": ["isExempt", "reverseCharge", "vatin", "evidenceBlobId"],
+        "type": "object",
+        "properties": {
+          "isExempt": {
+            "type": "boolean"
+          },
+          "reverseCharge": {
+            "type": "boolean"
+          },
+          "vatin": {
+            "type": ["null", "string"]
+          },
+          "evidenceBlobId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyTaxStatusResponse": {
+        "required": ["isExempt", "reverseCharge", "vatin", "evidenceBlobId"],
+        "type": "object",
+        "properties": {
+          "isExempt": {
+            "type": "boolean"
+          },
+          "reverseCharge": {
+            "type": "boolean"
+          },
+          "vatin": {
+            "type": ["null", "string"]
+          },
+          "evidenceBlobId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "PartyUpdateRequest": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "website": {
+            "type": ["null", "string"]
+          },
+          "language": {
+            "type": ["null", "string"]
+          },
+          "timezone": {
+            "type": ["null", "string"]
+          },
+          "internalNotes": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PhoneKind": {
+        "enum": ["Mobile", "Work", "Home", "Other"]
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "TaxStatus": {
+        "type": "object",
+        "properties": {
+          "isExempt": {
+            "type": "boolean"
+          },
+          "reverseCharge": {
+            "type": "boolean"
+          },
+          "vatin": {
+            "type": ["null", "string"]
+          },
+          "evidenceBlobId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "yieldsZeroRate": {
+            "type": "boolean"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Parties"
+    },
+    {
+      "name": "Parties - Classification"
+    },
+    {
+      "name": "Parties - Contact Info"
+    },
+    {
+      "name": "Parties - Duplicates"
+    },
+    {
+      "name": "Parties - Merge"
+    }
+  ]
+}

--- a/contracts/openapi/payments.json
+++ b/contracts/openapi/payments.json
@@ -1,0 +1,3654 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "payments",
+    "version": "1"
+  },
+  "paths": {
+    "/payments/transactions/mine": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Lists payment transactions belonging to the current tenant.",
+        "description": "Returns every payment transaction belonging to the current tenant, ordered by creation date. Each transaction includes its refunds and disputes. Tenant-scoped read; for cross-tenant admin grids with filtering, use the query endpoint on /transactions. Requires the Payments.Transactions.Read permission.",
+        "operationId": "ListMyPaymentTransactions",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PaymentTransactionResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/transactions/{id}": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Returns a payment transaction by its unique identifier.",
+        "description": "Fetches the full details of a single payment transaction including its status, provider reference, refunds, and disputes. Returns 404 if the transaction does not exist.",
+        "operationId": "GetPaymentTransaction",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentTransactionResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/charge": {
+      "post": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Initiates a payment charge for an invoice.",
+        "description": "Dispatches an InitiatePaymentCommand to charge the specified invoice amount using the given payment method type. The charge is processed asynchronously and the transaction can be tracked via the transactions endpoints. Returns 202 Accepted when the command has been dispatched.",
+        "operationId": "InitiatePaymentCharge",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentChargeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/refund": {
+      "post": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Requests a refund for a payment transaction.",
+        "description": "Dispatches a RequestRefundCommand for the specified transaction. Partial refunds are supported by specifying an amount less than the original charge. The refund is processed asynchronously via the payment provider. Returns 202 Accepted when the command has been dispatched.",
+        "operationId": "RequestPaymentRefund",
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentRefundRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "Accepted"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/checkout": {
+      "post": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Creates a hosted checkout session for a transaction.",
+        "description": "Generates a hosted payment page URL via the payment provider. The client should redirect the user to the returned URL. On completion, the provider redirects to the success or cancel URL. Returns the session details including URL and expiry.",
+        "operationId": "CreateCheckoutSession",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentCheckoutRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentCheckoutSessionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/transactions": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Returns a filtered, sorted, and paginated list of PaymentTransaction entries.",
+        "description": "Executes a dynamic query against PaymentTransaction using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryPaymentTransaction",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfPaymentTransaction"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfPaymentTransaction"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/transactions/meta": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Returns query metadata for PaymentTransaction (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for PaymentTransaction: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetPaymentTransactionMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/refunds": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Returns a filtered, sorted, and paginated list of Refund entries.",
+        "description": "Executes a dynamic query against Refund using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryRefund",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfRefund"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfRefund"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/refunds/meta": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Returns query metadata for Refund (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Refund: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetRefundMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/disputes": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Returns a filtered, sorted, and paginated list of Dispute entries.",
+        "description": "Executes a dynamic query against Dispute using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryDispute",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfDispute"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfDispute"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/disputes/meta": {
+      "get": {
+        "tags": ["Payments - Transactions"],
+        "summary": "Returns query metadata for Dispute (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Dispute: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetDisputeMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/methods/mine": {
+      "get": {
+        "tags": ["Payments - Methods"],
+        "summary": "Lists saved payment methods belonging to the current tenant.",
+        "description": "Returns all payment methods that have been attached to the current tenant, including their type, provider, display label, and default status. Tenant-scoped read; for cross-tenant admin grids with filtering, use the query endpoint on /methods. Requires the Payments.Methods.Read permission.",
+        "operationId": "ListMyPaymentMethods",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PaymentMethodResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/methods/available": {
+      "get": {
+        "tags": ["Payments - Methods"],
+        "summary": "Lists payment methods available for the current tenant and request context.",
+        "description": "Returns the payment methods that the tenant can use, filtered against the request context (billing country, currency, amount, sequence type). Each method returns its capability snapshot so the front-end can render explanatory UI (e.g., 'available in BE only', Klarna amount bounds). Query params are optional: an absent axis skips filtering on that axis. Returns 400 for malformed country/currency/amount/sequenceType values.",
+        "operationId": "GetAvailablePaymentMethods",
+        "parameters": [
+          {
+            "name": "country",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "currency",
+            "in": "query",
+            "description": "ISO 4217 three-letter currency code (e.g. 'EUR', 'USD').",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "amount",
+            "in": "query",
+            "schema": {
+              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+              "type": ["number", "string"],
+              "format": "double"
+            }
+          },
+          {
+            "name": "sequenceType",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PaymentAvailableMethodResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/methods": {
+      "post": {
+        "tags": ["Payments - Methods"],
+        "summary": "Attaches a payment method to the current tenant.",
+        "description": "Creates a payment method on the provider using the supplied token (e.g. a Stripe SetupIntent confirmation token) and persists it as a saved method for the tenant. Returns the newly created payment method. Requires the Payments.Methods.Manage permission.",
+        "operationId": "AttachPaymentMethod",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PaymentAttachMethodRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Payments - Methods"],
+        "summary": "Returns a filtered, sorted, and paginated list of PaymentMethod entries.",
+        "description": "Executes a dynamic query against PaymentMethod using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryPaymentMethod",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfPaymentMethod"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfPaymentMethod"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/methods/{id}": {
+      "delete": {
+        "tags": ["Payments - Methods"],
+        "summary": "Detaches a payment method from the current tenant.",
+        "description": "Removes the payment method from the provider and deletes the local record. Returns 204 No Content on success, or 404 if the method does not exist.",
+        "operationId": "DetachPaymentMethod",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/methods/meta": {
+      "get": {
+        "tags": ["Payments - Methods"],
+        "summary": "Returns query metadata for PaymentMethod (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for PaymentMethod: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetPaymentMethodMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/configuration": {
+      "get": {
+        "tags": ["Payments - Configuration"],
+        "summary": "Lists all payment methods declared by installed providers with their activation state.",
+        "description": "Returns the fused view of all payment methods supported by registered IPaymentProvider instances, grouped by provider. Each method shows its localized display label, category and current activation state plus the capability snapshot captured at activation time.",
+        "operationId": "ListPaymentMethodConfigurations",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PaymentProviderConfigurationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/configuration/catalog": {
+      "get": {
+        "tags": ["Payments - Configuration"],
+        "summary": "Returns the live catalog of a specific provider with activation state.",
+        "description": "Calls IPaymentProvider.GetCatalogAsync on the named provider and cross-references the result with the current activation records. Use this endpoint to power admin UIs where new provider methods should appear automatically (before any activation has snapshotted them). Returns 404 if the provider is not registered.",
+        "operationId": "GetPaymentProviderCatalog",
+        "parameters": [
+          {
+            "name": "providerName",
+            "in": "query",
+            "description": "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentProviderCatalogResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/configuration/{providerName}/{methodType}/activate": {
+      "post": {
+        "tags": ["Payments - Configuration"],
+        "summary": "Activates a payment method for the platform and snapshots its capability.",
+        "description": "Marks the method declared by the given provider as active and captures its current capability (countries, currencies, amount bounds, sequence types) on the activation record. Idempotent. Returns 404 if the provider is not registered, 400 if the provider no longer offers the given method type.",
+        "operationId": "ActivatePaymentMethodConfiguration",
+        "parameters": [
+          {
+            "name": "providerName",
+            "in": "path",
+            "description": "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "methodType",
+            "in": "path",
+            "description": "Payment method type (e.g. 'card', 'sepa', 'paypal').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/configuration/{providerName}/{methodType}/deactivate": {
+      "post": {
+        "tags": ["Payments - Configuration"],
+        "summary": "Deactivates a payment method for the platform.",
+        "description": "Marks the method as inactive. Tenants will no longer see it in GET /methods/available. The capability snapshot is preserved so a future reactivation does not require a re-sync.",
+        "operationId": "DeactivatePaymentMethodConfiguration",
+        "parameters": [
+          {
+            "name": "providerName",
+            "in": "path",
+            "description": "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "methodType",
+            "in": "path",
+            "description": "Payment method type (e.g. 'card', 'sepa', 'paypal').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/configuration/{providerName}/{methodType}/resync": {
+      "post": {
+        "tags": ["Payments - Configuration"],
+        "summary": "Re-fetches the provider catalog and updates the capability snapshot.",
+        "description": "Calls IPaymentProvider.GetCatalogAsync and overwrites the capability snapshot on the existing activation record. Use this to propagate provider-side changes (added countries, updated amount bounds) without deactivating/reactivating the method.",
+        "operationId": "ResyncPaymentMethodConfiguration",
+        "parameters": [
+          {
+            "name": "providerName",
+            "in": "path",
+            "description": "External provider identifier (e.g. 'keycloak', 'auth0', 'stripe').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "methodType",
+            "in": "path",
+            "description": "Payment method type (e.g. 'card', 'sepa', 'paypal').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/payments/webhooks/{provider}": {
+      "post": {
+        "tags": ["Payments - Webhooks"],
+        "summary": "Receives an inbound webhook from a payment provider.",
+        "description": "Verifies the webhook signature, deduplicates the event using the processed event store, and dispatches a ProcessWebhookCommand for asynchronous handling. This endpoint is anonymous — authentication relies on the provider's signature verification.",
+        "operationId": "HandlePaymentWebhook",
+        "parameters": [
+          {
+            "name": "provider",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [{}]
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "Dispute": {
+        "type": "object",
+        "properties": {
+          "providerDisputeId": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolvedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "DisputeStatus": {
+        "enum": ["Open", "Won", "Lost", "Closed"]
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfDispute": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfDispute"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupedResultOfPaymentMethod": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfPaymentMethod"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupedResultOfPaymentTransaction": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfPaymentTransaction"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupedResultOfRefund": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfRefund"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfDispute": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Dispute"
+            }
+          }
+        }
+      },
+      "GroupEntryOfPaymentMethod": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PaymentMethod"
+            }
+          }
+        }
+      },
+      "GroupEntryOfPaymentTransaction": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PaymentTransaction"
+            }
+          }
+        }
+      },
+      "GroupEntryOfRefund": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Refund"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "PagedResultOfDispute": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "providerDisputeId": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": ["Open", "Won", "Lost", "Closed"]
+                },
+                "reason": {
+                  "type": "string"
+                },
+                "amount": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "currency": {
+                  "type": "string"
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "resolvedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfPaymentMethod": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "providerName": {
+                  "type": "string"
+                },
+                "providerMethodId": {
+                  "type": "string"
+                },
+                "displayLabel": {
+                  "type": "string"
+                },
+                "isDefault": {
+                  "type": "boolean"
+                },
+                "expiresAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfPaymentTransaction": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "invoiceId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "amount": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "currency": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": [
+                    "Created",
+                    "RequiresAction",
+                    "Processing",
+                    "Succeeded",
+                    "Failed",
+                    "Canceled"
+                  ]
+                },
+                "providerName": {
+                  "type": "string"
+                },
+                "methodType": {
+                  "type": "string"
+                },
+                "providerTransactionId": {
+                  "type": ["null", "string"]
+                },
+                "paymentMethodId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "actionUrl": {
+                  "type": ["null", "string"]
+                },
+                "idempotencyKey": {
+                  "type": "string"
+                },
+                "failureCode": {
+                  "type": ["null", "string"]
+                },
+                "failureMessage": {
+                  "type": ["null", "string"]
+                },
+                "succeededAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "canceledAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "refunds": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "currency": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "enum": ["Pending", "Succeeded", "Failed"]
+                      },
+                      "providerRefundId": {
+                        "type": ["null", "string"]
+                      },
+                      "reason": {
+                        "type": ["null", "string"]
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "completedAt": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "disputes": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "providerDisputeId": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "enum": ["Open", "Won", "Lost", "Closed"]
+                      },
+                      "reason": {
+                        "type": "string"
+                      },
+                      "amount": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "currency": {
+                        "type": "string"
+                      },
+                      "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "resolvedAt": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfRefund": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "amount": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "currency": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": ["Pending", "Succeeded", "Failed"]
+                },
+                "providerRefundId": {
+                  "type": ["null", "string"]
+                },
+                "reason": {
+                  "type": ["null", "string"]
+                },
+                "createdAt": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "completedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PaymentAttachMethodRequest": {
+        "required": ["providerName", "type", "token"],
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        }
+      },
+      "PaymentAvailableMethodResponse": {
+        "required": ["methodType", "category", "providerName", "displayLabel", "capability"],
+        "type": "object",
+        "properties": {
+          "methodType": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/PaymentMethodCategory"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "displayLabel": {
+            "type": "string"
+          },
+          "capability": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PaymentMethodCapabilityResponse"
+              }
+            ]
+          }
+        }
+      },
+      "PaymentCatalogMethod": {
+        "required": [
+          "methodType",
+          "category",
+          "displayLabel",
+          "capability",
+          "activated",
+          "hasSnapshot"
+        ],
+        "type": "object",
+        "properties": {
+          "methodType": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/PaymentMethodCategory"
+          },
+          "displayLabel": {
+            "type": "string"
+          },
+          "capability": {
+            "$ref": "#/components/schemas/PaymentMethodCapabilityResponse"
+          },
+          "activated": {
+            "type": "boolean"
+          },
+          "hasSnapshot": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PaymentChargeRequest": {
+        "required": ["invoiceId", "amount", "currency", "methodType"],
+        "type": "object",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "methodType": {
+            "type": "string"
+          },
+          "providerName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaymentCheckoutRequest": {
+        "required": [
+          "transactionId",
+          "amount",
+          "currency",
+          "methodType",
+          "successUrl",
+          "cancelUrl"
+        ],
+        "type": "object",
+        "properties": {
+          "transactionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "methodType": {
+            "type": "string"
+          },
+          "successUrl": {
+            "type": "string"
+          },
+          "cancelUrl": {
+            "type": "string"
+          },
+          "providerName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaymentCheckoutSessionResponse": {
+        "required": ["url", "sessionId", "expiresAt"],
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "sessionId": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PaymentDisputeResponse": {
+        "required": [
+          "id",
+          "providerDisputeId",
+          "status",
+          "reason",
+          "amount",
+          "currency",
+          "createdAt",
+          "resolvedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "providerDisputeId": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/DisputeStatus"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "resolvedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "PaymentMethod": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "providerMethodId": {
+            "type": "string"
+          },
+          "displayLabel": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "expiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PaymentMethodAmountBoundResponse": {
+        "required": ["currencyCode", "minAmount", "maxAmount"],
+        "type": "object",
+        "properties": {
+          "currencyCode": {
+            "type": "string"
+          },
+          "minAmount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "maxAmount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          }
+        }
+      },
+      "PaymentMethodCapabilityResponse": {
+        "required": [
+          "supportedCountries",
+          "supportedCurrencies",
+          "supportedSequenceTypes",
+          "amountBounds"
+        ],
+        "type": "object",
+        "properties": {
+          "supportedCountries": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "supportedCurrencies": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "supportedSequenceTypes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "amountBounds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentMethodAmountBoundResponse"
+            }
+          }
+        }
+      },
+      "PaymentMethodCategory": {
+        "enum": [
+          "Card",
+          "BankRedirect",
+          "BankTransfer",
+          "BankDebit",
+          "Wallet",
+          "BuyNowPayLater",
+          "Voucher",
+          "PointOfSale"
+        ]
+      },
+      "PaymentMethodConfigurationItem": {
+        "required": ["methodType", "displayLabel", "category", "activated", "capabilitySnapshot"],
+        "type": "object",
+        "properties": {
+          "methodType": {
+            "type": "string"
+          },
+          "displayLabel": {
+            "type": "string"
+          },
+          "category": {
+            "$ref": "#/components/schemas/PaymentMethodCategory"
+          },
+          "activated": {
+            "type": "boolean"
+          },
+          "capabilitySnapshot": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/PaymentMethodCapabilityResponse"
+              }
+            ]
+          }
+        }
+      },
+      "PaymentMethodResponse": {
+        "required": [
+          "id",
+          "type",
+          "providerName",
+          "providerMethodId",
+          "displayLabel",
+          "isDefault",
+          "expiresAt",
+          "tenantId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "type": {
+            "type": "string"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "providerMethodId": {
+            "type": "string"
+          },
+          "displayLabel": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          },
+          "expiresAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "PaymentProviderCatalogResponse": {
+        "required": ["providerName", "methods"],
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "methods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentCatalogMethod"
+            }
+          }
+        }
+      },
+      "PaymentProviderConfigurationResponse": {
+        "required": ["providerName", "methods"],
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "methods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+            }
+          }
+        }
+      },
+      "PaymentRefundRequest": {
+        "required": ["transactionId", "amount", "reason"],
+        "type": "object",
+        "properties": {
+          "transactionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "reason": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaymentRefundResponse": {
+        "required": [
+          "id",
+          "amount",
+          "currency",
+          "status",
+          "providerRefundId",
+          "reason",
+          "createdAt",
+          "completedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/RefundStatus"
+          },
+          "providerRefundId": {
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "PaymentStatus": {
+        "enum": ["Created", "RequiresAction", "Processing", "Succeeded", "Failed", "Canceled"]
+      },
+      "PaymentTransaction": {
+        "type": "object",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PaymentStatus"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "methodType": {
+            "type": "string"
+          },
+          "providerTransactionId": {
+            "type": ["null", "string"]
+          },
+          "paymentMethodId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "actionUrl": {
+            "type": ["null", "string"]
+          },
+          "idempotencyKey": {
+            "type": "string"
+          },
+          "failureCode": {
+            "type": ["null", "string"]
+          },
+          "failureMessage": {
+            "type": ["null", "string"]
+          },
+          "succeededAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "canceledAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "refunds": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Refund"
+            }
+          },
+          "disputes": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Dispute"
+            }
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PaymentTransactionResponse": {
+        "required": [
+          "id",
+          "invoiceId",
+          "amount",
+          "currency",
+          "status",
+          "providerName",
+          "providerTransactionId",
+          "paymentMethodId",
+          "actionUrl",
+          "idempotencyKey",
+          "failureCode",
+          "succeededAt",
+          "canceledAt",
+          "refunds",
+          "disputes",
+          "tenantId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PaymentStatus"
+          },
+          "providerName": {
+            "type": "string"
+          },
+          "providerTransactionId": {
+            "type": ["null", "string"]
+          },
+          "paymentMethodId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "actionUrl": {
+            "type": ["null", "string"]
+          },
+          "idempotencyKey": {
+            "type": "string"
+          },
+          "failureCode": {
+            "type": ["null", "string"]
+          },
+          "succeededAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "canceledAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "refunds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentRefundResponse"
+            }
+          },
+          "disputes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PaymentDisputeResponse"
+            }
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Refund": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/RefundStatus"
+          },
+          "providerRefundId": {
+            "type": ["null", "string"]
+          },
+          "reason": {
+            "type": ["null", "string"]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "RefundStatus": {
+        "enum": ["Pending", "Succeeded", "Failed"]
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Payments - Configuration"
+    },
+    {
+      "name": "Payments - Methods"
+    },
+    {
+      "name": "Payments - Transactions"
+    },
+    {
+      "name": "Payments - Webhooks"
+    }
+  ]
+}

--- a/contracts/openapi/reference-data.json
+++ b/contracts/openapi/reference-data.json
@@ -1,0 +1,37 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "reference-data",
+    "version": "1"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      }
+    }
+  }
+}

--- a/contracts/openapi/subscriptions.json
+++ b/contracts/openapi/subscriptions.json
@@ -1,0 +1,3571 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "subscriptions",
+    "version": "1"
+  },
+  "paths": {
+    "/subscriptions/plans/active": {
+      "get": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Returns the active plan catalog (Published only).",
+        "description": "Catalog surface for tenant users — returns plans available for purchase (Published status). Draft and Archived plans are excluded. For the admin grid with full lifecycle visibility (Draft / Published / Archived), use GET /plans which requires Plans.Manage.",
+        "operationId": "ListActivePlans",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PlanResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/plans/{id}": {
+      "get": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Returns a plan by ID.",
+        "description": "Returns the full plan details including prices. Published and Archived plans are readable with Plans.Read. Draft plans require Plans.Manage; callers without it receive 404 (no existence leak).",
+        "operationId": "GetPlanById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Updates a draft plan.",
+        "description": "Only Draft plans can be updated. Published and Archived plans are immutable.",
+        "operationId": "UpdatePlan",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/plans": {
+      "post": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Creates a new plan in Draft status.",
+        "description": "Creates a plan that can be configured with prices and features before publishing.",
+        "operationId": "CreatePlan",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Returns a filtered, sorted, and paginated list of Plan entries.",
+        "description": "Executes a dynamic query against Plan using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryPlan",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfPlan"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfPlan"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/plans/{id}/publish": {
+      "post": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Publishes a draft plan, making it available for purchase.",
+        "description": "Transitions the plan from Draft to Published. This action is irreversible.",
+        "operationId": "PublishPlan",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/plans/{id}/archive": {
+      "post": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Archives a published plan.",
+        "description": "Archived plans are no longer purchasable but remain usable by existing subscribers.",
+        "operationId": "ArchivePlan",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/plans/meta": {
+      "get": {
+        "tags": ["Subscriptions - Plans"],
+        "summary": "Returns query metadata for Plan (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Plan: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetPlanMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/plans/{planId}/prices": {
+      "post": {
+        "tags": ["Subscriptions - Prices"],
+        "summary": "Creates a new price version for a plan.",
+        "description": "Adds a new price for the given currency and interval. If an active price already exists for the same slot, it is marked as replaced. Allowed on Draft and Published plans. Existing subscribers keep their pinned price (grandfathering).",
+        "operationId": "CreatePriceVersion",
+        "parameters": [
+          {
+            "name": "planId",
+            "in": "path",
+            "description": "Subscription plan identifier.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePriceVersionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanPriceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/plans/{planId}/prices/history": {
+      "get": {
+        "tags": ["Subscriptions - Prices"],
+        "summary": "Returns the price version history for a plan.",
+        "description": "Returns all price versions for the specified currency and interval, ordered from newest to oldest. Includes replaced prices for audit trail.",
+        "operationId": "GetPlanPriceHistory",
+        "parameters": [
+          {
+            "name": "planId",
+            "in": "path",
+            "description": "Subscription plan identifier.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "currency",
+            "in": "query",
+            "description": "ISO 4217 three-letter currency code (e.g. 'EUR', 'USD').",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "interval",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PlanPriceResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/{id}/migrate-price": {
+      "post": {
+        "tags": ["Subscriptions - Prices"],
+        "summary": "Migrates a subscription to a new price version.",
+        "description": "Updates the pinned price for a specific subscription. Only allowed for Active or Trial subscriptions. Publishes a SubscriptionPriceMigratedEto event.",
+        "operationId": "MigrateSubscriptionPrice",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MigratePriceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/bulk-migrate-price": {
+      "post": {
+        "tags": ["Subscriptions - Prices"],
+        "summary": "Bulk-migrates subscriptions to a new price version.",
+        "description": "Migrates all active subscriptions on a given plan to a new price version. Optionally filters by old price ID. Returns the number of migrated subscriptions.",
+        "operationId": "BulkMigrateSubscriptionPrice",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BulkMigratePriceRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BulkMigratePriceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/active": {
+      "get": {
+        "tags": ["Subscriptions - Instances"],
+        "summary": "Returns the active subscription for the current tenant.",
+        "description": "Returns the subscription in Active or Trial status. Returns 404 if no active subscription exists. Requires tenant context.",
+        "operationId": "GetActiveSubscription",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/{id}": {
+      "get": {
+        "tags": ["Subscriptions - Instances"],
+        "summary": "Returns a subscription by ID.",
+        "description": "Returns the full subscription details including seat count and dunning status.",
+        "operationId": "GetSubscriptionById",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions": {
+      "post": {
+        "tags": ["Subscriptions - Instances"],
+        "summary": "Creates a new subscription.",
+        "description": "Creates a subscription for the current tenant. If trialEndsAt is provided, starts in Trial status; otherwise starts as Active. Requires tenant context.",
+        "operationId": "CreateSubscription",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionCreateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubscriptionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Subscriptions - Instances"],
+        "summary": "Returns a filtered, sorted, and paginated list of Subscription entries.",
+        "description": "Executes a dynamic query against Subscription using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QuerySubscription",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfSubscription"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfSubscription"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/{id}/cancel": {
+      "post": {
+        "tags": ["Subscriptions - Instances"],
+        "summary": "Cancels a subscription.",
+        "description": "Cancels immediately or schedules cancellation at period end based on the request.",
+        "operationId": "CancelSubscription",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionCancelRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/{id}/change-plan": {
+      "post": {
+        "tags": ["Subscriptions - Instances"],
+        "summary": "Changes the subscription plan.",
+        "description": "Switches to a different plan. Only allowed for Active or Trial subscriptions.",
+        "operationId": "ChangeSubscriptionPlan",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SubscriptionChangePlanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/meta": {
+      "get": {
+        "tags": ["Subscriptions - Instances"],
+        "summary": "Returns query metadata for Subscription (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Subscription: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetSubscriptionMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/{id}/seats": {
+      "get": {
+        "tags": ["Subscriptions - Seats"],
+        "summary": "Returns all seat assignments for a subscription.",
+        "description": "Lists users assigned to seats on the specified subscription.",
+        "operationId": "ListSeats",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SeatResponse"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Subscriptions - Seats"],
+        "summary": "Assigns a seat to a user.",
+        "description": "Adds a user to the subscription. Fails if the seat limit is reached.",
+        "operationId": "AssignSeat",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SeatAssignRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SeatResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/subscriptions/{id}/seats/{userId}": {
+      "delete": {
+        "tags": ["Subscriptions - Seats"],
+        "summary": "Revokes a seat from a user.",
+        "description": "Removes the user's seat assignment from the subscription.",
+        "operationId": "RevokeSeat",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "userId",
+            "in": "path",
+            "description": "External user identifier from the identity provider.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BillingInterval": {
+        "enum": ["Monthly", "Quarterly", "Yearly"]
+      },
+      "BulkMigratePriceRequest": {
+        "required": ["planId", "newPlanPriceId"],
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "newPlanPriceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "oldPlanPriceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "BulkMigratePriceResponse": {
+        "required": ["migratedCount"],
+        "type": "object",
+        "properties": {
+          "migratedCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "CreatePriceVersionRequest": {
+        "required": ["amount", "currency", "interval"],
+        "type": "object",
+        "properties": {
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "interval": {
+            "type": "string"
+          },
+          "productId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfPlan": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfPlan"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupedResultOfSubscription": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfSubscription"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfPlan": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Plan"
+            }
+          }
+        }
+      },
+      "GroupEntryOfSubscription": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Subscription"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "MigratePriceRequest": {
+        "required": ["newPlanPriceId"],
+        "type": "object",
+        "properties": {
+          "newPlanPriceId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "PagedResultOfPlan": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": ["null", "string"]
+                },
+                "pricingModel": {
+                  "enum": ["Flat", "PerSeat", "PerUnit", "Tiered"]
+                },
+                "defaultInterval": {
+                  "enum": ["Monthly", "Quarterly", "Yearly"]
+                },
+                "trialDays": {
+                  "type": ["null", "integer"],
+                  "format": "int32"
+                },
+                "seatLimit": {
+                  "type": ["null", "integer"],
+                  "format": "int32"
+                },
+                "sortOrder": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "lifecycleStatus": {
+                  "enum": ["Draft", "PendingReview", "Published", "Archived"]
+                },
+                "prices": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "amount": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "currency": {
+                        "type": "string"
+                      },
+                      "interval": {
+                        "enum": ["Monthly", "Quarterly", "Yearly"]
+                      },
+                      "effectiveFrom": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "replacedByPriceId": {
+                        "type": ["null", "string"],
+                        "format": "uuid"
+                      },
+                      "replacedAt": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "productId": {
+                        "type": ["null", "string"],
+                        "format": "uuid"
+                      },
+                      "tieringMode": {
+                        "enum": ["Volume", "Graduated", null]
+                      },
+                      "tiers": {
+                        "type": ["null", "array"],
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "planPriceId": {
+                              "type": "string",
+                              "format": "uuid"
+                            },
+                            "sortOrder": {
+                              "type": "integer",
+                              "format": "int32"
+                            },
+                            "upToQuantity": {
+                              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                              "type": ["null", "number", "string"],
+                              "format": "double"
+                            },
+                            "unitAmount": {
+                              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                              "type": ["number", "string"],
+                              "format": "double"
+                            },
+                            "flatAmount": {
+                              "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                              "type": ["null", "number", "string"],
+                              "format": "double"
+                            },
+                            "id": {
+                              "type": "string",
+                              "description": "Unique identifier of the entity.",
+                              "format": "uuid"
+                            }
+                          }
+                        }
+                      },
+                      "isCurrent": {
+                        "type": "boolean"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "planFeatureValues": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "featureName": {
+                        "type": "string"
+                      },
+                      "value": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "externalMappings": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "providerName": {
+                        "type": "string"
+                      },
+                      "externalId": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PagedResultOfSubscription": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "planId": {},
+                "status": {
+                  "enum": ["Trial", "Active", "PastDue", "Suspended", "Cancelled", "Expired"]
+                },
+                "currentPeriodStart": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "currentPeriodEnd": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "billingCycleAnchor": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "trialEndsAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "cancelAtPeriodEnd": {
+                  "type": "boolean"
+                },
+                "cancelledAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "cancellationReason": {
+                  "type": ["null", "string"]
+                },
+                "currency": {
+                  "type": "string"
+                },
+                "planPriceId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "dunningAttempt": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "seats": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "userId": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "assignedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "externalMappings": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "providerName": {
+                        "type": "string"
+                      },
+                      "externalId": {
+                        "type": "string"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "phases": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "subscriptionId": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "startDate": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "endDate": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "planId": {},
+                      "overridePriceId": {
+                        "type": ["null", "string"],
+                        "format": "uuid"
+                      },
+                      "discountPercent": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["null", "number", "string"],
+                        "format": "double"
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "partyId": {},
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PartyId": {},
+      "Plan": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "pricingModel": {
+            "$ref": "#/components/schemas/PricingModel"
+          },
+          "defaultInterval": {
+            "$ref": "#/components/schemas/BillingInterval"
+          },
+          "trialDays": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "seatLimit": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lifecycleStatus": {
+            "$ref": "#/components/schemas/WorkflowLifecycleStatus"
+          },
+          "prices": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PlanPrice"
+            }
+          },
+          "planFeatureValues": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PlanFeatureValue"
+            }
+          },
+          "externalMappings": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PlanExternalMapping"
+            }
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PlanCreateRequest": {
+        "required": ["name", "description", "pricingModel", "defaultInterval"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "pricingModel": {
+            "type": "string"
+          },
+          "defaultInterval": {
+            "type": "string"
+          },
+          "trialDays": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "seatLimit": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          }
+        }
+      },
+      "PlanExternalMapping": {
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PlanFeatureValue": {
+        "type": "object",
+        "properties": {
+          "featureName": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PlanId": {},
+      "PlanPrice": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "interval": {
+            "$ref": "#/components/schemas/BillingInterval"
+          },
+          "effectiveFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "replacedByPriceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "replacedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "productId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "tieringMode": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/TieringMode"
+              }
+            ]
+          },
+          "tiers": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/PricingTier"
+            }
+          },
+          "isCurrent": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "PlanPriceResponse": {
+        "required": ["id", "amount", "currency", "interval", "effectiveFrom", "isCurrent"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "interval": {
+            "type": "string"
+          },
+          "effectiveFrom": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "isCurrent": {
+            "type": "boolean"
+          },
+          "replacedByPriceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "replacedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "productId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "PlanResponse": {
+        "required": [
+          "id",
+          "name",
+          "description",
+          "pricingModel",
+          "defaultInterval",
+          "trialDays",
+          "seatLimit",
+          "sortOrder",
+          "lifecycleStatus",
+          "prices"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "pricingModel": {
+            "type": "string"
+          },
+          "defaultInterval": {
+            "type": "string"
+          },
+          "trialDays": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "seatLimit": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lifecycleStatus": {
+            "type": "string"
+          },
+          "prices": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlanPriceResponse"
+            }
+          }
+        }
+      },
+      "PlanUpdateRequest": {
+        "required": ["name", "description", "sortOrder"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PricingModel": {
+        "enum": ["Flat", "PerSeat", "PerUnit", "Tiered"]
+      },
+      "PricingTier": {
+        "type": "object",
+        "properties": {
+          "planPriceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "sortOrder": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "upToQuantity": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "unitAmount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "flatAmount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SeatAssignRequest": {
+        "required": ["userId"],
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "SeatResponse": {
+        "required": ["id", "userId", "assignedAt"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Subscription": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "$ref": "#/components/schemas/PlanId"
+          },
+          "status": {
+            "$ref": "#/components/schemas/SubscriptionStatus"
+          },
+          "currentPeriodStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "currentPeriodEnd": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "billingCycleAnchor": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "trialEndsAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cancelAtPeriodEnd": {
+            "type": "boolean"
+          },
+          "cancelledAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cancellationReason": {
+            "type": ["null", "string"]
+          },
+          "currency": {
+            "type": "string"
+          },
+          "planPriceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "dunningAttempt": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "seats": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionSeat"
+            }
+          },
+          "externalMappings": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionExternalMapping"
+            }
+          },
+          "phases": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/SubscriptionPhase"
+            }
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "partyId": {
+            "$ref": "#/components/schemas/PartyId"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "SubscriptionCancelRequest": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": ["null", "string"]
+          },
+          "atPeriodEnd": {
+            "type": "boolean",
+            "default": false
+          }
+        }
+      },
+      "SubscriptionChangePlanRequest": {
+        "required": ["newPlanId"],
+        "type": "object",
+        "properties": {
+          "newPlanId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "SubscriptionCreateRequest": {
+        "required": ["partyId", "planId", "currency"],
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "trialEndsAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "SubscriptionExternalMapping": {
+        "type": "object",
+        "properties": {
+          "providerName": {
+            "type": "string"
+          },
+          "externalId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "SubscriptionPhase": {
+        "type": "object",
+        "properties": {
+          "subscriptionId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "planId": {
+            "$ref": "#/components/schemas/PlanId"
+          },
+          "overridePriceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "discountPercent": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "SubscriptionResponse": {
+        "required": [
+          "id",
+          "partyId",
+          "planId",
+          "status",
+          "currency",
+          "currentPeriodStart",
+          "currentPeriodEnd",
+          "trialEndsAt",
+          "cancelAtPeriodEnd",
+          "cancelledAt",
+          "cancellationReason",
+          "seatCount"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "status": {
+            "type": "string"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "currentPeriodStart": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "currentPeriodEnd": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "trialEndsAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cancelAtPeriodEnd": {
+            "type": "boolean"
+          },
+          "cancelledAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cancellationReason": {
+            "type": ["null", "string"]
+          },
+          "seatCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "planPriceId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "SubscriptionSeat": {
+        "type": "object",
+        "properties": {
+          "userId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "SubscriptionStatus": {
+        "enum": ["Trial", "Active", "PastDue", "Suspended", "Cancelled", "Expired"]
+      },
+      "TieringMode": {
+        "enum": ["Volume", "Graduated", null]
+      },
+      "WorkflowLifecycleStatus": {
+        "enum": ["Draft", "PendingReview", "Published", "Archived"]
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Subscriptions - Instances"
+    },
+    {
+      "name": "Subscriptions - Plans"
+    },
+    {
+      "name": "Subscriptions - Prices"
+    },
+    {
+      "name": "Subscriptions - Seats"
+    }
+  ]
+}

--- a/contracts/openapi/tax.json
+++ b/contracts/openapi/tax.json
@@ -1,0 +1,960 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "tax",
+    "version": "1"
+  },
+  "paths": {
+    "/tax/ids/validate": {
+      "post": {
+        "tags": ["Tax - Validation"],
+        "summary": "Validates a tax ID online against the relevant tax authority.",
+        "description": "Submits a tax identification number (e.g., EU VAT, UK VAT, US EIN) for online verification. Uses the configured provider (VIES for EU, Stripe for other jurisdictions). Results are cached according to the configured TTL to avoid repeated API calls.",
+        "operationId": "ValidateTaxId",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TaxValidateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaxValidateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tax/rates": {
+      "get": {
+        "tags": ["Tax - Rates"],
+        "summary": "Returns a filtered, sorted, and paginated list of TaxRateEntry entries.",
+        "description": "Executes a dynamic query against TaxRateEntry using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryTaxRateEntry",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfTaxRateEntry"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfTaxRateEntry"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tax/rates/meta": {
+      "get": {
+        "tags": ["Tax - Rates"],
+        "summary": "Returns query metadata for TaxRateEntry (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for TaxRateEntry: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetTaxRateEntryMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/tax/rates/{countryCode}": {
+      "get": {
+        "tags": ["Tax - Rates"],
+        "summary": "Returns the current tax rate for a specific country.",
+        "description": "Returns the effective tax rate for the given ISO 3166-1 alpha-2 country code at the current date. Returns 404 if no rate is configured for the country.",
+        "operationId": "GetTaxRateByCountry",
+        "parameters": [
+          {
+            "name": "countryCode",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "maxLength": 2,
+              "minLength": 2,
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TaxRateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfTaxRateEntry": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfTaxRateEntry"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfTaxRateEntry": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/TaxRateEntry"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "PagedResultOfTaxRateEntry": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "required": ["countryCode", "standardRate"],
+              "type": "object",
+              "properties": {
+                "countryCode": {
+                  "type": "string"
+                },
+                "standardRate": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["number", "string"],
+                  "format": "double"
+                },
+                "reducedRate": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["null", "number", "string"],
+                  "format": "double"
+                },
+                "superReducedRate": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["null", "number", "string"],
+                  "format": "double"
+                },
+                "parkingRate": {
+                  "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                  "type": ["null", "number", "string"],
+                  "format": "double"
+                },
+                "effectiveFrom": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "effectiveTo": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "TaxRateEntry": {
+        "required": ["countryCode", "standardRate"],
+        "type": "object",
+        "properties": {
+          "countryCode": {
+            "type": "string"
+          },
+          "standardRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "reducedRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "superReducedRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "parkingRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "effectiveFrom": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "effectiveTo": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "TaxRateResponse": {
+        "required": [
+          "countryCode",
+          "standardRate",
+          "reducedRate",
+          "superReducedRate",
+          "parkingRate",
+          "effectiveFrom",
+          "effectiveTo"
+        ],
+        "type": "object",
+        "properties": {
+          "countryCode": {
+            "type": "string"
+          },
+          "standardRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "reducedRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "superReducedRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "parkingRate": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "effectiveFrom": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "effectiveTo": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "TaxValidateRequest": {
+        "required": ["taxId", "countryCode"],
+        "type": "object",
+        "properties": {
+          "taxId": {
+            "type": "string"
+          },
+          "countryCode": {
+            "type": "string"
+          }
+        }
+      },
+      "TaxValidateResponse": {
+        "required": [
+          "isValid",
+          "companyName",
+          "companyAddress",
+          "requestIdentifier",
+          "validatedAt",
+          "source"
+        ],
+        "type": "object",
+        "properties": {
+          "isValid": {
+            "type": "boolean"
+          },
+          "companyName": {
+            "type": ["null", "string"]
+          },
+          "companyAddress": {
+            "type": ["null", "string"]
+          },
+          "requestIdentifier": {
+            "type": ["null", "string"]
+          },
+          "validatedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Tax - Rates"
+    },
+    {
+      "name": "Tax - Validation"
+    }
+  ]
+}

--- a/contracts/openapi/taxonomy.json
+++ b/contracts/openapi/taxonomy.json
@@ -1,43 +1,46 @@
 {
   "openapi": "3.1.1",
   "info": {
-    "title": "data-exchange",
+    "title": "taxonomy",
     "version": "1"
   },
   "paths": {
-    "/data-exchange/import/jobs": {
+    "/taxonomy/tags": {
       "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Lists import jobs with optional status filter and pagination.",
-        "description": "Returns a paginated list of import jobs ordered by creation date descending. Supports filtering by job status. Intended for admin dashboards monitoring import activity.",
-        "operationId": "ListImportJobs",
+        "tags": ["Taxonomy"],
+        "summary": "Lists tags in a scope, optionally filtered by a name prefix.",
+        "description": "Returns the tenant-scoped tags registered under the given scope, ordered by name. The scope query parameter is mandatory; cross-scope search is exposed by the dedicated /api/v1/taxonomy/search endpoint introduced in story T3.1. The optional q parameter applies a case-insensitive name prefix filter for autocomplete-style lookups.",
+        "operationId": "ListTaxonomyTags",
         "parameters": [
           {
-            "name": "status",
+            "name": "scope",
             "in": "query",
-            "description": "Filter by status value.",
+            "required": true,
             "schema": {
-              "$ref": "#/components/schemas/ImportJobStatus"
+              "type": "string"
             }
           },
           {
-            "name": "page",
+            "name": "q",
             "in": "query",
-            "description": "1-based page index.",
             "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 1
+              "type": "string"
             }
           },
           {
-            "name": "pageSize",
+            "name": "skip",
             "in": "query",
-            "description": "Number of items per page.",
             "schema": {
               "type": "integer",
-              "format": "int32",
-              "default": 20
+              "format": "int32"
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
             }
           }
         ],
@@ -47,7 +50,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedResultOfImportJobResponse"
+                  "$ref": "#/components/schemas/ListTagsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -85,34 +98,15 @@
         }
       },
       "post": {
-        "tags": ["Data Exchange"],
-        "summary": "Uploads a file and creates an import job.",
-        "description": "Accepts a multipart/form-data upload with the file and a definitionName field. Validates MIME type and file size against the import definition's constraints. Creates an import job in 'Created' status. The next step is to call the preview endpoint to inspect headers and mapping suggestions.",
-        "operationId": "UploadImportFile",
+        "tags": ["Taxonomy"],
+        "summary": "Creates a new tag in the current tenant.",
+        "description": "Creates a new tag in the supplied scope. Returns 201 with the persisted tag. Returns 422 when a tag with the same (TenantId, Scope, Name) already exists.",
+        "operationId": "CreateTaxonomyTag",
         "requestBody": {
           "content": {
-            "multipart/form-data": {
+            "application/json": {
               "schema": {
-                "required": ["file", "definitionName"],
-                "type": "object",
-                "allOf": [
-                  {
-                    "type": "object",
-                    "properties": {
-                      "file": {
-                        "$ref": "#/components/schemas/IFormFile"
-                      }
-                    }
-                  },
-                  {
-                    "type": "object",
-                    "properties": {
-                      "definitionName": {
-                        "type": "string"
-                      }
-                    }
-                  }
-                ]
+                "$ref": "#/components/schemas/CreateTagRequest"
               }
             }
           },
@@ -124,7 +118,17 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ImportJobResponse"
+                  "$ref": "#/components/schemas/TagResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
                 }
               }
             }
@@ -134,7 +138,7 @@
             "content": {
               "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -159,16 +163,6 @@
               }
             }
           },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "500": {
             "description": "Internal Server Error",
             "content": {
@@ -182,17 +176,17 @@
         }
       }
     },
-    "/data-exchange/import/{jobId}/preview": {
-      "post": {
-        "tags": ["Data Exchange"],
-        "summary": "Extracts headers, preview rows, and mapping suggestions for an import job.",
-        "description": "Parses the uploaded file to extract column headers, a preview of the first rows, available target field metadata, and AI-assisted mapping suggestions. Transitions the job to 'Previewed' status. Returns 404 if the job does not exist.",
-        "operationId": "PreviewImportJob",
+    "/taxonomy/tags/{id}": {
+      "get": {
+        "tags": ["Taxonomy"],
+        "summary": "Returns a tag by id.",
+        "description": "Returns the tag identified by the route id. Returns 404 when the tag is missing or excluded by the tenant filter.",
+        "operationId": "GetTaxonomyTag",
         "parameters": [
           {
-            "name": "jobId",
+            "name": "id",
             "in": "path",
-            "description": "Import or export job identifier (UUID).",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
               "type": "string",
@@ -206,7 +200,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ImportPreviewResponse"
+                  "$ref": "#/components/schemas/TagResponse"
                 }
               }
             }
@@ -252,19 +246,17 @@
             }
           }
         }
-      }
-    },
-    "/data-exchange/import/{jobId}/mappings": {
-      "put": {
-        "tags": ["Data Exchange"],
-        "summary": "Confirms the column-to-property mappings for an import job.",
-        "description": "Saves the user-confirmed column-to-property mappings and transitions the job to 'Mapped' status, making it eligible for execution or dry-run. At least one mapping is required. Returns 404 if the job does not exist. Returns 409 if the concurrency stamp does not match the stored value.",
-        "operationId": "ConfirmImportMappings",
+      },
+      "patch": {
+        "tags": ["Taxonomy"],
+        "summary": "Partially updates a tag (name / colour / hide-on-entity-card).",
+        "description": "Applies the supplied facets in turn. Each property is independently optional; an empty body is a no-op. Returns 404 when the tag is missing, 422 when a rename collides with an existing (TenantId, Scope, Name) row.",
+        "operationId": "UpdateTaxonomyTag",
         "parameters": [
           {
-            "name": "jobId",
+            "name": "id",
             "in": "path",
-            "description": "Import or export job identifier (UUID).",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
               "type": "string",
@@ -276,58 +268,25 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/ConfirmMappingsRequest"
+                "$ref": "#/components/schemas/UpdateTagRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "204": {
-            "description": "No Content"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagResponse"
+                }
+              }
+            }
           },
           "404": {
             "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Conflict",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -346,211 +305,12 @@
               }
             }
           },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/import/{jobId}/execute": {
-      "post": {
-        "tags": ["Data Exchange"],
-        "summary": "Dispatches the import job for asynchronous background execution.",
-        "description": "Enqueues the import job for background processing. Returns 202 Accepted — poll the status endpoint to track progress. The job must be in 'Mapped' status (mappings confirmed). Returns 400 if the job is in an invalid state, or 404 if not found.",
-        "operationId": "ExecuteImportJob",
-        "parameters": [
-          {
-            "name": "jobId",
-            "in": "path",
-            "description": "Import or export job identifier (UUID).",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "202": {
-            "description": "Accepted"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
               "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/import/{jobId}/dry-run": {
-      "post": {
-        "tags": ["Data Exchange"],
-        "summary": "Executes a dry-run of the import (validates without persisting data).",
-        "description": "Runs the full import pipeline (parsing, mapping, validation) without persisting any data. Returns a detailed report with row-level validation results. Use this to preview errors before committing. The job must be in 'Mapped' status.",
-        "operationId": "DryRunImportJob",
-        "parameters": [
-          {
-            "name": "jobId",
-            "in": "path",
-            "description": "Import or export job identifier (UUID).",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportReportResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/import/{jobId}": {
-      "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Returns the current status of an import job.",
-        "description": "Returns the current state of the import job including status (Created, Previewed, Mapped, Executing, Completed, PartiallyCompleted, Failed, Cancelled), original file name, row counts, and timing information. Returns 404 if not found.",
-        "operationId": "GetImportJobStatus",
-        "parameters": [
-          {
-            "name": "jobId",
-            "in": "path",
-            "description": "Import or export job identifier (UUID).",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportJobResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -588,15 +348,15 @@
         }
       },
       "delete": {
-        "tags": ["Data Exchange"],
-        "summary": "Cancels an import job that has not yet started execution.",
-        "description": "Cancels the import job and deletes the uploaded file from blob storage. Only jobs that have not yet started execution (Executing, Completed, PartiallyCompleted, Failed) can be cancelled. Returns 400 if the job is in a non-cancellable state.",
-        "operationId": "CancelImportJob",
+        "tags": ["Taxonomy"],
+        "summary": "Hard-deletes a tag.",
+        "description": "Removes the tag row. Cascading cleanup of orphan TagAssignment rows is handled by T5.1's EntityDeletedEto listener. Returns 404 when the tag is missing.",
+        "operationId": "DeleteTaxonomyTag",
         "parameters": [
           {
-            "name": "jobId",
+            "name": "id",
             "in": "path",
-            "description": "Import or export job identifier (UUID).",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
               "type": "string",
@@ -610,6 +370,98 @@
           },
           "404": {
             "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/taxonomy/tags/{id}/assign": {
+      "post": {
+        "tags": ["Taxonomy"],
+        "summary": "Idempotently assigns a tag to a target aggregate.",
+        "description": "Creates a new TagAssignment row for the given (TagId, TargetType, TargetId) triplet. When the row already exists, the existing row is returned with status 200 instead of 201 — the operation is idempotent. Returns 422 when targetType is not a registered taggable aggregate; 403 when the per-target permission check fails.",
+        "operationId": "AssignTaxonomyTag",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignTagRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagAssignmentResponse"
+                }
+              }
+            }
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagAssignmentResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
             "content": {
               "application/problem+json": {
                 "schema": {
@@ -623,7 +475,7 @@
             "content": {
               "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -661,89 +513,36 @@
         }
       }
     },
-    "/data-exchange/import/{jobId}/report": {
-      "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Returns the import execution report for a completed job.",
-        "description": "Returns the detailed execution report including total rows processed, success/failure counts, and per-row error details. Available after execution or dry-run completes. Returns 404 if the job does not exist or no report has been generated yet.",
-        "operationId": "GetImportReport",
+    "/taxonomy/tags/{id}/assign/{targetType}/{targetId}": {
+      "delete": {
+        "tags": ["Taxonomy"],
+        "summary": "Removes a tag assignment.",
+        "description": "Deletes the TagAssignment row matching the (TagId, TargetType, TargetId) triplet. Returns 204 on success, 404 when no matching row exists, 403 when the per-target permission check fails.",
+        "operationId": "UnassignTaxonomyTag",
         "parameters": [
           {
-            "name": "jobId",
+            "name": "id",
             "in": "path",
-            "description": "Import or export job identifier (UUID).",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
               "type": "string",
               "format": "uuid"
             }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ImportReportResponse"
-                }
-              }
-            }
           },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/import/{jobId}/correction-file": {
-      "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Downloads a correction file containing only the failed rows with error annotations.",
-        "description": "Generates and streams a file containing only the rows that failed validation or import, annotated with error messages. The file format matches the original upload. Users can fix the errors and re-upload. Returns 204 if there are no failed rows, or 404 if the job or report does not exist.",
-        "operationId": "GetImportCorrectionFile",
-        "parameters": [
           {
-            "name": "jobId",
+            "name": "targetType",
             "in": "path",
-            "description": "Import or export job identifier (UUID).",
+            "description": "Type of the target.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "targetId",
+            "in": "path",
+            "description": "Unique identifier of the target.",
             "required": true,
             "schema": {
               "type": "string",
@@ -755,9 +554,6 @@
           "204": {
             "description": "No Content"
           },
-          "200": {
-            "description": "OK"
-          },
           "404": {
             "description": "Not Found",
             "content": {
@@ -801,39 +597,28 @@
         }
       }
     },
-    "/data-exchange/export/jobs": {
+    "/taxonomy/assignments": {
       "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Lists export jobs with optional status filter and pagination.",
-        "description": "Returns a paginated list of export jobs ordered by creation date descending. Supports filtering by job status (Created, Processing, Completed, Failed). Intended for admin dashboards monitoring export activity.",
-        "operationId": "ListExportJobs",
+        "tags": ["Taxonomy"],
+        "summary": "Lists tags currently assigned to a target.",
+        "description": "Returns every Tag assigned to (targetType, targetId), ordered by tag name. Both query parameters are mandatory.",
+        "operationId": "ListTaxonomyAssignments",
         "parameters": [
           {
-            "name": "status",
+            "name": "targetType",
             "in": "query",
-            "description": "Filter by status value.",
+            "required": true,
             "schema": {
-              "$ref": "#/components/schemas/ExportJobStatus"
+              "type": "string"
             }
           },
           {
-            "name": "page",
+            "name": "targetId",
             "in": "query",
-            "description": "1-based page index.",
+            "required": true,
             "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 1
-            }
-          },
-          {
-            "name": "pageSize",
-            "in": "query",
-            "description": "Number of items per page.",
-            "schema": {
-              "type": "integer",
-              "format": "int32",
-              "default": 20
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -843,7 +628,188 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PagedResultOfExportJobResponse"
+                  "$ref": "#/components/schemas/ListTagsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/taxonomy/search": {
+      "get": {
+        "tags": ["Taxonomy"],
+        "summary": "Cross-entity tag search grouped by target type.",
+        "description": "Returns tags whose Name prefix-matches q (case-insensitive) along with the assignments grouped by TargetType so the frontend can dispatch to the matching rendering pipeline. Pass scope=* for cross-scope, otherwise the search is restricted to the matching Tag.Scope. SECURITY: results expose TargetIds the caller may not have per-entity read on — hosts MUST combine with their own per-entity ACL when rendering.",
+        "operationId": "SearchTaxonomy",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scope",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/taxonomy/categories": {
+      "get": {
+        "tags": ["Taxonomy"],
+        "summary": "Lists categories under a parent (or roots) within a scope.",
+        "description": "Returns the direct children of parentId in the given scope, ordered by name. When parentId is omitted, returns the root categories of the scope. Use GET /categories/{id} to fetch a single category with its breadcrumb chain.",
+        "operationId": "ListTaxonomyCategories",
+        "parameters": [
+          {
+            "name": "scope",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "parentId",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCategoriesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -881,15 +847,15 @@
         }
       },
       "post": {
-        "tags": ["Data Exchange"],
-        "summary": "Creates and dispatches an export job (sync or background).",
-        "description": "Creates an export job for the given definition, format, and field selection. Small datasets may complete synchronously; larger ones are dispatched for background processing. Poll the status endpoint to track progress. Returns 400 if the definition name or format is invalid.",
-        "operationId": "CreateExportJob",
+        "tags": ["Taxonomy"],
+        "summary": "Creates a new category — root or under an existing parent.",
+        "description": "Creates a new category in the supplied scope. When parentId is supplied the new category is placed under it (must share scope). Returns 422 when the parent does not exist or is in a different scope, or when sibling-name uniqueness is violated.",
+        "operationId": "CreateTaxonomyCategory",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateExportJobRequest"
+                "$ref": "#/components/schemas/CreateCategoryRequest"
               }
             }
           },
@@ -901,37 +867,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ExportJobResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/CategoryResponse"
                 }
               }
             }
@@ -946,129 +882,12 @@
               }
             }
           },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/export/jobs/{jobId}": {
-      "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Returns the current status of an export job.",
-        "description": "Returns the current status of the export job (Created, Processing, Completed, Failed). Once the status is Completed, the download endpoint becomes available. Returns 404 if the job ID is not found.",
-        "operationId": "GetExportJobStatus",
-        "parameters": [
-          {
-            "name": "jobId",
-            "in": "path",
-            "description": "Import or export job identifier (UUID).",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExportJobResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/export/jobs/{jobId}/download": {
-      "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Downloads the generated export file for a completed job.",
-        "description": "Streams the generated export file (xlsx, csv, etc.) as a binary download. The Content-Type and Content-Disposition headers are set according to the export format. Returns 404 if the job does not exist, or 400 if the job has not completed yet.",
-        "operationId": "DownloadExportFile",
-        "parameters": [
-          {
-            "name": "jobId",
-            "in": "path",
-            "description": "Import or export job identifier (UUID).",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
           "400": {
             "description": "Bad Request",
             "content": {
               "application/problem+json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -1106,73 +925,21 @@
         }
       }
     },
-    "/data-exchange/metadata/definitions": {
+    "/taxonomy/categories/{id}": {
       "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Lists all registered export definitions.",
-        "description": "Returns all export definitions registered by application modules. Each definition describes an exportable dataset, its supported output formats, and metadata. Use the fields endpoint to discover selectable columns for a specific definition.",
-        "operationId": "ListExportDefinitions",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExportDefinitionResponse"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/metadata/definitions/{name}/fields": {
-      "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Returns the available fields for a given export definition.",
-        "description": "Returns the list of selectable fields for the named export definition — each with its property name, display label, and data type. Use this to populate a field picker UI before creating an export job. Returns 404 if the definition name is not registered.",
-        "operationId": "GetExportDefinitionFields",
+        "tags": ["Taxonomy"],
+        "summary": "Returns a category with its breadcrumb chain.",
+        "description": "Returns the category and its breadcrumb (root → leaf). Returns 404 when the category is missing or excluded by the tenant filter.",
+        "operationId": "GetTaxonomyCategory",
         "parameters": [
           {
-            "name": "name",
+            "name": "id",
             "in": "path",
-            "description": "Unique registered name of the background job.",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1182,10 +949,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExportFieldResponse"
-                  }
+                  "$ref": "#/components/schemas/CategoryDetailResponse"
                 }
               }
             }
@@ -1231,98 +995,338 @@
             }
           }
         }
-      }
-    },
-    "/data-exchange/metadata/presets/{definitionName}": {
-      "get": {
-        "tags": ["Data Exchange"],
-        "summary": "Lists saved export presets for a given definition.",
-        "description": "Returns all saved export presets for the given export definition. Presets store a reusable field selection, output format, and sorting configuration so users can quickly re-export without reconfiguring.",
-        "operationId": "ListExportPresets",
+      },
+      "patch": {
+        "tags": ["Taxonomy"],
+        "summary": "Partially updates a category (rename / icon / hide).",
+        "description": "Applies the supplied facets in turn. Renaming a category re-materialises descendant paths via a single SQL UPDATE. Returns 404 when the category is missing.",
+        "operationId": "UpdateTaxonomyCategory",
         "parameters": [
           {
-            "name": "definitionName",
+            "name": "id",
             "in": "path",
-            "description": "Import or export definition name.",
+            "description": "Resource identifier (UUID).",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExportPresetResponse"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/problem+json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/data-exchange/metadata/presets": {
-      "post": {
-        "tags": ["Data Exchange"],
-        "summary": "Saves or updates an export preset.",
-        "description": "Creates or updates a named preset for the given export definition. If a preset with the same definition and name already exists, it is overwritten. The definition name must reference a registered export definition. At least one selected field is required.",
-        "operationId": "SaveExportPreset",
         "requestBody": {
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/SaveExportPresetRequest"
+                "$ref": "#/components/schemas/UpdateCategoryRequest"
               }
             }
           },
           "required": true
         },
         "responses": {
-          "201": {
-            "description": "Created"
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request",
             "content": {
               "application/problem+json": {
                 "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
                   "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Taxonomy"],
+        "summary": "Hard-deletes a leaf category with no active assignments.",
+        "description": "Returns 422 when the category has descendants OR when one or more CategoryAssignment rows still reference it — callers must move / delete descendants and reassign / unassign targets first.",
+        "operationId": "DeleteTaxonomyCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/taxonomy/categories/{id}/move": {
+      "post": {
+        "tags": ["Taxonomy"],
+        "summary": "Moves a category under a new parent (or to root).",
+        "description": "Re-parents the category and re-materialises descendant paths and depths in a single SQL UPDATE. Returns 422 on cycle / cross-scope violations, 404 when the category or target parent is missing.",
+        "operationId": "MoveTaxonomyCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MoveCategoryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/taxonomy/categories/{id}/assign": {
+      "post": {
+        "tags": ["Taxonomy"],
+        "summary": "Sets the category for a target. Replaces any existing assignment.",
+        "description": "Single-assignment per target: if a previous assignment exists for (targetType, targetId), it is updated in place to point at the supplied category. Returns 200 on update, 201 on first assignment.",
+        "operationId": "AssignTaxonomyCategory",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssignCategoryRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryAssignmentResponse"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CategoryAssignmentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
                 }
               }
             }
@@ -1370,29 +1374,30 @@
         }
       }
     },
-    "/data-exchange/metadata/presets/{definitionName}/{presetName}": {
+    "/taxonomy/categories/assign/{targetType}/{targetId}": {
       "delete": {
-        "tags": ["Data Exchange"],
-        "summary": "Deletes a saved export preset.",
-        "description": "Permanently removes the named export preset. Returns 404 if the preset does not exist.",
-        "operationId": "DeleteExportPreset",
+        "tags": ["Taxonomy"],
+        "summary": "Clears the category assignment for a target.",
+        "description": "Removes the CategoryAssignment row for (targetType, targetId). Returns 204 on success, 404 when no assignment matches.",
+        "operationId": "UnassignTaxonomyCategory",
         "parameters": [
           {
-            "name": "definitionName",
+            "name": "targetType",
             "in": "path",
-            "description": "Import or export definition name.",
+            "description": "Type of the target.",
             "required": true,
             "schema": {
               "type": "string"
             }
           },
           {
-            "name": "presetName",
+            "name": "targetId",
             "in": "path",
-            "description": "Export preset name.",
+            "description": "Unique identifier of the target.",
             "required": true,
             "schema": {
-              "type": "string"
+              "type": "string",
+              "format": "uuid"
             }
           }
         ],
@@ -1446,447 +1451,236 @@
   },
   "components": {
     "schemas": {
-      "ConfirmMappingsRequest": {
-        "required": ["mappings", "concurrencyStamp"],
+      "AssignCategoryRequest": {
+        "required": ["targetType", "targetId"],
         "type": "object",
         "properties": {
-          "mappings": {
+          "targetType": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "AssignTagRequest": {
+        "required": ["targetType", "targetId"],
+        "type": "object",
+        "properties": {
+          "targetType": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "CategoryAssignmentResponse": {
+        "required": [
+          "id",
+          "tenantId",
+          "categoryId",
+          "targetType",
+          "targetId",
+          "assignedAt",
+          "assignedByUserId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "categoryId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "targetType": {
+            "type": "string"
+          },
+          "targetId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "assignedByUserId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "CategoryDetailResponse": {
+        "required": ["category", "breadcrumb"],
+        "type": "object",
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/CategoryResponse"
+          },
+          "breadcrumb": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ImportColumnMapping"
+              "$ref": "#/components/schemas/CategoryResponse"
             }
-          },
-          "concurrencyStamp": {
-            "type": "string"
           }
         }
       },
-      "CreateExportJobRequest": {
-        "required": ["definitionName", "format"],
+      "CategoryResponse": {
+        "required": [
+          "id",
+          "tenantId",
+          "scope",
+          "parentId",
+          "name",
+          "path",
+          "depth",
+          "iconName",
+          "hideOnEntityCard"
+        ],
         "type": "object",
         "properties": {
-          "definitionName": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "scope": {
             "type": "string"
           },
-          "format": {
-            "type": "string"
+          "parentId": {
+            "type": ["null", "string"],
+            "format": "uuid"
           },
-          "selectedFields": {
-            "type": ["null", "array"],
-            "items": {
-              "type": "string"
-            }
-          },
-          "includeIdForImport": {
-            "type": "boolean",
-            "default": false
-          },
-          "sort": {
-            "type": ["null", "string"]
-          },
-          "filter": {
-            "type": ["null", "object"],
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "presets": {
-            "type": ["null", "object"],
-            "additionalProperties": {
-              "type": "string"
-            }
-          },
-          "search": {
-            "type": ["null", "string"]
-          }
-        }
-      },
-      "ExportDefinitionResponse": {
-        "required": ["name", "entityType", "supportedFormats", "isAutoGenerated"],
-        "type": "object",
-        "properties": {
           "name": {
             "type": "string"
           },
-          "entityType": {
+          "path": {
             "type": "string"
           },
-          "supportedFormats": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "isAutoGenerated": {
-            "type": "boolean"
-          }
-        }
-      },
-      "ExportFieldResponse": {
-        "required": ["propertyPath", "clrTypeName", "header", "format", "order", "isNavigation"],
-        "type": "object",
-        "properties": {
-          "propertyPath": {
-            "type": "string"
-          },
-          "clrTypeName": {
-            "type": "string"
-          },
-          "header": {
-            "type": ["null", "string"]
-          },
-          "format": {
-            "type": ["null", "string"]
-          },
-          "order": {
+          "depth": {
             "type": "integer",
             "format": "int32"
           },
-          "isNavigation": {
+          "iconName": {
+            "type": ["null", "string"]
+          },
+          "hideOnEntityCard": {
             "type": "boolean"
           }
         }
       },
-      "ExportJobResponse": {
-        "required": [
-          "id",
-          "definitionName",
-          "format",
-          "status",
-          "rowCount",
-          "fileName",
-          "errorMessage",
-          "createdAt",
-          "completedAt"
-        ],
+      "CreateCategoryRequest": {
+        "required": ["scope", "parentId", "name", "iconName", "hideOnEntityCard"],
         "type": "object",
         "properties": {
-          "id": {
-            "type": "string",
+          "scope": {
+            "type": "string"
+          },
+          "parentId": {
+            "type": ["null", "string"],
             "format": "uuid"
           },
-          "definitionName": {
+          "name": {
             "type": "string"
           },
-          "format": {
+          "iconName": {
+            "type": ["null", "string"]
+          },
+          "hideOnEntityCard": {
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "CreateTagRequest": {
+        "required": ["scope", "name", "color", "hideOnEntityCard"],
+        "type": "object",
+        "properties": {
+          "scope": {
             "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "hideOnEntityCard": {
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
           },
           "status": {
-            "$ref": "#/components/schemas/ExportJobStatus"
-          },
-          "rowCount": {
             "type": ["null", "integer"],
             "format": "int32"
           },
-          "fileName": {
+          "detail": {
             "type": ["null", "string"]
           },
-          "errorMessage": {
+          "instance": {
             "type": ["null", "string"]
           },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "completedAt": {
-            "type": ["null", "string"],
-            "format": "date-time"
-          }
-        }
-      },
-      "ExportJobStatus": {
-        "enum": ["Queued", "Exporting", "Completed", "Failed"]
-      },
-      "ExportPresetResponse": {
-        "required": [
-          "definitionName",
-          "presetName",
-          "selectedFields",
-          "format",
-          "includeIdForImport"
-        ],
-        "type": "object",
-        "properties": {
-          "definitionName": {
-            "type": "string"
-          },
-          "presetName": {
-            "type": "string"
-          },
-          "selectedFields": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "format": {
-            "type": "string"
-          },
-          "includeIdForImport": {
-            "type": "boolean"
-          }
-        }
-      },
-      "IFormFile": {
-        "type": "string",
-        "format": "binary"
-      },
-      "ImportColumnMapping": {
-        "required": ["sourceColumn", "targetProperty", "confidence"],
-        "type": "object",
-        "properties": {
-          "sourceColumn": {
-            "type": "string"
-          },
-          "targetProperty": {
-            "type": ["null", "string"]
-          },
-          "confidence": {
-            "$ref": "#/components/schemas/MappingConfidence"
-          }
-        }
-      },
-      "ImportFieldMetadata": {
-        "required": ["propertyPath", "clrTypeName", "displayName", "description", "isRequired"],
-        "type": "object",
-        "properties": {
-          "propertyPath": {
-            "type": "string"
-          },
-          "clrTypeName": {
-            "type": "string"
-          },
-          "displayName": {
-            "type": ["null", "string"]
-          },
-          "description": {
-            "type": ["null", "string"]
-          },
-          "isRequired": {
-            "type": "boolean"
-          }
-        }
-      },
-      "ImportJobResponse": {
-        "required": [
-          "id",
-          "definitionName",
-          "originalFileName",
-          "mimeType",
-          "fileSizeBytes",
-          "status",
-          "createdAt",
-          "completedAt",
-          "concurrencyStamp"
-        ],
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string",
-            "format": "uuid"
-          },
-          "definitionName": {
-            "type": "string"
-          },
-          "originalFileName": {
-            "type": "string"
-          },
-          "mimeType": {
-            "type": "string"
-          },
-          "fileSizeBytes": {
-            "pattern": "^-?(?:0|[1-9]\\d*)$",
-            "type": ["integer", "string"],
-            "format": "int64"
-          },
-          "status": {
-            "$ref": "#/components/schemas/ImportJobStatus"
-          },
-          "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "completedAt": {
-            "type": ["null", "string"],
-            "format": "date-time"
-          },
-          "concurrencyStamp": {
-            "type": "string"
-          }
-        }
-      },
-      "ImportJobStatus": {
-        "enum": [
-          "Created",
-          "Previewed",
-          "Mapped",
-          "Executing",
-          "Completed",
-          "PartiallyCompleted",
-          "Failed",
-          "Cancelled"
-        ]
-      },
-      "ImportPreviewResponse": {
-        "required": ["headers", "previewRows", "suggestions", "fieldMetadata"],
-        "type": "object",
-        "properties": {
-          "headers": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "previewRows": {
-            "type": "array",
-            "items": {
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
               "type": "array",
               "items": {
                 "type": "string"
               }
             }
-          },
-          "suggestions": {
+          }
+        }
+      },
+      "ListCategoriesResponse": {
+        "required": ["items"],
+        "type": "object",
+        "properties": {
+          "items": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/ImportColumnMapping"
-            }
-          },
-          "fieldMetadata": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ImportFieldMetadata"
+              "$ref": "#/components/schemas/CategoryResponse"
             }
           }
         }
       },
-      "ImportReportResponse": {
-        "required": [
-          "importJobId",
-          "finalStatus",
-          "totalRows",
-          "succeededRows",
-          "failedRows",
-          "skippedRows",
-          "insertedRows",
-          "updatedRows",
-          "duration",
-          "rowErrors"
-        ],
+      "ListTagsResponse": {
+        "required": ["items"],
         "type": "object",
         "properties": {
-          "importJobId": {
-            "type": "string",
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TagResponse"
+            }
+          }
+        }
+      },
+      "MoveCategoryRequest": {
+        "required": ["newParentId"],
+        "type": "object",
+        "properties": {
+          "newParentId": {
+            "type": ["null", "string"],
             "format": "uuid"
-          },
-          "finalStatus": {
-            "$ref": "#/components/schemas/ImportJobStatus"
-          },
-          "totalRows": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "succeededRows": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "failedRows": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "skippedRows": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "insertedRows": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "updatedRows": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "duration": {
-            "pattern": "^-?(\\d+\\.)?\\d{2}:\\d{2}:\\d{2}(\\.\\d{1,7})?$",
-            "type": "string"
-          },
-          "rowErrors": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ImportRowError"
-            }
-          }
-        }
-      },
-      "ImportRowError": {
-        "required": ["rowNumber", "kind", "errorCodes", "message"],
-        "type": "object",
-        "properties": {
-          "rowNumber": {
-            "type": "integer",
-            "format": "int32"
-          },
-          "kind": {
-            "$ref": "#/components/schemas/ImportRowErrorKind"
-          },
-          "errorCodes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
-      "ImportRowErrorKind": {
-        "enum": ["Conversion", "Validation", "Persistence", "Identity"]
-      },
-      "MappingConfidence": {
-        "enum": ["Manual", "Saved", "Exact", "Fuzzy", "Semantic"]
-      },
-      "PagedResultOfExportJobResponse": {
-        "required": ["items", "totalCount", "hasMore"],
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ExportJobResponse"
-            }
-          },
-          "totalCount": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          },
-          "hasMore": {
-            "type": "boolean"
-          },
-          "nextCursor": {
-            "type": ["null", "string"]
-          }
-        }
-      },
-      "PagedResultOfImportJobResponse": {
-        "required": ["items", "totalCount", "hasMore"],
-        "type": "object",
-        "properties": {
-          "items": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/ImportJobResponse"
-            }
-          },
-          "totalCount": {
-            "type": ["null", "integer"],
-            "format": "int32"
-          },
-          "hasMore": {
-            "type": "boolean"
-          },
-          "nextCursor": {
-            "type": ["null", "string"]
           }
         }
       },
@@ -1915,33 +1709,169 @@
           }
         }
       },
-      "SaveExportPresetRequest": {
+      "SearchHit": {
+        "required": ["targetId", "tagIds"],
+        "type": "object",
+        "properties": {
+          "targetId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tagIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "SearchResponse": {
+        "required": ["tags", "hits", "totalCount", "skip", "take"],
+        "type": "object",
+        "properties": {
+          "tags": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchTagItem"
+            }
+          },
+          "hits": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/SearchHit"
+              }
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "skip": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "take": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "SearchTagItem": {
+        "required": ["id", "name", "color", "scope"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "scope": {
+            "type": "string"
+          }
+        }
+      },
+      "TagAssignmentResponse": {
         "required": [
-          "definitionName",
-          "presetName",
-          "selectedFields",
-          "format",
-          "includeIdForImport"
+          "id",
+          "tenantId",
+          "tagId",
+          "targetType",
+          "targetId",
+          "assignedAt",
+          "assignedByUserId"
         ],
         "type": "object",
         "properties": {
-          "definitionName": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "tagId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "targetType": {
             "type": "string"
           },
-          "presetName": {
+          "targetId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "assignedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "assignedByUserId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        }
+      },
+      "TagResponse": {
+        "required": ["id", "tenantId", "scope", "name", "color", "hideOnEntityCard"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "scope": {
             "type": "string"
           },
-          "selectedFields": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "format": {
+          "name": {
             "type": "string"
           },
-          "includeIdForImport": {
+          "color": {
+            "type": "string"
+          },
+          "hideOnEntityCard": {
             "type": "boolean"
+          }
+        }
+      },
+      "UpdateCategoryRequest": {
+        "required": ["name", "iconName", "hideOnEntityCard"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "iconName": {
+            "type": ["null", "string"]
+          },
+          "hideOnEntityCard": {
+            "type": ["null", "boolean"]
+          }
+        }
+      },
+      "UpdateTagRequest": {
+        "required": ["name", "color", "hideOnEntityCard"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "color": {
+            "type": ["null", "string"]
+          },
+          "hideOnEntityCard": {
+            "type": ["null", "boolean"]
           }
         }
       }
@@ -1949,7 +1879,7 @@
   },
   "tags": [
     {
-      "name": "Data Exchange"
+      "name": "Taxonomy"
     }
   ]
 }

--- a/contracts/openapi/workspaces.json
+++ b/contracts/openapi/workspaces.json
@@ -1,0 +1,407 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "workspaces",
+    "version": "1"
+  },
+  "paths": {
+    "/workspaces": {
+      "get": {
+        "tags": ["Workspaces"],
+        "summary": "Returns the workspace tree filtered for the requesting user.",
+        "description": "Returns every WorkspaceDefinition the user is allowed to see — workspaces, sections, and items gated by a permission the user does NOT hold are absent from the payload (defense in depth, ADR-040). Empty branches (workspaces / sections with zero surviving items) are dropped. Pass ?includeShells=false to omit Framework shells. Cached 5 minutes per (user-perms-hash, culture, includeShells).",
+        "operationId": "GetWorkspacesTree",
+        "parameters": [
+          {
+            "name": "includeShells",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceTreeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/landing-route": {
+      "get": {
+        "tags": ["Workspaces"],
+        "summary": "Resolves the requesting user's landing route via the 5-tier precedence chain.",
+        "description": "Precedence per ADR-048: personal-sticky > personal-pinned > role-default > tenant-default > framework. Each tier may be null (provider not configured, no preference) — the resolver falls through. Routes that fail the URL whitelist (configured prefixes) or the access guard are also skipped to the next tier. The framework fallback is configured (not user-supplied) and always wins as the closing tier.",
+        "operationId": "GetLandingRoute",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LandingRouteResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/me/landing-route/pinned": {
+      "put": {
+        "tags": ["Workspaces"],
+        "summary": "Pins (or clears) the requesting user's preferred landing route.",
+        "description": "The pinned route is consulted at the second-highest precedence tier (after personal-sticky). Pass null in the body to clear the pin. Routes that don't match the URL whitelist are rejected with 400.",
+        "operationId": "SetPinnedLandingRoute",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SetPinnedLandingRouteRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "LandingRouteResponse": {
+        "required": ["route", "source"],
+        "type": "object",
+        "properties": {
+          "route": {
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/LandingRouteSource"
+          }
+        }
+      },
+      "LandingRouteSource": {
+        "enum": ["PersonalSticky", "PersonalPinned", "Role", "Tenant", "Framework"]
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "SetPinnedLandingRouteRequest": {
+        "required": ["route"],
+        "type": "object",
+        "properties": {
+          "route": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "WorkspaceItemKind": {
+        "enum": ["Entity", "Dashboard", "Link", "SubWorkspace", "Feature"]
+      },
+      "WorkspaceItemResponse": {
+        "required": [
+          "kind",
+          "order",
+          "displayKey",
+          "icon",
+          "entityName",
+          "entityViewName",
+          "entityPresetOverlay",
+          "dashboardName",
+          "linkUrl",
+          "subWorkspaceName",
+          "featureName",
+          "routeName"
+        ],
+        "type": "object",
+        "properties": {
+          "kind": {
+            "$ref": "#/components/schemas/WorkspaceItemKind"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "entityName": {
+            "type": ["null", "string"]
+          },
+          "entityViewName": {
+            "type": ["null", "string"]
+          },
+          "entityPresetOverlay": {
+            "type": ["null", "object"]
+          },
+          "dashboardName": {
+            "type": ["null", "string"]
+          },
+          "linkUrl": {
+            "type": ["null", "string"]
+          },
+          "subWorkspaceName": {
+            "type": ["null", "string"]
+          },
+          "featureName": {
+            "type": ["null", "string"]
+          },
+          "routeName": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "WorkspaceResponse": {
+        "required": ["name", "displayKey", "icon", "order", "isShell", "sections"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isShell": {
+            "type": "boolean"
+          },
+          "sections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceSectionResponse"
+            }
+          }
+        }
+      },
+      "WorkspaceSectionResponse": {
+        "required": ["key", "displayKey", "order", "collapsedByDefault", "items"],
+        "type": "object",
+        "properties": {
+          "key": {
+            "type": "string"
+          },
+          "displayKey": {
+            "type": ["null", "string"]
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "collapsedByDefault": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceItemResponse"
+            }
+          }
+        }
+      },
+      "WorkspaceTreeResponse": {
+        "required": ["schemaVersion", "workspaces"],
+        "type": "object",
+        "properties": {
+          "schemaVersion": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "workspaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/WorkspaceResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Workspaces"
+    }
+  ]
+}

--- a/packages/@granit/contract-tests/README.md
+++ b/packages/@granit/contract-tests/README.md
@@ -6,7 +6,7 @@ still mirror the backend contract, using the per-module OpenAPI snapshots in
 
 ## Why an oracle, not codegen
 
-The backend (`Granit.OpenApi.Generator`) emits one OpenAPI document per module.
+The backend OpenAPI generators emit one OpenAPI document per module.
 Generating TypeScript from it would **degrade** the curated public API — the
 spec materializes generics (`PagedResultOfX`), widens every integer to
 `number | string`, drops branded types (`ISODateString` → `string`), and names
@@ -46,8 +46,15 @@ node scripts/sync-openapi-contracts.mjs            # all modules
 node scripts/sync-openapi-contracts.mjs background-jobs
 ```
 
-Reads the build artifacts of `Granit.OpenApi.Generator` (override the source
-with `GRANIT_DOTNET=/path/to/granit-dotnet`).
+Reads the build artifacts of four backend generators — override each source
+with its env var:
+
+| Generator                           | Repo            | Env var           |
+| ----------------------------------- | --------------- | ----------------- |
+| `Granit.OpenApi.Generator`          | granit-dotnet   | `GRANIT_DOTNET`   |
+| `Granit.Cms.OpenApi.Generator`      | granit-website  | `GRANIT_WEBSITE`  |
+| `Granit.IoT.OpenApi.Generator`      | granit-iot      | `GRANIT_IOT`      |
+| `Granit.Business.OpenApi.Generator` | granit-business | `GRANIT_BUSINESS` |
 
 ## Extending coverage
 
@@ -70,5 +77,8 @@ Covered so far: `background-jobs`, `bff`, `blob-storage`, `api-keys`, `ai`,
 Axios-client ones). Modules whose front DTO names still diverge from the spec
 (e.g. `multi-tenancy` `AdminTenant` vs `TenantResponse`, several `webhooks`
 types) need the same rename treatment as auditing/authorization before wiring.
-The `Granit.OpenApi.Generator` ships the 30 framework modules; granit-business
-modules (dashboards, parties, …) need an equivalent generator.
+Four generators feed the snapshots: `Granit.OpenApi.Generator` (framework
+modules), `Granit.Cms.OpenApi.Generator` (CMS), `Granit.IoT.OpenApi.Generator`
+(IoT) and `Granit.Business.OpenApi.Generator` (business — dashboards, parties,
+…). Their slugs are vendored automatically; wiring each into `manifest.ts` is
+opt-in as the matching front DTOs land.

--- a/scripts/sync-openapi-contracts.mjs
+++ b/scripts/sync-openapi-contracts.mjs
@@ -7,9 +7,11 @@
 // NOT committed on the backend side, so we vendor a snapshot here to keep the
 // conformance oracle (@granit/contract-tests) hermetic in CI.
 //
-// Two backend sources, one per generator:
-//   - granit-dotnet  → Granit.OpenApi.Generator     (framework modules)
-//   - granit-website → Granit.Cms.OpenApi.Generator (CMS bounded context)
+// Four backend sources, one per generator:
+//   - granit-dotnet   → Granit.OpenApi.Generator          (framework modules)
+//   - granit-website  → Granit.Cms.OpenApi.Generator      (CMS bounded context)
+//   - granit-iot      → Granit.IoT.OpenApi.Generator      (IoT bounded context)
+//   - granit-business → Granit.Business.OpenApi.Generator (business bounded context)
 //
 // Source → target:
 //   <generator>/generated/<prefix><slug>.json → contracts/openapi/<slug>.json
@@ -19,6 +21,8 @@
 //   node scripts/sync-openapi-contracts.mjs background-jobs # selected slugs
 //   GRANIT_DOTNET=/path/to/granit-dotnet \
 //   GRANIT_WEBSITE=/path/to/granit-website \
+//   GRANIT_IOT=/path/to/granit-iot \
+//   GRANIT_BUSINESS=/path/to/granit-business \
 //     node scripts/sync-openapi-contracts.mjs
 // ---------------------------------------------------------------------------
 
@@ -34,6 +38,10 @@ const GRANIT_DOTNET =
   process.env.GRANIT_DOTNET ?? join(os.homedir(), 'dev', 'granit-fx', 'granit-dotnet');
 const GRANIT_WEBSITE =
   process.env.GRANIT_WEBSITE ?? join(os.homedir(), 'dev', 'granit-fx', 'granit-website');
+const GRANIT_IOT =
+  process.env.GRANIT_IOT ?? join(os.homedir(), 'dev', 'granit-fx', 'granit-iot');
+const GRANIT_BUSINESS =
+  process.env.GRANIT_BUSINESS ?? join(os.homedir(), 'dev', 'granit-fx', 'granit-business');
 
 // Each backend generator: its build-time output dir + the filename prefix it stamps.
 const SOURCES = [
@@ -46,6 +54,16 @@ const SOURCES = [
     label: 'granit-website',
     dir: join(GRANIT_WEBSITE, 'src', 'Granit.Cms.OpenApi.Generator', 'generated'),
     prefix: 'Granit.Cms.OpenApi.Generator_',
+  },
+  {
+    label: 'granit-iot',
+    dir: join(GRANIT_IOT, 'src', 'Granit.IoT.OpenApi.Generator', 'generated'),
+    prefix: 'Granit.IoT.OpenApi.Generator_',
+  },
+  {
+    label: 'granit-business',
+    dir: join(GRANIT_BUSINESS, 'src', 'Granit.Business.OpenApi.Generator', 'generated'),
+    prefix: 'Granit.Business.OpenApi.Generator_',
   },
 ];
 
@@ -79,8 +97,10 @@ for (const { label, dir, prefix } of SOURCES) {
 
 if (!anySource) {
   console.error(
-    'No backend generator output found. Build Granit.OpenApi.Generator (granit-dotnet) ' +
-      'and/or Granit.Cms.OpenApi.Generator (granit-website), or set GRANIT_DOTNET / GRANIT_WEBSITE.'
+    'No backend generator output found. Build one of Granit.OpenApi.Generator (granit-dotnet), ' +
+      'Granit.Cms.OpenApi.Generator (granit-website), Granit.IoT.OpenApi.Generator (granit-iot) ' +
+      'or Granit.Business.OpenApi.Generator (granit-business), or set ' +
+      'GRANIT_DOTNET / GRANIT_WEBSITE / GRANIT_IOT / GRANIT_BUSINESS.'
   );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

- Extends `scripts/sync-openapi-contracts.mjs` with two additional backend generators: `Granit.IoT.OpenApi.Generator` (granit-iot) and `Granit.Business.OpenApi.Generator` (granit-business)
- Vendors 24 new contract snapshots into `contracts/openapi/` (iot, iot-fleet-provisioning, iot-ingestion, activities, analytics, catalog, parties, …)
- Each source follows the existing pattern: env-var override (`GRANIT_IOT` / `GRANIT_BUSINESS`) with `~/dev/granit-fx/<repo>` as default
- Updates `@granit/contract-tests` README to document all four generators; removes stale note about granit-business needing one

## Test plan

- [ ] `node scripts/sync-openapi-contracts.mjs` syncs 58 contracts without error
- [ ] No slug collisions across the four sources (verified locally)
- [ ] `markdownlint` passes on updated README