### PR TITLE
fix(hostnames): complete DnsRecordType/DnsConflictType enum mirrors

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1587,6 +1587,11 @@
           "signature": "type CertificateStatus = 'Unprovisioned' | 'Provisioning' | 'Secured' | 'Error'"
         },
         {
+          "name": "DnsConflictType",
+          "kind": "type",
+          "signature": "type DnsConflictType ="
+        },
+        {
           "name": "ManagedHostnameStatus",
           "kind": "type",
           "signature": "type ManagedHostnameStatus = 'Pending' | 'Verifying' | 'Active' | 'Error'"
@@ -5151,7 +5156,7 @@
     },
     {
       "name": "@granit/react-hostnames",
-      "description": "React hooks for managed hostname management — useHostnames, useHostname, useCreateHostname, useUpdateHostname, useDeleteHostname, useVerifyNow, useCheckAvailability",
+      "description": "React hooks for managed hostname management — useHostnames, useHostname, useCreateHostname, useDeleteHostname, useSetPrimary, useClearPrimary, useVerifyNow, useCheckAvailability",
       "exports": [
         {
           "name": "HostnamesProvider",

--- a/packages/@granit/hostnames/src/index.ts
+++ b/packages/@granit/hostnames/src/index.ts
@@ -1,5 +1,5 @@
 // Types
-export { CertificateStatus, ManagedHostnameStatus } from './types/index';
+export { CertificateStatus, DnsConflictType, ManagedHostnameStatus } from './types/index';
 
 export type {
   CertificateStatusReportRequest,

--- a/packages/@granit/hostnames/src/types/index.ts
+++ b/packages/@granit/hostnames/src/types/index.ts
@@ -5,7 +5,7 @@
 /**
  * DNS verification and propagation status of a managed hostname.
  *
- * Mirrors `Granit.Hostnames.Domain.ManagedHostnameStatus` (.NET).
+ * Mirrors `Granit.Hostnames.Domain.HostnameStatus` (.NET).
  * Serialized as PascalCase strings via the framework's global `JsonStringEnumConverter`.
  */
 export type ManagedHostnameStatus = 'Pending' | 'Verifying' | 'Active' | 'Error';
@@ -32,8 +32,12 @@ export const CertificateStatus = {
   Error: 'Error',
 } as const satisfies Record<string, CertificateStatus>;
 
-/** DNS record type used for domain ownership verification. */
-export type DnsRecordType = 'Cname' | 'Txt' | 'A';
+/**
+ * DNS record type used for domain ownership verification.
+ *
+ * Mirrors `Granit.Hostnames.Domain.DnsRecordType` (.NET).
+ */
+export type DnsRecordType = 'A' | 'Aaaa' | 'Cname' | 'Txt';
 
 // ── DNS records ─────────────────────────────────────────────────────────────
 
@@ -46,9 +50,32 @@ export interface ExpectedDnsRecord {
 
 // ── Conflicts ───────────────────────────────────────────────────────────────
 
-/** A conflict preventing a hostname from becoming active. */
+/**
+ * Category of DNS conflict detected during verification.
+ *
+ * Mirrors `Granit.Hostnames.Domain.DnsConflictType` (.NET).
+ * Serialized as PascalCase strings via the framework's global `JsonStringEnumConverter`.
+ */
+export type DnsConflictType =
+  | 'UnexpectedA'
+  | 'UnexpectedAaaa'
+  | 'DivergentCname'
+  | 'MissingCname'
+  | 'MissingTxt'
+  | 'ResolutionFailure';
+
+export const DnsConflictType = {
+  UnexpectedA: 'UnexpectedA',
+  UnexpectedAaaa: 'UnexpectedAaaa',
+  DivergentCname: 'DivergentCname',
+  MissingCname: 'MissingCname',
+  MissingTxt: 'MissingTxt',
+  ResolutionFailure: 'ResolutionFailure',
+} as const satisfies Record<string, DnsConflictType>;
+
+/** A conflict preventing a hostname from becoming active. Mirrors `DnsConflict` (.NET). */
 export interface HostnameConflict {
-  readonly conflictType: string;
+  readonly conflictType: DnsConflictType;
   readonly details: string;
 }
 

--- a/packages/@granit/react-hostnames/package.json
+++ b/packages/@granit/react-hostnames/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@granit/react-hostnames",
-  "description": "React hooks for managed hostname management — useHostnames, useHostname, useCreateHostname, useUpdateHostname, useDeleteHostname, useVerifyNow, useCheckAvailability",
+  "description": "React hooks for managed hostname management — useHostnames, useHostname, useCreateHostname, useDeleteHostname, useSetPrimary, useClearPrimary, useVerifyNow, useCheckAvailability",
   "version": "0.1.0",
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/@granit/react-hostnames/src/testing/data.ts
+++ b/packages/@granit/react-hostnames/src/testing/data.ts
@@ -97,9 +97,7 @@ export const mockHostnames: ManagedHostnameResponse[] = [
       },
     ],
     lastCheckedAt: '2026-06-01T06:00:00Z',
-    conflicts: [
-      { conflictType: 'DnsNotPropagated', details: 'TXT record not found after 3 checks' },
-    ],
+    conflicts: [{ conflictType: 'MissingTxt', details: 'TXT record not found after 3 checks' }],
     failedCheckCount: 5,
     nextCheckAt: '2026-06-03T06:00:00Z',
     certificateStatus: C.Error,


### PR DESCRIPTION
## Context

Audit of `@granit/hostnames` + `@granit/react-hostnames` against the `Granit.Hostnames` .NET contract (`contracts/openapi/hostnames.json` + backend `Domain/` enums). Endpoint coverage was already 100% and HTTP/permissions/provider wiring correct; the gaps were in two enum mirrors (one of which hid a mock bug) and a stale doc.

## Changes

- **`DnsRecordType`**: add the missing `'Aaaa'` value — now fully mirrors `Granit.Hostnames.Domain.DnsRecordType` (`A | Aaaa | Cname | Txt`).
- **`DnsConflictType`**: add the enum (type + const) and type `HostnameConflict.conflictType` with it instead of `string`; export it from the barrel. Mirrors `Granit.Hostnames.Domain.DnsConflictType`.
- Correct `ManagedHostnameStatus` JSDoc to reference the real backend type `HostnameStatus` (the referenced `ManagedHostnameStatus` does not exist .NET-side).
- Fix invalid mock conflict value (`'DnsNotPropagated'` → `'MissingTxt'`) in the package MSW fixtures — the loose `string` typing had been hiding it.
- Drop the non-existent `useUpdateHostname` from the `react-hostnames` package description (there is no Update endpoint).

No exported symbol renames (the `HostnameConflict`/`CheckAvailabilityResponse`/`CertificateStatusReportRequest`/`ManagedHostnameStatus` name-drift findings were left for a separate coordinated PR).

## Verification

`tsc --noEmit` + ESLint clean on both packages · 40/40 tests pass.

## Companion

Showcase alignment (mock fix + conflict localization + cert/check details): granit-showcase-react MR `fix/hostnames-audit-showcase`.