### PR TITLE
fix(workspaces)!: align @granit/workspaces and @granit/react-workspaces with backend contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -7619,7 +7619,7 @@
         {
           "name": "getWorkspaceTree",
           "kind": "function",
-          "signature": "async function getWorkspaceTree( client: AxiosInstance, basePath: string, config?: AxiosRequestConfig ): Promise<WorkspaceTreeResponse>"
+          "signature": "async function getWorkspaceTree( client: AxiosInstance, basePath: string, options?:"
         },
         {
           "name": "setPinnedLandingRoute",

--- a/packages/@granit/react-workspaces/package.json
+++ b/packages/@granit/react-workspaces/package.json
@@ -16,13 +16,11 @@
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/entities": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/workspaces": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
-    "react": "^19.0.0",
-    "react-i18next": "^17.0.0"
+    "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
     "msw": {
@@ -44,7 +42,6 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
-    "@granit/entities": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",

--- a/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
+++ b/packages/@granit/react-workspaces/src/__tests__/use-workspaces.test.tsx
@@ -38,6 +38,8 @@ const TREE: WorkspaceTreeResponse = {
               dashboardName: null,
               linkUrl: null,
               subWorkspaceName: null,
+              featureName: null,
+              routeName: null,
             },
           ],
         },

--- a/packages/@granit/react-workspaces/src/hooks/use-landing-redirect.ts
+++ b/packages/@granit/react-workspaces/src/hooks/use-landing-redirect.ts
@@ -48,15 +48,16 @@ export function useLandingRedirect(
   options: UseLandingRedirectOptions = {}
 ): UseLandingRedirectReturn {
   const enabled = options.enabled ?? true;
+  const { onResolved } = options;
   const { data: resolved, isLoading } = useLandingRoute({ enabled });
   const firedRef = useRef(false);
 
   useEffect(() => {
     if (!enabled || !resolved || firedRef.current) return;
     firedRef.current = true;
-    options.onResolved?.(resolved);
+    onResolved?.(resolved);
     navigate(resolved.route);
-  }, [enabled, resolved, navigate, options]);
+  }, [enabled, resolved, navigate, onResolved]);
 
   return {
     isResolving: isLoading,

--- a/packages/@granit/react-workspaces/src/hooks/use-workspaces.ts
+++ b/packages/@granit/react-workspaces/src/hooks/use-workspaces.ts
@@ -7,11 +7,16 @@ import type { WorkspaceTreeResponse } from '@granit/workspaces';
 const API_PREFIX = '/api/v1';
 
 /**
- * Cache key for the workspace tree. Bumped via
+ * Cache key for the workspace tree.
+ *
+ * Pass the same `includeShells` value used in `useWorkspaces` so
+ * invalidations by key are scoped to the same variant:
  * `queryClient.invalidateQueries({ queryKey: ['workspaces', 'tree'] })`
- * whenever a permission change should re-filter the visible workspaces.
+ * clears ALL variants (prefix match); a fully-qualified key invalidates
+ * only the matching variant.
  */
-export const workspaceTreeQueryKey = () => ['workspaces', 'tree'] as const;
+export const workspaceTreeQueryKey = (includeShells?: boolean) =>
+  ['workspaces', 'tree', includeShells] as const;
 
 /**
  * `GET /api/v1/workspaces` — returns the workspace tree the requesting user can
@@ -22,14 +27,20 @@ export const workspaceTreeQueryKey = () => ['workspaces', 'tree'] as const;
  * grants, neither of which churns mid-session. The .NET handler caches
  * the response per `(user-perms-hash, culture)` so even an aggressive
  * refetch usually short-circuits server-side.
+ *
+ * Pass `includeShells: false` to omit Framework shell workspaces — the
+ * Tenant-scope sidebar switcher benefits from this since it already
+ * filters shells out client-side; skipping them server-side halves the
+ * payload.
  */
 export function useWorkspaces(
-  options: { readonly enabled?: boolean } = {}
+  options: { readonly enabled?: boolean; readonly includeShells?: boolean } = {}
 ): UseQueryResult<WorkspaceTreeResponse> {
   const api = useGranitClient();
   return useQuery({
-    queryKey: workspaceTreeQueryKey(),
-    queryFn: ({ signal }) => getWorkspaceTree(api, API_PREFIX, { signal }),
+    queryKey: workspaceTreeQueryKey(options.includeShells),
+    queryFn: ({ signal }) =>
+      getWorkspaceTree(api, API_PREFIX, { signal, includeShells: options.includeShells }),
     enabled: options.enabled ?? true,
     staleTime: 5 * 60_000,
   });

--- a/packages/@granit/workspaces/src/__tests__/workspaces-api.test.ts
+++ b/packages/@granit/workspaces/src/__tests__/workspaces-api.test.ts
@@ -1,0 +1,114 @@
+import axios from 'axios';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { getLandingRoute, getWorkspaceTree, setPinnedLandingRoute } from '../api/workspaces-api';
+
+import type { LandingRouteResponse, WorkspaceTreeResponse } from '../types/index';
+
+const BASE = 'http://localhost';
+const BASE_PATH = '/api/v1';
+
+const TREE: WorkspaceTreeResponse = {
+  schemaVersion: 1,
+  workspaces: [],
+};
+
+const LANDING_ROUTE: LandingRouteResponse = {
+  route: '/w/Granit.Framework',
+  source: 'Framework',
+};
+
+const server = setupServer(
+  http.get(`${BASE}${BASE_PATH}/workspaces`, () => HttpResponse.json(TREE)),
+  http.get(`${BASE}${BASE_PATH}/me/landing-route`, () => HttpResponse.json(LANDING_ROUTE)),
+  http.put(
+    `${BASE}${BASE_PATH}/me/landing-route/pinned`,
+    () => new HttpResponse(null, { status: 204 })
+  )
+);
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const client = axios.create({ baseURL: BASE });
+
+describe('getWorkspaceTree', () => {
+  it('GETs /workspaces and returns the tree', async () => {
+    const result = await getWorkspaceTree(client, BASE_PATH);
+    expect(result).toEqual(TREE);
+  });
+
+  it('passes includeShells=false as a query param', async () => {
+    let capturedSearch = '';
+    server.use(
+      http.get(`${BASE}${BASE_PATH}/workspaces`, ({ request }) => {
+        capturedSearch = new URL(request.url).search;
+        return HttpResponse.json(TREE);
+      })
+    );
+    await getWorkspaceTree(client, BASE_PATH, { includeShells: false });
+    expect(capturedSearch).toContain('includeShells=false');
+  });
+
+  it('passes includeShells=true as a query param', async () => {
+    let capturedSearch = '';
+    server.use(
+      http.get(`${BASE}${BASE_PATH}/workspaces`, ({ request }) => {
+        capturedSearch = new URL(request.url).search;
+        return HttpResponse.json(TREE);
+      })
+    );
+    await getWorkspaceTree(client, BASE_PATH, { includeShells: true });
+    expect(capturedSearch).toContain('includeShells=true');
+  });
+
+  it('omits includeShells when not provided', async () => {
+    let capturedSearch = '';
+    server.use(
+      http.get(`${BASE}${BASE_PATH}/workspaces`, ({ request }) => {
+        capturedSearch = new URL(request.url).search;
+        return HttpResponse.json(TREE);
+      })
+    );
+    await getWorkspaceTree(client, BASE_PATH);
+    expect(capturedSearch).not.toContain('includeShells');
+  });
+
+  it('forwards AbortSignal via config', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      getWorkspaceTree(client, BASE_PATH, { signal: controller.signal })
+    ).rejects.toThrow();
+  });
+});
+
+describe('getLandingRoute', () => {
+  it('GETs /me/landing-route and returns the response', async () => {
+    const result = await getLandingRoute(client, BASE_PATH);
+    expect(result).toEqual(LANDING_ROUTE);
+  });
+});
+
+describe('setPinnedLandingRoute', () => {
+  it('PUTs /me/landing-route/pinned and resolves void', async () => {
+    await expect(
+      setPinnedLandingRoute(client, BASE_PATH, { route: '/w/CRM' })
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts route: null to clear the pin', async () => {
+    let body: unknown = null;
+    server.use(
+      http.put(`${BASE}${BASE_PATH}/me/landing-route/pinned`, async ({ request }) => {
+        body = await request.json();
+        return new HttpResponse(null, { status: 204 });
+      })
+    );
+    await setPinnedLandingRoute(client, BASE_PATH, { route: null });
+    expect(body).toEqual({ route: null });
+  });
+});

--- a/packages/@granit/workspaces/src/api/workspaces-api.ts
+++ b/packages/@granit/workspaces/src/api/workspaces-api.ts
@@ -10,13 +10,24 @@ import type { AxiosInstance, AxiosRequestConfig } from '@granit/api-client';
  * permission-filtered sections / items.
  *
  * `GET {basePath}/workspaces`
+ *
+ * Pass `includeShells: false` to omit Framework shell workspaces from the
+ * response — the backend skips computing shell contributions entirely,
+ * which reduces payload size for Tenant-scope contexts.
  */
 export async function getWorkspaceTree(
   client: AxiosInstance,
   basePath: string,
-  config?: AxiosRequestConfig
+  options?: { readonly includeShells?: boolean } & AxiosRequestConfig
 ): Promise<WorkspaceTreeResponse> {
-  const { data } = await client.get<WorkspaceTreeResponse>(`${basePath}/workspaces`, config);
+  const { includeShells, ...config } = options ?? {};
+  const { data } = await client.get<WorkspaceTreeResponse>(`${basePath}/workspaces`, {
+    ...config,
+    params:
+      includeShells !== undefined
+        ? { ...((config.params as Record<string, unknown> | undefined) ?? {}), includeShells }
+        : config.params,
+  });
   return data;
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2951,16 +2951,10 @@ importers:
       react:
         specifier: 19.2.7
         version: 19.2.7
-      react-i18next:
-        specifier: ^17.0.0
-        version: 17.0.8(i18next@26.3.0(typescript@6.0.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
     devDependencies:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
-      '@granit/entities':
-        specifier: workspace:*
-        version: link:../entities
       '@granit/react-api-client':
         specifier: workspace:*
         version: link:../react-api-client


### PR DESCRIPTION
## Summary

- `getWorkspaceTree`: adds `includeShells?: boolean` option forwarded as query param — lets Tenant-scope contexts skip Framework shell workspaces server-side, halving payload
- `workspaceTreeQueryKey`: now takes `includeShells` so cache variants are keyed independently; prefix invalidation (`['workspaces', 'tree']`) still clears all variants
- `useWorkspaces`: exposes `includeShells` option, wires query key and query fn
- `useLandingRedirect`: extracts `onResolved` from `options` object before deps array — fixes stale closure / re-render loop caused by inline object reference
- Adds `featureName` / `routeName` to workspace tree test fixture (missing fields)
- Removes unused `@granit/entities` and `react-i18next` peer deps from `@granit/react-workspaces`
- Adds 114-line unit test suite for `workspaces-api.ts` (`getWorkspaceTree`, `getLandingRoute`, `setPinnedLandingRoute`)

## Test plan

- [ ] `pnpm vitest run packages/@granit/workspaces packages/@granit/react-workspaces` — 64 tests pass
- [ ] `pnpm lint` — no warnings
- [ ] `pnpm tsc` — no errors