### PR TITLE
fix(dashboards): align KPI configJson bridge with backend bare-Datasource contract

### DIFF
--- a/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
+++ b/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
@@ -260,6 +260,52 @@ describe('widgetDefinitionToUpdateRequest', () => {
   });
 });
 
+describe('KPI configJson bridge (bare-Datasource contract)', () => {
+  // The backend treats a KPI's `configJson` as the bare polymorphic
+  // `Datasource` (`JsonSerializer.Serialize<Datasource>`): a top-level
+  // `{ kind, metricName }`, NOT a `{ datasource: { … } }` wrapper. The bridge
+  // must lift it under `datasource` on read and re-emit it bare on write.
+  const BARE_DATASOURCE = {
+    kind: 'metric',
+    metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
+  };
+
+  it('lifts a bare-datasource configJson under `widget.datasource` (regression: KpiTile crash)', () => {
+    const instance: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Kpi',
+      position: 2,
+      width: 3,
+      height: 2,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.UnpaidCount`,
+      metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
+      queryName: null,
+      configJson: JSON.stringify(BARE_DATASOURCE),
+      requiredPermission: null,
+    };
+    const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as KpiWidgetStub;
+    // The crash was `isMetricDatasource(undefined)` — assert the binding is
+    // present and correctly shaped, not spread flat onto the widget.
+    expect(widget.datasource).toBeDefined();
+    expect(widget.datasource).toEqual(BARE_DATASOURCE);
+    expect((widget as unknown as Record<string, unknown>)['kind']).toBeUndefined();
+    expect((widget as unknown as Record<string, unknown>)['metricName']).toBeUndefined();
+  });
+
+  it('re-emits the bare datasource (not a wrapper) on write', () => {
+    const widget: KpiWidgetStub = {
+      slug: 'UnpaidCount',
+      type: 'kpi',
+      position: 2,
+      size: { width: 3, height: 2 },
+      datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+    };
+    const request = widgetDefinitionToAddRequest(widget, DASHBOARD_NAME);
+    expect(JSON.parse(request.configJson)).toEqual(BARE_DATASOURCE);
+    expect(JSON.parse(request.configJson)).not.toHaveProperty('datasource');
+  });
+});
+
 describe('round-trip: instance → definition → addRequest → instance-shaped fields', () => {
   it('preserves every widget field across the bridge', () => {
     const original: WidgetInstanceResponse = {
@@ -271,8 +317,10 @@ describe('round-trip: instance → definition → addRequest → instance-shaped
       titleLocalizationKey: `Widget:${DASHBOARD_NAME}.UnpaidCount`,
       metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
       queryName: null,
+      // Bare polymorphic Datasource — exactly what the backend persists.
       configJson: JSON.stringify({
-        datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+        kind: 'metric',
+        metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
       }),
       requiredPermission: null,
     };
@@ -283,6 +331,7 @@ describe('round-trip: instance → definition → addRequest → instance-shaped
     expect(addRequest.width).toBe(original.width);
     expect(addRequest.height).toBe(original.height);
     expect(addRequest.titleLocalizationKey).toBe(original.titleLocalizationKey);
+    // `metricName` is denormalized off the datasource, reproducing the column.
     expect(addRequest.metricName).toBe(original.metricName);
     expect(addRequest.queryName).toBe(original.queryName);
     expect(JSON.parse(addRequest.configJson)).toEqual(JSON.parse(original.configJson));

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -107,8 +107,19 @@ function denormalizeReferences(widget: WidgetDefinitionBase): {
  * Strips the structural fields from a widget definition and serializes
  * the remainder to JSON. Round-trip-safe: `configJsonToWidgetFields`
  * undoes this exactly when paired with the same structural fields.
+ *
+ * KPI is special-cased: its `configJson` is the *bare* polymorphic
+ * {@link Datasource} (matching the backend's `JsonSerializer.Serialize<Datasource>`),
+ * not the generic strip-structural-fields blob. KPI `actions` are intentionally
+ * not persisted — there's no server-side Actions column for KPI and the bare
+ * datasource has no room for them, so they don't round-trip. If KPI action
+ * persistence is wanted, that's a separate story.
  */
 function widgetFieldsToConfigJson(widget: WidgetDefinitionBase): string {
+  if (widget.type === 'kpi') {
+    const datasource = (widget as unknown as { datasource?: unknown }).datasource;
+    return JSON.stringify(datasource ?? null);
+  }
   const config: Record<string, unknown> = {};
   const w = widget as unknown as Readonly<Record<string, unknown>>;
   for (const key of Object.keys(w)) {
@@ -152,7 +163,16 @@ export function widgetInstanceToDefinition(
   dashboardName: string
 ): WidgetDefinition {
   const slug = extractSlugFromTitleKey(instance.titleLocalizationKey, dashboardName);
-  const fields = configJsonToWidgetFields(instance.configJson) ?? {};
+  const parsed = configJsonToWidgetFields(instance.configJson) ?? {};
+  // A KPI persists its `configJson` as the *bare* polymorphic `Datasource`
+  // (backend: `JsonSerializer.Serialize<Datasource>(k.Datasource)` →
+  // `{"kind":"metric","metricName":"…"}`), not a strip-structural-fields blob.
+  // Lift it under the `datasource` key the editor's `KpiWidgetDefinition`
+  // expects instead of spreading it flat — a flat spread leaves
+  // `widget.datasource` undefined and crashes `<KpiTile>`. KPI `actions` are
+  // not part of `configJson` (no server-side Actions column for KPI), so they
+  // don't round-trip through detail/edit — consistent with the backend.
+  const fields = instance.widgetType === 'Kpi' ? { datasource: parsed } : parsed;
   const widget: WidgetDefinitionBase & Readonly<Record<string, unknown>> = {
     ...fields,
     slug,

--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile.test.tsx
@@ -1,0 +1,84 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { createQueryWrapper } from '@granit/react-testing';
+import { render, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { KpiTile } from '../components/kpi-tile';
+
+import type { KpiWidgetDefinition } from '@granit/analytics';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+const QueryWrapper = createQueryWrapper();
+const apiClient = createApiClient({ baseURL: '/api' });
+
+function renderTile(node: ReactNode) {
+  return render(
+    <QueryWrapper>
+      <GranitClientProvider client={apiClient}>
+        <I18nextProvider i18n={testI18n}>{node}</I18nextProvider>
+      </GranitClientProvider>
+    </QueryWrapper>
+  );
+}
+
+const baseKpi = {
+  slug: 'UnpaidCount',
+  type: 'kpi',
+  position: 0,
+  size: { width: 3, height: 2 },
+} as const;
+
+describe('KpiTile (smart) — datasource guards', () => {
+  it('renders the unsupported tile (no crash) when `datasource` is undefined', () => {
+    // Regression: a persisted KPI whose `configJson` failed to parse — or a
+    // pre-fix flat-spread instance — reaches the renderer with no datasource.
+    // The guard must treat it like the "unsupported" branch, not crash on
+    // `isMetricDatasource(undefined)` / `datasource.kind`.
+    const widget = { ...baseKpi, datasource: undefined } as unknown as KpiWidgetDefinition;
+    const { container } = renderTile(<KpiTile widget={widget} />);
+    const tile = container.querySelector('[data-slot="kpi-tile"]');
+    expect(tile).toBeInTheDocument();
+    expect(tile?.getAttribute('data-datasource-kind')).toBe('none');
+  });
+
+  it('renders the unsupported tile for a non-metric datasource kind', () => {
+    const widget = {
+      ...baseKpi,
+      datasource: {
+        kind: 'iot-telemetry',
+        entityAlias: 'sensor',
+        telemetryKey: 'temp',
+        aggregation: 'Last',
+        keyFormats: null,
+      },
+    } as unknown as KpiWidgetDefinition;
+    const { container } = renderTile(<KpiTile widget={widget} />);
+    expect(
+      container.querySelector('[data-slot="kpi-tile"]')?.getAttribute('data-datasource-kind')
+    ).toBe('iot-telemetry');
+  });
+
+  it('binds a metric datasource and renders the value tile', () => {
+    const widget = {
+      ...baseKpi,
+      datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+    } as KpiWidgetDefinition;
+    renderTile(<KpiTile widget={widget} />);
+    // Metric branch mounts <KpiTileView> (loading skeleton while the disabled/
+    // pending query settles) — not the unsupported text node.
+    expect(screen.queryByText(/not supported/i)).toBeNull();
+  });
+});

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -36,7 +36,11 @@ export function KpiTile({ widget }: KpiTileProps) {
   const { t, i18n } = useTranslation();
   const { datasource } = widget;
 
-  const metricName = isMetricDatasource(datasource) ? datasource.metricName : '';
+  // `datasource` can be undefined when a persisted KPI's `configJson` failed to
+  // parse (or pre-fix data lifted the bare datasource flat) — guard before
+  // narrowing so a malformed binding renders the "unsupported" tile instead of
+  // crashing on `datasource.kind`.
+  const metricName = datasource && isMetricDatasource(datasource) ? datasource.metricName : '';
 
   const query = useMetric(metricName, DEFAULT_PERIOD, { enabled: metricName !== '' });
 
@@ -46,15 +50,16 @@ export function KpiTile({ widget }: KpiTileProps) {
   const onClick = useWidgetTriggerHandler('Click', widget.actions);
   const handleClick = onClick ? () => onClick() : undefined;
 
-  if (!isMetricDatasource(datasource)) {
+  if (!datasource || !isMetricDatasource(datasource)) {
+    const kind = datasource?.kind ?? 'none';
     const message = t('Analytics.UnsupportedDatasource', {
       defaultValue: 'Datasource not supported yet ({{kind}})',
-      kind: datasource.kind,
+      kind,
     });
     return (
       <div
         data-slot="kpi-tile"
-        data-datasource-kind={datasource.kind}
+        data-datasource-kind={kind}
         className="flex h-full items-center text-xs text-muted-foreground"
       >
         {message}

--- a/packages/@granit/react-dashboards/src/testing/data.ts
+++ b/packages/@granit/react-dashboards/src/testing/data.ts
@@ -15,7 +15,7 @@
 //
 // Mock data typed against `@granit/dashboards` wire contracts.
 
-import { Datasource, WIDGET_SIZE } from '@granit/dashboards';
+import { Datasource, WIDGET_SIZE, widgetDefinitionToAddRequest } from '@granit/dashboards';
 
 import type {
   DashboardCatalogEntryResponse,
@@ -411,8 +411,10 @@ const sampleFinanceDashboard: DashboardDefinition = {
       ],
     },
     // `kpi` widgets are declared by `@granit/analytics`; the testing module
-    // serialises them as plain data (no analytics dependency), so the
-    // persisted `configJson` matches the real import byte-for-byte.
+    // serialises them as plain data (no analytics dependency). The persisted
+    // `configJson` is produced by the write-direction bridge helper (see
+    // `seedStoredDashboard`), which emits the bare `Datasource` for KPI so the
+    // mock stays byte-compatible with the backend and the read-direction bridge.
   ] as DashboardDefinition['widgets'],
 };
 
@@ -474,18 +476,26 @@ function seedStoredDashboard(
     sourceDefinitionVersion: definition.version,
     layoutColumns: definition.layout.columns,
     layoutRowHeight: definition.layout.rowHeight,
-    widgets: definition.widgets.map((widget, index) => ({
-      id: `${id.slice(0, -3)}${(widgetIdBase + index).toString(16).padStart(3, '0')}`,
-      widgetType: widget.type.charAt(0).toUpperCase() + widget.type.slice(1),
-      position: widget.position,
-      width: widget.size.width,
-      height: widget.size.height,
-      titleLocalizationKey: `Widget:${definition.name}.${widget.slug}`,
-      metricName: null,
-      queryName: null,
-      configJson: JSON.stringify(widget),
-      requiredPermission: null,
-    })),
+    widgets: definition.widgets.map((widget, index) => {
+      // Derive the persisted shape through the write-direction bridge so the
+      // mock's `configJson` / `metricName` / `queryName` are byte-compatible
+      // with what the backend persists (and what the read-direction bridge
+      // expects) per widget kind — KPI emits a bare `Datasource`, not a
+      // wrapped or whole-widget blob.
+      const request = widgetDefinitionToAddRequest(widget, definition.name);
+      return {
+        id: `${id.slice(0, -3)}${(widgetIdBase + index).toString(16).padStart(3, '0')}`,
+        widgetType: widget.type.charAt(0).toUpperCase() + widget.type.slice(1),
+        position: widget.position,
+        width: widget.size.width,
+        height: widget.size.height,
+        titleLocalizationKey: `Widget:${definition.name}.${widget.slug}`,
+        metricName: request.metricName ?? null,
+        queryName: request.queryName ?? null,
+        configJson: request.configJson,
+        requiredPermission: null,
+      };
+    }),
   };
 }
 


### PR DESCRIPTION
## Problem

Against the **real backend**, opening the dashboard **edit page** for any persisted/imported dashboard with a KPI widget (e.g. seeded `InvoicingOverview`) white-screened:

```
TypeError: Cannot read properties of undefined (reading 'kind')
  at isMetricDatasource (dashboards/src/types/datasource.ts:68)
  at KpiTile (react-analytics/src/components/kpi-tile.tsx:39)
```

## Root cause — bidirectional contract mismatch on KPI `configJson`

The backend (authoritative, ADR-039) treats a KPI's `ConfigJson` as the **bare polymorphic `Datasource`**: `JsonSerializer.Serialize<Datasource>(k.Datasource)` → `{"kind":"metric","metricName":"…"}`. The generic frontend bridge assumed a nested `{datasource:{…}}` wrapper:

- **Read**: bare `{"kind":"metric",…}` spread flat → widget has no `datasource` → `KpiTile` calls `isMetricDatasource(undefined)` → crash.
- **Write**: editor emitted `{"datasource":{…}}`, which the backend KPI renderer can't deserialize.

Tests never caught it because the mock seed (`JSON.stringify(widget)`) and the round-trip fixture both encoded the wrong nested shape, so the mock agreed with the bug. **The backend is correct; the fix is entirely frontend-side.**

## Changes

- **`widget-bridge.ts`** — KPI-aware in both directions: read lifts the bare `configJson` under `datasource`; write emits the bare datasource via `widgetFieldsToConfigJson` (covers add + update). `denormalizeReferences` unchanged.
- **`react-dashboards/testing/data.ts`** — seed derives `configJson`/`metricName`/`queryName` through the write-direction bridge, so the mock is byte-compatible with the backend per kind (this is what masked the bug).
- **`react-analytics/kpi-tile.tsx`** — defensive guard: a missing/unknown `datasource` renders the "unsupported" tile instead of crashing.
- **Tests** — corrected KPI fixtures to the bare-datasource shape; added a regression test for the exact crash plus smart-`KpiTile` guard coverage (undefined / non-metric / metric).

KPI `actions` are not persisted on the instance (no server-side column) and don't round-trip through detail/edit — consistent with the backend; documented in a code comment. If action persistence is wanted, that's a separate story.

## Verification

- `pnpm lint` (eslint `--max-warnings 0`) — clean on all touched files
- `pnpm tsc` — clean (`dashboards`, `react-dashboards`, `react-analytics`)
- `pnpm test` — 312 passing across the three packages
- `npx prettier --check` — clean

No dependency changes → `THIRD-PARTY-NOTICES.md` untouched.

## Out of scope

- Backend changes (it's correct).
- KPI action persistence (no server-side support yet).