### PR TITLE
feat(identity): anonymous "Was this you?" session-review contract

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -1672,6 +1672,16 @@
           "signature": "async function getIdentityCapabilities( client: AxiosInstance, basePath: string ): Promise<IdentityProviderCapabilitiesResponse>"
         },
         {
+          "name": "getSessionReviewContext",
+          "kind": "function",
+          "signature": "async function getSessionReviewContext( client: AxiosInstance, basePath: string, token: string ): Promise<SessionReviewContextResponse>"
+        },
+        {
+          "name": "submitSessionReview",
+          "kind": "function",
+          "signature": "async function submitSessionReview( client: AxiosInstance, basePath: string, request: SessionReviewDecisionRequest ): Promise<SessionReviewResultResponse>"
+        },
+        {
           "name": "IdentityPermissions",
           "kind": "const",
           "signature": "const IdentityPermissions"
@@ -5337,6 +5347,16 @@
           "name": "TerminateSessionVariables",
           "kind": "type",
           "signature": "type TerminateSessionVariables = { readonly userId: UserId; readonly sessionId: UserSessionId; }"
+        },
+        {
+          "name": "useSessionReviewContext",
+          "kind": "function",
+          "signature": "function useSessionReviewContext( token: string | null | undefined ): UseQueryResult<SessionReviewContextResponse>"
+        },
+        {
+          "name": "useSubmitSessionReview",
+          "kind": "function",
+          "signature": "function useSubmitSessionReview(): UseMutationResult< SessionReviewResultResponse, Error, SessionReviewDecisionRequest >"
         },
         {
           "name": "SetTemporaryPasswordVariables",

--- a/packages/@granit/identity/src/__tests__/session-review-api.test.ts
+++ b/packages/@granit/identity/src/__tests__/session-review-api.test.ts
@@ -1,0 +1,68 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getSessionReviewContext, submitSessionReview } from '../api/session-review-api';
+
+import type { SessionReviewContextResponse, SessionReviewResultResponse } from '../types/index';
+
+const basePath = '/api/v1';
+
+describe('session-review-api', () => {
+  describe('getSessionReviewContext', () => {
+    it('should GET {basePath}/sessions/review with the token as a query param', async () => {
+      const client = createMockClient();
+      const context: SessionReviewContextResponse = { country: 'Belgium', decision: null };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(context));
+
+      const result = await getSessionReviewContext(client, basePath, 'tok-123');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/sessions/review`, {
+        params: { token: 'tok-123' },
+      });
+      expect(result).toEqual(context);
+    });
+
+    it('should return an already-reviewed context unchanged', async () => {
+      const client = createMockClient();
+      const context: SessionReviewContextResponse = { country: 'France', decision: 'Denied' };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(context));
+
+      const result = await getSessionReviewContext(client, basePath, 'tok-reviewed');
+
+      expect(result).toEqual(context);
+    });
+  });
+
+  describe('submitSessionReview', () => {
+    it('should POST {basePath}/sessions/review with the token and decision', async () => {
+      const client = createMockClient();
+      const outcome: SessionReviewResultResponse = { decision: 'Confirmed', applied: true };
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(outcome));
+
+      const result = await submitSessionReview(client, basePath, {
+        token: 'tok-123',
+        decision: 'Confirmed',
+      });
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/sessions/review`, {
+        token: 'tok-123',
+        decision: 'Confirmed',
+      });
+      expect(result).toEqual(outcome);
+    });
+
+    it('should surface applied=false for an idempotent re-submission', async () => {
+      const client = createMockClient();
+      const outcome: SessionReviewResultResponse = { decision: 'Denied', applied: false };
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(outcome));
+
+      const result = await submitSessionReview(client, basePath, {
+        token: 'tok-123',
+        decision: 'Denied',
+      });
+
+      expect(result.applied).toBe(false);
+      expect(result.decision).toBe('Denied');
+    });
+  });
+});

