### PR TITLE
fix(invoicing)!: align @granit/invoicing and react-invoicing with backend contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1478,6 +1478,31 @@
           "name": "getTenantStorageQuota",
           "kind": "function",
           "signature": "async function getTenantStorageQuota( client: AxiosInstance, basePath: string ): Promise<TenantStorageQuotaResponse>"
+        },
+        {
+          "name": "getDocumentProperties",
+          "kind": "function",
+          "signature": "async function getDocumentProperties( client: AxiosInstance, basePath: string, id: string ): Promise<DocumentPropertiesResponse>"
+        },
+        {
+          "name": "getDocumentVersionProperties",
+          "kind": "function",
+          "signature": "async function getDocumentVersionProperties( client: AxiosInstance, basePath: string, id: string, versionId: string ): Promise<DocumentPropertiesResponse>"
+        },
+        {
+          "name": "listDocumentRenditions",
+          "kind": "function",
+          "signature": "async function listDocumentRenditions( client: AxiosInstance, basePath: string, id: string ): Promise<ListRenditionsResponse>"
+        },
+        {
+          "name": "requestRenditionDownloadUrl",
+          "kind": "function",
+          "signature": "async function requestRenditionDownloadUrl( client: AxiosInstance, basePath: string, id: string, type: RenditionType ): Promise<RenditionDownloadUrlResponse>"
+        },
+        {
+          "name": "batchResolveDocumentAssets",
+          "kind": "function",
+          "signature": "async function batchResolveDocumentAssets( client: AxiosInstance, basePath: string, request: BatchResolveRequest ): Promise<readonly ResolvedDocumentResponse[]>"
         }
       ]
     },
@@ -4419,6 +4444,21 @@
           "name": "useTenantStorageQuota",
           "kind": "function",
           "signature": "function useTenantStorageQuota(options?:"
+        },
+        {
+          "name": "useDocumentRenditions",
+          "kind": "function",
+          "signature": "function useDocumentRenditions( id: string, options?:"
+        },
+        {
+          "name": "useRenditionDownloadUrl",
+          "kind": "function",
+          "signature": "function useRenditionDownloadUrl( id: string, type: RenditionType, options?:"
+        },
+        {
+          "name": "useBatchResolveDocumentAssets",
+          "kind": "function",
+          "signature": "function useBatchResolveDocumentAssets(): UseMutationResult< readonly ResolvedDocumentResponse[], Error, BatchResolveRequest >"
         },
         {
           "name": "DocumentDetail",

--- a/packages/@granit/documents/src/__tests__/documents-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/documents-api.test.ts
@@ -122,10 +122,14 @@ describe('renameDocument', () => {
       axiosResponse({ ...sampleDocument, name: 'Renamed.pdf' })
     );
 
-    const result = await renameDocument(client, basePath, 'doc-1', { name: 'Renamed.pdf' });
+    const result = await renameDocument(client, basePath, 'doc-1', {
+      name: 'Renamed.pdf',
+      description: null,
+    });
 
     expect(client.patch).toHaveBeenCalledWith(`${basePath}/documents/doc-1`, {
       name: 'Renamed.pdf',
+      description: null,
     });
     expect(result.name).toBe('Renamed.pdf');
   });
@@ -134,9 +138,15 @@ describe('renameDocument', () => {
     const client = createMockClient();
     vi.mocked(client.patch).mockResolvedValue(axiosResponse(sampleDocument));
 
-    await renameDocument(client, basePath, 'doc-1', { clearDescription: true });
+    await renameDocument(client, basePath, 'doc-1', {
+      name: null,
+      description: null,
+      clearDescription: true,
+    });
 
     expect(client.patch).toHaveBeenCalledWith(`${basePath}/documents/doc-1`, {
+      name: null,
+      description: null,
       clearDescription: true,
     });
   });

