### PR TITLE
feat(account): mirror external account-creation contract

### DIFF
--- a/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-external-login-api.test.ts
@@ -3,14 +3,18 @@ import { describe, expect, it, vi } from 'vitest';
 
 import {
   challengeExternalLogin,
+  completeExternalRegistration,
   externalLoginCallback,
+  getExternalLoginStartUrl,
   getExternalLogins,
   unlinkExternalLogin,
 } from '../api/account-external-login-api';
 
 import type {
-  AccountExternalLoginCallbackResponse,
+  AccountCompleteExternalRegistrationRequest,
+  AccountExternalLoginCompleted,
   AccountExternalLoginInfo,
+  AccountExternalLoginNeedsProfile,
 } from '../types/index';
 
 function makeAxiosError(status: number) {
@@ -83,21 +87,114 @@ describe('account-external-login-api', () => {
     });
   });
 
+  describe('getExternalLoginStartUrl', () => {
+    it('builds the challenge start URL without returnUrl', () => {
+      expect(getExternalLoginStartUrl(BASE, 'Google')).toBe(
+        `${BASE}/external-logins/challenge/Google/start`
+      );
+    });
+
+    it('appends and URL-encodes returnUrl', () => {
+      expect(getExternalLoginStartUrl(BASE, 'Google', '/account/security?tab=logins')).toBe(
+        `${BASE}/external-logins/challenge/Google/start?returnUrl=%2Faccount%2Fsecurity%3Ftab%3Dlogins`
+      );
+    });
+
+    it('omits returnUrl when empty', () => {
+      expect(getExternalLoginStartUrl(BASE, 'Google', '')).toBe(
+        `${BASE}/external-logins/challenge/Google/start`
+      );
+    });
+
+    it('encodes provider names with special characters', () => {
+      expect(getExternalLoginStartUrl(BASE, 'provider/name')).toBe(
+        `${BASE}/external-logins/challenge/provider%2Fname/start`
+      );
+    });
+  });
+
   describe('externalLoginCallback', () => {
-    it('sends GET /external-logins/callback with provider query param', async () => {
+    it('sends GET /external-logins/callback in headless json mode', async () => {
       const client = createMockClient();
-      const response: AccountExternalLoginCallbackResponse = {
+      const response: AccountExternalLoginCompleted = {
+        status: 'completed',
         userId: 'user-123',
-        isNewUser: false,
+        isNewUser: true,
+        continuationToken: null,
+        prefill: null,
       };
       vi.mocked(client.get).mockResolvedValueOnce({ data: response });
 
       const result = await externalLoginCallback(client, BASE, 'Google');
 
       expect(client.get).toHaveBeenCalledWith(`${BASE}/external-logins/callback`, {
-        params: { provider: 'Google' },
+        params: { provider: 'Google', mode: 'json' },
       });
       expect(result).toEqual(response);
+    });
+
+    it('returns the needs-profile-completion variant as-is', async () => {
+      const client = createMockClient();
+      const response: AccountExternalLoginNeedsProfile = {
+        status: 'needs-profile-completion',
+        userId: null,
+        isNewUser: false,
+        continuationToken: 'opaque-token',
+        prefill: { email: 'jane@example.com', firstName: 'Jane', lastName: null },
+      };
+      vi.mocked(client.get).mockResolvedValueOnce({ data: response });
+
+      const result = await externalLoginCallback(client, BASE, 'Google');
+
+      expect(result).toEqual(response);
+    });
+
+    it('normalizes a legacy { userId, isNewUser } payload to the completed variant', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValueOnce({
+        data: { userId: 'user-123', isNewUser: false },
+      });
+
+      const result = await externalLoginCallback(client, BASE, 'Google');
+
+      expect(result).toEqual({
+        status: 'completed',
+        userId: 'user-123',
+        isNewUser: false,
+        continuationToken: null,
+        prefill: null,
+      });
+    });
+  });
+
+  describe('completeExternalRegistration', () => {
+    const request: AccountCompleteExternalRegistrationRequest = {
+      token: 'opaque-token',
+      email: 'jane@example.com',
+      firstName: 'Jane',
+      lastName: 'Doe',
+    };
+
+    it('sends POST /external-logins/complete-registration with the request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValueOnce({ data: undefined });
+
+      await completeExternalRegistration(client, BASE, request);
+
+      expect(client.post).toHaveBeenCalledWith(
+        `${BASE}/external-logins/complete-registration`,
+        request
+      );
+    });
+
+    it.each([400, 403, 409, 422])('propagates HttpError(%i) from the server', async (status) => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockRejectedValueOnce(makeAxiosError(status));
+
+      await expect(completeExternalRegistration(client, BASE, request)).rejects.toMatchObject({
+        isAxiosError: true,
+        response: { status },
+      });
     });
   });
 

