### PR TITLE
fix(validation): mirror .NET validation key convention (Builtin:/Format:)

### DIFF
--- a/packages/@granit/react-validation/src/__tests__/create-constraints-resolver.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/create-constraints-resolver.test.ts
@@ -45,8 +45,8 @@ describe('createConstraintsResolver', () => {
       fields: createFields('name', 'email'),
     });
     expect(result.errors['name']).toEqual({
-      type: 'Validation:NotEmptyValidator',
-      message: 'Validation:NotEmptyValidator (PropertyName=name)',
+      type: 'Validation:Builtin:NotEmpty',
+      message: 'Validation:Builtin:NotEmpty (PropertyName=name)',
     });
   });
 
@@ -55,7 +55,7 @@ describe('createConstraintsResolver', () => {
     const result = await resolver({ name: 'a'.repeat(101), email: 'a@b.com' }, undefined, {
       fields: createFields('name', 'email'),
     });
-    expect(result.errors['name']!.type).toBe('Validation:MaximumLengthValidator');
+    expect(result.errors['name']!.type).toBe('Validation:Builtin:MaximumLength');
   });
 
   it('returns error for pattern violation', async () => {
@@ -66,7 +66,7 @@ describe('createConstraintsResolver', () => {
     const result = await resolver({ code: 'abc' }, undefined, {
       fields: createFields('code'),
     });
-    expect(result.errors['code']!.type).toBe('Validation:RegularExpressionValidator');
+    expect(result.errors['code']!.type).toBe('Validation:Builtin:RegularExpression');
   });
 
   it('calls t() with error code and params for parameterized errors', async () => {
@@ -75,7 +75,7 @@ describe('createConstraintsResolver', () => {
     await resolver({ name: 'a'.repeat(101), email: 'a@b.com' }, undefined, {
       fields: createFields('name', 'email'),
     });
-    expect(t).toHaveBeenCalledWith('Validation:MaximumLengthValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:Builtin:MaximumLength', {
       maxLength: 100,
       PropertyName: 'name',
       nsSeparator: false,
@@ -125,7 +125,7 @@ describe('createConstraintsResolver', () => {
     t.mockClear();
     const resolver = createConstraintsResolver(constraints, t);
     await resolver({ name: '' }, undefined, { fields: createFields('name') });
-    expect(t).toHaveBeenCalledWith('Validation:NotEmptyValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:Builtin:NotEmpty', {
       PropertyName: 'name',
       nsSeparator: false,
     });
@@ -137,7 +137,7 @@ describe('createConstraintsResolver', () => {
       labelResolver: (f) => f.toUpperCase(),
     });
     await resolver({ name: '' }, undefined, { fields: createFields('name') });
-    expect(t).toHaveBeenCalledWith('Validation:NotEmptyValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:Builtin:NotEmpty', {
       PropertyName: 'NAME',
       nsSeparator: false,
     });
@@ -147,7 +147,7 @@ describe('createConstraintsResolver', () => {
     t.mockClear();
     const resolver = createConstraintsResolver(constraints, t);
     await resolver({ email: '' }, undefined, { fields: createFields('email') });
-    expect(t).toHaveBeenCalledWith('Validation:NotEmptyValidator', {
+    expect(t).toHaveBeenCalledWith('Validation:Builtin:NotEmpty', {
       PropertyName: 'email',
       nsSeparator: false,
     });

--- a/packages/@granit/react-validation/src/__tests__/use-field-props.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/use-field-props.test.ts
@@ -12,7 +12,7 @@ describe('useFieldProps', () => {
     name: { required: true, maxLength: 100 },
     iban: {
       required: true,
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     },
   };
 
@@ -28,7 +28,7 @@ describe('useFieldProps', () => {
 
   it('returns serverHint when granitValidator is present', () => {
     const { result } = renderHook(() => useFieldProps(constraints, 'iban', t));
-    expect(result.current.serverHint).toBe('translated:Validation:InvalidIban');
+    expect(result.current.serverHint).toBe('translated:Validation:Format:Iban');
   });
 
   it('omits serverHint when no granitValidator', () => {

--- a/packages/@granit/react-validation/src/__tests__/use-server-validation-batch.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/use-server-validation-batch.test.ts
@@ -20,7 +20,7 @@ function createMockClient() {
 
 const t = vi.fn((key: string) => `translated:${key}`);
 
-const ibanConstraint: FieldConstraint = { granitValidator: 'Validation:InvalidIban' };
+const ibanConstraint: FieldConstraint = { granitValidator: 'Validation:Format:Iban' };
 const bceConstraint: FieldConstraint = { granitValidator: 'Validation:InvalidBce' };
 const plainConstraint: FieldConstraint = { required: true, maxLength: 100 };
 
@@ -94,7 +94,7 @@ describe('useServerValidationBatch', () => {
       { name: 'iban', constraint: ibanConstraint, value: 'BE68539007547034' },
     ];
     mockValidateFieldsBatch.mockResolvedValue([
-      { errorCode: 'Validation:InvalidIban', status: 'Valid' },
+      { errorCode: 'Validation:Format:Iban', status: 'Valid' },
     ]);
 
     const { result } = renderHook(() =>
@@ -113,7 +113,7 @@ describe('useServerValidationBatch', () => {
       { name: 'iban', constraint: ibanConstraint, value: 'INVALID' },
     ];
     mockValidateFieldsBatch.mockResolvedValue([
-      { errorCode: 'Validation:InvalidIban', status: 'Invalid' },
+      { errorCode: 'Validation:Format:Iban', status: 'Invalid' },
     ]);
 
     const { result } = renderHook(() =>
@@ -125,7 +125,7 @@ describe('useServerValidationBatch', () => {
     });
 
     expect(result.current['iban']?.status).toBe('invalid');
-    expect(result.current['iban']?.message).toBe('translated:Validation:InvalidIban');
+    expect(result.current['iban']?.message).toBe('translated:Validation:Format:Iban');
   });
 
   it('maps ValidatorNotFound to idle', async () => {
@@ -133,7 +133,7 @@ describe('useServerValidationBatch', () => {
       { name: 'iban', constraint: ibanConstraint, value: 'something' },
     ];
     mockValidateFieldsBatch.mockResolvedValue([
-      { errorCode: 'Validation:InvalidIban', status: 'ValidatorNotFound' },
+      { errorCode: 'Validation:Format:Iban', status: 'ValidatorNotFound' },
     ]);
 
     const { result } = renderHook(() =>
@@ -169,7 +169,7 @@ describe('useServerValidationBatch', () => {
   it('excludes fields that fail client-side validation', async () => {
     const strictConstraint: FieldConstraint = {
       maxLength: 5,
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     const fields: BatchFieldSpec[] = [
       { name: 'iban', constraint: strictConstraint, value: 'WAY_TOO_LONG_VALUE' },

--- a/packages/@granit/react-validation/src/__tests__/use-server-validation.test.ts
+++ b/packages/@granit/react-validation/src/__tests__/use-server-validation.test.ts
@@ -45,7 +45,7 @@ describe('useServerValidation', () => {
 
   it('returns idle when value is empty', () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     const { result } = renderHook(() =>
       useServerValidation({
@@ -62,7 +62,7 @@ describe('useServerValidation', () => {
     const constraint: FieldConstraint = {
       required: true,
       maxLength: 5,
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     const { result } = renderHook(() =>
       useServerValidation({
@@ -77,7 +77,7 @@ describe('useServerValidation', () => {
 
   it('returns idle when enabled is false', () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     const { result } = renderHook(() =>
       useServerValidation({
@@ -93,7 +93,7 @@ describe('useServerValidation', () => {
 
   it('transitions to validating after debounce', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     mockValidateFieldServer.mockReturnValue(new Promise(() => {}));
 
@@ -118,7 +118,7 @@ describe('useServerValidation', () => {
 
   it('transitions to valid when server returns Valid', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     mockValidateFieldServer.mockResolvedValue('Valid');
 
@@ -141,7 +141,7 @@ describe('useServerValidation', () => {
 
   it('transitions to invalid with translated message when server returns Invalid', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     mockValidateFieldServer.mockResolvedValue('Invalid');
 
@@ -160,7 +160,7 @@ describe('useServerValidation', () => {
     });
 
     expect(result.current.status).toBe('invalid');
-    expect(result.current.message).toBe('translated:Validation:InvalidIban');
+    expect(result.current.message).toBe('translated:Validation:Format:Iban');
   });
 
   it('transitions to idle when server returns ValidatorNotFound', async () => {
@@ -188,7 +188,7 @@ describe('useServerValidation', () => {
 
   it('transitions to error on network failure', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     mockValidateFieldServer.mockRejectedValue(new Error('Network error'));
 
@@ -212,7 +212,7 @@ describe('useServerValidation', () => {
 
   it('debounces — does not call server before debounce time', () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
 
     renderHook(() =>
@@ -231,7 +231,7 @@ describe('useServerValidation', () => {
 
   it('coerces non-string value to string before calling server', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     mockValidateFieldServer.mockResolvedValue('Valid');
 
@@ -251,7 +251,7 @@ describe('useServerValidation', () => {
 
     expect(mockValidateFieldServer).toHaveBeenCalledWith(
       expect.anything(),
-      'Validation:InvalidIban',
+      'Validation:Format:Iban',
       '42',
       undefined,
       expect.any(AbortSignal)
@@ -260,7 +260,7 @@ describe('useServerValidation', () => {
 
   it('resets to idle and restarts debounce when value changes', async () => {
     const constraint: FieldConstraint = {
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     };
     mockValidateFieldServer.mockResolvedValue('Valid');
 

--- a/packages/@granit/validation/src/__tests__/extract-constraints.test.ts
+++ b/packages/@granit/validation/src/__tests__/extract-constraints.test.ts
@@ -124,7 +124,7 @@ describe('extractConstraints', () => {
             properties: {
               iban: {
                 type: 'string',
-                'x-granit-validator': 'Validation:InvalidIban',
+                'x-granit-validator': 'Validation:Format:Iban',
               },
             },
           },
@@ -134,7 +134,7 @@ describe('extractConstraints', () => {
 
     const result = extractConstraints(spec);
     expect(result['Payment']!['iban']).toEqual({
-      granitValidator: 'Validation:InvalidIban',
+      granitValidator: 'Validation:Format:Iban',
     });
   });
 

--- a/packages/@granit/validation/src/__tests__/server-validation-api.test.ts
+++ b/packages/@granit/validation/src/__tests__/server-validation-api.test.ts
@@ -16,7 +16,7 @@ function createMockClient() {
 describe('listValidators', () => {
   it('calls GET /validators and returns the list', async () => {
     const client = createMockClient();
-    const validators = ['Validation:InvalidIban', 'Validation:InvalidBce'];
+    const validators = ['Validation:Format:Iban', 'Validation:InvalidBce'];
     client.get.mockResolvedValue({ data: validators });
 
     const result = await listValidators(client as never);
@@ -39,19 +39,19 @@ describe('validateFieldServer', () => {
   it('calls POST /validate and returns the status', async () => {
     const client = createMockClient();
     client.post.mockResolvedValue({
-      data: { errorCode: 'Validation:InvalidIban', status: 'Valid' },
+      data: { errorCode: 'Validation:Format:Iban', status: 'Valid' },
     });
 
     const result = await validateFieldServer(
       client as never,
-      'Validation:InvalidIban',
+      'Validation:Format:Iban',
       'BE68539007547034',
       '/api/v1/validation'
     );
 
     expect(client.post).toHaveBeenCalledWith(
       '/api/v1/validation/validate',
-      { errorCode: 'Validation:InvalidIban', value: 'BE68539007547034' },
+      { errorCode: 'Validation:Format:Iban', value: 'BE68539007547034' },
       { signal: undefined }
     );
     expect(result).toBe('Valid');
@@ -60,12 +60,12 @@ describe('validateFieldServer', () => {
   it('returns Invalid for invalid values', async () => {
     const client = createMockClient();
     client.post.mockResolvedValue({
-      data: { errorCode: 'Validation:InvalidIban', status: 'Invalid' },
+      data: { errorCode: 'Validation:Format:Iban', status: 'Invalid' },
     });
 
     const result = await validateFieldServer(
       client as never,
-      'Validation:InvalidIban',
+      'Validation:Format:Iban',
       'INVALID',
       '/api/v1/validation'
     );
@@ -139,13 +139,13 @@ describe('validateFieldsBatch', () => {
   it('calls POST /validate-batch and returns results', async () => {
     const client = createMockClient();
     const results = [
-      { errorCode: 'Validation:InvalidIban', status: 'Valid' as const },
+      { errorCode: 'Validation:Format:Iban', status: 'Valid' as const },
       { errorCode: 'Validation:InvalidBce', status: 'Invalid' as const },
     ];
     client.post.mockResolvedValue({ data: { results } });
 
     const fields = [
-      { errorCode: 'Validation:InvalidIban', value: 'BE68539007547034' },
+      { errorCode: 'Validation:Format:Iban', value: 'BE68539007547034' },
       { errorCode: 'Validation:InvalidBce', value: '0000000000' },
     ];
     const result = await validateFieldsBatch(client as never, fields, '/api/v1/validation');

--- a/packages/@granit/validation/src/constants/error-codes.ts
+++ b/packages/@granit/validation/src/constants/error-codes.ts
@@ -3,15 +3,15 @@
  * These keys mirror the .NET Validation: error-code convention.
  */
 export const VALIDATION_ERROR_CODES = {
-  required: 'Validation:NotEmptyValidator',
-  maxLength: 'Validation:MaximumLengthValidator',
-  minLength: 'Validation:MinimumLengthValidator',
-  pattern: 'Validation:RegularExpressionValidator',
-  formatEmail: 'Validation:EmailValidator',
-  minimum: 'Validation:GreaterThanOrEqualValidator',
-  maximum: 'Validation:LessThanOrEqualValidator',
-  exclusiveMinimum: 'Validation:GreaterThanValidator',
-  exclusiveMaximum: 'Validation:LessThanValidator',
+  required: 'Validation:Builtin:NotEmpty',
+  maxLength: 'Validation:Builtin:MaximumLength',
+  minLength: 'Validation:Builtin:MinimumLength',
+  pattern: 'Validation:Builtin:RegularExpression',
+  formatEmail: 'Validation:Builtin:Email',
+  minimum: 'Validation:Builtin:GreaterThanOrEqual',
+  maximum: 'Validation:Builtin:LessThanOrEqual',
+  exclusiveMinimum: 'Validation:Builtin:GreaterThan',
+  exclusiveMaximum: 'Validation:Builtin:LessThan',
 } as const;
 
 export type ValidationErrorCode =


### PR DESCRIPTION
Closes #625.

Mirrors the granit-dotnet ADR-066 validation-key rename (Phase 1a/1b) on the client side.

## Changes

- `@granit/validation/src/constants/error-codes.ts` — the 9 built-in constraint keys move to the `Builtin:` category:
  - `Validation:NotEmptyValidator` → `Validation:Builtin:NotEmpty`
  - `Validation:MaximumLengthValidator` → `Validation:Builtin:MaximumLength`
  - `Validation:RegularExpressionValidator` → `Validation:Builtin:RegularExpression`, … etc.
- Test fixtures: `Validation:InvalidIban` → `Validation:Format:Iban`.

These are the client-side i18n keys (`@granit/validation` does constraint extraction + client validation against the host app's catalogs). The wire `errorCode` for built-ins is unchanged on the .NET side, so this is a **convention-alignment** change, not a wire break — but the host app's i18n catalogs must carry the matching keys (mirrored in **granit-showcase-react**).

## Verification

`@granit/validation` + `@granit/react-validation` — **102 tests green**. Full-monorepo `tsc --noEmit` passes (pre-commit hook).