--- a/packages/@granit/identity/src/api/session-review-api.ts
+++ b/packages/@granit/identity/src/api/session-review-api.ts
@@ -1,0 +1,55 @@
+import type {
+  SessionReviewContextResponse,
+  SessionReviewDecisionRequest,
+  SessionReviewResultResponse,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+// ---------------------------------------------------------------------------
+// "Was this you?" session review — anonymous, token-protected endpoints behind
+// the security-alert email CTA (granit-dotnet #2669). No bearer auth: the token
+// is the only credential. These go through the centralized Axios client like
+// every other session call, but the caller is unauthenticated, so the auth
+// interceptor simply has nothing to attach.
+//
+// The token travels in the query string (GET) or request body (POST) by design
+// — the standard email-action pattern. It is never logged or echoed back.
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the side-effect-free review context for a token
+ * (`GET {basePath}/sessions/review?token=…`). Safe to call on page load.
+ *
+ * @throws AxiosError with `response.status === 400` when the token is invalid
+ *   or expired.
+ */
+export async function getSessionReviewContext(
+  client: AxiosInstance,
+  basePath: string,
+  token: string
+): Promise<SessionReviewContextResponse> {
+  const response = await client.get<SessionReviewContextResponse>(`${basePath}/sessions/review`, {
+    params: { token },
+  });
+  return response.data;
+}
+
+/**
+ * Commit a review decision (`POST {basePath}/sessions/review`). Single-use: a
+ * second submission for the same token resolves with `applied: false` and the
+ * already-recorded decision.
+ *
+ * @throws AxiosError with `response.status === 400` when the token is invalid
+ *   or expired.
+ */
+export async function submitSessionReview(
+  client: AxiosInstance,
+  basePath: string,
+  request: SessionReviewDecisionRequest
+): Promise<SessionReviewResultResponse> {
+  const response = await client.post<SessionReviewResultResponse>(
+    `${basePath}/sessions/review`,
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/identity/src/index.ts
+++ b/packages/@granit/identity/src/index.ts
@@ -19,6 +19,12 @@ export type {
   UserSessionRiskLevel,
   UserSessionsRevokedResponse,
 } from './types/index';
+export type {
+  SessionReviewContextResponse,
+  SessionReviewDecision,
+  SessionReviewDecisionRequest,
+  SessionReviewResultResponse,
+} from './types/index';
 export type { GeoLocation } from './types/index';
 export type { IdentityPasswordChangedAtResponse } from './types/index';
 export type {
@@ -78,6 +84,9 @@ export {
   revokeMyOtherUserSessions,
   revokeMyUserSession,
 } from './api/user-session-api';
+
+// API — Session review ("Was this you?" — anonymous, token-protected)
+export { getSessionReviewContext, submitSessionReview } from './api/session-review-api';
 export {
   getPasswordChangedAt,
   sendPasswordResetEmail,

--- a/packages/@granit/identity/src/types/index.ts
+++ b/packages/@granit/identity/src/types/index.ts
@@ -16,6 +16,12 @@ export type {
   UserSessionResponse,
   UserSessionsRevokedResponse,
 } from './user-session';
+export type {
+  SessionReviewContextResponse,
+  SessionReviewDecision,
+  SessionReviewDecisionRequest,
+  SessionReviewResultResponse,
+} from './session-review';
 
 // Shared session/device contracts re-exported so consumers can type the
 // `location` / `riskLevel` / `kind` fields without reaching into the owning

--- a/packages/@granit/identity/src/types/session-review.ts
+++ b/packages/@granit/identity/src/types/session-review.ts
@@ -1,0 +1,53 @@
+// ---------------------------------------------------------------------------
+// "Was this you?" session review — anonymous, token-protected contract behind
+// the security-alert email CTA. Mirrors Granit.Identity.Endpoints SessionReview
+// DTOs (granit-dotnet #2669). The caller is unauthenticated: the token from the
+// email link is the only credential.
+// ---------------------------------------------------------------------------
+
+/**
+ * The reviewer's verdict on a flagged sign-in. Serialized by the backend as the
+ * PascalCase strings `"Confirmed"` (it was me) / `"Denied"` (it wasn't me).
+ */
+export type SessionReviewDecision = 'Confirmed' | 'Denied';
+
+/**
+ * Side-effect-free review context — mirrors
+ * `Granit.Identity.Endpoints.Dtos.SessionReviewContextResponse`. Fetched on page
+ * load (`GET /sessions/review?token=…`).
+ */
+export type SessionReviewContextResponse = {
+  /** Approximate country of the flagged sign-in, or null when unresolved. */
+  readonly country: string | null;
+  /**
+   * The recorded verdict, or null when the sign-in has not been reviewed yet.
+   * Null → show the Yes/No prompt; non-null → show the recorded outcome.
+   */
+  readonly decision: SessionReviewDecision | null;
+};
+
+/**
+ * Request body for `POST /sessions/review` — mirrors
+ * `Granit.Identity.Endpoints.Dtos.SessionReviewDecisionRequest`. Single-use.
+ */
+export type SessionReviewDecisionRequest = {
+  /** The opaque token from the email link — the only credential. Never logged. */
+  readonly token: string;
+  /** The reviewer's verdict to commit. */
+  readonly decision: SessionReviewDecision;
+};
+
+/**
+ * Result of committing a review — mirrors
+ * `Granit.Identity.Endpoints.Dtos.SessionReviewResultResponse`.
+ */
+export type SessionReviewResultResponse = {
+  /** The verdict now on record. */
+  readonly decision: SessionReviewDecision;
+  /**
+   * Whether THIS request performed the action. `false` when the sign-in had
+   * already been reviewed earlier — an idempotent no-op that still reports the
+   * recorded outcome.
+   */
+  readonly applied: boolean;
+};

--- a/packages/@granit/react-identity/src/__tests__/use-session-review.test.tsx
+++ b/packages/@granit/react-identity/src/__tests__/use-session-review.test.tsx
@@ -1,0 +1,96 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useSessionReviewContext, useSubmitSessionReview } from '../hooks/use-session-review';
+import { IdentityProvider } from '../providers/identity-provider';
+
+import type { IdentityProviderProps } from '../providers/identity-provider';
+import type { SessionReviewContextResponse, SessionReviewResultResponse } from '@granit/identity';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance) {
+  const queryClient = createTestQueryClient();
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const config: IdentityProviderProps['config'] = { client };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <IdentityProvider config={config}>{children}</IdentityProvider>
+    );
+  };
+}
+
+describe('use-session-review', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useSessionReviewContext', () => {
+    it('should GET the review context for the token at /api/v1/sessions/review', async () => {
+      const client = createMockClient();
+      const context: SessionReviewContextResponse = { country: 'Belgium', decision: null };
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(context));
+
+      const { result } = renderHook(() => useSessionReviewContext('tok-123'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/api/v1/sessions/review', {
+        params: { token: 'tok-123' },
+      });
+      expect(result.current.data).toEqual(context);
+    });
+
+    it('should stay disabled (no request) when no token is provided', () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useSessionReviewContext(null), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+
+    it('should surface a 400 (invalid/expired token) as an error without retrying', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockRejectedValue({
+        isAxiosError: true,
+        response: { status: 400 },
+      });
+
+      const { result } = renderHook(() => useSessionReviewContext('bad-token'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isError).toBe(true));
+      expect(client.get).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('useSubmitSessionReview', () => {
+    it('should POST the decision and prime the cached context with the outcome', async () => {
+      const client = createMockClient();
+      const outcome: SessionReviewResultResponse = { decision: 'Denied', applied: true };
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(outcome));
+
+      const { result } = renderHook(() => useSubmitSessionReview(), {
+        wrapper: createWrapper(client),
+      });
+
+      const returned = await result.current.mutateAsync({ token: 'tok-123', decision: 'Denied' });
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/sessions/review', {
+        token: 'tok-123',
+        decision: 'Denied',
+      });
+      expect(returned).toEqual(outcome);
+    });
+  });
+});

