### PR TITLE
feat(account): handle challenge 400/500 for new external login providers

### DIFF
--- a/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
@@ -1,4 +1,3 @@
-import { HttpError } from '@granit/api-client';
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 

--- a/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
@@ -1,3 +1,4 @@
+import { HttpError } from '@granit/api-client';
 import { createMockClient } from '@granit/testing';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -12,6 +13,13 @@ import type {
   AccountExternalLoginCallbackResponse,
   AccountExternalLoginInfo,
 } from '../types/index';
+
+function makeAxiosError(status: number) {
+  return Object.assign(new Error(`Request failed with status code ${status}`), {
+    isAxiosError: true,
+    response: { status, data: { title: 'Error', status } },
+  });
+}
 
 const BASE = '/api/account';
 
@@ -50,6 +58,29 @@ describe('account-external-login-api', () => {
       await challengeExternalLogin(client, BASE, 'provider/name');
 
       expect(client.post).toHaveBeenCalledWith(`${BASE}/external-logins/challenge/provider%2Fname`);
+    });
+
+    it('throws HttpError(400) when provider is not configured', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockRejectedValueOnce(makeAxiosError(400));
+
+      await expect(challengeExternalLogin(client, BASE, 'Unknown')).rejects.toMatchObject({
+        name: 'HttpError',
+        status: 400,
+        message: 'External login provider "Unknown" is not configured.',
+      });
+    });
+
+    it('throws HttpError(500) when provider handler is not registered', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockRejectedValueOnce(makeAxiosError(500));
+
+      await expect(challengeExternalLogin(client, BASE, 'Apple')).rejects.toMatchObject({
+        name: 'HttpError',
+        status: 500,
+        message:
+          'External login provider "Apple" is unavailable: the authentication handler is not registered.',
+      });
     });
   });
 

--- a/packages/@granit/account/src/api/account-external-login-api.ts
+++ b/packages/@granit/account/src/api/account-external-login-api.ts
@@ -1,9 +1,10 @@
+import { HttpError, isAxiosError } from '@granit/api-client';
+
+import type { AxiosInstance } from '@granit/api-client';
 import type {
   AccountExternalLoginCallbackResponse,
   AccountExternalLoginInfo,
 } from '../types/index';
-import type { AxiosInstance } from '@granit/api-client';
-import { HttpError, isAxiosError } from '@granit/api-client';
 
 /**
  * List linked external login providers for the current user.

--- a/packages/@granit/account/src/api/account-external-login-api.ts
+++ b/packages/@granit/account/src/api/account-external-login-api.ts
@@ -1,10 +1,10 @@
 import { HttpError, isAxiosError } from '@granit/api-client';
 
-import type { AxiosInstance } from '@granit/api-client';
 import type {
   AccountExternalLoginCallbackResponse,
   AccountExternalLoginInfo,
 } from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
 
 /**
  * List linked external login providers for the current user.

--- a/packages/@granit/account/src/api/account-external-login-api.ts
+++ b/packages/@granit/account/src/api/account-external-login-api.ts
@@ -3,6 +3,7 @@ import type {
   AccountExternalLoginInfo,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
+import { HttpError, isAxiosError } from '@granit/api-client';
 
 /**
  * List linked external login providers for the current user.
@@ -23,13 +24,37 @@ export async function getExternalLogins(
  * Initiate an OAuth challenge with an external provider.
  *
  * `POST {basePath}/external-logins/challenge/{provider}`
+ *
+ * @throws {HttpError} status 400 — provider unknown / not configured in the registry
+ * @throws {HttpError} status 500 — provider configured but authentication handler not registered
  */
 export async function challengeExternalLogin(
   client: AxiosInstance,
   basePath: string,
   provider: string
 ): Promise<void> {
-  await client.post(`${basePath}/external-logins/challenge/${encodeURIComponent(provider)}`);
+  try {
+    await client.post(`${basePath}/external-logins/challenge/${encodeURIComponent(provider)}`);
+  } catch (err) {
+    if (isAxiosError(err)) {
+      const status = err.response?.status;
+      if (status === 400) {
+        throw new HttpError(
+          `External login provider "${provider}" is not configured.`,
+          400,
+          err.response?.data
+        );
+      }
+      if (status === 500) {
+        throw new HttpError(
+          `External login provider "${provider}" is unavailable: the authentication handler is not registered.`,
+          500,
+          err.response?.data
+        );
+      }
+    }
+    throw err;
+  }
 }
 
 /**

--- a/packages/@granit/api-client/src/index.ts
+++ b/packages/@granit/api-client/src/index.ts
@@ -307,3 +307,4 @@ export type {
   AxiosResponse,
   InternalAxiosRequestConfig,
 } from 'axios';
+export { isAxiosError } from 'axios';

--- a/packages/@granit/react-account/src/hooks/use-external-logins.ts
+++ b/packages/@granit/react-account/src/hooks/use-external-logins.ts
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { buildAccountQueryKey, useAccountConfig } from '../providers/account-provider';
 
 import type { AccountExternalLoginInfo } from '@granit/account';
+import type { HttpError } from '@granit/api-client';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
 /** Fetches the list of linked external login providers. */
