### PR TITLE
fix(entities)!: align entities and customization with backend contracts

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1525,16 +1525,6 @@
           "name": "CustomizationPermissions",
           "kind": "const",
           "signature": "const CustomizationPermissions"
-        },
-        {
-          "name": "getFormCustomization",
-          "kind": "function",
-          "signature": "async function getFormCustomization( client: AxiosInstance, apiBase: string, entityName: string, variant: FormVariant ): Promise<FormCustomizationResponse>"
-        },
-        {
-          "name": "putFormCustomization",
-          "kind": "function",
-          "signature": "async function putFormCustomization( client: AxiosInstance, apiBase: string, entityName: string, variant: FormVariant, request: FormCustomizationRequest ): Promise<FormCustomizationResponse>"
         }
       ]
     },
@@ -4947,14 +4937,14 @@
           "signature": "const DEFAULT_QUERY_KEY_PREFIX"
         },
         {
-          "name": "useFormCustomization",
+          "name": "useEntityCustomization",
           "kind": "function",
-          "signature": "function useFormCustomization("
+          "signature": "function useEntityCustomization("
         },
         {
-          "name": "usePutFormCustomization",
+          "name": "usePutEntityCustomization",
           "kind": "function",
-          "signature": "function usePutFormCustomization(): UseMutationResult< FormCustomizationResponse, Error, PutFormCustomizationArgs >"
+          "signature": "function usePutEntityCustomization(): UseMutationResult< EntityCustomizationResponse, Error, PutEntityCustomizationArgs >"
         },
         {
           "name": "EffectiveField",

--- a/packages/@granit/entities-customization/src/__tests__/form-customization-api.test.ts
+++ b/packages/@granit/entities-customization/src/__tests__/form-customization-api.test.ts
@@ -1,42 +1,48 @@
 import { axiosResponse, createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getFormCustomization, putFormCustomization } from '../api/form-customization-api';
+import {
+  deleteEntityCustomization,
+  getEntityCustomization,
+  putEntityCustomization,
+} from '../api/form-customization-api';
 
-import type { FormCustomizationRequest, FormCustomizationResponse } from '../types/customization';
+import type {
+  EntityCustomizationRequest,
+  EntityCustomizationResponse,
+} from '../types/customization';
 
 const apiBase = '/api/v1';
 
-const sampleResponse: FormCustomizationResponse = {
+const sampleResponse: EntityCustomizationResponse = {
+  id: 'cust-1',
   entityName: 'Quote',
-  variant: 'Edit',
+  layoutKind: 'FormDefault',
   deltas: [
-    { kind: 'Hide', fieldName: 'internalNotes' },
-    { kind: 'Reorder', fieldName: 'amount', afterFieldName: 'currency' },
+    { $type: 'hide', fieldName: 'internalNotes' },
+    { $type: 'reorder', fieldName: 'amount', beforeFieldName: null, afterFieldName: 'currency' },
   ],
-  updatedAt: '2026-05-06T10:00:00Z',
-  updatedByUserId: 'user-1',
 };
 
-describe('getFormCustomization', () => {
-  it('GETs /entities/{name}/customization/forms/{variant}', async () => {
+describe('getEntityCustomization', () => {
+  it('GETs /entities/{name}/customization/{layoutKind}', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
 
-    const result = await getFormCustomization(client, apiBase, 'Quote', 'Edit');
+    const result = await getEntityCustomization(client, apiBase, 'Quote', 'FormDefault');
 
-    expect(client.get).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/forms/Edit');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/FormDefault');
     expect(result).toEqual(sampleResponse);
   });
 
-  it('URI-encodes the entity name and variant', async () => {
+  it('URI-encodes the entity name and layoutKind', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
 
-    await getFormCustomization(client, apiBase, 'Custom/Entity', 'Read');
+    await getEntityCustomization(client, apiBase, 'Custom/Entity', 'FormDefault');
 
     expect(client.get).toHaveBeenCalledWith(
-      '/api/v1/entities/Custom%2FEntity/customization/forms/Read'
+      '/api/v1/entities/Custom%2FEntity/customization/FormDefault'
     );
   });
 
@@ -44,25 +50,27 @@ describe('getFormCustomization', () => {
     const client = createMockClient();
     vi.mocked(client.get).mockRejectedValue(new Error('Request failed with status code 403'));
 
-    await expect(getFormCustomization(client, apiBase, 'Quote', 'Edit')).rejects.toThrow(/403/);
+    await expect(getEntityCustomization(client, apiBase, 'Quote', 'FormDefault')).rejects.toThrow(
+      /403/
+    );
   });
 });
 
-describe('putFormCustomization', () => {
-  it('PUTs the deltas body to /entities/{name}/customization/forms/{variant}', async () => {
+describe('putEntityCustomization', () => {
+  it('PUTs the deltas body to /entities/{name}/customization/{layoutKind}', async () => {
     const client = createMockClient();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleResponse));
-    const request: FormCustomizationRequest = {
+    const request: EntityCustomizationRequest = {
       deltas: [
-        { kind: 'Regroup', fieldName: 'amount', groupKey: 'pricing' },
-        { kind: 'Hide', fieldName: 'internalNotes' },
+        { $type: 'regroup', fieldName: 'amount', groupKey: 'pricing' },
+        { $type: 'hide', fieldName: 'internalNotes' },
       ],
     };
 
-    const result = await putFormCustomization(client, apiBase, 'Quote', 'Edit', request);
+    const result = await putEntityCustomization(client, apiBase, 'Quote', 'FormDefault', request);
 
     expect(client.put).toHaveBeenCalledWith(
-      '/api/v1/entities/Quote/customization/forms/Edit',
+      '/api/v1/entities/Quote/customization/FormDefault',
       request
     );
     expect(result).toEqual(sampleResponse);
@@ -73,7 +81,18 @@ describe('putFormCustomization', () => {
     vi.mocked(client.put).mockRejectedValue(new Error('Request failed with status code 422'));
 
     await expect(
-      putFormCustomization(client, apiBase, 'Quote', 'Edit', { deltas: [] })
+      putEntityCustomization(client, apiBase, 'Quote', 'FormDefault', { deltas: [] })
     ).rejects.toThrow(/422/);
+  });
+});
+
+describe('deleteEntityCustomization', () => {
+  it('DELETEs /entities/{name}/customization/{layoutKind}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue({ status: 204 });
+
+    await deleteEntityCustomization(client, apiBase, 'Quote', 'FormDefault');
+
+    expect(client.delete).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/FormDefault');
   });
 });

--- a/packages/@granit/entities-customization/src/__tests__/workspace-customization-api.test.ts
+++ b/packages/@granit/entities-customization/src/__tests__/workspace-customization-api.test.ts
@@ -15,7 +15,7 @@ const apiBase = '/api/v1';
 
 const sampleResponse: WorkspaceCustomizationResponse = {
   workspaceName: 'sales',
-  deltas: [{ kind: 'Hide', fieldName: 'pipelineForecast' }],
+  deltas: [{ $type: 'hide', fieldName: 'pipelineForecast' }],
   updatedAt: '2026-05-06T10:00:00Z',
   updatedByUserId: 'user-1',
 };
@@ -46,7 +46,14 @@ describe('putWorkspaceCustomization', () => {
     const client = createMockClient();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleResponse));
     const request: WorkspaceCustomizationRequest = {
-      deltas: [{ kind: 'Reorder', fieldName: 'tile-pipeline', beforeFieldName: 'tile-quotes' }],
+      deltas: [
+        {
+          $type: 'reorder',
+          fieldName: 'tile-pipeline',
+          beforeFieldName: 'tile-quotes',
+          afterFieldName: null,
+        },
+      ],
     };
 
     const result = await putWorkspaceCustomization(client, apiBase, 'sales', request);

--- a/packages/@granit/entities-customization/src/api/form-customization-api.ts
+++ b/packages/@granit/entities-customization/src/api/form-customization-api.ts
@@ -1,48 +1,62 @@
 import type {
-  FormCustomizationRequest,
-  FormCustomizationResponse,
-  FormVariant,
+  EntityCustomizationRequest,
+  EntityCustomizationResponse,
+  LayoutKind,
 } from '../types/customization';
 import type { AxiosInstance } from '@granit/api-client';
 
-/** Builds the form-customization endpoint for a given entity + variant. */
-function formPath(apiBase: string, entityName: string, variant: FormVariant): string {
-  return `${apiBase}/entities/${encodeURIComponent(entityName)}/customization/forms/${encodeURIComponent(variant)}`;
+function customizationPath(apiBase: string, entityName: string, layoutKind: LayoutKind): string {
+  return `${apiBase}/entities/${encodeURIComponent(entityName)}/customization/${encodeURIComponent(layoutKind)}`;
 }
 
 /**
- * Read the active form layout deltas for `entityName`/`variant`.
+ * Read the active layout deltas for `entityName`/`layoutKind`.
  *
- * `GET {apiBase}/entities/{name}/customization/forms/{variant}`
+ * `GET {apiBase}/entities/{name}/customization/{layoutKind}`
  */
-export async function getFormCustomization(
+export async function getEntityCustomization(
   client: AxiosInstance,
   apiBase: string,
   entityName: string,
-  variant: FormVariant
-): Promise<FormCustomizationResponse> {
-  const response = await client.get<FormCustomizationResponse>(
-    formPath(apiBase, entityName, variant)
+  layoutKind: LayoutKind
+): Promise<EntityCustomizationResponse> {
+  const response = await client.get<EntityCustomizationResponse>(
+    customizationPath(apiBase, entityName, layoutKind)
   );
   return response.data;
 }
 
 /**
- * Replace the form layout deltas for `entityName`/`variant`. The backend
+ * Replace the layout deltas for `entityName`/`layoutKind`. The backend
  * audits the change (ADR-053 §7) and rejects unknown delta kinds.
  *
- * `PUT {apiBase}/entities/{name}/customization/forms/{variant}`
+ * `PUT {apiBase}/entities/{name}/customization/{layoutKind}`
  */
-export async function putFormCustomization(
+export async function putEntityCustomization(
   client: AxiosInstance,
   apiBase: string,
   entityName: string,
-  variant: FormVariant,
-  request: FormCustomizationRequest
-): Promise<FormCustomizationResponse> {
-  const response = await client.put<FormCustomizationResponse>(
-    formPath(apiBase, entityName, variant),
+  layoutKind: LayoutKind,
+  request: EntityCustomizationRequest
+): Promise<EntityCustomizationResponse> {
+  const response = await client.put<EntityCustomizationResponse>(
+    customizationPath(apiBase, entityName, layoutKind),
     request
   );
   return response.data;
+}
+
+/**
+ * Delete the customization record for `entityName`/`layoutKind`, restoring
+ * the base-layer layout.
+ *
+ * `DELETE {apiBase}/entities/{name}/customization/{layoutKind}`
+ */
+export async function deleteEntityCustomization(
+  client: AxiosInstance,
+  apiBase: string,
+  entityName: string,
+  layoutKind: LayoutKind
+): Promise<void> {
+  await client.delete(customizationPath(apiBase, entityName, layoutKind));
 }

--- a/packages/@granit/entities-customization/src/index.ts
+++ b/packages/@granit/entities-customization/src/index.ts
@@ -1,11 +1,11 @@
 // Types
 export type {
-  FormCustomizationRequest,
-  FormCustomizationResponse,
-  FormVariant,
+  EntityCustomizationRequest,
+  EntityCustomizationResponse,
   HideDelta,
   LayoutDelta,
   LayoutDeltaKind,
+  LayoutKind,
   RegroupDelta,
   ReorderDelta,
   WorkspaceCustomizationRequest,
@@ -15,8 +15,14 @@ export type {
 // Permissions
 export { CustomizationPermissions } from './permissions';
 
-// API
-export { getFormCustomization, putFormCustomization } from './api/form-customization-api';
+// API — entity customization
+export {
+  deleteEntityCustomization,
+  getEntityCustomization,
+  putEntityCustomization,
+} from './api/form-customization-api';
+
+// API — workspace customization
 export {
   getWorkspaceCustomization,
   putWorkspaceCustomization,

--- a/packages/@granit/entities-customization/src/types/customization.ts
+++ b/packages/@granit/entities-customization/src/types/customization.ts
@@ -1,32 +1,30 @@
 import type { LayoutDelta } from './delta';
 
 /**
- * Form variant — closed catalog mirroring `Granit.EntitiesCustomization.FormVariant`.
- * Customization scopes layouts per variant so the same entity can have different
- * field arrangements on the create form, the edit form, and the read view.
+ * Layout kind — the surface of an entity layout being customized. Mirrors
+ * `Granit.EntitiesCustomization.LayoutKind`.
  */
-export type FormVariant = 'Create' | 'Edit' | 'Read';
+export type LayoutKind = 'FormDefault' | 'DetailDefault' | 'List' | 'Calendar' | 'Gallery';
 
-/** Body for `PUT /api/entities/{name}/customization/forms/{variant}`. */
-export interface FormCustomizationRequest {
+/** Body for `PUT /entities/{name}/customization/{layoutKind}`. */
+export interface EntityCustomizationRequest {
   readonly deltas: readonly LayoutDelta[];
 }
 
-/** Response from `GET|PUT /api/entities/{name}/customization/forms/{variant}`. */
-export interface FormCustomizationResponse {
+/** Response from `GET|PUT /entities/{name}/customization/{layoutKind}`. */
+export interface EntityCustomizationResponse {
+  readonly id: string;
   readonly entityName: string;
-  readonly variant: FormVariant;
+  readonly layoutKind: LayoutKind;
   readonly deltas: readonly LayoutDelta[];
-  readonly updatedAt: string | null;
-  readonly updatedByUserId: string | null;
 }
 
-/** Body for `PUT /api/workspaces/{name}/customization`. */
+/** Body for `PUT /workspaces/{name}/customization`. */
 export interface WorkspaceCustomizationRequest {
   readonly deltas: readonly LayoutDelta[];
 }
 
-/** Response from `GET|PUT /api/workspaces/{name}/customization`. */
+/** Response from `GET|PUT /workspaces/{name}/customization`. */
 export interface WorkspaceCustomizationResponse {
   readonly workspaceName: string;
   readonly deltas: readonly LayoutDelta[];

--- a/packages/@granit/entities-customization/src/types/delta.ts
+++ b/packages/@granit/entities-customization/src/types/delta.ts
@@ -2,30 +2,34 @@
  * Closed catalog of layout deltas — mirrors `Granit.EntitiesCustomization.LayoutDelta`
  * (ADR-053 Layer 1). Adding a new delta kind requires an ADR amendment +
  * coordinated backend/front change; new shapes never appear "by convention".
+ *
+ * The `$type` discriminator and its lowercase values are the wire format used
+ * by the backend (`System.Text.Json` polymorphic serialization).
  */
-export type LayoutDeltaKind = 'Reorder' | 'Regroup' | 'Hide';
+export type LayoutDeltaKind = 'reorder' | 'regroup' | 'hide';
 
 /**
  * Move a field relative to a sibling. Exactly one of `beforeFieldName` or
- * `afterFieldName` must be defined; setting both is a backend 422.
+ * `afterFieldName` must be non-null; the other must be null. Setting both
+ * non-null is a backend 422.
  */
 export interface ReorderDelta {
-  readonly kind: 'Reorder';
+  readonly $type: 'reorder';
   readonly fieldName: string;
-  readonly beforeFieldName?: string;
-  readonly afterFieldName?: string;
+  readonly beforeFieldName: string | null;
+  readonly afterFieldName: string | null;
 }
 
 /** Move a field into a group (created on the fly if it doesn't exist yet). */
 export interface RegroupDelta {
-  readonly kind: 'Regroup';
+  readonly $type: 'regroup';
   readonly fieldName: string;
   readonly groupKey: string;
 }
 
-/** Hide a field from the current variant; backend keeps it in the schema. */
+/** Hide a field from the current layout; backend keeps it in the schema. */
 export interface HideDelta {
-  readonly kind: 'Hide';
+  readonly $type: 'hide';
   readonly fieldName: string;
 }
 

--- a/packages/@granit/entities-customization/src/types/index.ts
+++ b/packages/@granit/entities-customization/src/types/index.ts
@@ -1,8 +1,8 @@
 export type { HideDelta, LayoutDelta, LayoutDeltaKind, RegroupDelta, ReorderDelta } from './delta';
 export type {
-  FormCustomizationRequest,
-  FormCustomizationResponse,
-  FormVariant,
+  EntityCustomizationRequest,
+  EntityCustomizationResponse,
+  LayoutKind,
   WorkspaceCustomizationRequest,
   WorkspaceCustomizationResponse,
 } from './customization';

--- a/packages/@granit/entities/src/types/bulk.ts
+++ b/packages/@granit/entities/src/types/bulk.ts
@@ -1,51 +1,34 @@
 /**
  * Wire shapes for the bulk-action endpoint shipped by
- * `Granit.Entities.Endpoints` (per granit-fx/granit-dotnet#1792 / #1822).
+ * `Granit.Entities.Endpoints`.
  *
  * `POST /entities/{name}/bulk/{action}` fans out a single action across
- * many ids with **one batched event emitted per parent affected** —
- * avoids the N invalidations a per-row dispatch would trigger.
- *
- * Request: ids of the rows to act on + an optional bag of parameters
- * (passed through to the action executor; shape is action-specific).
- *
- * Response surfaces three lists so the client can:
- * - re-render the rows the action succeeded on (`ok`),
- * - keep the failed rows selected for retry + show their per-id error
- *   (`failed`),
- * - invalidate exactly the affected parents' relation-aggregate caches
- *   for smart-button refresh (`parents`).
+ * many ids in one round-trip. The backend captures per-id failures without
+ * short-circuiting and surfaces them in `failures`; `affected` counts the
+ * rows that were successfully processed.
  */
 export interface BulkActionRequest {
   /** Ids of the rows the action targets. Must be non-empty. */
   readonly ids: readonly string[];
   /**
-   * Optional action-specific parameter bag. Wire-passed verbatim to the
-   * action executor — the shape is owned by the action's contract, not
-   * by this envelope.
+   * Action-specific payload — wire-passed verbatim as a JSON value to the
+   * action executor. Shape is owned by the action's contract, not this
+   * envelope. Mirrors `Granit.Entities.Endpoints.Dtos.BulkActionRequest.Payload`
+   * (JsonElement on the .NET side).
    */
-  readonly parameters?: Readonly<Record<string, unknown>>;
+  readonly payload: unknown;
 }
 
-/** Per-id error captured by the bulk endpoint when a single row fails. */
+/** Per-id failure captured by the bulk endpoint when a single row fails. */
 export interface BulkActionFailure {
   readonly id: string;
   /** Human-readable reason — backend already localizes when applicable. */
-  readonly error: string;
-  /** Optional machine-readable error code. */
-  readonly errorCode: string | null;
+  readonly reason: string;
 }
 
 export interface BulkActionResponse {
-  /** Ids that succeeded. */
-  readonly ok: readonly string[];
+  /** Number of rows successfully processed. */
+  readonly affected: number;
   /** Per-id failures captured without short-circuiting the batch. */
-  readonly failed: readonly BulkActionFailure[];
-  /**
-   * Distinct parent entity instances impacted by the batch — the front
-   * uses this list to invalidate the right relation-aggregate caches in
-   * exactly one step per parent, mirroring the backend's batched-event
-   * semantics. Format: `"{ParentEntityName}:{ParentId}"`.
-   */
-  readonly parents: readonly string[];
+  readonly failures: readonly BulkActionFailure[];
 }

--- a/packages/@granit/entities/src/types/form.ts
+++ b/packages/@granit/entities/src/types/form.ts
@@ -2,6 +2,30 @@ import type { VisibilityCondition } from './visibility';
 import type { LookupDescriptor } from '@granit/data-lookup';
 
 /**
+ * Identifies the manifest layer that contributed a field, and the optional
+ * override record that introduced it. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityProvenance`.
+ */
+export interface EntityProvenance {
+  /** Layer identifier (e.g. `"base"`, `"tenant"`, `"user"`). */
+  readonly layer: string;
+  /** Id of the override record that introduced the field, or `null` for base-layer fields. */
+  readonly overrideId: string | null;
+}
+
+/**
+ * Describes an owned collection rendered inline within a form section.
+ * Mirrors `Granit.Entities.Endpoints.Dtos.EntityFormOwnedCollectionManifest`.
+ */
+export interface EntityFormOwnedCollectionManifest {
+  readonly propertyName: string;
+  readonly itemTypeName: string;
+  readonly itemFields: readonly string[];
+  readonly itemDisplayProperty: string | null;
+  readonly maxRendered: number | null;
+}
+
+/**
  * One form field. Mirrors
  * `Granit.Entities.Endpoints.Dtos.EntityFormFieldManifest`.
  */
@@ -37,6 +61,12 @@ export interface EntityFormFieldManifest {
    * .NET `FieldDescriptor.Lookup`; `null` for fields without a declared lookup.
    */
   readonly lookup: LookupDescriptor | null;
+  /**
+   * Provenance of the field declaration — identifies which manifest layer
+   * and, if applicable, which override record introduced it. `null` for
+   * base-layer fields without a tracked origin.
+   */
+  readonly provenance: EntityProvenance | null;
 }
 
 /**
@@ -54,6 +84,11 @@ export interface EntityFormSectionManifest {
   readonly collapsedByDefault: boolean;
   /** Fields the user is allowed to see — already permission-filtered server-side. */
   readonly fields: readonly EntityFormFieldManifest[];
+  /**
+   * Optional inline owned-collection rendered in this section. `null` when
+   * the section is a plain field group.
+   */
+  readonly ownedCollection: EntityFormOwnedCollectionManifest | null;
 }
 
 /**
@@ -67,4 +102,10 @@ export interface EntityFormManifest {
   readonly customizable: boolean;
   /** Sections in declaration order. */
   readonly sections: readonly EntityFormSectionManifest[];
+  /**
+   * Field names hidden by an active admin override (Layer 1). `null` when
+   * no fields are overridden, or when the manifest was fetched without the
+   * customization facet.
+   */
+  readonly hiddenByOverride: readonly string[] | null;
 }

--- a/packages/@granit/entities/src/types/index.ts
+++ b/packages/@granit/entities/src/types/index.ts
@@ -21,7 +21,9 @@ export type {
 export type {
   EntityFormFieldManifest,
   EntityFormManifest,
+  EntityFormOwnedCollectionManifest,
   EntityFormSectionManifest,
+  EntityProvenance,
 } from './form';
 export type { EntityIdentitySection } from './identity';
 export type {
@@ -43,7 +45,7 @@ export type {
   KanbanColumnState,
 } from './layouts';
 export { ALL_ENTITY_FACETS, MANIFEST_SCHEMA_VERSION } from './manifest';
-export type { EntityFacet, EntityManifestResponse } from './manifest';
+export type { EntityActivitiesManifest, EntityFacet, EntityManifestResponse } from './manifest';
 export type { EntityPermissionsSection } from './permissions';
 export type {
   EntityRelationAggregateManifest,

--- a/packages/@granit/entities/src/types/manifest.ts
+++ b/packages/@granit/entities/src/types/manifest.ts
@@ -7,6 +7,18 @@ import type { EntityPermissionsSection } from './permissions';
 import type { EntityRelationManifest } from './relations';
 
 /**
+ * Activities configuration for an entity — which activity types are allowed
+ * and the optional default assignee rule. Mirrors
+ * `Granit.Entities.Endpoints.Dtos.EntityActivitiesManifest`.
+ */
+export interface EntityActivitiesManifest {
+  /** Closed list of activity type identifiers allowed for this entity. */
+  readonly allowedTypes: readonly string[];
+  /** Default assignee rule identifier, or `null` when there is no default. */
+  readonly defaultAssignee: string | null;
+}
+
+/**
  * Selectable facets of the per-entity manifest. Wire form: comma-separated
  * lowercase names in the `?facets=` query parameter (e.g.
  * `?facets=identity,forms`). Default — when the query parameter is absent
@@ -26,7 +38,8 @@ export type EntityFacet =
   | 'exports'
   | 'views'
   | 'relations'
-  | 'actions';
+  | 'actions'
+  | 'activities';
 
 /** All facets — handy default value for callers that want everything explicit. */
 export const ALL_ENTITY_FACETS: readonly EntityFacet[] = Object.freeze([
@@ -40,6 +53,7 @@ export const ALL_ENTITY_FACETS: readonly EntityFacet[] = Object.freeze([
   'views',
   'relations',
   'actions',
+  'activities',
 ]);
 
 /**
@@ -61,6 +75,7 @@ export interface EntityManifestResponse {
   readonly collections: EntityCollectionsSection | null;
   readonly relations: readonly EntityRelationManifest[] | null;
   readonly actions: readonly EntityActionManifest[] | null;
+  readonly activities: EntityActivitiesManifest | null;
 }
 
 /**

--- a/packages/@granit/react-entities-customization/src/__tests__/apply-deltas.test.ts
+++ b/packages/@granit/react-entities-customization/src/__tests__/apply-deltas.test.ts
@@ -29,47 +29,62 @@ describe('applyDeltas', () => {
   });
 
   it('hides a field via Hide delta', () => {
-    const result = applyDeltas(fields, [{ kind: 'Hide', fieldName: 'internalNotes' }]);
+    const result = applyDeltas(fields, [{ $type: 'hide', fieldName: 'internalNotes' }]);
     expect(result.find((f) => f.name === 'internalNotes')?.hidden).toBe(true);
   });
 
   it('reassigns the group via Regroup delta', () => {
     const result = applyDeltas(fields, [
-      { kind: 'Regroup', fieldName: 'amount', groupKey: 'finance' },
+      { $type: 'regroup', fieldName: 'amount', groupKey: 'finance' },
     ]);
     expect(result.find((f) => f.name === 'amount')?.group).toBe('finance');
   });
 
   it('moves a field before an anchor via Reorder.beforeFieldName', () => {
     const result = applyDeltas(fields, [
-      { kind: 'Reorder', fieldName: 'currency', beforeFieldName: 'amount' },
+      {
+        $type: 'reorder',
+        fieldName: 'currency',
+        beforeFieldName: 'amount',
+        afterFieldName: null,
+      },
     ]);
     expect(result.map((f) => f.name)).toEqual(['name', 'currency', 'amount', 'internalNotes']);
   });
 
   it('moves a field after an anchor via Reorder.afterFieldName', () => {
     const result = applyDeltas(fields, [
-      { kind: 'Reorder', fieldName: 'name', afterFieldName: 'currency' },
+      {
+        $type: 'reorder',
+        fieldName: 'name',
+        beforeFieldName: null,
+        afterFieldName: 'currency',
+      },
     ]);
     expect(result.map((f) => f.name)).toEqual(['amount', 'currency', 'name', 'internalNotes']);
   });
 
   it('ignores Reorder when the anchor does not exist', () => {
     const result = applyDeltas(fields, [
-      { kind: 'Reorder', fieldName: 'name', beforeFieldName: 'unknownField' },
+      {
+        $type: 'reorder',
+        fieldName: 'name',
+        beforeFieldName: 'unknownField',
+        afterFieldName: null,
+      },
     ]);
     expect(result.map((f) => f.name)).toEqual(['name', 'amount', 'currency', 'internalNotes']);
   });
 
   it('ignores deltas targeting unknown fields', () => {
-    const result = applyDeltas(fields, [{ kind: 'Hide', fieldName: 'mystery' }]);
+    const result = applyDeltas(fields, [{ $type: 'hide', fieldName: 'mystery' }]);
     expect(result.every((f) => !f.hidden)).toBe(true);
   });
 
   it('applies deltas in order — later wins for the same field/kind', () => {
     const deltas: readonly LayoutDelta[] = [
-      { kind: 'Regroup', fieldName: 'amount', groupKey: 'finance' },
-      { kind: 'Regroup', fieldName: 'amount', groupKey: 'totals' },
+      { $type: 'regroup', fieldName: 'amount', groupKey: 'finance' },
+      { $type: 'regroup', fieldName: 'amount', groupKey: 'totals' },
     ];
     expect(applyDeltas(fields, deltas).find((f) => f.name === 'amount')?.group).toBe('totals');
   });
@@ -108,11 +123,11 @@ describe('moveFieldUp / moveFieldDown', () => {
 describe('toggleFieldHidden', () => {
   it('appends a Hide delta when the field is currently visible', () => {
     const next = toggleFieldHidden(fields, [], 'amount');
-    expect(next).toEqual([{ kind: 'Hide', fieldName: 'amount' }]);
+    expect(next).toEqual([{ $type: 'hide', fieldName: 'amount' }]);
   });
 
   it('strips Hide deltas when the field is currently hidden', () => {
-    const initial: readonly LayoutDelta[] = [{ kind: 'Hide', fieldName: 'amount' }];
+    const initial: readonly LayoutDelta[] = [{ $type: 'hide', fieldName: 'amount' }];
     expect(toggleFieldHidden(fields, initial, 'amount')).toEqual([]);
   });
 });
@@ -120,16 +135,16 @@ describe('toggleFieldHidden', () => {
 describe('setFieldGroup', () => {
   it('replaces any prior Regroup delta for the field', () => {
     const initial: readonly LayoutDelta[] = [
-      { kind: 'Regroup', fieldName: 'amount', groupKey: 'old' },
+      { $type: 'regroup', fieldName: 'amount', groupKey: 'old' },
     ];
     expect(setFieldGroup(initial, 'amount', 'new')).toEqual([
-      { kind: 'Regroup', fieldName: 'amount', groupKey: 'new' },
+      { $type: 'regroup', fieldName: 'amount', groupKey: 'new' },
     ]);
   });
 
   it('clears the group when groupKey is empty', () => {
     const initial: readonly LayoutDelta[] = [
-      { kind: 'Regroup', fieldName: 'amount', groupKey: 'old' },
+      { $type: 'regroup', fieldName: 'amount', groupKey: 'old' },
     ];
     expect(setFieldGroup(initial, 'amount', '')).toEqual([]);
   });

--- a/packages/@granit/react-entities-customization/src/__tests__/form-layout-editor.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/form-layout-editor.test.tsx
@@ -69,7 +69,12 @@ describe('FormLayoutEditor', () => {
     fireEvent.click(down);
 
     expect(onChange).toHaveBeenCalledWith([
-      { kind: 'Reorder', fieldName: 'amount', afterFieldName: 'currency' },
+      {
+        $type: 'reorder',
+        fieldName: 'amount',
+        beforeFieldName: null,
+        afterFieldName: 'currency',
+      },
     ]);
     const rows = document.querySelectorAll<HTMLElement>('[data-granit-form-layout-editor-row]');
     expect([...rows].map((r) => r.dataset.fieldName)).toEqual(['name', 'currency', 'amount']);
@@ -85,7 +90,7 @@ describe('FormLayoutEditor', () => {
     )!;
     fireEvent.click(toggle);
 
-    expect(onChange).toHaveBeenCalledWith([{ kind: 'Hide', fieldName: 'amount' }]);
+    expect(onChange).toHaveBeenCalledWith([{ $type: 'hide', fieldName: 'amount' }]);
     expect(row.dataset.hidden).toBe('');
   });
 
@@ -98,7 +103,7 @@ describe('FormLayoutEditor', () => {
     fireEvent.change(select, { target: { value: 'general' } });
 
     expect(onChange).toHaveBeenCalledWith([
-      { kind: 'Regroup', fieldName: 'amount', groupKey: 'general' },
+      { $type: 'regroup', fieldName: 'amount', groupKey: 'general' },
     ]);
   });
 

--- a/packages/@granit/react-entities-customization/src/__tests__/use-form-customization.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/use-form-customization.test.tsx
@@ -5,20 +5,19 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useFormCustomization, usePutFormCustomization } from '../hooks/use-form-customization';
+import { useEntityCustomization, usePutEntityCustomization } from '../hooks/use-form-customization';
 import { CustomizationProvider } from '../providers/customization-provider';
 
 import type { AxiosInstance } from '@granit/api-client';
-import type { FormCustomizationResponse } from '@granit/entities-customization';
+import type { EntityCustomizationResponse } from '@granit/entities-customization';
 import type { QueryClient } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
-const sampleResponse: FormCustomizationResponse = {
+const sampleResponse: EntityCustomizationResponse = {
+  id: 'cust-1',
   entityName: 'Quote',
-  variant: 'Edit',
+  layoutKind: 'FormDefault',
   deltas: [],
-  updatedAt: null,
-  updatedByUserId: null,
 };
 
 interface Harness {
@@ -43,48 +42,50 @@ function createHarness(): Harness {
   return { client, queryClient, onFormCustomizationChanged, wrapper };
 }
 
-describe('useFormCustomization', () => {
-  it('GETs the form customization endpoint with the resolved key', async () => {
+describe('useEntityCustomization', () => {
+  it('GETs the entity customization endpoint with the resolved key', async () => {
     const { client, wrapper } = createHarness();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleResponse));
 
     const { result } = renderHook(
-      () => useFormCustomization({ entityName: 'Quote', variant: 'Edit' }),
+      () => useEntityCustomization({ entityName: 'Quote', layoutKind: 'FormDefault' }),
       { wrapper }
     );
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/forms/Edit');
+    expect(client.get).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/FormDefault');
     expect(result.current.data).toEqual(sampleResponse);
   });
 
   it('is disabled when entityName is empty', () => {
     const { client, wrapper } = createHarness();
 
-    renderHook(() => useFormCustomization({ entityName: '', variant: 'Edit' }), { wrapper });
+    renderHook(() => useEntityCustomization({ entityName: '', layoutKind: 'FormDefault' }), {
+      wrapper,
+    });
 
     expect(client.get).not.toHaveBeenCalled();
   });
 });
 
-describe('usePutFormCustomization', () => {
+describe('usePutEntityCustomization', () => {
   it('PUTs the deltas, invalidates the read query, and fires the manifest hook', async () => {
     const { client, queryClient, onFormCustomizationChanged, wrapper } = createHarness();
     vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleResponse));
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
-    const { result } = renderHook(() => usePutFormCustomization(), { wrapper });
+    const { result } = renderHook(() => usePutEntityCustomization(), { wrapper });
     await result.current.mutateAsync({
       entityName: 'Quote',
-      variant: 'Edit',
-      request: { deltas: [{ kind: 'Hide', fieldName: 'internalNotes' }] },
+      layoutKind: 'FormDefault',
+      request: { deltas: [{ $type: 'hide', fieldName: 'internalNotes' }] },
     });
 
-    expect(client.put).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/forms/Edit', {
-      deltas: [{ kind: 'Hide', fieldName: 'internalNotes' }],
+    expect(client.put).toHaveBeenCalledWith('/api/v1/entities/Quote/customization/FormDefault', {
+      deltas: [{ $type: 'hide', fieldName: 'internalNotes' }],
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
-    expect(keys).toContainEqual(['entities-customization', 'forms', 'Quote', 'Edit']);
+    expect(keys).toContainEqual(['entities-customization', 'layout', 'Quote', 'FormDefault']);
     expect(onFormCustomizationChanged).toHaveBeenCalledWith('Quote');
   });
 });

--- a/packages/@granit/react-entities-customization/src/__tests__/use-workspace-customization.test.tsx
+++ b/packages/@granit/react-entities-customization/src/__tests__/use-workspace-customization.test.tsx
@@ -59,11 +59,11 @@ describe('usePutWorkspaceCustomization', () => {
     const { result } = renderHook(() => usePutWorkspaceCustomization(), { wrapper });
     await result.current.mutateAsync({
       workspaceName: 'sales',
-      request: { deltas: [{ kind: 'Hide', fieldName: 'tile-pipeline' }] },
+      request: { deltas: [{ $type: 'hide', fieldName: 'tile-pipeline' }] },
     });
 
     expect(client.put).toHaveBeenCalledWith('/api/v1/workspaces/sales/customization', {
-      deltas: [{ kind: 'Hide', fieldName: 'tile-pipeline' }],
+      deltas: [{ $type: 'hide', fieldName: 'tile-pipeline' }],
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toContainEqual(['entities-customization', 'workspaces', 'sales']);

--- a/packages/@granit/react-entities-customization/src/hooks/use-form-customization.ts
+++ b/packages/@granit/react-entities-customization/src/hooks/use-form-customization.ts
@@ -1,4 +1,4 @@
-import { getFormCustomization, putFormCustomization } from '@granit/entities-customization';
+import { getEntityCustomization, putEntityCustomization } from '@granit/entities-customization';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import {
@@ -7,61 +7,61 @@ import {
 } from '../providers/customization-provider';
 
 import type {
-  FormCustomizationRequest,
-  FormCustomizationResponse,
-  FormVariant,
+  EntityCustomizationRequest,
+  EntityCustomizationResponse,
+  LayoutKind,
 } from '@granit/entities-customization';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
-interface UseFormCustomizationArgs {
+interface UseEntityCustomizationArgs {
   readonly entityName: string;
-  readonly variant: FormVariant;
+  readonly layoutKind: LayoutKind;
 }
 
 /**
- * Read the active form layout deltas for an entity/variant pair. Disabled
+ * Read the active layout deltas for an entity/layoutKind pair. Disabled
  * when `entityName` is empty.
  */
-export function useFormCustomization({
+export function useEntityCustomization({
   entityName,
-  variant,
-}: UseFormCustomizationArgs): UseQueryResult<FormCustomizationResponse> {
+  layoutKind,
+}: UseEntityCustomizationArgs): UseQueryResult<EntityCustomizationResponse> {
   const config = useCustomizationConfig();
 
   return useQuery({
-    queryKey: buildCustomizationQueryKey(config, 'forms', entityName, variant),
-    queryFn: () => getFormCustomization(config.client, config.apiBase, entityName, variant),
+    queryKey: buildCustomizationQueryKey(config, 'layout', entityName, layoutKind),
+    queryFn: () => getEntityCustomization(config.client, config.apiBase, entityName, layoutKind),
     enabled: entityName.length > 0,
   });
 }
 
-interface PutFormCustomizationArgs {
+interface PutEntityCustomizationArgs {
   readonly entityName: string;
-  readonly variant: FormVariant;
-  readonly request: FormCustomizationRequest;
+  readonly layoutKind: LayoutKind;
+  readonly request: EntityCustomizationRequest;
 }
 
 /**
- * Replace the form layout deltas for an entity/variant. On success:
- * - the matching `useFormCustomization` query is invalidated
+ * Replace the layout deltas for an entity/layoutKind. On success:
+ * - the matching `useEntityCustomization` query is invalidated
  * - the optional `onFormCustomizationChanged(entityName)` provider hook
  *   fires (apps wire it to invalidate the entity manifest cache, since the
  *   layout flows through `@granit/react-entities`).
  */
-export function usePutFormCustomization(): UseMutationResult<
-  FormCustomizationResponse,
+export function usePutEntityCustomization(): UseMutationResult<
+  EntityCustomizationResponse,
   Error,
-  PutFormCustomizationArgs
+  PutEntityCustomizationArgs
 > {
   const config = useCustomizationConfig();
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({ entityName, variant, request }: PutFormCustomizationArgs) =>
-      putFormCustomization(config.client, config.apiBase, entityName, variant, request),
-    onSuccess: (_data, { entityName, variant }) => {
+    mutationFn: ({ entityName, layoutKind, request }: PutEntityCustomizationArgs) =>
+      putEntityCustomization(config.client, config.apiBase, entityName, layoutKind, request),
+    onSuccess: (_data, { entityName, layoutKind }) => {
       queryClient.invalidateQueries({
-        queryKey: buildCustomizationQueryKey(config, 'forms', entityName, variant),
+        queryKey: buildCustomizationQueryKey(config, 'layout', entityName, layoutKind),
       });
       config.onFormCustomizationChanged?.(entityName);
     },

--- a/packages/@granit/react-entities-customization/src/index.ts
+++ b/packages/@granit/react-entities-customization/src/index.ts
@@ -14,7 +14,7 @@ export type {
 export { API_VERSION, DEFAULT_API_BASE, DEFAULT_QUERY_KEY_PREFIX } from './constants';
 
 // Hooks
-export { useFormCustomization, usePutFormCustomization } from './hooks/use-form-customization';
+export { useEntityCustomization, usePutEntityCustomization } from './hooks/use-form-customization';
 export {
   usePutWorkspaceCustomization,
   useWorkspaceCustomization,

--- a/packages/@granit/react-entities-customization/src/layout/apply-deltas.ts
+++ b/packages/@granit/react-entities-customization/src/layout/apply-deltas.ts
@@ -33,17 +33,17 @@ function applyRegroupDelta(
 
 function applyReorderDelta(
   order: string[],
-  delta: Extract<LayoutDelta, { kind: 'Reorder' }>
+  delta: Extract<LayoutDelta, { $type: 'reorder' }>
 ): void {
   const fromIdx = order.indexOf(delta.fieldName);
   if (fromIdx === -1) return;
   const anchor = delta.beforeFieldName ?? delta.afterFieldName;
-  if (anchor === undefined) return;
+  if (anchor === null) return;
   const anchorIdx = order.indexOf(anchor);
   if (anchorIdx === -1 || anchor === delta.fieldName) return;
   order.splice(fromIdx, 1);
   const reAnchor = order.indexOf(anchor);
-  const targetIdx = delta.beforeFieldName === undefined ? reAnchor + 1 : reAnchor;
+  const targetIdx = delta.beforeFieldName === null ? reAnchor + 1 : reAnchor;
   order.splice(targetIdx, 0, delta.fieldName);
 }
 
@@ -54,15 +54,15 @@ function applyReorderDelta(
  *
  * Resolution semantics (mirrors backend, ADR-053 §4):
  *  - Deltas apply in order; later deltas override earlier ones for the
- *    same field (e.g. two `Hide` deltas idempotent; `Reorder` then
- *    `Reorder` keeps the latter).
- *  - `Reorder.beforeFieldName` and `Reorder.afterFieldName` are honored
+ *    same field (e.g. two `hide` deltas idempotent; `reorder` then
+ *    `reorder` keeps the latter).
+ *  - `reorder.beforeFieldName` and `reorder.afterFieldName` are honored
  *    only if the anchor exists in the current order. Unknown anchors
  *    are silently ignored — backend rejects on PUT, so the editor
  *    never persists an invalid delta.
- *  - `Regroup` overrides `defaultGroup`.
- *  - `Hide` flips `hidden` to true (no `Show` delta — un-hiding means
- *    removing the Hide delta from the list).
+ *  - `regroup` overrides `defaultGroup`.
+ *  - `hide` flips `hidden` to true (no `show` delta — un-hiding means
+ *    removing the hide delta from the list).
  */
 export function applyDeltas(
   fields: readonly SchemaField[],
@@ -76,11 +76,11 @@ export function applyDeltas(
 
   for (const delta of deltas) {
     if (!meta.has(delta.fieldName)) continue;
-    if (delta.kind === 'Hide') {
+    if (delta.$type === 'hide') {
       applyHideDelta(meta, delta.fieldName);
-    } else if (delta.kind === 'Regroup') {
+    } else if (delta.$type === 'regroup') {
       applyRegroupDelta(meta, delta.fieldName, delta.groupKey);
-    } else if (delta.kind === 'Reorder') {
+    } else if (delta.$type === 'reorder') {
       applyReorderDelta(order, delta);
     }
   }
@@ -102,7 +102,10 @@ export function moveFieldUp(
   if (idx <= 0) return deltas;
   const previous = effective[idx - 1];
   if (previous === undefined) return deltas;
-  return [...deltas, { kind: 'Reorder', fieldName, beforeFieldName: previous.name }];
+  return [
+    ...deltas,
+    { $type: 'reorder', fieldName, beforeFieldName: previous.name, afterFieldName: null },
+  ];
 }
 
 /**
@@ -119,12 +122,15 @@ export function moveFieldDown(
   if (idx === -1 || idx >= effective.length - 1) return deltas;
   const next = effective[idx + 1];
   if (next === undefined) return deltas;
-  return [...deltas, { kind: 'Reorder', fieldName, afterFieldName: next.name }];
+  return [
+    ...deltas,
+    { $type: 'reorder', fieldName, beforeFieldName: null, afterFieldName: next.name },
+  ];
 }
 
 /**
- * Flip a field's visibility. Adding a hide appends a `Hide` delta;
- * un-hiding strips every `Hide` delta for that field (deltas remain a
+ * Flip a field's visibility. Adding a hide appends a `hide` delta;
+ * un-hiding strips every `hide` delta for that field (deltas remain a
  * historical/append log on the wire, but the editor's view is
  * declarative).
  */
@@ -137,13 +143,13 @@ export function toggleFieldHidden(
   const target = effective.find((f) => f.name === fieldName);
   if (target === undefined) return deltas;
   if (target.hidden) {
-    return deltas.filter((d) => !(d.kind === 'Hide' && d.fieldName === fieldName));
+    return deltas.filter((d) => !(d.$type === 'hide' && d.fieldName === fieldName));
   }
-  return [...deltas, { kind: 'Hide', fieldName }];
+  return [...deltas, { $type: 'hide', fieldName }];
 }
 
 /**
- * Move a field into a group. Empty `groupKey` removes any `Regroup` delta
+ * Move a field into a group. Empty `groupKey` removes any `regroup` delta
  * (the field falls back to its schema default).
  */
 export function setFieldGroup(
@@ -151,7 +157,7 @@ export function setFieldGroup(
   fieldName: string,
   groupKey: string
 ): readonly LayoutDelta[] {
-  const stripped = deltas.filter((d) => !(d.kind === 'Regroup' && d.fieldName === fieldName));
+  const stripped = deltas.filter((d) => !(d.$type === 'regroup' && d.fieldName === fieldName));
   if (groupKey.length === 0) return stripped;
-  return [...stripped, { kind: 'Regroup', fieldName, groupKey }];
+  return [...stripped, { $type: 'regroup', fieldName, groupKey }];
 }

--- a/packages/@granit/react-entities/src/__tests__/bulk-action.test.ts
+++ b/packages/@granit/react-entities/src/__tests__/bulk-action.test.ts
@@ -11,15 +11,8 @@ const ACTION = 'Approve';
 const PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY)}/bulk/${encodeURIComponent(ACTION)}`;
 
 const RESPONSE: BulkActionResponse = {
-  ok: ['q-1', 'q-2'],
-  failed: [
-    {
-      id: 'q-3',
-      error: 'Workflow transition not allowed in state Draft.',
-      errorCode: 'workflow.invalid_transition',
-    },
-  ],
-  parents: ['Party:p-1', 'Party:p-2'],
+  affected: 2,
+  failures: [{ id: 'q-3', reason: 'Workflow transition not allowed in state Draft.' }],
 };
 
 let lastBody: unknown = null;
@@ -45,22 +38,22 @@ afterAll(() => server.close());
 describe('executeBulkAction', () => {
   const client = axios.create({ baseURL: 'http://localhost' });
 
-  it('POSTs the ids + parameters bag to /entities/{name}/bulk/{action}', async () => {
+  it('POSTs the ids + payload to /entities/{name}/bulk/{action}', async () => {
     const response = await executeBulkAction(client, ENTITY, ACTION, {
       ids: ['q-1', 'q-2', 'q-3'],
-      parameters: { reason: 'Quarterly batch approval' },
+      payload: { reason: 'Quarterly batch approval' },
     });
 
     expect(response).toEqual(RESPONSE);
     expect(lastBody).toEqual({
       ids: ['q-1', 'q-2', 'q-3'],
-      parameters: { reason: 'Quarterly batch approval' },
+      payload: { reason: 'Quarterly batch approval' },
     });
   });
 
-  it('omits parameters from the wire body when not provided', async () => {
-    await executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'] });
-    expect(lastBody).toEqual({ ids: ['q-1'] });
+  it('sends payload:null when there is no action-specific data', async () => {
+    await executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'], payload: null });
+    expect(lastBody).toEqual({ ids: ['q-1'], payload: null });
   });
 
   it('URI-encodes the entity name and the action segment', async () => {
@@ -77,12 +70,13 @@ describe('executeBulkAction', () => {
   it('returns the partial-failure recap as-is so the caller can drive retry UX', async () => {
     const response = await executeBulkAction(client, ENTITY, ACTION, {
       ids: ['q-1', 'q-2', 'q-3'],
+      payload: null,
     });
 
-    expect(response.ok).toEqual(['q-1', 'q-2']);
-    expect(response.failed).toHaveLength(1);
-    expect(response.failed[0]?.id).toBe('q-3');
-    expect(response.parents).toEqual(['Party:p-1', 'Party:p-2']);
+    expect(response.affected).toBe(2);
+    expect(response.failures).toHaveLength(1);
+    expect(response.failures[0]?.id).toBe('q-3');
+    expect(response.failures[0]?.reason).toContain('Workflow transition');
   });
 
   it('propagates 422 from the backend with the AxiosError surface intact', async () => {
@@ -91,15 +85,15 @@ describe('executeBulkAction', () => {
     );
 
     await expect(
-      executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'] })
+      executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'], payload: null })
     ).rejects.toBeInstanceOf(AxiosError);
   });
 
   it('propagates 403 when the caller lacks the action permission', async () => {
     server.use(http.post(PATH, () => HttpResponse.text('forbidden', { status: 403 })));
 
-    await expect(executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'] })).rejects.toMatchObject(
-      { response: { status: 403 } }
-    );
+    await expect(
+      executeBulkAction(client, ENTITY, ACTION, { ids: ['q-1'], payload: null })
+    ).rejects.toMatchObject({ response: { status: 403 } });
   });
 });

--- a/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
+++ b/packages/@granit/react-entities/src/__tests__/selection-bar-bulk.test.tsx
@@ -20,15 +20,13 @@ const ENTITY_NAME = 'Granit.Sales.Quote';
 const BULK_PATH = `http://localhost/api/v1/entities/${encodeURIComponent(ENTITY_NAME)}/bulk/approve`;
 
 const FULL_SUCCESS: BulkActionResponse = {
-  ok: ['q1', 'q2', 'q3'],
-  failed: [],
-  parents: ['Party:p1', 'Party:p2'],
+  affected: 3,
+  failures: [],
 };
 
 const PARTIAL_FAILURE: BulkActionResponse = {
-  ok: ['q1', 'q3'],
-  failed: [{ id: 'q2', error: 'Workflow blocked', errorCode: 'wf.blocked' }],
-  parents: ['Party:p1'],
+  affected: 2,
+  failures: [{ id: 'q2', reason: 'Workflow blocked' }],
 };
 
 let lastBulkBody: { ids: readonly string[] } | null = null;
@@ -142,10 +140,10 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
     expect(bulkCallCount).toBe(1);
     expect(perRowCallCount).toBe(0);
-    expect(lastBulkBody).toEqual({ ids: ['q1', 'q2', 'q3'] });
+    expect(lastBulkBody).toMatchObject({ ids: ['q1', 'q2', 'q3'] });
   });
 
-  it('exposes parents from the response in the recap (used by D3 cache eviction)', async () => {
+  it('derives succeeded ids as (input ids) \\ (failures) and surfaces an empty failed list on full success', async () => {
     const Wrapper = makeWrapper();
     const onComplete = vi.fn();
 
@@ -163,7 +161,6 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     const recap = onComplete.mock.calls[0]?.[1];
     expect(recap.succeeded).toEqual(['q1', 'q2', 'q3']);
     expect(recap.failed).toHaveLength(0);
-    expect(recap.parents).toEqual(['Party:p1', 'Party:p2']);
   });
 
   it('keeps failed rows selected and surfaces per-id errors on partial failure', async () => {
@@ -187,7 +184,8 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     expect(recap.succeeded).toEqual(['q1', 'q3']);
     expect(recap.failed).toHaveLength(1);
     expect(recap.failed[0]?.id).toBe('q2');
-    expect(recap.failed[0]?.error).toMatchObject({ errorCode: 'wf.blocked' });
+    expect(recap.failed[0]?.error).toBeInstanceOf(Error);
+    expect((recap.failed[0]?.error as Error).message).toBe('Workflow blocked');
 
     // After partial failure, selection narrows to the failed ids so the
     // user can retry without re-picking the rows.
@@ -215,7 +213,6 @@ describe('EntitySelectionBar — bulk endpoint dispatch', () => {
     const recap = onComplete.mock.calls[0]?.[1];
     expect(recap.succeeded).toHaveLength(0);
     expect(recap.failed.map((f: { id: string }) => f.id)).toEqual(['q1', 'q2', 'q3']);
-    expect(recap.parents).toBeUndefined();
   });
 
   it('predicate form: bulk path engaged only for matching action names', async () => {

--- a/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
+++ b/packages/@granit/react-entities/src/components/entity-selection-bar.tsx
@@ -285,8 +285,11 @@ export function EntitySelectionBar({
 /**
  * Single-shot bulk dispatch. Calls
  * `POST /entities/{name}/bulk/{action}` with all ids and maps the
- * response into the existing recap shape (`succeeded` / `failed`)
- * extended with `parents` for downstream cache-eviction wiring (D3).
+ * response into the existing recap shape (`succeeded` / `failed`).
+ *
+ * Succeeded ids are derived as `ids \ failures` since the backend only
+ * returns `affected` (a count) + per-id failures; the fan-out path
+ * returns per-id results directly.
  *
  * If the endpoint itself rejects (network / 4xx / 5xx), every id is
  * surfaced as failed against the same root error — the user-visible
@@ -300,17 +303,17 @@ async function dispatchBulk(
 ): Promise<EntitySelectionBarRecap> {
   let response: BulkActionResponse;
   try {
-    response = await executeBulkAction(client, entityName, actionName, { ids });
+    response = await executeBulkAction(client, entityName, actionName, { ids, payload: null });
   } catch (error) {
     return {
       succeeded: [],
       failed: ids.map((id) => ({ id, error })),
     };
   }
+  const failedIds = new Set(response.failures.map((f) => f.id));
   return {
-    succeeded: response.ok,
-    failed: response.failed.map((f) => ({ id: f.id, error: f })),
-    parents: response.parents,
+    succeeded: ids.filter((id) => !failedIds.has(id)),
+    failed: response.failures.map((f) => ({ id: f.id, error: new Error(f.reason) })),
   };
 }
 


### PR DESCRIPTION
## Summary

- **BREAKING** `LayoutDelta` discriminant changed from `kind` (PascalCase) to `$type` (lowercase) — matches the .NET `System.Text.Json` polymorphic wire format (`$type: 'reorder'|'regroup'|'hide'`). All delta constructors, `applyDeltas`, tests, and Showcase updated.
- **BREAKING** `BulkActionRequest.parameters` replaced by `payload: unknown` (required). `BulkActionResponse` shape changed from `{ok,failed,parents}` to `{affected: number, failures: {id,reason}[]}`. `dispatchBulk` now derives succeeded IDs as `ids \ failures`.
- **BREAKING** `@granit/entities-customization` route no longer uses `/forms/` segment — now `/customization/{layoutKind}`. `FormVariant` replaced by `LayoutKind` (`'FormDefault'|'DetailDefault'|'List'|'Calendar'|'Gallery'`). Hooks renamed `useEntityCustomization` / `usePutEntityCustomization`.

Additional GAP fixes:
- `@granit/entities`: add `EntityProvenance`, `EntityFormOwnedCollectionManifest`, `EntityActivitiesManifest`; add `hiddenByOverride` and `activities` facets to `EntityManifestResponse`
- `@granit/entities-customization`: `ReorderDelta.beforeFieldName`/`afterFieldName` are now required+nullable (`string | null`) matching the backend contract; add `deleteEntityCustomization`

## Test plan

- [x] `pnpm tsc` — passes (pre-commit hook)
- [x] `pnpm lint` — passes (pre-commit hook)
- [x] `@granit/react-entities` bulk tests: 12/12 pass
- [x] `@granit/react-entities-customization` apply-deltas + form-layout-editor + use-form-customization + use-workspace-customization tests pass
- [x] `@granit/entities-customization` form-customization-api + workspace-customization-api tests pass
- [ ] Showcase `customization-page.tsx` and MSW handlers updated — follow-up MR on `granit-showcase-react`