### PR TITLE
chore(contracts): re-vendor identity OpenAPI for moved session/device routes

### DIFF
--- a/contracts/openapi/identity.json
+++ b/contracts/openapi/identity.json
@@ -7,9 +7,7 @@
   "paths": {
     "/identity/users/capabilities": {
       "get": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Returns the capabilities of the active identity provider.",
         "description": "Returns the feature flags of the currently active identity provider (Keycloak, Azure AD, etc.): session termination support, native password reset, group hierarchy, custom attributes, credential verification, and user creation. The front-end uses this to conditionally render identity management features.",
         "operationId": "GetIdentityProviderCapabilities",
@@ -59,9 +57,7 @@
     },
     "/identity/users": {
       "get": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Searches the user cache by free-text term with pagination.",
         "description": "Performs a free-text search across cached user fields (name, email, etc.) with pagination and sorting. Only searches the local cache — does not query the identity provider. Use sync endpoints to refresh stale data.",
         "operationId": "SearchIdentityUserCache",
@@ -111,9 +107,7 @@
     },
     "/identity/users/{userId}": {
       "get": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Resolves a single user by external ID (cache-aside: fetches from provider if stale/missing).",
         "description": "Looks up the user in the local cache first. If the entry is missing or stale, transparently fetches from the identity provider and updates the cache before returning. Returns 404 if the user does not exist in either the cache or the provider.",
         "operationId": "GetIdentityUserById",
@@ -182,9 +176,7 @@
         }
       },
       "delete": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "GDPR Art. 17 — permanently deletes the cached entry for a user.",
         "description": "Implements the GDPR right to erasure (Article 17). Permanently removes the user's cached identity data. This does not affect the upstream identity provider — the data will be re-cached if the user is looked up again. For full erasure, also delete in the identity provider.",
         "operationId": "EraseIdentityUserCache",
@@ -238,9 +230,7 @@
     },
     "/identity/users/batch": {
       "post": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Resolves multiple user IDs to identity information in batch.",
         "description": "Resolves a list of user IDs in a single request, using the cache-aside pattern. Unknown IDs are silently omitted from the result. Useful for enriching lists of entities with user display names without N+1 calls.",
         "operationId": "BatchResolveIdentityUsers",
@@ -313,9 +303,7 @@
     },
     "/identity/users/stats": {
       "get": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Returns cache statistics: total entries, stale count, oldest/newest sync timestamps.",
         "description": "Returns aggregate statistics about the identity user cache: total number of cached entries, count of stale entries needing refresh, and the timestamp range of the oldest and newest synchronization. Useful for monitoring cache health and scheduling sync operations.",
         "operationId": "GetIdentityUserCacheStats",
@@ -365,9 +353,7 @@
     },
     "/identity/users/sync": {
       "post": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Forces refresh of specific users from the identity provider.",
         "description": "Fetches the latest data for the specified user IDs from the identity provider and updates the cache. Returns the refreshed user records. Users not found in the provider are silently skipped.",
         "operationId": "SyncIdentityUsers",
@@ -440,9 +426,7 @@
     },
     "/identity/users/sync-all": {
       "post": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Full sync — fetches all users from the identity provider and upserts the cache.",
         "description": "Fetches every user from the identity provider and upserts the entire cache. This is an expensive operation — use sparingly (e.g., nightly scheduled job or initial setup). Returns the count of synchronized entries.",
         "operationId": "SyncAllIdentityUsers",
@@ -492,9 +476,7 @@
     },
     "/identity/users/sync-stale": {
       "post": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "Incremental sync — refreshes only stale cache entries.",
         "description": "Refreshes only cache entries whose last sync timestamp exceeds the configured staleness threshold. More efficient than a full sync for routine maintenance. Returns the count of refreshed entries.",
         "operationId": "SyncStaleIdentityUsers",
@@ -544,9 +526,7 @@
     },
     "/identity/users/{userId}/pseudonymize": {
       "patch": {
-        "tags": [
-          "Identity - User Cache"
-        ],
+        "tags": ["Identity - User Cache"],
         "summary": "GDPR Art. 18 — replaces PII with anonymized data in the cached entry.",
         "description": "Implements the GDPR right to restriction of processing (Article 18). Replaces all personally identifiable information (name, email, etc.) with anonymized placeholders while preserving the entry for referential integrity. Irreversible.",
         "operationId": "PseudonymizeIdentityUserCache",
@@ -600,9 +580,7 @@
     },
     "/identity/webhook": {
       "post": {
-        "tags": [
-          "Identity - Webhook"
-        ],
+        "tags": ["Identity - Webhook"],
         "summary": "Receives identity provider webhook events (user created/updated/deleted).",
         "description": "Webhook receiver for identity provider event notifications. Validates the HMAC signature (if configured) and processes user_created, user_updated, and user_deleted events by refreshing or removing the corresponding cache entries. No bearer authentication — security relies on HMAC signature validation in the handler.",
         "operationId": "IdentityWebhook",
@@ -651,14 +629,270 @@
             }
           }
         },
