### PR TITLE
test: increase branch coverage above 80% threshold

### DIFF
--- a/packages/@granit/react-ai/src/__tests__/ai-hooks.test.tsx
+++ b/packages/@granit/react-ai/src/__tests__/ai-hooks.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { useAIChat } from '../hooks/use-ai-chat';
 import { useAIEmbeddings } from '../hooks/use-ai-embeddings';
+import { useAIProviders } from '../hooks/use-ai-providers';
 import { useAIWorkspace } from '../hooks/use-ai-workspace';
 import { useAIWorkspaces } from '../hooks/use-ai-workspaces';
 import { useCreateAIWorkspace } from '../hooks/use-create-ai-workspace';
@@ -222,6 +223,73 @@ describe('useAIEmbeddings', () => {
     expect(client.post).toHaveBeenCalledWith('/api/v1/ai/embeddings/default', {
       inputs: ['Hello'],
     });
+    expect(result.current.data).toEqual(response);
+  });
+});
+
+// -- AI Providers ------------------------------------------------------------
+
+describe('useAIProviders', () => {
+  it('GETs the list of AI providers', async () => {
+    const client = createMockClient();
+    const response = [{ name: 'openai', displayName: 'OpenAI' }];
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(response));
+
+    const { result } = renderHook(() => useAIProviders(), {
+      wrapper: createWrapper(client, '/api/v1/ai'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(expect.stringContaining('/providers'));
+    expect(result.current.data).toEqual(response);
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(() => useAIProviders({ enabled: false }), {
+      wrapper: createWrapper(client, '/api/v1/ai'),
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('uses empty basePath when provider has no basePath configured', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    const { result } = renderHook(() => useAIProviders(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+});
+
+// -- useAIChat no basePath ---------------------------------------------------
+
+describe('useAIChat — no basePath', () => {
+  it('falls back to empty string basePath when none is configured', async () => {
+    const client = createMockClient();
+    const response = {
+      workspaceName: 'default',
+      model: 'gpt-4o',
+      content: 'Hi!',
+      usage: null,
+      duration: '00:00:01',
+    };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(response));
+
+    const { result } = renderHook(() => useAIChat(), {
+      wrapper: createWrapper(client),
+    });
+
+    await act(async () => {
+      result.current.send('default', { messages: [{ role: 'user', content: 'Hello' }] });
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.data).toEqual(response);
   });
 });

--- a/packages/@granit/react-authorization/src/__tests__/use-permission-grants.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-permission-grants.test.tsx
@@ -1,0 +1,111 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { usePermissionGrantMeta, usePermissionGrants } from '../hooks/use-permission-grants';
+
+import type { PermissionGrant } from '@granit/authorization';
+import type { QueryMetadata, PagedResult } from '@granit/query-engine';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+const MOCK_PAGE: PagedResult<PermissionGrant> = {
+  items: [],
+  totalCount: 0,
+  hasMore: false,
+};
+
+const MOCK_META: QueryMetadata = {
+  columns: [],
+  filterableFields: [],
+  sortableFields: [],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: { defaultPageSize: 20, maxPageSize: 100, supportsCursor: false },
+  defaultSort: null,
+};
+
+describe('usePermissionGrants', () => {
+  it('GETs /authorization/grants with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: MOCK_PAGE });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePermissionGrants({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/authorization/grants'),
+      expect.anything()
+    );
+  });
+
+  it('uses custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: MOCK_PAGE });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => usePermissionGrants({ client, basePath: '/api/v2/authorization' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v2/authorization/grants'),
+      expect.anything()
+    );
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePermissionGrants({ client, enabled: false }), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('usePermissionGrantMeta', () => {
+  it('GETs /authorization/grants/meta', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: MOCK_META });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePermissionGrantMeta({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/authorization/grants/meta'),
+      expect.anything()
+    );
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => usePermissionGrantMeta({ client, enabled: false }), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-authorization/src/__tests__/use-role-metadata.test.tsx
+++ b/packages/@granit/react-authorization/src/__tests__/use-role-metadata.test.tsx
@@ -1,0 +1,109 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useRoleMetadata, useRoleMetadataMeta } from '../hooks/use-role-metadata';
+
+import type { RoleMetadata } from '@granit/authorization';
+import type { QueryMetadata, PagedResult } from '@granit/query-engine';
+
+function createWrapper() {
+  const queryClient = createTestQueryClient();
+  return {
+    wrapper: ({ children }: { children: React.ReactNode }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  };
+}
+
+const MOCK_PAGE: PagedResult<RoleMetadata> = {
+  items: [],
+  totalCount: 0,
+  hasMore: false,
+};
+
+const MOCK_META: QueryMetadata = {
+  columns: [],
+  filterableFields: [],
+  sortableFields: [],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: { defaultPageSize: 20, maxPageSize: 100, supportsCursor: false },
+  defaultSort: null,
+};
+
+describe('useRoleMetadata', () => {
+  it('GETs /authorization/role-metadata with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: MOCK_PAGE });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRoleMetadata({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/authorization/role-metadata'),
+      expect.anything()
+    );
+  });
+
+  it('uses custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: MOCK_PAGE });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(
+      () => useRoleMetadata({ client, basePath: '/api/v2/authorization' }),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v2/authorization/role-metadata'),
+      expect.anything()
+    );
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRoleMetadata({ client, enabled: false }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useRoleMetadataMeta', () => {
+  it('GETs /authorization/role-metadata/meta', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: MOCK_META });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRoleMetadataMeta({ client }), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v1/authorization/role-metadata/meta'),
+      expect.anything()
+    );
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useRoleMetadataMeta({ client, enabled: false }), {
+      wrapper,
+    });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/use-document-properties.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-document-properties.test.tsx
@@ -1,0 +1,146 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useDocumentProperties,
+  useDocumentVersionProperties,
+} from '../hooks/use-document-properties';
+import { DocumentsProvider } from '../providers/documents-provider';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { DocumentPropertiesResponse } from '@granit/documents';
+import type { ReactNode } from 'react';
+
+const sampleProperties: DocumentPropertiesResponse = {
+  id: 'prop-1',
+  documentId: 'doc-1',
+  documentVersionId: 'ver-1',
+  sourceContentType: 'application/pdf',
+  status: 'Ready',
+  createdAt: '2026-06-01T00:00:00Z',
+  completedAt: '2026-06-01T00:01:00Z',
+  failureReason: null,
+  extractorCount: 2,
+  width: null,
+  height: null,
+  cameraMake: null,
+  cameraModel: null,
+  lensModel: null,
+  iso: null,
+  fNumber: null,
+  exposureTimeMs: null,
+  takenAt: null,
+  gpsLatitude: null,
+  gpsLongitude: null,
+  gpsAltitude: null,
+  pageCount: 10,
+  title: 'Contract',
+  author: null,
+  subject: null,
+  keywords: null,
+  producer: null,
+  revision: null,
+  lastModifiedBy: null,
+  durationMs: null,
+  codec: null,
+  bitrate: null,
+  artist: null,
+  album: null,
+  trackNumber: null,
+  genre: null,
+  rawMetadata: {},
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <DocumentsProvider config={{ client }}>{children}</DocumentsProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useDocumentProperties', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('GETs /documents/{id}/metadata', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleProperties });
+
+    const { result } = renderHook(() => useDocumentProperties('doc-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/metadata');
+    expect(result.current.data).toEqual(sampleProperties);
+  });
+
+  it('does not fire when id is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentProperties(''), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('honours enabled: false', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentProperties('doc-1', { enabled: false }), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useDocumentVersionProperties', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('GETs /documents/{id}/versions/{versionId}/metadata', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleProperties });
+
+    const { result } = renderHook(() => useDocumentVersionProperties('doc-1', 'ver-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/documents/documents/doc-1/versions/ver-1/metadata'
+    );
+  });
+
+  it('does not fire when id is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentVersionProperties('', 'ver-1'), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when versionId is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentVersionProperties('doc-1', ''), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('honours enabled: false', () => {
+    const client = createMockClient();
+    const { result } = renderHook(
+      () => useDocumentVersionProperties('doc-1', 'ver-1', { enabled: false }),
+      { wrapper: createWrapper(client) }
+    );
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/use-public-links.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-public-links.test.tsx
@@ -1,0 +1,132 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useCreateDocumentPublicLink,
+  useDocumentPublicLinks,
+  useRevokeDocumentPublicLink,
+} from '../hooks/use-public-links';
+import { DocumentsProvider } from '../providers/documents-provider';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { CreatePublicLinkResponse, PublicLinkResponse } from '@granit/documents';
+import type { ReactNode } from 'react';
+
+const sampleLink: PublicLinkResponse = {
+  id: 'lnk-1',
+  documentId: 'doc-1',
+  scope: 'Download',
+  expiresAt: '2026-07-01T00:00:00Z',
+  maxUses: null,
+  currentUses: 0,
+  revokedAt: null,
+  revocationReason: null,
+  createdAt: '2026-06-01T00:00:00Z',
+};
+
+const createResponse: CreatePublicLinkResponse = {
+  id: 'lnk-2',
+  documentId: 'doc-1',
+  token: 'tok-abc',
+  url: 'https://example.com/dl/tok-abc',
+  scope: 'Download',
+  expiresAt: '2026-07-01T00:00:00Z',
+  maxUses: null,
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <DocumentsProvider config={{ client }}>{children}</DocumentsProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useDocumentPublicLinks', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('GETs /documents/{id}/public-links', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleLink] });
+
+    const { result } = renderHook(() => useDocumentPublicLinks('doc-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/documents/documents/doc-1/public-links'
+    );
+    expect(result.current.data).toEqual([sampleLink]);
+  });
+
+  it('does not fire when documentId is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentPublicLinks(''), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('honours enabled: false', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentPublicLinks('doc-1', { enabled: false }), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useCreateDocumentPublicLink', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('POSTs /documents/{id}/public-links and invalidates the list', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue({ data: createResponse });
+
+    const { result } = renderHook(() => useCreateDocumentPublicLink(), {
+      wrapper: createWrapper(client),
+    });
+
+    await result.current.mutateAsync({
+      documentId: 'doc-1',
+      request: { scope: 'Download', ttlDays: 7, maxUses: null },
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      '/api/v1/documents/documents/doc-1/public-links',
+      expect.any(Object)
+    );
+  });
+});
+
+describe('useRevokeDocumentPublicLink', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('DELETEs /public-links/{id}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+    const { result } = renderHook(() => useRevokeDocumentPublicLink(), {
+      wrapper: createWrapper(client),
+    });
+
+    await result.current.mutateAsync({
+      id: 'lnk-1',
+      documentId: 'doc-1',
+      request: { reason: null },
+    });
+
+    expect(client.delete).toHaveBeenCalledWith(
+      '/api/v1/documents/public-links/lnk-1',
+      expect.any(Object)
+    );
+  });
+});

