### PR TITLE
fix(multi-tenancy): align tenant DTOs with backend concurrency contract

### DIFF
--- a/packages/@granit/multi-tenancy/src/api/tenant-admin-api.ts
+++ b/packages/@granit/multi-tenancy/src/api/tenant-admin-api.ts
@@ -2,19 +2,6 @@ import type { AdminTenant, CreateTenantRequest, UpdateTenantRequest } from '../t
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
- * List all tenants.
- *
- * `GET {basePath}/tenants`
- */
-export async function listTenants(
-  client: AxiosInstance,
-  basePath: string
-): Promise<readonly AdminTenant[]> {
-  const { data } = await client.get<readonly AdminTenant[]>(`${basePath}/tenants`);
-  return data;
-}
-
-/**
  * Get a single tenant by ID.
  *
  * `GET {basePath}/tenants/{id}`

--- a/packages/@granit/multi-tenancy/src/index.ts
+++ b/packages/@granit/multi-tenancy/src/index.ts
@@ -15,11 +15,14 @@ export type { JwtClaimTenantResolverOptions } from './resolvers/jwt-claim-tenant
 export { createJwtClaimTenantResolver } from './resolvers/jwt-claim-tenant-resolver';
 
 // API — Tenant admin
+// Note: there is no `listTenants` — the backend deliberately does not expose a
+// plain list endpoint. Tenant listing is served by a Granit.QueryEngine endpoint
+// registered by the consumer at `{basePath}/tenants` (returns PagedResult),
+// consumed generically via @granit/react-query-engine.
 export {
   activateTenant,
   createTenant,
   deactivateTenant,
   getTenant,
-  listTenants,
   updateTenant,
 } from './api/tenant-admin-api';

--- a/packages/@granit/multi-tenancy/src/types/admin-tenant.ts
+++ b/packages/@granit/multi-tenancy/src/types/admin-tenant.ts
@@ -12,6 +12,11 @@ export interface AdminTenant {
   readonly activated: boolean;
   readonly jurisdiction: string | null;
   readonly createdAt: string;
+  /**
+   * Opaque optimistic-concurrency token. Echo it back in
+   * {@link UpdateTenantRequest} to detect concurrent modifications (HTTP 409).
+   */
+  readonly concurrencyStamp: string;
 }
 
 /**
@@ -31,6 +36,8 @@ export interface CreateTenantRequest {
  */
 export interface UpdateTenantRequest {
   readonly name: string;
+  /** Stamp from the last read; must match the stored value (prevents lost updates). */
+  readonly concurrencyStamp: string;
   readonly contactEmail?: string | null;
   readonly jurisdiction?: string | null;
 }

--- a/packages/@granit/react-multi-tenancy/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/testing-handlers.test.ts
@@ -18,3 +18,14 @@ describe('createTenantHandlers /meta', () => {
     expect(await response.json()).toEqual(tenantQueryMetadata);
   });
 });
