### PR TITLE
feat(identity-local): add email OTP 2FA, align login contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -882,11 +882,6 @@
           "signature": "async function loginAccount( client: AxiosInstance, basePath: string, request: AccountLoginRequest ): Promise<AccountLoginResponse>"
         },
         {
-          "name": "verifyTwoFactorLogin",
-          "kind": "function",
-          "signature": "async function verifyTwoFactorLogin( client: AxiosInstance, basePath: string, request: AccountTwoFactorLoginRequest ): Promise<AccountLoginResponse>"
-        },
-        {
           "name": "extractReturnUrl",
           "kind": "function",
           "signature": "function extractReturnUrl(search?: string): string | null"
@@ -3107,6 +3102,11 @@
           "name": "useVerifyTwoFactorLogin",
           "kind": "function",
           "signature": "function useVerifyTwoFactorLogin(): UseMutationResult< AccountLoginResponse, Error, AccountTwoFactorLoginRequest >"
+        },
+        {
+          "name": "useSendTwoFactorLoginEmailCode",
+          "kind": "function",
+          "signature": "function useSendTwoFactorLoginEmailCode(): UseMutationResult<void, Error, void>"
         },
         {
           "name": "useBeginPasskeyAssertion",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ Ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Ajouté
 
+- **@granit/account** et **@granit/react-account** : facteur 2FA par code à usage
+  unique envoyé par email (opt-in). Endpoints d'enrôlement
+  (`sendTwoFactorEmailEnrollmentCode`, `enableTwoFactorEmail`,
+  `disableTwoFactorEmail`) et hooks associés (`useSendTwoFactorEmailEnrollmentCode`,
+  `useEnableTwoFactorEmail`, `useDisableTwoFactorEmail`) ; champ `hasEmailOtp`
+  exposé par `useTwoFactorStatus` (2026-06-10)
+- **@granit/authentication-local** et **@granit/react-authentication-local** :
+  envoi du code OTP email au login 2FA (`sendTwoFactorLoginEmailCode`,
+  `useSendTwoFactorLoginEmailCode`) et exposition de `twoFactorMethods` dans la
+  réponse de login — l'UI n'offre que les méthodes enrôlées par l'utilisateur
+  (2026-06-10)
 - **@granit/query-engine** : enrichissement de `useSmartFilter` avec support enum, boolean,
   field search et labels localisables (2026-03-07)
 - **@granit/query-engine** : ajout de `labelParts` aux tokens et exposition de
@@ -62,6 +73,13 @@ Ce projet adhère au [Semantic Versioning](https://semver.org/lang/fr/).
 
 ### Modifié
 
+- **@granit/authentication-local** et **@granit/react-authentication-local** :
+  le contrat de login 2FA remplace `useRecoveryCode?: boolean` par
+  `method?: "Authenticator" | "RecoveryCode" | "Email"` (défaut `Authenticator`)
+  dans `AccountTwoFactorLoginRequest`. **Breaking** — alignement sur Granit dotnet
+  (Granit.Identity.Local). Migration : remplacer `{ useRecoveryCode: true }` par
+  `{ method: "RecoveryCode" }`. Pré-1.0, clean break sans shim de compatibilité.
+  (2026-06-10)
 - **@granit/identity, @granit/openiddict-admin, @granit/reference-data**
   (et leurs `react-*`) : renommage du champ wire format
   `extraProperties` → `metadata` pour s'aligner sur le renommage backend

--- a/contracts/openapi/identity-local.json
+++ b/contracts/openapi/identity-local.json
@@ -7,9 +7,7 @@
   "paths": {
     "/account/login": {
       "post": {
-        "tags": [
-          "Account - Login"
-        ],
+        "tags": ["Account - Login"],
         "summary": "Authenticates a user and sets the Identity session cookie.",
         "description": "Validates credentials (email or username + password) against ASP.NET Core Identity. On success, sets the Identity authentication cookie and returns 200. On failure, returns 401 with a generic message to prevent account enumeration. Locked-out users are notified exclusively via email with a password reset link. This endpoint is designed for headless/BFF architectures where the SPA handles the login UI and redirects back to /connect/authorize after successful authentication.",
         "operationId": "AccountLogin",
@@ -65,16 +63,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/login/two-factor": {
       "post": {
-        "tags": [
-          "Account - Login"
-        ],
+        "tags": ["Account - Login"],
         "summary": "Completes login with a TOTP code or recovery code.",
         "description": "Finalizes the two-factor authentication challenge after a successful password-based login returned requiresTwoFactor: true. The Identity.TwoFactorUserId cookie (set by the initial login) identifies the user. Accepts either a 6-digit TOTP code from an authenticator app or a single-use recovery code (when useRecoveryCode is true). On success, sets the Identity authentication cookie and returns 200. Returns 401 if the code is invalid or the 2FA session has expired.",
         "operationId": "AccountTwoFactorLogin",
@@ -140,16 +134,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/register": {
       "post": {
-        "tags": [
-          "Account - Registration"
-        ],
+        "tags": ["Account - Registration"],
         "summary": "Registers a new user account.",
         "description": "Creates a new user with the provided email and password. Returns 403 if self-registration is disabled for the current tenant. Always returns 202 to prevent email enumeration. Sends a confirmation email if the account is new, or a notification if the email is already taken. Returns 422 if the password does not meet policy requirements.",
         "operationId": "RegisterAccount",
@@ -208,16 +198,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/confirm-email": {
       "get": {
-        "tags": [
-          "Account - Registration"
-        ],
+        "tags": ["Account - Registration"],
         "summary": "Confirms a user's email address.",
         "description": "Validates the email confirmation token sent via email. Returns 204 on success, 400 if the token is invalid or expired.",
         "operationId": "ConfirmEmail",
@@ -266,16 +252,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/resend-confirmation-email": {
       "post": {
-        "tags": [
-          "Account - Registration"
-        ],
+        "tags": ["Account - Registration"],
         "summary": "Resends the email confirmation link.",
         "description": "Resends the confirmation email to the authenticated user. Always returns 202 to prevent email enumeration.",
         "operationId": "ResendConfirmationEmail",
@@ -318,9 +300,7 @@
     },
     "/account/profile": {
       "get": {
-        "tags": [
-          "Account - Profile"
-        ],
+        "tags": ["Account - Profile"],
         "summary": "Returns the current user's profile.",
         "description": "Fetches the authenticated user's profile including email, name, 2FA status, and linked external logins.",
         "operationId": "GetAccountProfile",
@@ -368,9 +348,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Account - Profile"
-        ],
+        "tags": ["Account - Profile"],
         "summary": "Updates the current user's profile.",
         "description": "Updates the authenticated user's first name and last name. Returns the updated profile.",
         "operationId": "UpdateAccountProfile",
@@ -450,9 +428,7 @@
     },
     "/account/change-email": {
       "post": {
-        "tags": [
-          "Account - Email Change"
-        ],
+        "tags": ["Account - Email Change"],
         "summary": "Requests an email address change.",
         "description": "Requires password confirmation as step-up authentication (OWASP ASVS V2.8.1) so a stolen session cookie alone cannot pivot a compromised account into a permanent take-over via email change followed by password reset. Generates a change-email token and publishes an EmailChangeRequestedEto event. A security alert is sent to the current email and a confirmation link to the new email. Returns 400 if the current password is incorrect; otherwise always returns 202 to prevent email enumeration.",
         "operationId": "ChangeEmail",
@@ -525,9 +501,7 @@
     },
     "/account/confirm-email-change": {
       "post": {
-        "tags": [
-          "Account - Email Change"
-        ],
+        "tags": ["Account - Email Change"],
         "summary": "Confirms an email address change using a token.",
         "description": "Validates the email change token from the confirmation link, applies the new email, and updates the username to match. Returns 400 if the token is invalid or expired.",
         "operationId": "ConfirmEmailChange",
@@ -576,16 +550,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/change-password": {
       "post": {
-        "tags": [
-          "Account - Password"
-        ],
+        "tags": ["Account - Password"],
         "summary": "Changes the authenticated user's password.",
         "description": "Validates the current password, then sets the new password. Returns 400 if the current password is incorrect or the new password is too weak.",
         "operationId": "ChangePassword",
@@ -658,9 +628,7 @@
     },
     "/account/forgot-password": {
       "post": {
-        "tags": [
-          "Account - Password"
-        ],
+        "tags": ["Account - Password"],
         "summary": "Sends a password reset email.",
         "description": "Sends a password reset link to the specified email if the account exists. Always returns 202 to prevent user enumeration.",
         "operationId": "ForgotPassword",
@@ -699,16 +667,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/reset-password": {
       "post": {
-        "tags": [
-          "Account - Password"
-        ],
+        "tags": ["Account - Password"],
         "summary": "Resets a user's password using a reset token.",
         "description": "Validates the reset token from the email link and sets the new password. Returns 400 if the token is invalid or expired.",
         "operationId": "ResetPassword",
@@ -757,16 +721,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/two-factor": {
       "get": {
-        "tags": [
-          "Account - Two-Factor"
-        ],
+        "tags": ["Account - Two-Factor"],
         "summary": "Returns the current 2FA status.",
         "description": "Returns whether 2FA is enabled, whether an authenticator app is configured, and the number of unused recovery codes.",
         "operationId": "GetTwoFactorStatus",
@@ -816,9 +776,7 @@
     },
     "/account/two-factor/authenticator-key": {
       "get": {
-        "tags": [
-          "Account - Two-Factor"
-        ],
+        "tags": ["Account - Two-Factor"],
         "summary": "Returns the TOTP shared key and QR code URI.",
         "description": "Generates or returns the existing TOTP shared key for the user. The QR code URI can be rendered by the frontend for authenticator app scanning.",
         "operationId": "GetAuthenticatorKey",
@@ -868,9 +826,7 @@
     },
     "/account/two-factor/enable": {
       "post": {
-        "tags": [
-          "Account - Two-Factor"
-        ],
+        "tags": ["Account - Two-Factor"],
         "summary": "Enables 2FA after TOTP code verification.",
         "description": "Validates the provided TOTP code against the shared key. On success, enables 2FA and returns single-use recovery codes. Returns 400 if the code is invalid.",
         "operationId": "EnableTwoFactor",
@@ -950,9 +906,7 @@
     },
     "/account/two-factor/disable": {
       "post": {
-        "tags": [
-          "Account - Two-Factor"
-        ],
+        "tags": ["Account - Two-Factor"],
         "summary": "Disables 2FA for the authenticated user.",
         "description": "Disables TOTP-based two-factor authentication. Requires password confirmation as step-up authentication (OWASP ASVS V2.8.1).",
         "operationId": "DisableTwoFactor",
@@ -1025,9 +979,7 @@
     },
     "/account/two-factor/recovery-codes": {
       "post": {
-        "tags": [
-          "Account - Two-Factor"
-        ],
+        "tags": ["Account - Two-Factor"],
         "summary": "Generates new recovery codes.",
         "description": "Generates 10 new single-use recovery codes. Previously generated codes are invalidated. Requires password confirmation as step-up authentication. Recovery codes can be used instead of a TOTP code during login.",
         "operationId": "GenerateRecoveryCodes",
@@ -1107,9 +1059,7 @@
     },
     "/account/external-logins": {
       "get": {
-        "tags": [
-          "Account - External Logins"
-        ],
+        "tags": ["Account - External Logins"],
         "summary": "Lists linked external login providers.",
         "description": "Returns the list of external providers (Google, Microsoft, GitHub) currently linked to the authenticated user's account.",
         "operationId": "ListExternalLogins",
@@ -1162,9 +1112,7 @@
     },
     "/account/external-logins/challenge/{provider}": {
       "post": {
-        "tags": [
-          "Account - External Logins"
-        ],
+        "tags": ["Account - External Logins"],
         "summary": "Initiates an OAuth flow with an external provider.",
         "description": "Validates that the specified provider is registered in IExternalProviderRegistry and returns 200 with metadata for the frontend to initiate the redirect via the standard OAuth client flow. Returns 400 if the provider is not configured.",
         "operationId": "ChallengeExternalLogin",
@@ -1203,16 +1151,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/external-logins/callback": {
       "get": {
-        "tags": [
-          "Account - External Logins"
-        ],
+        "tags": ["Account - External Logins"],
         "summary": "Processes the OAuth callback from an external provider.",
         "description": "Handles the redirect from the external provider. Links the external account to an existing user or creates a new one if AutoRegisterExternalUsers is enabled. Returns 400 if the provider query parameter is missing. Returns 409 if the email is taken by another account. Returns 403 if auto-registration is disabled and no account exists.",
         "operationId": "ExternalLoginCallback",
@@ -1268,16 +1212,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/external-logins/{provider}": {
       "delete": {
-        "tags": [
-          "Account - External Logins"
-        ],
+        "tags": ["Account - External Logins"],
         "summary": "Unlinks an external login provider.",
         "description": "Removes the association between the authenticated user and the specified provider. Returns 400 if it's the last login method and no password is set.",
         "operationId": "UnlinkExternalLogin",
@@ -1340,9 +1280,7 @@
     },
     "/account/passkeys": {
       "get": {
-        "tags": [
-          "Account - Passkeys"
-        ],
+        "tags": ["Account - Passkeys"],
         "summary": "Lists registered passkeys.",
         "description": "Returns the list of WebAuthn passkeys registered for the authenticated user.",
         "operationId": "ListPasskeys",
@@ -1395,9 +1333,7 @@
     },
     "/account/passkeys/register/begin": {
       "post": {
-        "tags": [
-          "Account - Passkeys"
-        ],
+        "tags": ["Account - Passkeys"],
         "summary": "Begins a WebAuthn passkey registration ceremony.",
         "description": "Returns PublicKeyCredentialCreationOptions with mediation: conditional for browser-native passkey autofill support.",
         "operationId": "BeginPasskeyRegistration",
@@ -1447,9 +1383,7 @@
     },
     "/account/passkeys/register/complete": {
       "post": {
-        "tags": [
-          "Account - Passkeys"
-        ],
+        "tags": ["Account - Passkeys"],
         "summary": "Completes a WebAuthn passkey registration ceremony.",
         "description": "Validates and stores the credential via ASP.NET Identity's built-in WebAuthn support.",
         "operationId": "CompletePasskeyRegistration",
@@ -1529,9 +1463,7 @@
     },
     "/account/passkeys/assertion/begin": {
       "post": {
-        "tags": [
-          "Account - Passkeys"
-        ],
+        "tags": ["Account - Passkeys"],
         "summary": "Begins a WebAuthn passkey assertion ceremony (login).",
         "description": "Returns PublicKeyCredentialRequestOptions with mediation: conditional and empty allowCredentials for Conditional UI autofill.",
         "operationId": "BeginPasskeyAssertion",
@@ -1557,16 +1489,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/passkeys/assertion/complete": {
       "post": {
-        "tags": [
-          "Account - Passkeys"
-        ],
+        "tags": ["Account - Passkeys"],
         "summary": "Completes a WebAuthn passkey assertion ceremony (login).",
         "description": "Validates the AuthenticatorAssertionResponse from the browser against stored public keys. On success, signs in the user via ASP.NET Core Identity and returns the login response. Returns 401 if the credential is invalid or no matching user is found.",
         "operationId": "CompletePasskeyAssertion",
@@ -1632,16 +1560,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/account/passkeys/{id}": {
       "patch": {
-        "tags": [
-          "Account - Passkeys"
-        ],
+        "tags": ["Account - Passkeys"],
         "summary": "Renames a passkey.",
         "description": "Updates the friendly name of a registered passkey.",
         "operationId": "RenamePasskey",
@@ -1724,9 +1648,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Account - Passkeys"
-        ],
+        "tags": ["Account - Passkeys"],
         "summary": "Deletes a passkey.",
         "description": "Removes a registered passkey. Returns 400 if this is the last credential and no password is set on the account.",
         "operationId": "DeletePasskey",
@@ -1801,9 +1723,7 @@
     },
     "/account/delete": {
       "post": {
-        "tags": [
-          "Account - Deletion"
-        ],
+        "tags": ["Account - Deletion"],
         "summary": "Deletes the authenticated user's account.",
         "description": "Initiates account deletion (GDPR Article 17 — right to erasure). Requires password confirmation. Triggers soft-delete, token revocation, and publishes AccountDeletedEto for downstream cleanup. Returns 202 as deletion is asynchronous.",
         "operationId": "DeleteAccount",
@@ -1876,9 +1796,7 @@
     },
     "/account/session/heartbeat": {
       "post": {
-        "tags": [
-          "Account - Session"
-        ],
+        "tags": ["Account - Session"],
         "summary": "Resets the idle session timer.",
         "description": "Updates LastActivityAt in the distributed cache. Returns 204 if the session is still active. No-op for sessions with remember_me claim.",
         "operationId": "SessionHeartbeat",
@@ -1921,9 +1839,7 @@
     },
     "/account/session/back-to-impersonator": {
       "post": {
-        "tags": [
-          "Impersonation"
-        ],
+        "tags": ["Impersonation"],
         "summary": "Ends an impersonation session and returns to the admin account.",
         "description": "Reads the impersonator_id claim from the current (impersonated) token and issues a fresh token set for the original admin user. Returns 400 if the current token is not an impersonation token.",
         "operationId": "BackToImpersonator",
@@ -1983,9 +1899,7 @@
     },
     "/account/config": {
       "get": {
-        "tags": [
-          "Account - Config"
-        ],
+        "tags": ["Account - Config"],
         "summary": "Returns the current Account - Config module configuration.",
         "description": "Returns the runtime configuration of the Account - Config module — the same shape used by SPAs to render module-specific UI without hardcoding values. The payload is module-defined and stable; clients should not assume new fields are absent.",
         "operationId": "GetAccountConfig",
@@ -2011,16 +1925,12 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
       }
     },
     "/admin/users/{userId}/impersonate": {
       "post": {
-        "tags": [
-          "Impersonation"
-        ],
+        "tags": ["Impersonation"],
         "summary": "Impersonates a user.",
         "description": "Issues a short-lived token (max 1h) with impersonator_id claim. Writes audit log and sends transparency notification.",
         "operationId": "ImpersonateUser",
@@ -2092,9 +2002,7 @@
     },
     "/admin/roles": {
       "get": {
-        "tags": [
-          "Identity - Roles"
-        ],
+        "tags": ["Identity - Roles"],
         "summary": "Lists roles visible in the caller's context.",
         "description": "Host admins see every role (CRUD on Host / Both, read-only on tenant roles). Tenant admins see Both roles (read-only) plus their own tenant roles (CRUD).",
         "operationId": "ListRoles",
@@ -2145,9 +2053,7 @@
         }
       },
       "post": {
-        "tags": [
-          "Identity - Roles"
-        ],
+        "tags": ["Identity - Roles"],
         "summary": "Creates a new local role and its RoleMetadata row.",
         "description": "Invariants: Host / Both ⇒ TenantId must be null; Tenant ⇒ TenantId required. Tenant admins may only create Tenant-scope roles in their own tenant. Set RoleEndpointsOptions.AllowTenantRoles = false to disable Tenant-scope creation entirely.",
         "operationId": "CreateRole",
@@ -2227,9 +2133,7 @@
     },
     "/admin/roles/{id}": {
       "get": {
-        "tags": [
-          "Identity - Roles"
-        ],
+        "tags": ["Identity - Roles"],
         "summary": "Returns a single role by identifier.",
         "description": "Returns 404 when the role is not visible in the caller's context (no 403 to prevent leak).",
         "operationId": "GetRole",
@@ -2299,9 +2203,7 @@
         }
       },
       "put": {
-        "tags": [
-          "Identity - Roles"
-        ],
+        "tags": ["Identity - Roles"],
         "summary": "Renames a role and updates its description.",
         "description": "Side and tenant scope are immutable. System roles and non-visible roles cannot be renamed.",
         "operationId": "RenameRole",
@@ -2401,9 +2303,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Identity - Roles"
-        ],
+        "tags": ["Identity - Roles"],
         "summary": "Hard-deletes a non-system role.",
         "description": "System roles (SuperAdmin, TenantAdministrator, User) and non-visible roles cannot be deleted.",
         "operationId": "DeleteRole",
@@ -2465,15 +2365,223 @@
           }
         }
       }
+    },
+    "/account/login/two-factor/send-email": {
+      "post": {
+        "tags": ["Account - Login"],
+        "summary": "Sends a one-time code to the email of the user pending two-factor login.",
+        "description": "Anonymous; identifies the user via the two-factor session cookie set during login. No-op (still 204) if the user has not enrolled the email factor. Returns 400 when there is no active two-factor session.",
+        "operationId": "SendTwoFactorLoginEmailCode",
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/account/two-factor/email/send": {
+      "post": {
+        "tags": ["Account - Two-Factor"],
+        "summary": "Sends an email enrollment code to the authenticated user.",
+        "operationId": "SendTwoFactorEmailEnrollmentCode",
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/account/two-factor/email/enable": {
+      "post": {
+        "tags": ["Account - Two-Factor"],
+        "summary": "Enables the email one-time-code two-factor method.",
+        "description": "Verifies the code previously sent via /two-factor/email/send. Returns 400 if the code is invalid.",
+        "operationId": "EnableTwoFactorEmail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountTwoFactorEmailEnableRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/account/two-factor/email/disable": {
+      "post": {
+        "tags": ["Account - Two-Factor"],
+        "summary": "Disables the email one-time-code two-factor method.",
+        "description": "Requires password confirmation as step-up authentication (OWASP ASVS V2.8.1). Returns 400 if the password is incorrect.",
+        "operationId": "DisableTwoFactorEmail",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AccountTwoFactorDisableRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
       "AccountAuthenticatorKeyResponse": {
-        "required": [
-          "sharedKey",
-          "qrCodeUri"
-        ],
+        "required": ["sharedKey", "qrCodeUri"],
         "type": "object",
         "properties": {
           "sharedKey": {
@@ -2485,10 +2593,7 @@
         }
       },
       "AccountChangeEmailRequest": {
-        "required": [
-          "newEmail",
-          "currentPassword"
-        ],
+        "required": ["newEmail", "currentPassword"],
         "type": "object",
         "properties": {
           "newEmail": {
@@ -2500,11 +2605,7 @@
         }
       },
       "AccountConfirmEmailChangeRequest": {
-        "required": [
-          "userId",
-          "newEmail",
-          "token"
-        ],
+        "required": ["userId", "newEmail", "token"],
         "type": "object",
         "properties": {
           "userId": {
@@ -2519,9 +2620,7 @@
         }
       },
       "AccountDeleteRequest": {
-        "required": [
-          "password"
-        ],
+        "required": ["password"],
         "type": "object",
         "properties": {
           "password": {
@@ -2530,9 +2629,7 @@
         }
       },
       "AccountForgotPasswordRequest": {
-        "required": [
-          "email"
-        ],
+        "required": ["email"],
         "type": "object",
         "properties": {
           "email": {
@@ -2541,9 +2638,7 @@
         }
       },
       "AccountGenerateRecoveryCodesRequest": {
-        "required": [
-          "password"
-        ],
+        "required": ["password"],
         "type": "object",
         "properties": {
           "password": {
@@ -2552,10 +2647,7 @@
         }
       },
       "AccountLoginRequest": {
-        "required": [
-          "login",
-          "password"
-        ],
+        "required": ["login", "password"],
         "type": "object",
         "properties": {
           "login": {
@@ -2571,9 +2663,7 @@
         }
       },
       "AccountLoginResponse": {
-        "required": [
-          "succeeded"
-        ],
+        "required": ["succeeded"],
         "type": "object",
         "properties": {
           "succeeded": {
@@ -2590,13 +2680,17 @@
           "isNotAllowed": {
             "type": "boolean",
             "default": false
+          },
+          "twoFactorMethods": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
           }
         }
       },
       "AccountPasskeyLoginRequest": {
-        "required": [
-          "credentialJson"
-        ],
+        "required": ["credentialJson"],
         "type": "object",
         "properties": {
           "credentialJson": {
@@ -2605,10 +2699,7 @@
         }
       },
       "AccountPasswordChangeRequest": {
-        "required": [
-          "currentPassword",
-          "newPassword"
-        ],
+        "required": ["currentPassword", "newPassword"],
         "type": "object",
         "properties": {
           "currentPassword": {
@@ -2620,11 +2711,7 @@
         }
       },
       "AccountPasswordResetRequest": {
-        "required": [
-          "userId",
-          "token",
-          "newPassword"
-        ],
+        "required": ["userId", "token", "newPassword"],
         "type": "object",
         "properties": {
           "userId": {
@@ -2662,16 +2749,10 @@
             "type": "boolean"
           },
           "firstName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "lastName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "twoFactorEnabled": {
             "type": "boolean"
@@ -2691,23 +2772,15 @@
         "type": "object",
         "properties": {
           "firstName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "lastName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "AccountRecoveryCodesResponse": {
-        "required": [
-          "recoveryCodes"
-        ],
+        "required": ["recoveryCodes"],
         "type": "object",
         "properties": {
           "recoveryCodes": {
@@ -2719,10 +2792,7 @@
         }
       },
       "AccountRegisterRequest": {
-        "required": [
-          "email",
-          "password"
-        ],
+        "required": ["email", "password"],
         "type": "object",
         "properties": {
           "email": {
@@ -2732,23 +2802,15 @@
             "type": "string"
           },
           "firstName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "lastName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "AccountTwoFactorDisableRequest": {
-        "required": [
-          "password"
-        ],
+        "required": ["password"],
         "type": "object",
         "properties": {
           "password": {
@@ -2757,9 +2819,7 @@
         }
       },
       "AccountTwoFactorEnableRequest": {
-        "required": [
-          "code"
-        ],
+        "required": ["code"],
         "type": "object",
         "properties": {
           "code": {
@@ -2768,9 +2828,7 @@
         }
       },
       "AccountTwoFactorEnableResponse": {
-        "required": [
-          "recoveryCodes"
-        ],
+        "required": ["recoveryCodes"],
         "type": "object",
         "properties": {
           "recoveryCodes": {
@@ -2782,17 +2840,14 @@
         }
       },
       "AccountTwoFactorLoginRequest": {
-        "required": [
-          "code"
-        ],
+        "required": ["code"],
         "type": "object",
         "properties": {
           "code": {
             "type": "string"
           },
-          "useRecoveryCode": {
-            "type": "boolean",
-            "default": false
+          "method": {
+            "$ref": "#/components/schemas/TwoFactorMethod"
           },
           "rememberMe": {
             "type": "boolean",
@@ -2801,17 +2856,16 @@
         }
       },
       "AccountTwoFactorStatusResponse": {
-        "required": [
-          "isEnabled",
-          "hasAuthenticatorApp",
-          "recoveryCodesLeft"
-        ],
+        "required": ["isEnabled", "hasAuthenticatorApp", "hasEmailOtp", "recoveryCodesLeft"],
         "type": "object",
         "properties": {
           "isEnabled": {
             "type": "boolean"
           },
           "hasAuthenticatorApp": {
+            "type": "boolean"
+          },
+          "hasEmailOtp": {
             "type": "boolean"
           },
           "recoveryCodesLeft": {
@@ -2821,11 +2875,7 @@
         }
       },
       "ExternalLoginInfoResponse": {
-        "required": [
-          "loginProvider",
-          "providerKey",
-          "providerDisplayName"
-        ],
+        "required": ["loginProvider", "providerKey", "providerDisplayName"],
         "type": "object",
         "properties": {
           "loginProvider": {
@@ -2835,10 +2885,7 @@
             "type": "string"
           },
           "providerDisplayName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -2846,35 +2893,20 @@
         "type": "object",
         "properties": {
           "type": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "title": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "status": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "detail": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "instance": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "errors": {
             "type": "object",
@@ -2888,9 +2920,7 @@
         }
       },
       "IdentityLocalConfigResponse": {
-        "required": [
-          "allowSelfRegistration"
-        ],
+        "required": ["allowSelfRegistration"],
         "type": "object",
         "properties": {
           "allowSelfRegistration": {
@@ -2899,11 +2929,7 @@
         }
       },
       "ImpersonationResponse": {
-        "required": [
-          "accessToken",
-          "refreshToken",
-          "expiresIn"
-        ],
+        "required": ["accessToken", "refreshToken", "expiresIn"],
         "type": "object",
         "properties": {
           "accessToken": {
@@ -2923,12 +2949,7 @@
         "description": "Scope of an object (permission, BFF frontend, ...) relative to the host/tenant boundary."
       },
       "PasskeyInfoResponse": {
-        "required": [
-          "id",
-          "name",
-          "createdAt",
-          "lastUsedAt"
-        ],
+        "required": ["id", "name", "createdAt", "lastUsedAt"],
         "type": "object",
         "properties": {
           "id": {
@@ -2936,45 +2957,32 @@
             "format": "uuid"
           },
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "createdAt": {
             "type": "string",
             "format": "date-time"
           },
           "lastUsedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "PasskeyRegistrationRequest": {
-        "required": [
-          "credentialJson"
-        ],
+        "required": ["credentialJson"],
         "type": "object",
         "properties": {
           "credentialJson": {
             "type": "string"
           },
           "name": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
       "PasskeyRenameRequest": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {
@@ -3008,10 +3016,7 @@
         }
       },
       "ProcessCallbackResult": {
-        "required": [
-          "userId",
-          "isNewUser"
-        ],
+        "required": ["userId", "isNewUser"],
         "type": "object",
         "properties": {
           "userId": {
@@ -3024,11 +3029,7 @@
         }
       },
       "RoleCreateRequest": {
-        "required": [
-          "name",
-          "multiTenancySides",
-          "tenantId"
-        ],
+        "required": ["name", "multiTenancySides", "tenantId"],
         "type": "object",
         "properties": {
           "name": {
@@ -3038,17 +3039,11 @@
             "$ref": "#/components/schemas/MultiTenancySides"
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -3077,23 +3072,14 @@
             "$ref": "#/components/schemas/MultiTenancySides"
           },
           "tenantId": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "uuid"
           },
           "clientId": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "isSystem": {
             "type": "boolean"
@@ -3103,28 +3089,32 @@
             "format": "date-time"
           },
           "modifiedAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "RoleUpdateRequest": {
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "type": "object",
         "properties": {
           "name": {
             "type": "string"
           },
           "description": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "TwoFactorMethod": {
+        "enum": ["Authenticator", "RecoveryCode", "Email"]
+      },
+      "AccountTwoFactorEmailEnableRequest": {
+        "required": ["code"],
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string"
           }
         }
       }

--- a/packages/@granit/account/src/__tests__/account-two-factor-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-two-factor-api.test.ts
@@ -3,10 +3,13 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   disableTwoFactor,
+  disableTwoFactorEmail,
   enableTwoFactor,
+  enableTwoFactorEmail,
   generateRecoveryCodes,
   getAuthenticatorKey,
   getTwoFactorStatus,
+  sendTwoFactorEmailEnrollmentCode,
 } from '../api/account-two-factor-api';
 
 import type {
@@ -21,6 +24,7 @@ const BASE = '/api/account';
 const mockStatus: AccountTwoFactorStatusResponse = {
   isEnabled: false,
   hasAuthenticatorApp: false,
+  hasEmailOtp: false,
   recoveryCodesLeft: 0,
 };
 
@@ -94,6 +98,43 @@ describe('account-two-factor-api', () => {
         password: 'P@ssw0rd!',
       });
       expect(result.recoveryCodes).toEqual(mockRecoveryCodes);
+    });
+  });
+
+  describe('sendTwoFactorEmailEnrollmentCode', () => {
+    it('sends POST /two-factor/email/send with no body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await sendTwoFactorEmailEnrollmentCode(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/email/send`);
+    });
+  });
+
+  describe('enableTwoFactorEmail', () => {
+    it('sends POST /two-factor/email/enable with the enrollment code', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await enableTwoFactorEmail(client, BASE, { code: '123456' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/email/enable`, {
+        code: '123456',
+      });
+    });
+  });
+
+  describe('disableTwoFactorEmail', () => {
+    it('sends POST /two-factor/email/disable with the current password', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await disableTwoFactorEmail(client, BASE, { password: 'P@ssw0rd!' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/two-factor/email/disable`, {
+        password: 'P@ssw0rd!',
+      });
     });
   });
 });

--- a/packages/@granit/account/src/api/account-two-factor-api.ts
+++ b/packages/@granit/account/src/api/account-two-factor-api.ts
@@ -3,6 +3,7 @@ import type {
   AccountGenerateRecoveryCodesRequest,
   AccountRecoveryCodesResponse,
   AccountTwoFactorDisableRequest,
+  AccountTwoFactorEmailEnableRequest,
   AccountTwoFactorEnableRequest,
   AccountTwoFactorEnableResponse,
   AccountTwoFactorStatusResponse,
@@ -84,4 +85,45 @@ export async function generateRecoveryCodes(
     request
   );
   return data;
+}
+
+/**
+ * Send an enrollment code to the current user's email address to begin enabling
+ * the email one-time-code factor.
+ *
+ * `POST {basePath}/two-factor/email/send`
+ */
+export async function sendTwoFactorEmailEnrollmentCode(
+  client: AxiosInstance,
+  basePath: string
+): Promise<void> {
+  await client.post(`${basePath}/two-factor/email/send`);
+}
+
+/**
+ * Enable the email one-time-code factor by verifying the code sent via
+ * {@link sendTwoFactorEmailEnrollmentCode}.
+ *
+ * `POST {basePath}/two-factor/email/enable`
+ */
+export async function enableTwoFactorEmail(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountTwoFactorEmailEnableRequest
+): Promise<void> {
+  await client.post(`${basePath}/two-factor/email/enable`, request);
+}
+
+/**
+ * Disable the email one-time-code factor. Requires the current password as
+ * step-up authentication.
+ *
+ * `POST {basePath}/two-factor/email/disable`
+ */
+export async function disableTwoFactorEmail(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountTwoFactorDisableRequest
+): Promise<void> {
+  await client.post(`${basePath}/two-factor/email/disable`, request);
 }

--- a/packages/@granit/account/src/index.ts
+++ b/packages/@granit/account/src/index.ts
@@ -19,10 +19,13 @@ export { changePassword, forgotPassword, resetPassword } from './api/account-pas
 // API — Two-Factor
 export {
   disableTwoFactor,
+  disableTwoFactorEmail,
   enableTwoFactor,
+  enableTwoFactorEmail,
   generateRecoveryCodes,
   getAuthenticatorKey,
   getTwoFactorStatus,
+  sendTwoFactorEmailEnrollmentCode,
 } from './api/account-two-factor-api';
 
 // API — External Logins

--- a/packages/@granit/account/src/types/account-two-factor.ts
+++ b/packages/@granit/account/src/types/account-two-factor.ts
@@ -6,6 +6,8 @@
 export interface AccountTwoFactorStatusResponse {
   readonly isEnabled: boolean;
   readonly hasAuthenticatorApp: boolean;
+  /** Whether the email one-time-code factor is enrolled. */
+  readonly hasEmailOtp: boolean;
   readonly recoveryCodesLeft: number;
 }
 
@@ -17,6 +19,14 @@ export interface AccountAuthenticatorKeyResponse {
 
 /** Request body for `POST /two-factor/enable`. */
 export interface AccountTwoFactorEnableRequest {
+  readonly code: string;
+}
+
+/**
+ * Request body for `POST /two-factor/email/enable`. The `code` is the one
+ * previously sent by `POST /two-factor/email/send`.
+ */
+export interface AccountTwoFactorEmailEnableRequest {
   readonly code: string;
 }
 

--- a/packages/@granit/account/src/types/index.ts
+++ b/packages/@granit/account/src/types/index.ts
@@ -13,6 +13,7 @@ export type {
   AccountGenerateRecoveryCodesRequest,
   AccountRecoveryCodesResponse,
   AccountTwoFactorDisableRequest,
+  AccountTwoFactorEmailEnableRequest,
   AccountTwoFactorEnableRequest,
   AccountTwoFactorEnableResponse,
   AccountTwoFactorStatusResponse,

--- a/packages/@granit/authentication-local/src/__tests__/account-two-factor-login-api.test.ts
+++ b/packages/@granit/authentication-local/src/__tests__/account-two-factor-login-api.test.ts
@@ -1,7 +1,10 @@
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
-import { verifyTwoFactorLogin } from '../api/account-two-factor-login-api';
+import {
+  sendTwoFactorLoginEmailCode,
+  verifyTwoFactorLogin,
+} from '../api/account-two-factor-login-api';
 
 import type { AccountLoginResponse } from '../types/index';
 
@@ -29,7 +32,7 @@ describe('account-two-factor-login-api', () => {
       expect(result).toEqual(response);
     });
 
-    it('sends POST /login/two-factor with recovery code', async () => {
+    it('sends POST /login/two-factor with a recovery code', async () => {
       const client = createMockClient();
       const response: AccountLoginResponse = {
         succeeded: true,
@@ -41,14 +44,43 @@ describe('account-two-factor-login-api', () => {
 
       const result = await verifyTwoFactorLogin(client, BASE, {
         code: 'ABCD-1234-EFGH',
-        useRecoveryCode: true,
+        method: 'RecoveryCode',
       });
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/login/two-factor`, {
         code: 'ABCD-1234-EFGH',
-        useRecoveryCode: true,
+        method: 'RecoveryCode',
       });
       expect(result.succeeded).toBe(true);
+    });
+
+    it('sends POST /login/two-factor with an emailed code', async () => {
+      const client = createMockClient();
+      const response: AccountLoginResponse = {
+        succeeded: true,
+        requiresTwoFactor: false,
+        isLockedOut: false,
+        isNotAllowed: false,
+      };
+      vi.mocked(client.post).mockResolvedValueOnce({ data: response });
+
+      await verifyTwoFactorLogin(client, BASE, { code: '123456', method: 'Email' });
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/login/two-factor`, {
+        code: '123456',
+        method: 'Email',
+      });
+    });
+  });
+
+  describe('sendTwoFactorLoginEmailCode', () => {
+    it('sends POST /login/two-factor/send-email with no body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await sendTwoFactorLoginEmailCode(client, BASE);
+
+      expect(client.post).toHaveBeenCalledWith(`${BASE}/login/two-factor/send-email`);
     });
   });
 });

--- a/packages/@granit/authentication-local/src/api/account-two-factor-login-api.ts
+++ b/packages/@granit/authentication-local/src/api/account-two-factor-login-api.ts
@@ -9,8 +9,9 @@ import type { AxiosInstance } from '@granit/api-client';
  * set during `POST {basePath}/login`. Spaces and dashes are stripped from
  * the code server-side (authenticator app formatting).
  *
- * Set `useRecoveryCode: true` to use a single-use recovery code instead
- * of a TOTP code.
+ * Set `request.method` to pick the factor the `code` belongs to
+ * (`"Authenticator"` — the default — `"RecoveryCode"`, or `"Email"`). Only
+ * offer methods listed in the login response's `twoFactorMethods`.
  *
  * `POST {basePath}/login/two-factor`
  */
@@ -21,4 +22,25 @@ export async function verifyTwoFactorLogin(
 ): Promise<AccountLoginResponse> {
   const { data } = await client.post<AccountLoginResponse>(`${basePath}/login/two-factor`, request);
   return data;
+}
+
+/**
+ * Send a one-time code by email to the user currently pending two-factor login.
+ *
+ * Anonymous: the server identifies the pending user via the two-factor session
+ * cookie set during `POST {basePath}/login`. The code is only sent if the user
+ * has enrolled the email factor — otherwise the call is a silent no-op (still
+ * `204`). Returns `400` when there is no active two-factor session.
+ *
+ * Call this when the user picks `"Email"` from the login response's
+ * `twoFactorMethods`, then submit the received code via {@link verifyTwoFactorLogin}
+ * with `method: "Email"`.
+ *
+ * `POST {basePath}/login/two-factor/send-email`
+ */
+export async function sendTwoFactorLoginEmailCode(
+  client: AxiosInstance,
+  basePath: string
+): Promise<void> {
+  await client.post(`${basePath}/login/two-factor/send-email`);
 }

--- a/packages/@granit/authentication-local/src/index.ts
+++ b/packages/@granit/authentication-local/src/index.ts
@@ -4,13 +4,17 @@ export type {
   AccountLoginResponse,
   AccountPasskeyLoginRequest,
   AccountTwoFactorLoginRequest,
+  TwoFactorMethod,
 } from './types/index';
 
 // API — Login
 export { loginAccount } from './api/account-login-api';
 
 // API — Two-factor login verification
-export { verifyTwoFactorLogin } from './api/account-two-factor-login-api';
+export {
+  sendTwoFactorLoginEmailCode,
+  verifyTwoFactorLogin,
+} from './api/account-two-factor-login-api';
 
 // API — Passkey assertion (for login)
 export {

--- a/packages/@granit/authentication-local/src/types/account-login.ts
+++ b/packages/@granit/authentication-local/src/types/account-login.ts
@@ -21,11 +21,28 @@ export interface AccountLoginResponse {
   readonly requiresTwoFactor: boolean;
   readonly isLockedOut: boolean;
   readonly isNotAllowed: boolean;
+  /**
+   * The factors this user can complete the challenge with — populated only when
+   * `requiresTwoFactor` is `true`, otherwise omitted. The UI must offer only the
+   * methods listed here (`"Email"` appears only if the user has opted in).
+   *
+   * Mirrors the backend `AccountLoginResponse.TwoFactorMethods`. Values align
+   * with {@link TwoFactorMethod} but are typed as `string` because the set is
+   * server-driven and may grow independently of this SDK.
+   */
+  readonly twoFactorMethods?: readonly string[];
 }
 
 // ---------------------------------------------------------------------------
 // Two-factor login verification
 // ---------------------------------------------------------------------------
+
+/**
+ * A second factor the user can complete the two-factor challenge with.
+ *
+ * Mirrors the backend `Granit.Identity.Local.Services.TwoFactorMethod` enum.
+ */
+export type TwoFactorMethod = 'Authenticator' | 'RecoveryCode' | 'Email';
 
 /**
  * Request body for `POST {basePath}/login/two-factor`.
@@ -36,7 +53,12 @@ export interface AccountLoginResponse {
  */
 export interface AccountTwoFactorLoginRequest {
   readonly code: string;
-  readonly useRecoveryCode?: boolean;
+  /**
+   * Which factor `code` belongs to. Must be one of the values returned in the
+   * login response's `twoFactorMethods`. Mirrors the backend
+   * `AccountTwoFactorLoginRequest.Method`. Default (server-side): `"Authenticator"`.
+   */
+  readonly method?: TwoFactorMethod;
   /**
    * When `true`, the Identity session cookie is marked as persistent.
    * Mirrors the backend `AccountTwoFactorLoginRequest.RememberMe`. Default: `false`.

--- a/packages/@granit/authentication-local/src/types/index.ts
+++ b/packages/@granit/authentication-local/src/types/index.ts
@@ -3,4 +3,5 @@ export type {
   AccountLoginResponse,
   AccountPasskeyLoginRequest,
   AccountTwoFactorLoginRequest,
+  TwoFactorMethod,
 } from './account-login';

--- a/packages/@granit/react-account/README.md
+++ b/packages/@granit/react-account/README.md
@@ -21,6 +21,7 @@ pnpm add @granit/react-account
 - `useRegister()`, `useConfirmEmail(...)`, `useResendConfirmation()` -- registration
 - `useChangePassword()`, `useForgotPassword()`, `useResetPassword()` -- password
 - `useTwoFactorStatus()`, `useEnableTwoFactor()`, `useDisableTwoFactor()`, `useAuthenticatorKey()`, `useGenerateRecoveryCodes()` -- 2FA
+- `useSendTwoFactorEmailEnrollmentCode()`, `useEnableTwoFactorEmail()`, `useDisableTwoFactorEmail()` -- email OTP factor (enrolled status via `useTwoFactorStatus().data.hasEmailOtp`)
 - `useExternalLogins()`, `useChallengeExternalLogin()`, `useUnlinkExternalLogin()` -- external logins
 - `usePasskeys()`, `useBeginPasskeyRegistration()`, `useCompletePasskeyRegistration()`, `useDeletePasskey()`, `useRenamePasskey(...)` -- passkeys
 - `useSessionHeartbeat()`, `useBackToImpersonator()` -- session

--- a/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-two-factor.test.tsx
@@ -8,8 +8,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   useAuthenticatorKey,
   useDisableTwoFactor,
+  useDisableTwoFactorEmail,
   useEnableTwoFactor,
+  useEnableTwoFactorEmail,
   useGenerateRecoveryCodes,
+  useSendTwoFactorEmailEnrollmentCode,
   useTwoFactorStatus,
 } from '../hooks/use-two-factor';
 import { AccountProvider } from '../providers/account-provider';
@@ -33,6 +36,9 @@ vi.mock('@granit/account', async (importOriginal) => {
     enableTwoFactor: vi.fn(),
     disableTwoFactor: vi.fn(),
     generateRecoveryCodes: vi.fn(),
+    sendTwoFactorEmailEnrollmentCode: vi.fn(),
+    enableTwoFactorEmail: vi.fn(),
+    disableTwoFactorEmail: vi.fn(),
   };
 });
 
@@ -42,6 +48,9 @@ const {
   enableTwoFactor,
   disableTwoFactor,
   generateRecoveryCodes,
+  sendTwoFactorEmailEnrollmentCode,
+  enableTwoFactorEmail,
+  disableTwoFactorEmail,
 } = await import('@granit/account');
 
 function createWrapper(client: AxiosInstance) {
@@ -73,6 +82,7 @@ function createWrapperWithQueryClient(client: AxiosInstance) {
 const mockStatus: AccountTwoFactorStatusResponse = {
   isEnabled: false,
   hasAuthenticatorApp: false,
+  hasEmailOtp: false,
   recoveryCodesLeft: 0,
 };
 
@@ -211,6 +221,69 @@ describe('useGenerateRecoveryCodes', () => {
       password: 'P@ssw0rd!',
     });
     expect(result.current.data).toEqual(response);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'two-factor'],
+    });
+  });
+});
+
+describe('useSendTwoFactorEmailEnrollmentCode', () => {
+  it('should call sendTwoFactorEmailEnrollmentCode with no arguments', async () => {
+    const client = createMockClient();
+    vi.mocked(sendTwoFactorEmailEnrollmentCode).mockResolvedValue();
+
+    const { result } = renderHook(() => useSendTwoFactorEmailEnrollmentCode(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(sendTwoFactorEmailEnrollmentCode).toHaveBeenCalledWith(client, '/api/v1/account');
+  });
+});
+
+describe('useEnableTwoFactorEmail', () => {
+  it('should call enableTwoFactorEmail and invalidate two-factor query on success', async () => {
+    const client = createMockClient();
+    vi.mocked(enableTwoFactorEmail).mockResolvedValue(undefined);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useEnableTwoFactorEmail(), { wrapper });
+
+    result.current.mutate({ code: '123456' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(enableTwoFactorEmail).toHaveBeenCalledWith(client, '/api/v1/account', {
+      code: '123456',
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['account', 'two-factor'],
+    });
+  });
+});
+
+describe('useDisableTwoFactorEmail', () => {
+  it('should call disableTwoFactorEmail and invalidate two-factor query on success', async () => {
+    const client = createMockClient();
+    vi.mocked(disableTwoFactorEmail).mockResolvedValue(undefined);
+
+    const { wrapper, queryClient } = createWrapperWithQueryClient(client);
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useDisableTwoFactorEmail(), { wrapper });
+
+    result.current.mutate({ password: 'P@ssw0rd!' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(disableTwoFactorEmail).toHaveBeenCalledWith(client, '/api/v1/account', {
+      password: 'P@ssw0rd!',
+    });
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: ['account', 'two-factor'],
     });

--- a/packages/@granit/react-account/src/hooks/use-two-factor.ts
+++ b/packages/@granit/react-account/src/hooks/use-two-factor.ts
@@ -1,9 +1,12 @@
 import {
   disableTwoFactor,
+  disableTwoFactorEmail,
   enableTwoFactor,
+  enableTwoFactorEmail,
   generateRecoveryCodes,
   getAuthenticatorKey,
   getTwoFactorStatus,
+  sendTwoFactorEmailEnrollmentCode,
 } from '@granit/account';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
@@ -14,6 +17,7 @@ import type {
   AccountGenerateRecoveryCodesRequest,
   AccountRecoveryCodesResponse,
   AccountTwoFactorDisableRequest,
+  AccountTwoFactorEmailEnableRequest,
   AccountTwoFactorEnableRequest,
   AccountTwoFactorEnableResponse,
   AccountTwoFactorStatusResponse,
@@ -92,6 +96,55 @@ export function useGenerateRecoveryCodes(): UseMutationResult<
   return useMutation({
     mutationFn: (request: AccountGenerateRecoveryCodesRequest) =>
       generateRecoveryCodes(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'two-factor'),
+      });
+    },
+  });
+}
+
+/** Sends an email enrollment code to begin enabling the email OTP factor. */
+export function useSendTwoFactorEmailEnrollmentCode(): UseMutationResult<void, Error, void> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: () => sendTwoFactorEmailEnrollmentCode(config.client, config.basePath!),
+  });
+}
+
+/** Enables the email OTP factor with an enrollment code. Invalidates 2FA status on success. */
+export function useEnableTwoFactorEmail(): UseMutationResult<
+  void,
+  Error,
+  AccountTwoFactorEmailEnableRequest
+> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountTwoFactorEmailEnableRequest) =>
+      enableTwoFactorEmail(config.client, config.basePath!, request),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: buildAccountQueryKey(config, 'two-factor'),
+      });
+    },
+  });
+}
+
+/** Disables the email OTP factor (requires the current password). Invalidates 2FA status on success. */
+export function useDisableTwoFactorEmail(): UseMutationResult<
+  void,
+  Error,
+  AccountTwoFactorDisableRequest
+> {
+  const config = useAccountConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: AccountTwoFactorDisableRequest) =>
+      disableTwoFactorEmail(config.client, config.basePath!, request),
     onSuccess: async () => {
       await queryClient.invalidateQueries({
         queryKey: buildAccountQueryKey(config, 'two-factor'),

--- a/packages/@granit/react-account/src/index.ts
+++ b/packages/@granit/react-account/src/index.ts
@@ -23,8 +23,11 @@ export { useChangePassword, useForgotPassword, useResetPassword } from './hooks/
 export {
   useAuthenticatorKey,
   useDisableTwoFactor,
+  useDisableTwoFactorEmail,
   useEnableTwoFactor,
+  useEnableTwoFactorEmail,
   useGenerateRecoveryCodes,
+  useSendTwoFactorEmailEnrollmentCode,
   useTwoFactorStatus,
 } from './hooks/use-two-factor';
 

--- a/packages/@granit/react-account/src/testing/data.ts
+++ b/packages/@granit/react-account/src/testing/data.ts
@@ -39,6 +39,7 @@ export const mockAccountSettings: Mutable<AccountSettingsResponse> = {
 export const mockTwoFactorStatus: Mutable<AccountTwoFactorStatusResponse> = {
   isEnabled: false,
   hasAuthenticatorApp: false,
+  hasEmailOtp: false,
   recoveryCodesLeft: 0,
 };
 

--- a/packages/@granit/react-account/src/testing/handlers.ts
+++ b/packages/@granit/react-account/src/testing/handlers.ts
@@ -65,6 +65,7 @@ export function createAccountHandlers(baseUrl = DEFAULT_BASE_PATH) {
     http.post(`${baseUrl}/two-factor/disable`, () => {
       mockTwoFactorStatus.isEnabled = false;
       mockTwoFactorStatus.hasAuthenticatorApp = false;
+      mockTwoFactorStatus.hasEmailOtp = false;
       mockTwoFactorStatus.recoveryCodesLeft = 0;
       return noContent();
     }),
@@ -83,6 +84,20 @@ export function createAccountHandlers(baseUrl = DEFAULT_BASE_PATH) {
           '5555-6666',
         ],
       });
+    }),
+
+    // Email OTP enrollment
+    http.post(`${baseUrl}/two-factor/email/send`, () => noContent()),
+
+    http.post(`${baseUrl}/two-factor/email/enable`, () => {
+      mockTwoFactorStatus.isEnabled = true;
+      mockTwoFactorStatus.hasEmailOtp = true;
+      return noContent();
+    }),
+
+    http.post(`${baseUrl}/two-factor/email/disable`, () => {
+      mockTwoFactorStatus.hasEmailOtp = false;
+      return noContent();
     }),
 
     // ── Passkeys ─────────────────────────────────────────────────────────────

--- a/packages/@granit/react-authentication-local/README.md
+++ b/packages/@granit/react-authentication-local/README.md
@@ -1,3 +1,3 @@
 # @granit/react-authentication-local
 
-React hooks for local credential authentication — useLogin, useBeginPasskeyAssertion
+React hooks for local credential authentication — useLogin, useVerifyTwoFactorLogin, useSendTwoFactorLoginEmailCode, useBeginPasskeyAssertion

--- a/packages/@granit/react-authentication-local/src/__tests__/use-send-two-factor-login-email-code.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-send-two-factor-login-email-code.test.tsx
@@ -1,0 +1,70 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useSendTwoFactorLoginEmailCode } from '../hooks/use-send-two-factor-login-email-code';
+import { LocalAuthProvider } from '../providers/local-auth-provider';
+
+import type { LocalAuthConfig } from '../providers/local-auth-provider';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+vi.mock('@granit/authentication-local', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    sendTwoFactorLoginEmailCode: vi.fn(),
+  };
+});
+
+const { sendTwoFactorLoginEmailCode } = await import('@granit/authentication-local');
+
+function createWrapper(client: AxiosInstance) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: LocalAuthConfig = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <LocalAuthProvider config={config}>{children}</LocalAuthProvider>
+    );
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useSendTwoFactorLoginEmailCode', () => {
+  it('should call sendTwoFactorLoginEmailCode with no arguments', async () => {
+    const client = createMockClient();
+    vi.mocked(sendTwoFactorLoginEmailCode).mockResolvedValue();
+
+    const { result } = renderHook(() => useSendTwoFactorLoginEmailCode(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(sendTwoFactorLoginEmailCode).toHaveBeenCalledWith(client, '/api/v1/account');
+  });
+
+  it('should surface a "no active 2FA session" error', async () => {
+    const client = createMockClient();
+    vi.mocked(sendTwoFactorLoginEmailCode).mockRejectedValue(new Error('No active 2FA session'));
+
+    const { result } = renderHook(() => useSendTwoFactorLoginEmailCode(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate();
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('No active 2FA session');
+  });
+});

--- a/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
+++ b/packages/@granit/react-authentication-local/src/__tests__/use-verify-two-factor-login.test.tsx
@@ -78,13 +78,37 @@ describe('useVerifyTwoFactorLogin', () => {
       wrapper: createWrapper(client),
     });
 
-    result.current.mutate({ code: 'ABCD-1234-EFGH', useRecoveryCode: true });
+    result.current.mutate({ code: 'ABCD-1234-EFGH', method: 'RecoveryCode' });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/v1/account', {
       code: 'ABCD-1234-EFGH',
-      useRecoveryCode: true,
+      method: 'RecoveryCode',
+    });
+  });
+
+  it('should call verifyTwoFactorLogin with an emailed code', async () => {
+    const client = createMockClient();
+    const response: AccountLoginResponse = {
+      succeeded: true,
+      requiresTwoFactor: false,
+      isLockedOut: false,
+      isNotAllowed: false,
+    };
+    vi.mocked(verifyTwoFactorLogin).mockResolvedValue(response);
+
+    const { result } = renderHook(() => useVerifyTwoFactorLogin(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate({ code: '654321', method: 'Email' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(verifyTwoFactorLogin).toHaveBeenCalledWith(client, '/api/v1/account', {
+      code: '654321',
+      method: 'Email',
     });
   });
 

--- a/packages/@granit/react-authentication-local/src/hooks/use-send-two-factor-login-email-code.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-send-two-factor-login-email-code.ts
@@ -1,0 +1,23 @@
+import { sendTwoFactorLoginEmailCode } from '@granit/authentication-local';
+import { useMutation } from '@tanstack/react-query';
+
+import { useLocalAuthConfig } from '../providers/local-auth-provider';
+
+import type { UseMutationResult } from '@tanstack/react-query';
+
+/**
+ * Sends a one-time code by email to the user pending two-factor login.
+ *
+ * Call this when the user picks `"Email"` from the login response's
+ * `twoFactorMethods`, then submit the received code via
+ * {@link useVerifyTwoFactorLogin} with `method: "Email"`. The server resolves
+ * the pending user from the two-factor session cookie, so the mutation takes no
+ * arguments.
+ */
+export function useSendTwoFactorLoginEmailCode(): UseMutationResult<void, Error, void> {
+  const config = useLocalAuthConfig();
+
+  return useMutation({
+    mutationFn: () => sendTwoFactorLoginEmailCode(config.client, config.basePath!),
+  });
+}

--- a/packages/@granit/react-authentication-local/src/hooks/use-verify-two-factor-login.ts
+++ b/packages/@granit/react-authentication-local/src/hooks/use-verify-two-factor-login.ts
@@ -11,7 +11,9 @@ import type { UseMutationResult } from '@tanstack/react-query';
 
 /**
  * Completes a two-factor login after the initial login returned
- * `requiresTwoFactor: true`. Submits a TOTP code or recovery code.
+ * `requiresTwoFactor: true`. Set `request.method` to pick the factor the code
+ * belongs to (`"Authenticator"` — the default — `"RecoveryCode"`, or `"Email"`);
+ * only offer methods present in the login response's `twoFactorMethods`.
  */
 export function useVerifyTwoFactorLogin(): UseMutationResult<
   AccountLoginResponse,

--- a/packages/@granit/react-authentication-local/src/index.ts
+++ b/packages/@granit/react-authentication-local/src/index.ts
@@ -10,5 +10,6 @@ export type {
   UseLoginWithRedirectResult,
 } from './hooks/use-login-with-redirect';
 export { useVerifyTwoFactorLogin } from './hooks/use-verify-two-factor-login';
+export { useSendTwoFactorLoginEmailCode } from './hooks/use-send-two-factor-login-email-code';
 export { useBeginPasskeyAssertion } from './hooks/use-begin-passkey-assertion';
 export { useCompletePasskeyAssertion } from './hooks/use-complete-passkey-assertion';

--- a/packages/@granit/react-authentication-local/src/testing/data.ts
+++ b/packages/@granit/react-authentication-local/src/testing/data.ts
@@ -12,6 +12,7 @@ export const mockLoginRequiresTwoFactor: AccountLoginResponse = {
   requiresTwoFactor: true,
   isLockedOut: false,
   isNotAllowed: false,
+  twoFactorMethods: ['Authenticator', 'Email', 'RecoveryCode'],
 };
 
 export const mockLoginNotAllowed: AccountLoginResponse = {
@@ -28,3 +29,4 @@ export const MOCK_CREDENTIALS = {
 
 export const MOCK_TOTP_CODE = '123456';
 export const MOCK_RECOVERY_CODE = 'XXXX-XXXX-XXXX';
+export const MOCK_EMAIL_OTP_CODE = '654321';

--- a/packages/@granit/react-authentication-local/src/testing/handlers.ts
+++ b/packages/@granit/react-authentication-local/src/testing/handlers.ts
@@ -4,10 +4,13 @@ import { DEFAULT_BASE_PATH } from '../constants';
 
 import {
   MOCK_CREDENTIALS,
+  MOCK_EMAIL_OTP_CODE,
   MOCK_TOTP_CODE,
   mockLoginRequiresTwoFactor,
   mockLoginSuccess,
 } from './data';
+
+import type { TwoFactorMethod } from '@granit/authentication-local';
 
 /**
  * Create MSW handlers for local authentication (login) endpoints: credential
@@ -44,9 +47,15 @@ export function createLocalAuthHandlers(baseUrl = DEFAULT_BASE_PATH) {
 
     // POST /login/two-factor
     http.post(`${baseUrl}/login/two-factor`, async ({ request }) => {
-      const body = (await request.json()) as { code: string; useRecoveryCode?: boolean };
+      const body = (await request.json()) as { code: string; method?: TwoFactorMethod };
+      const method = body.method ?? 'Authenticator';
 
-      if (body.code === MOCK_TOTP_CODE || body.useRecoveryCode) {
+      const accepted =
+        (method === 'Authenticator' && body.code === MOCK_TOTP_CODE) ||
+        (method === 'Email' && body.code === MOCK_EMAIL_OTP_CODE) ||
+        method === 'RecoveryCode';
+
+      if (accepted) {
         return HttpResponse.json(mockLoginSuccess);
       }
 
@@ -59,6 +68,12 @@ export function createLocalAuthHandlers(baseUrl = DEFAULT_BASE_PATH) {
         { status: 401 }
       );
     }),
+
+    // POST /login/two-factor/send-email — emails an OTP to the pending 2FA user
+    http.post(
+      `${baseUrl}/login/two-factor/send-email`,
+      () => new HttpResponse(null, { status: 204 })
+    ),
 
     // POST /passkeys/assertion/begin
     http.post(`${baseUrl}/passkeys/assertion/begin`, () => {

--- a/packages/@granit/react-authentication-local/src/testing/index.ts
+++ b/packages/@granit/react-authentication-local/src/testing/index.ts
@@ -4,6 +4,7 @@
 
 export {
   MOCK_CREDENTIALS,
+  MOCK_EMAIL_OTP_CODE,
   MOCK_RECOVERY_CODE,
   MOCK_TOTP_CODE,
   mockLoginNotAllowed,


### PR DESCRIPTION
## Summary

Adapts the React SDK to the new **Email-OTP 2FA** contract from `granit-dotnet` (`Granit.Identity.Local`). Email OTP is **opt-in**: it only appears at login when present in the new `twoFactorMethods` list.

> [!WARNING]
> **Draft — do not merge yet.** The backend contract is still **unpublished** (dev `0.1.0-dev.*`; the Email-OTP changes are uncommitted in the `granit-dotnet` working tree). Coordinate the OpenAPI version bump before merging, per the task brief.

## Breaking change

`AccountTwoFactorLoginRequest` replaces `useRecoveryCode?: boolean` with
`method?: "Authenticator" | "RecoveryCode" | "Email"` (default `Authenticator`).
Pre-1.0 **clean break**, no compat shim.

```diff
- verifyTwoFactorLogin(client, base, { code, useRecoveryCode: true })
+ verifyTwoFactorLogin(client, base, { code, method: "RecoveryCode" })
```

## Changes

**`@granit/authentication-local`** — `TwoFactorMethod` union; `twoFactorMethods` on the login response; `sendTwoFactorLoginEmailCode` (`POST /login/two-factor/send-email`).

**`@granit/react-authentication-local`** — `useSendTwoFactorLoginEmailCode`; method-aware verify hook; MSW handlers/data.

**`@granit/account`** — `hasEmailOtp` status field; email enrollment API (`sendTwoFactorEmailEnrollmentCode`, `enableTwoFactorEmail`, `disableTwoFactorEmail`) + `AccountTwoFactorEmailEnableRequest`.

**`@granit/react-account`** — `useSendTwoFactorEmailEnrollmentCode`, `useEnableTwoFactorEmail`, `useDisableTwoFactorEmail` (invalidate 2FA status); `hasEmailOtp` exposed via `useTwoFactorStatus`; MSW handlers/data.

**Contract + docs** — `contracts/openapi/identity-local.json` refreshed; `CHANGELOG.md` (Ajouté + Modifié/Breaking); react READMEs.

## Target flow (email login)

1. `POST /login` → `{ requiresTwoFactor: true, twoFactorMethods: [...] }`
2. user picks `"Email"` → `POST /login/two-factor/send-email` (204)
3. `POST /login/two-factor { code, method: "Email" }`

## Notes for reviewers

- **Snapshot hand-applied, not generator-emitted.** The canonical sync (`dotnet build src/Granit.OpenApi.Generator` → `scripts/sync-openapi-contracts.mjs`) fails locally on a **pre-existing, unrelated** error (`Microsoft.Extensions.Http.Resilience` v10.7.0 fails to load in the Webhooks module during doc generation). DTOs were mirrored by hand from the authoritative backend records; re-sync via the generator once CI builds the dotnet side. `identity-local` is not yet in the `@granit/contract-tests` manifest, so this is documentary, not test-enforced.
- **Showcase untouched** — demo UI is a separate follow-up once the SDK ships.

## Verification

- `tsc --noEmit` ✓ (all touched packages)
- `eslint --max-warnings 0` ✓
- Vitest ✓ — 131 package tests + 128 contract-tests
- `markdownlint-cli2` ✓