### PR TITLE
fix(react-admin): nested-button KPI tile + SSR-safe consent globals

### DIFF
--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile-view.test.tsx
@@ -122,6 +122,39 @@ describe('KpiTileView', () => {
     expect(onRetry).toHaveBeenCalledOnce();
   });
 
+  it('does not nest the retry button inside the tile button when onClick and error coexist', () => {
+    const { container } = render(
+      <KpiTileView
+        title="X"
+        data={undefined}
+        isLoading={false}
+        error={new Error('boom')}
+        onClick={vi.fn()}
+        onRetry={vi.fn()}
+        errorRetryLabel="Try again"
+      />
+    );
+    // The tile must not be an interactive <button> while erroring, otherwise the
+    // retry <button> would be a nested button (invalid HTML + hydration error).
+    expect(container.querySelector('[data-slot="kpi-tile"]')?.tagName).toBe('DIV');
+    expect(container.querySelectorAll('button')).toHaveLength(1);
+  });
+
+  it('renders the tile as an interactive button when onClick is set and there is no error', () => {
+    const { container } = render(
+      <KpiTileView
+        title="X"
+        data={makeResponse()}
+        isLoading={false}
+        error={null}
+        onClick={vi.fn()}
+      />
+    );
+    const tile = container.querySelector('[data-slot="kpi-tile"]');
+    expect(tile?.tagName).toBe('BUTTON');
+    expect(tile).toHaveAttribute('data-interactive', '');
+  });
+
   it('renders the trendVisual slot when provided', () => {
     const { container } = render(
       <KpiTileView

--- a/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile-view.tsx
@@ -101,7 +101,10 @@ export function KpiTileView({
     </>
   );
 
-  if (onClick) {
+  // In the error state the body renders its own Retry <button>; wrapping the tile in an
+  // outer <button> would nest buttons (invalid HTML + hydration error). Fall through to the
+  // non-interactive <div> wrapper while erroring — the tile isn't actionable until it loads.
+  if (onClick && !error) {
     return (
       <button
         type="button"

--- a/packages/@granit/react-openiddict-admin/src/hooks/use-consent-flow.ts
+++ b/packages/@granit/react-openiddict-admin/src/hooks/use-consent-flow.ts
@@ -32,7 +32,7 @@ export function useConsentFlow(returnUrl: string | null, subject: string | null)
     try {
       const url = new URL(
         returnUrl,
-        typeof window !== 'undefined' ? window.location.origin : 'http://localhost'
+        typeof globalThis.window === 'undefined' ? 'http://localhost' : globalThis.location.origin
       );
       return {
         clientId: url.searchParams.get('client_id'),
@@ -50,11 +50,11 @@ export function useConsentFlow(returnUrl: string | null, subject: string | null)
       clientId: parsed.clientId,
       scopes: parsed.scopes,
     });
-    window.location.href = returnUrl;
+    globalThis.location.href = returnUrl;
   };
 
   const deny = (redirectUrl = '/') => {
-    window.location.href = redirectUrl;
+    globalThis.location.href = redirectUrl;
   };
 
   return {


### PR DESCRIPTION
## Summary

Two small, unrelated correctness fixes in admin-facing React packages (carried over as WIP from the merged #631 branch).

### `@granit/react-analytics` — nested button in erroring KPI tile
When `onClick` and `error` coexist, the tile body already renders its own Retry `<button>`. Wrapping the tile in an outer `<button>` nested two buttons — invalid HTML and a hydration error. The tile now falls through to the non-interactive `<div>` wrapper while erroring (it isn't actionable until it loads).

### `@granit/react-openiddict-admin` — SSR-safe consent-flow globals
Access `globalThis.window` / `globalThis.location` instead of bare `window`, making the consent-flow guard SSR-safe and consistent with the global-access convention.

## Testing
- `eslint --max-warnings 0` clean on both packages
- 11 `kpi-tile-view` tests pass (2 new: asserts the tile is a `<div>` while erroring, a `<button>` otherwise)