-        "security": [
-          { }
-        ]
+        "security": [{}]
+      }
+    },
+    "/sessions": {
+      "get": {
+        "tags": ["User Sessions"],
+        "summary": "Lists the caller's active sessions.",
+        "description": "Returns the authenticated user's active sessions across the configured backend (BFF, OpenIddict or Keycloak), each enriched with its approximate location and persisted risk level. The current session is flagged. Raw IP addresses are never returned.",
+        "operationId": "ListUserSessions",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserSessionResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["User Sessions"],
+        "summary": "Revokes all of the caller's sessions except the current one.",
+        "description": "Revokes every session of the authenticated user except the one making the request, and returns how many were revoked.",
+        "operationId": "RevokeOtherUserSessions",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserSessionsRevokedResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sessions/{sessionId}": {
+      "delete": {
+        "tags": ["User Sessions"],
+        "summary": "Revokes one of the caller's sessions by ID.",
+        "description": "Revokes the specified session of the authenticated user. Returns 404 when no such session exists.",
+        "operationId": "RevokeUserSession",
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "description": "Session identifier — opaque token bound to a single browser/device session.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/devices": {
+      "get": {
+        "tags": ["User Sessions"],
+        "summary": "Lists the caller's devices.",
+        "description": "Returns the devices the authenticated user has signed in from — device type, OS, browser, last activity and approximate location — aggregated across the configured session backend.",
+        "operationId": "ListUserDevices",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/UserDeviceResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
   "components": {
     "schemas": {
+      "DeviceKind": {
+        "enum": [
+          "Unknown",
+          "Browser",
+          "BrowserExtension",
+          "MobileApp",
+          "DesktopApp",
+          "Wearable",
+          "Tv",
+          "Embedded",
+          "ApiClient"
+        ]
+      },
+      "GeoLocation": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": ["null", "string"]
+          },
+          "region": {
+            "type": ["null", "string"]
+          },
+          "country": {
+            "type": ["null", "string"]
+          },
+          "countryCode": {
+            "type": ["null", "string"]
+          },
+          "latitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          },
+          "longitude": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$",
+            "type": ["null", "number", "string"],
+            "format": "double"
+          }
+        }
+      },
       "IdentityProviderCapabilitiesResponse": {
         "required": [
           "providerName",
@@ -704,26 +938,21 @@
         }
       },
       "IdentityUserCacheBatchRequest": {
-        "required": [
-          "userIds"
-        ],
+        "required": ["userIds"],
         "type": "object",
         "properties": {
           "userIds": {
+            "maxLength": 256,
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-granit-validator": "Validation:Rule:MaxBatchSize"
           }
         }
       },
       "IdentityUserCacheStatsResponse": {
-        "required": [
-          "totalEntries",
-          "staleEntries",
-          "oldestSyncAt",
-          "newestSyncAt"
-        ],
+        "required": ["totalEntries", "staleEntries", "oldestSyncAt", "newestSyncAt"],
         "type": "object",
         "properties": {
           "totalEntries": {
@@ -735,25 +964,17 @@
             "format": "int32"
           },
           "oldestSyncAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           },
           "newestSyncAt": {
-            "type": [
-              "null",
-              "string"
-            ],
+            "type": ["null", "string"],
             "format": "date-time"
           }
         }
       },
       "IdentityUserCacheSyncAllResponse": {
-        "required": [
-          "syncedCount"
-        ],
+        "required": ["syncedCount"],
         "type": "object",
         "properties": {
           "syncedCount": {
@@ -763,23 +984,21 @@
         }
       },
       "IdentityUserCacheSyncRequest": {
-        "required": [
-          "userIds"
-        ],
+        "required": ["userIds"],
         "type": "object",
         "properties": {
           "userIds": {
+            "maxLength": 256,
             "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "x-granit-validator": "Validation:Rule:MaxBatchSize"
           }
         }
       },
       "IdentityUserCacheSyncStaleResponse": {
-        "required": [
-          "refreshedCount"
-        ],
+        "required": ["refreshedCount"],
         "type": "object",
         "properties": {
           "refreshedCount": {
@@ -789,43 +1008,23 @@
         }
       },
       "IdentityUserResponse": {
-        "required": [
-          "userId",
-          "username",
-          "email",
-          "firstName",
-          "lastName",
-          "enabled",
-          "metadata"
-        ],
+        "required": ["userId", "username", "email", "firstName", "lastName", "enabled", "metadata"],
         "type": "object",
         "properties": {
           "userId": {
             "type": "string"
           },
           "username": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "email": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "firstName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "lastName": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           },
           "enabled": {
             "type": "boolean"
@@ -839,11 +1038,7 @@
         }
       },
       "PagedResultOfIdentityUserResponse": {
-        "required": [
-          "items",
-          "totalCount",
-          "hasMore"
-        ],
+        "required": ["items", "totalCount", "hasMore"],
         "type": "object",
         "properties": {
           "items": {
@@ -853,20 +1048,14 @@
             }
           },
           "totalCount": {
-            "type": [
-              "null",
-              "integer"
-            ],
+            "type": ["null", "integer"],
             "format": "int32"
           },
           "hasMore": {
             "type": "boolean"
           },
           "nextCursor": {
-            "type": [
-              "null",
-              "string"
-            ]
+            "type": ["null", "string"]
           }
         }
       },
@@ -894,6 +1083,121 @@
             "description": "A URI reference that identifies the specific occurrence."
           }
         }
+      },
+      "UserDeviceResponse": {
+        "required": [
+          "deviceId",
+          "kind",
+          "operatingSystem",
+          "browser",
+          "lastSeen",
+          "sessionCount",
+          "lastLocation"
+        ],
+        "type": "object",
+        "properties": {
+          "deviceId": {
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/DeviceKind"
+          },
+          "operatingSystem": {
+            "type": ["null", "string"]
+          },
+          "browser": {
+            "type": ["null", "string"]
+          },
+          "lastSeen": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "sessionCount": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "lastLocation": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/GeoLocation"
+              }
+            ]
+          }
+        }
+      },
+      "UserSessionResponse": {
+        "required": [
+          "sessionId",
+          "isCurrent",
+          "createdAt",
+          "lastAccessedAt",
+          "userAgent",
+          "location",
+          "riskLevel",
+          "riskReasons"
+        ],
+        "type": "object",
+        "properties": {
+          "sessionId": {
+            "type": "string"
+          },
+          "isCurrent": {
+            "type": "boolean"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "lastAccessedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "userAgent": {
+            "type": ["null", "string"]
+          },
+          "location": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/GeoLocation"
+              }
+            ]
+          },
+          "riskLevel": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/UserSessionRiskLevel"
+              }
+            ]
+          },
+          "riskReasons": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "UserSessionRiskLevel": {
+        "enum": ["None", "Low", "Medium", "High", null]
+      },
+      "UserSessionsRevokedResponse": {
+        "required": ["revokedCount"],
+        "type": "object",
+        "properties": {
+          "revokedCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
       }
     }
   },
