### PR TITLE
feat(documents)!: align contracts with OpenAPI — properties, public-links, renditions, resolution

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1478,6 +1478,31 @@
           "name": "getTenantStorageQuota",
           "kind": "function",
           "signature": "async function getTenantStorageQuota( client: AxiosInstance, basePath: string ): Promise<TenantStorageQuotaResponse>"
+        },
+        {
+          "name": "getDocumentProperties",
+          "kind": "function",
+          "signature": "async function getDocumentProperties( client: AxiosInstance, basePath: string, id: string ): Promise<DocumentPropertiesResponse>"
+        },
+        {
+          "name": "getDocumentVersionProperties",
+          "kind": "function",
+          "signature": "async function getDocumentVersionProperties( client: AxiosInstance, basePath: string, id: string, versionId: string ): Promise<DocumentPropertiesResponse>"
+        },
+        {
+          "name": "listDocumentRenditions",
+          "kind": "function",
+          "signature": "async function listDocumentRenditions( client: AxiosInstance, basePath: string, id: string ): Promise<ListRenditionsResponse>"
+        },
+        {
+          "name": "requestRenditionDownloadUrl",
+          "kind": "function",
+          "signature": "async function requestRenditionDownloadUrl( client: AxiosInstance, basePath: string, id: string, type: RenditionType ): Promise<RenditionDownloadUrlResponse>"
+        },
+        {
+          "name": "batchResolveDocumentAssets",
+          "kind": "function",
+          "signature": "async function batchResolveDocumentAssets( client: AxiosInstance, basePath: string, request: BatchResolveRequest ): Promise<readonly ResolvedDocumentResponse[]>"
         }
       ]
     },
@@ -4419,6 +4444,21 @@
           "name": "useTenantStorageQuota",
           "kind": "function",
           "signature": "function useTenantStorageQuota(options?:"
+        },
+        {
+          "name": "useDocumentRenditions",
+          "kind": "function",
+          "signature": "function useDocumentRenditions( id: string, options?:"
+        },
+        {
+          "name": "useRenditionDownloadUrl",
+          "kind": "function",
+          "signature": "function useRenditionDownloadUrl( id: string, type: RenditionType, options?:"
+        },
+        {
+          "name": "useBatchResolveDocumentAssets",
+          "kind": "function",
+          "signature": "function useBatchResolveDocumentAssets(): UseMutationResult< readonly ResolvedDocumentResponse[], Error, BatchResolveRequest >"
         },
         {
           "name": "DocumentDetail",

--- a/packages/@granit/documents/src/__tests__/documents-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/documents-api.test.ts
@@ -122,10 +122,14 @@ describe('renameDocument', () => {
       axiosResponse({ ...sampleDocument, name: 'Renamed.pdf' })
     );
 
-    const result = await renameDocument(client, basePath, 'doc-1', { name: 'Renamed.pdf' });
+    const result = await renameDocument(client, basePath, 'doc-1', {
+      name: 'Renamed.pdf',
+      description: null,
+    });
 
     expect(client.patch).toHaveBeenCalledWith(`${basePath}/documents/doc-1`, {
       name: 'Renamed.pdf',
+      description: null,
     });
     expect(result.name).toBe('Renamed.pdf');
   });
@@ -134,9 +138,15 @@ describe('renameDocument', () => {
     const client = createMockClient();
     vi.mocked(client.patch).mockResolvedValue(axiosResponse(sampleDocument));
 
-    await renameDocument(client, basePath, 'doc-1', { clearDescription: true });
+    await renameDocument(client, basePath, 'doc-1', {
+      name: null,
+      description: null,
+      clearDescription: true,
+    });
 
     expect(client.patch).toHaveBeenCalledWith(`${basePath}/documents/doc-1`, {
+      name: null,
+      description: null,
       clearDescription: true,
     });
   });