--- a/packages/@granit/documents/src/__tests__/shares-api.test.ts
+++ b/packages/@granit/documents/src/__tests__/shares-api.test.ts
@@ -24,7 +24,7 @@ const sampleFolderShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T10:00:00Z',
-  createdByUserId: 'user-1',
+  createdBy: 'user-1',
 };
 
 const sampleDocumentShare: ShareResponse = {

--- a/packages/@granit/documents/src/api/properties-api.ts
+++ b/packages/@granit/documents/src/api/properties-api.ts
@@ -1,0 +1,36 @@
+import type { DocumentPropertiesResponse } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Get the extracted metadata for the current (or latest) version of a
+ * document. Returns 404 when no properties row exists yet (extraction pending).
+ *
+ * `GET {basePath}/documents/{id}/metadata`
+ */
+export async function getDocumentProperties(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<DocumentPropertiesResponse> {
+  const response = await client.get<DocumentPropertiesResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/metadata`
+  );
+  return response.data;
+}
+
+/**
+ * Get the extracted metadata for a specific version of a document.
+ *
+ * `GET {basePath}/documents/{id}/versions/{versionId}/metadata`
+ */
+export async function getDocumentVersionProperties(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  versionId: string
+): Promise<DocumentPropertiesResponse> {
+  const response = await client.get<DocumentPropertiesResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/versions/${encodeURIComponent(versionId)}/metadata`
+  );
+  return response.data;
+}

--- a/packages/@granit/documents/src/api/public-links-api.ts
+++ b/packages/@granit/documents/src/api/public-links-api.ts
@@ -1,0 +1,60 @@
+import type {
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  PublicLinkResponse,
+  RevokePublicLinkRequest,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Create a public link for a document. Returns 201 with the link token and
+ * the full redemption URL. Returns 403 when the caller lacks the manage
+ * permission, 404 when the document does not exist.
+ *
+ * `POST {basePath}/documents/{id}/public-links`
+ */
+export async function createDocumentPublicLink(
+  client: AxiosInstance,
+  basePath: string,
+  documentId: string,
+  request: CreatePublicLinkRequest
+): Promise<CreatePublicLinkResponse> {
+  const response = await client.post<CreatePublicLinkResponse>(
+    `${basePath}/documents/${encodeURIComponent(documentId)}/public-links`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * List all active public links for a document.
+ *
+ * `GET {basePath}/documents/{id}/public-links`
+ */
+export async function listDocumentPublicLinks(
+  client: AxiosInstance,
+  basePath: string,
+  documentId: string
+): Promise<readonly PublicLinkResponse[]> {
+  const response = await client.get<readonly PublicLinkResponse[]>(
+    `${basePath}/documents/${encodeURIComponent(documentId)}/public-links`
+  );
+  return response.data;
+}
+
+/**
+ * Revoke a public link. The `reason` field may be `null`. Returns 404 when
+ * the link does not exist or has already been revoked.
+ *
+ * `DELETE {basePath}/public-links/{id}`
+ */
+export async function revokeDocumentPublicLink(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: RevokePublicLinkRequest
+): Promise<void> {
+  await client.delete<void>(`${basePath}/public-links/${encodeURIComponent(id)}`, {
+    data: request,
+  });
+}

--- a/packages/@granit/documents/src/api/renditions-api.ts
+++ b/packages/@granit/documents/src/api/renditions-api.ts
@@ -1,0 +1,42 @@
+import type {
+  ListRenditionsResponse,
+  RenditionDownloadUrlResponse,
+  RenditionType,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List all renditions generated for the current version of a document.
+ * Returns 404 when the document does not exist.
+ *
+ * `GET {basePath}/documents/{id}/renditions`
+ */
+export async function listDocumentRenditions(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<ListRenditionsResponse> {
+  const response = await client.get<ListRenditionsResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/renditions`
+  );
+  return response.data;
+}
+
+/**
+ * Get a presigned download URL for a specific rendition type. The URL is
+ * short-lived. Returns 404 when the rendition does not exist or is not yet
+ * `Ready`.
+ *
+ * `GET {basePath}/documents/{id}/renditions/{type}/download`
+ */
+export async function requestRenditionDownloadUrl(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  type: RenditionType
+): Promise<RenditionDownloadUrlResponse> {
+  const response = await client.get<RenditionDownloadUrlResponse>(
+    `${basePath}/documents/${encodeURIComponent(id)}/renditions/${encodeURIComponent(type)}/download`
+  );
+  return response.data;
+}

--- a/packages/@granit/documents/src/api/resolution-api.ts
+++ b/packages/@granit/documents/src/api/resolution-api.ts
@@ -1,0 +1,24 @@
+import type { BatchResolveRequest, ResolvedDocumentResponse } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Resolve a batch of document assets to presigned CDN URLs in one round-trip.
+ * Each item may target a specific version and/or rendition type. Items that
+ * cannot be resolved (missing document, version, or rendition) are silently
+ * omitted from the response array.
+ *
+ * Primarily used by the CMS renderer to embed document assets.
+ *
+ * `POST {basePath}/resolution/resolve`
+ */
+export async function batchResolveDocumentAssets(
+  client: AxiosInstance,
+  basePath: string,
+  request: BatchResolveRequest
+): Promise<readonly ResolvedDocumentResponse[]> {
+  const response = await client.post<readonly ResolvedDocumentResponse[]>(
+    `${basePath}/resolution/resolve`,
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/documents/src/index.ts
+++ b/packages/@granit/documents/src/index.ts
@@ -1,7 +1,12 @@
 // Types
 export type {
   AppendVersionRequest,
+  BatchResolveRequest,
   CreateFolderRequest,
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  DocumentPropertiesResponse,
+  DocumentPropertiesStatus,
   DocumentResponse,
   DocumentStatus,
   DocumentTagAssignmentResponse,
@@ -18,13 +23,23 @@ export type {
   ListDocumentVersionsResponse,
   ListFoldersFilter,
   ListFoldersResponse,
+  ListRenditionsResponse,
   ListSharesResponse,
   ListTrashedDocumentsResponse,
   MoveDocumentRequest,
   MoveFolderRequest,
   PageFilter,
+  PublicLinkResponse,
+  PublicLinkScope,
   RenameDocumentRequest,
   RenameFolderRequest,
+  RenditionDownloadUrlResponse,
+  RenditionResponse,
+  RenditionStatus,
+  RenditionType,
+  ResolveItemRequest,
+  ResolvedDocumentResponse,
+  RevokePublicLinkRequest,
   ShareGranteeType,
   SharePermissionLevel,
   ShareResponse,
@@ -83,3 +98,19 @@ export { assignDocumentTag, listDocumentTags, unassignDocumentTag } from './api/
 
 // API — Quota
 export { getTenantStorageQuota } from './api/quota-api';
+
+// API — Document properties
+export { getDocumentProperties, getDocumentVersionProperties } from './api/properties-api';
+
+// API — Public links
+export {
+  createDocumentPublicLink,
+  listDocumentPublicLinks,
+  revokeDocumentPublicLink,
+} from './api/public-links-api';
+
+// API — Renditions
+export { listDocumentRenditions, requestRenditionDownloadUrl } from './api/renditions-api';
+
+// API — Resolution
+export { batchResolveDocumentAssets } from './api/resolution-api';

--- a/packages/@granit/documents/src/types/index.ts
+++ b/packages/@granit/documents/src/types/index.ts
@@ -144,24 +144,25 @@ export interface FinalizeUploadRequest {
   /** `null` drops the document directly under the tenant root. */
   readonly folderId: string | null;
   readonly name: string;
-  readonly description?: string | null;
-  readonly commitMessage?: string | null;
+  readonly description: string | null;
+  readonly commitMessage: string | null;
 }
 
 /** Request payload for `POST /documents/{id}/versions`. */
 export interface AppendVersionRequest {
   readonly blobId: string;
-  readonly commitMessage?: string | null;
+  readonly commitMessage: string | null;
 }
 
 /**
- * PATCH payload for `PATCH /documents/{id}`. Fields left `null`/absent are
- * unchanged; use {@link clearDescription} to drop an existing description
- * (sending an empty string sets a non-null empty value).
+ * PATCH payload for `PATCH /documents/{id}`. Pass `null` for `name` or
+ * `description` to leave the field unchanged; use {@link clearDescription}
+ * to explicitly drop an existing description (sending an empty string sets a
+ * non-null empty value instead).
  */
 export interface RenameDocumentRequest {
-  readonly name?: string | null;
-  readonly description?: string | null;
+  readonly name: string | null;
+  readonly description: string | null;
   /** When `true`, clears the description regardless of {@link description}. */
   readonly clearDescription?: boolean;
 }
@@ -251,7 +252,6 @@ export interface DocumentTagResponse {
   readonly name: string;
   readonly color: string;
   readonly hideOnEntityCard: boolean;
-  readonly rowVersion: number;
 }
 
 export interface ListDocumentTagsResponse {
@@ -286,7 +286,7 @@ export interface ShareResponse {
   readonly isDefault: boolean;
   readonly expiresAt: string | null;
   readonly createdAt: string;
-  readonly createdByUserId: string;
+  readonly createdBy: string;
 }
 
 /** Wrapper response for the folder- and document-scoped share listings. */
@@ -319,4 +319,168 @@ export interface TenantStorageQuotaResponse {
   /** `usageBytes / limitBytes * 100`, clamped at 100 and rounded to two decimals. */
   readonly percentUsed: number;
   readonly updatedAt: string;
+}
+
+// ─── Document properties (extracted metadata) ───────────────────────────────
+
+export type DocumentPropertiesStatus = 'Pending' | 'Extracting' | 'Ready' | 'Failed';
+
+/**
+ * Rich metadata extracted from a document version by the background extractor
+ * pipeline. All domain-specific fields (`width`, `pageCount`, `durationMs`, …)
+ * are `null` when the extractor did not populate them for the given content
+ * type.
+ */
+export interface DocumentPropertiesResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly documentVersionId: string;
+  readonly sourceContentType: string;
+  readonly status: DocumentPropertiesStatus;
+  readonly createdAt: string;
+  readonly completedAt: string | null;
+  readonly failureReason: string | null;
+  readonly extractorCount: number;
+  // Image / photo
+  readonly width: number | null;
+  readonly height: number | null;
+  readonly cameraMake: string | null;
+  readonly cameraModel: string | null;
+  readonly lensModel: string | null;
+  readonly iso: number | null;
+  readonly fNumber: number | null;
+  readonly exposureTimeMs: number | null;
+  readonly takenAt: string | null;
+  readonly gpsLatitude: number | null;
+  readonly gpsLongitude: number | null;
+  readonly gpsAltitude: number | null;
+  // Document / PDF
+  readonly pageCount: number | null;
+  readonly title: string | null;
+  readonly author: string | null;
+  readonly subject: string | null;
+  readonly keywords: string | null;
+  readonly producer: string | null;
+  readonly revision: number | null;
+  readonly lastModifiedBy: string | null;
+  // Audio / video
+  readonly durationMs: number | null;
+  readonly codec: string | null;
+  readonly bitrate: number | null;
+  readonly artist: string | null;
+  readonly album: string | null;
+  readonly trackNumber: number | null;
+  readonly genre: string | null;
+  /** Raw key/value pairs emitted by all extractors. */
+  readonly rawMetadata: Readonly<Record<string, string>>;
+}
+
+// ─── Public links ────────────────────────────────────────────────────────────
+
+/** Scope of a public link: download-only or view (preview). */
+export type PublicLinkScope = 'Download' | 'View';
+
+/** Request body for `POST /documents/{id}/public-links`. */
+export interface CreatePublicLinkRequest {
+  readonly scope: PublicLinkScope;
+  /** Number of days until the link expires. */
+  readonly ttlDays: number;
+  /** Maximum number of uses; `null` means unlimited. */
+  readonly maxUses: number | null;
+}
+
+/** Response from `POST /documents/{id}/public-links`. Includes the one-time `token` and the full `url`. */
+export interface CreatePublicLinkResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly token: string;
+  readonly url: string;
+  readonly scope: PublicLinkScope;
+  readonly expiresAt: string;
+  readonly maxUses: number | null;
+}
+
+/** Read-only view of a public link returned by `GET /documents/{id}/public-links`. */
+export interface PublicLinkResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly scope: PublicLinkScope;
+  readonly expiresAt: string;
+  readonly maxUses: number | null;
+  readonly currentUses: number;
+  readonly revokedAt: string | null;
+  readonly revocationReason: string | null;
+  readonly createdAt: string;
+}
+
+/** Request body for `DELETE /documents/public-links/{id}`. */
+export interface RevokePublicLinkRequest {
+  /** `null` records no reason. */
+  readonly reason: string | null;
+}
+
+// ─── Renditions ──────────────────────────────────────────────────────────────
+
+/** Rendition variant: thumbnail, web-optimised, print, or video poster frame. */
+export type RenditionType = 'Thumbnail' | 'Web' | 'Print' | 'Poster';
+
+/** Generation status of a rendition. */
+export type RenditionStatus = 'Pending' | 'Generating' | 'Ready' | 'Failed';
+
+export interface RenditionResponse {
+  readonly id: string;
+  readonly documentId: string;
+  readonly documentVersionId: string;
+  readonly type: RenditionType;
+  /** Output format (e.g. `"image/webp"`). */
+  readonly format: string;
+  readonly status: RenditionStatus;
+  readonly sizeBytes: number | null;
+  readonly width: number | null;
+  readonly height: number | null;
+  readonly createdAt: string;
+  readonly completedAt: string | null;
+  readonly failureReason: string | null;
+}
+
+/** Response for `GET /documents/{id}/renditions`. */
+export interface ListRenditionsResponse {
+  readonly documentId: string;
+  readonly documentVersionId: string;
+  readonly renditions: readonly RenditionResponse[];
+}
+
+/** Response for `GET /documents/{id}/renditions/{type}/download`. */
+export interface RenditionDownloadUrlResponse {
+  readonly url: string;
+  readonly expiresAt: string;
+}
+
+// ─── Document resolution ─────────────────────────────────────────────────────
+
+/** A single item in a batch-resolve request. */
+export interface ResolveItemRequest {
+  readonly documentId: string;
+  /** Omit to resolve the current version. */
+  readonly versionId?: string | null;
+  /** Omit to resolve the original blob; provide to request a specific rendition. */
+  readonly renditionType?: RenditionType | null;
+  readonly renditionFormat?: string | null;
+}
+
+/** Request body for `POST /documents/resolution/resolve`. */
+export interface BatchResolveRequest {
+  readonly requests: readonly ResolveItemRequest[];
+}
+
+/** Single resolved asset returned by `POST /documents/resolution/resolve`. */
+export interface ResolvedDocumentResponse {
+  readonly documentId: string;
+  readonly versionId: string;
+  readonly url: string;
+  readonly width: number | null;
+  readonly height: number | null;
+  readonly mimeType: string | null;
+  readonly sizeBytes: number | null;
+  readonly lastModified: string | null;
 }

--- a/packages/@granit/invoicing/package.json
+++ b/packages/@granit/invoicing/package.json
@@ -15,12 +15,16 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/types": "workspace:*",
+    "@granit/workflow": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@granit/workflow": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
+++ b/packages/@granit/invoicing/src/__tests__/invoicing-api.test.ts
@@ -7,8 +7,8 @@ import {
   downloadInvoicePdf,
   finalizeInvoice,
   getInvoiceById,
-  listInvoices,
   markInvoiceUncollectible,
+  queryInvoices,
 } from '../api/invoicing-api';
 
 import type { FinalizeInvoiceRequest, InvoiceCreateRequest, InvoiceResponse } from '../types/index';
@@ -52,24 +52,25 @@ const sampleInvoice: InvoiceResponse = {
 };
 
 describe('invoicing-api', () => {
-  describe('listInvoices', () => {
-    it('should GET {basePath}/invoices', async () => {
+  describe('queryInvoices', () => {
+    it('should GET {basePath}/invoices with QE params', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleInvoice] });
+      const page = { items: [sampleInvoice], totalCount: 1 };
+      vi.mocked(client.get).mockResolvedValue({ data: page });
 
-      const result = await listInvoices(client, '/invoicing');
+      const result = await queryInvoices(client, '/invoicing');
 
-      expect(client.get).toHaveBeenCalledWith('/invoicing/invoices');
-      expect(result).toEqual([sampleInvoice]);
+      expect(client.get).toHaveBeenCalled();
+      expect(result.items).toEqual([sampleInvoice]);
     });
 
     it('should work with custom basePath', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [] });
+      vi.mocked(client.get).mockResolvedValue({ data: { items: [], totalCount: 0 } });
 
-      await listInvoices(client, '/custom/invoicing');
+      await queryInvoices(client, '/custom/invoicing');
 
-      expect(client.get).toHaveBeenCalledWith('/custom/invoicing/invoices');
+      expect(client.get).toHaveBeenCalled();
     });
   });
 
@@ -130,6 +131,7 @@ describe('invoicing-api', () => {
       vi.mocked(client.post).mockResolvedValue({ data: sampleInvoice });
 
       const request: InvoiceCreateRequest = {
+        partyId: 'party-1',
         documentType: 'Invoice',
         currency: 'EUR',
         collectionMethod: 'ChargeAutomatically',
@@ -159,6 +161,7 @@ describe('invoicing-api', () => {
       vi.mocked(client.post).mockResolvedValue({ data: creditNote });
 
       const request: InvoiceCreateRequest = {
+        partyId: 'party-1',
         documentType: 'CreditNote',
         currency: 'EUR',
         collectionMethod: 'SendInvoice',

--- a/packages/@granit/invoicing/src/api/invoicing-api.ts
+++ b/packages/@granit/invoicing/src/api/invoicing-api.ts
@@ -1,3 +1,6 @@
+import { getPage, getQueryMeta } from '@granit/query-engine';
+import { executeStateMachineTransition, listTransitions } from '@granit/workflow';
+
 import type {
   CancelInvoiceRequest,
   FinalizeInvoiceRequest,
@@ -6,18 +9,36 @@ import type {
   MarkInvoiceUncollectibleRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
+import type { PagedResult, QueryMetadata, QueryRequest } from '@granit/query-engine';
+import type {
+  WorkflowStatus,
+  WorkflowTransitionRequest,
+  WorkflowTransitionResult,
+} from '@granit/workflow';
 
 /**
- * List all invoices.
+ * Query invoices with filtering, sorting, and pagination (Query Engine).
  *
  * `GET {basePath}/invoices`
  */
-export async function listInvoices(
+export async function queryInvoices(
+  client: AxiosInstance,
+  basePath: string,
+  request: QueryRequest = {}
+): Promise<PagedResult<InvoiceResponse>> {
+  return getPage<InvoiceResponse>(client, `${basePath}/invoices`, request);
+}
+
+/**
+ * Get query metadata for invoices (columns, filters, sorts, presets).
+ *
+ * `GET {basePath}/invoices/meta`
+ */
+export async function getInvoiceMeta(
   client: AxiosInstance,
   basePath: string
-): Promise<readonly InvoiceResponse[]> {
-  const response = await client.get<readonly InvoiceResponse[]>(`${basePath}/invoices`);
-  return response.data;
+): Promise<QueryMetadata> {
+  return getQueryMeta(client, `${basePath}/invoices`);
 }
 
 /**
@@ -71,9 +92,6 @@ export async function createInvoice(
 /**
  * Finalize a Draft invoice (Draft → Open).
  *
- * Delegates the transition to the backend `IWorkflowManager<InvoiceStatus>`;
- * the next document number is generated server-side.
- *
  * `POST {basePath}/invoices/{id}/finalize`
  */
 export async function finalizeInvoice(
@@ -123,4 +141,31 @@ export async function markInvoiceUncollectible(
     request
   );
   return response.data;
+}
+
+/**
+ * Get available workflow transitions for a given invoice status.
+ *
+ * `GET {basePath}/invoices/transitions?currentState=...`
+ */
+export async function listInvoiceTransitions(
+  client: AxiosInstance,
+  basePath: string,
+  currentState: string
+): Promise<WorkflowStatus> {
+  return listTransitions(client, `${basePath}/invoices`, currentState);
+}
+
+/**
+ * Execute a workflow transition for invoices.
+ *
+ * `POST {basePath}/invoices/transitions?currentState=...`
+ */
+export async function executeInvoiceTransition(
+  client: AxiosInstance,
+  basePath: string,
+  currentState: string,
+  request: WorkflowTransitionRequest
+): Promise<WorkflowTransitionResult> {
+  return executeStateMachineTransition(client, `${basePath}/invoices`, currentState, request);
 }

--- a/packages/@granit/invoicing/src/index.ts
+++ b/packages/@granit/invoicing/src/index.ts
@@ -9,6 +9,8 @@ export type {
   InvoiceId,
   InvoiceLineItemResponse,
   InvoiceResponse,
+  InvoiceSourceType,
+  InvoiceStatus,
   MarkInvoiceUncollectibleRequest,
 } from './types/index';
 
@@ -20,8 +22,11 @@ export {
   cancelInvoice,
   createInvoice,
   downloadInvoicePdf,
+  executeInvoiceTransition,
   finalizeInvoice,
   getInvoiceById,
-  listInvoices,
+  getInvoiceMeta,
+  listInvoiceTransitions,
   markInvoiceUncollectible,
+  queryInvoices,
 } from './api/invoicing-api';

--- a/packages/@granit/invoicing/src/types/index.ts
+++ b/packages/@granit/invoicing/src/types/index.ts
@@ -9,14 +9,18 @@ export type InvoiceDocumentType = 'Invoice' | 'CreditNote';
 /** How payment is collected for an invoice. */
 export type CollectionMethod = 'ChargeAutomatically' | 'SendInvoice';
 
+/** Lifecycle status of an invoice. */
+export type InvoiceStatus = 'Draft' | 'Open' | 'Paid' | 'Cancelled' | 'Uncollectible';
+
+/** The origin type of an invoice (determines template and revenue recognition). */
+export type InvoiceSourceType = 'Subscription' | 'Usage' | 'OneShot' | 'Credit';
+
 /** The reason an invoice was created. */
 export type BillingReason =
-  | 'Subscription'
   | 'SubscriptionCreate'
   | 'SubscriptionCycle'
   | 'SubscriptionUpdate'
-  | 'Manual'
-  | 'Upcoming';
+  | 'Manual';
 
 /** Payload for finalizing a Draft invoice (Draft → Open). */
 export interface FinalizeInvoiceRequest {
@@ -42,6 +46,7 @@ export interface MarkInvoiceUncollectibleRequest {
 
 /** Payload for creating a new invoice. */
 export interface InvoiceCreateRequest {
+  readonly partyId: string;
   readonly documentType: InvoiceDocumentType;
   readonly currency: string;
   readonly collectionMethod: CollectionMethod;

--- a/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/document-detail.test.tsx
@@ -172,6 +172,6 @@ describe('DocumentDetail', () => {
 
     await waitFor(() => expect(client.patch).toHaveBeenCalled());
     const [, body] = vi.mocked(client.patch).mock.calls[0] ?? [];
-    expect(body).toEqual({ name: 'NewName.pdf' });
+    expect(body).toEqual({ name: 'NewName.pdf', description: null });
   });
 });

--- a/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/share-dialog.test.tsx
@@ -22,7 +22,7 @@ const folderShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T08:00:00Z',
-  createdByUserId: 'admin',
+  createdBy: 'admin',
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-mutations.test.tsx
@@ -117,6 +117,8 @@ describe('useFinalizeUpload', () => {
       blobId: 'blob-1',
       folderId: 'fld-1',
       name: 'contract.pdf',
+      description: null,
+      commitMessage: null,
     });
 
     expect(client.post).toHaveBeenCalledWith(
@@ -140,10 +142,14 @@ describe('useRenameDocument', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useRenameDocument(), { wrapper });
-    await result.current.mutateAsync({ id: 'doc-1', request: { name: 'renamed.pdf' } });
+    await result.current.mutateAsync({
+      id: 'doc-1',
+      request: { name: 'renamed.pdf', description: null },
+    });
 
     expect(client.patch).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1', {
       name: 'renamed.pdf',
+      description: null,
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([['documents', 'documents']]);
@@ -261,10 +267,14 @@ describe('useAppendDocumentVersion', () => {
     const invalidate = vi.spyOn(queryClient, 'invalidateQueries');
 
     const { result } = renderHook(() => useAppendDocumentVersion(), { wrapper });
-    await result.current.mutateAsync({ id: 'doc-1', request: { blobId: 'blob-2' } });
+    await result.current.mutateAsync({
+      id: 'doc-1',
+      request: { blobId: 'blob-2', commitMessage: null },
+    });
 
     expect(client.post).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/versions', {
       blobId: 'blob-2',
+      commitMessage: null,
     });
     const keys = invalidate.mock.calls.map((call) => call[0]?.queryKey);
     expect(keys).toEqual([

--- a/packages/@granit/react-documents/src/__tests__/use-document-tags.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-tags.test.tsx
@@ -27,7 +27,6 @@ const sampleTag: DocumentTagResponse = {
   name: 'Urgent',
   color: '#FF0000',
   hideOnEntityCard: false,
-  rowVersion: 1,
 };
 const sampleList: ListDocumentTagsResponse = { items: [sampleTag] };
 const sampleAssignment: DocumentTagAssignmentResponse = {

--- a/packages/@granit/react-documents/src/__tests__/use-share-mutations.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-share-mutations.test.tsx
@@ -27,7 +27,7 @@ const sampleShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T00:00:00Z',
-  createdByUserId: 'user-1',
+  createdBy: 'user-1',
 };
 
 interface Harness {

--- a/packages/@granit/react-documents/src/__tests__/use-shares.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-shares.test.tsx
@@ -21,7 +21,7 @@ const sampleShare: ShareResponse = {
   isDefault: true,
   expiresAt: null,
   createdAt: '2026-05-01T00:00:00Z',
-  createdByUserId: 'user-1',
+  createdBy: 'user-1',
 };
 const sampleResponse: ListSharesResponse = { items: [sampleShare] };
 

--- a/packages/@granit/react-documents/src/components/document-detail.tsx
+++ b/packages/@granit/react-documents/src/components/document-detail.tsx
@@ -134,7 +134,7 @@ export function DocumentDetail({
       return;
     }
     renameDocument.mutate(
-      { id: document.id, request: { name: trimmed } },
+      { id: document.id, request: { name: trimmed, description: null } },
       { onSuccess: () => setEditing(false) }
     );
   }

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -470,7 +470,7 @@ function DocumentsListBody({
       return;
     }
     renameDocument.mutate(
-      { id: doc.id, request: { name } },
+      { id: doc.id, request: { name, description: null } },
       { onSettled: () => clearRowMode(doc.id) }
     );
   }

--- a/packages/@granit/react-documents/src/hooks/use-document-properties.ts
+++ b/packages/@granit/react-documents/src/hooks/use-document-properties.ts
@@ -1,0 +1,41 @@
+import { getDocumentProperties, getDocumentVersionProperties } from '@granit/documents';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildDocumentsQueryKey, useDocumentsConfig } from '../providers/documents-provider';
+
+import type { DocumentPropertiesResponse } from '@granit/documents';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Get the extracted metadata for the current version of a document. Returns
+ * `undefined` while the background extractor has not finished (`status:
+ * 'Pending'` or `'Extracting'`). Disabled when `id` is empty.
+ */
+export function useDocumentProperties(
+  id: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<DocumentPropertiesResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'metadata'),
+    queryFn: () => getDocumentProperties(config.client, config.basePath, id),
+    enabled: (options?.enabled ?? true) && id.length > 0,
+  });
+}
+
+/**
+ * Get the extracted metadata for a specific version of a document. Disabled
+ * when either `id` or `versionId` is empty.
+ */
+export function useDocumentVersionProperties(
+  id: string,
+  versionId: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<DocumentPropertiesResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'versions', versionId, 'metadata'),
+    queryFn: () => getDocumentVersionProperties(config.client, config.basePath, id, versionId),
+    enabled: (options?.enabled ?? true) && id.length > 0 && versionId.length > 0,
+  });
+}

--- a/packages/@granit/react-documents/src/hooks/use-file-upload.ts
+++ b/packages/@granit/react-documents/src/hooks/use-file-upload.ts
@@ -111,6 +111,8 @@ export function useFileUpload(options: UseFileUploadOptions = {}): UseFileUpload
           blobId: ticket.blobId,
           folderId,
           name: file.name,
+          description: null,
+          commitMessage: null,
         });
         setProgress(null);
         return document;

--- a/packages/@granit/react-documents/src/hooks/use-public-links.ts
+++ b/packages/@granit/react-documents/src/hooks/use-public-links.ts
@@ -1,0 +1,87 @@
+import {
+  createDocumentPublicLink,
+  listDocumentPublicLinks,
+  revokeDocumentPublicLink,
+} from '@granit/documents';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildDocumentsQueryKey, useDocumentsConfig } from '../providers/documents-provider';
+
+import type { ResolvedDocumentsConfig } from '../providers/documents-provider';
+import type {
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  PublicLinkResponse,
+  RevokePublicLinkRequest,
+} from '@granit/documents';
+import type { QueryClient, UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+function invalidatePublicLinks(
+  queryClient: QueryClient,
+  config: ResolvedDocumentsConfig,
+  documentId: string
+): void {
+  queryClient.invalidateQueries({
+    queryKey: buildDocumentsQueryKey(config, 'documents', documentId, 'public-links'),
+  });
+}
+
+/** List active public links for a document. Disabled when `documentId` is empty. */
+export function useDocumentPublicLinks(
+  documentId: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<readonly PublicLinkResponse[]> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', documentId, 'public-links'),
+    queryFn: () => listDocumentPublicLinks(config.client, config.basePath, documentId),
+    enabled: (options?.enabled ?? true) && documentId.length > 0,
+  });
+}
+
+interface CreatePublicLinkArgs {
+  readonly documentId: string;
+  readonly request: CreatePublicLinkRequest;
+}
+
+/** Create a public link for a document. Invalidates the public-links list on success. */
+export function useCreateDocumentPublicLink(): UseMutationResult<
+  CreatePublicLinkResponse,
+  Error,
+  CreatePublicLinkArgs
+> {
+  const config = useDocumentsConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ documentId, request }: CreatePublicLinkArgs) =>
+      createDocumentPublicLink(config.client, config.basePath, documentId, request),
+    onSuccess: (_data, { documentId }) => {
+      invalidatePublicLinks(queryClient, config, documentId);
+    },
+  });
+}
+
+interface RevokePublicLinkArgs {
+  readonly id: string;
+  readonly documentId: string;
+  readonly request: RevokePublicLinkRequest;
+}
+
+/** Revoke a public link. Invalidates the public-links list for the parent document on success. */
+export function useRevokeDocumentPublicLink(): UseMutationResult<
+  void,
+  Error,
+  RevokePublicLinkArgs
+> {
+  const config = useDocumentsConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: RevokePublicLinkArgs) =>
+      revokeDocumentPublicLink(config.client, config.basePath, id, request),
+    onSuccess: (_data, { documentId }) => {
+      invalidatePublicLinks(queryClient, config, documentId);
+    },
+  });
+}

--- a/packages/@granit/react-documents/src/hooks/use-renditions.ts
+++ b/packages/@granit/react-documents/src/hooks/use-renditions.ts
@@ -1,0 +1,47 @@
+import { listDocumentRenditions, requestRenditionDownloadUrl } from '@granit/documents';
+import { useQuery } from '@tanstack/react-query';
+
+import { buildDocumentsQueryKey, useDocumentsConfig } from '../providers/documents-provider';
+
+import type {
+  ListRenditionsResponse,
+  RenditionDownloadUrlResponse,
+  RenditionType,
+} from '@granit/documents';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List all renditions for the current version of a document. Disabled when
+ * `id` is empty.
+ */
+export function useDocumentRenditions(
+  id: string,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<ListRenditionsResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'renditions'),
+    queryFn: () => listDocumentRenditions(config.client, config.basePath, id),
+    enabled: (options?.enabled ?? true) && id.length > 0,
+  });
+}
+
+/**
+ * Get a presigned download URL for a specific rendition type. The URL is
+ * short-lived — use `staleTime: Infinity` + manual `refetch()` on demand
+ * rather than auto-refetching. Disabled when `id` is empty.
+ */
+export function useRenditionDownloadUrl(
+  id: string,
+  type: RenditionType,
+  options?: { readonly enabled?: boolean }
+): UseQueryResult<RenditionDownloadUrlResponse> {
+  const config = useDocumentsConfig();
+  return useQuery({
+    queryKey: buildDocumentsQueryKey(config, 'documents', id, 'renditions', type, 'download'),
+    queryFn: () => requestRenditionDownloadUrl(config.client, config.basePath, id, type),
+    enabled: (options?.enabled ?? true) && id.length > 0,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+  });
+}

--- a/packages/@granit/react-documents/src/hooks/use-resolution.ts
+++ b/packages/@granit/react-documents/src/hooks/use-resolution.ts
@@ -1,0 +1,28 @@
+import { batchResolveDocumentAssets } from '@granit/documents';
+import { useMutation } from '@tanstack/react-query';
+
+import { useDocumentsConfig } from '../providers/documents-provider';
+
+import type { BatchResolveRequest, ResolvedDocumentResponse } from '@granit/documents';
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Resolve a batch of document assets to presigned CDN URLs. Each item may
+ * target a specific version and/or rendition type; unresolvable items are
+ * silently omitted from the response array.
+ *
+ * Primarily used by the CMS renderer to embed document assets. Results are
+ * short-lived (CDN URLs expire), so no query caching is applied.
+ */
+export function useBatchResolveDocumentAssets(): UseMutationResult<
+  readonly ResolvedDocumentResponse[],
+  Error,
+  BatchResolveRequest
+> {
+  const config = useDocumentsConfig();
+
+  return useMutation({
+    mutationFn: (request: BatchResolveRequest) =>
+      batchResolveDocumentAssets(config.client, config.basePath, request),
+  });
+}

--- a/packages/@granit/react-documents/src/index.ts
+++ b/packages/@granit/react-documents/src/index.ts
@@ -73,6 +73,25 @@ export {
 // Quota
 export { useTenantStorageQuota } from './hooks/use-quota';
 
+// Document properties
+export {
+  useDocumentProperties,
+  useDocumentVersionProperties,
+} from './hooks/use-document-properties';
+
+// Public links
+export {
+  useCreateDocumentPublicLink,
+  useDocumentPublicLinks,
+  useRevokeDocumentPublicLink,
+} from './hooks/use-public-links';
+
+// Renditions
+export { useDocumentRenditions, useRenditionDownloadUrl } from './hooks/use-renditions';
+
+// Resolution
+export { useBatchResolveDocumentAssets } from './hooks/use-resolution';
+
 // Components — Documents
 export { DocumentDetail } from './components/document-detail';
 export type { DocumentDetailLabels, DocumentDetailProps } from './components/document-detail';

--- a/packages/@granit/react-documents/src/testing/handlers.ts
+++ b/packages/@granit/react-documents/src/testing/handlers.ts
@@ -2,10 +2,11 @@
 // @granit/react-documents/testing — MSW handlers
 // ---------------------------------------------------------------------------
 //
-// Stateful in-memory implementation of every endpoint in the Phase 1
-// Documents wire contract (folders, documents, versions, shares, tags, quota,
-// trash + QueryEngine list). Handlers mutate module-level arrays so subsequent
-// GETs reflect prior mutations within a single test/dev session.
+// Stateful in-memory implementation of every endpoint in the Documents wire
+// contract (folders, documents, versions, shares, tags, quota, trash,
+// QueryEngine list, properties, public-links, renditions, resolution).
+// Handlers mutate module-level arrays so subsequent GETs reflect prior
+// mutations within a single test/dev session.
 
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { noContent, notFound, pagedResponse, parseFilters, parseSort } from '@granit/testing/msw';
@@ -28,7 +29,11 @@ import { documentQueryMetadata } from './query-meta';
 
 import type {
   AppendVersionRequest,
+  BatchResolveRequest,
   CreateFolderRequest,
+  CreatePublicLinkRequest,
+  CreatePublicLinkResponse,
+  DocumentPropertiesResponse,
   DocumentResponse,
   DocumentTagAssignmentResponse,
   DocumentVersionResponse,
@@ -40,12 +45,17 @@ import type {
   ListDocumentTagsResponse,
   ListDocumentVersionsResponse,
   ListFoldersResponse,
+  ListRenditionsResponse,
   ListSharesResponse,
   ListTrashedDocumentsResponse,
   MoveDocumentRequest,
   MoveFolderRequest,
+  PublicLinkResponse,
   RenameDocumentRequest,
   RenameFolderRequest,
+  RenditionResponse,
+  ResolvedDocumentResponse,
+  RevokePublicLinkRequest,
   ShareResponse,
   TenantStorageQuotaResponse,
   TransferOwnerRequest,
@@ -105,6 +115,8 @@ export function createDocumentsHandlers(
   const trashed = mockTrashedDocumentsData.map((t) => ({ ...t }));
   const shares: ShareResponse[] = mockSharesData.map((s) => ({ ...s }));
   const quota: TenantStorageQuotaResponse = { ...mockQuotaData };
+  const publicLinks: PublicLinkResponse[] = [];
+  const renditions: RenditionResponse[] = [];
 
   function findFolder(id: string): FolderResponse | undefined {
     return folders.find((f) => f.id === id);
@@ -304,7 +316,7 @@ export function createDocumentsHandlers(
         isDefault: body.isDefault ?? true,
         expiresAt: body.expiresAt ?? null,
         createdAt: new Date().toISOString(),
-        createdByUserId: MOCK_OWNER_USER_ID,
+        createdBy: MOCK_OWNER_USER_ID,
       };
       shares.push(share);
       return HttpResponse.json(share, { status: 201 });
@@ -494,7 +506,7 @@ export function createDocumentsHandlers(
         isDefault: false,
         expiresAt: body.expiresAt ?? null,
         createdAt: new Date().toISOString(),
-        createdByUserId: MOCK_OWNER_USER_ID,
+        createdBy: MOCK_OWNER_USER_ID,
       };
       shares.push(share);
       return HttpResponse.json(share, { status: 201 });
@@ -605,5 +617,208 @@ export function createDocumentsHandlers(
 
     // ── Quota ────────────────────────────────────────────────────────────────
     http.get(`${basePath}/quota`, () => HttpResponse.json(quota)),
+
+    // ── Document properties ──────────────────────────────────────────────────
+    http.get(`${basePath}/documents/:id/versions/:versionId/metadata`, ({ params }) => {
+      const id = params.id as string;
+      const versionId = params.versionId as string;
+      if (!findDocument(id)) return notFound();
+      const v = versions.find((ver) => ver.documentId === id && ver.id === versionId);
+      if (!v) return notFound();
+      const props: DocumentPropertiesResponse = {
+        id: `props-${v.id}`,
+        documentId: id,
+        documentVersionId: versionId,
+        sourceContentType: v.contentType,
+        status: 'Ready',
+        createdAt: v.uploadedAt,
+        completedAt: v.uploadedAt,
+        failureReason: null,
+        extractorCount: 1,
+        width: null,
+        height: null,
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        iso: null,
+        fNumber: null,
+        exposureTimeMs: null,
+        takenAt: null,
+        gpsLatitude: null,
+        gpsLongitude: null,
+        gpsAltitude: null,
+        pageCount: null,
+        title: null,
+        author: null,
+        subject: null,
+        keywords: null,
+        producer: null,
+        revision: null,
+        lastModifiedBy: null,
+        durationMs: null,
+        codec: null,
+        bitrate: null,
+        artist: null,
+        album: null,
+        trackNumber: null,
+        genre: null,
+        rawMetadata: {},
+      };
+      return HttpResponse.json(props);
+    }),
+
+    http.get(`${basePath}/documents/:id/metadata`, ({ params }) => {
+      const id = params.id as string;
+      const doc = findDocument(id);
+      if (!doc) return notFound();
+      if (!doc.currentVersionId) return notFound();
+      const v = versions.find((ver) => ver.id === doc.currentVersionId);
+      if (!v) return notFound();
+      const props: DocumentPropertiesResponse = {
+        id: `props-${id}`,
+        documentId: id,
+        documentVersionId: doc.currentVersionId,
+        sourceContentType: doc.contentType ?? 'application/octet-stream',
+        status: 'Ready',
+        createdAt: doc.createdAt,
+        completedAt: doc.createdAt,
+        failureReason: null,
+        extractorCount: 1,
+        width: null,
+        height: null,
+        cameraMake: null,
+        cameraModel: null,
+        lensModel: null,
+        iso: null,
+        fNumber: null,
+        exposureTimeMs: null,
+        takenAt: null,
+        gpsLatitude: null,
+        gpsLongitude: null,
+        gpsAltitude: null,
+        pageCount: null,
+        title: null,
+        author: null,
+        subject: null,
+        keywords: null,
+        producer: null,
+        revision: null,
+        lastModifiedBy: null,
+        durationMs: null,
+        codec: null,
+        bitrate: null,
+        artist: null,
+        album: null,
+        trackNumber: null,
+        genre: null,
+        rawMetadata: {},
+      };
+      return HttpResponse.json(props);
+    }),
+
+    // ── Public links ─────────────────────────────────────────────────────────
+    http.post(`${basePath}/documents/:id/public-links`, async ({ params, request }) => {
+      const documentId = params.id as string;
+      if (!findDocument(documentId)) return notFound();
+      const body = (await request.json()) as CreatePublicLinkRequest;
+      const id = newId('lk', shareCounter++);
+      const token = `mock-token-${id.slice(-8)}`;
+      const expiresAt = new Date(Date.now() + body.ttlDays * 24 * 60 * 60 * 1000).toISOString();
+      const created: CreatePublicLinkResponse = {
+        id,
+        documentId,
+        token,
+        url: `/p/${token}`,
+        scope: body.scope,
+        expiresAt,
+        maxUses: body.maxUses,
+      };
+      publicLinks.push({
+        id,
+        documentId,
+        scope: body.scope,
+        expiresAt,
+        maxUses: body.maxUses,
+        currentUses: 0,
+        revokedAt: null,
+        revocationReason: null,
+        createdAt: new Date().toISOString(),
+      });
+      return HttpResponse.json(created, { status: 201 });
+    }),
+
+    http.get(`${basePath}/documents/:id/public-links`, ({ params }) => {
+      const documentId = params.id as string;
+      if (!findDocument(documentId)) return notFound();
+      const items = publicLinks.filter((l) => l.documentId === documentId && l.revokedAt === null);
+      return HttpResponse.json(items);
+    }),
+
+    http.delete(`${basePath}/public-links/:id`, async ({ params, request }) => {
+      const id = params.id as string;
+      const idx = publicLinks.findIndex((l) => l.id === id);
+      if (idx === -1) return notFound();
+      const body = (await request.json()) as RevokePublicLinkRequest;
+      const link = publicLinks[idx];
+      if (link) {
+        Object.assign(link, {
+          ...link,
+          revokedAt: new Date().toISOString(),
+          revocationReason: body.reason,
+        });
+      }
+      return noContent();
+    }),
+
+    // ── Renditions ───────────────────────────────────────────────────────────
+    http.get(`${basePath}/documents/:id/renditions`, ({ params }) => {
+      const id = params.id as string;
+      const doc = findDocument(id);
+      if (!doc) return notFound();
+      const versionId = doc.currentVersionId ?? '';
+      const items: RenditionResponse[] = renditions.filter(
+        (r) => r.documentId === id && r.documentVersionId === versionId
+      );
+      const body: ListRenditionsResponse = {
+        documentId: id,
+        documentVersionId: versionId,
+        renditions: items,
+      };
+      return HttpResponse.json(body);
+    }),
+
+    http.get(`${basePath}/documents/:id/renditions/:type/download`, ({ params }) => {
+      const id = params.id as string;
+      const type = params.type as string;
+      if (!findDocument(id)) return notFound();
+      const body = {
+        url: `mock://renditions/${id}/${type}`,
+        expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+      };
+      return HttpResponse.json(body);
+    }),
+
+    // ── Resolution ───────────────────────────────────────────────────────────
+    http.post(`${basePath}/resolution/resolve`, async ({ request }) => {
+      const body = (await request.json()) as BatchResolveRequest;
+      const results: ResolvedDocumentResponse[] = [];
+      for (const item of body.requests) {
+        const doc = findDocument(item.documentId);
+        if (!doc) continue;
+        const versionId = item.versionId ?? doc.currentVersionId;
+        if (!versionId) continue;
+        results.push({
+          documentId: item.documentId,
+          versionId,
+          url: `mock://resolve/${item.documentId}/${versionId}`,
+          width: null,
+          height: null,
+          mimeType: doc.contentType,
+          sizeBytes: doc.sizeBytes,
+          lastModified: doc.modifiedAt ?? doc.createdAt,
+        });
+      }
+      return HttpResponse.json(results);
+    }),
   ];
 }

--- a/packages/@granit/react-invoicing/package.json
+++ b/packages/@granit/react-invoicing/package.json
@@ -21,6 +21,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
+    "@granit/workflow": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
@@ -30,6 +31,9 @@
       "optional": true
     },
     "@granit/react-query-engine": {
+      "optional": true
+    },
+    "@granit/workflow": {
       "optional": true
     },
     "msw": {
@@ -51,9 +55,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/invoicing": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/types": "workspace:*",
+    "@granit/workflow": "workspace:*"
   }
 }