--- a/packages/@granit/account/src/__tests__/account-profile-api.test.ts
+++ b/packages/@granit/account/src/__tests__/account-profile-api.test.ts
@@ -43,5 +43,16 @@ describe('account-profile-api', () => {
       expect(client.put).toHaveBeenCalledWith(`${BASE}/profile`, { firstName: 'Jane' });
       expect(result.firstName).toBe('Jane');
     });
+
+    it('forwards email in the request body', async () => {
+      const client = createMockClient();
+      const updated = { ...mockProfile, email: 'jane@example.com' };
+      vi.mocked(client.put).mockResolvedValueOnce({ data: updated });
+
+      const result = await updateProfile(client, BASE, { email: 'jane@example.com' });
+
+      expect(client.put).toHaveBeenCalledWith(`${BASE}/profile`, { email: 'jane@example.com' });
+      expect(result.email).toBe('jane@example.com');
+    });
   });
 });

--- a/packages/@granit/account/src/api/account-external-login-api.ts
+++ b/packages/@granit/account/src/api/account-external-login-api.ts
@@ -1,6 +1,7 @@
 import { HttpError, isAxiosError } from '@granit/api-client';
 
 import type {
+  AccountCompleteExternalRegistrationRequest,
   AccountExternalLoginCallbackResponse,
   AccountExternalLoginInfo,
 } from '../types/index';
