### PR TITLE
feat(account): expose available external login providers

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2259,6 +2259,17 @@
           "signature": "function useAccountSettings(): UseQueryResult<AccountSettingsResponse>"
         },
         {
+          "name": "useAvailableExternalProviders",
+          "kind": "function",
+          "signature": "function useAvailableExternalProviders(): AvailableExternalProviders"
+        },
+        {
+          "name": "AvailableExternalProviders",
+          "kind": "interface",
+          "signature": "interface AvailableExternalProviders",
+          "members": []
+        },
+        {
           "name": "useProfile",
           "kind": "function",
           "signature": "function useProfile(): UseQueryResult<AccountProfileResponse>"

--- a/contracts/openapi/identity-local.json
+++ b/contracts/openapi/identity-local.json
@@ -2889,6 +2889,21 @@
           }
         }
       },
+      "ExternalLoginProviderInfo": {
+        "required": ["name", "type", "displayName"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          }
+        }
+      },
       "HttpValidationProblemDetails": {
         "type": "object",
         "properties": {
@@ -2920,11 +2935,17 @@
         }
       },
       "IdentityLocalConfigResponse": {
-        "required": ["allowSelfRegistration"],
+        "required": ["allowSelfRegistration", "externalProviders"],
         "type": "object",
         "properties": {
           "allowSelfRegistration": {
             "type": "boolean"
+          },
+          "externalProviders": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ExternalLoginProviderInfo"
+            }
           }
         }
       },

--- a/packages/@granit/account/src/types/account-settings.ts
+++ b/packages/@granit/account/src/types/account-settings.ts
@@ -2,7 +2,14 @@
 // Account settings types — mirrors Granit.Identity.Local.Endpoints .NET contract
 // ---------------------------------------------------------------------------
 
-/** Response from `GET /config`. */
+import type { ExternalLoginProvider } from './external-login-provider';
+
+/** Response from `GET /config` (anonymous) — `IdentityLocalConfigResponse`. */
 export interface AccountSettingsResponse {
   readonly allowSelfRegistration: boolean;
+  /**
+   * External login providers available for anonymous sign-in. Empty when none
+   * are configured or no auth-server is present.
+   */
+  readonly externalProviders: readonly ExternalLoginProvider[];
 }

--- a/packages/@granit/account/src/types/external-login-provider.ts
+++ b/packages/@granit/account/src/types/external-login-provider.ts
@@ -1,0 +1,32 @@
+// ---------------------------------------------------------------------------
+// External login provider types — mirrors Granit.Identity.Local.Endpoints .NET contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider kind for an external login button — selects the brand icon.
+ *
+ * Open union: a generic `Oidc` scheme can be registered under a free-form type,
+ * so unknown values are tolerated while the known set stays autocompletable.
+ */
+export type ExternalProviderType =
+  | 'Google'
+  | 'Microsoft'
+  | 'Apple'
+  | 'GitHub'
+  | 'Facebook'
+  | 'Oidc'
+  | (string & {});
+
+/**
+ * An external login provider available on the anonymous sign-in screen, as
+ * advertised by `GET /config`. The list only contains providers that are
+ * actually usable (scheme registered AND backed by an auth handler).
+ */
+export interface ExternalLoginProvider {
+  /** Authentication scheme name — passed to `POST /external-logins/challenge/{name}`. */
+  readonly name: string;
+  /** Provider kind — selects the brand icon (`Google`, `Oidc`, …). */
+  readonly type: ExternalProviderType;
+  /** Human-friendly label for the "Continue with …" button. */
+  readonly displayName: string;
+}

--- a/packages/@granit/account/src/types/index.ts
+++ b/packages/@granit/account/src/types/index.ts
@@ -38,4 +38,6 @@ export type { AccountDeleteRequest } from './account-deletion';
 
 export type { AccountSettingsResponse } from './account-settings';
 
+export type { ExternalLoginProvider, ExternalProviderType } from './external-login-provider';
+
 export type { AccountChangeEmailRequest, AccountConfirmEmailChangeRequest } from './account-email';

--- a/packages/@granit/react-account/src/__tests__/use-available-external-providers.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-available-external-providers.test.tsx
@@ -5,7 +5,7 @@ import { renderHook, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useAccountSettings } from '../hooks/use-account-settings';
+import { useAvailableExternalProviders } from '../hooks/use-available-external-providers';
 import { AccountProvider } from '../providers/account-provider';
 
 import type { AccountConfig } from '../providers/account-provider';
