### PR TITLE
fix(customer-balance)!: align contract with OpenAPI spec

### DIFF
--- a/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
+++ b/packages/@granit/customer-balance/src/__tests__/customer-balance-api.test.ts
@@ -3,12 +3,14 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   addAdminCredit,
+  applyAdminDebit,
   getCustomerBalance,
   listBalanceTransactions,
 } from '../api/customer-balance-api';
 
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from '../types/index';
@@ -36,23 +38,27 @@ const basePath = '/customer-balance';
 
 describe('customer-balance-api', () => {
   describe('getCustomerBalance', () => {
-    it('should GET {basePath}/balance', async () => {
+    it('should GET {basePath}/balance with currency param', async () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: sampleBalance });
 
-      const result = await getCustomerBalance(client, basePath);
+      const result = await getCustomerBalance(client, basePath, 'EUR');
 
-      expect(client.get).toHaveBeenCalledWith(`${basePath}/balance`);
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/balance`, {
+        params: { currency: 'EUR' },
+      });
       expect(result).toEqual(sampleBalance);
     });
 
-    it('should work with custom basePath', async () => {
+    it('should pass the requested currency to the query param', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: sampleBalance });
+      vi.mocked(client.get).mockResolvedValue({ data: { ...sampleBalance, currency: 'USD' } });
 
-      await getCustomerBalance(client, '/api/v2/balance');
+      await getCustomerBalance(client, basePath, 'USD');
 
-      expect(client.get).toHaveBeenCalledWith('/api/v2/balance/balance');
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/balance`, {
+        params: { currency: 'USD' },
+      });
     });
 
     it('should handle null updatedAt', async () => {
@@ -60,39 +66,61 @@ describe('customer-balance-api', () => {
       const balance: CustomerBalanceResponse = { ...sampleBalance, updatedAt: null };
       vi.mocked(client.get).mockResolvedValue({ data: balance });
 
-      const result = await getCustomerBalance(client, basePath);
+      const result = await getCustomerBalance(client, basePath, 'EUR');
 
       expect(result.updatedAt).toBeNull();
     });
   });
 
   describe('listBalanceTransactions', () => {
-    it('should GET {basePath}/transactions', async () => {
+    it('should GET {basePath}/transactions with all required params', async () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: [sampleTransaction] });
 
-      const result = await listBalanceTransactions(client, basePath);
+      const result = await listBalanceTransactions(client, basePath, {
+        currency: 'EUR',
+        page: 1,
+        pageSize: 25,
+      });
 
-      expect(client.get).toHaveBeenCalledWith(`${basePath}/transactions`);
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/transactions`, {
+        params: { currency: 'EUR', page: 1, pageSize: 25 },
+      });
       expect(result).toEqual([sampleTransaction]);
+    });
+
+    it('should pass page and pageSize correctly', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      await listBalanceTransactions(client, basePath, { currency: 'USD', page: 3, pageSize: 10 });
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/transactions`, {
+        params: { currency: 'USD', page: 3, pageSize: 10 },
+      });
     });
 
     it('should return empty array when no transactions', async () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: [] });
 
-      const result = await listBalanceTransactions(client, basePath);
+      const result = await listBalanceTransactions(client, basePath, {
+        currency: 'EUR',
+        page: 1,
+        pageSize: 25,
+      });
 
       expect(result).toEqual([]);
     });
   });
 
   describe('addAdminCredit', () => {
-    it('should POST {basePath}/credit', async () => {
+    it('should POST {basePath}/balance/credit and return CustomerBalanceResponse', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
 
       const request: AdminCreditRequest = {
+        partyId: 'party-001',
         amount: 50.0,
         currency: 'EUR',
         source: 'Promotional',
@@ -100,16 +128,18 @@ describe('customer-balance-api', () => {
         expiresAt: '2026-12-31T23:59:59Z',
       };
 
-      await addAdminCredit(client, basePath, request);
+      const result = await addAdminCredit(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith(`${basePath}/credit`, request);
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/balance/credit`, request);
+      expect(result).toEqual(sampleBalance);
     });
 
     it('should handle ManualAdjustment source', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
 
       const request: AdminCreditRequest = {
+        partyId: 'party-001',
         amount: 100.0,
         currency: 'USD',
         source: 'ManualAdjustment',
@@ -119,7 +149,44 @@ describe('customer-balance-api', () => {
 
       await addAdminCredit(client, basePath, request);
 
-      expect(client.post).toHaveBeenCalledWith(`${basePath}/credit`, request);
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/balance/credit`, request);
+    });
+  });
+
+  describe('applyAdminDebit', () => {
+    it('should POST {basePath}/balance/debit and return CustomerBalanceResponse', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
+
+      const request: AdminDebitRequest = {
+        partyId: 'party-001',
+        amount: 25.0,
+        currency: 'EUR',
+        reason: 'Manual correction',
+      };
+
+      const result = await applyAdminDebit(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/balance/debit`, request);
+      expect(result).toEqual(sampleBalance);
+    });
+
+    it('should pass optional referenceId and referenceType', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
+
+      const request: AdminDebitRequest = {
+        partyId: 'party-001',
+        amount: 50.0,
+        currency: 'EUR',
+        reason: 'Invoice adjustment',
+        referenceId: 'ref-uuid-001',
+        referenceType: 'AdminAdjustment',
+      };
+
+      await applyAdminDebit(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/balance/debit`, request);
     });
   });
 });

