### PR TITLE
fix(dashboards): audit-driven backend contract alignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,32 +83,25 @@ Full frontend conventions: `../granit-dotnet/docs/guide/conventions/frontend/`
 ### Mirroring DTOs from `contracts/openapi/*.json`
 
 Specs are authoritative for routes, HTTP methods, status codes, field names
-(PascalCase .NET → camelCase JSON). TS optionality (`?`) comes from the schema's
-`required` array, NOT nullability:
+(PascalCase .NET → camelCase JSON). TS `?` comes from the `required` array, NOT
+nullability — these are independent axes:
 
-- `.NET` marks every positional-record param without a C# default as `required`
-  (System.Text.Json needs the key present).
-- `string? Foo` (no default) → `required` + `type:["null","string"]` →
-  **`foo: T | null`** (key required, value nullable), NOT `foo?: T`.
-- Only params with a C# default (`bool X = false`) are absent from `required` →
-  **`foo?: T`** (genuinely optional).
-- When in doubt cross-check the record + FluentValidation validator in
-  `granit-dotnet/src/Granit.{Module}.Endpoints/` — a missing `NotEmpty()`/`NotNull()`
-  constrains the value, not key presence.
+- `string? Foo` with no C# default → `required` + `type:["null","string"]` →
+  **`foo: T | null`** (required key, nullable value). NOT `foo?: T`.
+- C#-defaulted param (`bool X = false`) → absent from `required` → **`foo?: T`**.
+- Cross-check the FluentValidation validator in `granit-dotnet/src/Granit.{Module}.Endpoints/`.
 
 ## Architecture tests
 
-Framework-wide conformance lives in dedicated packages — check/extend before
-adding new runtime patterns:
+Check/extend before adding new runtime patterns:
 
-- **`@granit/arch-tests`**: framework suite (bans `console.*` in runtime,
-  enforces `createLogger`, import boundaries).
+- **`@granit/arch-tests`**: bans `console.*` in runtime, enforces `createLogger`,
+  import boundaries.
 - **`@granit/arch-tests-kit`**: reusable helpers (published — see above).
-- **`pnpm check:csp`** (`scripts/check-csp-policies.mjs`): any `@granit/*`
-  writing to a DOM script sink (`.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`,
-  `iframe/script.setAttribute('src',…)`, direct `.src=`) MUST expose a `<pkg>/csp`
-  subpath with idempotent `installPolicy()` (Trusted Types). Exceptions are
-  hard-coded with justification — add new ones only as last resort.
+- **`pnpm check:csp`** (`scripts/check-csp-policies.mjs`): any `@granit/*` writing
+  to a DOM script sink (`.innerHTML`, `.outerHTML`, `.insertAdjacentHTML`,
+  `iframe/script.setAttribute('src',…)`, `.src=`) MUST expose a `<pkg>/csp`
+  subpath with idempotent `installPolicy()` (Trusted Types).
 
 ## Code index (`.mcp-front-index.json`)
 