+
+describe('createTenantHandlers list', () => {
+  it('responds with a PagedResult at GET /tenants', async () => {
+    server.use(...createTenantHandlers(BASE));
+    const response = await fetch(`${BASE}/tenants?page=1&pageSize=20`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { items: unknown[]; totalCount: number };
+    expect(Array.isArray(body.items)).toBe(true);
+    expect(body.totalCount).toBe(body.items.length);
+  });
+});

--- a/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
@@ -3,7 +3,6 @@ import {
   createTenant,
   deactivateTenant,
   getTenant,
-  listTenants,
   updateTenant,
 } from '@granit/multi-tenancy';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -15,7 +14,6 @@ import {
   useCreateTenant,
   useDeactivateTenant,
   useTenantDetail,
-  useTenants,
   useUpdateTenant,
 } from '../hooks/use-tenant-admin';
 import { TenantAdminProvider } from '../providers/tenant-admin-provider';
@@ -28,7 +26,6 @@ vi.mock('@granit/multi-tenancy', async () => {
   const actual = await vi.importActual('@granit/multi-tenancy');
   return {
     ...actual,
-    listTenants: vi.fn(),
     getTenant: vi.fn(),
     createTenant: vi.fn(),
     updateTenant: vi.fn(),
@@ -57,10 +54,10 @@ const SAMPLE_TENANT: AdminTenant = {
   activated: true,
   jurisdiction: 'BE',
   createdAt: '2026-01-01T00:00:00.000Z',
+  concurrencyStamp: 'stamp-1',
 } as unknown as AdminTenant;
 
 beforeEach(() => {
-  vi.mocked(listTenants).mockReset();
   vi.mocked(getTenant).mockReset();
   vi.mocked(createTenant).mockReset();
   vi.mocked(updateTenant).mockReset();
@@ -70,20 +67,6 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
-});
-
-describe('useTenants', () => {
-  it('calls listTenants with the configured basePath', async () => {
-    vi.mocked(listTenants).mockResolvedValue([SAMPLE_TENANT]);
-
-    const { result } = renderHook(() => useTenants(), {
-      wrapper: wrap(new QueryClient(), '/api/v1/multi-tenancy'),
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listTenants).toHaveBeenCalledWith(mockClient, '/api/v1/multi-tenancy');
-    expect(result.current.data).toEqual([SAMPLE_TENANT]);
-  });
 });
 
 describe('useTenantDetail', () => {

--- a/packages/@granit/react-multi-tenancy/src/hooks/use-tenant-admin.ts
+++ b/packages/@granit/react-multi-tenancy/src/hooks/use-tenant-admin.ts
@@ -3,7 +3,6 @@ import {
   createTenant,
   deactivateTenant,
   getTenant,
-  listTenants,
   updateTenant,
 } from '@granit/multi-tenancy';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -12,16 +11,6 @@ import { buildTenantAdminQueryKey, useTenantAdminConfig } from '../providers/ten
 
 import type { AdminTenant, CreateTenantRequest, UpdateTenantRequest } from '@granit/multi-tenancy';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
-
-/** Fetches all tenants. */
-export function useTenants(): UseQueryResult<readonly AdminTenant[]> {
-  const config = useTenantAdminConfig();
-
-  return useQuery({
-    queryKey: buildTenantAdminQueryKey(config, 'tenants'),
-    queryFn: () => listTenants(config.client, config.basePath!),
-  });
-}
 
 /** Fetches a single tenant by ID. Disabled when id is empty. */
 export function useTenantDetail(id: string): UseQueryResult<AdminTenant> {

--- a/packages/@granit/react-multi-tenancy/src/index.ts
+++ b/packages/@granit/react-multi-tenancy/src/index.ts
@@ -20,11 +20,12 @@ export { useClearQueriesOnTenantChange } from './hooks/use-clear-queries-on-tena
 export { useClearQueriesOnUserChange } from './hooks/use-clear-queries-on-user-change';
 
 // Hooks — Tenant admin
+// Note: no `useTenants` list hook — tenant listing goes through the
+// Granit.QueryEngine endpoint (PagedResult) via @granit/react-query-engine.
 export {
   useActivateTenant,
   useCreateTenant,
   useDeactivateTenant,
   useTenantDetail,
-  useTenants,
   useUpdateTenant,
 } from './hooks/use-tenant-admin';

--- a/packages/@granit/react-multi-tenancy/src/testing/data.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/data.ts
@@ -11,6 +11,7 @@ export const mockTenants: Mutable<AdminTenant>[] = [
     activated: true,
     jurisdiction: 'BE',
     createdAt: '2025-09-01T00:00:00Z',
+    concurrencyStamp: 'stamp-acme-0001',
   },
   {
     id: 'tnt_01HZ9KQX0000000000002' as AdminTenant['id'],
@@ -20,6 +21,7 @@ export const mockTenants: Mutable<AdminTenant>[] = [
     activated: true,
     jurisdiction: 'FR',
     createdAt: '2025-11-15T00:00:00Z',
+    concurrencyStamp: 'stamp-globex-0001',
   },
   {
     id: 'tnt_01HZ9KQX0000000000003' as AdminTenant['id'],
@@ -29,5 +31,6 @@ export const mockTenants: Mutable<AdminTenant>[] = [
     activated: false,
     jurisdiction: null,
     createdAt: '2026-01-20T00:00:00Z',
+    concurrencyStamp: 'stamp-initech-0001',
   },
 ];

--- a/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
@@ -124,8 +124,12 @@ export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // GET /tenants/meta — query metadata
     createQueryMetaHandler(`${baseUrl}/tenants`, tenantQueryMetadata),
 
-    // GET /tenants — list all
-    http.get(`${baseUrl}/tenants`, () => HttpResponse.json(mockTenants)),
+    // GET /tenants — QueryEngine admin grid (paged). The backend serves the
+    // tenant list through a Granit.QueryEngine endpoint returning PagedResult,
+    // consumed via @granit/react-query-engine (`useQueryEndpoint`/`getPage`).
+    http.get(`${baseUrl}/tenants`, () =>
+      HttpResponse.json({ items: mockTenants, totalCount: mockTenants.length })
+    ),
 
     // GET /tenants/:id — single tenant
     http.get(`${baseUrl}/tenants/:id`, ({ params }) => {
@@ -145,6 +149,7 @@ export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
         activated: true,
         jurisdiction: body.jurisdiction ?? null,
         createdAt: new Date().toISOString(),
+        concurrencyStamp: `stamp-${Date.now()}`,
       };
       mockTenants.push(newTenant);
       return HttpResponse.json(newTenant, { status: 201 });
@@ -160,6 +165,8 @@ export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
       if (body.name !== undefined) tenant.name = body.name;
       if (body.contactEmail !== undefined) tenant.contactEmail = body.contactEmail;
       if (body.jurisdiction !== undefined) tenant.jurisdiction = body.jurisdiction;
+      // Rotate the concurrency stamp, as the real backend does on each write.
+      tenant.concurrencyStamp = `stamp-${Date.now()}`;
       return noContent();
     }),
 


### PR DESCRIPTION
## Context

`/audit` of `@granit/multi-tenancy` + `@granit/react-multi-tenancy` against `Granit.MultiTenancy.Endpoints` and `contracts/openapi/multi-tenancy.json` surfaced backend contract drift on the tenant admin surface.

## Findings fixed (front)

**BREAKING — missing optimistic-concurrency token**
The backend `TenantResponse` and `UpdateTenantRequest` carry a **required** `ConcurrencyStamp` (lost-update protection, HTTP 409) that the front never mirrored. Without it, `getTenant` discards the stamp and `updateTenant` cannot satisfy the contract.
- `AdminTenant` ← add `concurrencyStamp: string`
- `UpdateTenantRequest` ← add required `concurrencyStamp: string`

**CLEANUP — orphan list function/hook**
The backend deliberately does **not** map a plain list endpoint (`MapGranitMultiTenancy` documents that listing is a `Granit.QueryEngine` endpoint returning `PagedResult`, consumed via `@granit/react-query-engine`). `listTenants`/`useTenants` returned a bare `AdminTenant[]` — wrong shape, and used by no consumer (showcase already uses the query engine).
- removed `listTenants`, `useTenants` + barrel exports

**BREAKING (mock) — list handler returned a bare array**
`createTenantHandlers` `GET /tenants` returned `mockTenants` (array) while the consumer drives the grid through `getPage` (expects `PagedResult`). In host mode the grid received the wrong shape.
- `GET /tenants` now returns `{ items, totalCount }`
- fixtures carry `concurrencyStamp`; the stamp rotates on update

## Verification

- `tsc --noEmit` — PASS (both packages)
- `eslint --max-warnings 0` — PASS
- `vitest run` (multi-tenancy + react-multi-tenancy) — 49 passed

## Follow-up (separate repo)

A showcase MR will thread `tenant.concurrencyStamp` through the edit submit (`tenant-edit-page.tsx`), opened as Draft referencing this PR per the cross-repo ordering rule.