### PR TITLE
feat(react-notifications): notification view registry

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -5605,6 +5605,26 @@
           "signature": "function useNotificationConfig(): NotificationContextValue"
         },
         {
+          "name": "registerNotificationView",
+          "kind": "function",
+          "signature": "function registerNotificationView<TData>(view: NotificationView<TData>): void"
+        },
+        {
+          "name": "getNotificationView",
+          "kind": "function",
+          "signature": "function getNotificationView(code: string): NotificationView | undefined"
+        },
+        {
+          "name": "resolveNotificationPresentation",
+          "kind": "function",
+          "signature": "function resolveNotificationPresentation( notification: PresentableNotification, ctx: NotificationPresentContext ): NotificationPresentation"
+        },
+        {
+          "name": "presentDefault",
+          "kind": "function",
+          "signature": "function presentDefault(notification: PresentableNotification): NotificationPresentation"
+        },
+        {
           "name": "useRealTimeNotifications",
           "kind": "function",
           "signature": "function useRealTimeNotifications(): UseRealTimeNotificationsReturn"

--- a/packages/@granit/react-notifications/src/__tests__/notification-rendering.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/notification-rendering.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { presentDefault } from '../rendering/default-view';
+import { registerNotificationView } from '../rendering/registry';
+import { resolveNotificationPresentation } from '../rendering/resolve';
+
+import type { NotificationPresentContext, PresentableNotification } from '../rendering/types';
+
+const ctx: NotificationPresentContext = { t: (key, options) => options?.defaultValue ?? key };
+
+function notification(overrides: Partial<PresentableNotification>): PresentableNotification {
+  return {
+    notificationTypeName: 'Unknown.Type',
+    severity: 'Info',
+    data: {},
+    relatedEntityType: null,
+    relatedEntityId: null,
+    ...overrides,
+  };
+}
+
+describe('notification rendering', () => {
+  describe('presentDefault', () => {
+    it('should read title/body from the payload', () => {
+      const result = presentDefault(notification({ data: { title: 'Hi', body: 'There' } }));
+      expect(result).toMatchObject({ title: 'Hi', body: 'There' });
+    });
+
+    it('should degrade to the type name when title is missing or non-string', () => {
+      expect(presentDefault(notification({ notificationTypeName: 'A.B', data: {} })).title).toBe(
+        'A.B'
+      );
+      expect(
+        presentDefault(notification({ notificationTypeName: 'A.B', data: { title: 42 } })).title
+      ).toBe('A.B');
+    });
+  });
+
+  describe('resolveNotificationPresentation', () => {
+    it('should fall back to the default view for an unregistered type', () => {
+      const result = resolveNotificationPresentation(
+        notification({ notificationTypeName: 'Not.Registered', data: { title: 'X' } }),
+        ctx
+      );
+      expect(result.title).toBe('X');
+      expect(result.action).toBeUndefined();
+    });
+
+    it('should use a registered view and pass it through the translate context', () => {
+      registerNotificationView<{ name: string }>({
+        code: 'Test.Registered',
+        parse: (data) => {
+          const d = data as { name?: unknown };
+          return typeof d.name === 'string' ? { name: d.name } : null;
+        },
+        present: (data, _n, c) => ({
+          title: data.name,
+          action: { label: c.t('Generic.Open', { defaultValue: 'Open' }), to: '/somewhere' },
+        }),
+      });
+
+      const result = resolveNotificationPresentation(
+        notification({ notificationTypeName: 'Test.Registered', data: { name: 'Widget' } }),
+        ctx
+      );
+
+      expect(result.title).toBe('Widget');
+      expect(result.action).toEqual({ label: 'Open', to: '/somewhere' });
+    });
+
+    it('should fall back to the default view when a registered payload fails validation', () => {
+      registerNotificationView<{ name: string }>({
+        code: 'Test.Strict',
+        parse: (data) => {
+          const d = data as { name?: unknown };
+          return typeof d.name === 'string' ? { name: d.name } : null;
+        },
+        present: (data) => ({ title: data.name }),
+      });
+
+      const result = resolveNotificationPresentation(
+        notification({
+          notificationTypeName: 'Test.Strict',
+          data: { name: 123, body: 'fallback body' },
+        }),
+        ctx
+      );
+
+      expect(result.title).toBe('Test.Strict');
+      expect(result.body).toBe('fallback body');
+    });
+  });
+});

--- a/packages/@granit/react-notifications/src/index.ts
+++ b/packages/@granit/react-notifications/src/index.ts
@@ -1,6 +1,19 @@
 // Provider
 export { NotificationProvider, useNotificationConfig } from './providers/notification-provider';
 
+// Rendering — view registry, resolution, default view
+export { registerNotificationView, getNotificationView } from './rendering/registry';
+export { resolveNotificationPresentation } from './rendering/resolve';
+export { presentDefault } from './rendering/default-view';
+export type {
+  NotificationActionLink,
+  NotificationPresentation,
+  NotificationPresentContext,
+  NotificationView,
+  PresentableNotification,
+  TranslateFn,
+} from './rendering/types';
+
 // Hooks
 export { useRealTimeNotifications } from './hooks/use-real-time-notifications';
 export type { UseRealTimeNotificationsReturn } from './hooks/use-real-time-notifications';

--- a/packages/@granit/react-notifications/src/rendering/default-view.ts
+++ b/packages/@granit/react-notifications/src/rendering/default-view.ts
@@ -1,0 +1,23 @@
+import type { NotificationPresentation, PresentableNotification } from './types';
+
+interface DefaultNotificationData {
+  readonly title?: string;
+  readonly body?: string;
+}
+
+/**
+ * Fallback presentation used when no view is registered for a type, or when a
+ * view's data validation fails. Reads the conventional `title` / `body` fields
+ * and degrades to the type name so a notification is never rendered blank.
+ */
+export function presentDefault(notification: PresentableNotification): NotificationPresentation {
+  const data = (notification.data ?? {}) as DefaultNotificationData;
+  const title =
+    typeof data.title === 'string' && data.title.length > 0
+      ? data.title
+      : notification.notificationTypeName;
+  return {
+    title,
+    body: typeof data.body === 'string' ? data.body : undefined,
+  };
+}

--- a/packages/@granit/react-notifications/src/rendering/registry.ts
+++ b/packages/@granit/react-notifications/src/rendering/registry.ts
@@ -1,0 +1,18 @@
+import type { NotificationView } from './types';
+
+/**
+ * Process-wide registry mapping `notificationTypeName` → view. Apps and feature
+ * packages populate it at load time via {@link registerNotificationView};
+ * lookups are idempotent and order-independent.
+ */
+const registry = new Map<string, NotificationView>();
+
+/** Registers (or replaces) the view for a notification type code. */
+export function registerNotificationView<TData>(view: NotificationView<TData>): void {
+  registry.set(view.code, view as NotificationView);
+}
+
+/** Returns the view registered for a type code, or `undefined` when none exists. */
+export function getNotificationView(code: string): NotificationView | undefined {
+  return registry.get(code);
+}

--- a/packages/@granit/react-notifications/src/rendering/resolve.ts
+++ b/packages/@granit/react-notifications/src/rendering/resolve.ts
@@ -1,0 +1,31 @@
+import { presentDefault } from './default-view';
+import { getNotificationView } from './registry';
+
+import type {
+  NotificationPresentContext,
+  NotificationPresentation,
+  PresentableNotification,
+} from './types';
+
+/**
+ * Resolves the rendering descriptor for a notification: looks up its view by
+ * `notificationTypeName`, validates the payload, and falls back to the default
+ * view when no view matches or validation fails (defensive — a malformed
+ * payload must never crash the inbox).
+ */
+export function resolveNotificationPresentation(
+  notification: PresentableNotification,
+  ctx: NotificationPresentContext
+): NotificationPresentation {
+  const view = getNotificationView(notification.notificationTypeName);
+  if (!view) {
+    return presentDefault(notification);
+  }
+
+  const data = view.parse(notification.data);
+  if (data === null) {
+    return presentDefault(notification);
+  }
+
+  return view.present(data, notification, ctx);
+}

--- a/packages/@granit/react-notifications/src/rendering/types.ts
+++ b/packages/@granit/react-notifications/src/rendering/types.ts
@@ -1,0 +1,72 @@
+import type { NotificationSeverity, UserNotification } from '@granit/notifications';
+import type { ComponentType } from 'react';
+
+/**
+ * Translate function shape the rendering layer relies on. Kept structural
+ * (rather than importing i18next's `TFunction`) so views and the consuming app
+ * stay decoupled from the i18n backend.
+ */
+export type TranslateFn = (
+  key: string,
+  options?: Record<string, unknown> & { defaultValue?: string }
+) => string;
+
+/** A click-through link produced by a notification view. */
+export interface NotificationActionLink {
+  readonly label: string;
+  /**
+   * Where the action points. Resolution is the host's concern: relative paths
+   * are typically routed in-app, absolute (`http(s)://`) URLs opened externally.
+   * Internal routes should be derived by the view from the notification's
+   * semantic fields — the backend never emits frontend routes.
+   */
+  readonly to: string;
+}
+
+/**
+ * Normalized rendering descriptor for a single notification. A view turns the
+ * raw `data` payload into this shape; the host renders the chrome uniformly so
+ * every notification respects the design system.
+ */
+export interface NotificationPresentation {
+  readonly title: string;
+  readonly body?: string;
+  readonly icon?: ComponentType<{ className?: string }>;
+  readonly iconClassName?: string;
+  /** Overrides the severity badge; defaults to the notification's own severity. */
+  readonly severity?: NotificationSeverity;
+  /** Extra outline badge (e.g. a notification subtype). */
+  readonly typeBadge?: string;
+  readonly action?: NotificationActionLink;
+}
+
+/**
+ * Subset of notification fields a view may rely on — the intersection of the
+ * REST shape (`UserNotification`) and the SSE transport shape, so the same view
+ * works for both live and persisted notifications.
+ */
+export type PresentableNotification = Pick<
+  UserNotification,
+  'notificationTypeName' | 'severity' | 'data' | 'relatedEntityType' | 'relatedEntityId'
+>;
+
+/** Ambient context handed to every view at render time. */
+export interface NotificationPresentContext {
+  readonly t: TranslateFn;
+}
+
+/**
+ * A registered renderer for one notification type, keyed by
+ * `notificationTypeName` (the backend-emitted "code").
+ */
+export interface NotificationView<TData = unknown> {
+  /** Matches `UserNotification.notificationTypeName`. */
+  readonly code: string;
+  /** Validates/narrows `data`; return `null` to fall back to the default view. */
+  readonly parse: (data: unknown) => TData | null;
+  readonly present: (
+    data: TData,
+    notification: PresentableNotification,
+    ctx: NotificationPresentContext
+  ) => NotificationPresentation;
+}


### PR DESCRIPTION
## What
Adds a rendering layer to `@granit/react-notifications`, keyed by `notificationTypeName`:
- **registry** — register/lookup views by type code
- **resolve** — resolve a notification to a normalized `NotificationPresentation`, with a `default-view` fallback on unknown type or invalid payload
- **types** — the `NotificationPresentation` / `NotificationView` contract

Lets apps and feature packages map a notification type to a presentation (title/body/icon/action) instead of per-type branching in the UI. Router- and logger-agnostic; concrete views and routing stay in the consuming app.

## Why
Generalizes the previous hardcoded `if (isActivityNotification)` branch in the showcase inbox into an extensible registry. Extraction-ready.

## Tests
New `notification-rendering.test.ts` (5 cases). Full package suite green (99 tests); lint / prettier / tsc clean.

## Consumed by
granit-showcase-react MR `feature/notification-view-registry` (wires inbox/bell + app views). That MR's CI needs `GRANIT_FRONT_REF=feature/notification-view-registry`.

## Base branch
Targets `fix/kpi-configjson-contract` so the diff is only the registry commit. Retarget to `develop` once that branch merges.