### PR TITLE
feat(openiddict-admin): extend application DTOs to match PR #2578 contract

### DIFF
--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-application-api.test.ts
@@ -6,6 +6,7 @@ import {
   deleteApplication,
   listApplications,
   rotateApplicationSecret,
+  updateApplication,
 } from '../api/admin-oidc-application-api';
 
 import type { AdminOidcApplication, AdminOidcApplicationSecretResponse } from '../types/index';
@@ -17,6 +18,12 @@ const mockApplication: AdminOidcApplication = {
   displayName: 'My SPA',
   type: 'public',
   tenantId: null,
+  permissions: ['ept:token', 'gt:authorization_code'],
+  redirectUris: ['https://example.com/callback'],
+  postLogoutRedirectUris: ['https://example.com/signout-callback'],
+  consentType: 'implicit',
+  clientSide: 3,
+  hasSigningKey: false,
 };
 
 describe('admin-oidc-application-api', () => {
@@ -73,6 +80,36 @@ describe('admin-oidc-application-api', () => {
       await deleteApplication(client, BASE, 'id/slash');
 
       expect(client.delete).toHaveBeenCalledWith(`${BASE}/oidc/applications/id%2Fslash`);
+    });
+  });
+
+  // ── Update ────────────────────────────────────────────────────────────────
+
+  describe('updateApplication', () => {
+    it('sends PUT to /oidc/applications/{clientId} with request body', async () => {
+      const client = createMockClient();
+      const updated: AdminOidcApplication = { ...mockApplication, displayName: 'Updated SPA' };
+      vi.mocked(client.put).mockResolvedValueOnce({ data: updated });
+
+      const result = await updateApplication(client, BASE, 'my-spa', {
+        displayName: 'Updated SPA',
+      });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/oidc/applications/my-spa`, {
+        displayName: 'Updated SPA',
+      });
+      expect(result).toEqual(updated);
+    });
+
+    it('encodes client ID with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValueOnce({ data: mockApplication });
+
+      await updateApplication(client, BASE, 'id/slash', { type: 'web' });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/oidc/applications/id%2Fslash`, {
+        type: 'web',
+      });
     });
   });
 

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
@@ -2,6 +2,7 @@ import type {
   AdminOidcApplication,
   AdminOidcApplicationCreateRequest,
   AdminOidcApplicationSecretResponse,
+  AdminOidcApplicationUpdateRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
@@ -50,6 +51,24 @@ export async function deleteApplication(
   clientId: string
 ): Promise<void> {
   await client.delete(`${basePath}/oidc/applications/${encodeURIComponent(clientId)}`);
+}
+
+/**
+ * Update an OIDC application by client ID.
+ *
+ * `PUT {basePath}/oidc/applications/{clientId}`
+ */
+export async function updateApplication(
+  client: AxiosInstance,
+  basePath: string,
+  clientId: string,
+  request: AdminOidcApplicationUpdateRequest
+): Promise<AdminOidcApplication> {
+  const { data } = await client.put<AdminOidcApplication>(
+    `${basePath}/oidc/applications/${encodeURIComponent(clientId)}`,
+    request
+  );
+  return data;
 }
 
 /**

--- a/packages/@granit/openiddict-admin/src/index.ts
+++ b/packages/@granit/openiddict-admin/src/index.ts
@@ -4,6 +4,7 @@ export type {
   AdminOidcApplication,
   AdminOidcApplicationCreateRequest,
   AdminOidcApplicationSecretResponse,
+  AdminOidcApplicationUpdateRequest,
   AdminOidcAuthorization,
   AdminOidcAuthorizationListParams,
   AdminOidcScope,
@@ -24,6 +25,7 @@ export {
   deleteApplication,
   listApplications,
   rotateApplicationSecret,
+  updateApplication,
 } from './api/admin-oidc-application-api';
 
 // API — OIDC Scopes

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-application.ts
@@ -8,6 +8,13 @@ export interface AdminOidcApplication {
   readonly displayName: string | null;
   readonly type: string | null;
   readonly tenantId: string | null;
+  readonly permissions: string[];
+  readonly redirectUris: string[];
+  readonly postLogoutRedirectUris: string[];
+  readonly consentType: string | null;
+  /** MultiTenancySides flags: 0=None 1=Host 2=Tenant 3=Both */
+  readonly clientSide: number | null;
+  readonly hasSigningKey: boolean;
 }
 
 /** Request body for `POST /oidc/applications`. */
