### PR TITLE
fix(scheduling)!: align reschedule endpoint with backend void contract

### DIFF
--- a/packages/@granit/react-scheduling/src/__tests__/use-scheduling.test.tsx
+++ b/packages/@granit/react-scheduling/src/__tests__/use-scheduling.test.tsx
@@ -29,7 +29,7 @@ const sampleAction: ScheduledActionResponse = {
   payloadType: 'SendEmail',
   executeAt: '2026-04-05T09:00:00Z',
   correlationId: null,
-  status: 0,
+  status: 'Pending',
   executedAt: null,
   cancelledBy: null,
   failureReason: null,
@@ -39,8 +39,7 @@ const sampleAction: ScheduledActionResponse = {
 const samplePagedResult: PagedResult<ScheduledActionResponse> = {
   items: [sampleAction],
   totalCount: 1,
-  page: 1,
-  pageSize: 20,
+  hasMore: false,
   nextCursor: undefined,
 };
 

--- a/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
+++ b/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
@@ -119,7 +119,7 @@ export function useCancelScheduledAction(): UseMutationResult<void, Error, strin
  * ```
  */
 export function useRescheduleScheduledAction(): UseMutationResult<
-  ScheduledActionResponse,
+  void,
   Error,
   RescheduleVariables
 > {
@@ -128,7 +128,7 @@ export function useRescheduleScheduledAction(): UseMutationResult<
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ id, request }: RescheduleVariables) =>
+    mutationFn: ({ id, request }: RescheduleVariables) =>
       rescheduleScheduledAction(config.client, actionsPath, id, request),
     onSuccess: async (_data, { id }) => {
       await queryClient.invalidateQueries({ queryKey: buildSchedulingQueryKey(config) });

--- a/packages/@granit/react-scheduling/src/testing/handlers.ts
+++ b/packages/@granit/react-scheduling/src/testing/handlers.ts
@@ -272,7 +272,7 @@ export function createSchedulingHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return new HttpResponse(null, { status: 204 });
     }),
 
-    // PUT — reschedule a pending action
+    // PUT — reschedule a pending action (200 with no body, matching the backend contract)
     http.put(`${actionsUrl}/:id/reschedule`, async ({ params, request }) => {
       const action = mockScheduledActions.find((a) => a.id === params.id);
       if (!action) {
@@ -294,7 +294,7 @@ export function createSchedulingHandlers(baseUrl = DEFAULT_BASE_PATH) {
       }
       const body = (await request.json()) as { newExecuteAt: string };
       action.executeAt = toISODateString(body.newExecuteAt);
-      return HttpResponse.json(action);
+      return new HttpResponse(null, { status: 200 });
     }),
   ];
 }

--- a/packages/@granit/scheduling/src/__tests__/scheduling-api.test.ts
+++ b/packages/@granit/scheduling/src/__tests__/scheduling-api.test.ts
@@ -11,11 +11,8 @@ import {
   listScheduledActions,
   rescheduleScheduledAction,
 } from '../api/scheduling-api';
-import {
-  SCHEDULING_PERMISSIONS,
-  SCHEDULING_STATUS_COLORS,
-  SCHEDULING_STATUS_LABELS,
-} from '../constants';
+import { SCHEDULING_STATUS_COLORS, SCHEDULING_STATUS_LABELS } from '../constants';
+import { SchedulingPermissions } from '../permissions';
 
 import type {
   RescheduleActionRequest,
@@ -164,38 +161,22 @@ describe('rescheduleScheduledAction', () => {
     newExecuteAt: toISODateString('2026-08-01T09:00:00Z'),
   };
 
-  const rescheduledAction: ScheduledActionResponse = {
-    ...sampleAction,
-    executeAt: toISODateString('2026-08-01T09:00:00Z'),
-  };
-
   it('PUTs to {basePath}/{id}/reschedule with the request body', async () => {
     const client = createMockClient();
-    vi.mocked(client.put).mockResolvedValue({ data: rescheduledAction });
+    vi.mocked(client.put).mockResolvedValue({});
 
     await rescheduleScheduledAction(client, basePath, actionId, request);
 
     expect(client.put).toHaveBeenCalledWith(`${basePath}/${actionId}/reschedule`, request);
   });
 
-  it('returns the updated ScheduledActionResponse', async () => {
+  it('resolves void on success', async () => {
     const client = createMockClient();
-    vi.mocked(client.put).mockResolvedValue({ data: rescheduledAction });
+    vi.mocked(client.put).mockResolvedValue({});
 
     const result = await rescheduleScheduledAction(client, basePath, actionId, request);
 
-    expect(result).toEqual(rescheduledAction);
-    expect(result.executeAt).toBe('2026-08-01T09:00:00Z');
-  });
-
-  it('preserves the action id and status from the server response', async () => {
-    const client = createMockClient();
-    vi.mocked(client.put).mockResolvedValue({ data: rescheduledAction });
-
-    const result = await rescheduleScheduledAction(client, basePath, actionId, request);
-
-    expect(result.id).toBe(actionId);
-    expect(result.status).toBe('Pending');
+    expect(result).toBeUndefined();
   });
 });
 
@@ -203,14 +184,14 @@ describe('rescheduleScheduledAction', () => {
 // Constants
 // ---------------------------------------------------------------------------
 
-describe('SCHEDULING_PERMISSIONS', () => {
-  it('exposes ACTIONS_READ and ACTIONS_MANAGE permission strings', () => {
-    expect(SCHEDULING_PERMISSIONS.ACTIONS_READ).toBe('Scheduling.Actions.Read');
-    expect(SCHEDULING_PERMISSIONS.ACTIONS_MANAGE).toBe('Scheduling.Actions.Manage');
+describe('SchedulingPermissions', () => {
+  it('exposes Actions.Read and Actions.Manage permission strings', () => {
+    expect(SchedulingPermissions.Actions.Read).toBe('Scheduling.Actions.Read');
+    expect(SchedulingPermissions.Actions.Manage).toBe('Scheduling.Actions.Manage');
   });
 
-  it('has exactly two permission entries', () => {
-    expect(Object.keys(SCHEDULING_PERMISSIONS)).toHaveLength(2);
+  it('has exactly one sub-group with two entries', () => {
+    expect(Object.keys(SchedulingPermissions.Actions)).toHaveLength(2);
   });
 });
 

--- a/packages/@granit/scheduling/src/api/scheduling-api.ts
+++ b/packages/@granit/scheduling/src/api/scheduling-api.ts
@@ -47,17 +47,13 @@ export async function cancelScheduledAction(
 /**
  * Reschedule a pending action to a new execution time.
  *
- * `PUT {basePath}/{id}/reschedule` — returns 200 on success, 404/409 on error.
+ * `PUT {basePath}/{id}/reschedule` — returns 200 with no body on success, 404/409 on error.
  */
 export async function rescheduleScheduledAction(
   client: AxiosInstance,
   basePath: string,
   id: string,
   request: RescheduleActionRequest
-): Promise<ScheduledActionResponse> {
-  const { data } = await client.put<ScheduledActionResponse>(
-    `${basePath}/${id}/reschedule`,
-    request
-  );
-  return data;
+): Promise<void> {
+  await client.put(`${basePath}/${id}/reschedule`, request);
 }

--- a/packages/@granit/scheduling/src/constants.ts
+++ b/packages/@granit/scheduling/src/constants.ts
@@ -1,11 +1,5 @@
 import type { ScheduledActionStatus } from './types/index';
 
-/** Permission strings for the Scheduling module. */
-export const SCHEDULING_PERMISSIONS = {
-  ACTIONS_READ: 'Scheduling.Actions.Read',
-  ACTIONS_MANAGE: 'Scheduling.Actions.Manage',
-} as const;
-
 /** Status → badge color mapping for UI rendering. */
 export const SCHEDULING_STATUS_COLORS = {
   Pending: 'blue',

--- a/packages/@granit/scheduling/src/index.ts
+++ b/packages/@granit/scheduling/src/index.ts
@@ -7,11 +7,7 @@ export {
 } from './types/index';
 
 // Constants
-export {
-  SCHEDULING_PERMISSIONS,
-  SCHEDULING_STATUS_COLORS,
-  SCHEDULING_STATUS_LABELS,
-} from './constants';
+export { SCHEDULING_STATUS_COLORS, SCHEDULING_STATUS_LABELS } from './constants';
 
 // API
 export {


### PR DESCRIPTION
## Summary

- `RescheduleScheduledAction` (`PUT /scheduling/scheduled-actions/{id}/reschedule`) returns `200 OK` with **no body** per the OpenAPI spec — the frontend was incorrectly typed as `Promise<ScheduledActionResponse>`
- `useRescheduleScheduledAction` mutation result type corrected: `ScheduledActionResponse` → `void`
- MSW reschedule handler fixed: `HttpResponse.json(action)` → `new HttpResponse(null, { status: 200 })` to match the real backend
- Remove duplicate `SCHEDULING_PERMISSIONS` flat export from `constants.ts` and barrel; `SchedulingPermissions` (nested) is the canonical pattern used across all other modules
- Test fixture fixes: `status: 0` → `'Pending'`, drop invalid `page`/`pageSize` fields from `PagedResult` fixture

## Breaking changes

`rescheduleScheduledAction()` now returns `Promise<void>`. Any consumer calling `.then(data => ...)` on the result must be updated (the real backend never returned a body — the old typing was a bug).

## Test plan

- [ ] `pnpm vitest run packages/@granit/scheduling packages/@granit/react-scheduling` → 32 tests pass
- [ ] `pnpm tsc` → no errors
- [ ] `pnpm lint` → no warnings