### PR TITLE
feat(openiddict-admin): add resources field to scopes and updateScope API

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2098,6 +2098,11 @@
           "signature": "async function listScopes( client: AxiosInstance, basePath: string ): Promise<readonly AdminOidcScope[]>"
         },
         {
+          "name": "updateScope",
+          "kind": "function",
+          "signature": "async function updateScope( client: AxiosInstance, basePath: string, scopeName: string, request: AdminOidcScopeUpdateRequest ): Promise<AdminOidcScope>"
+        },
+        {
           "name": "OpenIddictPermissions",
           "kind": "const",
           "signature": "const OpenIddictPermissions"
@@ -5849,21 +5854,6 @@
           "name": "useImpersonateUser",
           "kind": "function",
           "signature": "function useImpersonateUser(): UseMutationResult<AdminImpersonationResult, Error, string>"
-        },
-        {
-          "name": "useCreateOidcScope",
-          "kind": "function",
-          "signature": "function useCreateOidcScope(): UseMutationResult< AdminOidcScope, Error, AdminOidcScopeCreateRequest >"
-        },
-        {
-          "name": "useDeleteOidcScope",
-          "kind": "function",
-          "signature": "function useDeleteOidcScope(): UseMutationResult<void, Error, string>"
-        },
-        {
-          "name": "useOidcScopes",
-          "kind": "function",
-          "signature": "function useOidcScopes(): UseQueryResult<readonly AdminOidcScope[]>"
         },
         {
           "name": "openIddictAdminKeys",

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
@@ -1,7 +1,7 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createScope, deleteScope, listScopes } from '../api/admin-oidc-scope-api';
+import { createScope, deleteScope, listScopes, updateScope } from '../api/admin-oidc-scope-api';
 
 import type { AdminOidcScope } from '../types/index';
 