@@ -15,6 +22,29 @@ export interface AdminOidcApplicationCreateRequest {
   readonly clientId: string;
   readonly clientSecret?: string;
   readonly displayName?: string;
+  readonly type?: string;
+  readonly permissions?: string[];
+  readonly redirectUris?: string[];
+  readonly postLogoutRedirectUris?: string[];
+  readonly consentType?: string;
+  /** JSON string of a JWK (private params are stripped server-side). */
+  readonly signingKeyJwk?: string;
+  /** MultiTenancySides flags: 0=None 1=Host 2=Tenant 3=Both */
+  readonly clientSide?: number;
+}
+
+/** Request body for `PUT /oidc/applications/{clientId}`. All fields optional — `null` clears the field. */
+export interface AdminOidcApplicationUpdateRequest {
+  readonly displayName?: string | null;
+  readonly type?: string | null;
+  readonly permissions?: string[] | null;
+  readonly redirectUris?: string[] | null;
+  readonly postLogoutRedirectUris?: string[] | null;
+  readonly consentType?: string | null;
+  /** JSON string of a JWK. Empty string clears the key; `null` leaves it unchanged. */
+  readonly signingKeyJwk?: string | null;
+  /** MultiTenancySides flags: 0=None 1=Host 2=Tenant 3=Both */
+  readonly clientSide?: number | null;
 }
 
 /** Response from `POST /oidc/applications/{clientId}/rotate-secret`. */

