### PR TITLE
feat(identity): cache pseudonymize endpoint + return refreshed users from sync

### DIFF
--- a/packages/@granit/identity/src/__tests__/identity-user-cache-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-user-cache-api.test.ts
@@ -7,6 +7,7 @@ import {
   eraseUserCache,
   getCacheStats,
   getUserById,
+  pseudonymizeUserCache,
   searchUsers,
   syncAllUsers,
   syncStaleUsers,
@@ -126,11 +127,11 @@ describe('identity-user-cache-api', () => {
   });
 
   describe('syncUsers', () => {
-    it('should POST {basePath}/sync with userIds body', async () => {
+    it('should POST {basePath}/sync with userIds body and return refreshed users', async () => {
       const client = createMockClient();
-      vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
+      vi.mocked(client.post).mockResolvedValue(axiosResponse([sampleUser]));
 
-      await syncUsers(client, basePath, [
+      const actual = await syncUsers(client, basePath, [
         toEntityId<'User'>('user-1'),
         toEntityId<'User'>('user-2'),
       ]);
@@ -138,6 +139,7 @@ describe('identity-user-cache-api', () => {
       expect(client.post).toHaveBeenCalledWith(`${basePath}/sync`, {
         userIds: [toEntityId<'User'>('user-1'), toEntityId<'User'>('user-2')],
       });
+      expect(actual).toEqual([sampleUser]);
     });
   });
 
@@ -185,6 +187,28 @@ describe('identity-user-cache-api', () => {
 
       expect(client.delete).toHaveBeenCalledWith(
         `${basePath}/${encodeURIComponent('user/special@id')}`
+      );
+    });
+  });
+
+  describe('pseudonymizeUserCache', () => {
+    it('should PATCH {basePath}/{userId}/pseudonymize', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
+
+      await pseudonymizeUserCache(client, basePath, toEntityId<'User'>('user-1'));
+
+      expect(client.patch).toHaveBeenCalledWith(`${basePath}/user-1/pseudonymize`);
+    });
+
+    it('should encode userId with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
+
+      await pseudonymizeUserCache(client, basePath, toEntityId<'User'>('user/special@id'));
+
+      expect(client.patch).toHaveBeenCalledWith(
+        `${basePath}/${encodeURIComponent('user/special@id')}/pseudonymize`
       );
     });
   });

--- a/packages/@granit/identity/src/api/identity-user-cache-api.ts
+++ b/packages/@granit/identity/src/api/identity-user-cache-api.ts
@@ -65,7 +65,7 @@ export async function getCacheStats(
 }
 
 /**
- * Trigger a cache sync for specific user IDs.
+ * Trigger a cache sync for specific user IDs and return the refreshed records.
  *
  * `POST {basePath}/sync`
  */
@@ -73,8 +73,9 @@ export async function syncUsers(
   client: AxiosInstance,
   basePath: string,
   userIds: readonly UserId[]
-): Promise<void> {
-  await client.post(`${basePath}/sync`, { userIds });
+): Promise<readonly IdentityUser[]> {
+  const response = await client.post<readonly IdentityUser[]>(`${basePath}/sync`, { userIds });
+  return response.data;
 }
 
 /**
@@ -114,4 +115,18 @@ export async function eraseUserCache(
   userId: UserId
 ): Promise<void> {
   await client.delete(`${basePath}/${encodeURIComponent(userId)}`);
+}
+
+/**
+ * Pseudonymize a user's cached data (GDPR Art. 18 — replaces PII with
+ * anonymized placeholders while preserving the entry for referential integrity).
+ *
+ * `PATCH {basePath}/{userId}/pseudonymize`
+ */
+export async function pseudonymizeUserCache(
+  client: AxiosInstance,
+  basePath: string,
+  userId: UserId
+): Promise<void> {
+  await client.patch(`${basePath}/${encodeURIComponent(userId)}/pseudonymize`);
 }

--- a/packages/@granit/identity/src/index.ts
+++ b/packages/@granit/identity/src/index.ts
@@ -27,6 +27,7 @@ export {
   eraseUserCache,
   getCacheStats,
   getUserById,
+  pseudonymizeUserCache,
   searchUsers,
   syncAllUsers,
   syncStaleUsers,

--- a/packages/@granit/react-identity/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-identity/src/__tests__/testing-handlers.test.ts
@@ -1,7 +1,7 @@
 import { createMswServer } from '@granit/testing/msw-server';
 import { describe, expect, it } from 'vitest';
 
-import { createIdentityHandlers, identityUserQueryMetadata } from '../testing/index';
+import { createIdentityHandlers, identityUserQueryMetadata, mockUsers } from '../testing/index';
 
 const PROVIDER_BASE = 'http://api.test/api/v1/identity/provider';
 const CACHE_BASE = 'http://api.test/api/v1/identity/users';
@@ -13,5 +13,29 @@ describe('createIdentityHandlers /meta', () => {
     const response = await fetch(`${CACHE_BASE}/meta`);
     expect(response.status).toBe(200);
     expect(await response.json()).toEqual(identityUserQueryMetadata);
+  });
+});
+
+describe('createIdentityHandlers cache sync + GDPR', () => {
+  it('POST cacheBase/sync returns the refreshed user records', async () => {
+    server.use(...createIdentityHandlers(PROVIDER_BASE, CACHE_BASE));
+    const userId = mockUsers[0]!.userId;
+    const response = await fetch(`${CACHE_BASE}/sync`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ userIds: [userId] }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as ReadonlyArray<{ userId: string }>;
+    expect(body).toHaveLength(1);
+    expect(body[0]!.userId).toBe(userId);
+  });
+
+  it('PATCH cacheBase/{userId}/pseudonymize responds 204', async () => {
+    server.use(...createIdentityHandlers(PROVIDER_BASE, CACHE_BASE));
+    const response = await fetch(`${CACHE_BASE}/${mockUsers[0]!.userId}/pseudonymize`, {
+      method: 'PATCH',
+    });
+    expect(response.status).toBe(204);
   });
 });

--- a/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-rgpd.test.tsx
@@ -52,6 +52,20 @@ describe('useIdentityRgpd', () => {
     expect(client.delete).toHaveBeenCalledWith('/api/v1/identity/users/user-1');
   });
 
+  it('pseudonymize mutation patches user cache', async () => {
+    const client = createMockClient();
+    vi.mocked(client.patch).mockResolvedValue({ data: undefined });
+
+    const { result } = renderHook(() => useIdentityRgpd(), {
+      wrapper: createWrapper(client),
+    });
+
+    result.current.pseudonymize.mutate(toEntityId<'User'>('user-1'));
+
+    await waitFor(() => expect(result.current.pseudonymize.isSuccess).toBe(true));
+    expect(client.patch).toHaveBeenCalledWith('/api/v1/identity/users/user-1/pseudonymize');
+  });
+
   it('uses custom basePath', async () => {
     const client = createMockClient();
     vi.mocked(client.delete).mockResolvedValue({ data: undefined });

--- a/packages/@granit/react-identity/src/__tests__/use-identity-sync.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-identity-sync.test.tsx
@@ -47,7 +47,7 @@ describe('useIdentitySync', () => {
 
   it('sync mutation posts user IDs', async () => {
     const client = createMockClient();
-    vi.mocked(client.post).mockResolvedValue({ data: undefined });
+    vi.mocked(client.post).mockResolvedValue({ data: [] });
 
     const { result } = renderHook(() => useIdentitySync(), {
       wrapper: createWrapper(client),
@@ -59,6 +59,7 @@ describe('useIdentitySync', () => {
     expect(client.post).toHaveBeenCalledWith('/api/v1/identity/users/sync', {
       userIds: [toEntityId<'User'>('user-1'), toEntityId<'User'>('user-2')],
     });
+    expect(result.current.sync.data).toEqual([]);
   });
 
   it('syncAll mutation triggers full sync', async () => {

--- a/packages/@granit/react-identity/src/hooks/use-identity-rgpd.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-rgpd.ts
@@ -1,4 +1,4 @@
-import { eraseUserCache } from '@granit/identity';
+import { eraseUserCache, pseudonymizeUserCache } from '@granit/identity';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider';
@@ -9,31 +9,40 @@ import type { UseMutationResult } from '@tanstack/react-query';
 /**
  * Returns mutations for GDPR-related identity cache operations.
  *
- * - `erase` — hard-delete a user's cached data
+ * - `erase` — hard-delete a user's cached data (Art. 17)
+ * - `pseudonymize` — replace a user's cached PII with anonymized placeholders (Art. 18)
  *
- * Invalidates user queries on success.
+ * Both invalidate user queries on success.
  *
  * @example
  * ```tsx
- * const { erase } = useIdentityRgpd();
+ * const { erase, pseudonymize } = useIdentityRgpd();
  * await erase.mutateAsync('user-id');
+ * await pseudonymize.mutateAsync('user-id');
  * ```
  */
 export function useIdentityRgpd(): {
   erase: UseMutationResult<void, Error, UserId>;
+  pseudonymize: UseMutationResult<void, Error, UserId>;
 } {
   const config = useIdentityConfig();
   const queryClient = useQueryClient();
   const basePath = config.basePath;
 
+  const invalidateUsers = () =>
+    queryClient.invalidateQueries({
+      queryKey: buildIdentityQueryKey(config, 'users'),
+    });
+
   const erase = useMutation({
     mutationFn: (userId: UserId) => eraseUserCache(config.client, basePath, userId),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: buildIdentityQueryKey(config, 'users'),
-      });
-    },
+    onSuccess: invalidateUsers,
   });
 
-  return { erase };
+  const pseudonymize = useMutation({
+    mutationFn: (userId: UserId) => pseudonymizeUserCache(config.client, basePath, userId),
+    onSuccess: invalidateUsers,
+  });
+
+  return { erase, pseudonymize };
 }

--- a/packages/@granit/react-identity/src/hooks/use-identity-sync.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-sync.ts
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider';
 
 import type {
+  IdentityUser,
   IdentityUserCacheSyncAllResult,
   IdentityUserCacheSyncStaleResult,
 } from '@granit/identity';
@@ -13,7 +14,7 @@ import type { UseMutationResult } from '@tanstack/react-query';
 /**
  * Returns mutations for synchronizing the identity user cache.
  *
- * - `sync` — sync specific user IDs, invalidates user list queries
+ * - `sync` — sync specific user IDs (resolves to the refreshed records), invalidates user list queries
  * - `syncAll` — full sync of all identity provider users, invalidates all identity queries
  * - `syncStale` — sync stale entries only, invalidates user list queries
  *
@@ -26,7 +27,7 @@ import type { UseMutationResult } from '@tanstack/react-query';
  * ```
  */
 export function useIdentitySync(): {
-  sync: UseMutationResult<void, Error, UserId[]>;
+  sync: UseMutationResult<readonly IdentityUser[], Error, UserId[]>;
   syncAll: UseMutationResult<IdentityUserCacheSyncAllResult, Error, void>;
   syncStale: UseMutationResult<IdentityUserCacheSyncStaleResult, Error, void>;
 } {

--- a/packages/@granit/react-identity/src/testing/handlers.ts
+++ b/packages/@granit/react-identity/src/testing/handlers.ts
@@ -284,11 +284,19 @@ export function createIdentityHandlers(
       return HttpResponse.json(users);
     }),
 
-    http.post(`${cacheBase}/sync`, () => new HttpResponse(null, { status: 204 })),
+    http.post(`${cacheBase}/sync`, async ({ request }) => {
+      const body = (await request.json()) as { userIds: string[] };
+      const users = body.userIds
+        .map((id) => mockUsers.find((u) => u.userId === id))
+        .filter(Boolean)
+        .map((u) => toIdentityUser(u!));
+      return HttpResponse.json(users);
+    }),
     http.post(`${cacheBase}/sync-all`, () => HttpResponse.json({ syncedCount: mockUsers.length })),
     http.post(`${cacheBase}/sync-stale`, () => HttpResponse.json({ refreshedCount: 2 })),
 
     http.delete(`${cacheBase}/:userId`, () => new HttpResponse(null, { status: 204 })),
+    http.patch(`${cacheBase}/:userId/pseudonymize`, () => new HttpResponse(null, { status: 204 })),
 
     // ── Provider user endpoints (/identity/provider) ───────────────────────
 


### PR DESCRIPTION
## Summary

Closes two cache contract-conformance gaps from the `@granit/identity` audit. Independent of #635 (no shared files except the generated index).

## Changes

### GAP — missing `pseudonymize` (GDPR Art. 18)
The backend `PATCH /identity/users/{userId}/pseudonymize` (204) and the `Identity.Users.Delete` permission already existed, but the front had no function/hook.
- Add `pseudonymizeUserCache(client, basePath, userId)`.
- Expose it as `useIdentityRgpd().pseudonymize` (invalidates user queries, mirrors `erase`).

### GAP — `syncUsers` discarded its response
The backend returns `IReadOnlyList<IdentityUserResponse>` (`.Produces<…>`), but the front typed `syncUsers` as `Promise<void>` and dropped the body.
- `syncUsers` now returns `readonly IdentityUser[]`; `useIdentitySync().sync` surfaces the refreshed records.

### Mocks adapted to the new API
The identity mocks are centralized in `createIdentityHandlers` (`@granit/react-identity/testing`), which **showcase composes** (host/tenant handlers) — no separate showcase mock.
- `/sync` now returns the resolved users (was `204`).
- Added the `PATCH /{userId}/pseudonymize` → `204` handler.
- Added handler-level tests exercising both.

## Verification
- tsc (identity, react-identity): PASS
- Tests: 118 passing (identity + react-identity), incl. new pseudonymize + sync-array coverage
- ESLint: clean
- Pre-commit hook (gitleaks, lint-staged, tsc, front-index regen): PASS

## Note
Minor type widening: `useIdentitySync().sync` result goes `void` → `readonly IdentityUser[]`. No current consumer reads `sync.data`, so no downstream break.