### PR TITLE
refactor(identity): pass typed request DTOs to provider write fns

### DIFF
--- a/packages/@granit/identity/src/__tests__/identity-provider-password-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-password-api.test.ts
@@ -65,7 +65,9 @@ describe('identity-provider-password-api', () => {
       const client = createMockClient();
       vi.mocked(client.post).mockResolvedValue(axiosResponse(undefined));
 
-      await setTemporaryPassword(client, basePath, 'user-1', 'temp123!');
+      await setTemporaryPassword(client, basePath, toEntityId<'User'>('user-1'), {
+        password: 'temp123!',
+      });
 
       expect(client.post).toHaveBeenCalledWith(`${basePath}/users/user-1/password/temporary`, {
         password: 'temp123!',

--- a/packages/@granit/identity/src/__tests__/identity-provider-user-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/identity-provider-user-api.test.ts
@@ -118,7 +118,7 @@ describe('identity-provider-user-api', () => {
       const client = createMockClient();
       vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
 
-      await setUserEnabled(client, basePath, toEntityId<'User'>('user-1'), false);
+      await setUserEnabled(client, basePath, toEntityId<'User'>('user-1'), { enabled: false });
 
       expect(client.patch).toHaveBeenCalledWith(`${basePath}/users/user-1/enabled`, {
         enabled: false,
@@ -129,7 +129,9 @@ describe('identity-provider-user-api', () => {
       const client = createMockClient();
       vi.mocked(client.patch).mockResolvedValue(axiosResponse(undefined));
 
-      await setUserEnabled(client, basePath, toEntityId<'User'>('user/special@id'), true);
+      await setUserEnabled(client, basePath, toEntityId<'User'>('user/special@id'), {
+        enabled: true,
+      });
 
       expect(client.patch).toHaveBeenCalledWith(
         `${basePath}/users/${encodeURIComponent('user/special@id')}/enabled`,

--- a/packages/@granit/identity/src/api/identity-provider-password-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-password-api.ts
@@ -1,4 +1,7 @@
-import type { IdentityPasswordChangedAtResponse } from '../types/index';
+import type {
+  IdentityPasswordChangedAtResponse,
+  IdentitySetTemporaryPasswordRequest,
+} from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
 import type { UserId } from '@granit/types';
 
@@ -40,10 +43,11 @@ export async function sendPasswordResetEmail(
 export async function setTemporaryPassword(
   client: AxiosInstance,
   basePath: string,
-  userId: string,
-  password: string
+  userId: UserId,
+  request: IdentitySetTemporaryPasswordRequest
 ): Promise<void> {
-  await client.post(`${basePath}/users/${encodeURIComponent(userId)}/password/temporary`, {
-    password,
-  });
+  await client.post(
+    `${basePath}/users/${encodeURIComponent(userId)}/password/temporary`,
+    request
+  );
 }

--- a/packages/@granit/identity/src/api/identity-provider-user-api.ts
+++ b/packages/@granit/identity/src/api/identity-provider-user-api.ts
@@ -2,6 +2,7 @@ import type {
   IdentityProviderUserListParams,
   IdentityUser,
   IdentityUserCreateRequest,
+  IdentityUserSetEnabledRequest,
   IdentityUserUpdateRequest,
 } from '../types/index';
 import type { AxiosInstance } from '@granit/api-client';
@@ -79,7 +80,7 @@ export async function setUserEnabled(
   client: AxiosInstance,
   basePath: string,
   userId: UserId,
-  enabled: boolean
+  request: IdentityUserSetEnabledRequest
 ): Promise<void> {
-  await client.patch(`${basePath}/users/${encodeURIComponent(userId)}/enabled`, { enabled });
+  await client.patch(`${basePath}/users/${encodeURIComponent(userId)}/enabled`, request);
 }

--- a/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-passwords.ts
@@ -79,6 +79,6 @@ export function useSetTemporaryPassword(): UseMutationResult<
 
   return useMutation({
     mutationFn: ({ userId, password }: SetTemporaryPasswordVariables) =>
-      setTemporaryPassword(config.client, basePath, userId, password),
+      setTemporaryPassword(config.client, basePath, userId, { password }),
   });
 }

--- a/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
+++ b/packages/@granit/react-identity/src/hooks/use-identity-provider-users.ts
@@ -140,7 +140,7 @@ export function useSetUserEnabled(): UseMutationResult<void, Error, SetUserEnabl
 
   return useMutation({
     mutationFn: ({ userId, enabled }: SetUserEnabledVariables) =>
-      setUserEnabled(config.client, basePath, userId, enabled),
+      setUserEnabled(config.client, basePath, userId, { enabled }),
     onSuccess: () => {
       queryClient.invalidateQueries({
         queryKey: buildIdentityQueryKey(config, 'provider', 'users'),


### PR DESCRIPTION
## What

`setUserEnabled` and `setTemporaryPassword` in `@granit/identity` now accept their exported request DTOs (`IdentityUserSetEnabledRequest` / `IdentitySetTemporaryPasswordRequest`) instead of bare scalars — consistent with `createUser`/`updateUser`. This wires up two previously-unused exported types. `setTemporaryPassword`'s `userId` is now the branded `UserId` like every other function in the package.

`react-identity` hooks updated to pass `{ enabled }` / `{ password }`.

## Why

Surfaced by `/audit --scope api identity*`: the two write functions inlined `{ enabled }` / `{ password }` while exporting (but never consuming) the matching request DTO types, and `setTemporaryPassword` typed `userId` as a plain `string`.

## Impact

None on consumers — the public hook variables (`SetUserEnabledVariables` / `SetTemporaryPasswordVariables`) are unchanged, so `showcase-admin-react` is unaffected (verified: all usages go through the hooks, no direct core-function imports).

## Verification

- `tsc --noEmit` clean (`@granit/identity`, `@granit/react-identity`)
- ESLint `--max-warnings 0` clean on changed files
- 133 tests passing (22 files)