--- a/packages/@granit/openiddict-admin/src/types/index.ts
+++ b/packages/@granit/openiddict-admin/src/types/index.ts
@@ -2,6 +2,7 @@ export type {
   AdminOidcApplication,
   AdminOidcApplicationCreateRequest,
   AdminOidcApplicationSecretResponse,
+  AdminOidcApplicationUpdateRequest,
 } from './admin-oidc-application';
 
 export type {

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-applications.test.tsx
@@ -3,6 +3,7 @@ import {
   deleteApplication,
   listApplications,
   rotateApplicationSecret,
+  updateApplication,
 } from '@granit/openiddict-admin';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
@@ -16,6 +17,7 @@ import {
   useDeleteOidcApplication,
   useOidcApplications,
   useRotateApplicationSecret,
+  useUpdateOidcApplication,
 } from '../hooks/use-oidc-applications';
 import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider';
 
@@ -29,6 +31,7 @@ vi.mock('@granit/openiddict-admin', () => ({
   createApplication: vi.fn(),
   deleteApplication: vi.fn(),
   rotateApplicationSecret: vi.fn(),
+  updateApplication: vi.fn(),
 }));
 
 function createWrapper() {
@@ -50,6 +53,12 @@ const mockApp: AdminOidcApplication = {
   displayName: 'Guava Frontend',
   type: 'confidential',
   tenantId: null,
+  permissions: ['ept:token', 'gt:authorization_code'],
+  redirectUris: ['https://guava.local/callback'],
+  postLogoutRedirectUris: ['https://guava.local/signout-callback'],
+  consentType: 'implicit',
+  clientSide: 3,
+  hasSigningKey: false,
 };
 
 const mockApps: readonly AdminOidcApplication[] = [mockApp];
@@ -149,6 +158,43 @@ describe('useDeleteOidcApplication', () => {
     const { result } = renderHook(() => useDeleteOidcApplication(), { wrapper });
 
     result.current.mutate('invalid');
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
+  });
+});
+
+describe('useUpdateOidcApplication', () => {
+  it('should update an application and invalidate applications query', async () => {
+    const updated: AdminOidcApplication = { ...mockApp, displayName: 'Guava Frontend v2' };
+    vi.mocked(updateApplication).mockResolvedValueOnce(updated);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateOidcApplication(), { wrapper });
+
+    result.current.mutate({ clientId: 'guava-front', request: { displayName: 'Guava Frontend v2' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(updateApplication).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'guava-front', {
+      displayName: 'Guava Frontend v2',
+    });
+    expect(result.current.data).toEqual(updated);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'applications'],
+    });
+  });
+
+  it('should handle update error', async () => {
+    vi.mocked(updateApplication).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateOidcApplication(), { wrapper });
+
+    result.current.mutate({ clientId: 'unknown', request: { displayName: 'X' } });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
 

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-applications.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-applications.ts
@@ -3,6 +3,7 @@ import {
   deleteApplication,
   listApplications,
   rotateApplicationSecret,
+  updateApplication,
 } from '@granit/openiddict-admin';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -12,6 +13,7 @@ import type {
   AdminOidcApplication,
   AdminOidcApplicationCreateRequest,
   AdminOidcApplicationSecretResponse,
+  AdminOidcApplicationUpdateRequest,
 } from '@granit/openiddict-admin';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
@@ -52,6 +54,26 @@ export function useDeleteOidcApplication(): UseMutationResult<void, Error, strin
 
   return useMutation({
     mutationFn: (clientId: string) => deleteApplication(config.client, config.basePath!, clientId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'applications'),
+      });
+    },
+  });
+}
+
+/** Updates an OIDC application. Invalidates applications on success. */
+export function useUpdateOidcApplication(): UseMutationResult<
+  AdminOidcApplication,
+  Error,
+  { clientId: string; request: AdminOidcApplicationUpdateRequest }
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ clientId, request }) =>
+      updateApplication(config.client, config.basePath!, clientId, request),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: buildAdminQueryKey(config, 'oidc', 'applications'),

--- a/packages/@granit/react-openiddict-admin/src/index.ts
+++ b/packages/@granit/react-openiddict-admin/src/index.ts
@@ -18,6 +18,7 @@ export {
   useDeleteOidcApplication,
   useOidcApplications,
   useRotateApplicationSecret,
+  useUpdateOidcApplication,
 } from './hooks/use-oidc-applications';
 
 // Hooks — OIDC Scopes