--- a/packages/@granit/documents/src/__tests__/shares-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/shares-api.test.ts
@@ -24,7 +24,7 @@ const sampleFolderShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T10:00:00Z',
-  createdByUserId: 'user-1',
+  createdBy: 'user-1',
 };
 
 const sampleDocumentShare: ShareResponse = {

--- a/packages/@granit/documents/src/api/properties-api.ts
+++ b/packages/@granit/documents/src/api/properties-api.ts
@@ -1,0 +1,36 @@
+import type { DocumentPropertiesResponse } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Get the extracted metadata for the current (or latest) version of a
+ * document. Returns 404 when no properties row exists yet (extraction pending).
+ *
+ * `GET {basePath}/documents/{id}/metadata`
+ */
+export async function getDocumentProperties(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<DocumentPropertiesResponse> {
+  const response = await client.get<DocumentPropertiesResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/metadata`
+  );
+  return response.data;
+}
+
+/**
+ * Get the extracted metadata for a specific version of a document.
+ *
+ * `GET {basePath}/documents/{id}/versions/{versionId}/metadata`
+ */
+export async function getDocumentVersionProperties(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  versionId: string
+): Promise<DocumentPropertiesResponse> {
+  const response = await client.get<DocumentPropertiesResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/versions/${encodeURIComponent(versionId)}/metadata`
+  );
+  return response.data;
+}

--- a/packages/@granit/documents/src/api/public-links-api.ts
+++ b/packages/@granit/documents/src/api/public-links-api.ts
@@ -1,0 +1,60 @@
+import type {
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  PublicLinkResponse,
+  RevokePublicLinkRequest,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Create a public link for a document. Returns 201 with the link token and
+ * the full redemption URL. Returns 403 when the caller lacks the manage
+ * permission, 404 when the document does not exist.
+ *
+ * `POST {basePath}/documents/{id}/public-links`
+ */
+export async function createDocumentPublicLink(
+  client: AxiosInstance,
+  basePath: string,
+  documentId: string,
+  request: CreatePublicLinkRequest
+): Promise<CreatePublicLinkResponse> {
+  const response = await client.post<CreatePublicLinkResponse>(
+    `${basePath}/documents/${encodeURIComponent(documentId)}/public-links`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * List all active public links for a document.
+ *
+ * `GET {basePath}/documents/{id}/public-links`
+ */
+export async function listDocumentPublicLinks(
+  client: AxiosInstance,
+  basePath: string,
+  documentId: string
+): Promise<readonly PublicLinkResponse[]> {
+  const response = await client.get<readonly PublicLinkResponse[]>(
+    `${basePath}/documents/${encodeURIComponent(documentId)}/public-links`
+  );
+  return response.data;
+}
+
+/**
+ * Revoke a public link. The `reason` field may be `null`. Returns 404 when
+ * the link does not exist or has already been revoked.
+ *
+ * `DELETE {basePath}/public-links/{id}`
+ */
+export async function revokeDocumentPublicLink(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: RevokePublicLinkRequest
+): Promise<void> {
+  await client.delete<void>(`${basePath}/public-links/${encodeURIComponent(id)}`, {
+    data: request,
+  });
+}

--- a/packages/@granit/documents/src/api/renditions-api.ts
+++ b/packages/@granit/documents/src/api/renditions-api.ts
@@ -1,0 +1,42 @@
+import type {
+  ListRenditionsResponse,
+  RenditionDownloadUrlResponse,
+  RenditionType,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List all renditions generated for the current version of a document.
+ * Returns 404 when the document does not exist.
+ *
+ * `GET {basePath}/documents/{id}/renditions`
+ */
+export async function listDocumentRenditions(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<ListRenditionsResponse> {
+  const response = await client.get<ListRenditionsResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/renditions`
+  );
+  return response.data;
+}
+
+/**
+ * Get a presigned download URL for a specific rendition type. The URL is
+ * short-lived. Returns 404 when the rendition does not exist or is not yet
+ * `Ready`.
+ *
+ * `GET {basePath}/documents/{id}/renditions/{type}/download`
+ */
+export async function requestRenditionDownloadUrl(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  type: RenditionType
+): Promise<RenditionDownloadUrlResponse> {
+  const response = await client.get<RenditionDownloadUrlResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/renditions/${encodeURIComponent(type)}/download`
+  );
+  return response.data;
+}

--- a/packages/@granit/documents/src/api/resolution-api.ts
+++ b/packages/@granit/documents/src/api/resolution-api.ts
@@ -1,0 +1,24 @@
+import type { BatchResolveRequest, ResolvedDocumentResponse } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Resolve a batch of document assets to presigned CDN URLs in one round-trip.
+ * Each item may target a specific version and/or rendition type. Items that
+ * cannot be resolved (missing document, version, or rendition) are silently
+ * omitted from the response array.
+ *
+ * Primarily used by the CMS renderer to embed document assets.
+ *
+ * `POST {basePath}/resolution/resolve`
+ */
+export async function batchResolveDocumentAssets(
+  client: AxiosInstance,
+  basePath: string,
+  request: BatchResolveRequest
+): Promise<readonly ResolvedDocumentResponse[]> {
+  const response = await client.post<readonly ResolvedDocumentResponse[]>(
+    `${basePath}/resolution/resolve`,
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/documents/src/index.ts
+++ b/packages/@granit/documents/src/index.ts
@@ -1,7 +1,12 @@
 // Types
 export type {
   AppendVersionRequest,
+  BatchResolveRequest,
   CreateFolderRequest,
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  DocumentPropertiesResponse,
+  DocumentPropertiesStatus,
   DocumentResponse,
   DocumentStatus,
   DocumentTagAssignmentResponse,
@@ -18,13 +23,23 @@ export type {
   ListDocumentVersionsResponse,
   ListFoldersFilter,
   ListFoldersResponse,
+  ListRenditionsResponse,
   ListSharesResponse,
   ListTrashedDocumentsResponse,
   MoveDocumentRequest,
   MoveFolderRequest,
   PageFilter,
+  PublicLinkResponse,
+  PublicLinkScope,
   RenameDocumentRequest,
   RenameFolderRequest,
+  RenditionDownloadUrlResponse,
+  RenditionResponse,
+  RenditionStatus,
+  RenditionType,
+  ResolveItemRequest,
+  ResolvedDocumentResponse,
+  RevokePublicLinkRequest,
   ShareGranteeType,
   SharePermissionLevel,
   ShareResponse,
@@ -83,3 +98,19 @@ export { assignDocumentTag, listDocumentTags, unassignDocumentTag } from './api/
 
 // API — Quota
 export { getTenantStorageQuota } from './api/quota-api';
+
+// API — Document properties
+export { getDocumentProperties, getDocumentVersionProperties } from './api/properties-api';
+
+// API — Public links
+export {
+  createDocumentPublicLink,
+  listDocumentPublicLinks,
+  revokeDocumentPublicLink,
+} from './api/public-links-api';
+
+// API — Renditions
+export { listDocumentRenditions, requestRenditionDownloadUrl } from './api/renditions-api';
+
+// API — Resolution
+export { batchResolveDocumentAssets } from './api/resolution-api';

--- a/packages/@granit/documents/src/types/index.ts
+++ b/packages/@granit/documents/src/types/index.ts
@@ -144,24 +144,25 @@ export interface FinalizeUploadRequest {
   /** `null` drops the document directly under the tenant root. */
   readonly folderId: string | null;
   readonly name: string;
-  readonly description?: string | null;
-  readonly commitMessage?: string | null;
+  readonly description: string | null;
+  readonly commitMessage: string | null;
 }
 
 /** Request payload for `POST /documents/{id}/versions`. */
 export interface AppendVersionRequest {
   readonly blobId: string;
-  readonly commitMessage?: string | null;
+  readonly commitMessage: string | null;
 }
 
 /**
- * PATCH payload for `PATCH /documents/{id}`. Fields left `null`/absent are
- * unchanged; use {@link clearDescription} to drop an existing description
- * (sending an empty string sets a non-null empty value).
+ * PATCH payload for `PATCH /documents/{id}`. Pass `null` for `name` or
+ * `description` to leave the field unchanged; use {@link clearDescription}
+ * to explicitly drop an existing description (sending an empty string sets a
+ * non-null empty value instead).
  */
 export interface RenameDocumentRequest {
-  readonly name?: string | null;
-  readonly description?: string | null;
+  readonly name: string | null;
+  readonly description: string | null;
   /** When `true`, clears the description regardless of {@link description}. */
   readonly clearDescription?: boolean;
 }
@@ -251,7 +252,6 @@ export interface DocumentTagResponse {
   readonly name: string;
   readonly color: string;
   readonly hideOnEntityCard: boolean;
-  readonly rowVersion: number;
 }
 
 export interface ListDocumentTagsResponse {
@@ -286,7 +286,7 @@ export interface ShareResponse {
   readonly isDefault: boolean;
   readonly expiresAt: string | null;
   readonly createdAt: string;
-  readonly createdByUserId: string;
+  readonly createdBy: string;
 }
 
 /** Wrapper response for the folder- and document-scoped share listings. */
@@ -319,4 +319,168 @@ export interface TenantStorageQuotaResponse {
   /** `usageBytes / limitBytes * 100`, clamped at 100 and rounded to two decimals. */
   readonly percentUsed: number;
   readonly updatedAt: string;
+}
+
+// ─── Document properties (extracted metadata) ───────────────────────────────
+
+export type DocumentPropertiesStatus = 'Pending' | 'Extracting' | 'Ready' | 'Failed';
+
+/**
+ * Rich metadata extracted from a document version by the background extractor
+ * pipeline. All domain-specific fields (`width`, `pageCount`, `durationMs`, …)
+ * are `null` when the extractor did not populate them for the given content
+ * type.
+ */
+export interface DocumentPropertiesResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly documentVersionId: string;
+  readonly sourceContentType: string;
+  readonly status: DocumentPropertiesStatus;
+  readonly createdAt: string;
+  readonly completedAt: string | null;
+  readonly failureReason: string | null;
+  readonly extractorCount: number;
+  // Image / photo
+  readonly width: number | null;
+  readonly height: number | null;
+  readonly cameraMake: string | null;
+  readonly cameraModel: string | null;
+  readonly lensModel: string | null;
+  readonly iso: number | null;
+  readonly fNumber: number | null;
+  readonly exposureTimeMs: number | null;
+  readonly takenAt: string | null;
+  readonly gpsLatitude: number | null;
+  readonly gpsLongitude: number | null;
+  readonly gpsAltitude: number | null;
+  // Document / PDF
+  readonly pageCount: number | null;
+  readonly title: string | null;
+  readonly author: string | null;
+  readonly subject: string | null;
+  readonly keywords: string | null;
+  readonly producer: string | null;
+  readonly revision: number | null;
+  readonly lastModifiedBy: string | null;
+  // Audio / video
+  readonly durationMs: number | null;
+  readonly codec: string | null;
+  readonly bitrate: number | null;
+  readonly artist: string | null;
+  readonly album: string | null;
+  readonly trackNumber: number | null;
+  readonly genre: string | null;
+  /** Raw key/value pairs emitted by all extractors. */
+  readonly rawMetadata: Readonly<Record<string, string>>;
+}
+
+// ─── Public links ────────────────────────────────────────────────────────────
+
+/** Scope of a public link: download-only or view (preview). */
+export type PublicLinkScope = 'Download' | 'View';
+
+/** Request body for `POST /documents/{id}/public-links`. */
+export interface CreatePublicLinkRequest {
+  readonly scope: PublicLinkScope;
+  /** Number of days until the link expires. */
+  readonly ttlDays: number;
+  /** Maximum number of uses; `null` means unlimited. */
+  readonly maxUses: number | null;
+}
+
+/** Response from `POST /documents/{id}/public-links`. Includes the one-time `token` and the full `url`. */
+export interface CreatePublicLinkResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly token: string;
+  readonly url: string;
+  readonly scope: PublicLinkScope;
+  readonly expiresAt: string;
+  readonly maxUses: number | null;
+}
+
+/** Read-only view of a public link returned by `GET /documents/{id}/public-links`. */
+export interface PublicLinkResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly scope: PublicLinkScope;
+  readonly expiresAt: string;
+  readonly maxUses: number | null;
+  readonly currentUses: number;
+  readonly revokedAt: string | null;
+  readonly revocationReason: string | null;
+  readonly createdAt: string;
+}
+
+/** Request body for `DELETE /documents/public-links/{id}`. */
+export interface RevokePublicLinkRequest {
+  /** `null` records no reason. */
+  readonly reason: string | null;
+}
+
+// ─── Renditions ──────────────────────────────────────────────────────────────
+
+/** Rendition variant: thumbnail, web-optimised, print, or video poster frame. */
+export type RenditionType = 'Thumbnail' | 'Web' | 'Print' | 'Poster';
+
+/** Generation status of a rendition. */
+export type RenditionStatus = 'Pending' | 'Generating' | 'Ready' | 'Failed';
+
+export interface RenditionResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly documentVersionId: string;
+  readonly type: RenditionType;
+  /** Output format (e.g. `"image/webp"`). */
+  readonly format: string;
+  readonly status: RenditionStatus;
+  readonly sizeBytes: number | null;
+  readonly width: number | null;
+  readonly height: number | null;
+  readonly createdAt: string;
+  readonly completedAt: string | null;
+  readonly failureReason: string | null;
+}
+
+/** Response for `GET /documents/{id}/renditions`. */
+export interface ListRenditionsResponse {
+  readonly documentId: string;
+  readonly documentVersionId: string;
+  readonly renditions: readonly RenditionResponse[];
+}
+
+/** Response for `GET /documents/{id}/renditions/{type}/download`. */
+export interface RenditionDownloadUrlResponse {
+  readonly url: string;
+  readonly expiresAt: string;
+}
+
+// ─── Document resolution ─────────────────────────────────────────────────────
+
+/** A single item in a batch-resolve request. */
+export interface ResolveItemRequest {
+  readonly documentId: string;
+  /** Omit to resolve the current version. */
+  readonly versionId?: string | null;
+  /** Omit to resolve the original blob; provide to request a specific rendition. */
+  readonly renditionType?: RenditionType | null;
+  readonly renditionFormat?: string | null;
+}
+
+/** Request body for `POST /documents/resolution/resolve`. */
+export interface BatchResolveRequest {
+  readonly requests: readonly ResolveItemRequest[];
+}
+
+/** Single resolved asset returned by `POST /documents/resolution/resolve`. */
+export interface ResolvedDocumentResponse {
+  readonly documentId: string;
+  readonly versionId: string;
+  readonly url: string;
+  readonly width: number | null;
+  readonly height: number | null;
+  readonly mimeType: string | null;
+  readonly sizeBytes: number | null;
+  readonly lastModified: string | null;
 }

--- a/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
@@ -172,6 +172,6 @@ describe('DocumentDetail', () => {
 
     await waitFor(() => expect(client.patch).toHaveBeenCalled());
     const [, body] = vi.mocked(client.patch).mock.calls[0] ?? [];
-    expect(body).toEqual({ name: 'NewName.pdf' });
+    expect(body).toEqual({ name: 'NewName.pdf', description: null });
   });
 });

--- a/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
@@ -22,7 +22,7 @@ const folderShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T08:00:00Z',
-  createdByUserId: 'admin',
+  createdBy: 'admin',
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
@@ -117,6 +117,8 @@ describe('useFinalizeUpload', () => {
       blobId: 'blob-1',
       folderId: 'fld-1',
       name: 'contract.pdf',
+      description: null,
+      commitMessage: null,
     });
 
     expect(client.post).toHaveBeenCalledWith(
@@ -140,10 +142,14 @@ describe('useRenameDocument', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useRenameDocument(), { wrapper });
-    await result.current.mutateAsync({ id: 'doc-1', request: { name: 'renamed.pdf' } });
+    await result.current.mutateAsync({
+      id: 'doc-1',
+      request: { name: 'renamed.pdf', description: null },
+    });
 
     expect(client.patch).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1', {
       name: 'renamed.pdf',
+      description: null,
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([['documents', 'documents']]);
@@ -261,10 +267,14 @@ describe('useAppendDocumentVersion', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useAppendDocumentVersion(), { wrapper });
-    await result.current.mutateAsync({ id: 'doc-1', request: { blobId: 'blob-2' } });
+    await result.current.mutateAsync({
+      id: 'doc-1',
+      request: { blobId: 'blob-2', commitMessage: null },
+    });
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/versions', {
       blobId: 'blob-2',
+      commitMessage: null,
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([

--- a/packages/@granit/react-documents/src/__tests__/use-document-tags.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-tags.test.tsx
@@ -27,7 +27,6 @@ const sampleTag: DocumentTagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  rowVersion: 1,
 };
 const sampleList: ListDocumentTagsResponse = { items: [sampleTag] };
 const sampleAssignment: DocumentTagAssignmentResponse = {

--- a/packages/@granit/react-documents/src/__tests__/use-share-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-share-mutations.test.tsx
@@ -27,7 +27,7 @@ const sampleShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T00:00:00Z',
-  createdByUserId: 'user-1',
+  createdBy: 'user-1',
 };
 
 interface Harness {

--- a/packages/@granit/react-documents/src/__tests__/use-shares.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-shares.test.tsx
@@ -21,7 +21,7 @@ const sampleShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T00:00:00Z',
-  createdByUserId: 'user-1',
+  createdBy: 'user-1',
 };
 const sampleResponse: ListSharesResponse = { items: [sampleShare] };
 

--- a/packages/@granit/react-documents/src/components/document-detail.tsx
+++ b/packages/@granit/react-documents/src/components/document-detail.tsx
@@ -134,7 +134,7 @@ export function DocumentDetail({
       return;
     }
     renameDocument.mutate(
-      { id: document.id, request: { name: trimmed } },
+      { id: document.id, request: { name: trimmed, description: null } },
       { onSuccess: () => setEditing(false) }
     );
   }

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -470,7 +470,7 @@ function DocumentsListBody({
       return;
     }
     renameDocument.mutate(
-      { id: doc.id, request: { name } },
+      { id: doc.id, request: { name, description: null } },
       { onSettled: () => clearRowMode(doc.id) }
     );
   }

--- a/packages/@granit/react-documents/src/hooks/use-document-properties.ts
+++ b/packages/@granit/react-documents/src/hooks/use-document-properties.ts
@@ -1,0 +1,41 @@
+import { getDocumentProperties, getDocumentVersionProperties } from '@granit/documents';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildDocumentsQueryKey, useDocumentsConfig } from '../providers/documents-provider';
+
+import type { DocumentPropertiesResponse } from '@granit/documents';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Get the extracted metadata for the current version of a document. Returns
+ * `undefined` while the background extractor has not finished (`status:
+ * 'Pending'` or `'Extracting'`). Disabled when `id` is empty.
+ */
+export function useDocumentProperties(
+  id: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<DocumentPropertiesResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'metadata'),
+    queryFn: () => getDocumentProperties(config.client, config.basePath, id),
+    enabled: (options?.enabled ?? true) && id.length > 0,
+  });
+}
+
+/**
+ * Get the extracted metadata for a specific version of a document. Disabled
+ * when either `id` or `versionId` is empty.
+ */
+export function useDocumentVersionProperties(
+  id: string,
+  versionId: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<DocumentPropertiesResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'versions', versionId, 'metadata'),
+    queryFn: () => getDocumentVersionProperties(config.client, config.basePath, id, versionId),
+    enabled: (options?.enabled ?? true) && id.length > 0 && versionId.length > 0,
+  });
+}

