### PR TITLE
feat(openiddict-admin): add useConsentApplication hook for consent page

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -5838,6 +5838,17 @@
           "signature": "function useImpersonateUser(): UseMutationResult<AdminImpersonationResult, Error, string>"
         },
         {
+          "name": "useConsentApplication",
+          "kind": "function",
+          "signature": "function useConsentApplication( clientId: string | null ): UseQueryResult<ConsentApplicationInfo | null>"
+        },
+        {
+          "name": "ConsentApplicationInfo",
+          "kind": "interface",
+          "signature": "interface ConsentApplicationInfo",
+          "members": []
+        },
+        {
           "name": "useConsentFlow",
           "kind": "function",
           "signature": "function useConsentFlow(returnUrl: string | null, subject: string | null): ConsentFlowState"

--- a/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
+++ b/packages/@granit/openiddict-admin/src/api/admin-oidc-application-api.ts
@@ -40,6 +40,22 @@ export async function getApplication(
 }
 
 /**
+ * Get public display info for an OIDC application (non-admin, consent page use).
+ *
+ * `GET {oidcBasePath}/applications/{clientId}`
+ */
+export async function getApplicationInfo(
+  client: AxiosInstance,
+  oidcBasePath: string,
+  clientId: string
+): Promise<{ clientId: string | null; displayName: string | null }> {
+  const { data } = await client.get<{ clientId: string | null; displayName: string | null }>(
+    `${oidcBasePath}/applications/${encodeURIComponent(clientId)}`
+  );
+  return data;
+}
+
+/**
  * Create a new OIDC application.
  *
  * `POST {basePath}/oidc/applications`

--- a/packages/@granit/openiddict-admin/src/index.ts
+++ b/packages/@granit/openiddict-admin/src/index.ts
@@ -26,6 +26,7 @@ export {
   createApplication,
   deleteApplication,
   getApplication,
+  getApplicationInfo,
   listApplications,
   rotateApplicationSecret,
   updateApplication,

--- a/packages/@granit/react-openiddict-admin/src/constants.ts
+++ b/packages/@granit/react-openiddict-admin/src/constants.ts
@@ -1,3 +1,4 @@
 export const API_VERSION = 'v1';
 export const MODULE = 'admin';
 export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+export const DEFAULT_OIDC_BASE_PATH = `/api/${API_VERSION}/oidc`;

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-consent-application.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-consent-application.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getApplicationInfo } from '@granit/openiddict-admin';
+
+import { DEFAULT_OIDC_BASE_PATH } from '../constants';
+import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider';
+
+import type { UseQueryResult } from '@tanstack/react-query';
+
+export interface ConsentApplicationInfo {
+  readonly clientId: string | null;
+  readonly displayName: string | null;
+}
+
+/**
+ * Fetches public application display info for the OIDC consent page.
+ *
+ * Calls `GET {oidcBasePath}/applications/{clientId}` — requires authentication
+ * but no admin permission. Returns `null` if the application is not found (404).
+ *
+ * Must be used inside an `<OpenIddictAdminProvider>`.
+ */
+export function useConsentApplication(
+  clientId: string | null
+): UseQueryResult<ConsentApplicationInfo | null> {
+  const config = useAdminConfig();
+  const oidcBasePath = config.oidcBasePath ?? DEFAULT_OIDC_BASE_PATH;
+
+  return useQuery({
+    queryKey: buildAdminQueryKey(config, 'oidc', 'consent-application', clientId ?? ''),
+    queryFn: async () => {
+      try {
+        return await getApplicationInfo(config.client, oidcBasePath, clientId!);
+      } catch (err: unknown) {
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status === 404) return null;
+        throw err;
+      }
+    },
+    enabled: !!clientId,
+  });
+}

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-consent-application.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-consent-application.ts
@@ -1,6 +1,5 @@
-import { useQuery } from '@tanstack/react-query';
-
 import { getApplicationInfo } from '@granit/openiddict-admin';
