### PR TITLE
fix(settings)!: align @granit/settings and react-settings with backend contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6247,6 +6247,16 @@
       "description": "React bindings for @granit/settings — SettingsProvider, useSetting, useSettings, useUpdateSetting, useDeleteSetting",
       "exports": [
         {
+          "name": "SettingsProvider",
+          "kind": "function",
+          "signature": "function SettingsProvider("
+        },
+        {
+          "name": "useSettingsConfig",
+          "kind": "function",
+          "signature": "function useSettingsConfig(): ResolvedSettingsConfig"
+        },
+        {
           "name": "SettingsConfig",
           "kind": "interface",
           "signature": "interface SettingsConfig",
@@ -6259,9 +6269,14 @@
           "members": []
         },
         {
+          "name": "buildSettingsQueryKey",
+          "kind": "function",
+          "signature": "function buildSettingsQueryKey( config: SettingsConfig, ...segments: readonly string[] ): readonly unknown[]"
+        },
+        {
           "name": "useDeleteSetting",
           "kind": "function",
-          "signature": "function useDeleteSetting(scope: SettingScope): UseDeleteSettingReturn"
+          "signature": "function useDeleteSetting(): UseDeleteSettingReturn"
         },
         {
           "name": "UseDeleteSettingReturn",
@@ -6296,14 +6311,14 @@
           "signature": "function useAdminAppSettings( scope: AdminSettingsScope, options?:"
         },
         {
-          "name": "useSaveAdminAppSettings",
+          "name": "useBulkUpdateSettings",
           "kind": "function",
-          "signature": "function useSaveAdminAppSettings( scope: AdminSettingsScope ): UseMutationResult<BulkUpdateSettingsResponse, Error, SaveAppSettingsVariables>"
+          "signature": "function useBulkUpdateSettings( scope: AdminSettingsScope ): UseMutationResult<BulkUpdateSettingsResponse, Error, BulkUpdateSettingsVariables>"
         },
         {
-          "name": "SaveAppSettingsVariables",
+          "name": "BulkUpdateSettingsVariables",
           "kind": "type",
-          "signature": "type SaveAppSettingsVariables = readonly BulkSettingEntry[]"
+          "signature": "type BulkUpdateSettingsVariables = readonly BulkSettingEntry[]"
         }
       ]
     },