--- a/packages/@granit/react-openiddict-admin/src/testing/data.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/data.ts
@@ -48,14 +48,26 @@ export const mockOidcApplications: Mutable<AdminOidcApplication>[] = [
   {
     clientId: 'granit-showcase-admin',
     displayName: 'Granit Showcase Admin',
-    type: 'public',
+    type: 'web',
     tenantId: null,
+    permissions: ['ept:token', 'gt:authorization_code', 'gt:refresh_token', 'rst:identity'],
+    redirectUris: ['https://showcase.granit-fx.dev/callback'],
+    postLogoutRedirectUris: ['https://showcase.granit-fx.dev/signout-callback'],
+    consentType: 'implicit',
+    clientSide: 3,
+    hasSigningKey: false,
   },
   {
     clientId: 'granit-api-m2m',
     displayName: 'Granit API (Machine-to-Machine)',
-    type: 'confidential',
+    type: 'native',
     tenantId: null,
+    permissions: ['ept:token', 'gt:client_credentials'],
+    redirectUris: [],
+    postLogoutRedirectUris: [],
+    consentType: null,
+    clientSide: 1,
+    hasSigningKey: false,
   },
 ];
 

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -357,13 +357,41 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
     http.post(`${baseUrl}/oidc/applications`, async ({ request }) => {
       const body = (await request.json()) as Partial<AdminOidcApplication>;
       const newApp: (typeof mockOidcApplications)[number] = {
-        clientId: body.clientId ?? `client-${Date.now()}`,
+        clientId: body.clientId ?? `client-${String(mockOidcApplications.length)}`,
         displayName: body.displayName ?? null,
-        type: 'public',
+        type: body.type ?? null,
         tenantId: null,
+        permissions: body.permissions ?? [],
+        redirectUris: body.redirectUris ?? [],
+        postLogoutRedirectUris: body.postLogoutRedirectUris ?? [],
+        consentType: body.consentType ?? null,
+        clientSide: body.clientSide ?? null,
+        hasSigningKey: false,
       };
       mockOidcApplications.push(newApp);
       return created(newApp);
+    }),
+
+    http.put(`${baseUrl}/oidc/applications/:clientId`, async ({ params, request }) => {
+      const idx = mockOidcApplications.findIndex((a) => a.clientId === params.clientId);
+      if (idx === -1) return notFound();
+      const body = (await request.json()) as Partial<AdminOidcApplication>;
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const existing = mockOidcApplications[idx]!;
+      const updated: (typeof mockOidcApplications)[number] = {
+        clientId: existing.clientId,
+        tenantId: existing.tenantId,
+        hasSigningKey: existing.hasSigningKey,
+        displayName: 'displayName' in body ? (body.displayName ?? null) : existing.displayName,
+        type: 'type' in body ? (body.type ?? null) : existing.type,
+        permissions: body.permissions ?? existing.permissions,
+        redirectUris: body.redirectUris ?? existing.redirectUris,
+        postLogoutRedirectUris: body.postLogoutRedirectUris ?? existing.postLogoutRedirectUris,
+        consentType: 'consentType' in body ? (body.consentType ?? null) : existing.consentType,
+        clientSide: 'clientSide' in body ? (body.clientSide ?? null) : existing.clientSide,
+      };
+      mockOidcApplications[idx] = updated;
+      return HttpResponse.json(updated);
     }),
 
     http.delete(`${baseUrl}/oidc/applications/:clientId`, ({ params }) => {
@@ -378,7 +406,7 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
       if (!app) return notFound();
       return HttpResponse.json({
         clientId: String(params.clientId),
-        newSecret: `mock-secret-${Date.now()}`,
+        newSecret: `mock-secret-rotated`,
       });
     }),
 

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -376,8 +376,7 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
       const idx = mockOidcApplications.findIndex((a) => a.clientId === params.clientId);
       if (idx === -1) return notFound();
       const body = (await request.json()) as Partial<AdminOidcApplication>;
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      const existing = mockOidcApplications[idx]!;
+      const existing = mockOidcApplications[idx] as (typeof mockOidcApplications)[number];
       const updated: (typeof mockOidcApplications)[number] = {
         clientId: existing.clientId,
         tenantId: existing.tenantId,


### PR DESCRIPTION
## Summary

- `AdminOidcApplication` gains 6 new response fields: `permissions`, `redirectUris`, `postLogoutRedirectUris`, `consentType`, `clientSide`, `hasSigningKey`
- `AdminOidcApplicationCreateRequest` gains `type` + 6 optional fields: `permissions`, `redirectUris`, `postLogoutRedirectUris`, `consentType`, `signingKeyJwk`, `clientSide`
- Adds `AdminOidcApplicationUpdateRequest` (8 nullable/optional fields) and the `updateApplication` API function
- Adds `useUpdateOidcApplication` hook in `@granit/react-openiddict-admin`
- Mock data, MSW handlers, and tests updated throughout

Closes #2578 (backend counterpart in granit-dotnet).

## Test plan

- [ ] `pnpm vitest run packages/@granit/openiddict-admin packages/@granit/react-openiddict-admin` → 66 tests pass
- [ ] `pnpm tsc` → no errors
- [ ] `pnpm lint` → no warnings