--- a/packages/@granit/react-documents/src/hooks/use-file-upload.ts
+++ b/packages/@granit/react-documents/src/hooks/use-file-upload.ts
@@ -111,6 +111,8 @@ export function useFileUpload(options: UseFileUploadOptions = {}): UseFileUpload
           blobId: ticket.blobId,
           folderId,
           name: file.name,
+          description: null,
+          commitMessage: null,
         });
         setProgress(null);
         return document;

--- a/packages/@granit/react-documents/src/hooks/use-public-links.ts
+++ b/packages/@granit/react-documents/src/hooks/use-public-links.ts
@@ -1,0 +1,87 @@
+import {
+  createDocumentPublicLink,
+  listDocumentPublicLinks,
+  revokeDocumentPublicLink,
+} from '@granit/documents';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildDocumentsQueryKey, useDocumentsConfig } from '../providers/documents-provider';
+
+import type { ResolvedDocumentsConfig } from '../providers/documents-provider';
+import type {
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  PublicLinkResponse,
+  RevokePublicLinkRequest,
+} from '@granit/documents';
+import type { QueryClient, UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+function invalidatePublicLinks(
+  queryClient: QueryClient,
+  config: ResolvedDocumentsConfig,
+  documentId: string
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildDocumentsQueryKey(config, 'documents', documentId, 'public-links'),
+  });
+}
+
+/** List active public links for a document. Disabled when `documentId` is empty. */
+export function useDocumentPublicLinks(
+  documentId: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<readonly PublicLinkResponse[]> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', documentId, 'public-links'),
+    queryFn: () => listDocumentPublicLinks(config.client, config.basePath, documentId),
+    enabled: (options?.enabled ?? true) && documentId.length > 0,
+  });
+}
+
+interface CreatePublicLinkArgs {
+  readonly documentId: string;
+  readonly request: CreatePublicLinkRequest;
+}
+
+/** Create a public link for a document. Invalidates the public-links list on success. */
+export function useCreateDocumentPublicLink(): UseMutationResult<
+  CreatePublicLinkResponse,
+  Error,
+  CreatePublicLinkArgs
+> {
+  const config = useDocumentsConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ documentId, request }: CreatePublicLinkArgs) =>
+      createDocumentPublicLink(config.client, config.basePath, documentId, request),
+    onSuccess: (_data, { documentId }) => {
+      invalidatePublicLinks(queryClient, config, documentId);
+    },
+  });
+}
+
+interface RevokePublicLinkArgs {
+  readonly id: string;
+  readonly documentId: string;
+  readonly request: RevokePublicLinkRequest;
+}
+
+/** Revoke a public link. Invalidates the public-links list for the parent document on success. */
+export function useRevokeDocumentPublicLink(): UseMutationResult<
+  void,
+  Error,
+  RevokePublicLinkArgs
+> {
+  const config = useDocumentsConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: RevokePublicLinkArgs) =>
+      revokeDocumentPublicLink(config.client, config.basePath, id, request),
+    onSuccess: (_data, { documentId }) => {
+      invalidatePublicLinks(queryClient, config, documentId);
+    },
+  });
+}

