### PR TITLE
fix(tax)!: align @granit/tax and react-tax with OpenAPI contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -6424,21 +6424,6 @@
           "kind": "interface",
           "signature": "interface TaxProviderProps",
           "members": []
-        },
-        {
-          "name": "useTaxRateByCountry",
-          "kind": "function",
-          "signature": "function useTaxRateByCountry(countryCode: string): UseQueryResult<TaxRateResponse>"
-        },
-        {
-          "name": "useTaxRates",
-          "kind": "function",
-          "signature": "function useTaxRates(): UseQueryResult<readonly TaxRateResponse[]>"
-        },
-        {
-          "name": "useValidateTaxId",
-          "kind": "function",
-          "signature": "function useValidateTaxId(): UseMutationResult< TaxValidateResponse, Error, TaxValidateRequest >"
         }
       ]
     },
@@ -7286,24 +7271,6 @@
       "description": "Tax validation and rate lookup — types and API functions",
       "exports": [
         {
-          "name": "TaxRateResponse",
-          "kind": "interface",
-          "signature": "interface TaxRateResponse",
-          "members": []
-        },
-        {
-          "name": "TaxValidateRequest",
-          "kind": "interface",
-          "signature": "interface TaxValidateRequest",
-          "members": []
-        },
-        {
-          "name": "TaxValidateResponse",
-          "kind": "interface",
-          "signature": "interface TaxValidateResponse",
-          "members": []
-        },
-        {
           "name": "TaxPermissions",
           "kind": "const",
           "signature": "const TaxPermissions"
@@ -7314,9 +7281,14 @@
           "signature": "async function getTaxRateByCountry( client: AxiosInstance, basePath: string, countryCode: string ): Promise<TaxRateResponse>"
         },
         {
-          "name": "getTaxRates",
+          "name": "getTaxRatesMeta",
           "kind": "function",
-          "signature": "async function getTaxRates( client: AxiosInstance, basePath: string ): Promise<readonly TaxRateResponse[]>"
+          "signature": "async function getTaxRatesMeta( client: AxiosInstance, basePath: string ): Promise<QueryMetadata>"
+        },
+        {
+          "name": "queryTaxRates",
+          "kind": "function",
+          "signature": "async function queryTaxRates( client: AxiosInstance, basePath: string, request: QueryRequest ="
         },
         {
           "name": "validateTaxId",

--- a/packages/@granit/react-tax/package.json
+++ b/packages/@granit/react-tax/package.json
@@ -16,6 +16,7 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/tax": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
@@ -23,6 +24,9 @@
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }
@@ -42,6 +46,7 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",

--- a/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
+++ b/packages/@granit/react-tax/src/__tests__/use-tax.test.tsx
@@ -5,11 +5,17 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useTaxRateByCountry, useTaxRates, useValidateTaxId } from '../hooks/use-tax';
+import {
+  useTaxRateByCountry,
+  useTaxRates,
+  useTaxRatesMeta,
+  useValidateTaxId,
+} from '../hooks/use-tax';
 import { TaxProvider } from '../providers/tax-provider';
 
 import type { TaxConfig } from '../providers/tax-provider';
-import type { TaxRateResponse, TaxValidateResponse } from '@granit/tax';
+import type { PagedResult, QueryMetadata } from '@granit/query-engine';
+import type { TaxRateEntry, TaxRateResponse, TaxValidateResponse } from '@granit/tax';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -38,6 +44,26 @@ const mockValidateResponse: TaxValidateResponse = {
   source: 'VIES',
 };
 
