### PR TITLE
feat(sessions): shared geo/risk contracts across BFF & Identity (audit fixes)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1690,6 +1690,18 @@
       ]
     },
     {
+      "name": "@granit/ip-geolocation",
+      "description": "Geolocation contract — TypeScript mirror of Granit.IpGeolocation.GeoLocation",
+      "exports": [
+        {
+          "name": "GeoLocation",
+          "kind": "interface",
+          "signature": "interface GeoLocation",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/localization",
       "description": "i18next helpers and localization hooks",
       "exports": [
@@ -7547,6 +7559,17 @@
           "name": "TimeZoneId",
           "kind": "type",
           "signature": "type TimeZoneId = string & { readonly __brand: 'TimeZoneId' }"
+        }
+      ]
+    },
+    {
+      "name": "@granit/user-sessions",
+      "description": "User-session risk contract — TypeScript mirror of Granit.UserSessions",
+      "exports": [
+        {
+          "name": "UserSessionRiskLevel",
+          "kind": "type",
+          "signature": "type UserSessionRiskLevel = 'None' | 'Low' | 'Medium' | 'High'"
         }
       ]
     },

--- a/packages/@granit/bff/package.json
+++ b/packages/@granit/bff/package.json
@@ -14,8 +14,10 @@
     "build": "tsup"
   },
   "peerDependencies": {
+    "@granit/ip-geolocation": "workspace:*",
     "@granit/logger": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/types": "workspace:*",
+    "@granit/user-sessions": "workspace:*"
   },
   "peerDependenciesMeta": {
     "@granit/logger": {
@@ -23,9 +25,11 @@
     }
   },
   "devDependencies": {
+    "@granit/ip-geolocation": "workspace:*",
     "@granit/logger": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/types": "workspace:*",
+    "@granit/user-sessions": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/bff/src/index.ts
+++ b/packages/@granit/bff/src/index.ts
@@ -5,13 +5,17 @@ export type {
   BffSessionId,
   BffSessionInfo,
   BffSessionListResponse,
-  BffSessionLocation,
-  BffSessionRiskLevel,
   BffTenantUser,
   BffUnauthenticated,
   BffUser,
   BffUserResponse,
 } from './types/index';
+
+// Re-export the shared session-enrichment contracts so consumers can type the
+// `location` / `riskLevel` fields of BffSessionInfo without reaching into the
+// owning packages directly.
+export type { GeoLocation } from '@granit/ip-geolocation';
+export type { UserSessionRiskLevel } from '@granit/user-sessions';
 
 export { CsrfManager } from './csrf/index';
 

--- a/packages/@granit/bff/src/types/index.ts
+++ b/packages/@granit/bff/src/types/index.ts
@@ -1,5 +1,7 @@
+import type { GeoLocation } from '@granit/ip-geolocation';
 import type { Logger } from '@granit/logger';
 import type { EntityId, ISODateString, TenantId } from '@granit/types';
+import type { UserSessionRiskLevel } from '@granit/user-sessions';
 
 // ---------------------------------------------------------------------------
 // BFF authentication types — mirrors Granit.Bff .NET contract
@@ -49,38 +51,6 @@ export type BffUserResponse = BffUser | BffUnauthenticated;
 /** Branded BFF session identifier. */
 export type BffSessionId = EntityId<'BffSession'>;
 
-/**
- * Coarse session risk classification. Mirrors `Granit.UserSessions.UserSessionRiskLevel`,
- * serialized as its string name via the framework's `JsonStringEnumConverter`.
- *
- * `'None'` means anomaly detection ran and found nothing; a *null* `riskLevel`
- * on {@link BffSessionInfo} means no verdict was stored (detection not installed).
- */
-export type BffSessionRiskLevel = 'None' | 'Low' | 'Medium' | 'High';
-
-/**
- * Approximate geographic location of a session, resolved from its IP address.
- * Mirrors `Granit.IpGeolocation.GeoLocation` — every member is independently
- * optional (a country-only data source leaves city/region/coordinates null).
- *
- * These strings originate from a geolocation data source and are display-only:
- * render them as text, never as HTML.
- */
-export interface BffSessionLocation {
-  /** City name (e.g. "Brussels"), when resolved to city granularity. */
-  readonly city: string | null;
-  /** Most specific subdivision — region/state/province (e.g. "Brussels-Capital"). */
-  readonly region: string | null;
-  /** Country display name (e.g. "Belgium"). */
-  readonly country: string | null;
-  /** ISO 3166-1 alpha-2 country code (e.g. "BE"). */
-  readonly countryCode: string | null;
-  /** Approximate latitude in decimal degrees, when available. */
-  readonly latitude: number | null;
-  /** Approximate longitude in decimal degrees, when available. */
-  readonly longitude: number | null;
-}
-
 /** A single BFF session entry. Session IDs are masked server-side for security. */
 export interface BffSessionInfo {
   /** Masked session identifier (e.g. "ab12...yz89"). */
@@ -102,14 +72,14 @@ export interface BffSessionInfo {
    */
   readonly lastAccessedAt: ISODateString | null;
   /** Approximate geolocation of the session IP, or null when unresolved. */
-  readonly location: BffSessionLocation | null;
+  readonly location: GeoLocation | null;
   /**
    * Session IP address — masked by default, raw only when the BFF is configured
    * with `ExposeRawIpAddress`. Null when unavailable.
    */
   readonly ipAddress: string | null;
   /** Coarse risk level, or null when no verdict was stored for the session. */
-  readonly riskLevel: BffSessionRiskLevel | null;
+  readonly riskLevel: UserSessionRiskLevel | null;
 }
 
 /** Response from GET /{prefix}/bff/sessions. */

--- a/packages/@granit/bff/src/validation/parse-bff-session-list.ts
+++ b/packages/@granit/bff/src/validation/parse-bff-session-list.ts
@@ -18,13 +18,10 @@
 // ---------------------------------------------------------------------------
 
 import type { ParseResult } from './parse-bff-user';
-import type {
-  BffSessionId,
-  BffSessionInfo,
-  BffSessionLocation,
-  BffSessionRiskLevel,
-} from '../types/index';
+import type { BffSessionId, BffSessionInfo } from '../types/index';
+import type { GeoLocation } from '@granit/ip-geolocation';
 import type { ISODateString } from '@granit/types';
+import type { UserSessionRiskLevel } from '@granit/user-sessions';
 
 // Length bounds for untrusted free-text fields. Generous enough for legitimate
 // values, tight enough to stop an oversized string from bloating the UI/logs.
@@ -33,7 +30,7 @@ const MAX_IP = 64;
 const MAX_GEO_TEXT = 128;
 const MAX_COUNTRY_CODE = 8;
 
-const RISK_LEVELS: ReadonlySet<string> = new Set<BffSessionRiskLevel>([
+const RISK_LEVELS: ReadonlySet<string> = new Set<UserSessionRiskLevel>([
   'None',
   'Low',
   'Medium',
@@ -59,13 +56,13 @@ function finiteNumber(x: unknown): number | null {
   return typeof x === 'number' && Number.isFinite(x) ? x : null;
 }
 
-function normalizeRiskLevel(x: unknown): BffSessionRiskLevel | null {
-  return typeof x === 'string' && RISK_LEVELS.has(x) ? (x as BffSessionRiskLevel) : null;
+function normalizeRiskLevel(x: unknown): UserSessionRiskLevel | null {
+  return typeof x === 'string' && RISK_LEVELS.has(x) ? (x as UserSessionRiskLevel) : null;
 }
 
-function normalizeLocation(x: unknown): BffSessionLocation | null {
+function normalizeLocation(x: unknown): GeoLocation | null {
   if (!isObject(x)) return null;
-  const location: BffSessionLocation = {
+  const location: GeoLocation = {
     city: boundedString(x.city, MAX_GEO_TEXT),
     region: boundedString(x.region, MAX_GEO_TEXT),
     country: boundedString(x.country, MAX_GEO_TEXT),

--- a/packages/@granit/identity/package.json
+++ b/packages/@granit/identity/package.json
@@ -15,14 +15,18 @@
   },
   "devDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/ip-geolocation": "workspace:*",
     "@granit/query-engine": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/types": "workspace:*",
+    "@granit/user-sessions": "workspace:*"
   },
   "peerDependencies": {
     "@granit/api-client": "workspace:*",
+    "@granit/ip-geolocation": "workspace:*",
     "@granit/query-engine": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/types": "workspace:*",
+    "@granit/user-sessions": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/packages/@granit/identity/src/__tests__/identity-provider-session-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-session-api.test.ts
@@ -18,6 +18,8 @@ const sampleSession: IdentitySession = {
   lastAccess: toISODateString('2026-03-20T12:00:00Z'),
   rememberMe: false,
   clients: ['web-app'],
+  location: null,
+  riskLevel: null,
 };
 
 const sampleDeviceActivity: IdentityDeviceActivity = {
@@ -30,6 +32,7 @@ const sampleDeviceActivity: IdentityDeviceActivity = {
   mobile: false,
   current: true,
   sessions: [sampleSession],
+  location: null,
 };
 
 const basePath = '/identity/provider';

--- a/packages/@granit/identity/src/types/identity-session.ts
+++ b/packages/@granit/identity/src/types/identity-session.ts
@@ -1,4 +1,6 @@
+import type { GeoLocation } from '@granit/ip-geolocation';
 import type { EntityId, ISODateString } from '@granit/types';
+import type { UserSessionRiskLevel } from '@granit/user-sessions';
 
 /** Branded session identifier for identity provider sessions. */
 export type IdentitySessionId = EntityId<'IdentitySession'>;
@@ -11,6 +13,10 @@ export type IdentitySession = {
   readonly lastAccess: ISODateString;
   readonly rememberMe: boolean;
   readonly clients: readonly string[];
+  /** Approximate geolocation of the session IP, or null when unresolved. */
+  readonly location: GeoLocation | null;
+  /** Coarse risk level, or null when no verdict was stored for the session. */
+  readonly riskLevel: UserSessionRiskLevel | null;
 };
 
 /** Device activity from the identity provider — mirrors Granit.Identity.IdentityDeviceActivity .NET record. */
@@ -24,4 +30,6 @@ export type IdentityDeviceActivity = {
   readonly mobile: boolean;
   readonly current: boolean;
   readonly sessions: readonly IdentitySession[];
+  /** Approximate geolocation of the device's last-seen IP, or null when unresolved. */
+  readonly location: GeoLocation | null;
 };

--- a/packages/@granit/identity/src/types/index.ts
+++ b/packages/@granit/identity/src/types/index.ts
@@ -14,6 +14,12 @@ export type {
   IdentitySession,
   IdentitySessionId,
 } from './identity-session';
+
+// Shared session-enrichment contracts re-exported so consumers can type the
+// `location` / `riskLevel` fields without reaching into the owning packages.
+export type { GeoLocation } from '@granit/ip-geolocation';
+export type { UserSessionRiskLevel } from '@granit/user-sessions';
+
 export type { IdentityPasswordChangedAtResponse } from './identity-password';
 export type {
   IdentitySetTemporaryPasswordRequest,

--- a/packages/@granit/ip-geolocation/README.md
+++ b/packages/@granit/ip-geolocation/README.md
@@ -1,0 +1,15 @@
+# @granit/ip-geolocation
+
+Geolocation contract for the Granit framework — the TypeScript mirror of
+`Granit.IpGeolocation.GeoLocation`.
+
+A type-only package: it exposes the shared `GeoLocation` shape consumed by every
+front-end surface that displays an IP-resolved location (BFF sessions, identity
+sessions and devices). Keeping it standalone — mirroring the backend
+`Granit.IpGeolocation` module — prevents divergent per-package copies.
+
+## Usage
+
+```ts
+import type { GeoLocation } from '@granit/ip-geolocation';
+```

--- a/packages/@granit/ip-geolocation/package.json
+++ b/packages/@granit/ip-geolocation/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/ip-geolocation",
+  "description": "Geolocation contract — TypeScript mirror of Granit.IpGeolocation.GeoLocation",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/ip-geolocation/src/index.ts
+++ b/packages/@granit/ip-geolocation/src/index.ts
@@ -1,0 +1,1 @@
+export type { GeoLocation } from './types/index';

--- a/packages/@granit/ip-geolocation/src/types/index.ts
+++ b/packages/@granit/ip-geolocation/src/types/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Approximate geographic location, typically derived from an IP address.
+ * Mirrors `Granit.IpGeolocation.GeoLocation`.
+ *
+ * The shape is source-agnostic — a city/region/country is a location regardless
+ * of how it was resolved. Every member is independently optional: a provider
+ * populates only what its data source supports (an offline country-only database
+ * leaves {@link GeoLocation.city} and the coordinates `null`).
+ *
+ * These strings come from a geolocation data source and are display-only:
+ * render them as text, never as HTML.
+ */
+export interface GeoLocation {
+  /** City name (e.g. "Brussels"), when the data source resolves to city granularity. */
+  readonly city: string | null;
+  /** Most specific subdivision — region/state/province (e.g. "Brussels-Capital"). */
+  readonly region: string | null;
+  /** Country display name (e.g. "Belgium"). */
+  readonly country: string | null;
+  /** ISO 3166-1 alpha-2 country code (e.g. "BE"). */
+  readonly countryCode: string | null;
+  /** Approximate latitude in decimal degrees, when available. */
+  readonly latitude: number | null;
+  /** Approximate longitude in decimal degrees, when available. */
+  readonly longitude: number | null;
+}

--- a/packages/@granit/ip-geolocation/tsconfig.json
+++ b/packages/@granit/ip-geolocation/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/ip-geolocation/tsup.config.ts
+++ b/packages/@granit/ip-geolocation/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-bff/package.json
+++ b/packages/@granit/react-bff/package.json
@@ -17,10 +17,18 @@
   "peerDependencies": {
     "@granit/bff": "workspace:*",
     "@granit/logger": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
   "peerDependenciesMeta": {
+    "@granit/testing": {
+      "optional": true
+    },
+    "@granit/types": {
+      "optional": true
+    },
     "msw": {
       "optional": true
     }

--- a/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-sessions.test.tsx
@@ -26,6 +26,8 @@ const sampleSession: IdentitySession = {
   lastAccess: toISODateString('2026-03-20T12:00:00Z'),
   rememberMe: false,
   clients: ['web-app'],
+  location: null,
+  riskLevel: null,
 };
 
 const sampleDevice: IdentityDeviceActivity = {
@@ -38,6 +40,7 @@ const sampleDevice: IdentityDeviceActivity = {
   mobile: false,
   current: true,
   sessions: [sampleSession],
+  location: null,
 };
 
 function createWrapper(client: AxiosInstance) {

--- a/packages/@granit/react-identity/src/testing/data.ts
+++ b/packages/@granit/react-identity/src/testing/data.ts
@@ -148,6 +148,15 @@ export const mockSessions: IdentitySession[] = [
     lastAccess: toISODateString('2026-03-06T09:30:00Z'),
     rememberMe: false,
     clients: ['granit-showcase-admin', 'granit-showcase-app'],
+    location: {
+      city: 'Brussels',
+      region: 'Brussels-Capital',
+      country: 'Belgium',
+      countryCode: 'BE',
+      latitude: 50.8503,
+      longitude: 4.3517,
+    },
+    riskLevel: 'None',
   },
   {
     sessionId: toEntityId<'IdentitySession'>('sess-abc-002'),
@@ -156,6 +165,8 @@ export const mockSessions: IdentitySession[] = [
     lastAccess: toISODateString('2026-03-05T20:15:00Z'),
     rememberMe: true,
     clients: ['granit-showcase-app'],
+    location: null,
+    riskLevel: 'Low',
   },
 ];
 
@@ -170,6 +181,14 @@ export const mockDevices: IdentityDeviceActivity[] = [
     mobile: false,
     current: true,
     sessions: mockSessions,
+    location: {
+      city: 'Brussels',
+      region: 'Brussels-Capital',
+      country: 'Belgium',
+      countryCode: 'BE',
+      latitude: 50.8503,
+      longitude: 4.3517,
+    },
   },
   {
     ipAddress: '10.0.1.55',
@@ -181,6 +200,7 @@ export const mockDevices: IdentityDeviceActivity[] = [
     mobile: true,
     current: false,
     sessions: [],
+    location: null,
   },
 ];
 

--- a/packages/@granit/user-sessions/README.md
+++ b/packages/@granit/user-sessions/README.md
@@ -1,0 +1,15 @@
+# @granit/user-sessions
+
+User-session risk contract for the Granit framework — the TypeScript mirror of
+`Granit.UserSessions`.
+
+A type-only package exposing the shared `UserSessionRiskLevel` classification
+consumed by every front-end surface that displays session risk (BFF sessions,
+identity sessions). Keeping it standalone — mirroring the backend
+`Granit.UserSessions` module — prevents divergent per-package copies.
+
+## Usage
+
+```ts
+import type { UserSessionRiskLevel } from '@granit/user-sessions';
+```

--- a/packages/@granit/user-sessions/package.json
+++ b/packages/@granit/user-sessions/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@granit/user-sessions",
+  "description": "User-session risk contract — TypeScript mirror of Granit.UserSessions",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/user-sessions/src/index.ts
+++ b/packages/@granit/user-sessions/src/index.ts
@@ -1,0 +1,1 @@
+export type { UserSessionRiskLevel } from './types/index';

--- a/packages/@granit/user-sessions/src/types/index.ts
+++ b/packages/@granit/user-sessions/src/types/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Coarse risk classification for a user session, surfaced to users and used to
+ * drive security responses (notifications, step-up authentication). Mirrors
+ * `Granit.UserSessions.UserSessionRiskLevel`, serialized as its string name via
+ * the framework's `JsonStringEnumConverter`.
+ *
+ * `'None'` means anomaly detection ran and found nothing; a *null* risk level on
+ * a session means no verdict was stored (detection not installed).
+ */
+export type UserSessionRiskLevel = 'None' | 'Low' | 'Medium' | 'High';

--- a/packages/@granit/user-sessions/tsconfig.json
+++ b/packages/@granit/user-sessions/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/user-sessions/tsup.config.ts
+++ b/packages/@granit/user-sessions/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -364,6 +364,9 @@ importers:
 
   packages/@granit/bff:
     devDependencies:
+      '@granit/ip-geolocation':
+        specifier: workspace:*
+        version: link:../ip-geolocation
       '@granit/logger':
         specifier: workspace:*
         version: link:../logger
@@ -373,6 +376,9 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+      '@granit/user-sessions':
+        specifier: workspace:*
+        version: link:../user-sessions
 
   packages/@granit/blob-storage:
     devDependencies:
@@ -631,6 +637,9 @@ importers:
       '@granit/api-client':
         specifier: workspace:*
         version: link:../api-client
+      '@granit/ip-geolocation':
+        specifier: workspace:*
+        version: link:../ip-geolocation
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
@@ -640,6 +649,9 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+      '@granit/user-sessions':
+        specifier: workspace:*
+        version: link:../user-sessions
 
   packages/@granit/invoicing:
     devDependencies:
@@ -658,6 +670,8 @@ importers:
       '@granit/workflow':
         specifier: workspace:*
         version: link:../workflow
+
+  packages/@granit/ip-geolocation: {}
 
   packages/@granit/localization:
     dependencies:
@@ -3127,6 +3141,8 @@ importers:
       '@granit/testing':
         specifier: workspace:*
         version: link:../testing
+
+  packages/@granit/user-sessions: {}
 
   packages/@granit/utils:
     dependencies:


### PR DESCRIPTION
Follow-up to #631 — resolves the findings from the `/audit` of `@granit/bff` + `@granit/react-bff`.

## Why

The session-enrichment fields shipped in #631 were typed as **Bff-local** (`BffSessionLocation`, `BffSessionRiskLevel`). But those are shared backend contracts — `Granit.IpGeolocation.GeoLocation` and `Granit.UserSessions.UserSessionRiskLevel` are also returned by `Granit.Identity.Endpoints` (`IdentitySessionResponse`, `IdentityDeviceActivityResponse`). The audit also found the front `@granit/identity` session/device types had **drifted** — they were missing `location`/`riskLevel` entirely. Bff-local copies would have guaranteed divergence.

## Changes

**New shared type packages** (mirror the backend modules, published like `@granit/types`):
- `@granit/ip-geolocation` → `GeoLocation`
- `@granit/user-sessions` → `UserSessionRiskLevel`

**`@granit/bff`** — consumes + re-exports the shared types instead of the local duplicates (`BffSessionLocation`/`BffSessionRiskLevel` removed; they had no external consumers). `BffSessionInfo.location`/`riskLevel` and the `parseBffSessionList` normalizer now reference the shared types. Public surface: `GeoLocation` + `UserSessionRiskLevel` are re-exported from `@granit/bff`.

**`@granit/identity`** (audit GAP G-1) — surfaces the geolocation + risk enrichment the backend already returns: `IdentitySession` gains `location` + `riskLevel`, `IdentityDeviceActivity` gains `location`. Re-exports the shared types. Fixtures updated.

**`@granit/react-bff`** (audit INCONSISTENCY I-1) — declares the `./testing` entry's runtime deps (`@granit/types`, `@granit/testing`) as **optional peers**, matching how `msw` was already treated.

## Verification

- `pnpm tsc` (full workspace): PASS
- `eslint --max-warnings 0` (touched packages) + `markdownlint` (new READMEs): PASS
- Tests: **191 passed** across `bff`, `react-bff`, `identity`, `react-identity`
- Lockfile refreshed in-commit (`pnpm install`); pre-commit hooks green

## ⚠️ Coordinated downstream change required (showcase-admin-react)

`IdentitySession`/`IdentityDeviceActivity` and `BffSessionInfo` gained **required** `location`/`riskLevel` fields (consistent with the existing `ipAddress: string | null` house style). Two showcase **test fixtures** construct these types and will need the new fields once they link this branch:
- `src/features/identity/users/components/user-sessions-card.test.tsx`
- `src/features/authentication/components/my-sessions-card.test.tsx`

Per the cross-repo process: merge this PR first, then a Draft MR on showcase adds `location`/`riskLevel` to those fixtures. (Consumer components only *read* these fields and render `userAgent`/location as escaped text — no runtime break, type-check only.)

## Not done (deliberate)

Audit IMP-2 (`useBffSessions` → TanStack Query) is **not** applied: `react-bff` is the auth-bootstrap layer that intentionally avoids a `QueryClient` dependency (it can render before one exists). Converting it would be a design change, not a conformity fix.