--- a/packages/@granit/customer-balance/src/api/customer-balance-api.ts
+++ b/packages/@granit/customer-balance/src/api/customer-balance-api.ts
@@ -1,47 +1,72 @@
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
+  ListBalanceTransactionsParams,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
- * Fetch the current customer balance.
+ * Fetch the current customer balance for a given currency.
  *
- * `GET {basePath}/balance`
+ * `GET {basePath}/balance?currency=EUR`
  */
 export async function getCustomerBalance(
   client: AxiosInstance,
-  basePath: string
+  basePath: string,
+  currency: string
 ): Promise<CustomerBalanceResponse> {
-  const response = await client.get<CustomerBalanceResponse>(`${basePath}/balance`);
+  const response = await client.get<CustomerBalanceResponse>(`${basePath}/balance`, {
+    params: { currency },
+  });
   return response.data;
 }
 
 /**
- * List all balance transactions.
+ * List paginated balance transactions for a given currency.
  *
- * `GET {basePath}/transactions`
+ * `GET {basePath}/transactions?currency=EUR&page=1&pageSize=25`
  */
 export async function listBalanceTransactions(
   client: AxiosInstance,
-  basePath: string
+  basePath: string,
+  params: ListBalanceTransactionsParams
 ): Promise<readonly BalanceTransactionResponse[]> {
   const response = await client.get<readonly BalanceTransactionResponse[]>(
-    `${basePath}/transactions`
+    `${basePath}/transactions`,
+    { params }
   );
   return response.data;
 }
 
 /**
- * Add an administrative credit to the customer balance.
+ * Add an administrative credit to a party's balance.
  *
- * `POST {basePath}/credit`
+ * `POST {basePath}/balance/credit`
  */
 export async function addAdminCredit(
   client: AxiosInstance,
   basePath: string,
   request: AdminCreditRequest
-): Promise<void> {
-  await client.post(`${basePath}/credit`, request);
+): Promise<CustomerBalanceResponse> {
+  const response = await client.post<CustomerBalanceResponse>(
+    `${basePath}/balance/credit`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Apply a manual debit to a party's balance (admin tooling).
+ *
+ * `POST {basePath}/balance/debit`
+ */
+export async function applyAdminDebit(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminDebitRequest
+): Promise<CustomerBalanceResponse> {
+  const response = await client.post<CustomerBalanceResponse>(`${basePath}/balance/debit`, request);
+  return response.data;
 }

--- a/packages/@granit/customer-balance/src/index.ts
+++ b/packages/@granit/customer-balance/src/index.ts
@@ -1,8 +1,10 @@
 // Types
 export type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
+  ListBalanceTransactionsParams,
 } from './types/index';
 
 // Permissions
@@ -11,6 +13,7 @@ export { CustomerBalancePermissions } from './permissions';
 // API
 export {
   addAdminCredit,
+  applyAdminDebit,
   getCustomerBalance,
   listBalanceTransactions,
 } from './api/customer-balance-api';

--- a/packages/@granit/customer-balance/src/types/index.ts
+++ b/packages/@granit/customer-balance/src/types/index.ts
@@ -1,10 +1,28 @@
 /** Request payload for adding an administrative credit to a customer balance. */
 export interface AdminCreditRequest {
+  readonly partyId: string;
   readonly amount: number;
   readonly currency: string;
   readonly source: 'Promotional' | 'ManualAdjustment';
   readonly reason: string;
   readonly expiresAt: string | null;
+}
+
+/** Request payload for applying a manual debit to a customer balance (admin tooling). */
+export interface AdminDebitRequest {
+  readonly partyId: string;
+  readonly amount: number;
+  readonly currency: string;
+  readonly reason: string;
+  readonly referenceId?: string | null;
+  readonly referenceType?: string | null;
+}
+
+/** Query parameters for the list balance transactions endpoint. */
+export interface ListBalanceTransactionsParams {
+  readonly currency: string;
+  readonly page: number;
+  readonly pageSize: number;
 }
 
 /** The current state of a customer's balance account. */

--- a/packages/@granit/react-ai/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { aiWorkspaceQueryMetadata, createAIHandlers } from '../testing/index';

--- a/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-auditing/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-authentication-api-keys/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createApiKeyHandlers } from '../testing/index';