+import { useQuery } from '@tanstack/react-query';
 
 import { DEFAULT_OIDC_BASE_PATH } from '../constants';
 import { buildAdminQueryKey, useAdminConfig } from '../providers/openiddict-admin-provider';

--- a/packages/@granit/react-openiddict-admin/src/index.ts
+++ b/packages/@granit/react-openiddict-admin/src/index.ts
@@ -39,6 +39,8 @@ export {
 } from './hooks/use-oidc-authorizations';
 
 // Hooks — Auth flows
+export { useConsentApplication } from './hooks/use-consent-application';
+export type { ConsentApplicationInfo } from './hooks/use-consent-application';
 export { useConsentFlow } from './hooks/use-consent-flow';
 export type { ConsentFlowState } from './hooks/use-consent-flow';
 export { useDeviceVerification } from './hooks/use-device-verification';

--- a/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
+++ b/packages/@granit/react-openiddict-admin/src/providers/openiddict-admin-provider.tsx
@@ -9,6 +9,8 @@ import type { ReactNode } from 'react';
 export interface OpenIddictAdminConfig {
   readonly client?: AxiosInstance;
   readonly basePath?: string;
+  /** Base path for authenticated (non-admin) OIDC endpoints, e.g. `/api/v1/oidc`. Used by the consent page. */
+  readonly oidcBasePath?: string;
   readonly queryKeyPrefix?: readonly string[];
 }
 

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -312,9 +312,25 @@ export const oidcAuthorizationQueryMetadata: QueryMetadata = {
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
  *
  * @param baseUrl - API base path (default: `/api/v1/admin`)
+ * @param oidcBaseUrl - Base path for non-admin OIDC endpoints used by the consent page (default: `/api/v1/oidc`)
  */
-export function createOpenIddictAdminHandlers(baseUrl = DEFAULT_BASE_PATH) {
+export function createOpenIddictAdminHandlers(
+  baseUrl = DEFAULT_BASE_PATH,
+  oidcBaseUrl = '/api/v1/oidc'
+) {
   return [
+    // ── Consent (non-admin) ──────────────────────────────────────────────────
+
+    http.get(`${oidcBaseUrl}/applications/:clientId`, ({ params }) => {
+      const app = mockOidcApplications.find(
+        (a) => a.clientId === decodeURIComponent(params.clientId as string)
+      );
+      return app
+        ? HttpResponse.json({ clientId: app.clientId, displayName: app.displayName })
+        : notFound();
+    }),
+
+
     // ── Query metadata ───────────────────────────────────────────────────────
 
     createQueryMetaHandler(`${baseUrl}/users`, adminUserQueryMetadata),

--- a/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
+++ b/packages/@granit/react-openiddict-admin/src/testing/handlers.ts
@@ -330,7 +330,6 @@ export function createOpenIddictAdminHandlers(
         : notFound();
     }),
 
-
     // ── Query metadata ───────────────────────────────────────────────────────
 
     createQueryMetaHandler(`${baseUrl}/users`, adminUserQueryMetadata),


### PR DESCRIPTION
## Summary

- `getApplicationInfo`: new non-admin endpoint `GET {oidcBasePath}/applications/{clientId}` returning `{ clientId, displayName }` — authenticated but no admin permission required (consent page use)
- `useConsentApplication`: React Query hook wrapping the above, returns `null` on 404
- `oidcBasePath` added to `OpenIddictAdminConfig` (default `/api/v1/oidc`)
- `DEFAULT_OIDC_BASE_PATH` constant in `@granit/react-openiddict-admin`
- MSW handler wired into `createOpenIddictAdminHandlers`

## Test plan

- [ ] Verify `useConsentApplication` returns the app display name when a valid `clientId` is provided
- [ ] Verify it returns `null` when the application is not found (404)
- [ ] Verify the hook is disabled when `clientId` is `null`
- [ ] Verify `createOpenIddictAdminHandlers` mock responds correctly to `GET /api/v1/oidc/applications/:clientId`