### PR TITLE
refactor(hostnames)!: align exported DTO names with .NET, drop webhook hook

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1592,9 +1592,9 @@
           "signature": "type DnsConflictType ="
         },
         {
-          "name": "ManagedHostnameStatus",
+          "name": "HostnameStatus",
           "kind": "type",
-          "signature": "type ManagedHostnameStatus = 'Pending' | 'Verifying' | 'Active' | 'Error'"
+          "signature": "type HostnameStatus = 'Pending' | 'Verifying' | 'Active' | 'Error'"
         },
         {
           "name": "HostnamesPermissions",
@@ -5176,7 +5176,7 @@
         {
           "name": "useCheckAvailability",
           "kind": "function",
-          "signature": "function useCheckAvailability(host: string): UseQueryResult<CheckAvailabilityResponse>"
+          "signature": "function useCheckAvailability(host: string): UseQueryResult<HostnameAvailabilityResponse>"
         },
         {
           "name": "useHostname",

--- a/packages/@granit/hostnames/README.md
+++ b/packages/@granit/hostnames/README.md
@@ -14,18 +14,19 @@ Part of the [Granit](https://granit-fx.dev) framework.
 
 ### Types
 
-| Type                           | Description                                              |
-| ------------------------------ | -------------------------------------------------------- |
-| `ManagedHostnameResponse`      | Full hostname descriptor (id, host, status, DNS, TLS, …) |
-| `ManagedHostnameStatus`        | `Pending \| Verifying \| Active \| Error`                |
-| `CertificateStatus`            | `Unprovisioned \| Provisioning \| Secured \| Error`      |
-| `CreateManagedHostnameRequest` | Request body for hostname creation                       |
-| `UpdateManagedHostnameRequest` | Request body to toggle `isPrimary`                       |
-| `ListHostnamesParams`          | Query params for the paginated list endpoint             |
-| `CheckAvailabilityResponse`    | `{ isAvailable: boolean }`                               |
-| `ExpectedDnsRecord`            | DNS record required for domain ownership verification    |
-| `HostnameConflict`             | Conflict preventing a hostname from becoming active      |
-| `PagedResponse<T>`             | Generic 0-based pagination envelope                      |
+| Type                             | Description                                               |
+| -------------------------------- | --------------------------------------------------------- |
+| `ManagedHostnameResponse`        | Full hostname descriptor (id, host, status, DNS, TLS, …)  |
+| `HostnameStatus`                 | `Pending \| Verifying \| Active \| Error`                 |
+| `CertificateStatus`              | `Unprovisioned \| Provisioning \| Secured \| Error`       |
+| `DnsRecordType`                  | `A \| Aaaa \| Cname \| Txt`                               |
+| `DnsConflictType`                | DNS conflict category (`MissingTxt`, `DivergentCname`, …) |
+| `ExpectedDnsRecord`              | DNS record required for domain ownership verification     |
+| `DnsConflict`                    | Conflict preventing a hostname from becoming active       |
+| `CreateManagedHostnameRequest`   | Request body for hostname creation                        |
+| `ReportCertificateStatusRequest` | Request body for the certificate-status webhook           |
+| `HostnameAvailabilityResponse`   | `{ host, isAvailable }`                                   |
+| `ListHostnamesParams`            | Query params (`ownerType`, `ownerId`, `maxResults`)       |
 
 ### API functions
 
@@ -37,9 +38,10 @@ All functions take an `AxiosInstance` (from `@granit/api-client`) and a
 | `listHostnames`           | `GET {basePath}`                          |
 | `getHostname`             | `GET {basePath}/{id}`                     |
 | `createHostname`          | `POST {basePath}`                         |
-| `updateHostname`          | `PATCH {basePath}/{id}`                   |
+| `setPrimary`              | `POST {basePath}/{id}/primary`            |
+| `clearPrimary`            | `DELETE {basePath}/{id}/primary`          |
 | `deleteHostname`          | `DELETE {basePath}/{id}`                  |
-| `checkAvailability`       | `GET {basePath}/check-availability?host=` |
+| `checkAvailability`       | `GET {basePath}/availability?host=`       |
 | `verifyNow`               | `POST {basePath}/{id}/verify-now`         |
 | `reportCertificateStatus` | `POST {basePath}/{id}/certificate-status` |
 
@@ -59,9 +61,10 @@ This package is consumed indirectly through `@granit/react-hostnames`. Direct
 use is only needed for headless scenarios (server-side or non-React clients).
 
 ```ts
-import { listHostnames, ManagedHostnameStatus } from '@granit/hostnames';
+import { listHostnames, HostnameStatus } from '@granit/hostnames';
 import type { ListHostnamesParams } from '@granit/hostnames';
 
-const params: ListHostnamesParams = { page: 0, pageSize: 20, status: ManagedHostnameStatus.Active };
-const { items, totalCount } = await listHostnames(axiosClient, '/api/hostnames', params);
+const params: ListHostnamesParams = { ownerType: 'cms.site', ownerId: 'owner-1' };
+const hostnames = await listHostnames(axiosClient, '/api/hostnames', params);
+const active = hostnames.filter((h) => h.status === HostnameStatus.Active);
 ```

--- a/packages/@granit/hostnames/src/__tests__/hostnames-api.test.ts
+++ b/packages/@granit/hostnames/src/__tests__/hostnames-api.test.ts
@@ -12,9 +12,9 @@ import {
   setPrimary,
   verifyNow,
 } from '../api/hostnames-api';
-import { CertificateStatus, ManagedHostnameStatus } from '../types/index';
+import { CertificateStatus, HostnameStatus } from '../types/index';
 
-import type { CheckAvailabilityResponse, ManagedHostnameResponse } from '../types/index';
+import type { HostnameAvailabilityResponse, ManagedHostnameResponse } from '../types/index';
 
 const BASE = '/api/hostnames';
 
@@ -25,7 +25,7 @@ const mockHostname: ManagedHostnameResponse = {
   ownerId: '22222222-0002-4000-a000-000000000002',
   tenantId: '33333333-0003-4000-a000-000000000003',
   isPrimary: true,
-  status: ManagedHostnameStatus.Active,
+  status: HostnameStatus.Active,
   verificationToken: null,
   expectedDnsRecords: [],
   lastCheckedAt: '2026-06-01T10:00:00Z',
@@ -141,7 +141,7 @@ describe('hostnames-api', () => {
   describe('checkAvailability', () => {
     it('sends GET to /availability with host param', async () => {
       const client = createMockClient();
-      const response: CheckAvailabilityResponse = { host: 'new.example.com', isAvailable: true };
+      const response: HostnameAvailabilityResponse = { host: 'new.example.com', isAvailable: true };
       vi.mocked(client.get).mockResolvedValueOnce({ data: response });
 
       const result = await checkAvailability(client, BASE, 'new.example.com');

--- a/packages/@granit/hostnames/src/api/hostnames-api.ts
+++ b/packages/@granit/hostnames/src/api/hostnames-api.ts
@@ -1,9 +1,9 @@
 import type {
-  CertificateStatusReportRequest,
-  CheckAvailabilityResponse,
   CreateManagedHostnameRequest,
+  HostnameAvailabilityResponse,
   ListHostnamesParams,
   ManagedHostnameResponse,
+  ReportCertificateStatusRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
@@ -101,8 +101,8 @@ export async function checkAvailability(
   client: AxiosInstance,
   basePath: string,
   host: string
-): Promise<CheckAvailabilityResponse> {
-  const { data } = await client.get<CheckAvailabilityResponse>(`${basePath}/availability`, {
+): Promise<HostnameAvailabilityResponse> {
+  const { data } = await client.get<HostnameAvailabilityResponse>(`${basePath}/availability`, {
     params: { host },
   });
   return data;
@@ -134,7 +134,7 @@ export async function reportCertificateStatus(
   client: AxiosInstance,
   basePath: string,
   id: string,
-  request: CertificateStatusReportRequest
+  request: ReportCertificateStatusRequest
 ): Promise<void> {
   await client.post(`${basePath}/${encodeURIComponent(id)}/certificate-status`, request);
 }

--- a/packages/@granit/hostnames/src/index.ts
+++ b/packages/@granit/hostnames/src/index.ts
@@ -1,15 +1,15 @@
 // Types
-export { CertificateStatus, DnsConflictType, ManagedHostnameStatus } from './types/index';
+export { CertificateStatus, DnsConflictType, HostnameStatus } from './types/index';
 
 export type {
-  CertificateStatusReportRequest,
-  CheckAvailabilityResponse,
   CreateManagedHostnameRequest,
+  DnsConflict,
   DnsRecordType,
   ExpectedDnsRecord,
-  HostnameConflict,
+  HostnameAvailabilityResponse,
   ListHostnamesParams,
   ManagedHostnameResponse,
+  ReportCertificateStatusRequest,
 } from './types/index';
 
 // API

--- a/packages/@granit/hostnames/src/types/index.ts
+++ b/packages/@granit/hostnames/src/types/index.ts
@@ -8,14 +8,14 @@
  * Mirrors `Granit.Hostnames.Domain.HostnameStatus` (.NET).
  * Serialized as PascalCase strings via the framework's global `JsonStringEnumConverter`.
  */
-export type ManagedHostnameStatus = 'Pending' | 'Verifying' | 'Active' | 'Error';
+export type HostnameStatus = 'Pending' | 'Verifying' | 'Active' | 'Error';
 
-export const ManagedHostnameStatus = {
+export const HostnameStatus = {
   Pending: 'Pending',
   Verifying: 'Verifying',
   Active: 'Active',
   Error: 'Error',
-} as const satisfies Record<string, ManagedHostnameStatus>;
+} as const satisfies Record<string, HostnameStatus>;
 
 /**
  * TLS certificate provisioning status of a managed hostname.
@@ -74,7 +74,7 @@ export const DnsConflictType = {
 } as const satisfies Record<string, DnsConflictType>;
 
 /** A conflict preventing a hostname from becoming active. Mirrors `DnsConflict` (.NET). */
-export interface HostnameConflict {
+export interface DnsConflict {
   readonly conflictType: DnsConflictType;
   readonly details: string;
 }
@@ -89,11 +89,11 @@ export interface ManagedHostnameResponse {
   readonly ownerId: string;
   readonly tenantId: string | null;
   readonly isPrimary: boolean;
-  readonly status: ManagedHostnameStatus;
+  readonly status: HostnameStatus;
   readonly verificationToken: string | null;
   readonly expectedDnsRecords: readonly ExpectedDnsRecord[];
   readonly lastCheckedAt: string | null;
-  readonly conflicts: readonly HostnameConflict[];
+  readonly conflicts: readonly DnsConflict[];
   readonly failedCheckCount: number;
   readonly nextCheckAt: string | null;
   readonly certificateStatus: CertificateStatus;
@@ -126,7 +126,7 @@ export interface ListHostnamesParams {
 // ── Availability ─────────────────────────────────────────────────────────────
 
 /** Response from `GET /availability?host=`. Mirrors `HostnameAvailabilityResponse` (.NET). */
-export interface CheckAvailabilityResponse {
+export interface HostnameAvailabilityResponse {
   readonly host: string;
   readonly isAvailable: boolean;
 }
@@ -134,7 +134,7 @@ export interface CheckAvailabilityResponse {
 // ── Certificate status webhook ────────────────────────────────────────────────
 
 /** Request body for `POST /{id}/certificate-status`. Mirrors `ReportCertificateStatusRequest` (.NET). */
-export interface CertificateStatusReportRequest {
+export interface ReportCertificateStatusRequest {
   readonly status: CertificateStatus;
   readonly expiresAt?: string | null;
 }

--- a/packages/@granit/react-hostnames/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-hostnames/src/__tests__/testing-handlers.test.ts
@@ -4,7 +4,7 @@ import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 import { mockHostnames } from '../testing/data';
 import { createHostnamesHandlers } from '../testing/handlers';
 
-import type { CheckAvailabilityResponse, ManagedHostnameResponse } from '@granit/hostnames';
+import type { HostnameAvailabilityResponse, ManagedHostnameResponse } from '@granit/hostnames';
 
 const BASE = 'http://api.test/api/hostnames';
 const server = setupServer();
@@ -19,7 +19,7 @@ describe('createHostnamesHandlers', () => {
       server.use(...createHostnamesHandlers(BASE));
       const res = await fetch(`${BASE}/availability?host=brand-new.example.com`);
       expect(res.status).toBe(200);
-      const data = (await res.json()) as CheckAvailabilityResponse;
+      const data = (await res.json()) as HostnameAvailabilityResponse;
       expect(data.isAvailable).toBe(true);
       expect(data.host).toBe('brand-new.example.com');
     });
@@ -29,7 +29,7 @@ describe('createHostnamesHandlers', () => {
       const takenHost = mockHostnames[0]!.host;
       const res = await fetch(`${BASE}/availability?host=${takenHost}`);
       expect(res.status).toBe(200);
-      const data = (await res.json()) as CheckAvailabilityResponse;
+      const data = (await res.json()) as HostnameAvailabilityResponse;
       expect(data.isAvailable).toBe(false);
     });
   });

--- a/packages/@granit/react-hostnames/src/__tests__/use-hostname-mutations.test.tsx
+++ b/packages/@granit/react-hostnames/src/__tests__/use-hostname-mutations.test.tsx
@@ -10,7 +10,6 @@ import {
   useClearPrimary,
   useCreateHostname,
   useDeleteHostname,
-  useReportCertificateStatus,
   useSetPrimary,
   useVerifyNow,
 } from '../hooks/use-hostname-mutations';
@@ -202,33 +201,6 @@ describe('useVerifyNow', () => {
       '/api/hostnames/11111111-0001-4000-a000-000000000001/verify-now'
     );
     expect(result.current.data).toEqual(verifying);
-    expect(invalidateSpy).toHaveBeenCalledWith({
-      queryKey: hostnamesKeys.hostname('11111111-0001-4000-a000-000000000001'),
-    });
-  });
-});
-
-describe('useReportCertificateStatus', () => {
-  it('sends POST to /{id}/certificate-status and invalidates hostname query', async () => {
-    const client = createMockClient();
-    vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
-
-    const { wrapper, queryClient } = createWrapper(client);
-    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-
-    const { result } = renderHook(() => useReportCertificateStatus(), { wrapper });
-
-    result.current.mutate({
-      id: '11111111-0001-4000-a000-000000000001',
-      request: { status: 'Secured', expiresAt: '2027-06-01T00:00:00Z' },
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(client.post).toHaveBeenCalledWith(
-      '/api/hostnames/11111111-0001-4000-a000-000000000001/certificate-status',
-      { status: 'Secured', expiresAt: '2027-06-01T00:00:00Z' }
-    );
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: hostnamesKeys.hostname('11111111-0001-4000-a000-000000000001'),
     });

--- a/packages/@granit/react-hostnames/src/hooks/use-hostname-mutations.ts
+++ b/packages/@granit/react-hostnames/src/hooks/use-hostname-mutations.ts
@@ -2,7 +2,6 @@ import {
   clearPrimary,
   createHostname,
   deleteHostname,
-  reportCertificateStatus,
   setPrimary,
   verifyNow,
 } from '@granit/hostnames';
@@ -12,11 +11,7 @@ import { useHostnamesConfig } from '../providers/hostnames-provider';
 
 import { hostnamesKeys } from './query-keys';
 
-import type {
-  CertificateStatusReportRequest,
-  CreateManagedHostnameRequest,
-  ManagedHostnameResponse,
-} from '@granit/hostnames';
+import type { CreateManagedHostnameRequest, ManagedHostnameResponse } from '@granit/hostnames';
 import type { UseMutationResult } from '@tanstack/react-query';
 
 /**
@@ -140,33 +135,6 @@ export function useVerifyNow(): UseMutationResult<ManagedHostnameResponse, Error
   return useMutation({
     mutationFn: (id: string) => verifyNow(client, basePath, id),
     onSuccess: async (_, id) => {
-      await queryClient.invalidateQueries({ queryKey: hostnamesKeys.hostname(id) });
-    },
-  });
-}
-
-/**
- * Mutation hook to report a certificate status update from an external provider.
- *
- * Invalidates the affected hostname query on success.
- *
- * @example
- * ```tsx
- * const { mutate: report } = useReportCertificateStatus();
- * report({ id: 'hostname-id', request: { status: 'Secured', expiresAt: '2027-01-01T00:00:00Z' } });
- * ```
- */
-export function useReportCertificateStatus(): UseMutationResult<
-  void,
-  Error,
-  { id: string; request: CertificateStatusReportRequest }
-> {
-  const { client, basePath } = useHostnamesConfig();
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: ({ id, request }) => reportCertificateStatus(client, basePath, id, request),
-    onSuccess: async (_, { id }) => {
       await queryClient.invalidateQueries({ queryKey: hostnamesKeys.hostname(id) });
     },
   });

--- a/packages/@granit/react-hostnames/src/hooks/use-hostname.ts
+++ b/packages/@granit/react-hostnames/src/hooks/use-hostname.ts
@@ -5,7 +5,7 @@ import { useHostnamesConfig } from '../providers/hostnames-provider';
 
 import { hostnamesKeys } from './query-keys';
 
-import type { CheckAvailabilityResponse, ManagedHostnameResponse } from '@granit/hostnames';
+import type { HostnameAvailabilityResponse, ManagedHostnameResponse } from '@granit/hostnames';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -39,7 +39,7 @@ export function useHostname(id: string): UseQueryResult<ManagedHostnameResponse>
  * if (data?.isAvailable) { ... }
  * ```
  */
-export function useCheckAvailability(host: string): UseQueryResult<CheckAvailabilityResponse> {
+export function useCheckAvailability(host: string): UseQueryResult<HostnameAvailabilityResponse> {
   const { client, basePath } = useHostnamesConfig();
 
   return useQuery({

--- a/packages/@granit/react-hostnames/src/index.ts
+++ b/packages/@granit/react-hostnames/src/index.ts
@@ -15,7 +15,6 @@ export {
   useClearPrimary,
   useCreateHostname,
   useDeleteHostname,
-  useReportCertificateStatus,
   useSetPrimary,
   useVerifyNow,
 } from './hooks/use-hostname-mutations';

--- a/packages/@granit/react-hostnames/src/testing/data.ts
+++ b/packages/@granit/react-hostnames/src/testing/data.ts
@@ -1,9 +1,9 @@
-import { CertificateStatus, ManagedHostnameStatus } from '@granit/hostnames';
+import { CertificateStatus, HostnameStatus } from '@granit/hostnames';
 
 import type { ManagedHostnameResponse } from '@granit/hostnames';
 
 /** Short aliases for use inside the mock fixtures. */
-export const S = ManagedHostnameStatus;
+export const S = HostnameStatus;
 export const C = CertificateStatus;
 
 export const mockHostnames: ManagedHostnameResponse[] = [


### PR DESCRIPTION
## Context

Follow-up to #585. The hostnames audit flagged two deferred items, now done together (coordinated, breaking):

1. **DTO name drift** — four exported types didn't mirror their `Granit.Hostnames` .NET counterparts.
2. **Webhook hook over-reach** — `useReportCertificateStatus` mirrored a machine-to-machine webhook with no browser UI surface.

## Changes

**Renames (mirror the .NET contract):**

| Before | After |
| --- | --- |
| `ManagedHostnameStatus` | `HostnameStatus` |
| `HostnameConflict` | `DnsConflict` |
| `CheckAvailabilityResponse` | `HostnameAvailabilityResponse` |
| `CertificateStatusReportRequest` | `ReportCertificateStatusRequest` |

**Removal:** `useReportCertificateStatus` (react-hostnames). `POST /{id}/certificate-status` is an HMAC-signed webhook called by the edge provider (gated by `Hostnames.Certificates.Report`, granted to the provider — not admin users). The core `reportCertificateStatus` API function is kept for contract completeness.

**README:** fixed significant drift — removed non-existent `updateHostname` / `UpdateManagedHostnameRequest` / `PagedResponse<T>`, corrected the availability route (`/availability`, not `/check-availability`), replaced the stale pagination example with the real owner-scoped list, and documented `DnsRecordType` / `DnsConflictType` / `setPrimary` / `clearPrimary`.

## Blast radius

Only `HostnameStatus` is consumed externally (showcase-admin-react, 2 files); the other three renames + the hook are internal to the front packages. No cms-renderer / guava-front usage.

## Verification

`tsc --noEmit` + ESLint + markdownlint clean · 39/39 tests pass.

## Companion

showcase-admin-react: `HostnameStatus` rename applied in a companion MR (see below).

## BREAKING CHANGE

`@granit/hostnames` renames four exported types; `@granit/react-hostnames` removes the `useReportCertificateStatus` export.