### PR TITLE
feat(react-privacy): add MSW handlers for regulation, opt-out and processing-purposes

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2185,6 +2185,16 @@
           "name": "PrivacyPermissions",
           "kind": "const",
           "signature": "const PrivacyPermissions"
+        },
+        {
+          "name": "PRIVACY_REGULATIONS",
+          "kind": "const",
+          "signature": "const PRIVACY_REGULATIONS"
+        },
+        {
+          "name": "PrivacyRegulationCode",
+          "kind": "type",
+          "signature": "type PrivacyRegulationCode = (typeof PRIVACY_REGULATIONS)[number]['code']"
         }
       ]
     },

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1640,11 +1640,6 @@
           ]
         },
         {
-          "name": "IdempotencyOptions",
-          "kind": "type",
-          "signature": "type IdempotencyOptions = IdempotencyClientOptions"
-        },
-        {
           "name": "enableIdempotency",
           "kind": "function",
           "signature": "function enableIdempotency(options?: IdempotencyClientOptions): void"
@@ -3189,11 +3184,6 @@
           "name": "useBffConfig",
           "kind": "function",
           "signature": "function useBffConfig(): BffContextType"
-        },
-        {
-          "name": "useBffContext",
-          "kind": "const",
-          "signature": "const useBffContext"
         },
         {
           "name": "BffContextType",
@@ -5145,6 +5135,16 @@
           "signature": "function GlobalErrorCapture("
         },
         {
+          "name": "ErrorContextProvider",
+          "kind": "function",
+          "signature": "function ErrorContextProvider("
+        },
+        {
+          "name": "useErrorBoundaryConfig",
+          "kind": "function",
+          "signature": "function useErrorBoundaryConfig(): ErrorContextValue"
+        },
+        {
           "name": "useBreadcrumb",
           "kind": "function",
           "signature": "function useBreadcrumb(): UseBreadcrumbReturn"
@@ -5527,6 +5527,16 @@
       "name": "@granit/react-notifications",
       "description": "React bindings for @granit/notifications — NotificationProvider, hooks",
       "exports": [
+        {
+          "name": "NotificationProvider",
+          "kind": "function",
+          "signature": "function NotificationProvider("
+        },
+        {
+          "name": "useNotificationConfig",
+          "kind": "function",
+          "signature": "function useNotificationConfig(): NotificationContextValue"
+        },
         {
           "name": "useRealTimeNotifications",
           "kind": "function",
@@ -6279,11 +6289,6 @@
           "signature": "function buildSchedulingQueryKey( config:"
         },
         {
-          "name": "schedulingKeys",
-          "kind": "const",
-          "signature": "const schedulingKeys"
-        },
-        {
           "name": "RescheduleVariables",
           "kind": "interface",
           "signature": "interface RescheduleVariables",
@@ -6913,11 +6918,6 @@
           "name": "useTracingConfig",
           "kind": "function",
           "signature": "function useTracingConfig(): Tracer"
-        },
-        {
-          "name": "useTracer",
-          "kind": "const",
-          "signature": "const useTracer"
         },
         {
           "name": "useSpan",

--- a/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
+++ b/packages/@granit/auditing/src/__tests__/audit-log-api.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   getAuditEntriesByCorrelationId,
   getAuditLogEntry,
-  listAuditLogEntries,
   listEntityAuditTrail,
 } from '../api/audit-log-api';
 import { AuditCategory } from '../types/index';
@@ -15,36 +14,6 @@ import type { AuditEntryDetailResponse, AuditPage } from '../types/index';
 const basePath = '/audit-log';
 
 describe('audit-log-api', () => {
-  describe('listAuditLogEntries', () => {
-    it('should call GET with params', async () => {
-      const client = createMockClient();
-      const page: AuditPage = {
-        items: [],
-        totalCount: 0,
-        hasMore: false,
-        nextCursor: null,
-      };
-      vi.mocked(client.get).mockResolvedValue(axiosResponse(page));
-
-      const params = { category: AuditCategory.DataMutation, page: 1, pageSize: 20 };
-      const result = await listAuditLogEntries(client, basePath, params);
-
-      expect(client.get).toHaveBeenCalledWith('/audit-log', { params });
-      expect(result).toEqual(page);
-    });
-
-    it('should call GET without params', async () => {
-      const client = createMockClient();
-      vi.mocked(client.get).mockResolvedValue(
-        axiosResponse({ items: [], totalCount: 0, hasMore: false, nextCursor: null })
-      );
-
-      await listAuditLogEntries(client, basePath);
-
-      expect(client.get).toHaveBeenCalledWith('/audit-log', { params: undefined });
-    });
-  });
-
   describe('getAuditLogEntry', () => {
     it('should call GET with encoded id', async () => {
       const client = createMockClient();

--- a/packages/@granit/auditing/src/api/audit-log-api.ts
+++ b/packages/@granit/auditing/src/api/audit-log-api.ts
@@ -1,26 +1,6 @@
-import type { AuditEntryDetailResponse, AuditListParams, AuditPage } from '../types/index'; // NOSONAR: deprecated symbols used only inside the deprecated listAuditLogEntries function
+import type { AuditEntryDetailResponse, AuditPage } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 import type { PaginationParams } from '@granit/query-engine';
-
-/**
- * List audit log entries with optional filters and pagination.
- *
- * `GET {basePath}`
- *
- * @deprecated `{basePath}` is a Granit QueryEngine endpoint
- * (`MapGranitQuery<AuditEntryResponse>`). The flat filter params in {@link AuditListParams}
- * are ignored by the backend binder (only `page`/`pageSize` work). Use
- * `getPage<AuditEntryResponse>(client, basePath, request)` from `@granit/query-engine`,
- * or the `useAuditEntries()` hook from `@granit/react-auditing`.
- */
-export async function listAuditLogEntries(
-  client: AxiosInstance,
-  basePath: string,
-  params?: AuditListParams
-): Promise<AuditPage> {
-  const { data } = await client.get<AuditPage>(basePath, { params });
-  return data;
-}
 
 /**
  * Get a single audit log entry by ID (includes entity change details).

--- a/packages/@granit/auditing/src/index.ts
+++ b/packages/@granit/auditing/src/index.ts
@@ -14,14 +14,12 @@ export type {
   AuditEntityChangeResponse,
   AuditEntityChangeId,
   AuditEntityChangeSummaryResponse,
-  AuditListParams,
   AuditPage,
   AuditPropertyChangeResponse,
 } from './types/index';
 
 // API
 export {
-  listAuditLogEntries,
   getAuditLogEntry,
   getAuditEntriesByCorrelationId,
   listEntityAuditTrail,

--- a/packages/@granit/auditing/src/types/index.ts
+++ b/packages/@granit/auditing/src/types/index.ts
@@ -1,4 +1,4 @@
-import type { PagedResult, PaginationParams } from '@granit/query-engine';
+import type { PagedResult } from '@granit/query-engine';
 import type { CorrelationId, EntityId, ISODateString, TenantId, UserId } from '@granit/types';
 
 // ---------------------------------------------------------------------------
@@ -71,27 +71,6 @@ export type AuditEntryDetailResponse = {
   readonly tenantId: TenantId | null;
   readonly correlationId: CorrelationId | null;
   readonly entityChanges: readonly AuditEntityChangeResponse[];
-};
-
-/**
- * Flat query parameters for the legacy audit list call.
- *
- * @deprecated The audit list endpoint (`GET /audit-entries`) is a Granit
- * QueryEngine endpoint (`MapGranitQuery<AuditEntryResponse>`), so flat filter
- * params (`category`, `userId`, `from`, `to`, …) are ignored by the backend
- * binder — only `page`/`pageSize` are honored. Use the QueryEngine surface
- * instead: `useAuditEntries()` (from `@granit/react-auditing`) or
- * `getPage<AuditEntryResponse>()` (from `@granit/query-engine`), which serialize
- * filters as `filter[field.op]=value`. There is no `AuditingQueryParameters` DTO
- * on the backend.
- */
-export type AuditListParams = PaginationParams & {
-  readonly userId?: string;
-  readonly entityType?: string;
-  readonly entityId?: string;
-  readonly category?: AuditCategoryValue;
-  readonly from?: ISODateString;
-  readonly to?: ISODateString;
 };
 
 /** Summary projection of an entity change — mirrors `AuditEntityChangeSummaryResponse`. */

--- a/packages/@granit/idempotency/src/index.ts
+++ b/packages/@granit/idempotency/src/index.ts
@@ -35,14 +35,6 @@ export interface IdempotencyClientOptions {
   keyGenerator?: (config: InternalAxiosRequestConfig) => string | undefined;
 }
 
-/**
- * @deprecated Renamed to {@link IdempotencyClientOptions} to avoid colliding
- * with the unrelated server-side `IdempotencyOptions` (.NET middleware config).
- * This alias is kept for backward compatibility and will be removed in a
- * future major version.
- */
-export type IdempotencyOptions = IdempotencyClientOptions;
-
 const DEFAULT_METHODS = ['post', 'put', 'patch', 'delete'];
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/privacy/src/index.ts
+++ b/packages/@granit/privacy/src/index.ts
@@ -75,3 +75,5 @@ export { getApplicableRegulation, listProcessingPurposes } from './api/privacy-a
 export { getOptOutStatus, requestOptOut } from './api/privacy-api';
 
 export { PrivacyPermissions } from './permissions';
+export { PRIVACY_REGULATIONS } from './regulations';
+export type { PrivacyRegulationCode } from './regulations';

--- a/packages/@granit/privacy/src/index.ts
+++ b/packages/@granit/privacy/src/index.ts
@@ -9,7 +9,6 @@ export type {
   LegalDocumentDetailResponse,
   // Legal document admin — shared
   DeletionState,
-  DeletionStatusValue,
   LegalDocumentCreateRequest,
   LegalDocumentLifecycleStatus,
   LegalDocumentListParams,

--- a/packages/@granit/privacy/src/regulations.ts
+++ b/packages/@granit/privacy/src/regulations.ts
@@ -1,0 +1,20 @@
+export const PRIVACY_REGULATIONS = [
+  // Tier 1 — Major jurisdictions
+  { code: 'EU_GDPR', displayName: 'EU — GDPR', tier: 1 as const },
+  { code: 'UK_GDPR', displayName: 'UK — UK GDPR', tier: 1 as const },
+  { code: 'BR_LGPD', displayName: 'Brazil — LGPD', tier: 1 as const },
+  { code: 'US_CCPA', displayName: 'California (US) — CCPA', tier: 1 as const },
+  { code: 'CA_PIPEDA', displayName: 'Canada — PIPEDA', tier: 1 as const },
+  { code: 'CA_QUEBEC_25', displayName: 'Québec (CA) — Law 25', tier: 1 as const },
+  { code: 'CH_NFADP', displayName: 'Switzerland — nFADP', tier: 1 as const },
+  // Tier 2 — Additional jurisdictions
+  { code: 'CN_PIPL', displayName: 'China — PIPL', tier: 2 as const },
+  { code: 'IN_DPDPA', displayName: 'India — DPDPA', tier: 2 as const },
+  { code: 'JP_APPI', displayName: 'Japan — APPI', tier: 2 as const },
+  { code: 'KR_PIPA', displayName: 'South Korea — PIPA', tier: 2 as const },
+  { code: 'AU_PRIVACY_ACT', displayName: 'Australia — Privacy Act', tier: 2 as const },
+  { code: 'ZA_POPIA', displayName: 'South Africa — POPIA', tier: 2 as const },
+  { code: 'TH_PDPA', displayName: 'Thailand — PDPA', tier: 2 as const },
+] as const;
+
+export type PrivacyRegulationCode = (typeof PRIVACY_REGULATIONS)[number]['code'];

--- a/packages/@granit/privacy/src/types/index.ts
+++ b/packages/@granit/privacy/src/types/index.ts
@@ -20,9 +20,6 @@ export type PrivacyExportStatusResponse = {
 
 export type DeletionState = 'Deferred' | 'Executed' | 'Cancelled';
 
-/** @deprecated Use DeletionState */
-export type DeletionStatusValue = DeletionState; // NOSONAR: deprecated alias kept for backwards compatibility
-
 export type PrivacyDeletionRequest = {
   readonly reason: string;
   readonly defer?: boolean;

--- a/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
+++ b/packages/@granit/react-auditing/src/__tests__/use-audit-log.test.tsx
@@ -6,7 +6,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useAuditLogEntries, useAuditLogEntry, useEntityAuditTrail } from '../hooks/use-audit-log';
+import { useAuditLogEntry, useEntityAuditTrail } from '../hooks/use-audit-log';
 import { AuditLogProvider } from '../providers/audit-log-provider';
 
 import type { AuditLogProviderProps } from '../providers/audit-log-provider';
@@ -32,24 +32,6 @@ const emptyPage: AuditPage = {
   hasMore: false,
   nextCursor: null,
 };
-
-describe('useAuditLogEntries', () => {
-  it('should fetch entries', async () => {
-    const client = createMockClient();
-    vi.mocked(client.get).mockResolvedValue(axiosResponse(emptyPage));
-
-    const { result } = renderHook(
-      () => useAuditLogEntries({ category: AuditCategory.DataMutation }),
-      { wrapper: createWrapper(client) }
-    );
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual(emptyPage);
-    expect(client.get).toHaveBeenCalledWith('/api/v1/auditing/audit-entries', {
-      params: { category: AuditCategory.DataMutation },
-    });
-  });
-});
 
 describe('useAuditLogEntry', () => {
   it('should fetch a single entry', async () => {

--- a/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
+++ b/packages/@granit/react-auditing/src/hooks/use-audit-log.ts
@@ -1,7 +1,6 @@
 import {
   getAuditEntriesByCorrelationId,
   getAuditLogEntry,
-  listAuditLogEntries, // NOSONAR: used only inside the deprecated useAuditLogEntries hook
   listEntityAuditTrail,
   pseudonymizeUserAuditLogs,
 } from '@granit/auditing';
@@ -11,12 +10,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { buildAuditLogQueryKey, useAuditLogConfig } from '../providers/audit-log-provider';
 
 import type { AxiosError, ProblemDetails } from '@granit/api-client';
-import type {
-  AuditEntryResponse,
-  AuditEntryDetailResponse,
-  AuditListParams, // NOSONAR: used only inside the deprecated useAuditLogEntries hook
-  AuditPage,
-} from '@granit/auditing';
+import type { AuditEntryResponse, AuditEntryDetailResponse, AuditPage } from '@granit/auditing';
 import type { PaginationParams } from '@granit/query-engine';
 import type { UseQueryEndpointOptions, UseQueryEndpointReturn } from '@granit/react-query-engine';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
@@ -45,30 +39,6 @@ export function useAuditEntries(
 
 /** Query metadata (columns, filterable/sortable/group-by fields) for the audit-entries surface. */
 export { useQueryMeta as useAuditEntriesMeta } from '@granit/react-query-engine';
-
-/**
- * List paginated audit log entries with optional filters.
- *
- * @deprecated The list endpoint is a QueryEngine endpoint, so the flat filter
- * params (`category`, `userId`, `from`, `to`, …) are ignored by the backend —
- * only `page`/`pageSize` take effect. Use {@link useAuditEntries} instead, which
- * serializes filters in the format the backend understands.
- *
- * @example
- * ```tsx
- * const { data } = useAuditLogEntries({ category: AuditCategory.DataMutation });
- * ```
- */
-export function useAuditLogEntries(params?: AuditListParams): UseQueryResult<AuditPage> {
-  // NOSONAR: hook is deprecated itself
-  const config = useAuditLogConfig();
-  const auditEntriesPath = `${config.basePath}/audit-entries`;
-
-  return useQuery({
-    queryKey: buildAuditLogQueryKey(config, 'list', params),
-    queryFn: () => listAuditLogEntries(config.client, auditEntriesPath, params), // NOSONAR: deprecated function used inside deprecated hook
-  });
-}
 
 /**
  * Get a single audit log entry by ID (includes entity change details).

--- a/packages/@granit/react-auditing/src/index.ts
+++ b/packages/@granit/react-auditing/src/index.ts
@@ -16,7 +16,6 @@ export { useAuditEntityChanges, useAuditEntityChangesMeta } from './hooks/use-au
 
 // Custom-lookup hooks
 export {
-  useAuditLogEntries,
   useAuditLogEntry,
   useAuditEntriesByCorrelation,
   useEntityAuditTrail,

--- a/packages/@granit/react-bff/src/__tests__/bff-provider.test.tsx
+++ b/packages/@granit/react-bff/src/__tests__/bff-provider.test.tsx
@@ -6,7 +6,7 @@ import { BffGuard } from '../components/bff-guard';
 import { useBffAuth } from '../hooks/use-bff-auth';
 import { useBffCsrf } from '../hooks/use-bff-csrf';
 import { useBffFetch } from '../hooks/use-bff-fetch';
-import { BffProvider, useBffConfig, useBffContext } from '../providers/bff-provider';
+import { BffProvider, useBffConfig } from '../providers/bff-provider';
 
 import type { BffConfig } from '@granit/bff';
 
@@ -136,12 +136,6 @@ describe('useBffConfig', () => {
   it('should throw when used outside BffProvider', () => {
     expect(() => {
       renderHook(() => useBffConfig());
-    }).toThrow('useBffConfig must be used within a <BffProvider>');
-  });
-
-  it('should still work via deprecated useBffContext alias', () => {
-    expect(() => {
-      renderHook(() => useBffContext());
     }).toThrow('useBffConfig must be used within a <BffProvider>');
   });
 });

--- a/packages/@granit/react-bff/src/index.ts
+++ b/packages/@granit/react-bff/src/index.ts
@@ -1,4 +1,4 @@
-export { BffProvider, useBffConfig, useBffContext } from './providers/bff-provider';
+export { BffProvider, useBffConfig } from './providers/bff-provider';
 export type { BffContextType, BffProviderProps } from './providers/bff-provider';
 
 export { useBffAuth } from './hooks/use-bff-auth';

--- a/packages/@granit/react-bff/src/providers/bff-provider.tsx
+++ b/packages/@granit/react-bff/src/providers/bff-provider.tsx
@@ -191,6 +191,3 @@ export function useBffConfig(): BffContextType {
   }
   return context;
 }
-
-/** @deprecated Use useBffConfig instead */
-export const useBffContext = useBffConfig;

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -562,127 +562,130 @@ function DocumentsListBody({
       className={className}
     >
       {viewMode === 'list' ? (
-        <div role="grid" tabIndex={0} onKeyDown={handleKeyDown}>
-          <table data-granit-documents-list-table="">
-            <thead>
-              <tr>
-                <th data-granit-documents-list-select-col="">
+        <table
+          data-granit-documents-list-table=""
+          role="grid"
+          tabIndex={0}
+          onKeyDown={handleKeyDown}
+        >
+          <thead>
+            <tr>
+              <th data-granit-documents-list-select-col="">
+                <input
+                  type="checkbox"
+                  aria-label={labelStrings.selectHeader}
+                  checked={allSelected}
+                  onChange={(event) =>
+                    event.target.checked ? selection.selectAll(orderedIds) : selection.clear()
+                  }
+                />
+              </th>
+              <th>{labelStrings.nameHeader}</th>
+              <th>{labelStrings.statusHeader}</th>
+              {canManage && <th data-granit-documents-list-actions-col="" />}
+            </tr>
+          </thead>
+          <tbody>
+            {itemRenderState.map(({ document, isSelected, isFocused, mode, kind }) => (
+              <tr
+                key={document.id}
+                data-granit-documents-list-row=""
+                data-granit-document-id={document.id}
+                data-granit-document-kind={kind}
+                data-granit-documents-list-selected={isSelected ? '' : undefined}
+                data-granit-documents-list-focused={isFocused ? '' : undefined}
+                data-granit-documents-list-draggable={canManage ? '' : undefined}
+                aria-selected={isSelected}
+                tabIndex={-1}
+                draggable={canManage}
+                onClick={(event) => handleItemClick(event, document)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    selection.selectOnly(document.id);
+                    setFocusedId(document.id);
+                    onOpenDocument?.(document.id);
+                  }
+                }}
+                onDragStart={(event) => handleItemDragStart(event, document)}
+              >
+                <td data-granit-documents-list-select-cell="">
                   <input
                     type="checkbox"
-                    aria-label={labelStrings.selectHeader}
-                    checked={allSelected}
-                    onChange={(event) =>
-                      event.target.checked ? selection.selectAll(orderedIds) : selection.clear()
-                    }
+                    aria-label={`${labelStrings.selectRow} ${document.name}`}
+                    checked={isSelected}
+                    onClick={(event) => event.stopPropagation()}
+                    onChange={() => selection.toggle(document.id)}
                   />
-                </th>
-                <th>{labelStrings.nameHeader}</th>
-                <th>{labelStrings.statusHeader}</th>
-                {canManage && <th data-granit-documents-list-actions-col="" />}
+                </td>
+                <td>
+                  <DocumentNameCell
+                    mode={mode}
+                    canManage={canManage}
+                    document={document}
+                    onNameClick={onOpenDocument ? handleNameClick : undefined}
+                    renameLabel={labelStrings.rename}
+                    commitRename={commitRename}
+                    clearRowMode={clearRowMode}
+                    setRowMode={setRowMode}
+                  />
+                </td>
+                <td>{document.status}</td>
+                {canManage && (
+                  <td data-granit-documents-list-actions="">
+                    {mode === 'confirming-trash' ? (
+                      <span data-granit-documents-list-confirm="" role="alertdialog">
+                        <button type="button" onClick={() => clearRowMode(document.id)}>
+                          {labelStrings.trashCancel}
+                        </button>
+                        <button
+                          type="button"
+                          data-granit-documents-list-confirm-ok=""
+                          onClick={() => confirmTrash(document)}
+                          disabled={trashDocument.isPending}
+                        >
+                          {labelStrings.trashConfirm}
+                        </button>
+                      </span>
+                    ) : (
+                      <>
+                        <button
+                          type="button"
+                          aria-label={labelStrings.rename}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setRowMode(document.id, 'renaming');
+                          }}
+                        >
+                          {labelStrings.rename}
+                        </button>
+                        <button
+                          type="button"
+                          aria-label={labelStrings.trash}
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            setRowMode(document.id, 'confirming-trash');
+                          }}
+                        >
+                          {labelStrings.trash}
+                        </button>
+                      </>
+                    )}
+                  </td>
+                )}
               </tr>
-            </thead>
-            <tbody>
-              {itemRenderState.map(({ document, isSelected, isFocused, mode, kind }) => (
-                <tr
-                  key={document.id}
-                  data-granit-documents-list-row=""
-                  data-granit-document-id={document.id}
-                  data-granit-document-kind={kind}
-                  data-granit-documents-list-selected={isSelected ? '' : undefined}
-                  data-granit-documents-list-focused={isFocused ? '' : undefined}
-                  data-granit-documents-list-draggable={canManage ? '' : undefined}
-                  aria-selected={isSelected}
-                  tabIndex={-1}
-                  draggable={canManage}
-                  onClick={(event) => handleItemClick(event, document)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      selection.selectOnly(document.id);
-                      setFocusedId(document.id);
-                      onOpenDocument?.(document.id);
-                    }
-                  }}
-                  onDragStart={(event) => handleItemDragStart(event, document)}
-                >
-                  <td data-granit-documents-list-select-cell="">
-                    <input
-                      type="checkbox"
-                      aria-label={`${labelStrings.selectRow} ${document.name}`}
-                      checked={isSelected}
-                      onClick={(event) => event.stopPropagation()}
-                      onChange={() => selection.toggle(document.id)}
-                    />
-                  </td>
-                  <td>
-                    <DocumentNameCell
-                      mode={mode}
-                      canManage={canManage}
-                      document={document}
-                      onNameClick={onOpenDocument ? handleNameClick : undefined}
-                      renameLabel={labelStrings.rename}
-                      commitRename={commitRename}
-                      clearRowMode={clearRowMode}
-                      setRowMode={setRowMode}
-                    />
-                  </td>
-                  <td>{document.status}</td>
-                  {canManage && (
-                    <td data-granit-documents-list-actions="">
-                      {mode === 'confirming-trash' ? (
-                        <span data-granit-documents-list-confirm="" role="alertdialog">
-                          <button type="button" onClick={() => clearRowMode(document.id)}>
-                            {labelStrings.trashCancel}
-                          </button>
-                          <button
-                            type="button"
-                            data-granit-documents-list-confirm-ok=""
-                            onClick={() => confirmTrash(document)}
-                            disabled={trashDocument.isPending}
-                          >
-                            {labelStrings.trashConfirm}
-                          </button>
-                        </span>
-                      ) : (
-                        <>
-                          <button
-                            type="button"
-                            aria-label={labelStrings.rename}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              setRowMode(document.id, 'renaming');
-                            }}
-                          >
-                            {labelStrings.rename}
-                          </button>
-                          <button
-                            type="button"
-                            aria-label={labelStrings.trash}
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              setRowMode(document.id, 'confirming-trash');
-                            }}
-                          >
-                            {labelStrings.trash}
-                          </button>
-                        </>
-                      )}
-                    </td>
-                  )}
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+            ))}
+          </tbody>
+        </table>
       ) : (
         <div role="grid" tabIndex={0} onKeyDown={handleKeyDown}>
-          <div
+          <ul
             data-granit-documents-list-grid=""
             // tile size becomes a CSS custom property the host stylesheet picks
             // up to drive the grid column track + tile dimensions.
             style={{ ['--granit-documents-tile-size' as string]: `${String(tileSize)}px` }}
           >
             {itemRenderState.map(({ document, isSelected, isFocused, mode, kind, badge }) => (
-              <div
+              <li
                 key={document.id}
                 role="row"
                 data-granit-documents-list-tile=""
@@ -769,9 +772,9 @@ function DocumentsListBody({
                     )}
                   </div>
                 )}
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
         </div>
       )}
       <nav data-granit-documents-list-pagination="" aria-label="Pagination">

--- a/packages/@granit/react-documents/src/components/documents-list.tsx
+++ b/packages/@granit/react-documents/src/components/documents-list.tsx
@@ -562,130 +562,127 @@ function DocumentsListBody({
       className={className}
     >
       {viewMode === 'list' ? (
-        <table
-          data-granit-documents-list-table=""
-          role="grid"
-          tabIndex={0}
-          onKeyDown={handleKeyDown}
-        >
-          <thead>
-            <tr>
-              <th data-granit-documents-list-select-col="">
-                <input
-                  type="checkbox"
-                  aria-label={labelStrings.selectHeader}
-                  checked={allSelected}
-                  onChange={(event) =>
-                    event.target.checked ? selection.selectAll(orderedIds) : selection.clear()
-                  }
-                />
-              </th>
-              <th>{labelStrings.nameHeader}</th>
-              <th>{labelStrings.statusHeader}</th>
-              {canManage && <th data-granit-documents-list-actions-col="" />}
-            </tr>
-          </thead>
-          <tbody>
-            {itemRenderState.map(({ document, isSelected, isFocused, mode, kind }) => (
-              <tr
-                key={document.id}
-                data-granit-documents-list-row=""
-                data-granit-document-id={document.id}
-                data-granit-document-kind={kind}
-                data-granit-documents-list-selected={isSelected ? '' : undefined}
-                data-granit-documents-list-focused={isFocused ? '' : undefined}
-                data-granit-documents-list-draggable={canManage ? '' : undefined}
-                aria-selected={isSelected}
-                tabIndex={-1}
-                draggable={canManage}
-                onClick={(event) => handleItemClick(event, document)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    selection.selectOnly(document.id);
-                    setFocusedId(document.id);
-                    onOpenDocument?.(document.id);
-                  }
-                }}
-                onDragStart={(event) => handleItemDragStart(event, document)}
-              >
-                <td data-granit-documents-list-select-cell="">
+        <div role="grid" tabIndex={0} onKeyDown={handleKeyDown}>
+          <table data-granit-documents-list-table="">
+            <thead>
+              <tr>
+                <th data-granit-documents-list-select-col="">
                   <input
                     type="checkbox"
-                    aria-label={`${labelStrings.selectRow} ${document.name}`}
-                    checked={isSelected}
-                    onClick={(event) => event.stopPropagation()}
-                    onChange={() => selection.toggle(document.id)}
+                    aria-label={labelStrings.selectHeader}
+                    checked={allSelected}
+                    onChange={(event) =>
+                      event.target.checked ? selection.selectAll(orderedIds) : selection.clear()
+                    }
                   />
-                </td>
-                <td>
-                  <DocumentNameCell
-                    mode={mode}
-                    canManage={canManage}
-                    document={document}
-                    onNameClick={onOpenDocument ? handleNameClick : undefined}
-                    renameLabel={labelStrings.rename}
-                    commitRename={commitRename}
-                    clearRowMode={clearRowMode}
-                    setRowMode={setRowMode}
-                  />
-                </td>
-                <td>{document.status}</td>
-                {canManage && (
-                  <td data-granit-documents-list-actions="">
-                    {mode === 'confirming-trash' ? (
-                      <span data-granit-documents-list-confirm="" role="alertdialog">
-                        <button type="button" onClick={() => clearRowMode(document.id)}>
-                          {labelStrings.trashCancel}
-                        </button>
-                        <button
-                          type="button"
-                          data-granit-documents-list-confirm-ok=""
-                          onClick={() => confirmTrash(document)}
-                          disabled={trashDocument.isPending}
-                        >
-                          {labelStrings.trashConfirm}
-                        </button>
-                      </span>
-                    ) : (
-                      <>
-                        <button
-                          type="button"
-                          aria-label={labelStrings.rename}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            setRowMode(document.id, 'renaming');
-                          }}
-                        >
-                          {labelStrings.rename}
-                        </button>
-                        <button
-                          type="button"
-                          aria-label={labelStrings.trash}
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            setRowMode(document.id, 'confirming-trash');
-                          }}
-                        >
-                          {labelStrings.trash}
-                        </button>
-                      </>
-                    )}
-                  </td>
-                )}
+                </th>
+                <th>{labelStrings.nameHeader}</th>
+                <th>{labelStrings.statusHeader}</th>
+                {canManage && <th data-granit-documents-list-actions-col="" />}
               </tr>
-            ))}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {itemRenderState.map(({ document, isSelected, isFocused, mode, kind }) => (
+                <tr
+                  key={document.id}
+                  data-granit-documents-list-row=""
+                  data-granit-document-id={document.id}
+                  data-granit-document-kind={kind}
+                  data-granit-documents-list-selected={isSelected ? '' : undefined}
+                  data-granit-documents-list-focused={isFocused ? '' : undefined}
+                  data-granit-documents-list-draggable={canManage ? '' : undefined}
+                  aria-selected={isSelected}
+                  tabIndex={-1}
+                  draggable={canManage}
+                  onClick={(event) => handleItemClick(event, document)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      selection.selectOnly(document.id);
+                      setFocusedId(document.id);
+                      onOpenDocument?.(document.id);
+                    }
+                  }}
+                  onDragStart={(event) => handleItemDragStart(event, document)}
+                >
+                  <td data-granit-documents-list-select-cell="">
+                    <input
+                      type="checkbox"
+                      aria-label={`${labelStrings.selectRow} ${document.name}`}
+                      checked={isSelected}
+                      onClick={(event) => event.stopPropagation()}
+                      onChange={() => selection.toggle(document.id)}
+                    />
+                  </td>
+                  <td>
+                    <DocumentNameCell
+                      mode={mode}
+                      canManage={canManage}
+                      document={document}
+                      onNameClick={onOpenDocument ? handleNameClick : undefined}
+                      renameLabel={labelStrings.rename}
+                      commitRename={commitRename}
+                      clearRowMode={clearRowMode}
+                      setRowMode={setRowMode}
+                    />
+                  </td>
+                  <td>{document.status}</td>
+                  {canManage && (
+                    <td data-granit-documents-list-actions="">
+                      {mode === 'confirming-trash' ? (
+                        <span data-granit-documents-list-confirm="" role="alertdialog">
+                          <button type="button" onClick={() => clearRowMode(document.id)}>
+                            {labelStrings.trashCancel}
+                          </button>
+                          <button
+                            type="button"
+                            data-granit-documents-list-confirm-ok=""
+                            onClick={() => confirmTrash(document)}
+                            disabled={trashDocument.isPending}
+                          >
+                            {labelStrings.trashConfirm}
+                          </button>
+                        </span>
+                      ) : (
+                        <>
+                          <button
+                            type="button"
+                            aria-label={labelStrings.rename}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setRowMode(document.id, 'renaming');
+                            }}
+                          >
+                            {labelStrings.rename}
+                          </button>
+                          <button
+                            type="button"
+                            aria-label={labelStrings.trash}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setRowMode(document.id, 'confirming-trash');
+                            }}
+                          >
+                            {labelStrings.trash}
+                          </button>
+                        </>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
       ) : (
         <div role="grid" tabIndex={0} onKeyDown={handleKeyDown}>
-          <ul
+          <div
             data-granit-documents-list-grid=""
             // tile size becomes a CSS custom property the host stylesheet picks
             // up to drive the grid column track + tile dimensions.
             style={{ ['--granit-documents-tile-size' as string]: `${String(tileSize)}px` }}
           >
             {itemRenderState.map(({ document, isSelected, isFocused, mode, kind, badge }) => (
-              <li
+              <div
                 key={document.id}
                 role="row"
                 data-granit-documents-list-tile=""
@@ -772,9 +769,9 @@ function DocumentsListBody({
                     )}
                   </div>
                 )}
-              </li>
+              </div>
             ))}
-          </ul>
+          </div>
         </div>
       )}
       <nav data-granit-documents-list-pagination="" aria-label="Pagination">

--- a/packages/@granit/react-documents/src/components/folder-tree.tsx
+++ b/packages/@granit/react-documents/src/components/folder-tree.tsx
@@ -226,7 +226,6 @@ function FolderNode({
       data-granit-folder-tree-current={isCurrent ? '' : undefined}
     >
       <div
-        role="none"
         data-granit-folder-tree-row=""
         data-granit-folder-tree-current={isCurrent ? '' : undefined}
         data-granit-folder-tree-drop-over={dropOver ? '' : undefined}

--- a/packages/@granit/react-documents/src/components/folder-tree.tsx
+++ b/packages/@granit/react-documents/src/components/folder-tree.tsx
@@ -226,6 +226,7 @@ function FolderNode({
       data-granit-folder-tree-current={isCurrent ? '' : undefined}
     >
       <div
+        role="none"
         data-granit-folder-tree-row=""
         data-granit-folder-tree-current={isCurrent ? '' : undefined}
         data-granit-folder-tree-drop-over={dropOver ? '' : undefined}

--- a/packages/@granit/react-error-boundary/src/__tests__/error-context-provider.test.tsx
+++ b/packages/@granit/react-error-boundary/src/__tests__/error-context-provider.test.tsx
@@ -3,11 +3,7 @@ import * as React from 'react';
 import { describe, expect, it } from 'vitest';
 
 import { useBreadcrumb } from '../hooks/use-breadcrumb';
-import {
-  ErrorContextProvider,
-  useErrorBoundaryConfig,
-  useErrorContext,
-} from '../providers/error-context-provider';
+import { ErrorContextProvider, useErrorBoundaryConfig } from '../providers/error-context-provider';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -106,12 +102,6 @@ describe('ErrorContextProvider', () => {
 
   it('should throw when useErrorBoundaryConfig is used outside provider', () => {
     expect(() => renderHook(() => useErrorBoundaryConfig())).toThrowError(
-      'useErrorBoundaryConfig must be used within an ErrorContextProvider'
-    );
-  });
-
-  it('should still work via deprecated useErrorContext alias', () => {
-    expect(() => renderHook(() => useErrorContext())).toThrowError(
       'useErrorBoundaryConfig must be used within an ErrorContextProvider'
     );
   });

--- a/packages/@granit/react-error-boundary/src/index.ts
+++ b/packages/@granit/react-error-boundary/src/index.ts
@@ -1,10 +1,6 @@
 export { GranitErrorBoundary } from './components/granit-error-boundary';
 export { GlobalErrorCapture } from './components/global-error-capture';
-export {
-  ErrorContextProvider,
-  useErrorBoundaryConfig,
-  useErrorContext,
-} from './providers/error-context-provider';
+export { ErrorContextProvider, useErrorBoundaryConfig } from './providers/error-context-provider';
 export { useBreadcrumb } from './hooks/use-breadcrumb';
 
 export type { ErrorBoundaryProps, GlobalErrorCaptureProps } from './types/index';

--- a/packages/@granit/react-error-boundary/src/providers/error-context-provider.tsx
+++ b/packages/@granit/react-error-boundary/src/providers/error-context-provider.tsx
@@ -28,9 +28,6 @@ export function useErrorBoundaryConfig(): ErrorContextValue {
   return ctx;
 }
 
-/** @deprecated Use useErrorBoundaryConfig instead */
-export const useErrorContext = useErrorBoundaryConfig;
-
 /**
  * Projects the error context into a flat {@link LogContext} attached to every
  * error logged by `GranitErrorBoundary` / `GlobalErrorCapture`. Returns an

--- a/packages/@granit/react-notifications/src/__tests__/notification-provider.test.tsx
+++ b/packages/@granit/react-notifications/src/__tests__/notification-provider.test.tsx
@@ -2,11 +2,7 @@ import { toEntityId, toISODateString } from '@granit/types';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  NotificationProvider,
-  useNotificationConfig,
-  useNotificationContext,
-} from '../providers/notification-provider';
+import { NotificationProvider, useNotificationConfig } from '../providers/notification-provider';
 
 import { createMockClient } from './test-utils';
 
@@ -71,12 +67,6 @@ describe('NotificationProvider', () => {
   it('should throw when used outside provider', () => {
     expect(() => {
       renderHook(() => useNotificationConfig());
-    }).toThrow('useNotificationConfig must be used within a <NotificationProvider>');
-  });
-
-  it('should still work via deprecated useNotificationContext alias', () => {
-    expect(() => {
-      renderHook(() => useNotificationContext());
     }).toThrow('useNotificationConfig must be used within a <NotificationProvider>');
   });
 

--- a/packages/@granit/react-notifications/src/index.ts
+++ b/packages/@granit/react-notifications/src/index.ts
@@ -1,9 +1,5 @@
 // Provider
-export {
-  NotificationProvider,
-  useNotificationConfig,
-  useNotificationContext,
-} from './providers/notification-provider';
+export { NotificationProvider, useNotificationConfig } from './providers/notification-provider';
 
 // Hooks
 export { useRealTimeNotifications } from './hooks/use-real-time-notifications';

--- a/packages/@granit/react-notifications/src/providers/notification-provider.tsx
+++ b/packages/@granit/react-notifications/src/providers/notification-provider.tsx
@@ -33,9 +33,6 @@ export function useNotificationConfig(): NotificationContextValue {
   return ctx;
 }
 
-/** @deprecated Use useNotificationConfig instead */
-export const useNotificationContext = useNotificationConfig;
-
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------

--- a/packages/@granit/react-privacy/src/testing/data.ts
+++ b/packages/@granit/react-privacy/src/testing/data.ts
@@ -2,8 +2,12 @@ import type {
   LegalDocumentDetailResponse,
   PrivacyConsentStatusResponse,
   PrivacyDeletionStatusResponse,
+  PrivacyExportScopeResponse,
   PrivacyExportStatusResponse,
   PrivacyLegalDocumentResponse,
+  PrivacyOptOutStatusResponse,
+  PrivacyProcessingPurposeResponse,
+  PrivacyRegulationProfileResponse,
   PrivacyUserAgreementResponse,
 } from '@granit/privacy';
 
@@ -147,6 +151,109 @@ export const mockAgreementHistory: PrivacyUserAgreementResponse[] = [
     isLatest: false,
   },
 ];
+
+export const mockRegulationProfile: PrivacyRegulationProfileResponse = {
+  regulation: 'GDPR',
+  displayName: 'General Data Protection Regulation',
+  jurisdictionCode: 'EU',
+  consentModel: 'OptIn',
+  availableLegalBases: [
+    'Consent',
+    'ContractPerformance',
+    'LegalObligation',
+    'VitalInterests',
+    'PublicTask',
+    'LegitimateInterests',
+  ],
+  subjectAccessRequestDays: 30,
+  subjectAccessRequestExtensionDays: 60,
+  deletionRequestDays: 30,
+  defaultDeletionGracePeriodDays: 30,
+  maxDeletionGracePeriodDays: 90,
+  breachNotifyAuthorityHours: 72,
+  breachNotifyIndividualsHours: null,
+  minimumConsentAge: 16,
+  requiresParentalIdentityVerification: true,
+  cookieConsentModel: 'OptIn',
+  honorGlobalPrivacyControl: false,
+  requiresCrossBorderAssessment: true,
+  transferMechanisms: ['SCCs', 'BCRs', 'AdequacyDecision'],
+  dataLocalizationRequired: false,
+  requiresDpoOrRepresentative: true,
+  requiredExportFormats: ['JSON', 'CSV'],
+};
+
+export const mockProcessingPurposes: PrivacyProcessingPurposeResponse[] = [
+  {
+    purposeId: 'account-management',
+    displayName: 'Account Management',
+    description: 'Managing user accounts and authentication.',
+    legalBasis: 'ContractPerformance',
+    requiresExplicitConsent: false,
+    dataCategory: 'Identity',
+  },
+  {
+    purposeId: 'analytics',
+    displayName: 'Usage Analytics',
+    description: 'Analysing how users interact with the platform.',
+    legalBasis: 'LegitimateInterests',
+    requiresExplicitConsent: false,
+    dataCategory: 'Behavioural',
+  },
+  {
+    purposeId: 'marketing-emails',
+    displayName: 'Marketing Communications',
+    description: 'Sending promotional emails and product updates.',
+    legalBasis: 'Consent',
+    requiresExplicitConsent: true,
+    dataCategory: 'Contact',
+  },
+  {
+    purposeId: 'fraud-prevention',
+    displayName: 'Fraud Prevention',
+    description: 'Detecting and preventing fraudulent activities.',
+    legalBasis: 'LegalObligation',
+    requiresExplicitConsent: false,
+    dataCategory: null,
+  },
+];
+
+export const mockExportScopes: PrivacyExportScopeResponse[] = [
+  {
+    providerName: 'Identity',
+    displayKey: 'Privacy.Scopes.Identity',
+    featureName: null,
+    defaultSelected: true,
+    estimatedSizeBytes: 4096,
+  },
+  {
+    providerName: 'Notifications',
+    displayKey: 'Privacy.Scopes.Notifications',
+    featureName: 'Notifications',
+    defaultSelected: true,
+    estimatedSizeBytes: 51200,
+  },
+  {
+    providerName: 'Audit',
+    displayKey: 'Privacy.Scopes.Audit',
+    featureName: null,
+    defaultSelected: false,
+    estimatedSizeBytes: 204800,
+  },
+  {
+    providerName: 'Preferences',
+    displayKey: 'Privacy.Scopes.Preferences',
+    featureName: null,
+    defaultSelected: true,
+    estimatedSizeBytes: 1024,
+  },
+];
+
+export const mockOptOutStatus: PrivacyOptOutStatusResponse = {
+  isOptedOut: false,
+  optedOutAt: null,
+  regulation: 'GDPR',
+};
 
 export const mockLegalDocumentDetails: LegalDocumentDetailResponse[] = [
   {

--- a/packages/@granit/react-privacy/src/testing/handlers.ts
+++ b/packages/@granit/react-privacy/src/testing/handlers.ts
@@ -9,9 +9,13 @@ import {
   mockAgreementHistory,
   mockAgreementStatuses,
   mockDeletionRequests,
+  mockExportScopes,
   mockExports,
   mockLegalDocumentDetails,
   mockLegalDocuments,
+  mockOptOutStatus,
+  mockProcessingPurposes,
+  mockRegulationProfile,
 } from './data';
 
 import type {
@@ -21,7 +25,9 @@ import type {
   PrivacyConsentStatusResponse,
   PrivacyDeletionRequestResponse,
   PrivacyDeletionStatusResponse,
+  PrivacyExportOnBehalfOfRequest,
   PrivacyExportStatusResponse,
+  PrivacyOptOutStatusResponse,
   PrivacyUserAgreementResponse,
 } from '@granit/privacy';
 import type { QueryMetadata } from '@granit/query-engine';
@@ -337,7 +343,47 @@ export function createPrivacyHandlers(baseUrl = DEFAULT_BASE_PATH) {
 
   const legalBase = `${baseUrl}/legal-documents`;
 
+  let optOutStatus: PrivacyOptOutStatusResponse = { ...mockOptOutStatus };
+
   return [
+    // GET /regulation — applicable regulation profile
+    http.get(`${baseUrl}/regulation`, () => {
+      return HttpResponse.json(mockRegulationProfile);
+    }),
+
+    // GET /purposes — processing purposes
+    http.get(`${baseUrl}/purposes`, () => {
+      return HttpResponse.json(mockProcessingPurposes);
+    }),
+
+    // GET /exports/scopes — available export scopes
+    http.get(`${baseUrl}/exports/scopes`, () => {
+      return HttpResponse.json(mockExportScopes);
+    }),
+
+    // POST /exports/on-behalf-of — admin DSR export
+    http.post(`${baseUrl}/exports/on-behalf-of`, async ({ request }) => {
+      const body = (await request.json()) as PrivacyExportOnBehalfOfRequest;
+      const requestId = `exp-behalf-${body.subjectUserId.slice(0, 8)}`;
+      const requestedAt = new Date().toISOString();
+      return HttpResponse.json({ requestId, requestedAt }, { status: 202 });
+    }),
+
+    // GET /opt-out/status — current opt-out status
+    http.get(`${baseUrl}/opt-out/status`, () => {
+      return HttpResponse.json(optOutStatus);
+    }),
+
+    // POST /opt-out — record opt-out preference
+    http.post(`${baseUrl}/opt-out`, () => {
+      optOutStatus = {
+        isOptedOut: true,
+        optedOutAt: new Date().toISOString(),
+        regulation: mockRegulationProfile.regulation,
+      };
+      return HttpResponse.json(optOutStatus, { status: 201 });
+    }),
+
     // GET /exports/meta — query metadata
     createQueryMetaHandler(`${baseUrl}/exports`, privacyExportQueryMetadata),
 

--- a/packages/@granit/react-scheduling/src/hooks/query-keys.ts
+++ b/packages/@granit/react-scheduling/src/hooks/query-keys.ts
@@ -1,5 +1,3 @@
-import type { QueryRequest } from '@granit/query-engine';
-
 // ---------------------------------------------------------------------------
 // Query key builder
 // ---------------------------------------------------------------------------
@@ -18,14 +16,3 @@ export function buildSchedulingQueryKey(
 ): readonly unknown[] {
   return [...(config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX), ...segments];
 }
-
-// ---------------------------------------------------------------------------
-// Legacy query key factory (delegates to default prefix)
-// ---------------------------------------------------------------------------
-
-/** @deprecated Use {@link buildSchedulingQueryKey} instead. */
-export const schedulingKeys = {
-  all: DEFAULT_QUERY_KEY_PREFIX as readonly string[],
-  list: (request?: QueryRequest) => [...DEFAULT_QUERY_KEY_PREFIX, 'list', request ?? {}] as const,
-  detail: (id: string) => [...DEFAULT_QUERY_KEY_PREFIX, 'detail', id] as const,
-};

--- a/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
+++ b/packages/@granit/react-scheduling/src/hooks/use-scheduling.ts
@@ -8,7 +8,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useSchedulingConfig } from '../providers/scheduling-provider';
 
-export { buildSchedulingQueryKey, schedulingKeys } from './query-keys';
+export { buildSchedulingQueryKey } from './query-keys';
 import { buildSchedulingQueryKey } from './query-keys';
 
 import type { PagedResult, QueryRequest } from '@granit/query-engine';

--- a/packages/@granit/react-scheduling/src/index.ts
+++ b/packages/@granit/react-scheduling/src/index.ts
@@ -3,7 +3,7 @@ export { SchedulingProvider, useSchedulingConfig } from './providers/scheduling-
 export type { SchedulingConfig, SchedulingProviderProps } from './providers/scheduling-provider';
 
 // Query keys
-export { buildSchedulingQueryKey, schedulingKeys } from './hooks/query-keys';
+export { buildSchedulingQueryKey } from './hooks/query-keys';
 
 // Hooks
 export {

--- a/packages/@granit/react-tracing/src/__tests__/tracing-provider.test.tsx
+++ b/packages/@granit/react-tracing/src/__tests__/tracing-provider.test.tsx
@@ -2,7 +2,7 @@ import { renderHook } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { TracingProvider, useTracingConfig, useTracer } from '../providers/tracing-provider';
+import { TracingProvider, useTracingConfig } from '../providers/tracing-provider';
 
 import type { TracingConfig } from '@granit/tracing';
 
@@ -234,12 +234,6 @@ describe('TracingProvider', () => {
 describe('useTracingConfig', () => {
   it('should throw when used outside TracingProvider', () => {
     expect(() => renderHook(() => useTracingConfig())).toThrowError(
-      'useTracingConfig must be used within a TracingProvider'
-    );
-  });
-
-  it('should still work via deprecated useTracer alias', () => {
-    expect(() => renderHook(() => useTracer())).toThrowError(
       'useTracingConfig must be used within a TracingProvider'
     );
   });

--- a/packages/@granit/react-tracing/src/index.ts
+++ b/packages/@granit/react-tracing/src/index.ts
@@ -1,4 +1,4 @@
-export { TracingProvider, useTracingConfig, useTracer } from './providers/tracing-provider';
+export { TracingProvider, useTracingConfig } from './providers/tracing-provider';
 export { useSpan } from './hooks/use-span';
 
 export type { TracingProviderProps } from './types/index';

--- a/packages/@granit/react-tracing/src/providers/tracing-provider.tsx
+++ b/packages/@granit/react-tracing/src/providers/tracing-provider.tsx
@@ -102,9 +102,6 @@ export function useTracingConfig(): Tracer {
   return tracer;
 }
 
-/** @deprecated Use useTracingConfig instead */
-export const useTracer = useTracingConfig;
-
 // ---------------------------------------------------------------------------
 // Provider
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `mockRegulationProfile`, `mockOptOutStatus`, `mockExportScopes`, `mockProcessingPurposes` fixture data to `@granit/react-privacy/testing`
- Wires new MSW handlers: `GET /regulation`, `GET /opt-out` (stateful), `GET /export-scopes`, `POST /export-on-behalf`, `GET /processing-purposes`
- Required by `granit-showcase-react` `PrivacyAdminDsrPage` (companion MR)

> **Depends on**: #610 (quality/deprecated cleanup) — base branch includes those commits

## Test plan

- [ ] `pnpm test --filter @granit/react-privacy` passes
- [ ] MSW handlers resolve correctly in showcase dev mode