--- a/packages/@granit/react-identity/src/hooks/use-session-review.ts
+++ b/packages/@granit/react-identity/src/hooks/use-session-review.ts
@@ -1,0 +1,78 @@
+import { getSessionReviewContext, submitSessionReview } from '@granit/identity';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { buildIdentityQueryKey, useIdentityConfig } from '../providers/identity-provider';
+
+import type {
+  SessionReviewContextResponse,
+  SessionReviewDecisionRequest,
+  SessionReviewResultResponse,
+} from '@granit/identity';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// "Was this you?" session-review hooks — anonymous, token-protected flow behind
+// the security-alert email CTA (granit-dotnet #2669). The token from the email
+// link is the only credential; the page renders without an authenticated
+// session. Served at `/sessions/review` (sessionsBasePath — the API root).
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the side-effect-free review context for a token
+ * (`GET /sessions/review?token=…`). Disabled until a token is present, and not
+ * retried so an invalid/expired token (400) surfaces immediately.
+ *
+ * A 400 surfaces as the query error — inspect `error` for an AxiosError with
+ * `response.status === 400`.
+ *
+ * @example
+ * ```tsx
+ * const { data, isPending, isError } = useSessionReviewContext(token);
+ * ```
+ */
+export function useSessionReviewContext(
+  token: string | null | undefined
+): UseQueryResult<SessionReviewContextResponse> {
+  const config = useIdentityConfig();
+  const basePath = config.sessionsBasePath;
+
+  return useQuery({
+    queryKey: buildIdentityQueryKey(config, 'session-review', token ?? ''),
+    queryFn: () => getSessionReviewContext(config.client, basePath, token!),
+    enabled: Boolean(token),
+    retry: false,
+  });
+}
+
+/**
+ * Commit a review decision (`POST /sessions/review`). Single-use: a second
+ * submission for the same token resolves with `applied: false`. On success the
+ * cached review context for the token is primed with the recorded decision so a
+ * re-render shows the outcome without a refetch.
+ *
+ * @example
+ * ```tsx
+ * const submit = useSubmitSessionReview();
+ * const { decision, applied } = await submit.mutateAsync({ token, decision: 'Denied' });
+ * ```
+ */
+export function useSubmitSessionReview(): UseMutationResult<
+  SessionReviewResultResponse,
+  Error,
+  SessionReviewDecisionRequest
+> {
+  const config = useIdentityConfig();
+  const queryClient = useQueryClient();
+  const basePath = config.sessionsBasePath;
+
+  return useMutation({
+    mutationFn: (request: SessionReviewDecisionRequest) =>
+      submitSessionReview(config.client, basePath, request),
+    onSuccess: (result, variables) => {
+      queryClient.setQueryData<SessionReviewContextResponse>(
+        buildIdentityQueryKey(config, 'session-review', variables.token),
+        (previous) => ({ country: previous?.country ?? null, decision: result.decision })
+      );
+    },
+  });
+}