--- a/packages/@granit/react-documents/src/__tests__/use-renditions.test.tsx
+++ b/packages/@granit/react-documents/src/__tests__/use-renditions.test.tsx
@@ -1,0 +1,106 @@
+import { createMockClient, createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDocumentRenditions, useRenditionDownloadUrl } from '../hooks/use-renditions';
+import { DocumentsProvider } from '../providers/documents-provider';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ListRenditionsResponse, RenditionDownloadUrlResponse } from '@granit/documents';
+import type { ReactNode } from 'react';
+
+const sampleRenditions: ListRenditionsResponse = {
+  documentId: 'doc-1',
+  documentVersionId: 'ver-1',
+  renditions: [],
+};
+
+const sampleDownloadUrl: RenditionDownloadUrlResponse = {
+  url: 'https://cdn.example.com/rendition.webp',
+  expiresAt: '2026-06-06T01:00:00Z',
+};
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    return (
+      <QueryClientProvider client={queryClient}>
+        <DocumentsProvider config={{ client }}>{children}</DocumentsProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('useDocumentRenditions', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('GETs /documents/{id}/renditions', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleRenditions });
+
+    const { result } = renderHook(() => useDocumentRenditions('doc-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith('/api/v1/documents/documents/doc-1/renditions');
+    expect(result.current.data).toEqual(sampleRenditions);
+  });
+
+  it('does not fire when id is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentRenditions(''), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('honours enabled: false', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useDocumentRenditions('doc-1', { enabled: false }), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});
+
+describe('useRenditionDownloadUrl', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('GETs /documents/{id}/renditions/{type}/download', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: sampleDownloadUrl });
+
+    const { result } = renderHook(() => useRenditionDownloadUrl('doc-1', 'Thumbnail'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.get).toHaveBeenCalledWith(
+      '/api/v1/documents/documents/doc-1/renditions/Thumbnail/download'
+    );
+    expect(result.current.data).toEqual(sampleDownloadUrl);
+  });
+
+  it('does not fire when id is empty', () => {
+    const client = createMockClient();
+    const { result } = renderHook(() => useRenditionDownloadUrl('', 'Thumbnail'), {
+      wrapper: createWrapper(client),
+    });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+
+  it('honours enabled: false', () => {
+    const client = createMockClient();
+    const { result } = renderHook(
+      () => useRenditionDownloadUrl('doc-1', 'Thumbnail', { enabled: false }),
+      { wrapper: createWrapper(client) }
+    );
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(client.get).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-presence/src/__tests__/use-user-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-user-presence.test.tsx
@@ -1,5 +1,5 @@
 import { createMockClient } from '@granit/react-testing';
-import { toEntityId } from '@granit/types';
+import { toEntityId, toISODateString } from '@granit/types';
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,7 +24,7 @@ const MOCK_PRESENCE: PresenceResponse = {
   effectiveStatus: 'Online',
   manualOverride: null,
   overrideUntilUtc: null,
-  lastSeenUtc: '2026-06-06T12:00:00Z' as ReturnType<typeof import('@granit/types').toISODateString>,
+  lastSeenUtc: toISODateString('2026-06-06T12:00:00Z'),
 };
 
 afterEach(() => vi.clearAllMocks());

--- a/packages/@granit/react-presence/src/__tests__/use-user-presence.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-user-presence.test.tsx
@@ -1,0 +1,64 @@
+import { createMockClient } from '@granit/react-testing';
+import { toEntityId } from '@granit/types';
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserPresence } from '../hooks/use-user-presence';
+
+import { createPresenceTestHarness } from './test-utils';
+
+import type { PresenceResponse } from '@granit/presence';
+import type { UserId } from '@granit/types';
+
+vi.mock('@granit/presence', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, getUserPresence: vi.fn() };
+});
+
+const { getUserPresence } = await import('@granit/presence');
+
+const USER_ID = toEntityId<'User'>('user-1') as UserId;
+
+const MOCK_PRESENCE: PresenceResponse = {
+  userId: USER_ID,
+  effectiveStatus: 'Online',
+  manualOverride: null,
+  overrideUntilUtc: null,
+  lastSeenUtc: '2026-06-06T12:00:00Z' as ReturnType<typeof import('@granit/types').toISODateString>,
+};
+
+afterEach(() => vi.clearAllMocks());
+
+describe('useUserPresence', () => {
+  it('fetches presence for a valid user id', async () => {
+    const client = createMockClient();
+    vi.mocked(getUserPresence).mockResolvedValue(MOCK_PRESENCE);
+
+    const { wrapper } = createPresenceTestHarness(client);
+    const { result } = renderHook(() => useUserPresence(USER_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual(MOCK_PRESENCE);
+  });
+
+  it('does not fetch when userId is empty', () => {
+    const client = createMockClient();
+    const emptyId = '' as UserId;
+
+    const { wrapper } = createPresenceTestHarness(client);
+    const { result } = renderHook(() => useUserPresence(emptyId), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getUserPresence).not.toHaveBeenCalled();
+  });
+
+  it('does not fetch when enabled is false', () => {
+    const client = createMockClient();
+
+    const { wrapper } = createPresenceTestHarness(client);
+    const { result } = renderHook(() => useUserPresence(USER_ID, { enabled: false }), { wrapper });
+
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getUserPresence).not.toHaveBeenCalled();
+  });
+});

--- a/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
+++ b/packages/@granit/react-query-engine/src/__tests__/use-smart-filter.test.ts
@@ -357,3 +357,46 @@ describe('useSmartFilter — resilient to non-conforming metadata', () => {
     expect(result.current.suggestions).toEqual([]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// buildFieldSearchSuggestions — operator fallback and column-label paths
+// ---------------------------------------------------------------------------
+
+describe('useSmartFilter — field search suggestion branches', () => {
+  it('uses Eq operator when Contains is absent from the field operators', () => {
+    const metadata: QueryMetadata = {
+      ...MOCK_METADATA,
+      filterableFields: [{ name: 'Code', type: 'String', operators: ['Eq', 'StartsWith'] }],
+      columns: [{ name: 'Code', label: 'Code', type: 'String', order: 0, isSortable: false, isFilterable: true, isVisible: true }],
+    };
+    const { result } = renderHook(() => useSmartFilter({ metadata }));
+    act(() => result.current.setInput('A'));
+    const suggestion = result.current.suggestions.find((s) => s.field === 'Code');
+    expect(suggestion).toBeDefined();
+    expect(suggestion!.operator).toBe('Eq');
+  });
+
+  it('skips a String field whose operators include neither Contains nor Eq', () => {
+    const metadata: QueryMetadata = {
+      ...MOCK_METADATA,
+      filterableFields: [{ name: 'Slug', type: 'String', operators: ['StartsWith'] }],
+      columns: [{ name: 'Slug', label: 'Slug', type: 'String', order: 0, isSortable: false, isFilterable: true, isVisible: true }],
+    };
+    const { result } = renderHook(() => useSmartFilter({ metadata }));
+    act(() => result.current.setInput('a'));
+    expect(result.current.suggestions.find((s) => s.field === 'Slug')).toBeUndefined();
+  });
+
+  it('falls back to field.name when the field is absent from metadata.columns', () => {
+    const metadata: QueryMetadata = {
+      ...MOCK_METADATA,
+      filterableFields: [{ name: 'OrphanField', type: 'String', operators: ['Contains'] }],
+      columns: [],
+    };
+    const { result } = renderHook(() => useSmartFilter({ metadata }));
+    act(() => result.current.setInput('x'));
+    const suggestion = result.current.suggestions.find((s) => s.field === 'OrphanField');
+    expect(suggestion).toBeDefined();
+    expect(suggestion!.label).toBe('OrphanField');
+  });
+});

--- a/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
+++ b/packages/@granit/react-timeline/src/__tests__/use-toggle-reaction.test.tsx
@@ -96,6 +96,16 @@ describe('toggleReactionMap', () => {
     });
   });
 
+  it('removes only the toggled-off emoji when other emojis remain in the map', () => {
+    const before: ReactionMap = {
+      [THUMBS_UP]: { count: 1, byCurrentUser: true },
+      [HEART]: { count: 3, byCurrentUser: false },
+    };
+    expect(toggleReactionMap(before, THUMBS_UP)).toEqual({
+      [HEART]: { count: 3, byCurrentUser: false },
+    });
+  });
+
   it('removes the entry entirely when toggling off the last reactor', () => {
     const before: ReactionMap = { [EYES]: { count: 1, byCurrentUser: true } };
     expect(toggleReactionMap(before, EYES)).toBeUndefined();
@@ -166,6 +176,56 @@ describe('useToggleReaction — optimistic update', () => {
 
     const page = queryClient.getQueryData<TimelineEntryPage>(['timeline', 'Quote', 'q-1']);
     expect(page?.items[0]?.reactions).toEqual({ [HEART]: { count: 5, byCurrentUser: false } });
+  });
+});
+
+describe('useToggleReaction — bare TimelineEntry in cache', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('patches a bare TimelineEntry (not wrapped in a page) when its id matches', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    const bareEntry = makeEntry(ENTRY_ID);
+    queryClient.setQueryData(['timeline', 'Quote', 'q-1'], bareEntry);
+
+    vi.mocked(client.post).mockResolvedValue(
+      axiosResponse(makeToggleResult(ENTRY_ID, THUMBS_UP, 7, true))
+    );
+
+    const { result } = renderHook(() => useToggleReaction(), { wrapper });
+    result.current.mutate({
+      entityType: 'Quote',
+      entityId: 'q-1',
+      entryId: ENTRY_ID,
+      emoji: THUMBS_UP,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const entry = queryClient.getQueryData<TimelineEntry>(['timeline', 'Quote', 'q-1']);
+    expect(entry?.reactions?.[THUMBS_UP]).toBeDefined();
+  });
+
+  it('leaves a bare TimelineEntry unchanged when its id does not match', async () => {
+    const { client, queryClient, wrapper } = createHarness();
+    const otherEntry = makeEntry(OTHER_ENTRY_ID);
+    queryClient.setQueryData(['timeline', 'Quote', 'q-1'], otherEntry);
+
+    vi.mocked(client.post).mockResolvedValue(
+      axiosResponse(makeToggleResult(ENTRY_ID, HEART, 1, true))
+    );
+
+    const { result } = renderHook(() => useToggleReaction(), { wrapper });
+    result.current.mutate({
+      entityType: 'Quote',
+      entityId: 'q-1',
+      entryId: ENTRY_ID,
+      emoji: HEART,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const entry = queryClient.getQueryData<TimelineEntry>(['timeline', 'Quote', 'q-1']);
+    expect(entry?.reactions).toBeUndefined();
   });
 });
 

--- a/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
+++ b/packages/@granit/react-timeline/src/hooks/use-toggle-reaction.ts
@@ -207,6 +207,6 @@ function isTimelineEntry(value: unknown): value is TimelineEntry {
     typeof value === 'object' &&
     value !== null &&
     typeof (value as { id?: unknown }).id === 'string' &&
-    typeof (value as { entryType?: unknown }).entryType === 'number'
+    typeof (value as { entryType?: unknown }).entryType === 'string'
   );
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: corrects `isTimelineEntry` type guard in `use-toggle-reaction.ts` — was checking `typeof entryType === 'number'` but `TimelineEntryType` is a string union (`'Comment' | 'SystemLog' | 'InternalNote'`), making the bare-entry cache path dead code
- **New tests** for `@granit/react-documents` hooks added in #596: `useDocumentProperties`, `useDocumentVersionProperties`, `useDocumentPublicLinks`, `useCreateDocumentPublicLink`, `useRevokeDocumentPublicLink`, `useDocumentRenditions`, `useRenditionDownloadUrl`
- **New tests** for `@granit/react-authorization`: `usePermissionGrants`, `usePermissionGrantMeta`, `useRoleMetadata`, `useRoleMetadataMeta`
- **New tests** for `@granit/react-presence`: `useUserPresence`
- **Additional tests** for `useAIProviders` and `useAIChat` (no-basePath path)
- **Additional tests** for `buildFieldSearchSuggestions` branches in `use-smart-filter`
- **Additional tests** for `toggleReactionMap` multi-emoji and bare `TimelineEntry` cache paths

Branch coverage improves from **79.81% → ~81%** (above the 80% CI threshold with margin).

## Test plan

- [ ] `pnpm test:coverage` — branches ≥ 80%
- [ ] All 87 new/modified tests pass in isolation