### PR TITLE
fix(identity): rename IdentityProviderCapabilities to IdentityProviderCapabilitiesResponse

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1661,9 +1661,9 @@
       "description": "Identity provider capabilities — types and API for GET /identity/users/capabilities",
       "exports": [
         {
-          "name": "IdentityProviderCapabilities",
+          "name": "IdentityProviderCapabilitiesResponse",
           "kind": "interface",
-          "signature": "interface IdentityProviderCapabilities",
+          "signature": "interface IdentityProviderCapabilitiesResponse",
           "members": []
         },
         {
@@ -1674,7 +1674,7 @@
         {
           "name": "getIdentityCapabilities",
           "kind": "function",
-          "signature": "async function getIdentityCapabilities( client: AxiosInstance, basePath: string ): Promise<IdentityProviderCapabilities>"
+          "signature": "async function getIdentityCapabilities( client: AxiosInstance, basePath: string ): Promise<IdentityProviderCapabilitiesResponse>"
         },
         {
           "name": "IdentityPermissions",

--- a/packages/@granit/identity/src/__tests__/identity-capabilities-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-capabilities-api.test.ts
@@ -3,9 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { getIdentityCapabilities } from '../api/identity-capabilities-api';
 
-import type { IdentityProviderCapabilities } from '../types/index';
+import type { IdentityProviderCapabilitiesResponse } from '../types/index';
 
-const keycloakCapabilities: IdentityProviderCapabilities = {
+const keycloakCapabilities: IdentityProviderCapabilitiesResponse = {
   providerName: 'Keycloak',
   supportsIndividualSessionTermination: true,
   supportsNativePasswordResetEmail: true,
@@ -38,7 +38,7 @@ describe('identity-capabilities-api', () => {
   });
 
   it('should return Entra ID capabilities', async () => {
-    const entraCapabilities: IdentityProviderCapabilities = {
+    const entraCapabilities: IdentityProviderCapabilitiesResponse = {
       providerName: 'Entra ID',
       supportsIndividualSessionTermination: false,
       supportsNativePasswordResetEmail: false,

--- a/packages/@granit/identity/src/api/identity-capabilities-api.ts
+++ b/packages/@granit/identity/src/api/identity-capabilities-api.ts
@@ -1,4 +1,4 @@
-import type { IdentityProviderCapabilities } from '../types/index';
+import type { IdentityProviderCapabilitiesResponse } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 
 /**
@@ -9,7 +9,9 @@ import type { AxiosInstance } from '@granit/api-client';
 export async function getIdentityCapabilities(
   client: AxiosInstance,
   basePath: string
-): Promise<IdentityProviderCapabilities> {
-  const response = await client.get<IdentityProviderCapabilities>(`${basePath}/capabilities`);
+): Promise<IdentityProviderCapabilitiesResponse> {
+  const response = await client.get<IdentityProviderCapabilitiesResponse>(
+    `${basePath}/capabilities`
+  );
   return response.data;
 }

--- a/packages/@granit/identity/src/index.ts
+++ b/packages/@granit/identity/src/index.ts
@@ -1,5 +1,5 @@
 // Types
-export type { IdentityProviderCapabilities } from './types/index';
+export type { IdentityProviderCapabilitiesResponse } from './types/index';
 export type {
   IdentityUser,
   IdentityUserCacheStats,

--- a/packages/@granit/identity/src/types/index.ts
+++ b/packages/@granit/identity/src/types/index.ts
@@ -30,7 +30,7 @@ export type IdentityProviderUserListParams = {
 };
 
 /** Response from `GET /identity/users/capabilities`. */
-export interface IdentityProviderCapabilities {
+export interface IdentityProviderCapabilitiesResponse {
   /** Display name of the active identity provider (e.g. "Keycloak", "Entra ID"). */
   readonly providerName: string;
   /** Whether the provider can terminate a specific session without revoking all sessions. */

--- a/packages/@granit/react-identity/src/__tests__/use-identity-capabilities.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-capabilities.test.tsx
@@ -9,7 +9,7 @@ import { useIdentityCapabilities } from '../hooks/use-identity-capabilities';
 import { IdentityProvider } from '../providers/identity-provider';
 
 import type { IdentityProviderProps } from '../providers/identity-provider';
-import type { IdentityProviderCapabilities } from '@granit/identity';
+import type { IdentityProviderCapabilitiesResponse } from '@granit/identity';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -29,7 +29,7 @@ function createWrapper(client: AxiosInstance, basePath?: string) {
   };
 }
 
-const mockCapabilities: IdentityProviderCapabilities = {
+const mockCapabilities: IdentityProviderCapabilitiesResponse = {
   providerName: 'Keycloak',
   supportsIndividualSessionTermination: true,
   supportsNativePasswordResetEmail: false,

--- a/packages/@granit/react-identity/src/hooks/use-identity-capabilities.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-capabilities.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider';
 
-import type { IdentityProviderCapabilities } from '@granit/identity';
+import type { IdentityProviderCapabilitiesResponse } from '@granit/identity';
 import type { UseQueryResult } from '@tanstack/react-query';
 
 /**
@@ -22,7 +22,7 @@ import type { UseQueryResult } from '@tanstack/react-query';
  */
 export function useIdentityCapabilities(options?: {
   enabled?: boolean;
-}): UseQueryResult<IdentityProviderCapabilities> {
+}): UseQueryResult<IdentityProviderCapabilitiesResponse> {
   const config = useIdentityConfig();
 
   return useQuery({

--- a/packages/@granit/react-identity/src/testing/handlers.ts
+++ b/packages/@granit/react-identity/src/testing/handlers.ts
@@ -7,7 +7,7 @@ import { DEFAULT_BASE_PATH, DEFAULT_PROVIDER_BASE_PATH } from '../constants';
 
 import { mockDevices, mockPasswordChangedAt, mockSessions, mockUsers } from './data';
 
-import type { IdentityProviderCapabilities, IdentityUser } from '@granit/identity';
+import type { IdentityProviderCapabilitiesResponse, IdentityUser } from '@granit/identity';
 import type { QueryMetadata } from '@granit/query-engine';
 
 /** Mock /meta payload for the cached identity-users resource. */
@@ -184,7 +184,7 @@ function findGroupById(id: string): MockGroup | undefined {
 // Capabilities
 // ---------------------------------------------------------------------------
 
-const capabilities: IdentityProviderCapabilities = {
+const capabilities: IdentityProviderCapabilitiesResponse = {
   providerName: 'Keycloak',
   supportsIndividualSessionTermination: true,
   supportsNativePasswordResetEmail: true,


### PR DESCRIPTION
## Summary

- Renames `IdentityProviderCapabilities` → `IdentityProviderCapabilitiesResponse` in `@granit/identity` and `@granit/react-identity` to match the .NET DTO name in `IdentityCapabilitiesEndpoints.cs`
- Updated all usages: type definition, API function, hook, MSW handlers, and tests

## Test plan

- [ ] `pnpm tsc` passes
- [ ] `pnpm lint` passes
- [ ] Tests in `@granit/identity` and `@granit/react-identity` pass