### PR TITLE
feat(cms): drive sites/pages/menus/releases lists through QueryEngine

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1044,7 +1044,7 @@
         {
           "name": "listSites",
           "kind": "function",
-          "signature": "async function listSites( client: AxiosInstance, basePath: string, params?: ListSitesParams ): Promise<PagedResult<SiteResponse>>"
+          "signature": "async function listSites( client: AxiosInstance, basePath: string, params?: ListSitesParams, options?:"
         },
         {
           "name": "updateSite",
@@ -1069,7 +1069,7 @@
         {
           "name": "listMenus",
           "kind": "function",
-          "signature": "async function listMenus( client: AxiosInstance, basePath: string, params?: ListMenusParams ): Promise<PagedResult<MenuResponse>>"
+          "signature": "async function listMenus( client: AxiosInstance, basePath: string, params?: ListMenusParams, options?:"
         },
         {
           "name": "updateMenu",

--- a/packages/@granit/cms/src/__tests__/menus-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/menus-admin.test.ts
@@ -29,11 +29,11 @@ describe('listMenus', () => {
 
     const result = await listMenus(client, BASE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus`, { params: undefined });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus`, undefined);
     expect(result).toEqual(response);
   });
 
-  it('passes pagination params', async () => {
+  it('serializes the QueryEngine request into the query string', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(
       axiosResponse({ items: [], totalCount: 0, hasMore: false, nextCursor: null })
@@ -41,9 +41,7 @@ describe('listMenus', () => {
 
     await listMenus(client, BASE, { page: 1, pageSize: 20 });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus`, {
-      params: { page: 1, pageSize: 20 },
-    });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/menus?page=1&pageSize=20`, undefined);
   });
 });
 

--- a/packages/@granit/cms/src/__tests__/pages-admin.test.ts
+++ b/packages/@granit/cms/src/__tests__/pages-admin.test.ts
@@ -71,7 +71,7 @@ describe('getPageTree', () => {
 });
 
 describe('listPages', () => {
-  it('GET /api/cms/pages with params', async () => {
+  it('serializes the QueryEngine request into the query string', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(
       axiosResponse({ items: [page], totalCount: 1, hasMore: false, nextCursor: null })
@@ -79,9 +79,7 @@ describe('listPages', () => {
 
     await listPages(client, BASE, { page: 1, pageSize: 20 });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages`, {
-      params: { page: 1, pageSize: 20 },
-    });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/pages?page=1&pageSize=20`, undefined);
   });
 });
 

--- a/packages/@granit/cms/src/__tests__/releases.test.ts
+++ b/packages/@granit/cms/src/__tests__/releases.test.ts
@@ -42,8 +42,22 @@ describe('listReleases', () => {
 
     const result = await listReleases(client, BASE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/releases`, { params: undefined });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/releases`, undefined);
     expect(result).toEqual(response);
+  });
+
+  it('serializes the QueryEngine request into the query string', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(
+      axiosResponse({ items: [], totalCount: 0, hasMore: false, nextCursor: null })
+    );
+
+    await listReleases(client, BASE, { page: 1, pageSize: 20 });
+
+    expect(client.get).toHaveBeenCalledWith(
+      `${BASE}/api/cms/releases?page=1&pageSize=20`,
+      undefined
+    );
   });
 });
 

--- a/packages/@granit/cms/src/__tests__/sites.test.ts
+++ b/packages/@granit/cms/src/__tests__/sites.test.ts
@@ -33,11 +33,11 @@ describe('listSites', () => {
 
     const result = await listSites(client, BASE);
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/sites`, { params: undefined });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/sites`, undefined);
     expect(result).toEqual(response);
   });
 
-  it('passes pagination params', async () => {
+  it('serializes the QueryEngine request into the query string', async () => {
     const client = createMockClient();
     vi.mocked(client.get).mockResolvedValue(
       axiosResponse({ items: [], totalCount: 0, hasMore: false, nextCursor: null })
@@ -45,9 +45,7 @@ describe('listSites', () => {
 
     await listSites(client, BASE, { page: 1, pageSize: 10 });
 
-    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/sites`, {
-      params: { page: 1, pageSize: 10 },
-    });
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/api/cms/sites?page=1&pageSize=10`, undefined);
   });
 });
 

--- a/packages/@granit/cms/src/api/menus-admin.ts
+++ b/packages/@granit/cms/src/api/menus-admin.ts
@@ -1,3 +1,5 @@
+import { getPage } from '@granit/query-engine';
+
 import type {
   CreateMenuRequest,
   ListMenusParams,
@@ -7,16 +9,14 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
 
-/** `GET /api/cms/menus` — paged list. Requires `Cms.Menus.Read`. */
+/** `GET /api/cms/menus` — QueryEngine grid (filter/sort/quickFilters). Requires `Cms.Menus.Read`. */
 export async function listMenus(
   client: AxiosInstance,
   basePath: string,
-  params?: ListMenusParams
+  params?: ListMenusParams,
+  options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<MenuResponse>> {
-  const res = await client.get<PagedResult<MenuResponse>>(`${basePath}/api/cms/menus`, {
-    params,
-  });
-  return res.data;
+  return getPage<MenuResponse>(client, `${basePath}/api/cms/menus`, params ?? {}, options);
 }
 
 /** `GET /api/cms/menus/{id}`. Requires `Cms.Menus.Read`. */

--- a/packages/@granit/cms/src/api/pages-admin.ts
+++ b/packages/@granit/cms/src/api/pages-admin.ts
@@ -1,3 +1,5 @@
+import { getPage as getResultsPage } from '@granit/query-engine';
+
 import type {
   CreatePageRequest,
   ListPagesParams,
@@ -26,16 +28,14 @@ export async function getPageTree(
   return res.data;
 }
 
-/** `GET /api/cms/pages` — paged list. Requires `Cms.Pages.Read`. */
+/** `GET /api/cms/pages` — QueryEngine grid (filter/sort/quickFilters). Requires `Cms.Pages.Read`. */
 export async function listPages(
   client: AxiosInstance,
   basePath: string,
-  params?: ListPagesParams
+  params?: ListPagesParams,
+  options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<PageResponse>> {
-  const res = await client.get<PagedResult<PageResponse>>(`${basePath}/api/cms/pages`, {
-    params,
-  });
-  return res.data;
+  return getResultsPage<PageResponse>(client, `${basePath}/api/cms/pages`, params ?? {}, options);
 }
 
 /** `GET /api/cms/pages/{id}`. Requires `Cms.Pages.Read`. */

--- a/packages/@granit/cms/src/api/pages.ts
+++ b/packages/@granit/cms/src/api/pages.ts
@@ -41,7 +41,7 @@ export async function mintPreviewToken(
   request: MintPreviewTokenRequest
 ): Promise<MintPreviewTokenResponse> {
   const response = await client.post<MintPreviewTokenResponse>(
-    `${basePath}/api/cms/pages/${pageId}/preview-token`,
+    `${basePath}/api/cms/pages/${encodeURIComponent(pageId)}/preview-token`,
     request
   );
   return response.data;

--- a/packages/@granit/cms/src/api/releases.ts
+++ b/packages/@granit/cms/src/api/releases.ts
@@ -1,3 +1,5 @@
+import { getPage } from '@granit/query-engine';
+
 import type {
   AddReleaseActionRequest,
   CreateReleaseRequest,
@@ -9,16 +11,14 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
 
-/** `GET /api/cms/releases` — paged list. Requires `Cms.Releases.Read`. */
+/** `GET /api/cms/releases` — QueryEngine grid (filter/sort/quickFilters). Requires `Cms.Releases.Read`. */
 export async function listReleases(
   client: AxiosInstance,
   basePath: string,
-  params?: ListReleasesParams
+  params?: ListReleasesParams,
+  options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<ReleaseResponse>> {
-  const res = await client.get<PagedResult<ReleaseResponse>>(`${basePath}/api/cms/releases`, {
-    params,
-  });
-  return res.data;
+  return getPage<ReleaseResponse>(client, `${basePath}/api/cms/releases`, params ?? {}, options);
 }
 
 /** `GET /api/cms/releases/{id}`. Requires `Cms.Releases.Read`. */

--- a/packages/@granit/cms/src/api/sites.ts
+++ b/packages/@granit/cms/src/api/sites.ts
@@ -1,3 +1,5 @@
+import { getPage } from '@granit/query-engine';
+
 import type {
   CreateSiteRequest,
   ListSitesParams,
@@ -7,16 +9,14 @@ import type {
 import type { AxiosInstance } from '@granit/api-client';
 import type { PagedResult } from '@granit/query-engine';
 
-/** `GET /api/cms/sites` — list sites (paged). Requires `Cms.Sites.Read`. */
+/** `GET /api/cms/sites` — QueryEngine grid (filter/sort/quickFilters). Requires `Cms.Sites.Read`. */
 export async function listSites(
   client: AxiosInstance,
   basePath: string,
-  params?: ListSitesParams
+  params?: ListSitesParams,
+  options?: { readonly signal?: AbortSignal }
 ): Promise<PagedResult<SiteResponse>> {
-  const res = await client.get<PagedResult<SiteResponse>>(`${basePath}/api/cms/sites`, {
-    params,
-  });
-  return res.data;
+  return getPage<SiteResponse>(client, `${basePath}/api/cms/sites`, params ?? {}, options);
 }
 
 /** `GET /api/cms/sites/{id}`. Requires `Cms.Sites.Read`. */

--- a/packages/@granit/cms/src/types/index.ts
+++ b/packages/@granit/cms/src/types/index.ts
@@ -7,7 +7,7 @@
  * Source of truth: the running backend's OpenAPI spec.
  */
 
-import type { PaginationParams } from '@granit/query-engine';
+import type { QueryRequest } from '@granit/query-engine';
 
 // ─── Block Catalog ──────────────────────────────────────────────────────────
 
@@ -400,21 +400,22 @@ export interface ScheduleReleaseRequest {
 // ─── List params (admin) ─────────────────────────────────────────────────────
 //
 // All admin list endpoints are mapped via `MapGranitQuery<T>()` on the backend,
-// which binds the standard QueryEngine request (page/pageSize/filters/sort/…).
-// We expose only the pagination surface here; site scoping and free-text search
-// are QueryEngine filters, not ad-hoc query keys.
+// which binds the standard QueryEngine request (page/pageSize/filter/sort/
+// quickFilters/…). We expose the full `QueryRequest` so callers can drive
+// server-side filtering, sorting and quick filters — same as the sibling CMS
+// grids (`@granit/cms-redirects`, `@granit/cms-seo`).
 
-/** Query parameters for `GET /api/cms/sites` (paged). */
-export type ListSitesParams = PaginationParams;
+/** Query parameters for `GET /api/cms/sites` (QueryEngine grid). */
+export type ListSitesParams = QueryRequest;
 
-/** Query parameters for `GET /api/cms/pages` (paged). */
-export type ListPagesParams = PaginationParams;
+/** Query parameters for `GET /api/cms/pages` (QueryEngine grid). */
+export type ListPagesParams = QueryRequest;
 
-/** Query parameters for `GET /api/cms/menus` (paged). */
-export type ListMenusParams = PaginationParams;
+/** Query parameters for `GET /api/cms/menus` (QueryEngine grid). */
+export type ListMenusParams = QueryRequest;
 
-/** Query parameters for `GET /api/cms/releases` (paged). */
-export type ListReleasesParams = PaginationParams;
+/** Query parameters for `GET /api/cms/releases` (QueryEngine grid). */
+export type ListReleasesParams = QueryRequest;
 
 /**
  * Result of {@link saveDraft}.

--- a/packages/@granit/react-cms/src/__tests__/use-menus-admin.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-menus-admin.test.ts
@@ -58,7 +58,12 @@ describe('useMenus', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listMenus).toHaveBeenCalledWith(client, '', { page: 1, pageSize: 20 });
+    expect(listMenus).toHaveBeenCalledWith(
+      client,
+      '',
+      { page: 1, pageSize: 20 },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 });
 

--- a/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-pages.test.ts
@@ -103,7 +103,12 @@ describe('usePages', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listPages).toHaveBeenCalledWith(client, '', { page: 1, pageSize: 20 });
+    expect(listPages).toHaveBeenCalledWith(
+      client,
+      '',
+      { page: 1, pageSize: 20 },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 });
 

--- a/packages/@granit/react-cms/src/__tests__/use-releases.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-releases.test.ts
@@ -61,7 +61,12 @@ describe('useReleases', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listReleases).toHaveBeenCalledWith(client, '', { page: 1, pageSize: 20 });
+    expect(listReleases).toHaveBeenCalledWith(
+      client,
+      '',
+      { page: 1, pageSize: 20 },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 });
 

--- a/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
+++ b/packages/@granit/react-cms/src/__tests__/use-sites.test.ts
@@ -60,7 +60,12 @@ describe('useSites', () => {
     const { result } = renderHook(() => useSites(), { wrapper: createWrapper(client) });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listSites).toHaveBeenCalledWith(client, '', undefined);
+    expect(listSites).toHaveBeenCalledWith(
+      client,
+      '',
+      undefined,
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
     expect(result.current.data).toEqual(paged);
   });
 
@@ -78,7 +83,12 @@ describe('useSites', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(listSites).toHaveBeenCalledWith(client, '', { page: 1, pageSize: 10 });
+    expect(listSites).toHaveBeenCalledWith(
+      client,
+      '',
+      { page: 1, pageSize: 10 },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
   });
 });
 

--- a/packages/@granit/react-cms/src/hooks/use-menus-admin.ts
+++ b/packages/@granit/react-cms/src/hooks/use-menus-admin.ts
@@ -18,7 +18,7 @@ export function useMenus(
   const { client, basePath, queryKeyPrefix } = useCmsConfig();
   return useQuery({
     queryKey: cmsKeys.menus.list(queryKeyPrefix, params),
-    queryFn: () => listMenus(client, basePath, params),
+    queryFn: ({ signal }) => listMenus(client, basePath, params, { signal }),
     enabled: options?.enabled ?? true,
     staleTime: 30_000,
   });

--- a/packages/@granit/react-cms/src/hooks/use-pages.ts
+++ b/packages/@granit/react-cms/src/hooks/use-pages.ts
@@ -35,7 +35,7 @@ export function usePages(
   const { client, basePath, queryKeyPrefix } = useCmsConfig();
   return useQuery({
     queryKey: cmsKeys.pages.list(queryKeyPrefix, params),
-    queryFn: () => listPages(client, basePath, params),
+    queryFn: ({ signal }) => listPages(client, basePath, params, { signal }),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/@granit/react-cms/src/hooks/use-releases.ts
+++ b/packages/@granit/react-cms/src/hooks/use-releases.ts
@@ -18,7 +18,7 @@ export function useReleases(
   const { client, basePath, queryKeyPrefix } = useCmsConfig();
   return useQuery({
     queryKey: cmsKeys.releases.list(queryKeyPrefix, params),
-    queryFn: () => listReleases(client, basePath, params),
+    queryFn: ({ signal }) => listReleases(client, basePath, params, { signal }),
     enabled: options?.enabled ?? true,
     staleTime: 30_000,
   });

--- a/packages/@granit/react-cms/src/hooks/use-sites.ts
+++ b/packages/@granit/react-cms/src/hooks/use-sites.ts
@@ -18,7 +18,7 @@ export function useSites(
   const { client, basePath, queryKeyPrefix } = useCmsConfig();
   return useQuery({
     queryKey: cmsKeys.sites.list(queryKeyPrefix, params),
-    queryFn: () => listSites(client, basePath, params),
+    queryFn: ({ signal }) => listSites(client, basePath, params, { signal }),
     enabled: options?.enabled ?? true,
     staleTime: 30_000,
   });


### PR DESCRIPTION
## Context

Found via \`/audit --scope api\` over the CMS package family.

The four CMS admin lists — \`sites\`, \`pages\`, \`menus\`, \`releases\` — mirror \`MapGranitQuery<T>\` grids on the backend (\`QuerySite\`/\`QueryPage\`/\`QueryMenu\`/\`QueryRelease\` + companion \`/meta\`), exposing the full query surface: \`filter\`, \`sort\`, \`search\`, \`quickFilters\`, \`presets\`, \`cursor\`, \`skipTotalCount\`.

The frontend typed their params as bare \`PaginationParams\` and dumped the object into axios \`{ params }\` — silently dropping server-side filtering/sorting/quick-filters and the \`/meta\` descriptor. The two sibling CMS grids (\`@granit/cms-redirects\` → \`getRedirectsGrid\`, \`@granit/cms-seo\` → \`listSeoMetadata\`) already use the canonical \`QueryRequest\` + query-engine serializer pattern. This aligns the remaining four.

## Changes

- **types** — \`ListSitesParams\`/\`ListPagesParams\`/\`ListMenusParams\`/\`ListReleasesParams\`: \`PaginationParams → QueryRequest\` (source-compatible widening).
- **api** — \`listSites\`/\`listPages\`/\`listMenus\`/\`listReleases\` now route through \`getPage<T>()\` (canonical \`filter[field.op]=value\` serialization + \`AbortSignal\` support).
- **react-cms hooks** — wire \`{ signal }\` for request cancellation (matches \`useRedirectsGrid\`).
- **fix** — \`encodeURIComponent\` on \`pageId\` in \`mintPreviewToken\` (the only un-encoded dynamic segment in the package family).

\`/meta\` is now reachable for these grids via the generic \`getQueryMeta\`/\`useQueryMeta\` from \`@granit/query-engine\` — no per-package meta function needed (consistent with redirects/seo).

## Compatibility

Backward-compatible. \`showcase-admin-react\` calls \`useSites()\`/\`useReleases()\`/\`useMenus()\` with no args — verified \`tsc --noEmit\` clean against this branch. The new filter/sort/quickFilter capability is purely additive.

## Verification

- \`tsc --noEmit\` — clean (\`@granit/cms\`, \`@granit/react-cms\`, and showcase consumer)
- \`eslint --max-warnings 0\` — clean
- \`vitest run\` — **265 passed**