@@ -39,26 +39,40 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
-describe('useAccountSettings', () => {
-  it('should fetch account settings with default basePath', async () => {
+describe('useAvailableExternalProviders', () => {
+  it('derives the providers list from the account config', async () => {
     const client = createMockClient();
     const response: AccountSettingsResponse = {
       allowSelfRegistration: true,
-      externalProviders: [],
+      externalProviders: [
+        { name: 'Google', type: 'Google', displayName: 'Google' },
+        { name: 'corp-sso', type: 'Oidc', displayName: 'Corporate SSO' },
+      ],
     };
     vi.mocked(getAccountSettings).mockResolvedValue(response);
 
-    const { result } = renderHook(() => useAccountSettings(), {
+    const { result } = renderHook(() => useAvailableExternalProviders(), {
       wrapper: createWrapper(client),
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(getAccountSettings).toHaveBeenCalledWith(client, '/api/v1/account');
-    expect(result.current.data).toEqual({ allowSelfRegistration: true, externalProviders: [] });
+    expect(result.current.providers).toEqual(response.externalProviders);
   });
 
-  it('should return allowSelfRegistration false when endpoint returns false', async () => {
+  it('returns an empty list while loading', () => {
+    const client = createMockClient();
+    vi.mocked(getAccountSettings).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useAvailableExternalProviders(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.providers).toEqual([]);
+  });
+
+  it('returns an empty list when the config exposes no providers', async () => {
     const client = createMockClient();
     const response: AccountSettingsResponse = {
       allowSelfRegistration: false,
@@ -66,39 +80,25 @@ describe('useAccountSettings', () => {
     };
     vi.mocked(getAccountSettings).mockResolvedValue(response);
 
-    const { result } = renderHook(() => useAccountSettings(), {
+    const { result } = renderHook(() => useAvailableExternalProviders(), {
       wrapper: createWrapper(client),
     });
 
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.data?.allowSelfRegistration).toBe(false);
+    expect(result.current.providers).toEqual([]);
   });
 
-  it('should have no data when fetch fails (fail-closed)', async () => {
+  it('returns an empty list (fail-closed) when the config fetch fails', async () => {
     const client = createMockClient();
     vi.mocked(getAccountSettings).mockRejectedValue(new Error('Network Error'));
 
-    const { result } = renderHook(() => useAccountSettings(), {
+    const { result } = renderHook(() => useAvailableExternalProviders(), {
       wrapper: createWrapper(client),
     });
 
-    await waitFor(() => expect(result.current.isError).toBe(true));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    // No data on error — consumers use `data?.allowSelfRegistration ?? false`
-    expect(result.current.data).toBeUndefined();
-  });
-
-  it('should not retry on failure', async () => {
-    const client = createMockClient();
-    vi.mocked(getAccountSettings).mockRejectedValue(new Error('Network Error'));
-
-    const { result } = renderHook(() => useAccountSettings(), {
-      wrapper: createWrapper(client),
-    });
-
-    await waitFor(() => expect(result.current.isError).toBe(true));
-
-    expect(getAccountSettings).toHaveBeenCalledTimes(1);
+    expect(result.current.providers).toEqual([]);
   });
 });

--- a/packages/@granit/react-account/src/hooks/use-available-external-providers.ts
+++ b/packages/@granit/react-account/src/hooks/use-available-external-providers.ts
@@ -1,0 +1,27 @@
+import { useAccountSettings } from './use-account-settings';
+
+import type { ExternalLoginProvider } from '@granit/account';
+
+/** Stable empty reference so consumers don't re-render while the config loads. */
+const NO_PROVIDERS: readonly ExternalLoginProvider[] = [];
+
+export interface AvailableExternalProviders {
+  /** Providers advertised by `GET /config` — empty while loading or when none exist. */
+  readonly providers: readonly ExternalLoginProvider[];
+  readonly isLoading: boolean;
+}
+
+/**
+ * Selector over {@link useAccountSettings} exposing the external login providers
+ * available on the anonymous sign-in screen (`config.externalProviders`).
+ *
+ * The list is the backend's source of truth — there is no hardcoded provider
+ * registry. Each entry carries the scheme `name` (passed to
+ * `useChallengeExternalLogin`), a `type` (for branding) and a `displayName`
+ * (button label). Returns an empty list until the config query resolves, so UIs
+ * render no buttons rather than a flash of a static fallback.
+ */
+export function useAvailableExternalProviders(): AvailableExternalProviders {
+  const { data, isLoading } = useAccountSettings();
+  return { providers: data?.externalProviders ?? NO_PROVIDERS, isLoading };
+}

--- a/packages/@granit/react-account/src/index.ts
+++ b/packages/@granit/react-account/src/index.ts
@@ -8,6 +8,8 @@ export type { AccountConfig, AccountProviderProps } from './providers/account-pr
 
 // Hooks — Settings
 export { useAccountSettings } from './hooks/use-account-settings';
+export { useAvailableExternalProviders } from './hooks/use-available-external-providers';
+export type { AvailableExternalProviders } from './hooks/use-available-external-providers';
 
 // Hooks — Profile
 export { useProfile, useUpdateProfile } from './hooks/use-profile';

--- a/packages/@granit/react-account/src/testing/data.ts
+++ b/packages/@granit/react-account/src/testing/data.ts
@@ -30,6 +30,11 @@ export const mockProfile: Mutable<AccountProfileResponse> = {
 
 export const mockAccountSettings: Mutable<AccountSettingsResponse> = {
   allowSelfRegistration: true,
+  externalProviders: [
+    { name: 'Google', type: 'Google', displayName: 'Google' },
+    { name: 'Microsoft', type: 'Microsoft', displayName: 'Microsoft' },
+    { name: 'corp-sso', type: 'Oidc', displayName: 'Corporate SSO' },
+  ],
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/@granit/react-account/src/testing/handlers.ts
+++ b/packages/@granit/react-account/src/testing/handlers.ts
@@ -12,6 +12,8 @@ import {
   mockTwoFactorStatus,
 } from './data';
 
+import type { AccountSettingsResponse, ExternalLoginProvider } from '@granit/account';
+
 /**
  * Create stateful MSW handlers for account self-service endpoints.
  * Handlers mutate in-memory state — mutations are reflected by subsequent GETs.
@@ -21,15 +23,25 @@ import {
  *   (simulates a provider configured in the registry but whose authentication handler is
  *   not registered — `HttpError(500)` in the SDK). Useful for testing the "provider
  *   unavailable" UI state.
+ * @param options.externalProviders - Overrides `config.externalProviders` for `GET /config`.
+ *   Pass `[]` to exercise the "no external providers" state. Defaults to
+ *   {@link mockAccountSettings}'s providers (Google, Microsoft, an OIDC scheme).
  */
 export function createAccountHandlers(
   baseUrl = DEFAULT_BASE_PATH,
-  options: { unavailableProviders?: readonly string[] } = {}
+  options: {
+    unavailableProviders?: readonly string[];
+    externalProviders?: readonly ExternalLoginProvider[];
+  } = {}
 ) {
   const unavailableProviders = new Set(options.unavailableProviders ?? []);
+  const settings: AccountSettingsResponse = {
+    ...mockAccountSettings,
+    externalProviders: options.externalProviders ?? mockAccountSettings.externalProviders,
+  };
   return [
     // ── Settings (anonymous) ─────────────────────────────────────────────────
-    http.get(`${baseUrl}/config`, () => HttpResponse.json(mockAccountSettings)),
+    http.get(`${baseUrl}/config`, () => HttpResponse.json(settings)),
 
     // ── Profile ──────────────────────────────────────────────────────────────
     http.get(`${baseUrl}/profile`, () => HttpResponse.json(mockProfile)),
@@ -146,10 +158,7 @@ export function createAccountHandlers(
     http.post(`${baseUrl}/external-logins/challenge/:provider`, ({ params }) => {
       const provider = String(params.provider);
       if (unavailableProviders.has(provider)) {
-        return HttpResponse.json(
-          { title: 'Internal Server Error', status: 500 },
-          { status: 500 }
-        );
+        return HttpResponse.json({ title: 'Internal Server Error', status: 500 }, { status: 500 });
       }
       return noContent();
     }),


### PR DESCRIPTION
## Summary

Exposes the external login providers advertised by `GET /config` so anonymous sign-in screens render their "Continue with …" buttons from the backend's source of truth — no hardcoded provider registry on the front.

As a Frontend Developer.

## Changes

- **Contract** (`contracts/openapi/identity-local.json`): add `ExternalLoginProviderInfo` schema and the `externalProviders` field (required) on `IdentityLocalConfigResponse`.
- **`@granit/account`** (core):
  - New `external-login-provider.ts` — `ExternalLoginProvider` DTO + open union `ExternalProviderType` (`Google`/`Microsoft`/`Apple`/`GitHub`/`Facebook`/`Oidc` + `string & {}`, tolerant to unknown schemes).
  - `AccountSettingsResponse` gains `externalProviders` (required, mirrors the `required` array).
- **`@granit/react-account`** (react):
  - New `useAvailableExternalProviders` selector hook over `useAccountSettings`, returning `{ providers, isLoading }` with a stable empty-array reference (no flash of a static fallback).
  - MSW handler `createAccountHandlers` gains an `externalProviders` override to exercise the "no providers" state.

## Conventions

- OpenAPI `required` → non-optional fields (per the DTO-mirroring rule).
- Core type in `@granit/account`, React hook in `@granit/react-account` (layering respected).

## Tests

- ESLint (`--max-warnings 0`): clean
- `tsc --noEmit` (account + react-account): clean
- Vitest: 98 passed (incl. new `use-available-external-providers.test.tsx`)