--- a/packages/@granit/react-documents/src/hooks/use-renditions.ts
+++ b/packages/@granit/react-documents/src/hooks/use-renditions.ts
@@ -1,0 +1,47 @@
+import { listDocumentRenditions, requestRenditionDownloadUrl } from '@granit/documents';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildDocumentsQueryKey, useDocumentsConfig } from '../providers/documents-provider';
+
+import type {
+  ListRenditionsResponse,
+  RenditionDownloadUrlResponse,
+  RenditionType,
+} from '@granit/documents';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List all renditions for the current version of a document. Disabled when
+ * `id` is empty.
+ */
+export function useDocumentRenditions(
+  id: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<ListRenditionsResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'renditions'),
+    queryFn: () => listDocumentRenditions(config.client, config.basePath, id),
+    enabled: (options?.enabled ?? true) && id.length > 0,
+  });
+}
+
+/**
+ * Get a presigned download URL for a specific rendition type. The URL is
+ * short-lived — use `staleTime: Infinity` + manual `refetch()` on demand
+ * rather than auto-refetching. Disabled when `id` is empty.
+ */
+export function useRenditionDownloadUrl(
+  id: string,
+  type: RenditionType,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<RenditionDownloadUrlResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'renditions', type, 'download'),
+    queryFn: () => requestRenditionDownloadUrl(config.client, config.basePath, id, type),
+    enabled: (options?.enabled ?? true) && id.length > 0,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/packages/@granit/react-documents/src/hooks/use-resolution.ts
+++ b/packages/@granit/react-documents/src/hooks/use-resolution.ts
@@ -1,0 +1,28 @@
+import { batchResolveDocumentAssets } from '@granit/documents';
+import { useMutation } from '@tanstack/react-query';
+
+import { useDocumentsConfig } from '../providers/documents-provider';
+
+import type { BatchResolveRequest, ResolvedDocumentResponse } from '@granit/documents';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Resolve a batch of document assets to presigned CDN URLs. Each item may
+ * target a specific version and/or rendition type; unresolvable items are
+ * silently omitted from the response array.
+ *
+ * Primarily used by the CMS renderer to embed document assets. Results are
+ * short-lived (CDN URLs expire), so no query caching is applied.
+ */
+export function useBatchResolveDocumentAssets(): UseMutationResult<
+  readonly ResolvedDocumentResponse[],
+  Error,
+  BatchResolveRequest
+> {
+  const config = useDocumentsConfig();
+
+  return useMutation({
+    mutationFn: (request: BatchResolveRequest) =>
+      batchResolveDocumentAssets(config.client, config.basePath, request),
+  });
+}