+const mockBelgiumEntry: TaxRateEntry = {
+  countryCode: 'BE',
+  standardRate: 21,
+  reducedRate: 6,
+  superReducedRate: null,
+  parkingRate: 12,
+  effectiveFrom: '2024-01-01',
+  effectiveTo: null,
+};
+
+const mockLuxembourgEntry: TaxRateEntry = {
+  countryCode: 'LU',
+  standardRate: 17,
+  reducedRate: 8,
+  superReducedRate: 3,
+  parkingRate: 14,
+  effectiveFrom: '2024-01-01',
+  effectiveTo: null,
+};
+
 const mockBelgiumRate: TaxRateResponse = {
   countryCode: 'BE',
   standardRate: 21,
@@ -56,6 +82,23 @@ const mockLuxembourgRate: TaxRateResponse = {
   parkingRate: 14,
   effectiveFrom: '2024-01-01',
   effectiveTo: null,
+};
+
+const mockPagedRates: PagedResult<TaxRateEntry> = {
+  items: [mockBelgiumEntry, mockLuxembourgEntry],
+  totalCount: 2,
+  hasMore: false,
+};
+
+const mockMeta: QueryMetadata = {
+  columns: [],
+  filterableFields: [],
+  sortableFields: [],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: { defaultPageSize: 25, maxPageSize: 500, maxStreamSize: 1000, supportsCursor: true },
 };
 
 // ---------------------------------------------------------------------------
@@ -126,30 +169,47 @@ describe('useTaxRates', () => {
     vi.restoreAllMocks();
   });
 
-  it('fetches all tax rates with default basePath', async () => {
+  it('fetches paged tax rates with default basePath', async () => {
     const client = createMockClient();
-    const rates = [mockBelgiumRate, mockLuxembourgRate];
-    vi.mocked(client.get).mockResolvedValue({ data: rates });
+    vi.mocked(client.get).mockResolvedValue({ data: mockPagedRates });
 
     const { result } = renderHook(() => useTaxRates(), {
       wrapper: createWrapper(client),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/api/v1/tax/rates');
-    expect(result.current.data).toEqual(rates);
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/api/v1/tax/rates');
+    expect(result.current.data?.items).toEqual([mockBelgiumEntry, mockLuxembourgEntry]);
+    expect(result.current.data?.totalCount).toBe(2);
   });
 
-  it('fetches all tax rates with custom basePath', async () => {
+  it('forwards query request params', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.get).mockResolvedValue({
+      data: { items: [mockBelgiumEntry], totalCount: 1, hasMore: false },
+    });
+
+    const { result } = renderHook(() => useTaxRates({ page: 2, pageSize: 10 }), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/api/v1/tax/rates');
+  });
+
+  it('fetches paged rates with custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: { items: [], totalCount: 0, hasMore: false } });
 
     const { result } = renderHook(() => useTaxRates(), {
       wrapper: createWrapper(client, '/custom/tax'),
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(client.get).toHaveBeenCalledWith('/custom/tax/rates');
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/custom/tax/rates');
   });
 
   it('exposes error state on failure', async () => {
@@ -162,6 +222,43 @@ describe('useTaxRates', () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
     expect(result.current.error?.message).toBe('Network error');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useTaxRatesMeta
+// ---------------------------------------------------------------------------
+
+describe('useTaxRatesMeta', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('fetches query metadata with default basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: mockMeta });
+
+    const { result } = renderHook(() => useTaxRatesMeta(), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/api/v1/tax/rates/meta');
+    expect(result.current.data).toEqual(mockMeta);
+  });
+
+  it('fetches metadata with custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: mockMeta });
+
+    const { result } = renderHook(() => useTaxRatesMeta(), {
+      wrapper: createWrapper(client, '/custom/tax'),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/custom/tax/rates/meta');
   });
 });
 

--- a/packages/@granit/react-tax/src/hooks/use-tax.ts
+++ b/packages/@granit/react-tax/src/hooks/use-tax.ts
@@ -1,9 +1,15 @@
-import { getTaxRateByCountry, getTaxRates, validateTaxId } from '@granit/tax';
+import { getTaxRateByCountry, getTaxRatesMeta, queryTaxRates, validateTaxId } from '@granit/tax';
 import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { buildTaxQueryKey, useTaxConfig } from '../providers/tax-provider';
 
-import type { TaxRateResponse, TaxValidateRequest, TaxValidateResponse } from '@granit/tax';
+import type { PagedResult, QueryMetadata, QueryRequest } from '@granit/query-engine';
+import type {
+  TaxRateEntry,
+  TaxRateResponse,
+  TaxValidateRequest,
+  TaxValidateResponse,
+} from '@granit/tax';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -31,20 +37,43 @@ export function useValidateTaxId(): UseMutationResult<
 }
 
 /**
- * Fetch all available tax rates.
+ * Query tax rates with filtering, sorting, and pagination (Query Engine).
  *
  * @example
  * ```tsx
- * const { data: rates } = useTaxRates();
+ * const { data } = useTaxRates();
+ * const rows = data?.items ?? [];
  * ```
  */
-export function useTaxRates(): UseQueryResult<readonly TaxRateResponse[]> {
+export function useTaxRates(request: QueryRequest = {}): UseQueryResult<PagedResult<TaxRateEntry>> {
   const config = useTaxConfig();
   const basePath = config.basePath!;
 
   return useQuery({
-    queryKey: buildTaxQueryKey(config, 'rates'),
-    queryFn: () => getTaxRates(config.client, basePath),
+    queryKey: [...buildTaxQueryKey(config, 'rates', 'list'), request],
+    queryFn: () => queryTaxRates(config.client, basePath, request),
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/**
+ * Fetch query metadata for tax rates (columns, filters, sorts, presets).
+ *
+ * Metadata is stable — cached indefinitely until the page is refreshed.
+ *
+ * @example
+ * ```tsx
+ * const { data: meta } = useTaxRatesMeta();
+ * ```
+ */
+export function useTaxRatesMeta(): UseQueryResult<QueryMetadata> {
+  const config = useTaxConfig();
+  const basePath = config.basePath!;
+
+  return useQuery({
+    queryKey: buildTaxQueryKey(config, 'rates', 'meta'),
+    queryFn: () => getTaxRatesMeta(config.client, basePath),
+    staleTime: Infinity,
   });
 }
 
@@ -66,5 +95,6 @@ export function useTaxRateByCountry(countryCode: string): UseQueryResult<TaxRate
     queryKey: buildTaxQueryKey(config, 'rates', countryCode),
     queryFn: () => getTaxRateByCountry(config.client, basePath, countryCode),
     enabled: countryCode.length > 0,
+    staleTime: 5 * 60 * 1000,
   });
 }

--- a/packages/@granit/react-tax/src/index.ts
+++ b/packages/@granit/react-tax/src/index.ts
@@ -3,4 +3,9 @@ export { TaxProvider, buildTaxQueryKey, useTaxConfig } from './providers/tax-pro
 export type { TaxConfig, TaxProviderProps } from './providers/tax-provider';
 
 // Hooks
-export { useTaxRateByCountry, useTaxRates, useValidateTaxId } from './hooks/use-tax';
+export {
+  useTaxRateByCountry,
+  useTaxRates,
+  useTaxRatesMeta,
+  useValidateTaxId,
+} from './hooks/use-tax';

--- a/packages/@granit/react-tax/src/testing/data.ts
+++ b/packages/@granit/react-tax/src/testing/data.ts
@@ -1,7 +1,7 @@
-import type { TaxRateResponse, TaxValidateResponse } from '@granit/tax';
+import type { TaxRateEntry, TaxValidateResponse } from '@granit/tax';
 import type { ISODateString } from '@granit/types';
 
-export const sampleTaxRates: TaxRateResponse[] = [
+export const sampleTaxRates: TaxRateEntry[] = [
   {
     countryCode: 'BE',
     standardRate: 21,

--- a/packages/@granit/react-tax/src/testing/handlers.ts
+++ b/packages/@granit/react-tax/src/testing/handlers.ts
@@ -12,8 +12,33 @@ import { sampleTaxRates, sampleValidation } from './data';
  */
 export function createTaxHandlers(baseUrl = DEFAULT_BASE_PATH) {
   return [
-    // GET /rates — all rates
-    http.get(`${baseUrl}/rates`, () => HttpResponse.json(sampleTaxRates)),
+    // GET /rates/meta — query metadata (must come before /rates/:countryCode)
+    http.get(`${baseUrl}/rates/meta`, () =>
+      HttpResponse.json({
+        columns: [],
+        filterableFields: [],
+        sortableFields: [],
+        presetFilterGroups: [],
+        quickFilters: [],
+        dateFilters: [],
+        groupByFields: [],
+        pagination: {
+          defaultPageSize: 25,
+          maxPageSize: 500,
+          maxStreamSize: 1000,
+          supportsCursor: true,
+        },
+      })
+    ),
+
+    // GET /rates — query engine list (PagedResult)
+    http.get(`${baseUrl}/rates`, () =>
+      HttpResponse.json({
+        items: sampleTaxRates,
+        totalCount: sampleTaxRates.length,
+        hasMore: false,
+      })
+    ),
 
     // GET /rates/:countryCode — single rate by country
     http.get(`${baseUrl}/rates/:countryCode`, ({ params }) => {

--- a/packages/@granit/tax/package.json
+++ b/packages/@granit/tax/package.json
@@ -15,10 +15,12 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*"
   },
   "peerDependencies": {
-    "@granit/api-client": "workspace:*"
+    "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/tax/src/__tests__/tax-api.test.ts
+++ b/packages/@granit/tax/src/__tests__/tax-api.test.ts
@@ -1,9 +1,15 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { getTaxRateByCountry, getTaxRates, validateTaxId } from '../api/tax-api';
+import { getTaxRateByCountry, getTaxRatesMeta, queryTaxRates, validateTaxId } from '../api/tax-api';
 
-import type { TaxRateResponse, TaxValidateRequest, TaxValidateResponse } from '../types/index';
+import type {
+  TaxRateEntry,
+  TaxRateResponse,
+  TaxValidateRequest,
+  TaxValidateResponse,
+} from '../types/index';
+import type { PagedResult, QueryMetadata } from '@granit/query-engine';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -21,6 +27,26 @@ const mockValidateResponse: TaxValidateResponse = {
   requestIdentifier: 'req-abc-123',
   validatedAt: '2026-04-04T10:00:00Z',
   source: 'VIES',
+};
+
+const mockBelgiumEntry: TaxRateEntry = {
+  countryCode: 'BE',
+  standardRate: 21,
+  reducedRate: 6,
+  superReducedRate: null,
+  parkingRate: 12,
+  effectiveFrom: '2024-01-01T00:00:00Z',
+  effectiveTo: null,
+};
+
+const mockLuxembourgEntry: TaxRateEntry = {
+  countryCode: 'LU',
+  standardRate: 17,
+  reducedRate: 8,
+  superReducedRate: 3,
+  parkingRate: 14,
+  effectiveFrom: '2024-01-01T00:00:00Z',
+  effectiveTo: null,
 };
 
 const mockBelgiumRate: TaxRateResponse = {
@@ -41,6 +67,23 @@ const mockLuxembourgRate: TaxRateResponse = {
   parkingRate: 14,
   effectiveFrom: '2024-01-01',
   effectiveTo: null,
+};
+
+const mockPagedRates: PagedResult<TaxRateEntry> = {
+  items: [mockBelgiumEntry, mockLuxembourgEntry],
+  totalCount: 2,
+  hasMore: false,
+};
+
+const mockMeta: QueryMetadata = {
+  columns: [],
+  filterableFields: [],
+  sortableFields: [],
+  presetFilterGroups: [],
+  quickFilters: [],
+  dateFilters: [],
+  groupByFields: [],
+  pagination: { defaultPageSize: 25, maxPageSize: 500, maxStreamSize: 1000, supportsCursor: true },
 };
 
 // ---------------------------------------------------------------------------
@@ -87,38 +130,79 @@ describe('validateTaxId', () => {
 });
 
 // ---------------------------------------------------------------------------
-// getTaxRates
+// queryTaxRates
 // ---------------------------------------------------------------------------
 
-describe('getTaxRates', () => {
-  it('should GET {basePath}/rates', async () => {
+describe('queryTaxRates', () => {
+  it('should GET {basePath}/rates and return PagedResult', async () => {
     const client = createMockClient();
-    const rates = [mockBelgiumRate, mockLuxembourgRate];
-    vi.mocked(client.get).mockResolvedValue({ data: rates });
+    vi.mocked(client.get).mockResolvedValue({ data: mockPagedRates });
 
-    const result = await getTaxRates(client, '/tax');
+    const result = await queryTaxRates(client, '/tax');
 
-    expect(client.get).toHaveBeenCalledWith('/tax/rates');
-    expect(result).toEqual(rates);
-    expect(result).toHaveLength(2);
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/tax/rates');
+    expect(result).toEqual(mockPagedRates);
+    expect(result.items).toHaveLength(2);
+  });
+
+  it('should forward query params', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({
+      data: { items: [mockBelgiumEntry], totalCount: 1, hasMore: false },
+    });
+
+    await queryTaxRates(client, '/tax', { page: 2, pageSize: 10, search: 'BE' });
+
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/tax/rates');
   });
 
   it('should work with custom basePath', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.get).mockResolvedValue({ data: mockPagedRates });
 
-    await getTaxRates(client, '/custom/tax');
+    await queryTaxRates(client, '/custom/tax');
 
-    expect(client.get).toHaveBeenCalledWith('/custom/tax/rates');
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/custom/tax/rates');
   });
 
-  it('should return empty array when no rates', async () => {
+  it('should return empty page when no rates', async () => {
     const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue({ data: [] });
+    vi.mocked(client.get).mockResolvedValue({ data: { items: [], totalCount: 0, hasMore: false } });
 
-    const result = await getTaxRates(client, '/tax');
+    const result = await queryTaxRates(client, '/tax');
 
-    expect(result).toEqual([]);
+    expect(result.items).toEqual([]);
+    expect(result.totalCount).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTaxRatesMeta
+// ---------------------------------------------------------------------------
+
+describe('getTaxRatesMeta', () => {
+  it('should GET {basePath}/rates/meta', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: mockMeta });
+
+    const result = await getTaxRatesMeta(client, '/tax');
+
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/tax/rates/meta');
+    expect(result).toEqual(mockMeta);
+  });
+
+  it('should work with custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: mockMeta });
+
+    await getTaxRatesMeta(client, '/custom/tax');
+
+    const [url] = vi.mocked(client.get).mock.calls[0]!;
+    expect(url).toContain('/custom/tax/rates/meta');
   });
 });
 

--- a/packages/@granit/tax/src/api/tax-api.ts
+++ b/packages/@granit/tax/src/api/tax-api.ts
@@ -1,5 +1,13 @@
-import type { TaxRateResponse, TaxValidateRequest, TaxValidateResponse } from '../types/index';
+import { getPage, getQueryMeta } from '@granit/query-engine';
+
+import type {
+  TaxRateEntry,
+  TaxRateResponse,
+  TaxValidateRequest,
+  TaxValidateResponse,
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
+import type { PagedResult, QueryMetadata, QueryRequest } from '@granit/query-engine';
 
 /**
  * Validate a tax ID (e.g. VAT number) against the configured tax service.
@@ -16,20 +24,32 @@ export async function validateTaxId(
 }
 
 /**
- * Fetch all available tax rates.
+ * Query tax rates with filtering, sorting, and pagination (Query Engine).
  *
  * `GET {basePath}/rates`
  */
-export async function getTaxRates(
+export async function queryTaxRates(
   client: AxiosInstance,
-  basePath: string
-): Promise<readonly TaxRateResponse[]> {
-  const response = await client.get<readonly TaxRateResponse[]>(`${basePath}/rates`);
-  return response.data;
+  basePath: string,
+  request: QueryRequest = {}
+): Promise<PagedResult<TaxRateEntry>> {
+  return getPage<TaxRateEntry>(client, `${basePath}/rates`, request);
 }
 
 /**
- * Fetch the tax rate for a specific country.
+ * Get query metadata for tax rates (columns, filters, sorts, presets).
+ *
+ * `GET {basePath}/rates/meta`
+ */
+export async function getTaxRatesMeta(
+  client: AxiosInstance,
+  basePath: string
+): Promise<QueryMetadata> {
+  return getQueryMeta(client, `${basePath}/rates`);
+}
+
+/**
+ * Get the tax rate for a specific country.
  *
  * `GET {basePath}/rates/{countryCode}`
  */

--- a/packages/@granit/tax/src/index.ts
+++ b/packages/@granit/tax/src/index.ts
@@ -1,8 +1,13 @@
 // Types
-export type { TaxRateResponse, TaxValidateRequest, TaxValidateResponse } from './types/index';
+export type {
+  TaxRateEntry,
+  TaxRateResponse,
+  TaxValidateRequest,
+  TaxValidateResponse,
+} from './types/index';
 
 // Permissions
 export { TaxPermissions } from './permissions';
 
 // API
-export { getTaxRateByCountry, getTaxRates, validateTaxId } from './api/tax-api';
+export { getTaxRateByCountry, getTaxRatesMeta, queryTaxRates, validateTaxId } from './api/tax-api';

--- a/packages/@granit/tax/src/types/index.ts
+++ b/packages/@granit/tax/src/types/index.ts
@@ -14,7 +14,18 @@ export interface TaxValidateResponse {
   readonly source: string;
 }
 
-/** Tax rate information for a specific country. */
+/** Tax rate row returned by the query engine (`GET /tax/rates`). */
+export interface TaxRateEntry {
+  readonly countryCode: string;
+  readonly standardRate: number;
+  readonly reducedRate?: number | null;
+  readonly superReducedRate?: number | null;
+  readonly parkingRate?: number | null;
+  readonly effectiveFrom?: string | null;
+  readonly effectiveTo?: string | null;
+}
+
+/** Full tax rate detail for a specific country (`GET /tax/rates/{countryCode}`). */
 export interface TaxRateResponse {
   readonly countryCode: string;
   readonly standardRate: number;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2683,6 +2683,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client
@@ -3047,6 +3050,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing


### PR DESCRIPTION
## Summary

- `GET /tax/rates` is a Query Engine endpoint — replace flat `TaxRateResponse[]` with `PagedResult<TaxRateEntry>` and a `QueryRequest` param
- Add `TaxRateEntry` (QE list rows, fewer required fields) distinct from `TaxRateResponse` (single-country lookup, all fields required+nullable)
- Replace `getTaxRates` with `queryTaxRates` (uses `getPage` helper) and add `getTaxRatesMeta` (uses `getQueryMeta` helper for `/rates/meta`)
- Add `useTaxRates(QueryRequest)` and `useTaxRatesMeta()` hooks; set `staleTime` on all queries
- Register `@granit/query-engine` as peer+dev dep in both packages; regenerate lockfile
- Fix MSW handlers: `/rates/meta` handler registered before `/:countryCode`; `/rates` returns `PagedResult` shape
- Rewrite tests: use `PagedResult<TaxRateEntry>` and `QueryMetadata` fixtures, `mock.calls[0]!` assertion pattern

## Breaking change

`useTaxRates` now returns `UseQueryResult<PagedResult<TaxRateEntry>>` (previously `UseQueryResult<TaxRateResponse[]>`). Showcase updated in a companion MR.

## Test plan

- [x] `pnpm --filter @granit/tax --filter @granit/react-tax exec tsc --noEmit` — clean
- [x] `npx vitest run packages/@granit/tax packages/@granit/react-tax` — 179 tests pass