### PR TITLE
fix(react-account): align account self-service test handlers with backend routes

### DIFF
--- a/packages/@granit/react-account/src/testing/handlers.ts
+++ b/packages/@granit/react-account/src/testing/handlers.ts
@@ -1,4 +1,4 @@
-import { noContent, notFound } from '@granit/testing/msw';
+import { accepted, noContent, notFound } from '@granit/testing/msw';
 import { toISODateString } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
@@ -132,24 +132,44 @@ export function createAccountHandlers(baseUrl = DEFAULT_BASE_PATH) {
     }),
 
     // ── Password ─────────────────────────────────────────────────────────────
-    http.post(`${baseUrl}/password/change`, () => noContent()),
-    http.post(`${baseUrl}/password/forgot`, () => noContent()),
-    http.post(`${baseUrl}/password/reset`, () => noContent()),
+    http.post(`${baseUrl}/change-password`, () => noContent()),
+    http.post(`${baseUrl}/forgot-password`, () => accepted()),
+    http.post(`${baseUrl}/reset-password`, () => noContent()),
 
     // ── Registration ─────────────────────────────────────────────────────────
     http.post(`${baseUrl}/register`, async ({ request }) => {
       const body = (await request.json()) as { email?: string };
+      if (body.email === 'existing@granit-showcase.local') {
+        return HttpResponse.json(
+          {
+            type: 'https://tools.ietf.org/html/rfc9110#section-15.5.10',
+            title: 'Conflict',
+            status: 409,
+          },
+          { status: 409 }
+        );
+      }
+      return accepted();
+    }),
+    http.get(`${baseUrl}/confirm-email`, ({ request }) => {
+      const url = new URL(request.url);
+      const userId = url.searchParams.get('userId');
+      const token = url.searchParams.get('token');
+      if (userId && token) return noContent();
       return HttpResponse.json(
-        { userId: `usr_${Date.now()}`, email: body.email ?? '' },
-        { status: 201 }
+        {
+          type: 'https://tools.ietf.org/html/rfc9110#section-15.5.1',
+          title: 'Bad Request',
+          status: 400,
+        },
+        { status: 400 }
       );
     }),
-    http.post(`${baseUrl}/confirm-email`, () => noContent()),
-    http.post(`${baseUrl}/resend-confirmation`, () => noContent()),
+    http.post(`${baseUrl}/resend-confirmation-email`, () => accepted()),
 
     // ── Email change ─────────────────────────────────────────────────────────
-    http.post(`${baseUrl}/email/change`, () => noContent()),
-    http.post(`${baseUrl}/email/confirm-change`, () => noContent()),
+    http.post(`${baseUrl}/change-email`, () => accepted()),
+    http.post(`${baseUrl}/confirm-email-change`, () => noContent()),
 
     // ── Session ──────────────────────────────────────────────────────────────
     http.post(`${baseUrl}/session/heartbeat`, () => noContent()),
@@ -162,6 +182,6 @@ export function createAccountHandlers(baseUrl = DEFAULT_BASE_PATH) {
     ),
 
     // ── Account deletion ─────────────────────────────────────────────────────
-    http.delete(`${baseUrl}/account`, () => noContent()),
+    http.post(`${baseUrl}/delete`, () => accepted()),
   ];
 }

--- a/packages/@granit/react-authentication-local/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-local/src/testing/handlers.ts
@@ -10,8 +10,11 @@ import {
 } from './data';
 
 /**
- * Create MSW handlers for local authentication endpoints (login, 2FA,
- * passkeys, password reset, registration, email confirmation).
+ * Create MSW handlers for local authentication (login) endpoints: credential
+ * login, two-factor login, and passkey assertion (begin/complete).
+ *
+ * Account self-service flows (forgot/reset password, registration, email
+ * confirmation) live in `@granit/react-account/testing` — `createAccountHandlers`.
  *
  * @param baseUrl - API base path (default: `/api/v1/account`)
  */