--- a/packages/@granit/react-documents/src/index.ts
+++ b/packages/@granit/react-documents/src/index.ts
@@ -73,6 +73,25 @@ export {
 // Quota
 export { useTenantStorageQuota } from './hooks/use-quota';
 
+// Document properties
+export {
+  useDocumentProperties,
+  useDocumentVersionProperties,
+} from './hooks/use-document-properties';
+
+// Public links
+export {
+  useCreateDocumentPublicLink,
+  useDocumentPublicLinks,
+  useRevokeDocumentPublicLink,
+} from './hooks/use-public-links';
+
+// Renditions
+export { useDocumentRenditions, useRenditionDownloadUrl } from './hooks/use-renditions';
+
+// Resolution
+export { useBatchResolveDocumentAssets } from './hooks/use-resolution';
+
 // Components — Documents
 export { DocumentDetail } from './components/document-detail';
 export type { DocumentDetailLabels, DocumentDetailProps } from './components/document-detail';

--- a/packages/@granit/react-documents/src/testing/handlers.ts
+++ b/packages/@granit/react-documents/src/testing/handlers.ts
@@ -2,10 +2,11 @@
 // @granit/react-documents/testing — MSW handlers
 // ---------------------------------------------------------------------------
 //
-// Stateful in-memory implementation of every endpoint in the Phase 1
-// Documents wire contract (folders, documents, versions, shares, tags, quota,
-// trash + QueryEngine list). Handlers mutate module-level arrays so subsequent
-// GETs reflect prior mutations within a single test/dev session.
+// Stateful in-memory implementation of every endpoint in the Documents wire
+// contract (folders, documents, versions, shares, tags, quota, trash,
+// QueryEngine list, properties, public-links, renditions, resolution).
+// Handlers mutate module-level arrays so subsequent GETs reflect prior
+// mutations within a single test/dev session.
 
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound, pagedResponse, parseFilters, parseSort } from '@granit/testing/msw';
@@ -28,7 +29,11 @@ import { documentQueryMetadata } from './query-meta';
 
 import type {
   AppendVersionRequest,
+  BatchResolveRequest,
   CreateFolderRequest,
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  DocumentPropertiesResponse,
   DocumentResponse,
   DocumentTagAssignmentResponse,
   DocumentVersionResponse,
@@ -40,12 +45,17 @@ import type {
   ListDocumentTagsResponse,
   ListDocumentVersionsResponse,
   ListFoldersResponse,
+  ListRenditionsResponse,
   ListSharesResponse,
   ListTrashedDocumentsResponse,
   MoveDocumentRequest,
   MoveFolderRequest,
+  PublicLinkResponse,
   RenameDocumentRequest,
   RenameFolderRequest,
+  RenditionResponse,
+  ResolvedDocumentResponse,
+  RevokePublicLinkRequest,
   ShareResponse,
   TenantStorageQuotaResponse,
   TransferOwnerRequest,
@@ -105,6 +115,8 @@ export function createDocumentsHandlers(
   const trashed = mockTrashedDocumentsData.map((t) => ({ ...t }));
   const shares: ShareResponse[] = mockSharesData.map((s) => ({ ...s }));
   const quota: TenantStorageQuotaResponse = { ...mockQuotaData };
+  const publicLinks: PublicLinkResponse[] = [];
+  const renditions: RenditionResponse[] = [];
 
   function findFolder(id: string): FolderResponse | undefined {
     return folders.find((f) => f.id === id);
@@ -304,7 +316,7 @@ export function createDocumentsHandlers(
         isDefault: body.isDefault ?? true,
         expiresAt: body.expiresAt ?? null,
         createdAt: new Date().toISOString(),
-        createdByUserId: MOCK_OWNER_USER_ID,
+        createdBy: MOCK_OWNER_USER_ID,
       };
       shares.push(share);
       return HttpResponse.json(share, { status: 201 });
@@ -494,7 +506,7 @@ export function createDocumentsHandlers(
         isDefault: false,
         expiresAt: body.expiresAt ?? null,
         createdAt: new Date().toISOString(),
-        createdByUserId: MOCK_OWNER_USER_ID,
+        createdBy: MOCK_OWNER_USER_ID,
       };
       shares.push(share);
       return HttpResponse.json(share, { status: 201 });
@@ -605,5 +617,208 @@ export function createDocumentsHandlers(
 
     // ── Quota ────────────────────────────────────────────────────────────────
     http.get(`${basePath}/quota`, () => HttpResponse.json(quota)),
+
+    // ── Document properties ──────────────────────────────────────────────────
+    http.get(`${basePath}/documents/:id/versions/:versionId/metadata`, ({ params }) => {
+      const id = params.id as string;
+      const versionId = params.versionId as string;
+      if (!findDocument(id)) return notFound();
+      const v = versions.find((ver) => ver.documentId === id && ver.id === versionId);
+      if (!v) return notFound();
+      const props: DocumentPropertiesResponse = {
+        id: `props-${v.id}`,
+        documentId: id,
+        documentVersionId: versionId,
+        sourceContentType: v.contentType,
+        status: 'Ready',
+        createdAt: v.uploadedAt,
+        completedAt: v.uploadedAt,
+        failureReason: null,
+        extractorCount: 1,
+        width: null,
+        height: null,
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        iso: null,
+        fNumber: null,
+        exposureTimeMs: null,
+        takenAt: null,
+        gpsLatitude: null,
+        gpsLongitude: null,
+        gpsAltitude: null,
+        pageCount: null,
+        title: null,
+        author: null,
+        subject: null,
+        keywords: null,
+        producer: null,
+        revision: null,
+        lastModifiedBy: null,
+        durationMs: null,
+        codec: null,
+        bitrate: null,
+        artist: null,
+        album: null,
+        trackNumber: null,
+        genre: null,
+        rawMetadata: {},
+      };
+      return HttpResponse.json(props);
+    }),
+
+    http.get(`${basePath}/documents/:id/metadata`, ({ params }) => {
+      const id = params.id as string;
+      const doc = findDocument(id);
+      if (!doc) return notFound();
+      if (!doc.currentVersionId) return notFound();
+      const v = versions.find((ver) => ver.id === doc.currentVersionId);
+      if (!v) return notFound();
+      const props: DocumentPropertiesResponse = {
+        id: `props-${id}`,
+        documentId: id,
+        documentVersionId: doc.currentVersionId,
+        sourceContentType: doc.contentType ?? 'application/octet-stream',
+        status: 'Ready',
+        createdAt: doc.createdAt,
+        completedAt: doc.createdAt,
+        failureReason: null,
+        extractorCount: 1,
+        width: null,
+        height: null,
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        iso: null,
+        fNumber: null,
+        exposureTimeMs: null,
+        takenAt: null,
+        gpsLatitude: null,
+        gpsLongitude: null,
+        gpsAltitude: null,
+        pageCount: null,
+        title: null,
+        author: null,
+        subject: null,
+        keywords: null,
+        producer: null,
+        revision: null,
+        lastModifiedBy: null,
+        durationMs: null,
+        codec: null,
+        bitrate: null,
+        artist: null,
+        album: null,
+        trackNumber: null,
+        genre: null,
+        rawMetadata: {},
+      };
+      return HttpResponse.json(props);
+    }),
+
+    // ── Public links ─────────────────────────────────────────────────────────
+    http.post(`${basePath}/documents/:id/public-links`, async ({ params, request }) => {
+      const documentId = params.id as string;
+      if (!findDocument(documentId)) return notFound();
+      const body = (await request.json()) as CreatePublicLinkRequest;
+      const id = newId('lk', shareCounter++);
+      const token = `mock-token-${id.slice(-8)}`;
+      const expiresAt = new Date(Date.now() + body.ttlDays * 24 * 60 * 60 * 1000).toISOString();
+      const created: CreatePublicLinkResponse = {
+        id,
+        documentId,
+        token,
+        url: `/p/${token}`,
+        scope: body.scope,
+        expiresAt,
+        maxUses: body.maxUses,
+      };
+      publicLinks.push({
+        id,
+        documentId,
+        scope: body.scope,
+        expiresAt,
+        maxUses: body.maxUses,
+        currentUses: 0,
+        revokedAt: null,
+        revocationReason: null,
+        createdAt: new Date().toISOString(),
+      });
+      return HttpResponse.json(created, { status: 201 });
+    }),
+
+    http.get(`${basePath}/documents/:id/public-links`, ({ params }) => {
+      const documentId = params.id as string;
+      if (!findDocument(documentId)) return notFound();
+      const items = publicLinks.filter((l) => l.documentId === documentId && l.revokedAt === null);
+      return HttpResponse.json(items);
+    }),
+
+    http.delete(`${basePath}/public-links/:id`, async ({ params, request }) => {
+      const id = params.id as string;
+      const idx = publicLinks.findIndex((l) => l.id === id);
+      if (idx === -1) return notFound();
+      const body = (await request.json()) as RevokePublicLinkRequest;
+      const link = publicLinks[idx];
+      if (link) {
+        Object.assign(link, {
+          ...link,
+          revokedAt: new Date().toISOString(),
+          revocationReason: body.reason,
+        });
+      }
+      return noContent();
+    }),
+
+    // ── Renditions ───────────────────────────────────────────────────────────
+    http.get(`${basePath}/documents/:id/renditions`, ({ params }) => {
+      const id = params.id as string;
+      const doc = findDocument(id);
+      if (!doc) return notFound();
+      const versionId = doc.currentVersionId ?? '';
+      const items: RenditionResponse[] = renditions.filter(
+        (r) => r.documentId === id && r.documentVersionId === versionId
+      );
+      const body: ListRenditionsResponse = {
+        documentId: id,
+        documentVersionId: versionId,
+        renditions: items,
+      };
+      return HttpResponse.json(body);
+    }),
+
+    http.get(`${basePath}/documents/:id/renditions/:type/download`, ({ params }) => {
+      const id = params.id as string;
+      const type = params.type as string;
+      if (!findDocument(id)) return notFound();
+      const body = {
+        url: `mock://renditions/${id}/${type}`,
+        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+      };
+      return HttpResponse.json(body);
+    }),
+
+    // ── Resolution ───────────────────────────────────────────────────────────
+    http.post(`${basePath}/resolution/resolve`, async ({ request }) => {
+      const body = (await request.json()) as BatchResolveRequest;
+      const results: ResolvedDocumentResponse[] = [];
+      for (const item of body.requests) {
+        const doc = findDocument(item.documentId);
+        if (!doc) continue;
+        const versionId = item.versionId ?? doc.currentVersionId;
+        if (!versionId) continue;
+        results.push({
+          documentId: item.documentId,
+          versionId,
+          url: `mock://resolve/${item.documentId}/${versionId}`,
+          width: null,
+          height: null,
+          mimeType: doc.contentType,
+          sizeBytes: doc.sizeBytes,
+          lastModified: doc.modifiedAt ?? doc.createdAt,
+        });
+      }
+      return HttpResponse.json(results);
+    }),
   ];
 }


### PR DESCRIPTION
## Summary

- **BREAKING** — fix type contracts in `@granit/documents` that were drifted from the OpenAPI spec:
  - `ShareResponse.createdByUserId` → `createdBy` (field rename)
  - `FinalizeUploadRequest.description` / `.commitMessage` — now required `string | null` (not optional)
  - `AppendVersionRequest.commitMessage` — now required `string | null`
  - `RenameDocumentRequest.name` / `.description` — now required `string | null`; `clearDescription` remains optional (C# default = false)
  - `DocumentTagResponse.rowVersion` removed (not in spec)
- Add 4 new API files in `@granit/documents` for the previously-missing sub-modules: `properties-api`, `public-links-api`, `renditions-api`, `resolution-api`
- Add 4 new hook groups in `@granit/react-documents`: `use-document-properties`, `use-public-links`, `use-renditions`, `use-resolution`
- Update `createDocumentsHandlers` with stateful MSW handlers for all new endpoints
- Cascade-fix all affected tests and components

## Test plan

- [ ] `pnpm --filter @granit/documents --filter @granit/react-documents exec tsc --noEmit` — passes
- [ ] `pnpm --filter @granit/documents --filter @granit/react-documents run test` — all tests green
- [ ] `pnpm lint` — 0 warnings
- [ ] Showcase: `DocumentDetailPage` now has Properties / Public Links / Renditions buttons linking to sub-pages (wired via `granit-showcase-react` MR, pending this PR merge)