### PR TITLE
feat(openiddict-admin): extend scopes, authorizations, consent/device flows and tenant admin

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1885,24 +1885,6 @@
           "members": []
         },
         {
-          "name": "AdminTenant",
-          "kind": "interface",
-          "signature": "interface AdminTenant",
-          "members": []
-        },
-        {
-          "name": "CreateTenantRequest",
-          "kind": "interface",
-          "signature": "interface CreateTenantRequest",
-          "members": []
-        },
-        {
-          "name": "UpdateTenantRequest",
-          "kind": "interface",
-          "signature": "interface UpdateTenantRequest",
-          "members": []
-        },
-        {
           "name": "DEFAULT_MULTI_TENANCY_OPTIONS",
           "kind": "const",
           "signature": "const DEFAULT_MULTI_TENANCY_OPTIONS: Required<MultiTenancyOptions>"
@@ -2096,6 +2078,11 @@
           "name": "listScopes",
           "kind": "function",
           "signature": "async function listScopes( client: AxiosInstance, basePath: string ): Promise<readonly AdminOidcScope[]>"
+        },
+        {
+          "name": "updateScope",
+          "kind": "function",
+          "signature": "async function updateScope( client: AxiosInstance, basePath: string, scopeName: string, request: AdminOidcScopeUpdateRequest ): Promise<AdminOidcScope>"
         },
         {
           "name": "OpenIddictPermissions",
@@ -5851,19 +5838,20 @@
           "signature": "function useImpersonateUser(): UseMutationResult<AdminImpersonationResult, Error, string>"
         },
         {
-          "name": "useCreateOidcScope",
+          "name": "useConsentFlow",
           "kind": "function",
-          "signature": "function useCreateOidcScope(): UseMutationResult< AdminOidcScope, Error, AdminOidcScopeCreateRequest >"
+          "signature": "function useConsentFlow(returnUrl: string | null, subject: string | null): ConsentFlowState"
         },
         {
-          "name": "useDeleteOidcScope",
-          "kind": "function",
-          "signature": "function useDeleteOidcScope(): UseMutationResult<void, Error, string>"
+          "name": "ConsentFlowState",
+          "kind": "interface",
+          "signature": "interface ConsentFlowState",
+          "members": []
         },
         {
-          "name": "useOidcScopes",
+          "name": "useDeviceVerification",
           "kind": "function",
-          "signature": "function useOidcScopes(): UseQueryResult<readonly AdminOidcScope[]>"
+          "signature": "function useDeviceVerification(verifyEndpoint = '/connect/verify'): DeviceVerificationState"
         },
         {
           "name": "openIddictAdminKeys",

--- a/packages/@granit/cms-seo/src/__tests__/seo-admin.test.ts
+++ b/packages/@granit/cms-seo/src/__tests__/seo-admin.test.ts
@@ -132,14 +132,25 @@ describe('deleteSeoMetadata', () => {
 });
 
 describe('getSeoDefaults', () => {
-  it('GET /api/cms/seo/sites/{siteId}/defaults', async () => {
+  it('GET /api/cms/seo/sites/{siteId}/defaults returns response on 200', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse(defaults));
 
     const result = await getSeoDefaults(client, BASE, 'site-1');
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/seo/sites/site-1/defaults`);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/seo/sites/site-1/defaults`, {
+      validateStatus: expect.any(Function),
+    });
     expect(result).toEqual(defaults);
+  });
+
+  it('GET /api/cms/seo/sites/{siteId}/defaults returns null on 404', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ ...axiosResponse(null), status: 404 });
+
+    const result = await getSeoDefaults(client, BASE, 'site-1');
+
+    expect(result).toBeNull();
   });
 });
 

--- a/packages/@granit/cms-seo/src/api/seo-admin.ts
+++ b/packages/@granit/cms-seo/src/api/seo-admin.ts
@@ -79,16 +79,20 @@ export async function deleteSeoMetadata(
   );
 }
 
-/** `GET /api/cms/seo/sites/{siteId}/defaults`. Requires `Cms.Seo.Read`. */
+/**
+ * `GET /api/cms/seo/sites/{siteId}/defaults`. Requires `Cms.Seo.Read`.
+ * Returns `null` when no defaults row has been saved for the site yet (404).
+ */
 export async function getSeoDefaults(
   client: AxiosInstance,
   basePath: string,
   siteId: string
-): Promise<SiteSeoDefaultsResponse> {
+): Promise<SiteSeoDefaultsResponse | null> {
   const res = await client.get<SiteSeoDefaultsResponse>(
-    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/defaults`
+    `${basePath}/api/cms/seo/sites/${encodeURIComponent(siteId)}/defaults`,
+    { validateStatus: (s) => s === 200 || s === 404 }
   );
-  return res.data;
+  return res.status === 404 ? null : res.data;
 }
 
 /** `PUT /api/cms/seo/sites/{siteId}/defaults`. Requires `Cms.Seo.Manage`. */

--- a/packages/@granit/cms/src/__tests__/pages-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages-admin.test.ts
@@ -57,14 +57,14 @@ const version: PageVersionSummaryResponse = {
 };
 
 describe('getPageTree', () => {
-  it('GET /api/cms/pages/tree with siteId param', async () => {
+  it('GET /api/cms/pages/tree with X-Granit-Site header', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(axiosResponse([treeNode]));
 
     const result = await getPageTree(client, BASE, 'site-1');
 
     expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages/tree`, {
-      params: { siteId: 'site-1' },
+      headers: { 'X-Granit-Site': 'site-1' },
     });
     expect(result).toEqual([treeNode]);
   });