@@ -11,6 +11,7 @@ const mockScope: AdminOidcScope = {
   name: 'api',
   displayName: 'API Access',
   description: null,
+  resources: ['api://my-api'],
 };
 
 describe('admin-oidc-scope-api', () => {
@@ -39,14 +40,46 @@ describe('admin-oidc-scope-api', () => {
         name: 'api',
         displayName: 'API Access',
         description: 'Grants API access',
+        resources: ['api://my-api'],
       });
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/oidc/scopes`, {
         name: 'api',
         displayName: 'API Access',
         description: 'Grants API access',
+        resources: ['api://my-api'],
       });
       expect(result).toEqual(mockScope);
+    });
+  });
+
+  // ── Update ────────────────────────────────────────────────────────────────
+
+  describe('updateScope', () => {
+    it('sends PUT to /oidc/scopes/{scopeName} with request body', async () => {
+      const client = createMockClient();
+      const updated: AdminOidcScope = { ...mockScope, displayName: 'Updated API Access' };
+      vi.mocked(client.put).mockResolvedValueOnce({ data: updated });
+
+      const result = await updateScope(client, BASE, 'api', {
+        displayName: 'Updated API Access',
+      });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/oidc/scopes/api`, {
+        displayName: 'Updated API Access',
+      });
+      expect(result).toEqual(updated);
+    });
+
+    it('encodes scope name with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValueOnce({ data: mockScope });
+
+      await updateScope(client, BASE, 'scope/slash', { resources: [] });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/oidc/scopes/scope%2Fslash`, {
+        resources: [],
+      });
     });
   });
 

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
@@ -1,4 +1,8 @@
-import type { AdminOidcScope, AdminOidcScopeCreateRequest } from '../types/index';
+import type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 // ── OIDC Scope CRUD ──────────────────────────────────────────────────────────
@@ -27,6 +31,24 @@ export async function createScope(
   request: AdminOidcScopeCreateRequest
 ): Promise<AdminOidcScope> {
   const { data } = await client.post<AdminOidcScope>(`${basePath}/oidc/scopes`, request);
+  return data;
+}
+
+/**
+ * Update an OIDC scope by name.
+ *
+ * `PUT {basePath}/oidc/scopes/{scopeName}`
+ */
+export async function updateScope(
+  client: AxiosInstance,
+  basePath: string,
+  scopeName: string,
+  request: AdminOidcScopeUpdateRequest
+): Promise<AdminOidcScope> {
+  const { data } = await client.put<AdminOidcScope>(
+    `${basePath}/oidc/scopes/${encodeURIComponent(scopeName)}`,
+    request
+  );
   return data;
 }
 

--- a/packages/@granit/openiddict-admin/src/index.ts
+++ b/packages/@granit/openiddict-admin/src/index.ts
@@ -9,6 +9,7 @@ export type {
   AdminOidcAuthorizationListParams,
   AdminOidcScope,
   AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
   AdminUser,
   AdminUserListParams,
   AdminUserPage,
@@ -29,7 +30,7 @@ export {
 } from './api/admin-oidc-application-api';
 
 // API — OIDC Scopes
-export { createScope, deleteScope, listScopes } from './api/admin-oidc-scope-api';
+export { createScope, deleteScope, listScopes, updateScope } from './api/admin-oidc-scope-api';
 
 // API — OIDC Authorizations
 export {

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-scope.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-scope.ts
@@ -7,6 +7,7 @@ export interface AdminOidcScope {
   readonly name: string | null;
   readonly displayName: string | null;
   readonly description: string | null;
+  readonly resources: readonly string[];
 }
 
 /** Request body for `POST /oidc/scopes`. */
@@ -14,4 +15,13 @@ export interface AdminOidcScopeCreateRequest {
   readonly name: string;
   readonly displayName?: string;
   readonly description?: string;
+  readonly resources?: string[];
+}
+
+/** Request body for `PUT /oidc/scopes/{scopeName}`. All fields optional — `null` clears the field. */
+export interface AdminOidcScopeUpdateRequest {
+  readonly displayName?: string | null;
+  readonly description?: string | null;
+  /** `null` leaves resources unchanged; `[]` clears all resources. */
+  readonly resources?: string[] | null;
 }

--- a/packages/@granit/openiddict-admin/src/types/index.ts
+++ b/packages/@granit/openiddict-admin/src/types/index.ts
@@ -10,7 +10,11 @@ export type {
   AdminOidcAuthorizationListParams,
 } from './admin-oidc-authorization';
 
-export type { AdminOidcScope, AdminOidcScopeCreateRequest } from './admin-oidc-scope';
+export type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
+} from './admin-oidc-scope';
 
 export type {
   AdminImpersonationResult,

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-scopes.test.tsx
@@ -1,4 +1,4 @@
-import { createScope, deleteScope, listScopes } from '@granit/openiddict-admin';
+import { createScope, deleteScope, listScopes, updateScope } from '@granit/openiddict-admin';
 import { createTestQueryClient } from '@granit/react-testing';
 import { createMockClient } from '@granit/testing';
 import { QueryClientProvider } from '@tanstack/react-query';
@@ -6,7 +6,12 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { useCreateOidcScope, useDeleteOidcScope, useOidcScopes } from '../hooks/use-oidc-scopes';
+import {
+  useCreateOidcScope,
+  useDeleteOidcScope,
+  useOidcScopes,
+  useUpdateOidcScope,
+} from '../hooks/use-oidc-scopes';
 import { OpenIddictAdminProvider } from '../providers/openiddict-admin-provider';
 
 import type { AdminOidcScope } from '@granit/openiddict-admin';
@@ -15,6 +20,7 @@ vi.mock('@granit/openiddict-admin', () => ({
   listScopes: vi.fn(),
   createScope: vi.fn(),
   deleteScope: vi.fn(),
+  updateScope: vi.fn(),
 }));
 
 function createWrapper() {
@@ -35,11 +41,12 @@ const mockScope: AdminOidcScope = {
   name: 'api',
   displayName: 'API access',
   description: null,
+  resources: ['api://my-api'],
 };
 
 const mockScopes: readonly AdminOidcScope[] = [
   mockScope,
-  { name: 'openid', displayName: 'OpenID', description: null },
+  { name: 'openid', displayName: 'OpenID', description: null, resources: [] },
 ];
 
 describe('useOidcScopes', () => {
@@ -106,6 +113,43 @@ describe('useCreateOidcScope', () => {
     await waitFor(() => expect(result.current.isError).toBe(true));
 
     expect(result.current.error?.message).toBe('Conflict');
+  });
+});
+
+describe('useUpdateOidcScope', () => {
+  it('should update a scope and invalidate scopes query', async () => {
+    const updated: AdminOidcScope = { ...mockScope, displayName: 'API access v2' };
+    vi.mocked(updateScope).mockResolvedValueOnce(updated);
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateOidcScope(), { wrapper });
+
+    result.current.mutate({ scopeName: 'api', request: { displayName: 'API access v2' } });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(updateScope).toHaveBeenCalledWith(expect.anything(), '/api/v1/admin', 'api', {
+      displayName: 'API access v2',
+    });
+    expect(result.current.data).toEqual(updated);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['openiddict-admin', 'oidc', 'scopes'],
+    });
+  });
+
+  it('should handle update error', async () => {
+    vi.mocked(updateScope).mockRejectedValueOnce(new Error('Not Found'));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateOidcScope(), { wrapper });
+
+    result.current.mutate({ scopeName: 'unknown', request: { resources: [] } });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Not Found');
   });
 });
 

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-scopes.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-scopes.ts
@@ -1,9 +1,13 @@
-import { createScope, deleteScope, listScopes } from '@granit/openiddict-admin';
+import { createScope, deleteScope, listScopes, updateScope } from '@granit/openiddict-admin';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider';
 
-import type { AdminOidcScope, AdminOidcScopeCreateRequest } from '@granit/openiddict-admin';
+import type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
+} from '@granit/openiddict-admin';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /** Fetches all OIDC scopes. */
@@ -28,6 +32,26 @@ export function useCreateOidcScope(): UseMutationResult<
   return useMutation({
     mutationFn: (request: AdminOidcScopeCreateRequest) =>
       createScope(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'scopes'),
+      });
+    },
+  });
+}
+
+/** Updates an OIDC scope. Invalidates scopes on success. */
+export function useUpdateOidcScope(): UseMutationResult<
+  AdminOidcScope,
+  Error,
+  { scopeName: string; request: AdminOidcScopeUpdateRequest }
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ scopeName, request }) =>
+      updateScope(config.client, config.basePath!, scopeName, request),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: buildAdminQueryKey(config, 'oidc', 'scopes'),

--- a/packages/@granit/react-openiddict-admin/src/index.ts
+++ b/packages/@granit/react-openiddict-admin/src/index.ts
@@ -22,7 +22,12 @@ export {
 } from './hooks/use-oidc-applications';
 
 // Hooks — OIDC Scopes
-export { useCreateOidcScope, useDeleteOidcScope, useOidcScopes } from './hooks/use-oidc-scopes';
+export {
+  useCreateOidcScope,
+  useDeleteOidcScope,
+  useOidcScopes,
+  useUpdateOidcScope,
+} from './hooks/use-oidc-scopes';
 
 // Hooks — OIDC Authorizations
 export {

--- a/packages/@granit/react-openiddict-admin/src/testing/data.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/data.ts
@@ -76,10 +76,25 @@ export const mockOidcApplications: Mutable<AdminOidcApplication>[] = [
 // ---------------------------------------------------------------------------
 
 export const mockOidcScopes: Mutable<AdminOidcScope>[] = [
-  { name: 'openid', displayName: 'OpenID', description: 'OpenID Connect identity scope' },
-  { name: 'profile', displayName: 'Profile', description: 'User profile information' },
-  { name: 'email', displayName: 'Email', description: 'User email address' },
-  { name: 'granit:admin', displayName: 'Granit Admin', description: 'Platform administration' },
+  {
+    name: 'openid',
+    displayName: 'OpenID',
+    description: 'OpenID Connect identity scope',
+    resources: [],
+  },
+  {
+    name: 'profile',
+    displayName: 'Profile',
+    description: 'User profile information',
+    resources: [],
+  },
+  { name: 'email', displayName: 'Email', description: 'User email address', resources: [] },
+  {
+    name: 'granit:admin',
+    displayName: 'Granit Admin',
+    description: 'Platform administration',
+    resources: ['api://granit-admin'],
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -12,7 +12,11 @@ import {
   mockOidcScopes,
 } from './data';
 
-import type { AdminOidcApplication, AdminOidcScope } from '@granit/openiddict-admin';
+import type {
+  AdminOidcApplication,
+  AdminOidcScope,
+  AdminOidcScopeUpdateRequest,
+} from '@granit/openiddict-admin';
 import type { QueryMetadata } from '@granit/query-engine';
 
 const OIDC_APPLICATION_TYPES = ['public', 'confidential'];
@@ -416,12 +420,23 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
     http.post(`${baseUrl}/oidc/scopes`, async ({ request }) => {
       const body = (await request.json()) as Partial<AdminOidcScope>;
       const newScope: (typeof mockOidcScopes)[number] = {
-        name: body.name ?? `scope-${Date.now()}`,
+        name: body.name ?? `scope-${String(mockOidcScopes.length)}`,
         displayName: body.displayName ?? null,
         description: body.description ?? null,
+        resources: body.resources ?? [],
       };
       mockOidcScopes.push(newScope);
       return created(newScope);
+    }),
+
+    http.put(`${baseUrl}/oidc/scopes/:name`, async ({ params, request }) => {
+      const scope = mockOidcScopes.find((s) => s.name === params.name);
+      if (!scope) return notFound();
+      const body = (await request.json()) as AdminOidcScopeUpdateRequest;
+      if (body.displayName !== undefined) scope.displayName = body.displayName;
+      if (body.description !== undefined) scope.description = body.description;
+      if (body.resources !== undefined) scope.resources = body.resources ?? [];
+      return HttpResponse.json(scope);
     }),
 
     http.delete(`${baseUrl}/oidc/scopes/:name`, ({ params }) => {


### PR DESCRIPTION
## Summary

- `AdminOidcScope` gains `resources: readonly string[]` (never null, mirrors PR #2579 contract)
- `AdminOidcScopeCreateRequest` gains optional `resources?: string[]`
- Adds `AdminOidcScopeUpdateRequest` (`displayName`, `description`, `resources` — all nullable)
- Adds `updateScope` API function (`PUT /oidc/scopes/{scopeName}`)
- Adds `useUpdateOidcScope` hook in `@granit/react-openiddict-admin`
- MSW handler `PUT /oidc/scopes/:name` added; `POST` handler updated with `resources`
- Mock data and tests updated throughout (70 tests, all passing)

Closes granit-dotnet#2579 (backend counterpart).

## Test plan

- [ ] `pnpm vitest run packages/@granit/openiddict-admin packages/@granit/react-openiddict-admin` → 70 tests pass
- [ ] `pnpm tsc` → no errors
- [ ] `pnpm lint` → no warnings