--- a/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-blob-storage/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { blobQueryMetadata, createBlobStorageHandlers } from '../testing/index';

--- a/packages/@granit/react-customer-balance/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-customer-balance/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { balanceTransactionQueryMetadata, createCustomerBalanceHandlers } from '../testing/index';

--- a/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
+++ b/packages/@granit/react-customer-balance/src/__tests__/use-customer-balance.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   useAddAdminCredit,
+  useApplyAdminDebit,
   useBalanceTransactions,
   useCustomerBalance,
 } from '../hooks/use-customer-balance';
@@ -15,6 +16,7 @@ import { CustomerBalanceProvider } from '../providers/customer-balance-provider'
 import type { CustomerBalanceConfig } from '../providers/customer-balance-provider';
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
 } from '@granit/customer-balance';
@@ -58,16 +60,18 @@ describe('use-customer-balance', () => {
   });
 
   describe('useCustomerBalance', () => {
-    it('fetches the current balance', async () => {
+    it('fetches the current balance with currency param', async () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: sampleBalance });
 
-      const { result } = renderHook(() => useCustomerBalance(), {
+      const { result } = renderHook(() => useCustomerBalance('EUR'), {
         wrapper: createWrapper(client),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/v1/customer-balance/balance');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/customer-balance/balance', {
+        params: { currency: 'EUR' },
+      });
       expect(result.current.data).toEqual(sampleBalance);
     });
 
@@ -75,26 +79,31 @@ describe('use-customer-balance', () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: sampleBalance });
 
-      const { result } = renderHook(() => useCustomerBalance(), {
+      const { result } = renderHook(() => useCustomerBalance('USD'), {
         wrapper: createWrapper(client, '/custom/balance'),
       });
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/custom/balance/balance');
+      expect(client.get).toHaveBeenCalledWith('/custom/balance/balance', {
+        params: { currency: 'USD' },
+      });
     });
   });
 
   describe('useBalanceTransactions', () => {
-    it('fetches all transactions', async () => {
+    it('fetches transactions with all required params', async () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: [sampleTransaction] });
 
-      const { result } = renderHook(() => useBalanceTransactions(), {
-        wrapper: createWrapper(client),
-      });
+      const { result } = renderHook(
+        () => useBalanceTransactions({ currency: 'EUR', page: 1, pageSize: 25 }),
+        { wrapper: createWrapper(client) }
+      );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.get).toHaveBeenCalledWith('/api/v1/customer-balance/transactions');
+      expect(client.get).toHaveBeenCalledWith('/api/v1/customer-balance/transactions', {
+        params: { currency: 'EUR', page: 1, pageSize: 25 },
+      });
       expect(result.current.data).toEqual([sampleTransaction]);
     });
 
@@ -102,9 +111,10 @@ describe('use-customer-balance', () => {
       const client = createMockClient();
       vi.mocked(client.get).mockResolvedValue({ data: [] });
 
-      const { result } = renderHook(() => useBalanceTransactions(), {
-        wrapper: createWrapper(client),
-      });
+      const { result } = renderHook(
+        () => useBalanceTransactions({ currency: 'EUR', page: 1, pageSize: 25 }),
+        { wrapper: createWrapper(client) }
+      );
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
       expect(result.current.data).toEqual([]);
@@ -112,11 +122,12 @@ describe('use-customer-balance', () => {
   });
 
   describe('useAddAdminCredit', () => {
-    it('posts a credit via POST', async () => {
+    it('posts a credit via POST /balance/credit and returns CustomerBalanceResponse', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
 
       const request: AdminCreditRequest = {
+        partyId: 'party-001',
         amount: 50.0,
         currency: 'EUR',
         source: 'Promotional',
@@ -131,14 +142,16 @@ describe('use-customer-balance', () => {
       result.current.mutate(request);
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/api/v1/customer-balance/credit', request);
+      expect(client.post).toHaveBeenCalledWith('/api/v1/customer-balance/balance/credit', request);
+      expect(result.current.data).toEqual(sampleBalance);
     });
 
     it('uses custom basePath', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue({ data: undefined });
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
 
       const request: AdminCreditRequest = {
+        partyId: 'party-001',
         amount: 100.0,
         currency: 'USD',
         source: 'ManualAdjustment',
@@ -153,7 +166,54 @@ describe('use-customer-balance', () => {
       result.current.mutate(request);
 
       await waitFor(() => expect(result.current.isSuccess).toBe(true));
-      expect(client.post).toHaveBeenCalledWith('/custom/balance/credit', request);
+      expect(client.post).toHaveBeenCalledWith('/custom/balance/balance/credit', request);
+    });
+  });
+
+  describe('useApplyAdminDebit', () => {
+    it('posts a debit via POST /balance/debit and returns CustomerBalanceResponse', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
+
+      const request: AdminDebitRequest = {
+        partyId: 'party-001',
+        amount: 25.0,
+        currency: 'EUR',
+        reason: 'Manual correction',
+      };
+
+      const { result } = renderHook(() => useApplyAdminDebit(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate(request);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/customer-balance/balance/debit', request);
+      expect(result.current.data).toEqual(sampleBalance);
+    });
+
+    it('passes optional referenceId and referenceType', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleBalance });
+
+      const request: AdminDebitRequest = {
+        partyId: 'party-001',
+        amount: 50.0,
+        currency: 'EUR',
+        reason: 'Invoice adjustment',
+        referenceId: 'ref-uuid-001',
+        referenceType: 'AdminAdjustment',
+      };
+
+      const { result } = renderHook(() => useApplyAdminDebit(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate(request);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/customer-balance/balance/debit', request);
     });
   });
 });

--- a/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
+++ b/packages/@granit/react-customer-balance/src/hooks/use-customer-balance.ts
@@ -1,5 +1,6 @@
 import {
   addAdminCredit,
+  applyAdminDebit,
   getCustomerBalance,
   listBalanceTransactions,
 } from '@granit/customer-balance';
@@ -12,68 +13,116 @@ import {
 
 import type {
   AdminCreditRequest,
+  AdminDebitRequest,
   BalanceTransactionResponse,
   CustomerBalanceResponse,
+  ListBalanceTransactionsParams,
 } from '@granit/customer-balance';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /**
- * Fetch the current customer balance.
+ * Fetch the current customer balance for a given currency.
  *
  * @example
  * ```tsx
- * const { data: balance } = useCustomerBalance();
+ * const { data: balance } = useCustomerBalance('EUR');
  * ```
  */
-export function useCustomerBalance(): UseQueryResult<CustomerBalanceResponse> {
+export function useCustomerBalance(currency: string): UseQueryResult<CustomerBalanceResponse> {
   const config = useCustomerBalanceConfig();
   const basePath = config.basePath!;
 
   return useQuery({
-    queryKey: buildCustomerBalanceQueryKey(config, 'balance'),
-    queryFn: () => getCustomerBalance(config.client, basePath),
+    queryKey: buildCustomerBalanceQueryKey(config, 'balance', currency),
+    queryFn: () => getCustomerBalance(config.client, basePath, currency),
   });
 }
 
 /**
- * List all balance transactions.
+ * List paginated balance transactions for a given currency.
  *
  * @example
  * ```tsx
- * const { data: transactions } = useBalanceTransactions();
+ * const { data: transactions } = useBalanceTransactions({ currency: 'EUR', page: 1, pageSize: 25 });
  * ```
  */
-export function useBalanceTransactions(): UseQueryResult<readonly BalanceTransactionResponse[]> {
+export function useBalanceTransactions(
+  params: ListBalanceTransactionsParams
+): UseQueryResult<readonly BalanceTransactionResponse[]> {
   const config = useCustomerBalanceConfig();
   const basePath = config.basePath!;
 
   return useQuery({
-    queryKey: buildCustomerBalanceQueryKey(config, 'transactions'),
-    queryFn: () => listBalanceTransactions(config.client, basePath),
+    queryKey: buildCustomerBalanceQueryKey(
+      config,
+      'transactions',
+      params.currency,
+      params.page,
+      params.pageSize
+    ),
+    queryFn: () => listBalanceTransactions(config.client, basePath, params),
   });
 }
 
 /**
- * Add an administrative credit to the customer balance.
- * Invalidates balance and transaction queries on success.
+ * Add an administrative credit to a party's balance.
+ * Updates the balance cache from the response and invalidates transaction queries on success.
  *
  * @example
  * ```tsx
  * const credit = useAddAdminCredit();
- * await credit.mutateAsync({ amount: 50, currency: 'EUR', source: 'Promotional', reason: 'Welcome', expiresAt: null });
+ * await credit.mutateAsync({ partyId: '...', amount: 50, currency: 'EUR', source: 'Promotional', reason: 'Welcome', expiresAt: null });
  * ```
  */
-export function useAddAdminCredit(): UseMutationResult<void, Error, AdminCreditRequest> {
+export function useAddAdminCredit(): UseMutationResult<
+  CustomerBalanceResponse,
+  Error,
+  AdminCreditRequest
+> {
   const config = useCustomerBalanceConfig();
   const queryClient = useQueryClient();
   const basePath = config.basePath!;
 
   return useMutation({
     mutationFn: (request: AdminCreditRequest) => addAdminCredit(config.client, basePath, request),
-    onSuccess: () => {
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(
+        buildCustomerBalanceQueryKey(config, 'balance', variables.currency),
+        data
+      );
       queryClient.invalidateQueries({
-        queryKey: buildCustomerBalanceQueryKey(config, 'balance'),
+        queryKey: buildCustomerBalanceQueryKey(config, 'transactions'),
       });
+    },
+  });
+}
+
+/**
+ * Apply a manual debit to a party's balance (admin tooling).
+ * Updates the balance cache from the response and invalidates transaction queries on success.
+ *
+ * @example
+ * ```tsx
+ * const debit = useApplyAdminDebit();
+ * await debit.mutateAsync({ partyId: '...', amount: 25, currency: 'EUR', reason: 'Correction' });
+ * ```
+ */
+export function useApplyAdminDebit(): UseMutationResult<
+  CustomerBalanceResponse,
+  Error,
+  AdminDebitRequest
+> {
+  const config = useCustomerBalanceConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.basePath!;
+
+  return useMutation({
+    mutationFn: (request: AdminDebitRequest) => applyAdminDebit(config.client, basePath, request),
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(
+        buildCustomerBalanceQueryKey(config, 'balance', variables.currency),
+        data
+      );
       queryClient.invalidateQueries({
         queryKey: buildCustomerBalanceQueryKey(config, 'transactions'),
       });

--- a/packages/@granit/react-customer-balance/src/index.ts
+++ b/packages/@granit/react-customer-balance/src/index.ts
@@ -7,11 +7,13 @@ export {
 export type {
   CustomerBalanceConfig,
   CustomerBalanceProviderProps,
+  ResolvedCustomerBalanceConfig,
 } from './providers/customer-balance-provider';
 
 // Hooks
 export {
   useAddAdminCredit,
+  useApplyAdminDebit,
   useBalanceTransactions,
   useCustomerBalance,
 } from './hooks/use-customer-balance';

--- a/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
+++ b/packages/@granit/react-customer-balance/src/providers/customer-balance-provider.tsx
@@ -63,7 +63,7 @@ export function useCustomerBalanceConfig(): ResolvedCustomerBalanceConfig {
 /** Builds a consistent React Query key for customer-balance operations. */
 export function buildCustomerBalanceQueryKey(
   config: CustomerBalanceConfig,
-  ...segments: readonly string[]
+  ...segments: readonly (string | number)[]
 ): readonly unknown[] {
   const prefix = config.queryKeyPrefix ?? ['customer-balance'];
   return [...prefix, ...segments];

--- a/packages/@granit/react-customer-balance/src/testing/handlers.ts
+++ b/packages/@granit/react-customer-balance/src/testing/handlers.ts
@@ -13,7 +13,7 @@ import { DEFAULT_BASE_PATH } from '../constants';
 
 import { sampleBalance, sampleTransactions } from './data';
 
-import type { AdminCreditRequest } from '@granit/customer-balance';
+import type { AdminCreditRequest, AdminDebitRequest } from '@granit/customer-balance';
 import type { QueryMetadata } from '@granit/query-engine';
 
 /** Mock /meta payload for the customer balance transactions resource. */
@@ -152,7 +152,7 @@ export const balanceTransactionQueryMetadata: QueryMetadata = {
 
 /**
  * Create stateful MSW handlers for customer balance endpoints.
- * Credit mutations update the in-memory balance amount.
+ * Credit/debit mutations update the in-memory balance amount.
  *
  * @param baseUrl - API base path (default: `/api/v1/customer-balance`)
  */
@@ -172,11 +172,19 @@ export function createCustomerBalanceHandlers(baseUrl = DEFAULT_BASE_PATH) {
     }),
 
     // POST admin credit
-    http.post(`${baseUrl}/credit`, async ({ request }) => {
+    http.post(`${baseUrl}/balance/credit`, async ({ request }) => {
       const body = (await request.json()) as AdminCreditRequest;
       sampleBalance.balance = sampleBalance.balance + body.amount;
       sampleBalance.updatedAt = toISODateString(new Date().toISOString());
       return created({ ...sampleBalance });
+    }),
+
+    // POST admin debit
+    http.post(`${baseUrl}/balance/debit`, async ({ request }) => {
+      const body = (await request.json()) as AdminDebitRequest;
+      sampleBalance.balance = sampleBalance.balance - body.amount;
+      sampleBalance.updatedAt = toISODateString(new Date().toISOString());
+      return HttpResponse.json({ ...sampleBalance });
     }),
   ];
 }

--- a/packages/@granit/react-data-exchange/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-data-exchange/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-documents/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-documents/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-hostnames/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-hostnames/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { mockHostnames } from '../testing/data';

--- a/packages/@granit/react-identity/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-identity/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createIdentityHandlers, identityUserQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-invoicing/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-invoicing/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createInvoicingHandlers, invoiceQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-localization/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-localization/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createLocalizationHandlers, localizationOverrideQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-metering/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-metering/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-multi-tenancy/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createTenantHandlers, tenantQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-notifications/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-openiddict-admin/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-parties/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-parties/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createPartiesHandlers, partyQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-payments/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-payments/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createPaymentsHandlers, paymentTransactionQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-privacy/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-privacy/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-query-engine/src/__tests__/testing.test.ts
+++ b/packages/@granit/react-query-engine/src/__tests__/testing.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { buildEmptyQueryMeta, createQueryMetaHandler } from '../testing/index';

--- a/packages/@granit/react-scheduling/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-scheduling/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createSchedulingHandlers, scheduledActionQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-subscriptions/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-subscriptions/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import {

--- a/packages/@granit/react-templating/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-templating/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createTemplatesHandlers, templateQueryMetadata } from '../testing/index';

--- a/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-webhooks/src/__tests__/testing-handlers.test.ts
@@ -1,4 +1,4 @@
-import { createMswServer } from '@granit/testing/msw';
+import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
 import { createWebhooksHandlers, webhookSubscriptionQueryMetadata } from '../testing/index';

--- a/packages/@granit/testing/package.json
+++ b/packages/@granit/testing/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": "./src/index.ts",
     "./msw": "./src/msw.ts",
+    "./msw-server": "./src/msw-server.ts",
     "./setup": "./src/setup.ts"
   },
   "files": [
@@ -38,6 +39,10 @@
       "./msw": {
         "types": "./dist/msw.d.ts",
         "import": "./dist/msw.js"
+      },
+      "./msw-server": {
+        "types": "./dist/msw-server.d.ts",
+        "import": "./dist/msw-server.js"
       },
       "./setup": {
         "types": "./dist/setup.d.ts",

--- a/packages/@granit/testing/src/msw.ts
+++ b/packages/@granit/testing/src/msw.ts
@@ -1,5 +1,7 @@
 // ---------------------------------------------------------------------------
-// @granit/testing/msw — MSW response helpers for @granit/* handler factories
+// @granit/testing/msw — browser-safe MSW response helpers for @granit/* handler factories
+//
+// Node-only: import createMswServer from '@granit/testing/msw-server'
 // ---------------------------------------------------------------------------
 
 export {
@@ -21,7 +23,3 @@ export {
 } from './msw-helpers';
 
 export type { FilterEntry, SortEntry } from './msw-helpers';
-
-export { createMswServer } from './msw-server';
-
-export type { MswServerOptions } from './msw-server';

--- a/packages/@granit/testing/tsup.config.ts
+++ b/packages/@granit/testing/tsup.config.ts
@@ -1,7 +1,7 @@
 import { createTsupConfig } from '../../../tsup.preset';
 
 export default createTsupConfig({
-  entry: ['src/index.ts', 'src/msw.ts'],
+  entry: ['src/index.ts', 'src/msw.ts', 'src/msw-server.ts'],
   splitting: false,
   external: [/^@granit\//, 'vitest', 'msw'],
 });


### PR DESCRIPTION
## Summary

- **BREAKING** `AdminCreditRequest`: add required `partyId` field (mirrors `Granit.CustomerBalance.Endpoints.Dtos.AdminCreditRequest`)
- **NEW** `AdminDebitRequest` type + `applyAdminDebit` API function (`POST /balance/debit`)
- **NEW** `ListBalanceTransactionsParams` type; `listBalanceTransactions` now accepts `{ currency, page, pageSize }`
- **FIX** `getCustomerBalance`: add required `currency` query param
- **FIX** `addAdminCredit`: wrong URL `/credit` → `/balance/credit`; return type `void` → `CustomerBalanceResponse`
- **NEW** `useApplyAdminDebit` hook; `useAddAdminCredit` now returns `CustomerBalanceResponse` and uses `setQueryData`
- **FIX** `useCustomerBalance` / `useBalanceTransactions`: accept currency/pagination params, include in query key
- **FIX** MSW handlers: credit URL fixed, debit handler added
- `buildCustomerBalanceQueryKey` accepts `number` segments
- `ResolvedCustomerBalanceConfig` exported from `react-customer-balance`

## Test plan

- [ ] `npx vitest run packages/@granit/customer-balance packages/@granit/react-customer-balance` — 24 tests pass
- [ ] `pnpm tsc` — no errors
- [ ] `pnpm lint` — no warnings