@@ -59,20 +60,84 @@ export async function challengeExternalLogin(
 }
 
 /**
- * Process the external login callback after OAuth redirect.
+ * Build the browser-navigation URL that starts an external login challenge.
  *
- * `GET {basePath}/external-logins/callback?provider=...`
+ * `GET {basePath}/external-logins/challenge/{provider}/start?returnUrl=...`
+ *
+ * The endpoint responds with a `302` to the provider, so this URL is meant for
+ * a top-level navigation (`window.location.assign(...)`), NOT an XHR.
+ *
+ * @param returnUrl optional relative URL the backend redirects to after the flow.
+ */
+export function getExternalLoginStartUrl(
+  basePath: string,
+  provider: string,
+  returnUrl?: string
+): string {
+  const url = `${basePath}/external-logins/challenge/${encodeURIComponent(provider)}/start`;
+  if (returnUrl == null || returnUrl === '') {
+    return url;
+  }
+  const query = new URLSearchParams({ returnUrl });
+  return `${url}?${query.toString()}`;
+}
+
+/**
+ * Process the external login callback headlessly after the OAuth redirect.
+ *
+ * `GET {basePath}/external-logins/callback?provider=...&mode=json`
+ *
+ * `mode=json` forces a JSON body instead of a server-side redirect. Legacy
+ * `{ userId, isNewUser }` payloads are normalized to the `completed` variant.
  */
 export async function externalLoginCallback(
   client: AxiosInstance,
   basePath: string,
   provider: string
 ): Promise<AccountExternalLoginCallbackResponse> {
-  const { data } = await client.get<AccountExternalLoginCallbackResponse>(
+  const { data } = await client.get<AccountExternalLoginCallbackResponse | LegacyCallbackResponse>(
     `${basePath}/external-logins/callback`,
-    { params: { provider } }
+    { params: { provider, mode: 'json' } }
   );
-  return data;
+
+  if ('status' in data) {
+    return data;
+  }
+
+  // Legacy shape: { userId, isNewUser } → completed variant.
+  return {
+    status: 'completed',
+    userId: data.userId,
+    isNewUser: data.isNewUser,
+    continuationToken: null,
+    prefill: null,
+  };
+}
+
+/** Pre-#2613 callback payload, normalized by {@link externalLoginCallback}. */
+interface LegacyCallbackResponse {
+  readonly userId: string;
+  readonly isNewUser: boolean;
+}
+
+/**
+ * Complete an external login registration that required profile completion.
+ *
+ * `POST {basePath}/external-logins/complete-registration`
+ *
+ * Establishes the session server-side on success (`200`).
+ *
+ * @throws {HttpError} 400 — token invalid/expired
+ * @throws {HttpError} 403 — self-registration disabled or tenant mismatch
+ * @throws {HttpError} 409 — email already taken
+ * @throws {HttpError} 422 — email differs from the provider-verified email / validation
+ */
+export async function completeExternalRegistration(
+  client: AxiosInstance,
+  basePath: string,
+  request: AccountCompleteExternalRegistrationRequest
+): Promise<void> {
+  await client.post(`${basePath}/external-logins/complete-registration`, request);
 }
 
 /**

--- a/packages/@granit/account/src/index.ts
+++ b/packages/@granit/account/src/index.ts
@@ -31,7 +31,9 @@ export {
 // API — External Logins
 export {
   challengeExternalLogin,
+  completeExternalRegistration,
   externalLoginCallback,
+  getExternalLoginStartUrl,
   getExternalLogins,
   unlinkExternalLogin,
 } from './api/account-external-login-api';

--- a/packages/@granit/account/src/types/account-external-login.ts
+++ b/packages/@granit/account/src/types/account-external-login.ts
@@ -9,8 +9,50 @@ export interface AccountExternalLoginInfo {
   readonly providerDisplayName: string | null;
 }
 
-/** Response from `GET /external-logins/callback`. */
-export interface AccountExternalLoginCallbackResponse {
+/** Prefill values proposed by the provider for a profile-completion flow. */
+export interface AccountExternalLoginPrefill {
+  readonly email: string | null;
+  readonly firstName: string | null;
+  readonly lastName: string | null;
+}
+
+/** Callback result when the session is established server-side and registration is done. */
+export interface AccountExternalLoginCompleted {
+  readonly status: 'completed';
   readonly userId: string;
   readonly isNewUser: boolean;
+  readonly continuationToken: null;
+  readonly prefill: null;
+}
+
+/** Callback result when the provider authenticated but the local profile must be completed. */
+export interface AccountExternalLoginNeedsProfile {
+  readonly status: 'needs-profile-completion';
+  readonly userId: null;
+  readonly isNewUser: false;
+  readonly continuationToken: string;
+  readonly prefill: AccountExternalLoginPrefill;
+}
+
+/**
+ * Discriminated response from `GET /external-logins/callback` (headless `?mode=json`).
+ *
+ * Discriminate on `status`: `'completed'` carries `userId`/`isNewUser`;
+ * `'needs-profile-completion'` carries a `continuationToken` and `prefill`.
+ */
+export type AccountExternalLoginCallbackResponse =
+  | AccountExternalLoginCompleted
+  | AccountExternalLoginNeedsProfile;
+
+/**
+ * Request body for `POST /external-logins/complete-registration`
+ * (mirrors the .NET `RegisterExternalRequest`).
+ *
+ * `token` is the `continuationToken` returned by a `needs-profile-completion` callback.
+ */
+export interface AccountCompleteExternalRegistrationRequest {
+  readonly token: string;
+  readonly email: string;
+  readonly firstName?: string;
+  readonly lastName?: string;
 }

--- a/packages/@granit/account/src/types/account-profile.ts
+++ b/packages/@granit/account/src/types/account-profile.ts
@@ -18,6 +18,7 @@ export interface AccountProfileResponse {
 
 /** Request body for `PUT /profile`. */
 export interface AccountProfileUpdateRequest {
+  readonly email?: string;
   readonly firstName?: string;
   readonly lastName?: string;
 }

--- a/packages/@granit/account/src/types/index.ts
+++ b/packages/@granit/account/src/types/index.ts
@@ -20,8 +20,12 @@ export type {
 } from './account-two-factor';
 
 export type {
+  AccountCompleteExternalRegistrationRequest,
   AccountExternalLoginCallbackResponse,
+  AccountExternalLoginCompleted,
   AccountExternalLoginInfo,
+  AccountExternalLoginNeedsProfile,
+  AccountExternalLoginPrefill,
 } from './account-external-login';
 
 export type {

--- a/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
+++ b/packages/@granit/react-account/src/__tests__/use-external-logins.test.tsx
@@ -7,13 +7,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
   useChallengeExternalLogin,
+  useCompleteExternalRegistration,
+  useExternalLoginStartUrl,
   useExternalLogins,
   useUnlinkExternalLogin,
 } from '../hooks/use-external-logins';
 import { AccountProvider } from '../providers/account-provider';
 
 import type { AccountConfig } from '../providers/account-provider';
-import type { AccountExternalLoginInfo } from '@granit/account';
+import type {
+  AccountCompleteExternalRegistrationRequest,
+  AccountExternalLoginInfo,
+} from '@granit/account';
 import type { AxiosInstance } from 'axios';
 import type { ReactNode } from 'react';
 
@@ -23,12 +28,17 @@ vi.mock('@granit/account', async (importOriginal) => {
     ...actual,
     getExternalLogins: vi.fn(),
     challengeExternalLogin: vi.fn(),
+    completeExternalRegistration: vi.fn(),
     unlinkExternalLogin: vi.fn(),
   };
 });
 
-const { getExternalLogins, challengeExternalLogin, unlinkExternalLogin } =
-  await import('@granit/account');
+const {
+  getExternalLogins,
+  challengeExternalLogin,
+  completeExternalRegistration,
+  unlinkExternalLogin,
+} = await import('@granit/account');
 
 function createWrapper(client: AxiosInstance) {
   return function Wrapper({ children }: { children: ReactNode }) {
@@ -115,6 +125,58 @@ describe('useChallengeExternalLogin', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(challengeExternalLogin).toHaveBeenCalledWith(client, '/api/v1/account', 'Google');
+  });
+});
+
+describe('useExternalLoginStartUrl', () => {
+  it('builds the challenge start URL bound to the configured basePath', () => {
+    const client = createMockClient();
+
+    const { result } = renderHook(() => useExternalLoginStartUrl(), {
+      wrapper: createWrapper(client),
+    });
+
+    expect(result.current('Google')).toBe('/api/v1/account/external-logins/challenge/Google/start');
+    expect(result.current('Google', '/account/security')).toBe(
+      '/api/v1/account/external-logins/challenge/Google/start?returnUrl=%2Faccount%2Fsecurity'
+    );
+  });
+});
+
+describe('useCompleteExternalRegistration', () => {
+  const request: AccountCompleteExternalRegistrationRequest = {
+    token: 'opaque-token',
+    email: 'jane@example.com',
+    firstName: 'Jane',
+  };
+
+  it('should call completeExternalRegistration with the request', async () => {
+    const client = createMockClient();
+    vi.mocked(completeExternalRegistration).mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useCompleteExternalRegistration(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate(request);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(completeExternalRegistration).toHaveBeenCalledWith(client, '/api/v1/account', request);
+  });
+
+  it('should surface the error on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(completeExternalRegistration).mockRejectedValue(new Error('Conflict'));
+
+    const { result } = renderHook(() => useCompleteExternalRegistration(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.mutate(request);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Conflict');
   });
 });
 

--- a/packages/@granit/react-account/src/hooks/use-external-logins.ts
+++ b/packages/@granit/react-account/src/hooks/use-external-logins.ts
@@ -1,9 +1,19 @@
-import { challengeExternalLogin, getExternalLogins, unlinkExternalLogin } from '@granit/account';
+import {
+  challengeExternalLogin,
+  completeExternalRegistration,
+  getExternalLoginStartUrl,
+  getExternalLogins,
+  unlinkExternalLogin,
+} from '@granit/account';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
 
 import { buildAccountQueryKey, useAccountConfig } from '../providers/account-provider';
 
-import type { AccountExternalLoginInfo } from '@granit/account';
+import type {
+  AccountCompleteExternalRegistrationRequest,
+  AccountExternalLoginInfo,
+} from '@granit/account';
 import type { HttpError } from '@granit/api-client';
 import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
 
@@ -30,6 +40,45 @@ export function useChallengeExternalLogin(): UseMutationResult<void, HttpError |
   return useMutation({
     mutationFn: (provider: string) =>
       challengeExternalLogin(config.client, config.basePath!, provider),
+  });
+}
+
+/**
+ * Returns a builder for the external login challenge start URL, bound to the
+ * configured `basePath`.
+ *
+ * The returned URL is for a top-level browser navigation
+ * (`window.location.assign(buildUrl(provider, returnUrl))`), not an XHR.
+ */
+export function useExternalLoginStartUrl(): (provider: string, returnUrl?: string) => string {
+  const config = useAccountConfig();
+
+  return useCallback(
+    (provider: string, returnUrl?: string) =>
+      getExternalLoginStartUrl(config.basePath!, provider, returnUrl),
+    [config.basePath]
+  );
+}
+
+/**
+ * Completes an external login registration that required profile completion.
+ *
+ * On error, `mutation.error` is an `HttpError`:
+ * - `status === 400` — token invalid / expired
+ * - `status === 403` — self-registration disabled or tenant mismatch
+ * - `status === 409` — email already taken
+ * - `status === 422` — email differs from the provider-verified email / validation
+ */
+export function useCompleteExternalRegistration(): UseMutationResult<
+  void,
+  HttpError | Error,
+  AccountCompleteExternalRegistrationRequest
+> {
+  const config = useAccountConfig();
+
+  return useMutation({
+    mutationFn: (request: AccountCompleteExternalRegistrationRequest) =>
+      completeExternalRegistration(config.client, config.basePath!, request),
   });
 }
 

--- a/packages/@granit/react-account/src/index.ts
+++ b/packages/@granit/react-account/src/index.ts
@@ -36,6 +36,8 @@ export {
 // Hooks — External Logins
 export {
   useChallengeExternalLogin,
+  useCompleteExternalRegistration,
+  useExternalLoginStartUrl,
   useExternalLogins,
   useUnlinkExternalLogin,
 } from './hooks/use-external-logins';


### PR DESCRIPTION
## Context

granit-dotnet #2613 (merged) reworked external login. This brings the TS SDK
(`@granit/account`, `@granit/react-account`) into conformance so showcase-admin-react
can build the external-login UI.

Backend contract changes (base path `/api/account`):
- **Challenge start** is now a **browser navigation**: `GET …/challenge/{provider}/start?returnUrl=` → 302 to provider. The old `POST …/challenge/{provider}` stays (validation only).
- **Callback** (`GET …/callback`, headless `?mode=json`) now returns a **discriminated union**: `completed` | `needs-profile-completion`.
- **New** `POST …/complete-registration` finalizes the profile-completion flow.

## Changes

### `@granit/account`
- `AccountExternalLoginCallbackResponse` is now a discriminated union (`status`); adds `AccountExternalLoginCompleted`, `AccountExternalLoginNeedsProfile`, `AccountExternalLoginPrefill`, and `AccountCompleteExternalRegistrationRequest`.
- `getExternalLoginStartUrl(basePath, provider, returnUrl?)` — pure URL builder for `window.location.assign`.
- `completeExternalRegistration(client, basePath, request)` — `POST …/complete-registration` (errors 400/403/409/422 propagate).
- `externalLoginCallback` now sends `?mode=json` and **normalizes the legacy** `{ userId, isNewUser }` payload to the `completed` variant (backward compatible).
- `AccountProfileUpdateRequest` gains optional `email` (additive).

### `@granit/react-account`
- `useCompleteExternalRegistration()` mutation.
- `useExternalLoginStartUrl()` — returns a memoized builder bound to `basePath`.

## Notes
- `token` (not `continuationToken`) is used as the request field name to match the .NET `RegisterExternalRequest` wire body exactly.
- The exported name `AccountExternalLoginCallbackResponse` is preserved (union alias) — no breaking rename.

## Verification
- `tsc --noEmit` ✅ · vitest **113 passed** ✅ · tsup build (d.ts exports verified) ✅ · ESLint `--max-warnings 0` ✅