@@ -72,57 +75,6 @@ export function createLocalAuthHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // POST /passkeys/assertion/complete
     http.post(`${baseUrl}/passkeys/assertion/complete`, () => {
       return HttpResponse.json(mockLoginSuccess);
-    }),
-
-    // POST /forgot-password
-    http.post(`${baseUrl}/forgot-password`, () => {
-      return new HttpResponse(null, { status: 200 });
-    }),
-
-    // POST /reset-password
-    http.post(`${baseUrl}/reset-password`, () => {
-      return new HttpResponse(null, { status: 200 });
-    }),
-
-    // POST /register
-    http.post(`${baseUrl}/register`, async ({ request }) => {
-      const body = (await request.json()) as { email: string };
-
-      if (body.email === 'existing@granit-showcase.local') {
-        return HttpResponse.json(
-          {
-            type: 'https://tools.ietf.org/html/rfc9110#section-15.5.10',
-            title: 'Conflict',
-            status: 409,
-          },
-          { status: 409 }
-        );
-      }
-
-      return HttpResponse.json({
-        userId: 'd2c47314-4d08-4952-98b1-a1b8a6e22ef1',
-        requiresEmailConfirmation: true,
-      });
-    }),
-
-    // GET /confirm-email
-    http.get(`${baseUrl}/confirm-email`, ({ request }) => {
-      const url = new URL(request.url);
-      const userId = url.searchParams.get('userId');
-      const token = url.searchParams.get('token');
-
-      if (userId && token) {
-        return new HttpResponse(null, { status: 200 });
-      }
-
-      return HttpResponse.json(
-        {
-          type: 'https://tools.ietf.org/html/rfc9110#section-15.5.1',
-          title: 'Bad Request',
-          status: 400,
-        },
-        { status: 400 }
-      );
     }),
   ];
 }


### PR DESCRIPTION
## Context

Follow-up to the #560 → #562 account/login split. While making
`createLocalAuthHandlers` strictly login-only, the orphan password/register
handlers it carried turned out to be **compensating for a systematic route
drift** in `@granit/react-account/testing`.

## Problem

`createAccountHandlers` (react-account/testing) had drifted from the backend
contract (`contracts/openapi/identity-local.json`) and the `@granit/account`
API on **9 self-service endpoints** — wrong routes, methods and status codes.
The mocks never matched the real calls; forgot/reset password only worked in
the showcase because `createLocalAuthHandlers` carried vestigial account
"orphan" handlers (with the *correct* routes) that masked the drift.

## Fix

**1. Align `react-account/testing` to the backend** (routes / methods / codes):

| ❌ before | ✅ after (backend) |
|---|---|
| `POST /password/change` | `POST /change-password` (204) |
| `POST /password/forgot` | `POST /forgot-password` (202) |
| `POST /password/reset` | `POST /reset-password` (204) |
| `POST /register` (201, body) | `POST /register` (202, no body, 409 on conflict) |
| `POST /confirm-email` | `GET /confirm-email` (204) |
| `POST /resend-confirmation` | `POST /resend-confirmation-email` (202) |
| `POST /email/change` | `POST /change-email` (202) |
| `POST /email/confirm-change` | `POST /confirm-email-change` (204) |
| `DELETE /account` | `POST /delete` (202) |

(profile / two-factor / passkeys / external-logins / session / config sections
were already correct — untouched.)

**2. Trim `createLocalAuthHandlers` to login-only** — credential login,
two-factor login, passkey assertion (begin/complete). Account self-service
flows now live exclusively in `createAccountHandlers`. No route overlap remains
between the two handler sets.

## Verification

- `pnpm tsc` (project-wide) ✅
- ESLint ✅ (changed files)
- Vitest: **75** tests pass (`@granit/react-account`, `@granit/react-authentication-local`) ✅
- Showcase: **28** auth-local tests pass (decoupled — they mock the hooks); the
  showcase `register-page` already expects the corrected `202 Accepted / no body`
  contract this PR now serves ✅

No production code changed — testing fixtures only.