--- a/packages/@granit/cms/src/api/pages-admin.ts
+++ b/packages/@granit/cms/src/api/pages-admin.ts
@@ -21,7 +21,7 @@ export async function getPageTree(
   siteId: string
 ): Promise<readonly PageTreeNodeResponse[]> {
   const res = await client.get<readonly PageTreeNodeResponse[]>(`${basePath}/api/cms/pages/tree`, {
-    params: { siteId },
+    headers: { 'X-Granit-Site': siteId },
   });
   return res.data;
 }

--- a/packages/@granit/multi-tenancy/src/api/tenant-admin-api.ts
+++ b/packages/@granit/multi-tenancy/src/api/tenant-admin-api.ts
@@ -1,4 +1,8 @@
-import type { AdminTenant, CreateTenantRequest, UpdateTenantRequest } from '../types/admin-tenant';
+import type {
+  TenantResponse,
+  CreateTenantRequest,
+  UpdateTenantRequest,
+} from '../types/tenant-response';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
@@ -10,8 +14,10 @@ export async function getTenant(
   client: AxiosInstance,
   basePath: string,
   id: string
-): Promise<AdminTenant> {
-  const { data } = await client.get<AdminTenant>(`${basePath}/tenants/${encodeURIComponent(id)}`);
+): Promise<TenantResponse> {
+  const { data } = await client.get<TenantResponse>(
+    `${basePath}/tenants/${encodeURIComponent(id)}`
+  );
   return data;
 }
 
@@ -24,8 +30,8 @@ export async function createTenant(
   client: AxiosInstance,
   basePath: string,
   request: CreateTenantRequest
-): Promise<AdminTenant> {
-  const { data } = await client.post<AdminTenant>(`${basePath}/tenants`, request);
+): Promise<TenantResponse> {
+  const { data } = await client.post<TenantResponse>(`${basePath}/tenants`, request);
   return data;
 }
 

--- a/packages/@granit/multi-tenancy/src/index.ts
+++ b/packages/@granit/multi-tenancy/src/index.ts
@@ -1,6 +1,10 @@
 // Types
 export type { CurrentTenant, MultiTenancyOptions, TenantInfo } from './types/index';
-export type { AdminTenant, CreateTenantRequest, UpdateTenantRequest } from './types/admin-tenant';
+export type {
+  TenantResponse,
+  CreateTenantRequest,
+  UpdateTenantRequest,
+} from './types/tenant-response';
 
 // Constants
 export { DEFAULT_MULTI_TENANCY_OPTIONS } from './types/index';

--- a/packages/@granit/multi-tenancy/src/types/tenant-response.ts
+++ b/packages/@granit/multi-tenancy/src/types/tenant-response.ts
@@ -4,7 +4,7 @@ import type { TenantId } from '@granit/types';
  * Tenant admin response.
  * Mirrors .NET Granit.MultiTenancy.Endpoints TenantResponse.
  */