@@ -903,6 +1207,9 @@
     },
     {
       "name": "Identity - Webhook"
+    },
+    {
+      "name": "User Sessions"
     }
   ]
 }


### PR DESCRIPTION
## Context

`Granit.Identity.Endpoints` now owns the self-service session/device API. On the backend OpenAPI generator (`GeneratorEndpoints.All`), the `identity` document slug now calls `MapGranitUserSessions()`, and the standalone `user-sessions` document is gone. So `/sessions`, `/sessions/{sessionId}` and `/devices` are emitted in the **identity** document instead of the retired **user-sessions** one.

**The HTTP contract is unchanged** — same paths, same payloads, identical `UserSessionResponse` / `UserDeviceResponse`. Only the OpenAPI *document grouping* moved.

## What changed (front)

A single vendored snapshot: `contracts/openapi/identity.json` gains the three routes and their schemas (`UserSessionResponse`, `UserDeviceResponse`, `UserSessionRiskLevel`, `UserSessionsRevokedResponse`). All pre-existing `/identity/users/*` + `/identity/webhook` paths are retained.

Regenerated through the sanctioned path, not hand-edited:

```bash
# granit-dotnet
dotnet build src/Granit.OpenApi.Generator --no-incremental
# granit-front
node scripts/sync-openapi-contracts.mjs identity
```

## Why no code change

The front client is **hand-written** (`@granit/identity` DTOs `IdentitySession` / `IdentityDeviceActivity`, API in `identity-provider-session-api.ts`) — there is no openapi-typescript/Orval codegen here. Because the routes and payloads are identical, the DTOs need no adaptation. The front never vendored a `user-sessions.json` snapshot, so nothing to delete.

The only `user-sessions` references in front `src/` are `import type { UserSessionRiskLevel } from '@granit/user-sessions'` — the shared geo/risk **contracts** package, which is unaffected by the route move. No module import/path breaks.

## Verification

- `pnpm tsc` — clean (exit 0)
- `pnpm lint` — clean (exit 0)
- Vitest (session API + contract conformance) — 134 passed