--- a/packages/@granit/react-identity/src/index.ts
+++ b/packages/@granit/react-identity/src/index.ts
@@ -62,6 +62,9 @@ export {
   useRevokeMyUserSession,
 } from './hooks/use-my-sessions';
 
+// Hooks — Session review ("Was this you?" — anonymous, token-protected)
+export { useSessionReviewContext, useSubmitSessionReview } from './hooks/use-session-review';
+
 // i18next resource bundles (namespace: "identity")
 export { identityTranslationsEn, identityTranslationsFr } from './locales/index';
 export type { IdentityTranslations } from './locales/index';

--- a/packages/@granit/react-identity/src/testing/handlers.ts
+++ b/packages/@granit/react-identity/src/testing/handlers.ts
@@ -232,6 +232,16 @@ export function createIdentityHandlers(
   cacheBase = DEFAULT_BASE_PATH,
   sessionsBase = DEFAULT_SESSIONS_BASE_PATH
 ) {
+  // Mutable per handler-set, so the single-use session-review flow stays
+  // isolated between tests that build their own handlers.
+  const sessionReviews: Record<
+    string,
+    { country: string | null; decision: 'Confirmed' | 'Denied' | null }
+  > = {
+    'valid-review-token': { country: 'Belgium', decision: null },
+    'reviewed-review-token': { country: 'France', decision: 'Confirmed' },
+  };
+
   return [
     // ── Cache endpoints (/identity/users) ───────────────────────────────────
 
@@ -504,5 +514,30 @@ export function createIdentityHandlers(
     http.delete(`${sessionsBase}/sessions`, () =>
       HttpResponse.json({ revokedCount: mockSessions.filter((s) => !s.isCurrent).length })
     ),
+
+    // ── Session review ("Was this you?" — anonymous, token-protected) ───────
+    // Stateful per handler-set so the single-use / idempotency flow is testable.
+    // `valid-review-token` is unreviewed; `reviewed-review-token` already has a
+    // verdict; any other token is treated as invalid/expired (400).
+    http.get(`${sessionsBase}/sessions/review`, ({ request }) => {
+      const token = new URL(request.url).searchParams.get('token');
+      const review = token ? sessionReviews[token] : undefined;
+      if (!review) return new HttpResponse(null, { status: 400 });
+      return HttpResponse.json({ country: review.country, decision: review.decision });
+    }),
+
+    http.post(`${sessionsBase}/sessions/review`, async ({ request }) => {
+      const body = (await request.json()) as {
+        token: string;
+        decision: 'Confirmed' | 'Denied';
+      };
+      const review = sessionReviews[body.token];
+      if (!review) return new HttpResponse(null, { status: 400 });
+      if (review.decision !== null) {
+        return HttpResponse.json({ decision: review.decision, applied: false });
+      }
+      review.decision = body.decision;
+      return HttpResponse.json({ decision: body.decision, applied: true });
+    }),
   ];
 }


### PR DESCRIPTION
## Context

Front-side framework piece for the **"Was this you?"** session-review flow (granit-dotnet #2663). Granit's anomaly detector emails a security alert when a sign-in looks risky; the CTA links to an **anonymous, token-protected** review page (`/account/security/review?token=…`). The backend endpoints are live in granit-dotnet (#2669, tag *Identity – User Sessions*).

This PR adds the **reusable framework surface**; the page + route land in showcase-admin-react (separate MR, opened as Draft until this merges).

## What's here

**`@granit/identity`**
- `SessionReview*` DTOs (`SessionReviewContextResponse`, `SessionReviewDecisionRequest`, `SessionReviewResultResponse`, `SessionReviewDecision = 'Confirmed' | 'Denied'`).
- `getSessionReviewContext` / `submitSessionReview` against `/api/v1/sessions/review` (the `sessionsBasePath` root). No bearer auth — the email token is the only credential, carried in the query string (GET) or body (POST) and **never logged**.

**`@granit/react-identity`**
- `useSessionReviewContext(token)` — query, `enabled` on token, `retry: false` so an invalid/expired token (400) surfaces immediately.
- `useSubmitSessionReview()` — mutation; on success primes the cached context with the recorded decision (single-use / idempotent).
- Stateful MSW handlers for the flow.

## Notes
- Placed in identity (not account): the endpoints are session-scoped at the API root, matching the self-service `/sessions` surface.
- Hand-written DTOs (front doesn't use Orval); they mirror the .NET contract and the OpenAPI client regen is pending the dev-package publish.

## Tests
- `@granit/identity` + `@granit/react-identity`: **141** pass (incl. new api + hook tests).
- `@granit/contract-tests`: **131** pass.
- tsc clean, ESLint clean.