### PR TITLE
fix(storage): align @granit/storage and react-storage with framework conventions

### DIFF
--- a/packages/@granit/react-storage/README.md
+++ b/packages/@granit/react-storage/README.md
@@ -12,7 +12,7 @@ pnpm add @granit/react-storage
 
 ### Hooks
 
-- `useStorage(key, options?)` -- read and write to browser storage (localStorage/sessionStorage) with cross-tab synchronization
+- `useStorage<T>(key, defaultValue, options?)` — read and write to browser storage (localStorage/sessionStorage) with cross-tab synchronization
 
 ## Usage
 
@@ -20,9 +20,7 @@ pnpm add @granit/react-storage
 import { useStorage } from '@granit/react-storage';
 
 function ThemeSelector() {
-  const [theme, setTheme] = useStorage('app.theme', {
-    defaultValue: 'light',
-  });
+  const [theme, setTheme] = useStorage('app.theme', 'light');
 
   return (
     <select value={theme} onChange={(e) => setTheme(e.target.value)}>

--- a/packages/@granit/react-storage/package.json
+++ b/packages/@granit/react-storage/package.json
@@ -23,6 +23,7 @@
         "types": "./dist/index.d.ts",
         "import": "./dist/index.js"
       }
-    }
+    },
+    "registry": "https://npm.pkg.github.com"
   }
 }

--- a/packages/@granit/react-storage/src/__tests__/use-storage.test.ts
+++ b/packages/@granit/react-storage/src/__tests__/use-storage.test.ts
@@ -1,7 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { useStorage } from '../use-storage';
+import { useStorage } from '../hooks/use-storage';
 
 afterEach(() => {
   localStorage.clear();

--- a/packages/@granit/react-storage/src/hooks/use-storage.ts
+++ b/packages/@granit/react-storage/src/hooks/use-storage.ts
@@ -9,6 +9,10 @@ import type { StorageOptions } from '@granit/storage';
  * Uses `useSyncExternalStore` for tear-free reads and automatic re-renders
  * when the stored value changes (including cross-tab via the `storage` event).
  *
+ * @remarks `serialize` and `deserialize` options must be referentially stable
+ * (defined outside the component or memoized). Changing them between renders
+ * without also changing the `storage` type will have no effect.
+ *
  * @example
  * ```tsx
  * function Sidebar() {
@@ -27,8 +31,10 @@ export function useStorage<T>(
   // Cache the raw string + parsed value to keep referential stability.
   // useSyncExternalStore requires getSnapshot to return the same reference
   // when the underlying data has not changed.
-  const cacheRef = useRef<{ raw: string | null; value: T }>({
-    raw: undefined as unknown as string | null,
+  // `undefined` is used as the initial sentinel: getItem() never returns undefined,
+  // so the first call always populates the cache.
+  const cacheRef = useRef<{ raw: string | null | undefined; value: T }>({
+    raw: undefined,
     value: defaultValue,
   });
 

--- a/packages/@granit/react-storage/src/index.ts
+++ b/packages/@granit/react-storage/src/index.ts
@@ -1,1 +1,1 @@
-export { useStorage } from './use-storage';
+export { useStorage } from './hooks/use-storage';

--- a/packages/@granit/storage/README.md
+++ b/packages/@granit/storage/README.md
@@ -2,7 +2,7 @@
 
 # @granit/storage
 
-Typed storage abstraction: `createStorage` factory, `useStorage` hook for localStorage/sessionStorage with JSON serialization.
+Typed localStorage/sessionStorage wrapper: `createStorage` factory with JSON serialization and automatic key prefixing.
 
 Part of the [Granit](https://granit-fx.dev) framework.
 

--- a/packages/@granit/storage/package.json
+++ b/packages/@granit/storage/package.json
@@ -14,9 +14,6 @@
     "build": "tsup"
   },
   "peerDependencies": {},
-  "devDependencies": {
-    "@granit/testing": "workspace:*"
-  },
   "publishConfig": {
     "exports": {
       ".": {


### PR DESCRIPTION
## Summary

- Move `useStorage` to `src/hooks/use-storage.ts` (canonical `react-*` structure)
- Fix `cacheRef` initial type: drop `undefined as unknown as string | null` coercion
- Add `@remarks` documenting `serialize`/`deserialize` stability requirement
- Add missing `publishConfig.registry` in `@granit/react-storage`
- Fix README in `@granit/storage`: remove erroneous `useStorage` mention (hook lives in `react-storage`)
- Fix README in `@granit/react-storage`: correct `useStorage` API example (signature + usage)
- Remove unused `@granit/testing` devDependency from `@granit/storage`

Findings from `/audit storage react-storage` — no BREAKING or GAP, 4 INCONSISTENCY + 2 CLEANUP + 2 IMPROVEMENT resolved.

## Test plan

- [ ] `pnpm tsc` passes
- [ ] 21 tests pass (`@granit/storage` + `@granit/react-storage`)
- [ ] ESLint 0 warnings
- [ ] markdownlint 0 errors