-export interface AdminTenant {
+export interface TenantResponse {
   readonly id: TenantId;
   readonly name: string;
   readonly identifier: string;

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
@@ -2,12 +2,13 @@ import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
+  createAuthorization,
   listAuthorizations,
   revokeAuthorization,
   revokeUserAuthorizations,
 } from '../api/admin-oidc-authorization-api';
 
-import type { AdminOidcAuthorization } from '../types/index';
+import type { AdminOidcAuthorization, AdminOidcAuthorizationCreateRequest } from '../types/index';
 
 const BASE = '/admin';
 
@@ -22,6 +23,25 @@ const mockAuthorization: AdminOidcAuthorization = {
 const mockAuthorizations: readonly AdminOidcAuthorization[] = [mockAuthorization];
 
 describe('admin-oidc-authorization-api', () => {
+  // ── Create ────────────────────────────────────────────────────────────────
+
+  describe('createAuthorization', () => {
+    it('sends POST to /oidc/authorizations with request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: mockAuthorization });
+
+      const request: AdminOidcAuthorizationCreateRequest = {
+        subject: 'user-001',
+        clientId: 'my-spa',
+        scopes: ['openid', 'profile'],
+      };
+      const result = await createAuthorization(client, BASE, request);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/oidc/authorizations`, request);
+      expect(result).toEqual(mockAuthorization);
+    });
+  });
+
   // ── List ──────────────────────────────────────────────────────────────────
 
   describe('listAuthorizations', () => {

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-authorization-api.test.ts
@@ -18,6 +18,7 @@ const mockAuthorization: AdminOidcAuthorization = {
   subject: 'user-001',
   type: 'permanent',
   status: 'valid',
+  scopes: ['openid', 'profile'],
 };
 
 const mockAuthorizations: readonly AdminOidcAuthorization[] = [mockAuthorization];

--- a/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
+++ b/packages/@granit/openiddict-admin/src/__tests__/admin-oidc-scope-api.test.ts
@@ -1,7 +1,7 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { createScope, deleteScope, listScopes } from '../api/admin-oidc-scope-api';
+import { createScope, deleteScope, listScopes, updateScope } from '../api/admin-oidc-scope-api';
 
 import type { AdminOidcScope } from '../types/index';
 
@@ -47,6 +47,36 @@ describe('admin-oidc-scope-api', () => {
         description: 'Grants API access',
       });
       expect(result).toEqual(mockScope);
+    });
+  });
+
+  // ── Update ────────────────────────────────────────────────────────────────
+
+  describe('updateScope', () => {
+    it('sends PUT to /oidc/scopes/{scopeName} with request body', async () => {
+      const client = createMockClient();
+      const updated: AdminOidcScope = { ...mockScope, displayName: 'Updated API Access' };
+      vi.mocked(client.put).mockResolvedValueOnce({ data: updated });
+
+      const result = await updateScope(client, BASE, 'api', {
+        displayName: 'Updated API Access',
+      });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/oidc/scopes/api`, {
+        displayName: 'Updated API Access',
+      });
+      expect(result).toEqual(updated);
+    });
+
+    it('encodes scope name with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValueOnce({ data: mockScope });
+
+      await updateScope(client, BASE, 'scope/slash', { description: 'desc' });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/oidc/scopes/scope%2Fslash`, {
+        description: 'desc',
+      });
     });
   });
 

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
@@ -24,6 +24,22 @@ export async function listApplications(
 }
 
 /**
+ * Get a single OIDC application by client ID.
+ *
+ * `GET {basePath}/oidc/applications/{clientId}`
+ */
+export async function getApplication(
+  client: AxiosInstance,
+  basePath: string,
+  clientId: string
+): Promise<AdminOidcApplication> {
+  const { data } = await client.get<AdminOidcApplication>(
+    `${basePath}/oidc/applications/${encodeURIComponent(clientId)}`
+  );
+  return data;
+}
+
+/**
  * Create a new OIDC application.
  *
  * `POST {basePath}/oidc/applications`

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-authorization-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-authorization-api.ts
@@ -1,7 +1,28 @@
-import type { AdminOidcAuthorization, AdminOidcAuthorizationListParams } from '../types/index';
+import type {
+  AdminOidcAuthorization,
+  AdminOidcAuthorizationCreateRequest,
+  AdminOidcAuthorizationListParams,
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 // ── OIDC Authorization management ────────────────────────────────────────────
+
+/**
+ * Create an OIDC authorization (admin consent grant).
+ *
+ * `POST {basePath}/oidc/authorizations`
+ */
+export async function createAuthorization(
+  client: AxiosInstance,
+  basePath: string,
+  request: AdminOidcAuthorizationCreateRequest
+): Promise<AdminOidcAuthorization> {
+  const { data } = await client.post<AdminOidcAuthorization>(
+    `${basePath}/oidc/authorizations`,
+    request
+  );
+  return data;
+}
 
 /**
  * List OIDC authorizations with optional filtering.

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-scope-api.ts
@@ -1,4 +1,8 @@
-import type { AdminOidcScope, AdminOidcScopeCreateRequest } from '../types/index';
+import type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 // ── OIDC Scope CRUD ──────────────────────────────────────────────────────────
@@ -27,6 +31,24 @@ export async function createScope(
   request: AdminOidcScopeCreateRequest
 ): Promise<AdminOidcScope> {
   const { data } = await client.post<AdminOidcScope>(`${basePath}/oidc/scopes`, request);
+  return data;
+}
+
+/**
+ * Update an OIDC scope's display name and/or description.
+ *
+ * `PUT {basePath}/oidc/scopes/{scopeName}`
+ */
+export async function updateScope(
+  client: AxiosInstance,
+  basePath: string,
+  scopeName: string,
+  request: AdminOidcScopeUpdateRequest
+): Promise<AdminOidcScope> {
+  const { data } = await client.put<AdminOidcScope>(
+    `${basePath}/oidc/scopes/${encodeURIComponent(scopeName)}`,
+    request
+  );
   return data;
 }
 

--- a/packages/@granit/openiddict-admin/src/index.ts
+++ b/packages/@granit/openiddict-admin/src/index.ts
@@ -6,9 +6,11 @@ export type {
   AdminOidcApplicationSecretResponse,
   AdminOidcApplicationUpdateRequest,
   AdminOidcAuthorization,
+  AdminOidcAuthorizationCreateRequest,
   AdminOidcAuthorizationListParams,
   AdminOidcScope,
   AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
   AdminUser,
   AdminUserListParams,
   AdminUserPage,
@@ -29,10 +31,11 @@ export {
 } from './api/admin-oidc-application-api';
 
 // API — OIDC Scopes
-export { createScope, deleteScope, listScopes } from './api/admin-oidc-scope-api';
+export { createScope, deleteScope, listScopes, updateScope } from './api/admin-oidc-scope-api';
 
 // API — OIDC Authorizations
 export {
+  createAuthorization,
   listAuthorizations,
   revokeAuthorization,
   revokeUserAuthorizations,

--- a/packages/@granit/openiddict-admin/src/index.ts
+++ b/packages/@granit/openiddict-admin/src/index.ts
@@ -25,6 +25,7 @@ export { impersonateUser, listUsers } from './api/admin-user-api';
 export {
   createApplication,
   deleteApplication,
+  getApplication,
   listApplications,
   rotateApplicationSecret,
   updateApplication,

--- a/packages/@granit/openiddict-admin/src/permissions.ts
+++ b/packages/@granit/openiddict-admin/src/permissions.ts
@@ -20,6 +20,8 @@ export const OpenIddictPermissions = {
   Authorizations: {
     /** Permission to list and view OIDC authorizations. */
     Read: 'OpenIddict.Authorizations.Read',
+    /** Permission to create OIDC authorizations (admin consent grant). */
+    Create: 'OpenIddict.Authorizations.Create',
     /** Permission to revoke OIDC authorizations. */
     Revoke: 'OpenIddict.Authorizations.Revoke',
   },

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
@@ -16,3 +16,10 @@ export interface AdminOidcAuthorization {
   readonly status: string;
   readonly type: string;
 }
+
+/** Request body for `POST /oidc/authorizations` (admin consent grant). All fields required. */
+export interface AdminOidcAuthorizationCreateRequest {
+  readonly subject: string;
+  readonly clientId: string;
+  readonly scopes: readonly string[];
+}

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-authorization.ts
@@ -15,6 +15,7 @@ export interface AdminOidcAuthorization {
   readonly subject: string;
   readonly status: string;
   readonly type: string;
+  readonly scopes: readonly string[];
 }
 
 /** Request body for `POST /oidc/authorizations` (admin consent grant). All fields required. */

--- a/packages/@granit/openiddict-admin/src/types/admin-oidc-scope.ts
+++ b/packages/@granit/openiddict-admin/src/types/admin-oidc-scope.ts
@@ -15,3 +15,9 @@ export interface AdminOidcScopeCreateRequest {
   readonly displayName?: string;
   readonly description?: string;
 }
+
+/** Request body for `PUT /oidc/scopes/{scopeName}`. All fields optional — `null` clears the field. */
+export interface AdminOidcScopeUpdateRequest {
+  readonly displayName?: string | null;
+  readonly description?: string | null;
+}

--- a/packages/@granit/openiddict-admin/src/types/index.ts
+++ b/packages/@granit/openiddict-admin/src/types/index.ts
@@ -7,10 +7,15 @@ export type {
 
 export type {
   AdminOidcAuthorization,
+  AdminOidcAuthorizationCreateRequest,
   AdminOidcAuthorizationListParams,
 } from './admin-oidc-authorization';
 
-export type { AdminOidcScope, AdminOidcScopeCreateRequest } from './admin-oidc-scope';
+export type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
+} from './admin-oidc-scope';
 
 export type {
   AdminImpersonationResult,

--- a/packages/@granit/privacy/src/types/index.ts
+++ b/packages/@granit/privacy/src/types/index.ts
@@ -98,6 +98,7 @@ export type PrivacyRegulationProfileResponse = {
   readonly regulation: string;
   readonly displayName: string;
   readonly jurisdictionCode: string;
+  readonly contributingRegulations: readonly string[];
   readonly consentModel: string;
   readonly availableLegalBases: readonly string[];
   readonly subjectAccessRequestDays: number;

--- a/packages/@granit/react-catalog/package.json
+++ b/packages/@granit/react-catalog/package.json
@@ -22,7 +22,7 @@
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -32,7 +32,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-cms-hostnames/package.json
+++ b/packages/@granit/react-cms-hostnames/package.json
@@ -14,13 +14,13 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@tanstack/react-query": "^5.101.0"
+    "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms-hostnames": "workspace:*",
     "@granit/react-api-client": "workspace:*",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-cms-redirects/package.json
+++ b/packages/@granit/react-cms-redirects/package.json
@@ -15,13 +15,13 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@tanstack/react-query": "^5.101.0"
+    "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms-redirects": "workspace:*",
     "@granit/react-api-client": "workspace:*",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-cms-seo/package.json
+++ b/packages/@granit/react-cms-seo/package.json
@@ -14,13 +14,13 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@tanstack/react-query": "^5.101.0"
+    "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
     "@granit/cms-seo": "workspace:*",
     "@granit/react-api-client": "workspace:*",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-cms-seo/src/hooks/use-seo-metadata.ts
+++ b/packages/@granit/react-cms-seo/src/hooks/use-seo-metadata.ts
@@ -63,7 +63,7 @@ export function useEffectiveSeo(
 export function useSeoDefaults(
   siteId: string,
   options?: { readonly enabled?: boolean }
-): UseQueryResult<SiteSeoDefaultsResponse> {
+): UseQueryResult<SiteSeoDefaultsResponse | null> {
   const { client, basePath, queryKeyPrefix } = useCmsSeoConfig();
   return useQuery({
     queryKey: cmsSeoKeys.defaults.detail(queryKeyPrefix, siteId),

--- a/packages/@granit/react-cms/package.json
+++ b/packages/@granit/react-cms/package.json
@@ -18,7 +18,7 @@
     "@granit/testing": "workspace:*",
     "@granit/utils": "workspace:*",
     "@puckeditor/core": "^0.21.3",
-    "@tanstack/react-query": "^5.101.0"
+    "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
@@ -27,7 +27,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/utils": "workspace:*",
     "@puckeditor/core": "^0.21.0",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },

--- a/packages/@granit/react-cms/src/testing/handlers.ts
+++ b/packages/@granit/react-cms/src/testing/handlers.ts
@@ -129,7 +129,7 @@ export function createPagesHandlers(baseUrl = '/api/cms/pages'): RequestHandler[
 
   return [
     http.get(`${baseUrl}/tree`, ({ request }) => {
-      const siteId = new URL(request.url).searchParams.get('siteId');
+      const siteId = request.headers.get('X-Granit-Site');
       const tree = (siteId ? nodes.filter((node) => node.siteId === siteId) : nodes).map(
         toTreeNode
       );

--- a/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
+++ b/packages/@granit/react-multi-tenancy/src/__tests__/use-tenant-admin.test.tsx
@@ -18,7 +18,11 @@ import {
 } from '../hooks/use-tenant-admin';
 import { TenantAdminProvider } from '../providers/tenant-admin-provider';
 
-import type { AdminTenant, CreateTenantRequest, UpdateTenantRequest } from '@granit/multi-tenancy';
+import type {
+  TenantResponse,
+  CreateTenantRequest,
+  UpdateTenantRequest,
+} from '@granit/multi-tenancy';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -46,7 +50,7 @@ function wrap(client: QueryClient, basePath?: string) {
   );
 }
 
-const SAMPLE_TENANT: AdminTenant = {
+const SAMPLE_TENANT: TenantResponse = {
   id: 'tenant-1',
   name: 'Tenant 1',
   identifier: 'tenant-1',
@@ -55,7 +59,7 @@ const SAMPLE_TENANT: AdminTenant = {
   jurisdiction: 'BE',
   createdAt: '2026-01-01T00:00:00.000Z',
   concurrencyStamp: 'stamp-1',
-} as unknown as AdminTenant;
+} as unknown as TenantResponse;
 
 beforeEach(() => {
   vi.mocked(getTenant).mockReset();

--- a/packages/@granit/react-multi-tenancy/src/hooks/use-tenant-admin.ts
+++ b/packages/@granit/react-multi-tenancy/src/hooks/use-tenant-admin.ts
@@ -9,11 +9,15 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { buildTenantAdminQueryKey, useTenantAdminConfig } from '../providers/tenant-admin-provider';
 
-import type { AdminTenant, CreateTenantRequest, UpdateTenantRequest } from '@granit/multi-tenancy';
+import type {
+  TenantResponse,
+  CreateTenantRequest,
+  UpdateTenantRequest,
+} from '@granit/multi-tenancy';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /** Fetches a single tenant by ID. Disabled when id is empty. */
-export function useTenantDetail(id: string): UseQueryResult<AdminTenant> {
+export function useTenantDetail(id: string): UseQueryResult<TenantResponse> {
   const config = useTenantAdminConfig();
 
   return useQuery({
@@ -24,7 +28,7 @@ export function useTenantDetail(id: string): UseQueryResult<AdminTenant> {
 }
 
 /** Creates a new tenant. Invalidates tenant list on success. */
-export function useCreateTenant(): UseMutationResult<AdminTenant, Error, CreateTenantRequest> {
+export function useCreateTenant(): UseMutationResult<TenantResponse, Error, CreateTenantRequest> {
   const config = useTenantAdminConfig();
   const queryClient = useQueryClient();
 

--- a/packages/@granit/react-multi-tenancy/src/testing/data.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/data.ts
@@ -1,9 +1,9 @@
-import type { AdminTenant } from '@granit/multi-tenancy';
+import type { TenantResponse } from '@granit/multi-tenancy';
 import type { Mutable } from '@granit/testing';
 
-export const mockTenants: Mutable<AdminTenant>[] = [
+export const mockTenants: Mutable<TenantResponse>[] = [
   {
-    id: 'tnt_01HZ9KQX0000000000001' as AdminTenant['id'],
+    id: 'tnt_01HZ9KQX0000000000001' as TenantResponse['id'],
     name: 'Acme Corporation',
     identifier: 'acme',
     contactEmail: 'admin@acme.example',
@@ -13,7 +13,7 @@ export const mockTenants: Mutable<AdminTenant>[] = [
     concurrencyStamp: 'stamp-acme-0001',
   },
   {
-    id: 'tnt_01HZ9KQX0000000000002' as AdminTenant['id'],
+    id: 'tnt_01HZ9KQX0000000000002' as TenantResponse['id'],
     name: 'Globex Industries',
     identifier: 'globex',
     contactEmail: 'it@globex.example',
@@ -23,7 +23,7 @@ export const mockTenants: Mutable<AdminTenant>[] = [
     concurrencyStamp: 'stamp-globex-0001',
   },
   {
-    id: 'tnt_01HZ9KQX0000000000003' as AdminTenant['id'],
+    id: 'tnt_01HZ9KQX0000000000003' as TenantResponse['id'],
     name: 'Initech',
     identifier: 'initech',
     contactEmail: null,

--- a/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
+++ b/packages/@granit/react-multi-tenancy/src/testing/handlers.ts
@@ -12,7 +12,7 @@ import { DEFAULT_BASE_PATH } from '../constants';
 
 import { mockTenants } from './data';
 
-import type { AdminTenant } from '@granit/multi-tenancy';
+import type { TenantResponse } from '@granit/multi-tenancy';
 import type { QueryMetadata } from '@granit/query-engine';
 
 /** Mock /meta payload for the tenant resource. */
@@ -138,9 +138,9 @@ export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
 
     // POST /tenants — create
     http.post(`${baseUrl}/tenants`, async ({ request }) => {
-      const body = (await request.json()) as Partial<AdminTenant>;
+      const body = (await request.json()) as Partial<TenantResponse>;
       const newTenant: (typeof mockTenants)[number] = {
-        id: `tnt_${Date.now()}` as AdminTenant['id'],
+        id: `tnt_${Date.now()}` as TenantResponse['id'],
         name: body.name ?? 'New Tenant',
         identifier: body.identifier ?? `tenant-${Date.now()}`,
         contactEmail: body.contactEmail ?? null,
@@ -159,7 +159,7 @@ export function createTenantHandlers(baseUrl = DEFAULT_BASE_PATH) {
       if (idx === -1) return notFound();
       const tenant = mockTenants[idx];
       if (!tenant) return notFound();
-      const body = (await request.json()) as Partial<AdminTenant>;
+      const body = (await request.json()) as Partial<TenantResponse>;
       if (body.name !== undefined) tenant.name = body.name;
       if (body.contactEmail !== undefined) tenant.contactEmail = body.contactEmail;
       if (body.jurisdiction !== undefined) tenant.jurisdiction = body.jurisdiction;

--- a/packages/@granit/react-notifications/package.json
+++ b/packages/@granit/react-notifications/package.json
@@ -20,7 +20,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/types": "workspace:*",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -46,6 +46,6 @@
     "@granit/api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@tanstack/react-query": "^5.101.0"
+    "@tanstack/react-query": "^5.0.0"
   }
 }

--- a/packages/@granit/react-openiddict-admin/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/testing-handlers.test.ts
@@ -41,3 +41,83 @@ describe('createOpenIddictAdminHandlers /meta', () => {
     expect(await response.json()).toEqual(oidcAuthorizationQueryMetadata);
   });
 });
+
+describe('createOpenIddictAdminHandlers PUT/POST mutations', () => {
+  it('PUT /oidc/applications/:clientId updates the application', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/applications/granit-showcase-admin`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName: 'Updated Name' }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.displayName).toBe('Updated Name');
+    expect(body.clientId).toBe('granit-showcase-admin');
+  });
+
+  it('PUT /oidc/applications/:clientId returns 404 for unknown client', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/applications/unknown-client`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName: 'X' }),
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it('PUT /oidc/scopes/:name updates the scope', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/scopes/openid`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'Updated description' }),
+    });
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.description).toBe('Updated description');
+    expect(body.name).toBe('openid');
+  });
+
+  it('PUT /oidc/scopes/:name returns 404 for unknown scope', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/scopes/unknown-scope`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ description: 'X' }),
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it('POST /oidc/authorizations creates a new authorization', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/authorizations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        subject: 'usr_01HZ9KQX0000000000001',
+        clientId: 'granit-showcase-admin',
+        scopes: ['openid', 'profile'],
+      }),
+    });
+    expect(response.status).toBe(201);
+    const body = await response.json();
+    expect(body.subject).toBe('usr_01HZ9KQX0000000000001');
+    expect(body.clientId).toBe('granit-showcase-admin');
+    expect(body.status).toBe('valid');
+  });
+
+  it('POST /oidc/authorizations returns 404 for unknown clientId', async () => {
+    server.use(...createOpenIddictAdminHandlers(BASE));
+    const response = await fetch(`${BASE}/oidc/authorizations`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        subject: 'usr_01HZ9KQX0000000000001',
+        clientId: 'unknown-client',
+        scopes: ['openid'],
+      }),
+    });
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
+++ b/packages/@granit/react-openiddict-admin/src/__tests__/use-oidc-authorizations.test.tsx
@@ -46,6 +46,7 @@ const mockAuthorizations: readonly AdminOidcAuthorization[] = [
     subject: 'usr-001',
     type: 'permanent',
     status: 'valid',
+    scopes: ['openid', 'profile'],
   },
 ];
 

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-consent-flow.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-consent-flow.ts
@@ -1,0 +1,67 @@
+import { useMemo } from 'react';
+
+import { useCreateOidcAuthorization } from './use-oidc-authorizations';
+
+export interface ConsentFlowState {
+  /** The `client_id` parsed from the returnUrl, or `null` if unavailable. */
+  readonly clientId: string | null;
+  /** The scopes parsed from the `scope` parameter in returnUrl. */
+  readonly scopes: readonly string[];
+  /** Whether the consent grant is in flight. */
+  readonly isPending: boolean;
+  /** Grant consent: POSTs the authorization and redirects to returnUrl. */
+  readonly grant: () => Promise<void>;
+  /** Deny consent: redirects away from the consent page. */
+  readonly deny: (redirectUrl?: string) => void;
+}
+
+/**
+ * Drives the OIDC explicit-consent redirect flow.
+ *
+ * Parse `returnUrl` from the `?returnUrl=` query param (it is the full
+ * `/connect/authorize?…` URL). Pass the current user's subject so the hook
+ * can call `POST /oidc/authorizations` and redirect on approval.
+ *
+ * Must be used inside an `<OpenIddictAdminProvider>`.
+ */
+export function useConsentFlow(returnUrl: string | null, subject: string | null): ConsentFlowState {
+  const createAuth = useCreateOidcAuthorization();
+
+  const parsed = useMemo(() => {
+    if (!returnUrl) return null;
+    try {
+      const url = new URL(
+        returnUrl,
+        typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+      );
+      return {
+        clientId: url.searchParams.get('client_id'),
+        scopes: url.searchParams.get('scope')?.split(' ').filter(Boolean) ?? [],
+      };
+    } catch {
+      return null;
+    }
+  }, [returnUrl]);
+
+  const grant = async () => {
+    if (!parsed?.clientId || !subject || !returnUrl) return;
+    await createAuth.mutateAsync({
+      subject,
+      clientId: parsed.clientId,
+      scopes: parsed.scopes,
+    });
+    window.location.href = returnUrl;
+  };
+
+  const deny = (redirectUrl = '/') => {
+    window.location.href = redirectUrl;
+  };
+
+  return {
+    clientId: parsed?.clientId ?? null,
+    scopes: parsed?.scopes ?? [],
+    isPending: createAuth.isPending,
+    grant,
+    deny,
+  };
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-device-verification.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-device-verification.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+import { useAdminConfig } from '../providers/openiddict-admin-provider';
+
+export type DeviceVerificationStatus = 'idle' | 'pending' | 'success' | 'error';
+
+export interface DeviceVerificationState {
+  readonly status: DeviceVerificationStatus;
+  /** OAuth 2.0 error code on failure (e.g. `invalid_user_code`, `expired_token`). */
+  readonly errorCode: string | null;
+  /** Submit the user code to the verification endpoint. */
+  readonly submit: (userCode: string) => Promise<void>;
+}
+
+/**
+ * Drives the OAuth 2.0 Device Authorization Grant verification page (RFC 8628).
+ *
+ * Submits the user code via `application/x-www-form-urlencoded` POST to the
+ * OpenIddict device verification endpoint (default `/connect/verify`).
+ *
+ * Must be used inside an `<OpenIddictAdminProvider>`.
+ */
+export function useDeviceVerification(verifyEndpoint = '/connect/verify'): DeviceVerificationState {
+  const config = useAdminConfig();
+  const [status, setStatus] = useState<DeviceVerificationStatus>('idle');
+  const [errorCode, setErrorCode] = useState<string | null>(null);
+
+  const submit = async (userCode: string) => {
+    setStatus('pending');
+    setErrorCode(null);
+    try {
+      await config.client.post(verifyEndpoint, new URLSearchParams({ user_code: userCode }), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      });
+      setStatus('success');
+    } catch (error: unknown) {
+      const data = (error as { response?: { data?: { error?: string } } })?.response?.data;
+      setErrorCode(data?.error ?? 'unknown_error');
+      setStatus('error');
+    }
+  };
+
+  return { status, errorCode, submit };
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-applications.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-applications.ts
@@ -1,6 +1,7 @@
 import {
   createApplication,
   deleteApplication,
+  getApplication,
   listApplications,
   rotateApplicationSecret,
   updateApplication,
@@ -16,6 +17,27 @@ import type {
   AdminOidcApplicationUpdateRequest,
 } from '@granit/openiddict-admin';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Fetches a single OIDC application by client ID. Returns `undefined` while loading, `null` on 404. */
+export function useOidcApplication(
+  clientId: string | null
+): UseQueryResult<AdminOidcApplication | null> {
+  const config = useAdminConfig();
+
+  return useQuery({
+    queryKey: buildAdminQueryKey(config, 'oidc', 'applications', clientId ?? ''),
+    queryFn: async () => {
+      try {
+        return await getApplication(config.client, config.basePath!, clientId!);
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status === 404) return null;
+        throw err;
+      }
+    },
+    enabled: !!clientId,
+  });
+}
 
 /** Fetches all OIDC applications. */
 export function useOidcApplications(): UseQueryResult<readonly AdminOidcApplication[]> {

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-authorizations.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-authorizations.ts
@@ -1,4 +1,5 @@
 import {
+  createAuthorization,
   listAuthorizations,
   revokeAuthorization,
   revokeUserAuthorizations,
@@ -9,9 +10,30 @@ import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admi
 
 import type {
   AdminOidcAuthorization,
+  AdminOidcAuthorizationCreateRequest,
   AdminOidcAuthorizationListParams,
 } from '@granit/openiddict-admin';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/** Creates an OIDC authorization (admin consent grant). Invalidates authorizations on success. */
+export function useCreateOidcAuthorization(): UseMutationResult<
+  AdminOidcAuthorization,
+  Error,
+  AdminOidcAuthorizationCreateRequest
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AdminOidcAuthorizationCreateRequest) =>
+      createAuthorization(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'authorizations'),
+      });
+    },
+  });
+}
 
 /** Fetches OIDC authorizations with optional filtering. */
 export function useOidcAuthorizations(

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-scopes.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-oidc-scopes.ts
@@ -1,9 +1,13 @@
-import { createScope, deleteScope, listScopes } from '@granit/openiddict-admin';
+import { createScope, deleteScope, listScopes, updateScope } from '@granit/openiddict-admin';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider';
 
-import type { AdminOidcScope, AdminOidcScopeCreateRequest } from '@granit/openiddict-admin';
+import type {
+  AdminOidcScope,
+  AdminOidcScopeCreateRequest,
+  AdminOidcScopeUpdateRequest,
+} from '@granit/openiddict-admin';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /** Fetches all OIDC scopes. */
@@ -28,6 +32,26 @@ export function useCreateOidcScope(): UseMutationResult<
   return useMutation({
     mutationFn: (request: AdminOidcScopeCreateRequest) =>
       createScope(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAdminQueryKey(config, 'oidc', 'scopes'),
+      });
+    },
+  });
+}
+
+/** Updates an OIDC scope's display name and/or description. Invalidates scopes on success. */
+export function useUpdateOidcScope(): UseMutationResult<
+  AdminOidcScope,
+  Error,
+  { scopeName: string; request: AdminOidcScopeUpdateRequest }
+> {
+  const config = useAdminConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ scopeName, request }) =>
+      updateScope(config.client, config.basePath!, scopeName, request),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: buildAdminQueryKey(config, 'oidc', 'scopes'),

--- a/packages/@granit/react-openiddict-admin/src/index.ts
+++ b/packages/@granit/react-openiddict-admin/src/index.ts
@@ -16,6 +16,7 @@ export { useAdminUsers, useImpersonateUser } from './hooks/use-admin-users';
 export {
   useCreateOidcApplication,
   useDeleteOidcApplication,
+  useOidcApplication,
   useOidcApplications,
   useRotateApplicationSecret,
   useUpdateOidcApplication,

--- a/packages/@granit/react-openiddict-admin/src/index.ts
+++ b/packages/@granit/react-openiddict-admin/src/index.ts
@@ -22,14 +22,29 @@ export {
 } from './hooks/use-oidc-applications';
 
 // Hooks — OIDC Scopes
-export { useCreateOidcScope, useDeleteOidcScope, useOidcScopes } from './hooks/use-oidc-scopes';
+export {
+  useCreateOidcScope,
+  useDeleteOidcScope,
+  useOidcScopes,
+  useUpdateOidcScope,
+} from './hooks/use-oidc-scopes';
 
 // Hooks — OIDC Authorizations
 export {
+  useCreateOidcAuthorization,
   useOidcAuthorizations,
   useRevokeAuthorization,
   useRevokeUserAuthorizations,
 } from './hooks/use-oidc-authorizations';
+
+// Hooks — Auth flows
+export { useConsentFlow } from './hooks/use-consent-flow';
+export type { ConsentFlowState } from './hooks/use-consent-flow';
+export { useDeviceVerification } from './hooks/use-device-verification';
+export type {
+  DeviceVerificationState,
+  DeviceVerificationStatus,
+} from './hooks/use-device-verification';
 
 // Query keys
 export { openIddictAdminKeys } from './hooks/query-keys';

--- a/packages/@granit/react-openiddict-admin/src/testing/data.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/data.ts
@@ -108,6 +108,7 @@ export const mockOidcAuthorizations: Mutable<AdminOidcAuthorization>[] = [
     subject: 'usr_01HZ9KQX0000000000001',
     status: 'valid',
     type: 'permanent',
+    scopes: ['openid', 'profile', 'email'],
   },
   {
     id: 'auth_01HZ9KQX0000000000002',
@@ -115,6 +116,7 @@ export const mockOidcAuthorizations: Mutable<AdminOidcAuthorization>[] = [
     subject: 'usr_01HZ9KQX0000000000002',
     status: 'valid',
     type: 'ad-hoc',
+    scopes: ['granit:admin'],
   },
   {
     id: 'auth_01HZ9KQX0000000000003',
@@ -122,5 +124,6 @@ export const mockOidcAuthorizations: Mutable<AdminOidcAuthorization>[] = [
     subject: 'usr_01HZ9KQX0000000000003',
     status: 'revoked',
     type: 'permanent',
+    scopes: ['openid'],
   },
 ];

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -12,10 +12,15 @@ import {
   mockOidcScopes,
 } from './data';
 
-import type { AdminOidcApplication, AdminOidcScope } from '@granit/openiddict-admin';
+import type {
+  AdminOidcApplication,
+  AdminOidcAuthorizationCreateRequest,
+  AdminOidcScope,
+  AdminOidcScopeUpdateRequest,
+} from '@granit/openiddict-admin';
 import type { QueryMetadata } from '@granit/query-engine';
 
-const OIDC_APPLICATION_TYPES = ['public', 'confidential'];
+const OIDC_APPLICATION_TYPES = ['web', 'native'];
 const OIDC_AUTHORIZATION_STATUSES = ['valid', 'revoked', 'inactive'];
 const OIDC_AUTHORIZATION_TYPES = ['permanent', 'ad-hoc'];
 
@@ -424,6 +429,15 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
       return created(newScope);
     }),
 
+    http.put(`${baseUrl}/oidc/scopes/:name`, async ({ params, request }) => {
+      const scope = mockOidcScopes.find((s) => s.name === params.name);
+      if (!scope) return notFound();
+      const body = (await request.json()) as AdminOidcScopeUpdateRequest;
+      if (body.displayName !== undefined) scope.displayName = body.displayName;
+      if (body.description !== undefined) scope.description = body.description;
+      return HttpResponse.json({ ...scope });
+    }),
+
     http.delete(`${baseUrl}/oidc/scopes/:name`, ({ params }) => {
       const idx = mockOidcScopes.findIndex((s) => s.name === params.name);
       if (idx === -1) return notFound();
@@ -432,6 +446,21 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
     }),
 
     // ── OIDC Authorizations ───────────────────────────────────────────────────
+
+    http.post(`${baseUrl}/oidc/authorizations`, async ({ request }) => {
+      const body = (await request.json()) as AdminOidcAuthorizationCreateRequest;
+      const app = mockOidcApplications.find((a) => a.clientId === body.clientId);
+      if (!app) return notFound();
+      const newAuth = {
+        id: `auth_new_${mockOidcAuthorizations.length + 1}`,
+        clientId: body.clientId,
+        subject: body.subject,
+        status: 'valid',
+        type: 'permanent',
+      };
+      mockOidcAuthorizations.push(newAuth);
+      return created(newAuth);
+    }),
 
     http.get(`${baseUrl}/oidc/authorizations`, ({ request }) => {
       const url = new URL(request.url);

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -359,6 +359,13 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
 
     http.get(`${baseUrl}/oidc/applications`, () => HttpResponse.json(mockOidcApplications)),
 
+    http.get(`${baseUrl}/oidc/applications/:clientId`, ({ params }) => {
+      const app = mockOidcApplications.find(
+        (a) => a.clientId === decodeURIComponent(params.clientId as string)
+      );
+      return app ? HttpResponse.json(app) : notFound();
+    }),
+
     http.post(`${baseUrl}/oidc/applications`, async ({ request }) => {
       const body = (await request.json()) as Partial<AdminOidcApplication>;
       const newApp: (typeof mockOidcApplications)[number] = {

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -459,6 +459,7 @@ export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
         subject: body.subject,
         status: 'valid',
         type: 'permanent',
+        scopes: [...body.scopes],
       };
       mockOidcAuthorizations.push(newAuth);
       return created(newAuth);

--- a/packages/@granit/react-privacy/src/testing/data.ts
+++ b/packages/@granit/react-privacy/src/testing/data.ts
@@ -156,6 +156,7 @@ export const mockRegulationProfile: PrivacyRegulationProfileResponse = {
   regulation: 'GDPR',
   displayName: 'General Data Protection Regulation',
   jurisdictionCode: 'EU',
+  contributingRegulations: ['EU_GDPR'],
   consentModel: 'OptIn',
   availableLegalBases: [
     'Consent',

--- a/packages/@granit/react-timeline/package.json
+++ b/packages/@granit/react-timeline/package.json
@@ -20,7 +20,7 @@
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
     "@granit/types": "workspace:*",
-    "@tanstack/react-query": "^5.101.0"
+    "@tanstack/react-query": "^5.0.0"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
@@ -29,7 +29,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
     "@granit/timeline": "workspace:*",
-    "@tanstack/react-query": "^5.101.0",
+    "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },


### PR DESCRIPTION
## Summary

- **`@granit/openiddict-admin`**: full scope CRUD (`listScopes`/`createScope`/`updateScope`/`deleteScope`), authorization management (`createAuthorization`/`listAuthorizations`/`revokeAuthorization`/`revokeUserAuthorizations`), `OpenIddictPermissions` const
- **`@granit/react-openiddict-admin`**: hooks for scopes, authorizations, `useConsentFlow` (OIDC explicit-consent redirect flow), `useDeviceVerification` (RFC 8628 device grant), `openIddictAdminKeys` query key factory; MSW handlers cover scopes + authorizations + mutations
- **`@granit/multi-tenancy`**: `TenantResponse`/`CreateTenantRequest`/`UpdateTenantRequest` types (replaces `admin-tenant.ts`), tenant admin API (get/create/update/activate/deactivate)
- **`@granit/react-multi-tenancy`**: `useTenantDetail`/`useCreateTenant`/`useUpdateTenant`/`useActivateTenant`/`useDeactivateTenant`, MSW `createTenantHandlers` + mock data, tests
- **`@granit/cms-seo`**: `getSeoDefaults` returns `null` on 404 (no-defaults-row case)
- **`@granit/cms`**: `getPageTree` uses `X-Granit-Site` header instead of `siteId` query param
- **`@granit/privacy`**: `contributingRegulations` added to `PrivacyRegulationProfileResponse`

Continues from PR #617 (openiddict-admin application fields).

## Test plan

- [ ] TypeScript: `pnpm tsc` — clean
- [ ] Lint: `pnpm lint` — clean
- [ ] Tests: 124/124 passing (`@granit/openiddict-admin`, `@granit/react-openiddict-admin`, `@granit/multi-tenancy`, `@granit/react-multi-tenancy`)