### PR TITLE
fix(activities)!: align @granit/activities and @granit/react-activities with OpenAPI contract

### DIFF
--- a/packages/@granit/activities/src/__tests__/permissions.test.ts
+++ b/packages/@granit/activities/src/__tests__/permissions.test.ts
@@ -3,9 +3,11 @@ import { describe, expect, it } from 'vitest';
 import { ActivitiesPermissions } from '../permissions';
 
 describe('ActivitiesPermissions', () => {
-  it('exposes the three Activities permissions matching the backend keys', () => {
+  it('exposes all five Activities permission keys matching the backend', () => {
     expect(ActivitiesPermissions.Activities.Read).toBe('Activities.Activities.Read');
+    expect(ActivitiesPermissions.Activities.ReadOthers).toBe('Activities.Activities.ReadOthers');
     expect(ActivitiesPermissions.Activities.Manage).toBe('Activities.Activities.Manage');
+    expect(ActivitiesPermissions.Activities.Reassign).toBe('Activities.Activities.Reassign');
     expect(ActivitiesPermissions.Activities.Execute).toBe('Activities.Activities.Execute');
   });
 });

--- a/packages/@granit/react-activities/src/hooks/use-activities.ts
+++ b/packages/@granit/react-activities/src/hooks/use-activities.ts
@@ -72,5 +72,8 @@ export function useActivitiesCalendar(
   return useQuery({
     queryKey: buildActivitiesQueryKey(config, 'calendar', filter),
     queryFn: () => getActivitiesCalendar(config.client, config.basePath, filter),
+    // Matches the backend FusionCache TTL (1 min default) — avoids redundant
+    // network requests on component re-mounts within the same time window.
+    staleTime: 60_000,
   });
 }


### PR DESCRIPTION
## Summary

- **permissions.test.ts**: ajoute les assertions `ReadOthers` et `Reassign` qui manquaient (3 → 5 clés testées sur 5 définies dans le backend)
- **useActivitiesCalendar**: ajoute `staleTime: 60 000 ms` pour correspondre au TTL FusionCache 1 min du backend, évitant des requêtes réseau redondantes sur les re-mounts

## Test plan

- [ ] `pnpm vitest run` → `@granit/activities` permissions test passe avec les 5 clés
- [ ] `@granit/react-activities` calendar hook ne re-fetch pas avant 60 s sur les re-mounts
- [ ] `pnpm lint` → aucun warning