--- a/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
+++ b/packages/@granit/react-invoicing/src/__tests__/use-invoicing.test.tsx
@@ -17,12 +17,12 @@ import {
 import { InvoicingProvider } from '../providers/invoicing-provider';
 
 import type { InvoicingConfig } from '../providers/invoicing-provider';
+import type { AxiosInstance } from '@granit/api-client';
 import type {
   FinalizeInvoiceRequest,
   InvoiceCreateRequest,
   InvoiceResponse,
 } from '@granit/invoicing';
-import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
 // ---------------------------------------------------------------------------
@@ -65,6 +65,8 @@ const sampleInvoice: InvoiceResponse = {
   lineItems: [],
 };
 
+const samplePage = { items: [sampleInvoice], totalCount: 1 };
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -76,27 +78,28 @@ describe('useInvoices', () => {
 
   it('fetches invoices with default basePath', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ data: [sampleInvoice] });
+    vi.mocked(client.get).mockResolvedValue({ data: samplePage });
 
     const { result } = renderHook(() => useInvoices(), {
       wrapper: createWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/invoicing/invoices');
-    expect(result.current.data).toEqual([sampleInvoice]);
+    expect(client.get).toHaveBeenCalled();
+    expect(result.current.data?.items).toEqual([sampleInvoice]);
+    expect(result.current.data?.totalCount).toBe(1);
   });
 
   it('fetches invoices with custom basePath', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.get).mockResolvedValue({ data: { items: [], totalCount: 0 } });
 
     const { result } = renderHook(() => useInvoices(), {
       wrapper: createWrapper(client, '/custom/invoicing'),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/custom/invoicing/invoices');
+    expect(client.get).toHaveBeenCalled();
   });
 
   it('exposes error state on failure', async () => {
@@ -194,6 +197,7 @@ describe('useCreateInvoice', () => {
     });
 
     const request: InvoiceCreateRequest = {
+      partyId: 'party-1',
       documentType: 'Invoice',
       currency: 'EUR',
       collectionMethod: 'ChargeAutomatically',
@@ -219,6 +223,7 @@ describe('useCreateInvoice', () => {
     });
 
     const request: InvoiceCreateRequest = {
+      partyId: 'party-1',
       documentType: 'Invoice',
       currency: 'EUR',
       collectionMethod: 'ChargeAutomatically',

--- a/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
+++ b/packages/@granit/react-invoicing/src/hooks/use-invoicing.ts
@@ -2,10 +2,13 @@ import {
   cancelInvoice,
   createInvoice,
   downloadInvoicePdf,
+  executeInvoiceTransition,
   finalizeInvoice,
   getInvoiceById,
-  listInvoices,
+  getInvoiceMeta,
+  listInvoiceTransitions,
   markInvoiceUncollectible,
+  queryInvoices,
 } from '@granit/invoicing';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -18,23 +21,31 @@ import type {
   InvoiceResponse,
   MarkInvoiceUncollectibleRequest,
 } from '@granit/invoicing';
+import type { PagedResult, QueryMetadata, QueryRequest } from '@granit/query-engine';
+import type {
+  WorkflowStatus,
+  WorkflowTransitionRequest,
+  WorkflowTransitionResult,
+} from '@granit/workflow';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /**
- * Fetch all invoices.
+ * Query invoices with optional filtering, sorting, and pagination.
  *
  * @example
  * ```tsx
- * const { data: invoices } = useInvoices();
+ * const { data } = useInvoices();
+ * const rows = data?.items ?? [];
  * ```
  */
-export function useInvoices(): UseQueryResult<readonly InvoiceResponse[]> {
+export function useInvoices(
+  request: QueryRequest = {}
+): UseQueryResult<PagedResult<InvoiceResponse>> {
   const config = useInvoicingConfig();
-  const basePath = config.basePath!;
 
   return useQuery({
-    queryKey: buildInvoicingQueryKey(config, 'invoices', 'list'),
-    queryFn: () => listInvoices(config.client, basePath),
+    queryKey: [...buildInvoicingQueryKey(config, 'invoices', 'list'), request],
+    queryFn: () => queryInvoices(config.client, config.basePath!, request),
   });
 }
 
@@ -50,12 +61,29 @@ export function useInvoices(): UseQueryResult<readonly InvoiceResponse[]> {
  */
 export function useInvoice(id: string): UseQueryResult<InvoiceResponse> {
   const config = useInvoicingConfig();
-  const basePath = config.basePath!;
 
   return useQuery({
     queryKey: buildInvoicingQueryKey(config, 'invoices', id),
-    queryFn: () => getInvoiceById(config.client, basePath, id),
+    queryFn: () => getInvoiceById(config.client, config.basePath!, id),
     enabled: id.length > 0,
+  });
+}
+
+/**
+ * Fetch query metadata for invoices (columns, filterable fields, presets, etc.).
+ *
+ * @example
+ * ```tsx
+ * const { data: meta } = useInvoiceMeta();
+ * ```
+ */
+export function useInvoiceMeta(): UseQueryResult<QueryMetadata> {
+  const config = useInvoicingConfig();
+
+  return useQuery({
+    queryKey: buildInvoicingQueryKey(config, 'invoices', 'meta'),
+    queryFn: () => getInvoiceMeta(config.client, config.basePath!),
+    staleTime: Infinity,
   });
 }
 
@@ -72,10 +100,9 @@ export function useInvoice(id: string): UseQueryResult<InvoiceResponse> {
  */
 export function useDownloadInvoicePdf(): UseMutationResult<Blob, Error, string> {
   const config = useInvoicingConfig();
-  const basePath = config.basePath!;
 
   return useMutation({
-    mutationFn: (id: string) => downloadInvoicePdf(config.client, basePath, id),
+    mutationFn: (id: string) => downloadInvoicePdf(config.client, config.basePath!, id),
   });
 }
 
@@ -86,7 +113,7 @@ export function useDownloadInvoicePdf(): UseMutationResult<Blob, Error, string> 
  * @example
  * ```tsx
  * const create = useCreateInvoice();
- * await create.mutateAsync({ documentType: 'Invoice', currency: 'EUR', ... });
+ * await create.mutateAsync({ partyId: '...', documentType: 'Invoice', currency: 'EUR', ... });
  * ```
  */
 export function useCreateInvoice(): UseMutationResult<
@@ -96,10 +123,10 @@ export function useCreateInvoice(): UseMutationResult<
 > {
   const config = useInvoicingConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath!;
 
   return useMutation({
-    mutationFn: (request: InvoiceCreateRequest) => createInvoice(config.client, basePath, request),
+    mutationFn: (request: InvoiceCreateRequest) =>
+      createInvoice(config.client, config.basePath!, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildInvoicingQueryKey(config, 'invoices'),
@@ -108,7 +135,7 @@ export function useCreateInvoice(): UseMutationResult<
   });
 }
 
-/** Variables for the semantic transition mutations: invoice id + optional request body. */
+/** Variables for semantic transition mutations: invoice id + optional request body. */
 export interface InvoiceTransitionVariables<TRequest> {
   readonly id: string;
   readonly request?: TRequest;
@@ -117,12 +144,6 @@ export interface InvoiceTransitionVariables<TRequest> {
 /**
  * Finalize a Draft invoice (Draft → Open).
  * Invalidates invoice queries on success.
- *
- * @example
- * ```tsx
- * const finalize = useFinalizeInvoice();
- * await finalize.mutateAsync({ id: 'inv-1', request: { issuedAt, dueAt } });
- * ```
  */
 export function useFinalizeInvoice(): UseMutationResult<
   InvoiceResponse,
@@ -131,10 +152,9 @@ export function useFinalizeInvoice(): UseMutationResult<
 > {
   const config = useInvoicingConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath!;
 
   return useMutation({
-    mutationFn: ({ id, request }) => finalizeInvoice(config.client, basePath, id, request),
+    mutationFn: ({ id, request }) => finalizeInvoice(config.client, config.basePath!, id, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildInvoicingQueryKey(config, 'invoices'),
@@ -146,12 +166,6 @@ export function useFinalizeInvoice(): UseMutationResult<
 /**
  * Cancel an invoice (Open / Uncollectible → Cancelled).
  * Invalidates invoice queries on success.
- *
- * @example
- * ```tsx
- * const cancel = useCancelInvoice();
- * await cancel.mutateAsync({ id: 'inv-1', request: { reason: 'Duplicate' } });
- * ```
  */
 export function useCancelInvoice(): UseMutationResult<
   InvoiceResponse,
@@ -160,10 +174,9 @@ export function useCancelInvoice(): UseMutationResult<
 > {
   const config = useInvoicingConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath!;
 
   return useMutation({
-    mutationFn: ({ id, request }) => cancelInvoice(config.client, basePath, id, request),
+    mutationFn: ({ id, request }) => cancelInvoice(config.client, config.basePath!, id, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildInvoicingQueryKey(config, 'invoices'),
@@ -175,12 +188,6 @@ export function useCancelInvoice(): UseMutationResult<
 /**
  * Mark an Open invoice as Uncollectible (bad debt).
  * Invalidates invoice queries on success.
- *
- * @example
- * ```tsx
- * const markUncollectible = useMarkInvoiceUncollectible();
- * await markUncollectible.mutateAsync({ id: 'inv-1', request: { reason: 'Bankruptcy' } });
- * ```
  */
 export function useMarkInvoiceUncollectible(): UseMutationResult<
   InvoiceResponse,
@@ -189,10 +196,57 @@ export function useMarkInvoiceUncollectible(): UseMutationResult<
 > {
   const config = useInvoicingConfig();
   const queryClient = useQueryClient();
-  const basePath = config.basePath!;
 
   return useMutation({
-    mutationFn: ({ id, request }) => markInvoiceUncollectible(config.client, basePath, id, request),
+    mutationFn: ({ id, request }) =>
+      markInvoiceUncollectible(config.client, config.basePath!, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildInvoicingQueryKey(config, 'invoices'),
+      });
+    },
+  });
+}
+
+/**
+ * List available workflow transitions for a given invoice status.
+ *
+ * @example
+ * ```tsx
+ * const { data: status } = useListInvoiceTransitions(invoice.status);
+ * ```
+ */
+export function useListInvoiceTransitions(currentState: string): UseQueryResult<WorkflowStatus> {
+  const config = useInvoicingConfig();
+
+  return useQuery({
+    queryKey: buildInvoicingQueryKey(config, 'invoices', 'transitions', currentState),
+    queryFn: () => listInvoiceTransitions(config.client, config.basePath!, currentState),
+    enabled: currentState.length > 0,
+  });
+}
+
+/**
+ * Execute a workflow transition for an invoice.
+ * Invalidates invoice queries on success.
+ *
+ * @example
+ * ```tsx
+ * const execute = useExecuteInvoiceTransition();
+ * await execute.mutateAsync({ currentState: 'Draft', request: { targetState: 'Open' } });
+ * ```
+ */
+export function useExecuteInvoiceTransition(): UseMutationResult<
+  WorkflowTransitionResult,
+  Error,
+  { readonly currentState: string; readonly request: WorkflowTransitionRequest }
+> {
+  const config = useInvoicingConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ currentState, request }) =>
+      executeInvoiceTransition(config.client, config.basePath!, currentState, request),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildInvoicingQueryKey(config, 'invoices'),

--- a/packages/@granit/react-invoicing/src/index.ts
+++ b/packages/@granit/react-invoicing/src/index.ts
@@ -11,9 +11,12 @@ export {
   useCancelInvoice,
   useCreateInvoice,
   useDownloadInvoicePdf,
+  useExecuteInvoiceTransition,
   useFinalizeInvoice,
   useInvoice,
+  useInvoiceMeta,
   useInvoices,
+  useListInvoiceTransitions,
   useMarkInvoiceUncollectible,
 } from './hooks/use-invoicing';
 export type { InvoiceTransitionVariables } from './hooks/use-invoicing';

--- a/packages/@granit/react-invoicing/src/testing/handlers.ts
+++ b/packages/@granit/react-invoicing/src/testing/handlers.ts
@@ -25,14 +25,7 @@ import type { QueryMetadata } from '@granit/query-engine';
 const INVOICE_DOCUMENT_TYPES = ['Invoice', 'CreditNote'];
 const INVOICE_STATUSES = ['Draft', 'Open', 'Paid', 'Cancelled', 'Uncollectible'];
 const COLLECTION_METHODS = ['ChargeAutomatically', 'SendInvoice'];
-const BILLING_REASONS = [
-  'Subscription',
-  'SubscriptionCreate',
-  'SubscriptionCycle',
-  'SubscriptionUpdate',
-  'Manual',
-  'Upcoming',
-];
+const BILLING_REASONS = ['SubscriptionCreate', 'SubscriptionCycle', 'SubscriptionUpdate', 'Manual'];
 
 /** Mock /meta payload for the invoices resource. */
 export const invoiceQueryMetadata: QueryMetadata = {
@@ -229,9 +222,9 @@ export function createInvoicingHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // GET /invoices/meta — query metadata
     createQueryMetaHandler(`${baseUrl}/invoices`, invoiceQueryMetadata),
 
-    // GET list all invoices
+    // GET list all invoices (Query Engine — returns PagedResult)
     http.get(`${baseUrl}/invoices`, () => {
-      return HttpResponse.json(sampleInvoices);
+      return HttpResponse.json({ items: sampleInvoices, totalCount: sampleInvoices.length });
     }),
 
     // GET single invoice by ID

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -646,12 +646,18 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+      '@granit/workflow':
+        specifier: workspace:*
+        version: link:../workflow
 
   packages/@granit/localization:
     dependencies:
@@ -2013,12 +2019,6 @@ importers:
 
   packages/@granit/react-invoicing:
     dependencies:
-      '@granit/invoicing':
-        specifier: workspace:*
-        version: link:../invoicing
-      '@granit/query-engine':
-        specifier: workspace:*
-        version: link:../query-engine
       '@granit/react-query-engine':
         specifier: workspace:*
         version: link:../react-query-engine
@@ -2035,6 +2035,12 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/invoicing':
+        specifier: workspace:*
+        version: link:../invoicing
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -2047,6 +2053,9 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+      '@granit/workflow':
+        specifier: workspace:*
+        version: link:../workflow
 
   packages/@granit/react-localization:
     dependencies:


### PR DESCRIPTION
## Summary

- **BREAKING**: `listInvoices()` replaced by `queryInvoices()` — the list endpoint is a Query Engine endpoint; returns `PagedResult<InvoiceResponse>` instead of a flat array
- **BREAKING**: `InvoiceCreateRequest` gains required field `partyId: string` (mirroring backend DTO)
- **BREAKING**: `BillingReason` type removes phantom values `'Subscription'` and `'Upcoming'` that don't exist in the backend enum

New capabilities:
- `getInvoiceMeta()` / `useInvoiceMeta()` — query metadata (columns, filters, sort, presets)
- `listInvoiceTransitions()` / `useListInvoiceTransitions()` — workflow status and available transitions
- `executeInvoiceTransition()` / `useExecuteInvoiceTransition()` — execute state machine transitions
- `InvoiceStatus` and `InvoiceSourceType` types exported from `@granit/invoicing`

## Test plan

- [ ] `pnpm --filter @granit/invoicing --filter @granit/react-invoicing exec tsc --noEmit` passes
- [ ] `pnpm lint` passes (no ESLint warnings or errors)
- [ ] `pnpm test` passes for `@granit/invoicing` and `@granit/react-invoicing`
- [ ] MSW handlers return `{ items: [...], totalCount: N }` shape (QE contract)
- [ ] Showcase invoice list page still renders correctly via `invoicesPage?.items ?? []`