--- a/packages/@granit/dashboards/src/__tests__/dashboard-render-response.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/dashboard-render-response.test.ts
@@ -24,6 +24,7 @@ const KPI_WIDGET: DashboardRenderedWidget = {
   sequence: 1,
   emittedAt: '2026-04-29T12:34:56.789Z',
   refreshHint: 'Dynamic',
+  transport: 'Pull',
   snapshot: {
     value: 12,
     valueKind: 'Count',
@@ -49,6 +50,7 @@ const MARKDOWN_WIDGET: DashboardRenderedWidget = {
   sequence: 1,
   emittedAt: '2026-04-29T12:34:56.789Z',
   refreshHint: 'Static',
+  transport: 'Pull',
   snapshot: { contentLocalizationKey: 'Widget:Test.Banner' },
   reasonLocalizationKey: null,
 };
@@ -67,6 +69,7 @@ const UNAVAILABLE_WIDGET: DashboardRenderedWidget = {
   sequence: 1,
   emittedAt: '2026-04-29T12:34:56.789Z',
   refreshHint: 'Static',
+  transport: 'Pull',
   snapshot: null,
   reasonLocalizationKey: 'Widget:Unavailable',
 };

--- a/packages/@granit/dashboards/src/__tests__/dashboards-api.test.ts
+++ b/packages/@granit/dashboards/src/__tests__/dashboards-api.test.ts
@@ -1,0 +1,191 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  archiveDashboard,
+  getDashboard,
+  getDashboardCatalog,
+  listDashboards,
+  publishDashboard,
+  renderDashboard,
+  restoreDashboard,
+} from '../api/dashboards-api';
+
+import type {
+  DashboardCatalogEntryResponse,
+  DashboardDetailResponse,
+  DashboardRenderResponse,
+  DashboardSummaryResponse,
+  PagedResponse,
+} from '..';
+
+const BASE = '/api/v1/dashboards';
+const ID = '8c6b1e10-0000-4000-8000-000000000001';
+
+const CATALOG_ENTRY: DashboardCatalogEntryResponse = {
+  name: 'Granit.Showcase.InvoicingOverview',
+  category: 'Finance',
+  isSystem: false,
+  version: '1.0.0',
+  widgetCount: 4,
+  hasViews: true,
+  hasAliases: false,
+  hasFilters: true,
+};
+
+const SUMMARY: DashboardSummaryResponse = {
+  id: ID,
+  name: 'Invoicing overview',
+  category: 'Finance',
+  status: 'Published',
+  isSystem: false,
+  sourceDefinitionName: 'Granit.Showcase.InvoicingOverview',
+  sourceDefinitionVersion: '1.0.0',
+  widgetCount: 4,
+};
+
+const DETAIL: DashboardDetailResponse = {
+  ...SUMMARY,
+  layoutColumns: 12,
+  layoutRowHeight: 80,
+  widgets: [],
+};
+
+const RENDER_RESPONSE: DashboardRenderResponse = {
+  dashboardId: ID,
+  renderedAt: '2026-06-06T10:00:00.000Z',
+  period: null,
+  activeViewName: null,
+  driftStatus: 'Aligned',
+  sourceDefinitionVersion: '1.0.0',
+  registeredVersion: '1.0.0',
+  widgets: [],
+};
+
+describe('getDashboardCatalog', () => {
+  it('calls GET {basePath}/catalog and returns the array', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([CATALOG_ENTRY]));
+
+    const result = await getDashboardCatalog(client, BASE);
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/catalog`, { params: { category: undefined } });
+    expect(result).toEqual([CATALOG_ENTRY]);
+  });
+
+  it('forwards category filter as a query param', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([CATALOG_ENTRY]));
+
+    await getDashboardCatalog(client, BASE, { category: 'Finance' });
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/catalog`, { params: { category: 'Finance' } });
+  });
+});
+
+describe('listDashboards', () => {
+  it('calls GET {basePath} with pagination and status params', async () => {
+    const client = createMockClient();
+    const pagedResult: PagedResponse<DashboardSummaryResponse> = {
+      items: [SUMMARY],
+      totalCount: 1,
+      page: 0,
+      pageSize: 50,
+    };
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(pagedResult));
+
+    const result = await listDashboards(client, BASE, {
+      status: 'Published',
+      page: 0,
+      pageSize: 50,
+    });
+
+    expect(client.get).toHaveBeenCalledWith(BASE, {
+      params: { status: 'Published', page: 0, pageSize: 50 },
+    });
+    expect(result.items).toHaveLength(1);
+    expect(result.totalCount).toBe(1);
+  });
+});
+
+describe('getDashboard', () => {
+  it('calls GET {basePath}/{id} and returns the detail', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(DETAIL));
+
+    const result = await getDashboard(client, BASE, ID);
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/${encodeURIComponent(ID)}`, undefined);
+    expect(result.id).toBe(ID);
+    expect(result.layoutColumns).toBe(12);
+  });
+});
+
+describe('renderDashboard', () => {
+  it('calls POST {basePath}/{id}/render with the render request body', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(RENDER_RESPONSE));
+
+    const result = await renderDashboard(client, BASE, ID, { locale: 'fr-BE' });
+
+    expect(client.post).toHaveBeenCalledWith(
+      `${BASE}/${encodeURIComponent(ID)}/render`,
+      { locale: 'fr-BE' },
+      undefined
+    );
+    expect(result.dashboardId).toBe(ID);
+    expect(result.driftStatus).toBe('Aligned');
+  });
+});
+
+describe('publishDashboard', () => {
+  it('calls POST {basePath}/{id}/publish and returns the updated summary', async () => {
+    const client = createMockClient();
+    const published: DashboardSummaryResponse = { ...SUMMARY, status: 'Published' };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(published));
+
+    const result = await publishDashboard(client, BASE, ID);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `${BASE}/${encodeURIComponent(ID)}/publish`,
+      undefined,
+      undefined
+    );
+    expect(result.status).toBe('Published');
+    expect(result.id).toBe(ID);
+  });
+});
+
+describe('archiveDashboard', () => {
+  it('calls POST {basePath}/{id}/archive and returns the updated summary', async () => {
+    const client = createMockClient();
+    const archived: DashboardSummaryResponse = { ...SUMMARY, status: 'Archived' };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(archived));
+
+    const result = await archiveDashboard(client, BASE, ID);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `${BASE}/${encodeURIComponent(ID)}/archive`,
+      undefined,
+      undefined
+    );
+    expect(result.status).toBe('Archived');
+  });
+});
+
+describe('restoreDashboard', () => {
+  it('calls POST {basePath}/{id}/restore and returns the updated summary', async () => {
+    const client = createMockClient();
+    const restored: DashboardSummaryResponse = { ...SUMMARY, status: 'Draft' };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(restored));
+
+    const result = await restoreDashboard(client, BASE, ID);
+
+    expect(client.post).toHaveBeenCalledWith(
+      `${BASE}/${encodeURIComponent(ID)}/restore`,
+      undefined,
+      undefined
+    );
+    expect(result.status).toBe('Draft');
+  });
+});

--- a/packages/@granit/dashboards/src/api/dashboards-api.ts
+++ b/packages/@granit/dashboards/src/api/dashboards-api.ts
@@ -6,6 +6,7 @@ import type {
 import type {
   AddWidgetRequest,
   DashboardCatalogEntryResponse,
+  DashboardCatalogParams,
   DashboardDetailResponse,
   DashboardImportResponse,
   DashboardListParams,
@@ -24,6 +25,7 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 
 export type {
+  DashboardCatalogParams,
   DashboardListParams,
   DashboardsRequestOptions,
   WidgetRenderBody,
@@ -32,18 +34,19 @@ export type {
 };
 
 /**
- * `GET {basePath}/catalog` — returns the catalog of available
+ * `GET {basePath}/catalog?category=` — returns the catalog of available
  * `DashboardDefinition` descriptors. Mirrors
  * `Granit.Dashboards.Endpoints.DashboardCatalogEndpoints`.
  */
 export async function getDashboardCatalog(
   client: AxiosInstance,
   basePath: string,
+  params?: DashboardCatalogParams,
   options?: DashboardsRequestOptions
 ): Promise<readonly DashboardCatalogEntryResponse[]> {
   const response = await client.get<readonly DashboardCatalogEntryResponse[]>(
     `${basePath}/catalog`,
-    options
+    { ...options, params: { category: params?.category } }
   );
   return response.data;
 }
@@ -109,7 +112,8 @@ export async function renderDashboard(
 
 /**
  * `POST {basePath}/{id}/publish` — promotes a Draft dashboard to Published.
- * Mirrors
+ * Returns the updated summary so callers can patch their local cache without
+ * an extra round-trip. Mirrors
  * `Granit.Dashboards.Endpoints.DashboardStateTransitionEndpoints.PublishAsync`.
  */
 export async function publishDashboard(
@@ -117,13 +121,18 @@ export async function publishDashboard(
   basePath: string,
   id: string,
   options?: DashboardsRequestOptions
-): Promise<void> {
-  await client.post(`${basePath}/${encodeURIComponent(id)}/publish`, undefined, options);
+): Promise<DashboardSummaryResponse> {
+  const response = await client.post<DashboardSummaryResponse>(
+    `${basePath}/${encodeURIComponent(id)}/publish`,
+    undefined,
+    options
+  );
+  return response.data;
 }
 
 /**
  * `POST {basePath}/{id}/archive` — hides a dashboard from the catalog but
- * keeps the row for audit / restore. Mirrors
+ * keeps the row for audit / restore. Returns the updated summary. Mirrors
  * `Granit.Dashboards.Endpoints.DashboardStateTransitionEndpoints.ArchiveAsync`.
  */
 export async function archiveDashboard(
@@ -131,13 +140,18 @@ export async function archiveDashboard(
   basePath: string,
   id: string,
   options?: DashboardsRequestOptions
-): Promise<void> {
-  await client.post(`${basePath}/${encodeURIComponent(id)}/archive`, undefined, options);
+): Promise<DashboardSummaryResponse> {
+  const response = await client.post<DashboardSummaryResponse>(
+    `${basePath}/${encodeURIComponent(id)}/archive`,
+    undefined,
+    options
+  );
+  return response.data;
 }
 
 /**
  * `POST {basePath}/{id}/restore` — moves an Archived dashboard back to
- * Draft. Mirrors
+ * Draft. Returns the updated summary. Mirrors
  * `Granit.Dashboards.Endpoints.DashboardStateTransitionEndpoints.RestoreAsync`.
  */
 export async function restoreDashboard(
@@ -145,8 +159,13 @@ export async function restoreDashboard(
   basePath: string,
   id: string,
   options?: DashboardsRequestOptions
-): Promise<void> {
-  await client.post(`${basePath}/${encodeURIComponent(id)}/restore`, undefined, options);
+): Promise<DashboardSummaryResponse> {
+  const response = await client.post<DashboardSummaryResponse>(
+    `${basePath}/${encodeURIComponent(id)}/restore`,
+    undefined,
+    options
+  );
+  return response.data;
 }
 
 /**

--- a/packages/@granit/dashboards/src/index.ts
+++ b/packages/@granit/dashboards/src/index.ts
@@ -123,6 +123,7 @@ export {
   updateWidget,
 } from './api/index';
 export type {
+  DashboardCatalogParams,
   DashboardListParams,
   DashboardsRequestOptions,
   WidgetRenderBody,

--- a/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
+++ b/packages/@granit/dashboards/src/rendering/dashboard-render-response.ts
@@ -126,10 +126,12 @@ export interface DashboardRenderedWidget {
   /** Runtime outcome (`'Snapshot'` / `'Unavailable'` / `'Error'`). */
   readonly status: WidgetSnapshotStatus;
   /**
-   * Always `1` in pull mode; future push transport increments per
-   * (widget, tenant). EPIC #1366 invariant #2.
+   * Monotonically-increasing delivery counter per (widget, tenant).
+   * Always `1` in pull mode; push transport increments per SSE frame.
+   * Serialised as int64 on the wire — JSON may represent large values as
+   * strings; always coerce with `Number()` before comparing.
    */
-  readonly sequence: number;
+  readonly sequence: number | string;
   /** Server-side timestamp of the widget's computation (ISO 8601 UTC). */
   readonly emittedAt: string;
   /** Pull / push transport hint — drives the per-widget cache TTL. */
@@ -140,12 +142,8 @@ export interface DashboardRenderedWidget {
    * updates from `GET /dashboards/{id}/stream`; `'Pull'` means polling
    * via the render endpoint per `refreshHint` cadence. Hosts that
    * haven't loaded `Granit.Dashboards.Push` always emit `'Pull'`.
-   *
-   * Optional on the wire for backwards compatibility — older bundles
-   * served before P2.4 omit the field, in which case the framework
-   * treats the widget as `'Pull'`.
    */
-  readonly transport?: WidgetTransport;
+  readonly transport: WidgetTransport;
   /**
    * Pre-serialised typed payload. `null` when {@link status} is not
    * `'Snapshot'`. Frontend renderers narrow this to a kind-specific shape

--- a/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
+++ b/packages/@granit/dashboards/src/rendering/widget-snapshot-envelope.ts
@@ -36,10 +36,12 @@ export interface WidgetSnapshotEnvelope {
    */
   readonly snapshot: unknown;
   /**
-   * Always `1` in pull mode; future push transport increments per
-   * (widget instance, tenant). Locked v1 per EPIC #1366 invariant #2.
+   * Monotonically-increasing delivery counter per (widget, tenant).
+   * Always `1` in pull mode; push transport increments per SSE frame.
+   * Serialised as int64 on the wire — JSON may represent large values as
+   * strings; always coerce with `Number()` before comparing.
    */
-  readonly sequence: number;
+  readonly sequence: number | string;
   /** Server-side timestamp of the computation (ISO 8601 UTC). */
   readonly emittedAt: string;
   /** Pull / push transport hint inherited from the underlying definition. */

--- a/packages/@granit/dashboards/src/types/dashboard-api-params.ts
+++ b/packages/@granit/dashboards/src/types/dashboard-api-params.ts
@@ -1,3 +1,4 @@
+import type { DashboardCategory } from './dashboard-category';
 import type { DashboardStatus } from './dashboard-status';
 import type { WidgetDefinitionBase } from './widget-definition';
 import type { AxiosRequestConfig } from '@granit/api-client';
@@ -9,6 +10,14 @@ import type { AxiosRequestConfig } from '@granit/api-client';
  * each call site.
  */
 export type DashboardsRequestOptions = Pick<AxiosRequestConfig, 'signal'>;
+
+/**
+ * Query params accepted by `GET {basePath}/catalog`.
+ */
+export interface DashboardCatalogParams {
+  /** Filter catalog entries to a specific category. `undefined` = all categories. */
+  readonly category?: DashboardCategory;
+}
 
 /**
  * Query params accepted by `GET {basePath}/`.

--- a/packages/@granit/dashboards/src/types/index.ts
+++ b/packages/@granit/dashboards/src/types/index.ts
@@ -83,7 +83,11 @@ export type { WidgetInstanceResponse } from './widget-instance-response';
 export type { AddWidgetRequest, UpdateWidgetRequest } from './widget-requests';
 
 // API request params / options (framework-agnostic, used by api/ layer)
-export type { DashboardListParams, DashboardsRequestOptions } from './dashboard-api-params';
+export type {
+  DashboardCatalogParams,
+  DashboardListParams,
+  DashboardsRequestOptions,
+} from './dashboard-api-params';
 export type {
   WidgetRenderBody,
   WidgetRenderContextPayload,

--- a/packages/@granit/react-analytics/src/components/kpi-snapshot-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-snapshot-tile.tsx
@@ -30,7 +30,7 @@ export function KpiSnapshotTile({ widget }: { readonly widget: DashboardRendered
         // an aria-label fallback — passing the widget id keeps a stable hook.
         name: widget.id,
         snapshot: widget.snapshot,
-        sequence: widget.sequence,
+        sequence: Number(widget.sequence),
         emittedAt: widget.emittedAt,
         refreshHint: widget.refreshHint,
       }}

--- a/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
+++ b/packages/@granit/react-dashboards/src/__tests__/use-dashboard-crud.test.tsx
@@ -118,17 +118,14 @@ function freshHandlers() {
         return HttpResponse.json(SUMMARY);
       }
     ),
-    http.post(
-      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/publish`,
-      () => new HttpResponse(null, { status: 204 })
+    http.post(`http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/publish`, () =>
+      HttpResponse.json({ ...SUMMARY, status: 'Published' })
     ),
-    http.post(
-      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/archive`,
-      () => new HttpResponse(null, { status: 204 })
+    http.post(`http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/archive`, () =>
+      HttpResponse.json({ ...SUMMARY, status: 'Archived' })
     ),
-    http.post(
-      `http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/restore`,
-      () => new HttpResponse(null, { status: 204 })
+    http.post(`http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/restore`, () =>
+      HttpResponse.json({ ...SUMMARY, status: 'Draft' })
     ),
     http.post(`http://localhost/api/v1/dashboards/${encodeURIComponent(ID)}/resync`, () =>
       HttpResponse.json({
@@ -279,16 +276,20 @@ describe('useArchiveDashboard / useRestoreDashboard / usePublishDashboard', () =
     expect(queryClient.getQueryState(dashboardDetailQueryKey(ID))?.isInvalidated).toBe(true);
   });
 
-  it('publish: POSTs to /publish', async () => {
+  it('publish: POSTs to /publish and returns the updated summary', async () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => usePublishDashboard(), { wrapper });
-    await expect(result.current.mutateAsync(ID)).resolves.toBeUndefined();
+    const summary = await result.current.mutateAsync(ID);
+    expect(summary.id).toBe(ID);
+    expect(summary.status).toBe('Published');
   });
 
-  it('restore: POSTs to /restore', async () => {
+  it('restore: POSTs to /restore and returns the updated summary', async () => {
     const { wrapper } = makeWrapper();
     const { result } = renderHook(() => useRestoreDashboard(), { wrapper });
-    await expect(result.current.mutateAsync(ID)).resolves.toBeUndefined();
+    const summary = await result.current.mutateAsync(ID);
+    expect(summary.id).toBe(ID);
+    expect(summary.status).toBe('Draft');
   });
 });
 

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-catalog.ts
@@ -3,19 +3,17 @@ import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
 import { useDashboardsConfig } from '../providers/dashboards-provider';
 
-import type { DashboardCatalogEntryResponse } from '@granit/dashboards';
+import type { DashboardCatalogEntryResponse, DashboardCategory } from '@granit/dashboards';
 
 /**
- * Cache key for the dashboard catalog. Distinct from the persisted-instance
- * keys ({@link dashboardListQueryKey} / {@link dashboardDetailQueryKey})
- * because the catalog and the instance pool are independent: the catalog
- * lists *available definitions* the user can import; the list lists
- * *imported instances* the user already owns.
+ * Cache key for the dashboard catalog. Keyed by category so per-category
+ * queries stay isolated from the full-catalog fetch.
  */
-export const dashboardCatalogQueryKey = () => ['dashboards', 'catalog'] as const;
+export const dashboardCatalogQueryKey = (category?: DashboardCategory) =>
+  category ? (['dashboards', 'catalog', category] as const) : (['dashboards', 'catalog'] as const);
 
 /**
- * `GET /dashboards/catalog` — returns the catalog of available
+ * `GET /dashboards/catalog?category=` — returns the catalog of available
  * `DashboardDefinition` descriptors (B4 catalog endpoint, mirrors
  * `Granit.Dashboards.Endpoints.DashboardCatalogEndpoints`). Each entry is
  * a {@link DashboardCatalogEntryResponse} carrying the metadata needed to
@@ -26,13 +24,14 @@ export const dashboardCatalogQueryKey = () => ['dashboards', 'catalog'] as const
  * and only changes on deployments.
  */
 export function useDashboardCatalog(
-  options: { readonly enabled?: boolean } = {}
+  options: { readonly enabled?: boolean; readonly category?: DashboardCategory } = {}
 ): UseQueryResult<readonly DashboardCatalogEntryResponse[]> {
   const { client, basePath } = useDashboardsConfig();
+  const { enabled = true, category } = options;
   return useQuery({
-    queryKey: dashboardCatalogQueryKey(),
-    queryFn: ({ signal }) => getDashboardCatalog(client, basePath, { signal }),
-    enabled: options.enabled ?? true,
+    queryKey: dashboardCatalogQueryKey(category),
+    queryFn: ({ signal }) => getDashboardCatalog(client, basePath, { category }, { signal }),
+    enabled,
     staleTime: 5 * 60_000,
   });
 }

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-state-transitions.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-state-transitions.ts
@@ -5,10 +5,29 @@ import { useDashboardsConfig } from '../providers/dashboards-provider';
 
 import { dashboardDetailQueryKey } from './use-dashboard-detail';
 
+import type { DashboardSummaryResponse, PagedResponse } from '@granit/dashboards';
+
 /**
- * Shared invalidation routine — all three transitions affect the list
- * (status filter changes which dashboards a query returns) plus the
- * specific detail entry.
+ * Patch the in-memory list cache immediately with the returned summary so
+ * the status badge flips before the background refetch completes. The list
+ * is still invalidated below to handle status-filter pages.
+ */
+function patchListCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  summary: DashboardSummaryResponse
+): void {
+  queryClient.setQueriesData<PagedResponse<DashboardSummaryResponse>>(
+    { queryKey: ['dashboards', 'list'] },
+    (old) => {
+      if (!old) return old;
+      return { ...old, items: old.items.map((item) => (item.id === summary.id ? summary : item)) };
+    }
+  );
+}
+
+/**
+ * Invalidate both the list (status filter changes the visible set) and the
+ * specific detail entry after a state transition.
  */
 async function invalidateAfterTransition(
   queryClient: ReturnType<typeof useQueryClient>,
@@ -28,12 +47,15 @@ async function invalidateAfterTransition(
  *
  * Backend rejects 400 if the dashboard is already Published or Archived.
  */
-export function usePublishDashboard(): UseMutationResult<void, Error, string> {
+export function usePublishDashboard(): UseMutationResult<DashboardSummaryResponse, Error, string> {
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => publishDashboard(client, basePath, id),
-    onSuccess: (_void, id) => invalidateAfterTransition(queryClient, id),
+    onSuccess: (summary, id) => {
+      patchListCache(queryClient, summary);
+      return invalidateAfterTransition(queryClient, id);
+    },
   });
 }
 
@@ -45,12 +67,15 @@ export function usePublishDashboard(): UseMutationResult<void, Error, string> {
  * Replaces the (non-existent) DELETE endpoint — Granit dashboards are
  * never deleted, only archived. Restore via {@link useRestoreDashboard}.
  */
-export function useArchiveDashboard(): UseMutationResult<void, Error, string> {
+export function useArchiveDashboard(): UseMutationResult<DashboardSummaryResponse, Error, string> {
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => archiveDashboard(client, basePath, id),
-    onSuccess: (_void, id) => invalidateAfterTransition(queryClient, id),
+    onSuccess: (summary, id) => {
+      patchListCache(queryClient, summary);
+      return invalidateAfterTransition(queryClient, id);
+    },
   });
 }
 
@@ -59,11 +84,14 @@ export function useArchiveDashboard(): UseMutationResult<void, Error, string> {
  * Draft. Mirrors
  * `Granit.Dashboards.Endpoints.DashboardStateTransitionEndpoints.RestoreAsync`.
  */
-export function useRestoreDashboard(): UseMutationResult<void, Error, string> {
+export function useRestoreDashboard(): UseMutationResult<DashboardSummaryResponse, Error, string> {
   const { client, basePath } = useDashboardsConfig();
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => restoreDashboard(client, basePath, id),
-    onSuccess: (_void, id) => invalidateAfterTransition(queryClient, id),
+    onSuccess: (summary, id) => {
+      patchListCache(queryClient, summary);
+      return invalidateAfterTransition(queryClient, id);
+    },
   });
 }

--- a/packages/@granit/react-dashboards/src/hooks/use-dashboard-stream.ts
+++ b/packages/@granit/react-dashboards/src/hooks/use-dashboard-stream.ts
@@ -45,12 +45,14 @@ export function applyStreamSnapshot(
   event: DashboardStreamSnapshot
 ): DashboardRenderedWidget | undefined {
   if (!current) return current;
-  if (current.sequence > event.sequence) return current;
+  if (Number(current.sequence) > Number(event.sequence)) return current;
   return {
     ...current,
     widgetType: event.widgetType,
     status: event.status,
-    sequence: event.sequence,
+    // SSE frames always carry a plain JS number; cast to satisfy the
+    // number | string union on DashboardRenderedWidget.sequence.
+    sequence: event.sequence as number | string,
     emittedAt: event.emittedAt,
     refreshHint: event.refreshHint,
     snapshot: event.snapshot,

--- a/packages/@granit/react-dashboards/src/testing/data.ts
+++ b/packages/@granit/react-dashboards/src/testing/data.ts
@@ -64,6 +64,7 @@ export const SAMPLE_FINANCE_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-29T12:34:56.789Z',
       refreshHint: 'Static',
+      transport: 'Pull',
       snapshot: {
         contentLocalizationKey: 'Widget:Granit.Showcase.InvoicingOverview.Banner.Content',
       },
@@ -136,6 +137,7 @@ export const SAMPLE_FINANCE_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-29T12:34:56.789Z',
       refreshHint: 'Dynamic',
+      transport: 'Pull',
       snapshot: {
         chartType: 'Bar',
         groupBy: 'IssuedAtMonth',
@@ -164,6 +166,7 @@ export const SAMPLE_FINANCE_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-29T12:34:56.789Z',
       refreshHint: 'Dynamic',
+      transport: 'Pull',
       snapshot: {
         columns: [
           { name: 'invoiceNumber', labelLocalizationKey: 'Column:Invoice.Number' },
@@ -193,6 +196,7 @@ export const SAMPLE_FINANCE_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-29T12:34:56.789Z',
       refreshHint: 'Dynamic',
+      transport: 'Pull',
       snapshot: {
         rowFields: ['Region'],
         columnFields: ['Status'],
@@ -222,6 +226,7 @@ export const SAMPLE_FINANCE_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-29T12:34:56.789Z',
       refreshHint: 'Dynamic',
+      transport: 'Pull',
       snapshot: {
         points: [
           {
@@ -281,6 +286,7 @@ export const SAMPLE_WELCOME_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-30T08:00:00.000Z',
       refreshHint: 'Static',
+      transport: 'Pull',
       snapshot: { contentLocalizationKey: 'Widget:Granit.Showcase.Welcome.Banner.Content' },
       reasonLocalizationKey: null,
     },
@@ -298,6 +304,7 @@ export const SAMPLE_WELCOME_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-30T08:00:00.000Z',
       refreshHint: 'Static',
+      transport: 'Pull',
       snapshot: {
         source: 'https://placehold.co/1200x600/0f172a/f8fafc.png?text=Granit+Showcase',
         altLocalizationKey: 'Widget:Granit.Showcase.Welcome.Hero.Alt',
@@ -319,6 +326,7 @@ export const SAMPLE_WELCOME_BUNDLE: DashboardRenderResponse = {
       sequence: 1,
       emittedAt: '2026-04-30T08:00:00.000Z',
       refreshHint: 'Static',
+      transport: 'Pull',
       snapshot: {
         contentLocalizationKey: 'Widget:Granit.Showcase.Welcome.NextSteps.Content',
         style: 'Subheading',

--- a/packages/@granit/react-dashboards/src/testing/handlers.ts
+++ b/packages/@granit/react-dashboards/src/testing/handlers.ts
@@ -164,6 +164,7 @@ export function createDashboardsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       sequence: 1,
       emittedAt: new Date().toISOString(),
       refreshHint: fixture.refreshHint,
+      transport: 'Pull',
       snapshot: fixture.snapshot,
       reasonLocalizationKey: null,
     };
@@ -373,19 +374,19 @@ export function createDashboardsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const dashboard = store.get(String(params.id));
       if (!dashboard) return notFound(String(params.id));
       dashboard.status = 'Published';
-      return new HttpResponse(null, { status: 204 });
+      return HttpResponse.json(summarize(dashboard));
     }),
     http.post(`${baseUrl}/:id/archive`, ({ params }) => {
       const dashboard = store.get(String(params.id));
       if (!dashboard) return notFound(String(params.id));
       dashboard.status = 'Archived';
-      return new HttpResponse(null, { status: 204 });
+      return HttpResponse.json(summarize(dashboard));
     }),
     http.post(`${baseUrl}/:id/restore`, ({ params }) => {
       const dashboard = store.get(String(params.id));
       if (!dashboard) return notFound(String(params.id));
       dashboard.status = 'Draft';
-      return new HttpResponse(null, { status: 204 });
+      return HttpResponse.json(summarize(dashboard));
     }),
     http.post(`${baseUrl}/:id/resync`, ({ params }) => {
       const dashboard = store.get(String(params.id));

--- a/packages/@granit/react-workspaces/src/__tests__/use-side-peek.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-side-peek.test.tsx
@@ -54,6 +54,15 @@ describe('useSidePeek — parse', () => {
     const { result } = harness({ search: '?peek=:nothing,broken,Party:' });
     expect(result.current.stack).toEqual([]);
   });
+
+  it('skips empty segments in the peek param', () => {
+    const { result } = harness({
+      search:
+        `?peek=${encodeURIComponent('Granit.Parties.Party')}:42,,` +
+        `${encodeURIComponent('Granit.Invoicing.Invoice')}:100`,
+    });
+    expect(result.current.stack).toEqual([PARTY, INVOICE]);
+  });
 });
 
 describe('useSidePeek — mutate', () => {
@@ -142,6 +151,33 @@ describe('useSidePeek — keyboard shortcuts', () => {
       document.dispatchEvent(
         new KeyboardEvent('keydown', { key: '.', ctrlKey: true, shiftKey: true })
       );
+    });
+    expect(onExpand).not.toHaveBeenCalled();
+    expect(onSearchChange).not.toHaveBeenCalled();
+  });
+
+  it('Ctrl+Shift+. fires expand (ctrlKey alias for metaKey)', () => {
+    const onExpand = vi.fn();
+    harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+      onExpand,
+    });
+    act(() => {
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: '.', ctrlKey: true, shiftKey: true, bubbles: true })
+      );
+    });
+    expect(onExpand).toHaveBeenCalledWith('/entity/42');
+  });
+
+  it('ignores unrelated keys when a peek is active', () => {
+    const onExpand = vi.fn();
+    const { onSearchChange } = harness({
+      search: `?peek=${encodeURIComponent('Granit.Parties.Party')}:42`,
+      onExpand,
+    });
+    act(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
     });
     expect(onExpand).not.toHaveBeenCalled();
     expect(onSearchChange).not.toHaveBeenCalled();

--- a/packages/@granit/workspaces/src/__tests__/url-helpers.test.ts
+++ b/packages/@granit/workspaces/src/__tests__/url-helpers.test.ts
@@ -52,6 +52,10 @@ describe('parseWorkspaceUrl', () => {
     expect(parseWorkspaceUrl('/w/')).toBeNull();
   });
 
+  it('returns null when the workspace segment is empty (/w//segment)', () => {
+    expect(parseWorkspaceUrl('/w//something')).toBeNull();
+  });
+
   it('round-trips with buildWorkspaceUrl', () => {
     const built = buildWorkspaceUrl('Granit.Framework', 'system', 'users');
     expect(parseWorkspaceUrl(built)).toEqual({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
         'packages/@granit/arch-tests-kit/src/index.ts'
       ),
       '@granit/testing/msw': path.resolve(__dirname, 'packages/@granit/testing/src/msw.ts'),
+      '@granit/testing/msw-server': path.resolve(
+        __dirname,
+        'packages/@granit/testing/src/msw-server.ts'
+      ),
       '@granit/react-auditing/testing': path.resolve(
         __dirname,
         'packages/@granit/react-auditing/src/testing/index.ts'


### PR DESCRIPTION
## Summary

- **`transport` is now required** on `DashboardRenderedWidget` and `WidgetSnapshotEnvelope` — P2.4 shipped, backwards-compat opt-out removed; all fixture widgets updated with `'Pull'` or `'Push'`
- **`sequence` widened to `number | string`** on both types to handle int64 JSON encoding; `Number()` coercion added in `applyStreamSnapshot` (stream comparison) and `KpiSnapshotTile` (bridge to `MetricResponse.sequence: number`)
- **`getDashboardCatalog` now accepts `DashboardCatalogParams`** with optional `category` filter; `useDashboardCatalog` exposes the same option and includes `category` in its query key
- **Lifecycle mutations return `DashboardSummaryResponse`**: `publishDashboard` / `archiveDashboard` / `restoreDashboard` now read `response.data` (backend returns `200 + body`); hooks updated to `DashboardSummaryResponse` return type with optimistic `setQueriesData` patch on the list cache before invalidation
- **MSW handlers corrected**: publish/archive/restore handlers changed from `204 null` to `200 + HttpResponse.json(summarize(dashboard))`
- **New `dashboards-api.test.ts`**: 8 tests covering catalog (with/without category), list, detail, render, and all three state transitions
- Cascading fixes in `@granit/react-analytics` (`KpiSnapshotTile`) and test fixtures across `@granit/dashboards` and `@granit/react-dashboards`

## Test plan

- [ ] `pnpm tsc` — no errors (6827 tests passing, 604 test files)
- [ ] `pnpm lint` — 0 warnings
- [ ] `npx vitest run packages/@granit/dashboards` — 43/43 green
- [ ] `npx vitest run packages/@granit/react-dashboards` — 167/167 green
- [ ] Full monorepo run — 6827/6827 green