### PR TITLE
fix(payments)!: align @granit/payments and react-payments with OpenAPI contract

### DIFF
--- a/packages/@granit/payments/src/__tests__/payments-api.test.ts
+++ b/packages/@granit/payments/src/__tests__/payments-api.test.ts
@@ -28,9 +28,8 @@ import type {
   PaymentMethodConfigurationItem,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
-  PaymentProviderConfiguration,
+  PaymentProviderConfigurationResponse,
   PaymentRefundRequest,
-  PaymentRefundResponse,
   PaymentTransactionResponse,
 } from '../types/index';
 
@@ -53,17 +52,6 @@ const sampleTransaction: PaymentTransactionResponse = {
   refunds: [],
   disputes: [],
   tenantId: null,
-};
-
-const sampleRefund: PaymentRefundResponse = {
-  id: 'ref-1',
-  amount: 2000,
-  currency: 'EUR',
-  status: 'Succeeded',
-  providerRefundId: 're_abc123',
-  reason: 'Customer request',
-  createdAt: '2026-04-02T10:00:00Z',
-  completedAt: '2026-04-02T10:05:00Z',
 };
 
 const sampleCheckoutSession: PaymentCheckoutSessionResponse = {
@@ -101,7 +89,7 @@ const sampleAvailableMethod: PaymentAvailableMethodResponse = {
 const sampleConfigurationItem: PaymentMethodConfigurationItem = {
   methodType: 'bancontact',
   displayLabel: 'Bancontact',
-  category: 1,
+  category: 'BankRedirect',
   activated: true,
   capabilitySnapshot: sampleCapability,
 };
@@ -111,7 +99,7 @@ const sampleProviderCatalog: PaymentProviderCatalogResponse = {
   methods: [
     {
       methodType: 'bancontact',
-      category: 1,
+      category: 'BankRedirect',
       displayLabel: 'Bancontact',
       capability: sampleCapability,
       activated: true,
@@ -119,7 +107,7 @@ const sampleProviderCatalog: PaymentProviderCatalogResponse = {
     },
     {
       methodType: 'ideal',
-      category: 1,
+      category: 'BankRedirect',
       displayLabel: 'iDEAL',
       capability: {
         supportedCountries: ['NL'],
@@ -170,7 +158,7 @@ describe('payments-api', () => {
   });
 
   describe('initiatePaymentCharge', () => {
-    it('should POST {basePath}/charge', async () => {
+    it('should POST {basePath}/charge and return void (202 no body)', async () => {
       const client = createMockClient();
       const request: PaymentChargeRequest = {
         invoiceId: 'inv-1',
@@ -179,29 +167,27 @@ describe('payments-api', () => {
         methodType: 'card',
         providerName: null,
       };
-      vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleTransaction));
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
 
-      const result = await initiatePaymentCharge(client, basePath, request);
+      await initiatePaymentCharge(client, basePath, request);
 
       expect(client.post).toHaveBeenCalledWith(`${basePath}/charge`, request);
-      expect(result).toEqual(sampleTransaction);
     });
   });
 
   describe('requestPaymentRefund', () => {
-    it('should POST {basePath}/refund', async () => {
+    it('should POST {basePath}/refund and return void (202 no body)', async () => {
       const client = createMockClient();
       const request: PaymentRefundRequest = {
         transactionId: 'txn-1',
         amount: 2000,
         reason: 'Customer request',
       };
-      vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleRefund));
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
 
-      const result = await requestPaymentRefund(client, basePath, request);
+      await requestPaymentRefund(client, basePath, request);
 
       expect(client.post).toHaveBeenCalledWith(`${basePath}/refund`, request);
-      expect(result).toEqual(sampleRefund);
     });
   });
 
@@ -306,7 +292,7 @@ describe('payments-api', () => {
   describe('listPaymentMethodConfigurations', () => {
     it('should GET {basePath}/configuration', async () => {
       const client = createMockClient();
-      const payload: readonly PaymentProviderConfiguration[] = [
+      const payload: readonly PaymentProviderConfigurationResponse[] = [
         { providerName: 'mollie', methods: [sampleConfigurationItem] },
       ];
       vi.mocked(client.get).mockResolvedValue(axiosResponse(payload));

--- a/packages/@granit/payments/src/api/payments-api.ts
+++ b/packages/@granit/payments/src/api/payments-api.ts
@@ -8,9 +8,8 @@ import type {
   PaymentMethodConfigurationItem,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
-  PaymentProviderConfiguration,
+  PaymentProviderConfigurationResponse,
   PaymentRefundRequest,
-  PaymentRefundResponse,
   PaymentTransactionResponse,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
@@ -52,29 +51,27 @@ export async function getPaymentTransaction(
 /**
  * Initiate a payment charge.
  *
- * `POST {basePath}/charge`
+ * `POST {basePath}/charge` → 202 Accepted (fire-and-forget command dispatch, no response body)
  */
 export async function initiatePaymentCharge(
   client: AxiosInstance,
   basePath: string,
   request: PaymentChargeRequest
-): Promise<PaymentTransactionResponse> {
-  const response = await client.post<PaymentTransactionResponse>(`${basePath}/charge`, request);
-  return response.data;
+): Promise<void> {
+  await client.post(`${basePath}/charge`, request);
 }
 
 /**
  * Request a payment refund.
  *
- * `POST {basePath}/refund`
+ * `POST {basePath}/refund` → 202 Accepted (fire-and-forget command dispatch, no response body)
  */
 export async function requestPaymentRefund(
   client: AxiosInstance,
   basePath: string,
   request: PaymentRefundRequest
-): Promise<PaymentRefundResponse> {
-  const response = await client.post<PaymentRefundResponse>(`${basePath}/refund`, request);
-  return response.data;
+): Promise<void> {
+  await client.post(`${basePath}/refund`, request);
 }
 
 /**
@@ -185,8 +182,8 @@ export async function detachPaymentMethod(
 export async function listPaymentMethodConfigurations(
   client: AxiosInstance,
   basePath: string
-): Promise<readonly PaymentProviderConfiguration[]> {
-  const response = await client.get<readonly PaymentProviderConfiguration[]>(
+): Promise<readonly PaymentProviderConfigurationResponse[]> {
+  const response = await client.get<readonly PaymentProviderConfigurationResponse[]>(
     `${basePath}/configuration`
   );
   return response.data;

--- a/packages/@granit/payments/src/index.ts
+++ b/packages/@granit/payments/src/index.ts
@@ -14,7 +14,7 @@ export type {
   PaymentMethodResponse,
   PaymentMethodSequenceTypeName,
   PaymentProviderCatalogResponse,
-  PaymentProviderConfiguration,
+  PaymentProviderConfigurationResponse,
   PaymentRefundRequest,
   PaymentRefundResponse,
   PaymentTransactionResponse,

--- a/packages/@granit/payments/src/types/index.ts
+++ b/packages/@granit/payments/src/types/index.ts
@@ -1,16 +1,24 @@
 export type PaymentStatus =
-  | 'Pending'
+  | 'Created'
+  | 'RequiresAction'
   | 'Processing'
   | 'Succeeded'
   | 'Failed'
-  | 'Canceled'
-  | 'RequiresAction';
+  | 'Canceled';
 
 export type RefundStatus = 'Pending' | 'Succeeded' | 'Failed';
 
-export type DisputeStatus = 'Open' | 'UnderReview' | 'Won' | 'Lost';
+export type DisputeStatus = 'Open' | 'Won' | 'Lost' | 'Closed';
 
-export type PaymentMethodCategory = 'Card' | 'BankTransfer' | 'Wallet' | 'DirectDebit';
+export type PaymentMethodCategory =
+  | 'Card'
+  | 'BankRedirect'
+  | 'BankTransfer'
+  | 'BankDebit'
+  | 'Wallet'
+  | 'BuyNowPayLater'
+  | 'Voucher'
+  | 'PointOfSale';
 
 export interface PaymentChargeRequest {
   readonly invoiceId: string;
@@ -149,8 +157,7 @@ export interface PaymentMethodCapabilityResponse {
 export interface PaymentMethodConfigurationItem {
   readonly methodType: string;
   readonly displayLabel: string;
-  /** Backend enum value (0=Card, 1=BankRedirect, 2=BankTransfer, 3=BankDebit, 4=Wallet, 5=BuyNowPayLater, 6=Voucher, 7=PointOfSale). */
-  readonly category: number;
+  readonly category: PaymentMethodCategory;
   readonly activated: boolean;
   /**
    * Capability snapshot captured at activation (or last resync).
@@ -161,7 +168,7 @@ export interface PaymentMethodConfigurationItem {
 }
 
 /** All methods declared by a single provider, with activation state. */
-export interface PaymentProviderConfiguration {
+export interface PaymentProviderConfigurationResponse {
   readonly providerName: string;
   readonly methods: readonly PaymentMethodConfigurationItem[];
 }
@@ -174,7 +181,7 @@ export interface PaymentProviderConfiguration {
  */
 export interface PaymentCatalogMethod {
   readonly methodType: string;
-  readonly category: number;
+  readonly category: PaymentMethodCategory;
   readonly displayLabel: string;
   readonly capability: PaymentMethodCapabilityResponse;
   readonly activated: boolean;

--- a/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
+++ b/packages/@granit/react-parties/src/__tests__/use-parties.test.tsx
@@ -109,7 +109,7 @@ describe('use-parties', () => {
   describe('usePartiesQuery', () => {
     it('lists parties without role filter', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [sampleListItem] });
+      vi.mocked(client.get).mockResolvedValue({ data: { items: [sampleListItem] } });
 
       const { result } = renderHook(() => usePartiesQuery(), {
         wrapper: createWrapper(client),
@@ -124,7 +124,7 @@ describe('use-parties', () => {
 
     it('passes role as query param', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [] });
+      vi.mocked(client.get).mockResolvedValue({ data: { items: [] } });
 
       const { result } = renderHook(() => usePartiesQuery({ role: 'Customer' }), {
         wrapper: createWrapper(client),
@@ -138,7 +138,7 @@ describe('use-parties', () => {
 
     it('uses custom basePath', async () => {
       const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue({ data: [] });
+      vi.mocked(client.get).mockResolvedValue({ data: { items: [] } });
 
       const { result } = renderHook(() => usePartiesQuery(), {
         wrapper: createWrapper(client, '/custom/parties'),

--- a/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
@@ -31,7 +31,7 @@ import type {
   PaymentMethodConfigurationItem,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
-  PaymentProviderConfiguration,
+  PaymentProviderConfigurationResponse,
   PaymentRefundResponse,
   PaymentTransactionResponse,
 } from '@granit/payments';
@@ -107,7 +107,7 @@ const sampleAvailableMethod: PaymentAvailableMethodResponse = {
 const sampleConfigurationItem: PaymentMethodConfigurationItem = {
   methodType: 'bancontact',
   displayLabel: 'Bancontact',
-  category: 1,
+  category: 'BankRedirect',
   activated: true,
   capabilitySnapshot: sampleCapability,
 };
@@ -117,7 +117,7 @@ const sampleProviderCatalog: PaymentProviderCatalogResponse = {
   methods: [
     {
       methodType: 'bancontact',
-      category: 1,
+      category: 'BankRedirect',
       displayLabel: 'Bancontact',
       capability: sampleCapability,
       activated: true,
@@ -381,7 +381,7 @@ describe('use-payments', () => {
   describe('usePaymentMethodConfigurations', () => {
     it('fetches the fused provider configuration list', async () => {
       const client = createMockClient();
-      const payload: readonly PaymentProviderConfiguration[] = [
+      const payload: readonly PaymentProviderConfigurationResponse[] = [
         { providerName: 'mollie', methods: [sampleConfigurationItem] },
       ];
       vi.mocked(client.get).mockResolvedValue({ data: payload });

--- a/packages/@granit/react-payments/src/hooks/use-payments.ts
+++ b/packages/@granit/react-payments/src/hooks/use-payments.ts
@@ -28,9 +28,8 @@ import type {
   PaymentMethodConfigurationItem,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
-  PaymentProviderConfiguration,
+  PaymentProviderConfigurationResponse,
   PaymentRefundRequest,
-  PaymentRefundResponse,
   PaymentTransactionResponse,
 } from '@granit/payments';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
@@ -84,11 +83,7 @@ export function usePaymentTransaction(id: string): UseQueryResult<PaymentTransac
  * await charge.mutateAsync({ invoiceId: 'inv-1', amount: 5000, ... });
  * ```
  */
-export function useInitiatePaymentCharge(): UseMutationResult<
-  PaymentTransactionResponse,
-  Error,
-  PaymentChargeRequest
-> {
+export function useInitiatePaymentCharge(): UseMutationResult<void, Error, PaymentChargeRequest> {
   const config = usePaymentsConfig();
   const queryClient = useQueryClient();
   const basePath = config.basePath!;
@@ -114,11 +109,7 @@ export function useInitiatePaymentCharge(): UseMutationResult<
  * await refund.mutateAsync({ transactionId: 'txn-1', amount: 2000, ... });
  * ```
  */
-export function useRequestPaymentRefund(): UseMutationResult<
-  PaymentRefundResponse,
-  Error,
-  PaymentRefundRequest
-> {
+export function useRequestPaymentRefund(): UseMutationResult<void, Error, PaymentRefundRequest> {
   const config = usePaymentsConfig();
   const queryClient = useQueryClient();
   const basePath = config.basePath!;
@@ -282,7 +273,7 @@ interface PaymentMethodToggleArgs {
  * ```
  */
 export function usePaymentMethodConfigurations(): UseQueryResult<
-  readonly PaymentProviderConfiguration[]
+  readonly PaymentProviderConfigurationResponse[]
 > {
   const config = usePaymentsConfig();
   const basePath = config.basePath!;

--- a/packages/@granit/react-payments/src/testing/configuration.ts
+++ b/packages/@granit/react-payments/src/testing/configuration.ts
@@ -13,9 +13,10 @@ import { DEFAULT_BASE_PATH } from '../constants';
 import type {
   PaymentCatalogMethod,
   PaymentMethodCapabilityResponse,
+  PaymentMethodCategory,
   PaymentMethodConfigurationItem,
   PaymentProviderCatalogResponse,
-  PaymentProviderConfiguration,
+  PaymentProviderConfigurationResponse,
 } from '@granit/payments';
 
 const cardCapability: PaymentMethodCapabilityResponse = {
@@ -49,7 +50,7 @@ const walletCapability: PaymentMethodCapabilityResponse = {
 interface MockMethod {
   readonly methodType: string;
   readonly displayLabel: string;
-  readonly category: number;
+  readonly category: PaymentMethodCategory;
   readonly capability: PaymentMethodCapabilityResponse;
 }
 
@@ -63,23 +64,23 @@ export const mockPaymentProviders: readonly MockProvider[] = [
   {
     providerName: 'stripe',
     methods: [
-      { methodType: 'card', displayLabel: 'Card', category: 0, capability: cardCapability },
+      { methodType: 'card', displayLabel: 'Card', category: 'Card', capability: cardCapability },
       {
         methodType: 'bancontact',
         displayLabel: 'Bancontact',
-        category: 1,
+        category: 'BankRedirect',
         capability: bankRedirectCapability,
       },
       {
         methodType: 'sepa_debit',
         displayLabel: 'SEPA Direct Debit',
-        category: 3,
+        category: 'BankDebit',
         capability: sepaCapability,
       },
       {
         methodType: 'apple_pay',
         displayLabel: 'Apple Pay',
-        category: 4,
+        category: 'Wallet',
         capability: walletCapability,
       },
     ],
@@ -90,16 +91,21 @@ export const mockPaymentProviders: readonly MockProvider[] = [
       {
         methodType: 'bancontact',
         displayLabel: 'Bancontact',
-        category: 1,
+        category: 'BankRedirect',
         capability: bankRedirectCapability,
       },
       {
         methodType: 'ideal',
         displayLabel: 'iDEAL',
-        category: 1,
+        category: 'BankRedirect',
         capability: { ...bankRedirectCapability, supportedCountries: ['NL'] },
       },
-      { methodType: 'eps', displayLabel: 'EPS', category: 1, capability: bankRedirectCapability },
+      {
+        methodType: 'eps',
+        displayLabel: 'EPS',
+        category: 'BankRedirect',
+        capability: bankRedirectCapability,
+      },
     ],
   },
 ];
@@ -123,7 +129,7 @@ export function createPaymentsConfigurationHandlers(baseUrl = DEFAULT_BASE_PATH)
   // Legacy record without snapshot — exercises the "pending refresh" badge.
   activated.set(key('mollie', 'ideal'), null);
 
-  function buildConfiguration(provider: MockProvider): PaymentProviderConfiguration {
+  function buildConfiguration(provider: MockProvider): PaymentProviderConfigurationResponse {
     const items: PaymentMethodConfigurationItem[] = provider.methods.map((m) => {
       const k = key(provider.providerName, m.methodType);
       const isActive = activated.has(k);

--- a/packages/@granit/react-payments/src/testing/data.ts
+++ b/packages/@granit/react-payments/src/testing/data.ts
@@ -32,7 +32,7 @@ export const sampleTransactions: Mutable<PaymentTransactionResponse>[] = [
   {
     id: toEntityId<'PaymentTransaction'>('txn_7xYzAbCdEf'),
     invoiceId: toEntityId<'Invoice'>('inv_002'),
-    status: 'Pending',
+    status: 'Created',
     amount: 5000,
     currency: 'EUR' as CurrencyCode,
     providerName: 'Stripe',

--- a/packages/@granit/react-payments/src/testing/handlers.ts
+++ b/packages/@granit/react-payments/src/testing/handlers.ts
@@ -6,7 +6,7 @@ import {
 } from '@granit/query-engine';
 import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
 import { created, noContent, notFound } from '@granit/testing/msw';
-import { toEntityId, toISODateString } from '@granit/types';
+import { toEntityId } from '@granit/types';
 import { http, HttpResponse } from 'msw';
 
 import { DEFAULT_BASE_PATH } from '../constants';
@@ -19,22 +19,16 @@ import {
   sampleTransactions,
 } from './data';
 
-import type {
-  PaymentAttachMethodRequest,
-  PaymentChargeRequest,
-  PaymentCheckoutRequest,
-  PaymentRefundRequest,
-} from '@granit/payments';
+import type { PaymentAttachMethodRequest, PaymentCheckoutRequest } from '@granit/payments';
 import type { QueryMetadata } from '@granit/query-engine';
-import type { CurrencyCode } from '@granit/types';
 
 const PAYMENT_STATUSES = [
-  'Pending',
+  'Created',
+  'RequiresAction',
   'Processing',
   'Succeeded',
   'Failed',
   'Canceled',
-  'RequiresAction',
 ];
 
 /** Mock /meta payload for the payment transactions resource. */
@@ -213,47 +207,14 @@ export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       });
     }),
 
-    // POST charge
-    http.post(`${baseUrl}/charge`, async ({ request }) => {
-      const body = (await request.json()) as PaymentChargeRequest;
-      return created({
-        id: toEntityId<'PaymentTransaction'>(
-          `txn_mock_${String(sampleTransactions.length + 1).padStart(3, '0')}`
-        ),
-        invoiceId: body.invoiceId,
-        status: 'Processing',
-        amount: body.amount,
-        currency: body.currency as CurrencyCode,
-        providerName: body.providerName,
-        providerTransactionId: null,
-        paymentMethodId: null,
-        actionUrl: null,
-        idempotencyKey: 'idem_mock',
-        failureCode: null,
-        succeededAt: null,
-        canceledAt: null,
-        refunds: [],
-        disputes: [],
-        tenantId: toEntityId<'Tenant'>('tenant_mock'),
-      });
+    // POST charge → 202 Accepted (fire-and-forget, no body)
+    http.post(`${baseUrl}/charge`, () => {
+      return new HttpResponse(null, { status: 202 });
     }),
 
-    // POST refund
-    http.post(`${baseUrl}/transactions/:id/refund`, async ({ params, request }) => {
-      const body = (await request.json()) as PaymentRefundRequest;
-      return created({
-        id: toEntityId<'PaymentRefund'>(
-          `ref_mock_${String(sampleRefunds.length + 1).padStart(3, '0')}`
-        ),
-        transactionId: params.id,
-        status: 'Pending',
-        amount: body.amount,
-        currency: 'EUR' as CurrencyCode,
-        reason: body.reason,
-        providerRefundId: null,
-        createdAt: toISODateString(new Date().toISOString()),
-        completedAt: null,
-      });
+    // POST refund → 202 Accepted (fire-and-forget, no body)
+    http.post(`${baseUrl}/refund`, () => {
+      return new HttpResponse(null, { status: 202 });
     }),
 
     // GET payment methods for the current tenant
@@ -267,7 +228,7 @@ export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
     }),
 
     // POST attach payment method
-    http.post(`${baseUrl}/methods/attach`, async ({ request }) => {
+    http.post(`${baseUrl}/methods`, async ({ request }) => {
       const body = (await request.json()) as PaymentAttachMethodRequest;
       return created({
         id: toEntityId<'PaymentMethod'>(
@@ -288,13 +249,17 @@ export function createPaymentsHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return noContent();
     }),
 
-    // POST checkout session
+    // POST checkout session → 201 Created
     http.post(`${baseUrl}/checkout`, async ({ request }) => {
       const body = (await request.json()) as PaymentCheckoutRequest;
-      return HttpResponse.json({
-        sessionId: `cs_mock_${String(Date.now()).slice(-8)}`,
-        url: `https://checkout.example.com/pay?amount=${body.amount}`,
-      });
+      return HttpResponse.json(
+        {
+          sessionId: 'cs_mock_checkout',
+          url: `https://checkout.example.com/pay?amount=${body.amount}`,
+          expiresAt: '2099-01-01T00:00:00Z',
+        },
+        { status: 201 }
+      );
     }),
   ];
 }


### PR DESCRIPTION
## Summary

- **CI fix**: `usePartiesQuery` test mocks updated to return paged envelope `{ items: [...] }` — `listParties` unwraps `response.data.items` after the parties alignment (#600) but the mocks were still passing flat arrays, causing React Query v5 to treat `undefined` as an error
- **`PaymentStatus`**: `Pending` → `Created` to match the backend's `CreateChargeCommand` default status
- **`DisputeStatus`**: removed `UnderReview` (not in OpenAPI spec), kept `Open / Won / Lost / Closed`
- **`PaymentMethodCategory`**: replaced numeric enum with string union (`Card | BankRedirect | BankTransfer | BankDebit | Wallet | BuyNowPayLater | Voucher | PointOfSale`)
- **`initiatePaymentCharge` / `requestPaymentRefund`**: return `void` — both endpoints return 202 with no body (fire-and-forget CQRS commands)
- **MSW handlers**: fix refund URL (`/refund` not `/transactions/:id/refund`), fix attach URL (`/methods` not `/methods/attach`), add `expiresAt` to checkout mock response
- **`PaymentProviderConfiguration`** renamed to **`PaymentProviderConfigurationResponse`** to match the .NET DTO naming convention; all tests and fixtures updated

## Test plan

- [ ] `pnpm tsc` — no errors
- [ ] `pnpm lint` — no warnings
- [ ] `npx vitest run packages/@granit/payments packages/@granit/react-payments packages/@granit/react-parties` — all tests pass