@@ -7076,6 +7091,16 @@
       "name": "@granit/scheduling",
       "description": "Scheduled action types and API — mirrors Granit.Scheduling .NET contract",
       "exports": [
+        {
+          "name": "SCHEDULING_STATUS_COLORS",
+          "kind": "const",
+          "signature": "const SCHEDULING_STATUS_COLORS"
+        },
+        {
+          "name": "SCHEDULING_STATUS_LABELS",
+          "kind": "const",
+          "signature": "const SCHEDULING_STATUS_LABELS"
+        },
         {
           "name": "SchedulingPermissions",
           "kind": "const",

--- a/packages/@granit/react-settings/src/__tests__/admin-settings-hooks.test.tsx
+++ b/packages/@granit/react-settings/src/__tests__/admin-settings-hooks.test.tsx
@@ -4,10 +4,10 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useAdminAppSettings, useSaveAdminAppSettings } from '../hooks/use-admin-app-settings';
+import { useAdminAppSettings, useBulkUpdateSettings } from '../hooks/use-admin-app-settings';
 import { SettingsProvider } from '../providers/settings-provider';
 
-import type { AdminAppSetting, BulkUpdateSettingsResponse } from '@granit/settings';
+import type { AdminAppSettingResponse, BulkUpdateSettingsResponse } from '@granit/settings';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -16,11 +16,11 @@ vi.mock('@granit/settings', async (importOriginal) => {
   return {
     ...actual,
     getAdminAppSettings: vi.fn(),
-    saveAdminAppSettings: vi.fn(),
+    bulkUpdateSettings: vi.fn(),
   };
 });
 
-const { getAdminAppSettings, saveAdminAppSettings } = await import('@granit/settings');
+const { getAdminAppSettings, bulkUpdateSettings } = await import('@granit/settings');
 
 function createWrapper(client: AxiosInstance, basePath?: string) {
   const queryClient = createTestQueryClient();
@@ -38,7 +38,7 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-const mockSettings: AdminAppSetting[] = [
+const mockSettings: AdminAppSettingResponse[] = [
   {
     key: 'ui.theme',
     label: 'Theme',
@@ -78,17 +78,17 @@ describe('useAdminAppSettings', () => {
   });
 });
 
-describe('useSaveAdminAppSettings', () => {
+describe('useBulkUpdateSettings', () => {
   it('should save settings and invalidate the scope cache', async () => {
     const client = createMockClient();
     const envelope: BulkUpdateSettingsResponse = {
       results: [{ key: 'ui.theme', outcome: 'Updated', errorCode: null }],
     };
-    vi.mocked(saveAdminAppSettings).mockResolvedValue(envelope);
+    vi.mocked(bulkUpdateSettings).mockResolvedValue(envelope);
 
     const { wrapper, queryClient } = createWrapper(client, '/api');
     const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
-    const { result } = renderHook(() => useSaveAdminAppSettings('global'), { wrapper });
+    const { result } = renderHook(() => useBulkUpdateSettings('global'), { wrapper });
 
     const payload = [{ key: 'ui.theme', value: 'dark' }];
 
@@ -97,7 +97,7 @@ describe('useSaveAdminAppSettings', () => {
       returned = await result.current.mutateAsync(payload);
     });
 
-    expect(saveAdminAppSettings).toHaveBeenCalledWith(client, '/api', 'global', payload);
+    expect(bulkUpdateSettings).toHaveBeenCalledWith(client, '/api', 'global', payload);
     expect(invalidateSpy).toHaveBeenCalled();
     expect(returned).toEqual(envelope);
   });
@@ -114,10 +114,10 @@ describe('useSaveAdminAppSettings', () => {
         },
       ],
     };
-    vi.mocked(saveAdminAppSettings).mockResolvedValue(envelope);
+    vi.mocked(bulkUpdateSettings).mockResolvedValue(envelope);
 
     const { wrapper } = createWrapper(client, '/api');
-    const { result } = renderHook(() => useSaveAdminAppSettings('tenant'), { wrapper });
+    const { result } = renderHook(() => useBulkUpdateSettings('tenant'), { wrapper });
 
     await act(async () => {
       const res = await result.current.mutateAsync([

--- a/packages/@granit/react-settings/src/__tests__/settings-hooks.test.tsx
+++ b/packages/@granit/react-settings/src/__tests__/settings-hooks.test.tsx
@@ -42,7 +42,7 @@ afterEach(() => {
 describe('useSetting', () => {
   it('should fetch a single setting by name', async () => {
     const client = createMockClient();
-    const settingValue = { name: 'Granit.Locale', value: 'fr', scope: 'user' };
+    const settingValue = { name: 'Granit.Locale', value: 'fr' };
     vi.mocked(client.get).mockResolvedValue(axiosResponse(settingValue));
 
     const { result } = renderHook(() => useSetting('user', 'Granit.Locale'), {
@@ -57,9 +57,7 @@ describe('useSetting', () => {
 
   it('should use empty string when basePath is undefined', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(
-      axiosResponse({ name: 'x', value: 'y', scope: 'user' })
-    );
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ name: 'x', value: 'y' }));
 
     const { result } = renderHook(() => useSetting('user', 'x'), {
       wrapper: createWrapper(client),
@@ -83,9 +81,7 @@ describe('useSetting', () => {
 
   it('should fetch when enabled is true explicitly', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(
-      axiosResponse({ name: 'x', value: 'v', scope: 'user' })
-    );
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ name: 'x', value: 'v' }));
 
     const { result } = renderHook(() => useSetting('user', 'x', { enabled: true }), {
       wrapper: createWrapper(client, '/api'),
@@ -97,9 +93,7 @@ describe('useSetting', () => {
 
   it('should fetch by default when options are omitted', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(
-      axiosResponse({ name: 'x', value: 'v', scope: 'user' })
-    );
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ name: 'x', value: 'v' }));
 
     const { result } = renderHook(() => useSetting('user', 'x'), {
       wrapper: createWrapper(client, '/api'),
@@ -265,7 +259,7 @@ describe('useDeleteSetting', () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
 
-    const { result } = renderHook(() => useDeleteSetting('user'), {
+    const { result } = renderHook(() => useDeleteSetting(), {
       wrapper: createWrapper(client, '/api'),
     });
 
@@ -282,7 +276,7 @@ describe('useDeleteSetting', () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
 
-    const { result } = renderHook(() => useDeleteSetting('user'), {
+    const { result } = renderHook(() => useDeleteSetting(), {
       wrapper: createWrapper(client, '/api'),
     });
 
@@ -297,7 +291,7 @@ describe('useDeleteSetting', () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
 
-    const { result } = renderHook(() => useDeleteSetting('tenant'), {
+    const { result } = renderHook(() => useDeleteSetting(), {
       wrapper: createWrapper(client),
     });
 
@@ -307,14 +301,14 @@ describe('useDeleteSetting', () => {
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
 
-    expect(client.delete).toHaveBeenCalledWith('/settings/tenant/key');
+    expect(client.delete).toHaveBeenCalledWith('/settings/user/key');
   });
 
   it('should expose error on mutation failure', async () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockRejectedValue(new Error('Not found'));
 
-    const { result } = renderHook(() => useDeleteSetting('user'), {
+    const { result } = renderHook(() => useDeleteSetting(), {
       wrapper: createWrapper(client, '/api'),
     });
 

--- a/packages/@granit/react-settings/src/__tests__/settings-provider.test.tsx
+++ b/packages/@granit/react-settings/src/__tests__/settings-provider.test.tsx
@@ -4,11 +4,8 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  SettingsProvider,
-  buildSettingsQueryKey,
-  useSettingsConfig,
-} from '../providers/settings-provider';
+import { buildSettingsQueryKey } from '../hooks/query-keys';
+import { SettingsProvider, useSettingsConfig } from '../providers/settings-provider';
 
 import type { SettingsConfig } from '../providers/settings-provider';
 import type { AxiosInstance } from 'axios';

--- a/packages/@granit/react-settings/src/hooks/query-keys.ts
+++ b/packages/@granit/react-settings/src/hooks/query-keys.ts
@@ -1,0 +1,10 @@
+import type { SettingsConfig } from '../providers/settings-provider';
+
+/** Builds a consistent React Query key for settings operations. */
+export function buildSettingsQueryKey(
+  config: SettingsConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? ['settings'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-settings/src/hooks/use-admin-app-settings.ts
+++ b/packages/@granit/react-settings/src/hooks/use-admin-app-settings.ts
@@ -1,10 +1,12 @@
-import { getAdminAppSettings, saveAdminAppSettings } from '@granit/settings';
+import { bulkUpdateSettings, getAdminAppSettings } from '@granit/settings';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { buildSettingsQueryKey, useSettingsConfig } from '../providers/settings-provider';
+import { useSettingsConfig } from '../providers/settings-provider';
+
+import { buildSettingsQueryKey } from './query-keys';
 
 import type {
-  AdminAppSetting,
+  AdminAppSettingResponse,
   AdminSettingsScope,
   BulkSettingEntry,
   BulkUpdateSettingsResponse,
@@ -23,7 +25,7 @@ import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 export function useAdminAppSettings(
   scope: AdminSettingsScope,
   options?: { enabled?: boolean }
-): UseQueryResult<AdminAppSetting[]> {
+): UseQueryResult<AdminAppSettingResponse[]> {
   const config = useSettingsConfig();
 
   return useQuery({
@@ -34,7 +36,7 @@ export function useAdminAppSettings(
   });
 }
 
-export type SaveAppSettingsVariables = readonly BulkSettingEntry[];
+export type BulkUpdateSettingsVariables = readonly BulkSettingEntry[];
 
 /**
  * Batch-update admin settings for a scope.
@@ -45,15 +47,15 @@ export type SaveAppSettingsVariables = readonly BulkSettingEntry[];
  * is responsible for surfacing non-`Updated` outcomes. Invalidates the
  * corresponding definitions cache on success.
  */
-export function useSaveAdminAppSettings(
+export function useBulkUpdateSettings(
   scope: AdminSettingsScope
-): UseMutationResult<BulkUpdateSettingsResponse, Error, SaveAppSettingsVariables> {
+): UseMutationResult<BulkUpdateSettingsResponse, Error, BulkUpdateSettingsVariables> {
   const config = useSettingsConfig();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (settings: SaveAppSettingsVariables) =>
-      saveAdminAppSettings(config.client, config.basePath ?? '', scope, settings),
+    mutationFn: (settings: BulkUpdateSettingsVariables) =>
+      bulkUpdateSettings(config.client, config.basePath ?? '', scope, settings),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildSettingsQueryKey(config, 'admin', 'definitions', scope),

--- a/packages/@granit/react-settings/src/hooks/use-delete-setting.ts
+++ b/packages/@granit/react-settings/src/hooks/use-delete-setting.ts
@@ -2,9 +2,9 @@ import { deleteSetting } from '@granit/settings';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import { buildSettingsQueryKey, useSettingsConfig } from '../providers/settings-provider';
+import { useSettingsConfig } from '../providers/settings-provider';
 
-import type { SettingScope } from '@granit/settings';
+import { buildSettingsQueryKey } from './query-keys';
 
 export interface UseDeleteSettingReturn {
   readonly remove: (name: string) => void;
@@ -14,29 +14,30 @@ export interface UseDeleteSettingReturn {
 }
 
 /**
- * Mutation to delete (reset) a setting value.
+ * Mutation to delete (reset) a user-level setting value.
  *
  * After deletion, the setting falls back to the next level in the cascade
- * (User → Tenant → Global → Config → Default).
+ * (Tenant → Global → Config → Default). Only valid for the user scope —
+ * to clear a global or tenant setting use `useUpdateSetting` with `null`.
  *
  * @example
  * ```tsx
- * const { remove } = useDeleteSetting('user');
+ * const { remove } = useDeleteSetting();
  * remove(SETTING_NAMES.PREFERRED_CULTURE); // resets to tenant/global default
  * ```
  */
-export function useDeleteSetting(scope: SettingScope): UseDeleteSettingReturn {
+export function useDeleteSetting(): UseDeleteSettingReturn {
   const config = useSettingsConfig();
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (name: string) => deleteSetting(config.client, config.basePath ?? '', scope, name),
+    mutationFn: (name: string) => deleteSetting(config.client, config.basePath ?? '', 'user', name),
     onSuccess: (_data, name) => {
       queryClient
-        .invalidateQueries({ queryKey: buildSettingsQueryKey(config, scope) })
+        .invalidateQueries({ queryKey: buildSettingsQueryKey(config, 'user') })
         .catch(() => undefined);
       queryClient
-        .invalidateQueries({ queryKey: buildSettingsQueryKey(config, scope, name) })
+        .invalidateQueries({ queryKey: buildSettingsQueryKey(config, 'user', name) })
         .catch(() => undefined);
     },
   });

--- a/packages/@granit/react-settings/src/hooks/use-setting.ts
+++ b/packages/@granit/react-settings/src/hooks/use-setting.ts
@@ -1,7 +1,9 @@
 import { getSetting } from '@granit/settings';
 import { useQuery } from '@tanstack/react-query';
 
-import { buildSettingsQueryKey, useSettingsConfig } from '../providers/settings-provider';
+import { useSettingsConfig } from '../providers/settings-provider';
+
+import { buildSettingsQueryKey } from './query-keys';
 
 import type { SettingScope, SettingValueResponse } from '@granit/settings';
 import type { UseQueryResult } from '@tanstack/react-query';

--- a/packages/@granit/react-settings/src/hooks/use-settings.ts
+++ b/packages/@granit/react-settings/src/hooks/use-settings.ts
@@ -1,7 +1,9 @@
 import { getSettings } from '@granit/settings';
 import { useQuery } from '@tanstack/react-query';
 
-import { buildSettingsQueryKey, useSettingsConfig } from '../providers/settings-provider';
+import { useSettingsConfig } from '../providers/settings-provider';
+
+import { buildSettingsQueryKey } from './query-keys';
 
 import type { SettingScope, SettingsMap } from '@granit/settings';
 import type { UseQueryResult } from '@tanstack/react-query';

--- a/packages/@granit/react-settings/src/hooks/use-update-setting.ts
+++ b/packages/@granit/react-settings/src/hooks/use-update-setting.ts
@@ -2,7 +2,9 @@ import { updateSetting } from '@granit/settings';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import { buildSettingsQueryKey, useSettingsConfig } from '../providers/settings-provider';
+import { useSettingsConfig } from '../providers/settings-provider';
+
+import { buildSettingsQueryKey } from './query-keys';
 
 import type { SettingScope } from '@granit/settings';
 

--- a/packages/@granit/react-settings/src/index.ts
+++ b/packages/@granit/react-settings/src/index.ts
@@ -1,10 +1,9 @@
 // Provider
-export {
-  SettingsProvider,
-  buildSettingsQueryKey,
-  useSettingsConfig,
-} from './providers/settings-provider';
+export { SettingsProvider, useSettingsConfig } from './providers/settings-provider';
 export type { SettingsConfig, SettingsProviderProps } from './providers/settings-provider';
+
+// Query key factory
+export { buildSettingsQueryKey } from './hooks/query-keys';
 
 // Hooks
 export { useDeleteSetting } from './hooks/use-delete-setting';
@@ -15,5 +14,5 @@ export { useUpdateSetting } from './hooks/use-update-setting';
 export type { UseUpdateSettingReturn } from './hooks/use-update-setting';
 
 // Hooks — Admin
-export { useAdminAppSettings, useSaveAdminAppSettings } from './hooks/use-admin-app-settings';
-export type { SaveAppSettingsVariables } from './hooks/use-admin-app-settings';
+export { useAdminAppSettings, useBulkUpdateSettings } from './hooks/use-admin-app-settings';
+export type { BulkUpdateSettingsVariables } from './hooks/use-admin-app-settings';

--- a/packages/@granit/react-settings/src/providers/settings-provider.tsx
+++ b/packages/@granit/react-settings/src/providers/settings-provider.tsx
@@ -50,12 +50,3 @@ export function useSettingsConfig(): ResolvedSettingsConfig {
   }
   return ctx;
 }
-
-/** Builds a consistent React Query key for settings operations. */
-export function buildSettingsQueryKey(
-  config: SettingsConfig,
-  ...segments: readonly string[]
-): readonly unknown[] {
-  const prefix = config.queryKeyPrefix ?? ['settings'];
-  return [...prefix, ...segments];
-}

--- a/packages/@granit/react-settings/src/testing/data.ts
+++ b/packages/@granit/react-settings/src/testing/data.ts
@@ -1,7 +1,7 @@
-import type { AdminAppSetting } from '@granit/settings';
+import type { AdminAppSettingResponse } from '@granit/settings';
 import type { Mutable } from '@granit/testing';
 
-export const mockAppSettings: Mutable<AdminAppSetting>[] = [
+export const mockAppSettings: Mutable<AdminAppSettingResponse>[] = [
   {
     key: 'audit.retention_days',
     label: 'Audit Log Retention',
@@ -84,7 +84,7 @@ export const mockAppSettings: Mutable<AdminAppSetting>[] = [
   },
 ];
 
-/** In-memory settings store per scope. */
+/** In-memory settings store per scope. Null values represent cleared overrides. */
 export const mockSettingsStore: Record<string, Record<string, string | null>> = {
   user: {
     'Granit.Localization.PreferredCulture': 'fr',

--- a/packages/@granit/react-settings/src/testing/handlers.ts
+++ b/packages/@granit/react-settings/src/testing/handlers.ts
@@ -8,6 +8,7 @@ import type {
   BulkSettingResult,
   BulkUpdateSettingsRequest,
   BulkUpdateSettingsResponse,
+  SettingsMap,
 } from '@granit/settings';
 
 /**
@@ -83,7 +84,13 @@ export function createSettingsHandlers(baseUrl = '/api/v1') {
 
     http.get(`${baseUrl}/settings/:scope`, ({ params }) => {
       const scope = params.scope as string;
-      return HttpResponse.json(store[scope] ?? {});
+      // Strip null/cleared entries — the backend only returns keys with an
+      // effective resolved value (absent key = unset, not null).
+      const scopeData = store[scope] ?? {};
+      const result: SettingsMap = Object.fromEntries(
+        Object.entries(scopeData).filter((entry): entry is [string, string] => entry[1] !== null)
+      );
+      return HttpResponse.json(result);
     }),
 
     http.get(`${baseUrl}/settings/:scope/:name`, ({ params }) => {
@@ -96,9 +103,9 @@ export function createSettingsHandlers(baseUrl = '/api/v1') {
     http.put(`${baseUrl}/settings/:scope/:name`, async ({ params, request }) => {
       const scope = params.scope as string;
       const name = decodeURIComponent(params.name as string);
-      const body = (await request.json()) as { value: string | null };
+      const body = (await request.json()) as { value?: string | null };
       store[scope] ??= {};
-      store[scope][name] = body.value;
+      store[scope][name] = body.value ?? null;
       return noContent();
     }),
 

--- a/packages/@granit/settings/src/__tests__/settings-admin-api.test.ts
+++ b/packages/@granit/settings/src/__tests__/settings-admin-api.test.ts
@@ -1,15 +1,15 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getAdminAppSettings, saveAdminAppSettings } from '../api/settings-api';
+import { bulkUpdateSettings, getAdminAppSettings } from '../api/settings-api';
 
-import type { AdminAppSetting, BulkUpdateSettingsResponse } from '../types/index';
+import type { AdminAppSettingResponse, BulkUpdateSettingsResponse } from '../types/index';
 
 describe('settings-admin-api', () => {
   describe('getAdminAppSettings', () => {
     it('should GET {basePath}/settings/global/definitions', async () => {
       const client = createMockClient();
-      const data: AdminAppSetting[] = [
+      const data: AdminAppSettingResponse[] = [
         {
           key: 'app.name',
           label: 'App Name',
@@ -48,7 +48,7 @@ describe('settings-admin-api', () => {
     });
   });
 
-  describe('saveAdminAppSettings', () => {
+  describe('bulkUpdateSettings', () => {
     it('should PUT {basePath}/settings/global/bulk with the entries wrapped in { settings }', async () => {
       const client = createMockClient();
       const envelope: BulkUpdateSettingsResponse = {
@@ -63,7 +63,7 @@ describe('settings-admin-api', () => {
         { key: 'app.name', value: 'Guava Pro' },
         { key: 'app.theme', value: 'dark' },
       ];
-      const result = await saveAdminAppSettings(client, '/api/v1', 'global', settings);
+      const result = await bulkUpdateSettings(client, '/api/v1', 'global', settings);
 
       expect(client.put).toHaveBeenCalledWith('/api/v1/settings/global/bulk', { settings });
       expect(result).toEqual(envelope);
@@ -73,7 +73,7 @@ describe('settings-admin-api', () => {
       const client = createMockClient();
       vi.mocked(client.put).mockResolvedValue({ data: { results: [] } });
 
-      await saveAdminAppSettings(client, '/api/v1', 'tenant', [{ key: 'k', value: 'v' }]);
+      await bulkUpdateSettings(client, '/api/v1', 'tenant', [{ key: 'k', value: 'v' }]);
 
       expect(client.put).toHaveBeenCalledWith('/api/v1/settings/tenant/bulk', {
         settings: [{ key: 'k', value: 'v' }],
@@ -95,7 +95,7 @@ describe('settings-admin-api', () => {
       };
       vi.mocked(client.put).mockResolvedValue({ data: envelope });
 
-      const result = await saveAdminAppSettings(client, '', 'global', []);
+      const result = await bulkUpdateSettings(client, '', 'global', []);
 
       expect(result.results.filter((r) => r.outcome !== 'Updated')).toHaveLength(2);
     });

--- a/packages/@granit/settings/src/api/settings-api.ts
+++ b/packages/@granit/settings/src/api/settings-api.ts
@@ -1,5 +1,5 @@
 import type {
-  AdminAppSetting,
+  AdminAppSettingResponse,
   AdminSettingsScope,
   BulkSettingEntry,
   BulkUpdateSettingsResponse,
@@ -56,14 +56,15 @@ export async function updateSetting(
 }
 
 /**
- * Delete (reset) a setting value so the cascade takes over.
+ * Delete (reset) a user-level setting so the cascade takes over.
  *
- * `DELETE /settings/{scope}/{name}`
+ * `DELETE /settings/user/{name}` — only valid for the user scope.
+ * To clear a global or tenant setting, use `updateSetting` with `{ value: null }`.
  */
 export async function deleteSetting(
   client: AxiosInstance,
   basePath: string,
-  scope: string,
+  scope: 'user',
   name: string
 ): Promise<void> {
   await client.delete(`${basePath}/settings/${scope}/${encodeURIComponent(name)}`);
@@ -80,8 +81,10 @@ export async function getAdminAppSettings(
   client: AxiosInstance,
   basePath: string,
   scope: AdminSettingsScope
-): Promise<AdminAppSetting[]> {
-  const response = await client.get<AdminAppSetting[]>(`${basePath}/settings/${scope}/definitions`);
+): Promise<AdminAppSettingResponse[]> {
+  const response = await client.get<AdminAppSettingResponse[]>(
+    `${basePath}/settings/${scope}/definitions`
+  );
   return response.data;
 }
 
@@ -95,7 +98,7 @@ export async function getAdminAppSettings(
  * A 422 is returned only for structural validation failures on the request
  * envelope (empty list, too many entries).
  */
-export async function saveAdminAppSettings(
+export async function bulkUpdateSettings(
   client: AxiosInstance,
   basePath: string,
   scope: AdminSettingsScope,

--- a/packages/@granit/settings/src/index.ts
+++ b/packages/@granit/settings/src/index.ts
@@ -1,6 +1,6 @@
 // Types
 export type {
-  AdminAppSetting,
+  AdminAppSettingResponse,
   AdminSettingsScope,
   BulkSettingEntry,
   BulkSettingOutcome,
@@ -8,10 +8,10 @@ export type {
   BulkUpdateSettingsRequest,
   BulkUpdateSettingsResponse,
   SettingScope,
-  SettingValueKind,
-  SettingValueResponse,
   SettingsMap,
+  SettingValueResponse,
   UpdateSettingValueRequest,
+  ValueKind,
 } from './types/index';
 
 // Constants
@@ -19,11 +19,11 @@ export { SETTING_NAMES } from './constants';
 
 // API
 export {
+  bulkUpdateSettings,
   deleteSetting,
   getAdminAppSettings,
   getSetting,
   getSettings,
-  saveAdminAppSettings,
   updateSetting,
 } from './api/settings-api';
 export { SettingsPermissions } from './permissions';

--- a/packages/@granit/settings/src/types/index.ts
+++ b/packages/@granit/settings/src/types/index.ts
@@ -6,11 +6,12 @@ export interface SettingValueResponse {
 
 /** Request body for `PUT /settings/{scope}/{name}`. */
 export interface UpdateSettingValueRequest {
-  readonly value: string | null;
+  /** Pass `null` to clear the override; omit entirely to leave unchanged. */
+  readonly value?: string | null;
 }
 
-/** Response for `GET /settings/user` — flat key/value map. */
-export type SettingsMap = Record<string, string | null>;
+/** Response for `GET /settings/{scope}` — flat key/value map. Absent keys are unset. */
+export type SettingsMap = Record<string, string>;
 
 /** Setting scope for API routing. */
 export type SettingScope = 'user' | 'global' | 'tenant';
@@ -21,9 +22,9 @@ export type SettingScope = 'user' | 'global' | 'tenant';
  * Value shape of a setting as declared at definition time.
  *
  * Mirrors the .NET `ValueKind` enum. Used by admin UIs to pick the right input
- * control. Encryption is orthogonal — see `AdminAppSetting.isEncrypted`.
+ * control. Encryption is orthogonal — see `AdminAppSettingResponse.isEncrypted`.
  */
-export type SettingValueKind = 'String' | 'Bool' | 'Int' | 'Double' | 'Json';
+export type ValueKind = 'String' | 'Bool' | 'Int' | 'Double' | 'Json';
 
 /**
  * Admin-scoped application setting.
@@ -32,13 +33,13 @@ export type SettingValueKind = 'String' | 'Bool' | 'Int' | 'Double' | 'Json';
  * Encrypted values are returned as `"***"` by the backend; the admin UI must
  * surface a reset-then-rewrite flow rather than an editable value.
  */
-export interface AdminAppSetting {
+export interface AdminAppSettingResponse {
   readonly key: string;
   readonly label: string | null;
   readonly description: string | null;
   readonly defaultValue: string | null;
   readonly value: string | null;
-  readonly valueKind: SettingValueKind;
+  readonly valueKind: ValueKind;
   /**
    * Optional allow-list. When non-null and non-empty, the UI should render a
    * dropdown whose options are these values (labels are localized client-side

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3004,11 +3004,7 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
-  packages/@granit/storage:
-    devDependencies:
-      '@granit/testing':
-        specifier: workspace:*
-        version: link:../testing
+  packages/@granit/storage: {}
 
   packages/@granit/subscriptions:
     devDependencies:


### PR DESCRIPTION
## Summary

- **`AdminAppSetting` → `AdminAppSettingResponse`** — mirrors the .NET DTO name exactly
- **`SettingValueKind` → `ValueKind`** — mirrors the .NET enum name
- **`UpdateSettingValueRequest.value` made optional** (`value?: string | null`) — absent from the OpenAPI `required` array, meaning the C# has a default
- **`SettingsMap` fixed to `Record<string, string>`** — backend flat map never returns null values; absent key = unset
- **`saveAdminAppSettings` → `bulkUpdateSettings`** / **`useSaveAdminAppSettings` → `useBulkUpdateSettings`** — verb convention (`update*` for PUT)
- **`deleteSetting`/`useDeleteSetting` restricted to `scope: 'user'`** — `DELETE /settings/{scope}/{name}` only exists for the user scope in the OpenAPI contract
- **`buildSettingsQueryKey` moved to `hooks/query-keys.ts`** — per canonical structure (query-keys belong in `hooks/`, not providers)
- **MSW GET handler strips null entries** from flat settings map (cleared settings are absent, not null)
- **Phantom `scope` field removed** from `SettingValueResponse` test mocks
- **`pnpm-lock.yaml` regenerated** — fixes CI `ERR_PNPM_OUTDATED_LOCKFILE` on `@granit/storage`

## Test plan

- [x] `pnpm tsc` — no errors on `@granit/settings` and `@granit/react-settings`
- [x] `pnpm lint` — no warnings or errors
- [x] `vitest run` on both packages — 39/39 tests passing
- [ ] Companion showcase MR `fix(settings): align with @granit/settings contract renames` on `develop`