### PR TITLE
fix(react-presence): stop stale GET from clobbering heartbeat snapshot

### DIFF
--- a/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
+++ b/packages/@granit/react-presence/src/__tests__/use-heartbeat.test.tsx
@@ -3,7 +3,9 @@ import { toEntityId, toISODateString } from '@granit/types';
 import { act, renderHook } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { presenceKeys } from '../hooks/query-keys';
 import { useHeartbeat } from '../hooks/use-heartbeat';
+import { useMyPresence } from '../hooks/use-my-presence';
 
 import { createPresenceTestHarness } from './test-utils';
 
@@ -12,10 +14,10 @@ import type { UserId } from '@granit/types';
 
 vi.mock('@granit/presence', async (importOriginal) => {
   const actual = await importOriginal<Record<string, unknown>>();
-  return { ...actual, pollMyPresence: vi.fn() };
+  return { ...actual, pollMyPresence: vi.fn(), getMyPresence: vi.fn() };
 });
 
-const { pollMyPresence } = await import('@granit/presence');
+const { pollMyPresence, getMyPresence } = await import('@granit/presence');
 
 const snapshot: PresenceResponse = {
   userId: toEntityId<'User'>('user-1') as UserId,
@@ -83,6 +85,43 @@ describe('useHeartbeat', () => {
       await vi.advanceTimersByTimeAsync(0);
     });
     expect(pollMyPresence).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps the heartbeat snapshot when a concurrent useMyPresence GET resolves later with a staler one', async () => {
+    const client = createMockClient();
+    const { wrapper, queryClient } = createPresenceTestHarness(client);
+
+    const offlineSnapshot: PresenceResponse = { ...snapshot, effectiveStatus: 'Offline' };
+    let resolveGet: (value: PresenceResponse) => void = () => {};
+    vi.mocked(getMyPresence).mockReturnValue(
+      new Promise<PresenceResponse>((resolve) => {
+        resolveGet = resolve;
+      })
+    );
+
+    renderHook(
+      () => {
+        useMyPresence();
+        useHeartbeat({ intervalMs: 1_000 });
+      },
+      { wrapper }
+    );
+
+    // Immediate heartbeat resolves (Online) and takes ownership of the cache,
+    // cancelling the still-in-flight GET on the same key.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    // The initial GET resolves last with a stale Offline snapshot — it must not
+    // clobber the authoritative heartbeat result.
+    await act(async () => {
+      resolveGet(offlineSnapshot);
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    const cached = queryClient.getQueryData<PresenceResponse>(['presence', ...presenceKeys.my()]);
+    expect(cached?.effectiveStatus).toBe('Online');
   });
 
   it('does nothing when disabled', async () => {

--- a/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
+++ b/packages/@granit/react-presence/src/hooks/use-heartbeat.ts
@@ -72,6 +72,13 @@ export function useHeartbeat(options: UseHeartbeatOptions = {}): void {
         const idleSeconds = Math.max(0, Math.floor((Date.now() - lastActivityRef.current) / 1000));
         const data = await pollMyPresence(config.client, config.basePath, { idleSeconds });
         if (!cancelled) {
+          // The poll returns the authoritative snapshot, so it owns the cache.
+          // Cancel any in-flight `useMyPresence` GET on the same key first: a
+          // concurrent GET resolving after this write would otherwise clobber
+          // the cache with a staler snapshot (e.g. Offline, captured before the
+          // server registered this heartbeat) and regress the UI until the next
+          // tick. This races on initial mount and on every tab re-focus.
+          await queryClient.cancelQueries({ queryKey });
           queryClient.setQueryData<PresenceResponse>(queryKey, data);
         }
       } catch {


### PR DESCRIPTION
## Problem

`useHeartbeat`'s immediate poll and `useMyPresence`'s GET race on the same React Query key `['presence','my']`:

- [use-my-presence.ts](packages/@granit/react-presence/src/hooks/use-my-presence.ts) — `useQuery` GET `/presence/my` (no `refetchInterval`, 30s `staleTime`)
- [use-heartbeat.ts](packages/@granit/react-presence/src/hooks/use-heartbeat.ts) — immediate `tick()` POST poll → `setQueryData`

When the GET's `queryFn` resolves **after** the poll's `setQueryData`, React Query writes the GET result unconditionally and clobbers the fresh snapshot with a staler one (e.g. `Offline`, captured before the server registered the heartbeat). Nothing corrects it until the next ~30s heartbeat tick — hence the user-visible **Offline → Online after exactly ~30s**. The backend config (HeartbeatCacheTtl 120s > OfflineThreshold 90s) is valid and not involved.

## Fix

After the poll returns its authoritative snapshot, `await queryClient.cancelQueries({ queryKey })` before `setQueryData`. A cancelled query discards its resolved result, so the concurrent GET can no longer regress the cache.

Cancelling **after** the poll (not before) is order-independent: React Query starts `useMyPresence`'s fetch in an effect whose ordering vs `<PresenceHeartbeat>` isn't guaranteed, so a pre-poll cancel could miss a GET that starts slightly later. Once the network poll resolves, the GET is guaranteed in flight. This also closes the identical race on every tab re-focus (`refetchOnWindowFocus` + `start()→tick()`).

## Tests

New regression test asserts the cache stays `Online` when a concurrent `useMyPresence` GET resolves later with a stale `Offline` snapshot. Full `@granit/react-presence` suite: **40 tests pass**; `tsc --noEmit` + ESLint clean.