@@ -16,8 +17,14 @@ export function useExternalLogins(): UseQueryResult<readonly AccountExternalLogi
   });
 }
 
-/** Initiates an OAuth challenge with an external provider. */
-export function useChallengeExternalLogin(): UseMutationResult<void, Error, string> {
+/**
+ * Initiates an OAuth challenge with an external provider.
+ *
+ * On error, `mutation.error` is an `HttpError`:
+ * - `status === 400` — provider name unknown / not configured
+ * - `status === 500` — provider configured but authentication handler not registered
+ */
+export function useChallengeExternalLogin(): UseMutationResult<void, HttpError | Error, string> {
   const config = useAccountConfig();
 
   return useMutation({

--- a/packages/@granit/react-account/src/testing/handlers.ts
+++ b/packages/@granit/react-account/src/testing/handlers.ts
@@ -17,8 +17,16 @@ import {
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
  *
  * @param baseUrl - API base path (default: `/api/v1/account`)
+ * @param options.unavailableProviders - Provider scheme names that return 500 on challenge
+ *   (simulates a provider configured in the registry but whose authentication handler is
+ *   not registered — `HttpError(500)` in the SDK). Useful for testing the "provider
+ *   unavailable" UI state.
  */
-export function createAccountHandlers(baseUrl = DEFAULT_BASE_PATH) {
+export function createAccountHandlers(
+  baseUrl = DEFAULT_BASE_PATH,
+  options: { unavailableProviders?: readonly string[] } = {}
+) {
+  const unavailableProviders = new Set(options.unavailableProviders ?? []);
   return [
     // ── Settings (anonymous) ─────────────────────────────────────────────────
     http.get(`${baseUrl}/config`, () => HttpResponse.json(mockAccountSettings)),
@@ -120,7 +128,16 @@ export function createAccountHandlers(baseUrl = DEFAULT_BASE_PATH) {
     // ── External logins ──────────────────────────────────────────────────────
     http.get(`${baseUrl}/external-logins`, () => HttpResponse.json(mockExternalLogins)),
 
-    http.post(`${baseUrl}/external-logins/challenge/:provider`, () => noContent()),
+    http.post(`${baseUrl}/external-logins/challenge/:provider`, ({ params }) => {
+      const provider = String(params.provider);
+      if (unavailableProviders.has(provider)) {
+        return HttpResponse.json(
+          { title: 'Internal Server Error', status: 500 },
+          { status: 500 }
+        );
+      }
+      return noContent();
+    }),
 
     http.delete(`${baseUrl}/external-logins/:provider`, ({ params }) => {
       const idx = mockExternalLogins.findIndex(


### PR DESCRIPTION
## Summary

Adapts the SDK to the new `Granit.Authentication.External` backend family (Apple, GitHub, Facebook, OIDC générique).

- **`@granit/api-client`**: re-exports `isAxiosError` from axios (keeps the single-seam contract)
- **`@granit/account`**: `challengeExternalLogin` now catches Axios errors and rethrows as typed `HttpError`:
  - `status 400` — provider not registered in `IExternalProviderRegistry`
  - `status 500` — provider registered but authentication handler not wired (new behaviour from `Granit.Authentication.External`)
- **`@granit/react-account`**:
  - `useChallengeExternalLogin` error type widened to `HttpError | Error`
  - `createAccountHandlers` accepts `unavailableProviders` option to simulate the 500 scenario in tests

No breaking change: `provider` was already a free `string`, no hardcoded `'Google' | 'Microsoft'` enum existed.

## Test plan

- [ ] `pnpm tsc` passes
- [ ] `pnpm lint` passes
- [ ] 7 tests in `account-external-login-api.test.ts` pass (including new 400/500 cases)