### PR TITLE
feat(ai-chat): agentic chat core + React surface (@granit/ai-chat, @granit/react-ai-chat)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2738,6 +2738,88 @@
           "kind": "interface",
           "signature": "interface UseChatStreamReturn",
           "members": []
+        },
+        {
+          "name": "ChatMessage",
+          "kind": "function",
+          "signature": "function ChatMessage("
+        },
+        {
+          "name": "ChatMessageProps",
+          "kind": "interface",
+          "signature": "interface ChatMessageProps",
+          "members": []
+        },
+        {
+          "name": "ConversationThread",
+          "kind": "function",
+          "signature": "function ConversationThread("
+        },
+        {
+          "name": "ConversationThreadProps",
+          "kind": "interface",
+          "signature": "interface ConversationThreadProps",
+          "members": []
+        },
+        {
+          "name": "SuggestedActions",
+          "kind": "function",
+          "signature": "function SuggestedActions("
+        },
+        {
+          "name": "SuggestedActionsProps",
+          "kind": "interface",
+          "signature": "interface SuggestedActionsProps",
+          "members": []
+        },
+        {
+          "name": "ClarificationPrompt",
+          "kind": "function",
+          "signature": "function ClarificationPrompt("
+        },
+        {
+          "name": "ClarificationPromptProps",
+          "kind": "interface",
+          "signature": "interface ClarificationPromptProps",
+          "members": []
+        },
+        {
+          "name": "AttachmentChips",
+          "kind": "function",
+          "signature": "function AttachmentChips("
+        },
+        {
+          "name": "ChatComposer",
+          "kind": "function",
+          "signature": "function ChatComposer("
+        },
+        {
+          "name": "ChatComposerProps",
+          "kind": "interface",
+          "signature": "interface ChatComposerProps",
+          "members": []
+        },
+        {
+          "name": "ComposerSuggestions",
+          "kind": "function",
+          "signature": "function ComposerSuggestions<T>("
+        },
+        {
+          "name": "ComposerSuggestionsProps",
+          "kind": "interface",
+          "signature": "interface ComposerSuggestionsProps<T>",
+          "members": []
+        },
+        {
+          "name": "detectTrigger",
+          "kind": "function",
+          "signature": "function detectTrigger(text: string, caret: number): ActiveTrigger | null"
+        },
+        {
+          "name": "ActiveTrigger",
+          "kind": "interface",
+          "signature": "interface ActiveTrigger",
+          "members": []
         }
       ]
     },

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2662,6 +2662,86 @@
       ]
     },
     {
+      "name": "@granit/react-ai-chat",
+      "description": "React bindings for @granit/ai-chat — AIChatProvider, useChatStream (SSE), conversation CRUD hooks, and headless chat UI (thread, composer with / and @ pickers, attachments, suggested actions, clarifications)",
+      "exports": [
+        {
+          "name": "AIChatProvider",
+          "kind": "function",
+          "signature": "function AIChatProvider("
+        },
+        {
+          "name": "useAIChatConfig",
+          "kind": "function",
+          "signature": "function useAIChatConfig(): ResolvedAIChatConfig"
+        },
+        {
+          "name": "conversationKeys",
+          "kind": "const",
+          "signature": "const conversationKeys"
+        },
+        {
+          "name": "useConversations",
+          "kind": "function",
+          "signature": "function useConversations(options?:"
+        },
+        {
+          "name": "useConversation",
+          "kind": "function",
+          "signature": "function useConversation( id: ConversationId | null, options?:"
+        },
+        {
+          "name": "useChatWorkspaces",
+          "kind": "function",
+          "signature": "function useChatWorkspaces(options?:"
+        },
+        {
+          "name": "useCreateConversation",
+          "kind": "function",
+          "signature": "function useCreateConversation(): UseCreateConversationReturn"
+        },
+        {
+          "name": "UseCreateConversationReturn",
+          "kind": "interface",
+          "signature": "interface UseCreateConversationReturn",
+          "members": []
+        },
+        {
+          "name": "useRenameConversation",
+          "kind": "function",
+          "signature": "function useRenameConversation(): UseRenameConversationReturn"
+        },
+        {
+          "name": "useDeleteConversation",
+          "kind": "function",
+          "signature": "function useDeleteConversation(): UseDeleteConversationReturn"
+        },
+        {
+          "name": "UseDeleteConversationReturn",
+          "kind": "interface",
+          "signature": "interface UseDeleteConversationReturn",
+          "members": []
+        },
+        {
+          "name": "useChatStream",
+          "kind": "function",
+          "signature": "function useChatStream(): UseChatStreamReturn"
+        },
+        {
+          "name": "ChatStreamUsage",
+          "kind": "interface",
+          "signature": "interface ChatStreamUsage",
+          "members": []
+        },
+        {
+          "name": "UseChatStreamReturn",
+          "kind": "interface",
+          "signature": "interface UseChatStreamReturn",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-analytics",
       "description": "React hooks and renderers for @granit/analytics — useMetric hook plus KpiTile widget renderer registered into the @granit/dashboards widget registry",
       "exports": [

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -105,6 +105,17 @@
       ]
     },
     {
+      "name": "@granit/ai-chat",
+      "description": "Agentic AI chat — conversation CRUD and the SSE message stream types and API functions. Mirrors Granit.AI.Chat.Endpoints .NET",
+      "exports": [
+        {
+          "name": "AIChatPermissions",
+          "kind": "const",
+          "signature": "const AIChatPermissions"
+        }
+      ]
+    },
+    {
       "name": "@granit/analytics",
       "description": "Framework-agnostic types for Granit.Analytics — MetricResponse runtime envelopes plus KPI / Chart / Table / Pivot widget definitions consumed by @granit/dashboards",
       "exports": [

--- a/contracts/openapi/ai-chat.json
+++ b/contracts/openapi/ai-chat.json
@@ -1,0 +1,824 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "ai-chat",
+    "version": "1"
+  },
+  "paths": {
+    "/conversations": {
+      "get": {
+        "tags": ["AI - Conversations"],
+        "summary": "Lists the current user's conversations.",
+        "description": "Returns the caller's own conversations, newest first, without their messages.",
+        "operationId": "ListConversations",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ConversationSummaryResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["AI - Conversations"],
+        "summary": "Creates a conversation owned by the current user.",
+        "description": "Creates an empty conversation with the given title, owned by the caller.",
+        "operationId": "CreateConversation",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateConversationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/conversations/{id}": {
+      "get": {
+        "tags": ["AI - Conversations"],
+        "summary": "Returns one of the current user's conversations by ID.",
+        "description": "Returns the conversation and its messages. Scoped to the caller: another user's conversation is reported as not found.",
+        "operationId": "GetConversation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConversationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["AI - Conversations"],
+        "summary": "Deletes one of the current user's conversations.",
+        "description": "Soft-deletes the conversation. Scoped to the caller: another user's conversation is reported as not found.",
+        "operationId": "DeleteConversation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/conversations/{id}/title": {
+      "put": {
+        "tags": ["AI - Conversations"],
+        "summary": "Renames one of the current user's conversations.",
+        "description": "Updates the conversation title. Scoped to the caller: another user's conversation is reported as not found.",
+        "operationId": "RenameConversation",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RenameConversationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/conversations/messages": {
+      "post": {
+        "tags": ["AI - Conversations"],
+        "summary": "Sends a message and streams a tool-grounded answer over SSE.",
+        "description": "Runs the agentic loop within the caller's permissions, persists the user and assistant messages, and streams the answer as Server-Sent Events: a 'conversation' frame with the (possibly new) conversation id, incremental 'delta' content frames, then a 'usage' frame. Rejects a non-chat-capable workspace before streaming.",
+        "operationId": "SendChatMessage",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SendMessageRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatStreamEvent"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/conversations/workspaces": {
+      "get": {
+        "tags": ["AI - Conversations"],
+        "summary": "Lists the selectable default chat workspaces.",
+        "description": "Returns the workspaces a user may set as their default chat workspace: the reserved 'Auto' option plus the chat-capable workspaces visible to the tenant. Vector/embedding-only workspaces are excluded.",
+        "operationId": "ListChatWorkspaces",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ChatWorkspacesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "AttachmentRequest": {
+        "required": ["reference", "fileName", "contentType", "sizeBytes"],
+        "type": "object",
+        "properties": {
+          "reference": {
+            "type": "string"
+          },
+          "fileName": {
+            "type": "string"
+          },
+          "contentType": {
+            "type": "string"
+          },
+          "sizeBytes": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": ["integer", "string"],
+            "format": "int64"
+          }
+        }
+      },
+      "ChatStreamEvent": {
+        "required": ["type"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "content": {
+            "type": ["null", "string"]
+          },
+          "conversationId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "inputTokens": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "outputTokens": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "suggestedActions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/SuggestedActionResponse"
+            }
+          },
+          "clarification": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ClarificationResponse"
+              }
+            ]
+          }
+        }
+      },
+      "ChatWorkspacesResponse": {
+        "required": ["workspaces"],
+        "type": "object",
+        "properties": {
+          "workspaces": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ClarificationOptionResponse": {
+        "required": ["label", "value"],
+        "type": "object",
+        "properties": {
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "ClarificationResponse": {
+        "required": ["question", "options", "allowOther"],
+        "type": "object",
+        "properties": {
+          "question": {
+            "type": "string"
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ClarificationOptionResponse"
+            }
+          },
+          "allowOther": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ConversationResponse": {
+        "required": ["id", "title", "ownerId", "createdAt", "modifiedAt", "messages"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "messages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MessageResponse"
+            }
+          }
+        }
+      },
+      "ConversationSummaryResponse": {
+        "required": ["id", "title", "createdAt", "modifiedAt"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "CreateConversationRequest": {
+        "required": ["title"],
+        "type": "object",
+        "properties": {
+          "title": {
+            "maxLength": 500,
+            "type": "string"
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "MentionRequest": {
+        "required": ["type", "id"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          }
+        }
+      },
+      "MessageResponse": {
+        "required": ["id", "role", "content", "createdAt"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "role": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "RenameConversationRequest": {
+        "required": ["title"],
+        "type": "object",
+        "properties": {
+          "title": {
+            "maxLength": 500,
+            "type": "string"
+          }
+        }
+      },
+      "SendMessageRequest": {
+        "required": ["message"],
+        "type": "object",
+        "properties": {
+          "message": {
+            "maxLength": 16000,
+            "type": "string"
+          },
+          "conversationId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "workspaceName": {
+            "type": ["null", "string"]
+          },
+          "mentions": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/MentionRequest"
+            }
+          },
+          "attachments": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/AttachmentRequest"
+            }
+          },
+          "promptRefs": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "SuggestedActionResponse": {
+        "required": ["type", "label", "deepLink"],
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "deepLink": {
+            "type": "string"
+          },
+          "description": {
+            "type": ["null", "string"]
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "AI - Conversations"
+    }
+  ]
+}

--- a/packages/@granit/ai-chat/README.md
+++ b/packages/@granit/ai-chat/README.md
@@ -1,0 +1,52 @@
+# @granit/ai-chat
+
+Framework-agnostic types and API functions for the agentic AI chat. Mirrors the
+`Granit.AI.Chat.Endpoints` .NET contract (prefix `/conversations`).
+
+This is the core, headless layer: DTOs, conversation CRUD, and the
+Server-Sent Events message stream. React bindings (hooks, composer, pickers)
+live in `@granit/react-ai-chat`.
+
+## Installation
+
+```bash
+pnpm add @granit/ai-chat
+```
+
+## API
+
+### Types
+
+- `ConversationSummaryResponse`, `ConversationResponse`, `MessageResponse` —
+  conversation read models (owner-private; v1 lists only the caller's own).
+- `CreateConversationRequest`, `RenameConversationRequest` — CRUD bodies.
+- `SendMessageRequest`, `MentionRequest`, `AttachmentRequest` — the composer
+  payload (`/` prompt refs, `@` mentions, attachments).
+- `ChatStreamEvent`, `SuggestedActionResponse`, `ClarificationResponse`,
+  `ClarificationOptionResponse` — the SSE frame and its embedded payloads.
+- `ChatWorkspacesResponse` — selectable default workspaces (`Auto` first).
+- `ConversationId`, `MessageId`, `PromptId` — branded identifiers.
+
+### Constants
+
+- `AUTO_WORKSPACE`, `CHAT_STREAM_EVENT_TYPES`, `SEND_MESSAGE_LIMITS`,
+  `CONVERSATION_TITLE_MAX_LENGTH`.
+
+### Functions
+
+- `listConversations`, `getConversation`, `createConversation`,
+  `renameConversation`, `deleteConversation`, `listChatWorkspaces` — JSON CRUD
+  over the Axios client.
+- `streamConversationMessage` — `POST /conversations/messages` as an async
+  generator of `ChatStreamEvent` frames over SSE (Axios `adapter: 'fetch'`).
+  The stream ends when the connection closes — there is **no `[DONE]`
+  sentinel**. Pass an `AbortSignal` to cancel.
+
+> ⚠️ `ChatStreamEvent.content` is **untrusted** model output. Render it as plain
+> text, or sanitize it (and scheme-allowlist links) before rendering as
+> HTML/markdown. Never pass it to a DOM HTML sink unsanitized.
+
+### Permissions
+
+`AIChatPermissions.Conversations.{Read,Send,Manage,Delete}` — the server
+enforces them; the client only gates affordances.

--- a/packages/@granit/ai-chat/package.json
+++ b/packages/@granit/ai-chat/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/ai-chat",
+  "description": "Agentic AI chat — conversation CRUD and the SSE message stream types and API functions. Mirrors Granit.AI.Chat.Endpoints .NET",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-api.test.ts
@@ -1,0 +1,87 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createConversation,
+  deleteConversation,
+  getConversation,
+  listChatWorkspaces,
+  listConversations,
+  renameConversation,
+} from '../api/conversations-api';
+
+import type { ConversationId, ConversationResponse } from '../types/index';
+
+const BASE = '/api/v1/conversations';
+const ID = 'a1111111-1111-1111-1111-111111111111' as ConversationId;
+
+const CONVERSATION: ConversationResponse = {
+  id: ID,
+  title: 'Untitled',
+  ownerId: 'b2222222-2222-2222-2222-222222222222' as ConversationResponse['ownerId'],
+  createdAt: '2026-06-15T10:00:00Z' as ConversationResponse['createdAt'],
+  modifiedAt: null,
+  messages: [],
+};
+
+describe('conversations-api', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listConversations GETs the base path', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+
+    await listConversations(client, BASE);
+
+    expect(client.get).toHaveBeenCalledWith(BASE);
+  });
+
+  it('getConversation GETs {basePath}/{id} (encoded)', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(CONVERSATION));
+
+    const result = await getConversation(client, BASE, ID);
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/${ID}`);
+    expect(result).toEqual(CONVERSATION);
+  });
+
+  it('createConversation POSTs to the base path with the title body', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(CONVERSATION));
+
+    await createConversation(client, BASE, { title: 'New chat' });
+
+    expect(client.post).toHaveBeenCalledWith(BASE, { title: 'New chat' });
+  });
+
+  it('renameConversation PUTs to {basePath}/{id}/title', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(undefined));
+
+    await renameConversation(client, BASE, ID, { title: 'Renamed' });
+
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/${ID}/title`, { title: 'Renamed' });
+  });
+
+  it('deleteConversation DELETEs {basePath}/{id}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    await deleteConversation(client, BASE, ID);
+
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/${ID}`);
+  });
+
+  it('listChatWorkspaces GETs {basePath}/workspaces', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ workspaces: ['Auto'] }));
+
+    const result = await listChatWorkspaces(client, BASE);
+
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/workspaces`);
+    expect(result.workspaces).toContain('Auto');
+  });
+});

--- a/packages/@granit/ai-chat/src/__tests__/conversations-stream.test.ts
+++ b/packages/@granit/ai-chat/src/__tests__/conversations-stream.test.ts
@@ -1,0 +1,137 @@
+import { createMockClient } from '@granit/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { streamConversationMessage } from '../api/conversations-api';
+
+import type { ChatStreamEvent, SendMessageRequest } from '../types/index';
+
+function createSSEStream(chunks: readonly string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(encoder.encode(chunk));
+      }
+      controller.close();
+    },
+  });
+}
+
+const REQUEST: SendMessageRequest = { message: 'Hi' };
+
+async function collect(stream: AsyncGenerator<ChatStreamEvent>): Promise<ChatStreamEvent[]> {
+  const events: ChatStreamEvent[] = [];
+  for await (const event of stream) events.push(event);
+  return events;
+}
+
+describe('streamConversationMessage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('yields each flat ChatStreamEvent frame in order', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: {"type":"conversation","conversationId":"11111111-1111-1111-1111-111111111111"}\n\n',
+      'data: {"type":"delta","content":"Hello"}\n\n',
+      'data: {"type":"delta","content":" world"}\n\n',
+      'data: {"type":"usage","inputTokens":12,"outputTokens":3}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const events = await collect(
+      streamConversationMessage(client, '/api/v1/conversations', REQUEST)
+    );
+
+    expect(events).toEqual([
+      { type: 'conversation', conversationId: '11111111-1111-1111-1111-111111111111' },
+      { type: 'delta', content: 'Hello' },
+      { type: 'delta', content: ' world' },
+      { type: 'usage', inputTokens: 12, outputTokens: 3 },
+    ]);
+  });
+
+  it('reassembles a frame split across reads', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream(['data: {"type":"del', 'ta","content":"split"}\n\n']);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const events = await collect(streamConversationMessage(client, '', REQUEST));
+
+    expect(events).toEqual([{ type: 'delta', content: 'split' }]);
+  });
+
+  it('flushes a final frame with no trailing newline (no [DONE] sentinel)', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream(['data: {"type":"delta","content":"tail"}']);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const events = await collect(streamConversationMessage(client, '', REQUEST));
+
+    expect(events).toEqual([{ type: 'delta', content: 'tail' }]);
+  });
+
+  it('surfaces suggestions and clarification frames', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: {"type":"suggestions","suggestedActions":[{"type":"open","label":"Open invoice","deepLink":"/invoices/42"}]}\n\n',
+      'data: {"type":"clarification","clarification":{"question":"Which one?","options":[{"label":"A","value":null}],"allowOther":true}}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const events = await collect(streamConversationMessage(client, '', REQUEST));
+
+    expect(events[0]?.suggestedActions?.[0]?.deepLink).toBe('/invoices/42');
+    expect(events[1]?.clarification?.question).toBe('Which one?');
+  });
+
+  it('skips malformed frames without aborting the stream', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: not-json\n\n',
+      'data: {"type":"delta","content":"valid"}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const events = await collect(streamConversationMessage(client, '', REQUEST));
+
+    expect(events).toEqual([{ type: 'delta', content: 'valid' }]);
+  });
+
+  it('posts to {basePath}/messages with the fetch streaming adapter', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream(['data: {"type":"usage","inputTokens":1,"outputTokens":1}\n\n']);
+    const postSpy = vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    await collect(streamConversationMessage(client, '/api/v1/conversations', REQUEST));
+
+    expect(postSpy).toHaveBeenCalledWith(
+      '/api/v1/conversations/messages',
+      REQUEST,
+      expect.objectContaining({
+        adapter: 'fetch',
+        responseType: 'stream',
+        headers: { Accept: 'text/event-stream' },
+      })
+    );
+  });
+
+  it('returns no events for an empty body', async () => {
+    const client = createMockClient();
+    vi.spyOn(client, 'post').mockResolvedValue({ data: null });
+
+    const events = await collect(streamConversationMessage(client, '', REQUEST));
+
+    expect(events).toEqual([]);
+  });
+
+  it('propagates axios errors (e.g. 403 before streaming)', async () => {
+    const client = createMockClient();
+    vi.spyOn(client, 'post').mockRejectedValue(new Error('Request failed with status 403'));
+
+    const generator = streamConversationMessage(client, '', REQUEST);
+
+    await expect(generator.next()).rejects.toThrow('Request failed with status 403');
+  });
+});

--- a/packages/@granit/ai-chat/src/api/conversations-api.ts
+++ b/packages/@granit/ai-chat/src/api/conversations-api.ts
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------
+// Agentic chat API functions.
+// Mirrors Granit.AI.Chat.Endpoints — conversation CRUD plus the SSE message
+// stream. Routes are relative to `basePath` (the `/conversations` prefix).
+// ---------------------------------------------------------------------------
+
+import type {
+  ChatStreamEvent,
+  ChatWorkspacesResponse,
+  ConversationId,
+  ConversationResponse,
+  ConversationSummaryResponse,
+  CreateConversationRequest,
+  RenameConversationRequest,
+  SendMessageRequest,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List the current user's conversations, newest first, without their messages.
+ *
+ * `GET {basePath}`
+ */
+export async function listConversations(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly ConversationSummaryResponse[]> {
+  const response = await client.get<readonly ConversationSummaryResponse[]>(basePath);
+  return response.data;
+}
+
+/**
+ * Get one of the current user's conversations and its messages.
+ *
+ * `GET {basePath}/{id}`
+ */
+export async function getConversation(
+  client: AxiosInstance,
+  basePath: string,
+  id: ConversationId
+): Promise<ConversationResponse> {
+  const response = await client.get<ConversationResponse>(`${basePath}/${encodeURIComponent(id)}`);
+  return response.data;
+}
+
+/**
+ * Create an empty conversation owned by the current user.
+ *
+ * `POST {basePath}`
+ */
+export async function createConversation(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreateConversationRequest
+): Promise<ConversationResponse> {
+  const response = await client.post<ConversationResponse>(basePath, request);
+  return response.data;
+}
+
+/**
+ * Rename one of the current user's conversations.
+ *
+ * `PUT {basePath}/{id}/title`
+ */
+export async function renameConversation(
+  client: AxiosInstance,
+  basePath: string,
+  id: ConversationId,
+  request: RenameConversationRequest
+): Promise<void> {
+  await client.put(`${basePath}/${encodeURIComponent(id)}/title`, request);
+}
+
+/**
+ * Delete one of the current user's conversations.
+ *
+ * `DELETE {basePath}/{id}`
+ */
+export async function deleteConversation(
+  client: AxiosInstance,
+  basePath: string,
+  id: ConversationId
+): Promise<void> {
+  await client.delete(`${basePath}/${encodeURIComponent(id)}`);
+}
+
+/**
+ * List the workspaces a user may set as their default chat workspace
+ * (`Auto` first, then chat-capable workspaces).
+ *
+ * `GET {basePath}/workspaces`
+ */
+export async function listChatWorkspaces(
+  client: AxiosInstance,
+  basePath: string
+): Promise<ChatWorkspacesResponse> {
+  const response = await client.get<ChatWorkspacesResponse>(`${basePath}/workspaces`);
+  return response.data;
+}
+
+/** Parse one raw SSE line into a {@link ChatStreamEvent}, or `null` to skip it. */
+function parseEventLine(line: string): ChatStreamEvent | null {
+  const trimmed = line.trimEnd();
+  if (!trimmed.startsWith('data:')) return null;
+  const data = trimmed.slice('data:'.length).trimStart();
+  if (data === '') return null;
+  try {
+    return JSON.parse(data) as ChatStreamEvent;
+  } catch {
+    // A malformed or partial frame — skip it rather than aborting the stream.
+    return null;
+  }
+}
+
+/**
+ * Send a message and stream the agent's answer over Server-Sent Events.
+ *
+ * Uses Axios `adapter: 'fetch'` with `responseType: 'stream'` so the request
+ * still flows through the interceptor pipeline (CSRF, auth, tenant headers).
+ * Yields each {@link ChatStreamEvent} frame as it arrives. The stream ends when
+ * the connection closes — there is **no `[DONE]` sentinel**. Pass a `signal`
+ * to abort on unmount or a stop button.
+ *
+ * `POST {basePath}/messages`
+ *
+ * @example
+ * ```ts
+ * const controller = new AbortController();
+ * for await (const ev of streamConversationMessage(client, '/api/v1/conversations', req, controller.signal)) {
+ *   if (ev.type === 'delta') append(ev.content);
+ * }
+ * ```
+ */
+export async function* streamConversationMessage(
+  client: AxiosInstance,
+  basePath: string,
+  request: SendMessageRequest,
+  signal?: AbortSignal
+): AsyncGenerator<ChatStreamEvent, void, undefined> {
+  const url = `${basePath}/messages`;
+
+  const response = await client.post(url, request, {
+    adapter: 'fetch',
+    responseType: 'stream',
+    headers: { Accept: 'text/event-stream' },
+    signal,
+  });
+
+  const body = response.data as ReadableStream<Uint8Array> | null;
+  if (!body) return;
+
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split('\n');
+      buffer = lines.pop() ?? '';
+
+      for (const line of lines) {
+        const event = parseEventLine(line);
+        if (event) yield event;
+      }
+    }
+
+    // Flush a final frame that arrived without a trailing newline.
+    const tail = parseEventLine(buffer);
+    if (tail) yield tail;
+  } finally {
+    reader.releaseLock();
+  }
+}

--- a/packages/@granit/ai-chat/src/index.ts
+++ b/packages/@granit/ai-chat/src/index.ts
@@ -1,0 +1,43 @@
+// Types
+export type {
+  AttachmentRequest,
+  ChatMessageRole,
+  ChatStreamEvent,
+  ChatStreamEventType,
+  ChatWorkspacesResponse,
+  ClarificationOptionResponse,
+  ClarificationResponse,
+  ConversationId,
+  ConversationResponse,
+  ConversationSummaryResponse,
+  CreateConversationRequest,
+  MentionRequest,
+  MessageId,
+  MessageResponse,
+  PromptId,
+  RenameConversationRequest,
+  SendMessageRequest,
+  SuggestedActionResponse,
+} from './types/index';
+
+// Constants
+export {
+  AUTO_WORKSPACE,
+  CHAT_STREAM_EVENT_TYPES,
+  CONVERSATION_TITLE_MAX_LENGTH,
+  SEND_MESSAGE_LIMITS,
+} from './types/index';
+
+// API
+export {
+  createConversation,
+  deleteConversation,
+  getConversation,
+  listChatWorkspaces,
+  listConversations,
+  renameConversation,
+  streamConversationMessage,
+} from './api/conversations-api';
+
+// Permissions
+export { AIChatPermissions } from './permissions';

--- a/packages/@granit/ai-chat/src/permissions.ts
+++ b/packages/@granit/ai-chat/src/permissions.ts
@@ -1,0 +1,19 @@
+/**
+ * Permission constants for the agentic chat module.
+ * Mirrors `Granit.AI.Chat.Endpoints.Permissions.AIChatPermissions`.
+ *
+ * The server enforces these; the client only gates affordances. Conversations
+ * are owner-private — never build cross-user views.
+ */
+export const AIChatPermissions = {
+  Conversations: {
+    /** List/read the caller's own conversations. */
+    Read: 'AIChat.Conversations.Read',
+    /** Send a message and stream an answer. */
+    Send: 'AIChat.Conversations.Send',
+    /** Create or rename a conversation. */
+    Manage: 'AIChat.Conversations.Manage',
+    /** Delete a conversation. */
+    Delete: 'AIChat.Conversations.Delete',
+  },
+} as const;

--- a/packages/@granit/ai-chat/src/types/index.ts
+++ b/packages/@granit/ai-chat/src/types/index.ts
@@ -1,0 +1,182 @@
+import type { EntityId, ISODateString, UserId } from '@granit/types';
+
+// ---------------------------------------------------------------------------
+// Types mirroring Granit.AI.Chat and Granit.AI.Chat.Endpoints .NET contracts.
+// Property names match the camelCase JSON serialization from the backend.
+// Optionality follows the OpenAPI `required` array, not C# nullability.
+// ---------------------------------------------------------------------------
+
+// -- Branded identifiers -----------------------------------------------------
+
+/** Conversation identifier (UUID). */
+export type ConversationId = EntityId<'Conversation'>;
+
+/** Chat message identifier (UUID). */
+export type MessageId = EntityId<'Message'>;
+
+/** Prompt-catalogue template identifier (UUID). Owned by the prompts module. */
+export type PromptId = EntityId<'Prompt'>;
+
+// -- Constants ---------------------------------------------------------------
+
+/**
+ * The reserved workspace name that lets the backend pick the workspace for the
+ * turn. Always listed first by `GET /conversations/workspaces`.
+ */
+export const AUTO_WORKSPACE = 'Auto';
+
+/**
+ * `ChatStreamEvent.type` discriminator values. The stream ends when the
+ * connection closes — there is no `[DONE]` sentinel.
+ */
+export const CHAT_STREAM_EVENT_TYPES = {
+  /** First frame — carries the new/continued `conversationId`. */
+  CONVERSATION: 'conversation',
+  /** Incremental answer chunk — append `content` in order. */
+  DELTA: 'delta',
+  /** Token counts, near the end of the stream. */
+  USAGE: 'usage',
+  /** Suggested deep-link actions to render — never auto-invoked. */
+  SUGGESTIONS: 'suggestions',
+  /** The turn is blocked on a clarifying question. */
+  CLARIFICATION: 'clarification',
+} as const;
+
+/** Discriminator union for {@link ChatStreamEvent.type}. */
+export type ChatStreamEventType =
+  (typeof CHAT_STREAM_EVENT_TYPES)[keyof typeof CHAT_STREAM_EVENT_TYPES];
+
+/** Role of a persisted chat message. */
+export type ChatMessageRole = 'user' | 'assistant' | 'system';
+
+/** Server-enforced limits for a single `SendMessageRequest` turn. */
+export const SEND_MESSAGE_LIMITS = {
+  /** `message` maximum length. */
+  MESSAGE_MAX_LENGTH: 16_000,
+  /** Maximum `@` mentions per turn. */
+  MENTIONS_MAX: 25,
+  /** Maximum `/` prompt badges per turn. */
+  PROMPT_REFS_MAX: 5,
+  /** Documented default maximum attachments per turn (server-configurable). */
+  ATTACHMENTS_MAX: 5,
+} as const;
+
+/** `title` maximum length for create/rename conversation requests. */
+export const CONVERSATION_TITLE_MAX_LENGTH = 500;
+
+// -- Composer inputs ---------------------------------------------------------
+
+/** An `@` mention the server resolves to grounded, untrusted context. */
+export interface MentionRequest {
+  readonly type: string;
+  readonly id: string;
+}
+
+/**
+ * An app-uploaded attachment. The front uploads the blob to the app's own
+ * store, then sends this opaque reference; the backend reads the bytes back.
+ */
+export interface AttachmentRequest {
+  readonly reference: string;
+  readonly fileName: string;
+  readonly contentType: string;
+  /** int64 — surfaces as `number | string` in generated clients. */
+  readonly sizeBytes: number | string;
+}
+
+/** Body of `POST /conversations/messages`. */
+export interface SendMessageRequest {
+  readonly message: string;
+  readonly conversationId?: ConversationId | null;
+  readonly workspaceName?: string | null;
+  readonly mentions?: readonly MentionRequest[] | null;
+  readonly attachments?: readonly AttachmentRequest[] | null;
+  readonly promptRefs?: readonly PromptId[] | null;
+}
+
+// -- Stream events -----------------------------------------------------------
+
+/** A suggested deep-link action streamed by the agent. Never auto-invoked. */
+export interface SuggestedActionResponse {
+  readonly type: string;
+  readonly label: string;
+  readonly deepLink: string;
+  readonly description?: string | null;
+}
+
+/** One clickable option for a clarifying question. */
+export interface ClarificationOptionResponse {
+  readonly label: string;
+  /** The value sent as the next message; falls back to `label` when null. */
+  readonly value: string | null;
+}
+
+/** A clarifying question that blocks the turn until the user answers. */
+export interface ClarificationResponse {
+  readonly question: string;
+  readonly options: readonly ClarificationOptionResponse[];
+  readonly allowOther: boolean;
+}
+
+/**
+ * A single Server-Sent Event frame from `POST /conversations/messages`.
+ * Discriminated by {@link ChatStreamEvent.type}; only the fields relevant to
+ * that type are populated.
+ *
+ * ⚠️ `content` is **untrusted** model output — steerable by prompt injection,
+ * poisoned RAG, or echoed tool results. Render it as plain text, or sanitize
+ * it (and scheme-allowlist any links) before rendering as HTML/markdown. Never
+ * pass it to a DOM HTML sink unsanitized.
+ */
+export interface ChatStreamEvent {
+  readonly type: ChatStreamEventType;
+  readonly content?: string | null;
+  readonly conversationId?: ConversationId | null;
+  readonly inputTokens?: number | null;
+  readonly outputTokens?: number | null;
+  readonly suggestedActions?: readonly SuggestedActionResponse[] | null;
+  readonly clarification?: ClarificationResponse | null;
+}
+
+// -- Conversation CRUD -------------------------------------------------------
+
+/** A persisted message within a conversation. */
+export interface MessageResponse {
+  readonly id: MessageId;
+  readonly role: ChatMessageRole;
+  readonly content: string;
+  readonly createdAt: ISODateString;
+}
+
+/** A conversation with its messages. */
+export interface ConversationResponse {
+  readonly id: ConversationId;
+  readonly title: string;
+  readonly ownerId: UserId;
+  readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString | null;
+  readonly messages: readonly MessageResponse[];
+}
+
+/** A conversation list item, without its messages. */
+export interface ConversationSummaryResponse {
+  readonly id: ConversationId;
+  readonly title: string;
+  readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString | null;
+}
+
+/** Body of `POST /conversations`. */
+export interface CreateConversationRequest {
+  readonly title: string;
+}
+
+/** Body of `PUT /conversations/{id}/title`. */
+export interface RenameConversationRequest {
+  readonly title: string;
+}
+
+/** The workspaces a user may set as their default chat workspace. */
+export interface ChatWorkspacesResponse {
+  readonly workspaces: readonly string[];
+}

--- a/packages/@granit/ai-chat/tsconfig.json
+++ b/packages/@granit/ai-chat/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/ai-chat/tsup.config.ts
+++ b/packages/@granit/ai-chat/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -102,6 +102,26 @@ export const CONTRACTS: readonly ModuleContract[] = [
     endpointIgnore: ['/usage', '/usage/meta'],
   },
   {
+    slug: 'ai-chat',
+    package: 'ai-chat',
+    types: [
+      'ConversationSummaryResponse',
+      'ConversationResponse',
+      'MessageResponse',
+      'CreateConversationRequest',
+      'RenameConversationRequest',
+      'SendMessageRequest',
+      'MentionRequest',
+      'AttachmentRequest',
+      'ChatStreamEvent',
+      'SuggestedActionResponse',
+      'ClarificationResponse',
+      'ClarificationOptionResponse',
+      'ChatWorkspacesResponse',
+    ],
+    checkEndpoints: true,
+  },
+  {
     slug: 'auditing',
     package: 'auditing',
     types: [

--- a/packages/@granit/react-ai-chat/README.md
+++ b/packages/@granit/react-ai-chat/README.md
@@ -1,0 +1,47 @@
+# @granit/react-ai-chat
+
+React bindings for [`@granit/ai-chat`](../ai-chat) — the agentic "Ask your app"
+chat. Provides the `AIChatProvider`, a streaming SSE hook, and conversation
+CRUD hooks. Headless chat UI (thread, composer with `/` and `@` pickers,
+attachment chips, suggested actions, clarifications) is added on top of these
+hooks.
+
+## Installation
+
+```bash
+pnpm add @granit/react-ai-chat
+```
+
+## Usage
+
+Wrap the app once, providing the Axios client (or rely on a
+`<GranitClientProvider>`):
+
+```tsx
+import { AIChatProvider } from '@granit/react-ai-chat';
+
+<AIChatProvider config={{ client }}>{children}</AIChatProvider>;
+```
+
+### Hooks
+
+- `useChatStream()` — streams a turn over SSE (`POST /conversations/messages`).
+  Accumulates `delta` content, captures the conversation id, suggested actions,
+  a clarification, and token usage. `send(request)` resets per-turn state and
+  cancels any in-progress stream; `abort()` stops it.
+- `useConversations()` / `useConversation(id)` — list / read (owner-private).
+- `useChatWorkspaces()` — selectable default workspaces (`Auto` first).
+- `useCreateConversation()` / `useRenameConversation()` / `useDeleteConversation()`
+  — mutations that invalidate the affected queries.
+- `conversationKeys` — the query-key factory (namespaced by the provider prefix).
+
+> ⚠️ `useChatStream().content` is **untrusted** model output. Render it as plain
+> text, or sanitize it (and scheme-allowlist links) before rendering as
+> HTML/markdown. Suggested actions are links the user clicks — **never**
+> auto-invoke them.
+
+## Testing
+
+`@granit/react-ai-chat/testing` exports `createAIChatHandlers(baseUrl)` (stateful
+MSW handlers, including the SSE stream) plus `mockConversation`,
+`mockConversationSummaries`, and `mockChatWorkspaces`.

--- a/packages/@granit/react-ai-chat/package.json
+++ b/packages/@granit/react-ai-chat/package.json
@@ -18,7 +18,9 @@
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
+    "lucide-react": "^1.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"
   },
@@ -46,6 +48,7 @@
     "@granit/react-api-client": "workspace:*",
     "@granit/react-testing": "workspace:*",
     "@granit/testing": "workspace:*",
-    "@granit/types": "workspace:*"
+    "@granit/types": "workspace:*",
+    "@granit/utils": "workspace:*"
   }
 }

--- a/packages/@granit/react-ai-chat/package.json
+++ b/packages/@granit/react-ai-chat/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@granit/react-ai-chat",
+  "description": "React bindings for @granit/ai-chat — AIChatProvider, useChatStream (SSE), conversation CRUD hooks, and headless chat UI (thread, composer with / and @ pickers, attachments, suggested actions, clarifications)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/ai-chat": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/ai-chat": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  }
+}

--- a/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/chat-composer.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChatComposer } from '../components/chat-composer';
+
+import type { MentionOption, PromptOption } from '../components/composer-types';
+import type { PromptId, SendMessageRequest } from '@granit/ai-chat';
+
+const PROMPTS: PromptOption[] = [
+  { id: 'p1' as PromptId, name: 'Summarize', shortDescription: 'Summarize this' },
+  { id: 'p2' as PromptId, name: 'Daily brief', shortDescription: 'Your day' },
+];
+
+describe('ChatComposer', () => {
+  it('inserts a prompt badge from the / picker and keeps it out of the message text', async () => {
+    const onSubmit = vi.fn<(r: SendMessageRequest) => void>();
+    render(<ChatComposer onSubmit={onSubmit} prompts={PROMPTS} />);
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, '/Sum');
+    await userEvent.click(await screen.findByText('Summarize'));
+
+    // Badge present, textarea cleared of the /token.
+    expect(screen.getByText('/Summarize')).toBeInTheDocument();
+    expect((input as HTMLTextAreaElement).value).toBe('');
+
+    await userEvent.type(input, 'do it');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const request = onSubmit.mock.calls[0]![0];
+    expect(request.message).toBe('do it');
+    expect(request.promptRefs).toEqual(['p1']);
+  });
+
+  it('resolves @ mentions via the injected adapter and includes them in the request', async () => {
+    const searchMentions = vi.fn(
+      async (query: string): Promise<readonly MentionOption[]> => [
+        { type: 'contact', id: 'c42', label: `Customer ${query}`, description: 'A contact' },
+      ]
+    );
+    const onSubmit = vi.fn<(r: SendMessageRequest) => void>();
+    render(<ChatComposer onSubmit={onSubmit} searchMentions={searchMentions} />);
+
+    const input = screen.getByRole('combobox');
+    await userEvent.type(input, 'hi @ali');
+
+    await waitFor(() => expect(searchMentions).toHaveBeenCalledWith('ali'));
+    await userEvent.click(await screen.findByText('Customer ali'));
+
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    const request = onSubmit.mock.calls[0]![0];
+    expect(request.mentions).toEqual([{ type: 'contact', id: 'c42' }]);
+    expect(request.message).toContain('@Customer ali');
+  });
+
+  it('submits on Enter and inserts a newline on Shift+Enter', async () => {
+    const onSubmit = vi.fn();
+    render(<ChatComposer onSubmit={onSubmit} />);
+    const input = screen.getByRole('combobox');
+
+    await userEvent.type(input, 'line one{Shift>}{Enter}{/Shift}line two');
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect((input as HTMLTextAreaElement).value).toBe('line one\nline two');
+
+    await userEvent.type(input, '{Enter}');
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the selected workspace and disables send on an empty message', async () => {
+    const onSubmit = vi.fn<(r: SendMessageRequest) => void>();
+    render(
+      <ChatComposer onSubmit={onSubmit} workspaces={['Auto', 'support']} workspace="support" />
+    );
+
+    expect(screen.getByRole('button', { name: /send/i })).toBeDisabled();
+
+    await userEvent.type(screen.getByRole('combobox', { name: /ask your app/i }), 'hello');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    expect(onSubmit.mock.calls[0]![0].workspaceName).toBe('support');
+  });
+
+  it('shows a Stop button while streaming', async () => {
+    const onStop = vi.fn();
+    render(<ChatComposer onSubmit={vi.fn()} isStreaming onStop={onStop} />);
+    await userEvent.click(screen.getByRole('button', { name: /stop/i }));
+    expect(onStop).toHaveBeenCalled();
+  });
+
+  it('uploads attachments via the adapter and includes the reference on submit', async () => {
+    const uploadAttachment = vi.fn(async (file: File) => ({
+      reference: 'blob://xyz',
+      fileName: file.name,
+      contentType: file.type || 'text/plain',
+      sizeBytes: file.size,
+    }));
+    const onSubmit = vi.fn<(r: SendMessageRequest) => void>();
+    render(<ChatComposer onSubmit={onSubmit} uploadAttachment={uploadAttachment} />);
+
+    const file = new File(['hello'], 'note.txt', { type: 'text/plain' });
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() => expect(screen.getByText('note.txt')).toBeInTheDocument());
+
+    await userEvent.type(screen.getByRole('combobox'), 'see attached');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+
+    const request = onSubmit.mock.calls[0]![0];
+    expect(request.attachments).toEqual([
+      { reference: 'blob://xyz', fileName: 'note.txt', contentType: 'text/plain', sizeBytes: 5 },
+    ]);
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/components.test.tsx
@@ -1,0 +1,119 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { AttachmentChips } from '../components/attachment-chips';
+import { ClarificationPrompt } from '../components/clarification-prompt';
+import { ConversationThread } from '../components/conversation-thread';
+import { SuggestedActions } from '../components/suggested-actions';
+
+import type { ComposerAttachment } from '../components/attachment-chips';
+import type {
+  ClarificationResponse,
+  MessageResponse,
+  SuggestedActionResponse,
+} from '@granit/ai-chat';
+
+const messages: MessageResponse[] = [
+  {
+    id: 'm1' as MessageResponse['id'],
+    role: 'user',
+    content: 'Hello',
+    createdAt: '2026-06-15T09:00:00Z' as MessageResponse['createdAt'],
+  },
+  {
+    id: 'm2' as MessageResponse['id'],
+    role: 'assistant',
+    content: 'Hi there',
+    createdAt: '2026-06-15T09:00:02Z' as MessageResponse['createdAt'],
+  },
+];
+
+describe('ConversationThread', () => {
+  it('renders messages inside an ARIA live log region', () => {
+    const { container } = render(<ConversationThread messages={messages} />);
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+    expect(screen.getByText('Hi there')).toBeInTheDocument();
+    const log = container.querySelector('[data-slot="conversation-thread"]');
+    expect(log).toHaveAttribute('role', 'log');
+    expect(log).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('shows the empty state when there are no messages', () => {
+    const { container } = render(<ConversationThread messages={[]} />);
+    expect(container.querySelector('[data-slot="thread-empty"]')).toBeInTheDocument();
+  });
+
+  it('renders streaming content as a live assistant bubble', () => {
+    render(<ConversationThread messages={messages} streamingContent="Streaming…" isStreaming />);
+    expect(screen.getByText('Streaming…')).toBeInTheDocument();
+  });
+});
+
+describe('SuggestedActions', () => {
+  const actions: SuggestedActionResponse[] = [
+    { type: 'open', label: 'Open invoice', deepLink: '/invoices/42', description: 'View it' },
+  ];
+
+  it('emits onSelect on click and never navigates by itself', async () => {
+    const onSelect = vi.fn();
+    render(<SuggestedActions actions={actions} onSelect={onSelect} />);
+    await userEvent.click(screen.getByRole('button', { name: /open invoice/i }));
+    expect(onSelect).toHaveBeenCalledWith(actions[0]);
+  });
+
+  it('renders nothing when there are no actions', () => {
+    const { container } = render(<SuggestedActions actions={[]} onSelect={vi.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('ClarificationPrompt', () => {
+  const clarification: ClarificationResponse = {
+    question: 'Which invoice?',
+    options: [
+      { label: '#42', value: '42' },
+      { label: 'Latest', value: null },
+    ],
+    allowOther: true,
+  };
+
+  it('emits value ?? label when an option is chosen', async () => {
+    const onChoose = vi.fn();
+    render(<ClarificationPrompt clarification={clarification} onChoose={onChoose} />);
+    await userEvent.click(screen.getByRole('button', { name: '#42' }));
+    expect(onChoose).toHaveBeenCalledWith('42');
+    await userEvent.click(screen.getByRole('button', { name: 'Latest' }));
+    expect(onChoose).toHaveBeenLastCalledWith('Latest');
+  });
+
+  it('submits free text when allowOther is set', async () => {
+    const onChoose = vi.fn();
+    render(<ClarificationPrompt clarification={clarification} onChoose={onChoose} />);
+    await userEvent.type(screen.getByRole('textbox'), 'invoice 99');
+    await userEvent.click(screen.getByRole('button', { name: /send/i }));
+    expect(onChoose).toHaveBeenCalledWith('invoice 99');
+  });
+});
+
+describe('AttachmentChips', () => {
+  const attachments: ComposerAttachment[] = [
+    {
+      id: 'a1',
+      status: 'ready',
+      reference: 'blob://1',
+      fileName: 'report.pdf',
+      contentType: 'application/pdf',
+      sizeBytes: 2048,
+    },
+  ];
+
+  it('renders a chip and removes it on click', async () => {
+    const onRemove = vi.fn();
+    render(<AttachmentChips attachments={attachments} onRemove={onRemove} />);
+    expect(screen.getByText('report.pdf')).toBeInTheDocument();
+    expect(screen.getByText('2.0 KB')).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /remove attachment report\.pdf/i }));
+    expect(onRemove).toHaveBeenCalledWith('a1');
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/detect-trigger.test.ts
+++ b/packages/@granit/react-ai-chat/src/__tests__/detect-trigger.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectTrigger } from '../components/detect-trigger';
+
+describe('detectTrigger', () => {
+  it('detects a / at the start of the input', () => {
+    expect(detectTrigger('/sum', 4)).toEqual({ kind: '/', query: 'sum', start: 0 });
+  });
+
+  it('detects an @ after whitespace', () => {
+    expect(detectTrigger('hi @ali', 7)).toEqual({ kind: '@', query: 'ali', start: 3 });
+  });
+
+  it('returns null when the trigger is mid-word (e.g. an email)', () => {
+    expect(detectTrigger('me@example', 10)).toBeNull();
+  });
+
+  it('returns null once the query contains whitespace', () => {
+    expect(detectTrigger('/daily brief', 12)).toBeNull();
+  });
+
+  it('returns null when there is no trigger before the caret', () => {
+    expect(detectTrigger('just text', 9)).toBeNull();
+  });
+
+  it('uses the caret position, not the end of the text', () => {
+    expect(detectTrigger('/sum extra', 4)).toEqual({ kind: '/', query: 'sum', start: 0 });
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/test-utils.tsx
@@ -1,0 +1,35 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+
+import { AIChatProvider } from '../providers/ai-chat-provider';
+
+import type { AIChatConfig } from '../providers/ai-chat-provider';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+export const TEST_BASE_PATH = '/api/v1/conversations';
+
+/** Wraps hooks in a fresh QueryClient + AIChatProvider bound to `client`. */
+export function createWrapper(client: AxiosInstance, basePath = TEST_BASE_PATH) {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AIChatConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AIChatProvider config={config}>{children}</AIChatProvider>
+    );
+  };
+}
+
+/** Build an SSE `ReadableStream` from raw frame strings. */
+export function createSSEStream(chunks: readonly string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(encoder.encode(chunk));
+      controller.close();
+    },
+  });
+}

--- a/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai-chat/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,74 @@
+import { createMswServer } from '@granit/testing/msw-server';
+import { describe, expect, it } from 'vitest';
+
+import { createAIChatHandlers } from '../testing/index';
+
+import type { ChatStreamEvent, ConversationSummaryResponse } from '@granit/ai-chat';
+
+const BASE = 'http://api.test/api/v1/conversations';
+const server = createMswServer();
+
+/** Read an SSE response body into parsed ChatStreamEvent frames. */
+async function readEvents(body: ReadableStream<Uint8Array> | null): Promise<ChatStreamEvent[]> {
+  if (!body) return [];
+  const reader = body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  const events: ChatStreamEvent[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      if (line.startsWith('data:'))
+        events.push(JSON.parse(line.slice(5).trim()) as ChatStreamEvent);
+    }
+  }
+  return events;
+}
+
+describe('createAIChatHandlers', () => {
+  it('lists conversation summaries, newest first', async () => {
+    server.use(...createAIChatHandlers(BASE));
+    const response = await fetch(BASE);
+    expect(response.status).toBe(200);
+    const list = (await response.json()) as ConversationSummaryResponse[];
+    expect(list).toHaveLength(2);
+  });
+
+  it('returns workspaces with Auto first (not swallowed by /:id)', async () => {
+    server.use(...createAIChatHandlers(BASE));
+    const response = await fetch(`${BASE}/workspaces`);
+    const body = (await response.json()) as { workspaces: string[] };
+    expect(body.workspaces[0]).toBe('Auto');
+  });
+
+  it('create then list reflects the new conversation', async () => {
+    server.use(...createAIChatHandlers(BASE));
+    const created = await fetch(BASE, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: 'Fresh' }),
+    });
+    expect(created.status).toBe(201);
+
+    const list = (await (await fetch(BASE)).json()) as ConversationSummaryResponse[];
+    expect(list[0]?.title).toBe('Fresh');
+  });
+
+  it('streams flat ChatStreamEvent frames ending without a [DONE] sentinel', async () => {
+    server.use(...createAIChatHandlers(BASE));
+    const response = await fetch(`${BASE}/messages`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'Hello there' }),
+    });
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream');
+
+    const events = await readEvents(response.body);
+    expect(events.map((e) => e.type)).toEqual(['conversation', 'delta', 'delta', 'usage']);
+    expect(events.at(-1)).toMatchObject({ type: 'usage', inputTokens: 12, outputTokens: 8 });
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-chat-stream.test.tsx
@@ -1,0 +1,140 @@
+import { createMockClient } from '@granit/testing';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useChatStream } from '../hooks/use-chat-stream';
+
+import { createSSEStream, createWrapper } from './test-utils';
+
+const CONV_ID = '11111111-1111-1111-1111-111111111111';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useChatStream', () => {
+  it('accumulates delta content and captures the conversation id', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      `data: {"type":"conversation","conversationId":"${CONV_ID}"}\n\n`,
+      'data: {"type":"delta","content":"Hello"}\n\n',
+      'data: {"type":"delta","content":" world"}\n\n',
+      'data: {"type":"usage","inputTokens":12,"outputTokens":8}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    expect(result.current.isStreaming).toBe(false);
+
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    expect(result.current.content).toBe('Hello world');
+    expect(result.current.conversationId).toBe(CONV_ID);
+    expect(result.current.usage).toEqual({ inputTokens: 12, outputTokens: 8 });
+    expect(result.current.error).toBeNull();
+  });
+
+  it('surfaces suggested actions without auto-invoking them', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: {"type":"delta","content":"See:"}\n\n',
+      'data: {"type":"suggestions","suggestedActions":[{"type":"open","label":"Open invoice 42","deepLink":"/invoices/42"}]}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'Show invoice 42' });
+    });
+
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    expect(result.current.suggestedActions).toHaveLength(1);
+    expect(result.current.suggestedActions[0]?.deepLink).toBe('/invoices/42');
+  });
+
+  it('exposes a clarification that blocks the turn', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream([
+      'data: {"type":"clarification","clarification":{"question":"Which invoice?","options":[{"label":"#42","value":"42"}],"allowOther":true}}\n\n',
+    ]);
+    vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'Show the invoice' });
+    });
+
+    await waitFor(() => expect(result.current.clarification).not.toBeNull());
+
+    expect(result.current.clarification?.question).toBe('Which invoice?');
+    expect(result.current.clarification?.options[0]?.value).toBe('42');
+  });
+
+  it('resets per-turn state on a new send()', async () => {
+    const client = createMockClient();
+    const first = createSSEStream(['data: {"type":"delta","content":"First"}\n\n']);
+    const second = createSSEStream(['data: {"type":"delta","content":"Second"}\n\n']);
+    vi.spyOn(client, 'post')
+      .mockResolvedValueOnce({ data: first })
+      .mockResolvedValueOnce({ data: second });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'A' });
+    });
+    await waitFor(() => expect(result.current.content).toBe('First'));
+
+    act(() => {
+      result.current.send({ message: 'B' });
+    });
+    await waitFor(() => expect(result.current.content).toBe('Second'));
+  });
+
+  it('posts the SendMessageRequest to {basePath}/messages with the fetch adapter', async () => {
+    const client = createMockClient();
+    const stream = createSSEStream(['data: {"type":"usage","inputTokens":1,"outputTokens":1}\n\n']);
+    const postSpy = vi.spyOn(client, 'post').mockResolvedValue({ data: stream });
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    const request = { message: 'Hi', promptRefs: [] };
+    act(() => {
+      result.current.send(request);
+    });
+    await waitFor(() => expect(result.current.isStreaming).toBe(false));
+
+    expect(postSpy).toHaveBeenCalledWith(
+      '/api/v1/conversations/messages',
+      request,
+      expect.objectContaining({
+        adapter: 'fetch',
+        responseType: 'stream',
+        headers: { Accept: 'text/event-stream' },
+      })
+    );
+  });
+
+  it('sets error on a failed request', async () => {
+    const client = createMockClient();
+    vi.spyOn(client, 'post').mockRejectedValue(new Error('Request failed with status 403'));
+
+    const { result } = renderHook(() => useChatStream(), { wrapper: createWrapper(client) });
+
+    act(() => {
+      result.current.send({ message: 'Hi' });
+    });
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toContain('403');
+    expect(result.current.isStreaming).toBe(false);
+  });
+});

--- a/packages/@granit/react-ai-chat/src/__tests__/use-conversations.test.tsx
+++ b/packages/@granit/react-ai-chat/src/__tests__/use-conversations.test.tsx
@@ -1,0 +1,76 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useChatWorkspaces } from '../hooks/use-chat-workspaces';
+import { useConversations } from '../hooks/use-conversations';
+import { useCreateConversation } from '../hooks/use-create-conversation';
+import { useDeleteConversation } from '../hooks/use-delete-conversation';
+import { mockConversation, mockConversationSummaries } from '../testing/data';
+
+import { createWrapper, TEST_BASE_PATH } from './test-utils';
+
+import type { ConversationId } from '@granit/ai-chat';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('conversation hooks', () => {
+  it('useConversations returns the list, newest first', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(mockConversationSummaries));
+
+    const { result } = renderHook(() => useConversations(), { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toHaveLength(2);
+    expect(client.get).toHaveBeenCalledWith(TEST_BASE_PATH);
+  });
+
+  it('useChatWorkspaces returns workspaces with Auto first', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ workspaces: ['Auto', 'default'] }));
+
+    const { result } = renderHook(() => useChatWorkspaces(), { wrapper: createWrapper(client) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.workspaces[0]).toBe('Auto');
+    expect(client.get).toHaveBeenCalledWith(`${TEST_BASE_PATH}/workspaces`);
+  });
+
+  it('useCreateConversation POSTs the title and resolves the new conversation', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(mockConversation));
+
+    const { result } = renderHook(() => useCreateConversation(), {
+      wrapper: createWrapper(client),
+    });
+
+    let created: unknown;
+    await act(async () => {
+      created = await result.current.createAsync({ title: 'New chat' });
+    });
+
+    expect(client.post).toHaveBeenCalledWith(TEST_BASE_PATH, { title: 'New chat' });
+    expect(created).toEqual(mockConversation);
+  });
+
+  it('useDeleteConversation DELETEs the conversation by id', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+
+    const { result } = renderHook(() => useDeleteConversation(), {
+      wrapper: createWrapper(client),
+    });
+
+    const id = mockConversation.id as ConversationId;
+    await act(async () => {
+      await result.current.removeAsync(id);
+    });
+
+    expect(client.delete).toHaveBeenCalledWith(`${TEST_BASE_PATH}/${id}`);
+  });
+});

--- a/packages/@granit/react-ai-chat/src/components/attachment-chips.tsx
+++ b/packages/@granit/react-ai-chat/src/components/attachment-chips.tsx
@@ -1,0 +1,79 @@
+import { cn } from '@granit/utils';
+import { File as FileIcon, Loader2, X } from 'lucide-react';
+
+import { defaultChatLabels } from '../locales/index';
+
+import type { ChatTranslations } from '../locales/index';
+import type { AttachmentRequest } from '@granit/ai-chat';
+
+/** Upload lifecycle of a composer attachment. */
+export type AttachmentStatus = 'uploading' | 'ready' | 'error';
+
+/** A composer attachment: the request payload plus its upload status. */
+export interface ComposerAttachment extends AttachmentRequest {
+  /** Stable client id (the upload may not have a `reference` yet). */
+  readonly id: string;
+  readonly status: AttachmentStatus;
+}
+
+export interface AttachmentChipsProps {
+  readonly attachments: readonly ComposerAttachment[];
+  readonly onRemove: (id: string) => void;
+  readonly labels?: ChatTranslations['Composer'];
+  readonly className?: string;
+}
+
+const UNITS = ['B', 'KB', 'MB', 'GB'] as const;
+
+/** Human-readable byte size; accepts the int64 `number | string` shape. */
+function formatBytes(sizeBytes: number | string): string {
+  let size = typeof sizeBytes === 'string' ? Number(sizeBytes) : sizeBytes;
+  if (!Number.isFinite(size) || size <= 0) return '0 B';
+  let unit = 0;
+  while (size >= 1024 && unit < UNITS.length - 1) {
+    size /= 1024;
+    unit++;
+  }
+  return `${size.toFixed(unit === 0 ? 0 : 1)} ${UNITS[unit]}`;
+}
+
+/** Renders the staged attachments as removable chips with upload status. */
+export function AttachmentChips({
+  attachments,
+  onRemove,
+  labels = defaultChatLabels.Composer,
+  className,
+}: Readonly<AttachmentChipsProps>) {
+  if (attachments.length === 0) return null;
+
+  return (
+    <ul data-slot="attachment-chips" className={cn('flex flex-wrap gap-2', className)}>
+      {attachments.map((attachment) => (
+        <li
+          key={attachment.id}
+          data-slot="attachment-chip"
+          data-status={attachment.status}
+          className="border-border bg-muted flex items-center gap-1.5 rounded-md border px-2 py-1 text-xs"
+        >
+          {attachment.status === 'uploading' ? (
+            <Loader2 className="size-3.5 animate-spin" aria-hidden />
+          ) : (
+            <FileIcon className="size-3.5" aria-hidden />
+          )}
+          <span className="max-w-40 truncate">{attachment.fileName}</span>
+          <span className="text-muted-foreground">{formatBytes(attachment.sizeBytes)}</span>
+          <button
+            type="button"
+            aria-label={`${labels.RemoveAttachment} ${attachment.fileName}`}
+            onClick={() => {
+              onRemove(attachment.id);
+            }}
+            className="hover:text-foreground text-muted-foreground"
+          >
+            <X className="size-3.5" aria-hidden />
+          </button>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-composer.tsx
@@ -1,0 +1,441 @@
+import { SEND_MESSAGE_LIMITS } from '@granit/ai-chat';
+import { cn } from '@granit/utils';
+import { Paperclip, Send, Square } from 'lucide-react';
+import { useCallback, useId, useMemo, useRef, useState } from 'react';
+
+import { defaultChatLabels } from '../locales/index';
+
+import { AttachmentChips } from './attachment-chips';
+import { ComposerSuggestions } from './composer-suggestions';
+import { detectTrigger } from './detect-trigger';
+
+import type { ComposerAttachment } from './attachment-chips';
+import type {
+  MentionOption,
+  PromptOption,
+  SearchMentions,
+  StagedMention,
+  UploadAttachment,
+} from './composer-types';
+import type { ActiveTrigger } from './detect-trigger';
+import type { ChatTranslations } from '../locales/index';
+import type { SendMessageRequest } from '@granit/ai-chat';
+import type { ChangeEvent, KeyboardEvent } from 'react';
+
+export interface ChatComposerProps {
+  /** Builds and submits a {@link SendMessageRequest} for the turn. */
+  readonly onSubmit: (request: SendMessageRequest) => void;
+  /** Whether a turn is streaming — flips Send into a Stop button. */
+  readonly isStreaming?: boolean;
+  /** Abort the in-flight turn. */
+  readonly onStop?: () => void;
+  /** Prompt options for the `/` picker (filtered client-side by the query). */
+  readonly prompts?: readonly PromptOption[];
+  /** App-specific `@` mention search. Omit to disable the mention picker. */
+  readonly searchMentions?: SearchMentions;
+  /** App-specific attachment upload. Omit to hide the attach button. */
+  readonly uploadAttachment?: UploadAttachment;
+  /** Selectable workspaces (`Auto` first); omit to hide the selector. */
+  readonly workspaces?: readonly string[];
+  readonly workspace?: string;
+  readonly onWorkspaceChange?: (workspace: string) => void;
+  readonly labels?: ChatTranslations['Composer'];
+  readonly pickerLabels?: ChatTranslations['Pickers'];
+  readonly disabled?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * The streaming chat composer: a textarea with `/` prompt and `@` mention
+ * autocomplete, attachment chips, an optional workspace selector, and a
+ * Send/Stop button. App-specific concerns (mention search, blob upload) are
+ * injected as adapters; everything else is headless and framework-agnostic.
+ */
+export function ChatComposer({
+  onSubmit,
+  isStreaming = false,
+  onStop,
+  prompts = [],
+  searchMentions,
+  uploadAttachment,
+  workspaces,
+  workspace,
+  onWorkspaceChange,
+  labels = defaultChatLabels.Composer,
+  pickerLabels = defaultChatLabels.Pickers,
+  disabled = false,
+  className,
+}: Readonly<ChatComposerProps>) {
+  const [text, setText] = useState('');
+  const [promptBadges, setPromptBadges] = useState<readonly PromptOption[]>([]);
+  const [mentions, setMentions] = useState<readonly StagedMention[]>([]);
+  const [attachments, setAttachments] = useState<readonly ComposerAttachment[]>([]);
+  const [trigger, setTrigger] = useState<ActiveTrigger | null>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [mentionResults, setMentionResults] = useState<readonly MentionOption[]>([]);
+  const [mentionLoading, setMentionLoading] = useState(false);
+
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const searchSeq = useRef(0);
+  const attachmentSeq = useRef(0);
+
+  const baseId = useId();
+  const listboxId = `${baseId}-listbox`;
+  const getOptionId = useCallback((index: number) => `${baseId}-opt-${index}`, [baseId]);
+
+  const promptMatches = useMemo<readonly PromptOption[]>(() => {
+    if (trigger?.kind !== '/') return [];
+    const q = trigger.query.toLowerCase();
+    return prompts.filter((p) => p.name.toLowerCase().includes(q)).slice(0, 8);
+  }, [trigger, prompts]);
+
+  const suggestionItems = trigger?.kind === '@' ? mentionResults : promptMatches;
+  const showSuggestions =
+    trigger !== null && (trigger.kind === '/' || searchMentions !== undefined);
+
+  const runMentionSearch = useCallback(
+    (query: string) => {
+      if (!searchMentions) return;
+      const seq = ++searchSeq.current;
+      setMentionLoading(true);
+      searchMentions(query)
+        .then((results) => {
+          if (seq === searchSeq.current) {
+            setMentionResults(results);
+            setMentionLoading(false);
+          }
+        })
+        .catch(() => {
+          if (seq === searchSeq.current) {
+            setMentionResults([]);
+            setMentionLoading(false);
+          }
+        });
+    },
+    [searchMentions]
+  );
+
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLTextAreaElement>) => {
+      const next = event.target.value;
+      setText(next);
+      const caret = event.target.selectionStart ?? next.length;
+      const active = detectTrigger(next, caret);
+      setTrigger(active);
+      setActiveIndex(0);
+      if (active?.kind === '@') runMentionSearch(active.query);
+      else setMentionResults([]);
+    },
+    [runMentionSearch]
+  );
+
+  const replaceTriggerToken = useCallback(
+    (replacement: string) => {
+      if (!trigger) return;
+      const caret = textareaRef.current?.selectionStart ?? text.length;
+      setText((current) => current.slice(0, trigger.start) + replacement + current.slice(caret));
+      setTrigger(null);
+      setMentionResults([]);
+    },
+    [trigger, text.length]
+  );
+
+  const selectPrompt = useCallback(
+    (option: PromptOption) => {
+      setPromptBadges((current) => {
+        if (current.some((p) => p.id === option.id)) return current;
+        if (current.length >= SEND_MESSAGE_LIMITS.PROMPT_REFS_MAX) return current;
+        return [...current, option];
+      });
+      replaceTriggerToken('');
+      textareaRef.current?.focus();
+    },
+    [replaceTriggerToken]
+  );
+
+  const selectMention = useCallback(
+    (option: MentionOption) => {
+      setMentions((current) => {
+        if (current.length >= SEND_MESSAGE_LIMITS.MENTIONS_MAX) return current;
+        return [...current, { type: option.type, id: option.id, label: option.label }];
+      });
+      replaceTriggerToken(`@${option.label} `);
+      textareaRef.current?.focus();
+    },
+    [replaceTriggerToken]
+  );
+
+  const selectActive = useCallback(() => {
+    const item = suggestionItems[activeIndex];
+    if (!item) return;
+    if (trigger?.kind === '/') selectPrompt(item as PromptOption);
+    else selectMention(item as MentionOption);
+  }, [suggestionItems, activeIndex, trigger, selectPrompt, selectMention]);
+
+  const hasUploading = attachments.some((a) => a.status === 'uploading');
+  const canSend = text.trim().length > 0 && !hasUploading && !disabled;
+
+  const submit = useCallback(() => {
+    if (!canSend) return;
+    const request: SendMessageRequest = {
+      message: text.trim(),
+      ...(workspace ? { workspaceName: workspace } : {}),
+      ...(promptBadges.length > 0 ? { promptRefs: promptBadges.map((p) => p.id) } : {}),
+      ...(mentions.length > 0 ? { mentions: mentions.map(({ type, id }) => ({ type, id })) } : {}),
+      ...(attachments.length > 0
+        ? {
+            attachments: attachments
+              .filter((a) => a.status === 'ready')
+              .map(({ reference, fileName, contentType, sizeBytes }) => ({
+                reference,
+                fileName,
+                contentType,
+                sizeBytes,
+              })),
+          }
+        : {}),
+    };
+    onSubmit(request);
+    setText('');
+    setPromptBadges([]);
+    setMentions([]);
+    setAttachments([]);
+    setTrigger(null);
+  }, [canSend, text, workspace, promptBadges, mentions, attachments, onSubmit]);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (showSuggestions && suggestionItems.length > 0) {
+        if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          setActiveIndex((i) => (i + 1) % suggestionItems.length);
+          return;
+        }
+        if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          setActiveIndex((i) => (i - 1 + suggestionItems.length) % suggestionItems.length);
+          return;
+        }
+        if (event.key === 'Enter' || event.key === 'Tab') {
+          event.preventDefault();
+          selectActive();
+          return;
+        }
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          setTrigger(null);
+          return;
+        }
+      }
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        submit();
+      }
+    },
+    [showSuggestions, suggestionItems.length, selectActive, submit]
+  );
+
+  const handleFiles = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(event.target.files ?? []);
+      event.target.value = '';
+      if (!uploadAttachment) return;
+      for (const file of files) {
+        const id = `att-${++attachmentSeq.current}`;
+        setAttachments((current) => {
+          if (current.length >= SEND_MESSAGE_LIMITS.ATTACHMENTS_MAX) return current;
+          return [
+            ...current,
+            {
+              id,
+              status: 'uploading',
+              reference: '',
+              fileName: file.name,
+              contentType: file.type,
+              sizeBytes: file.size,
+            },
+          ];
+        });
+        uploadAttachment(file)
+          .then((uploaded) => {
+            setAttachments((current) =>
+              current.map((a) => (a.id === id ? { ...a, ...uploaded, status: 'ready' } : a))
+            );
+          })
+          .catch(() => {
+            setAttachments((current) =>
+              current.map((a) => (a.id === id ? { ...a, status: 'error' } : a))
+            );
+          });
+      }
+    },
+    [uploadAttachment]
+  );
+
+  return (
+    <div data-slot="chat-composer" className={cn('flex flex-col gap-2', className)}>
+      {promptBadges.length > 0 ? (
+        <ul data-slot="prompt-badges" className="flex flex-wrap gap-2">
+          {promptBadges.map((badge) => (
+            <li
+              key={badge.id}
+              data-slot="prompt-badge"
+              className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium"
+            >
+              <span>/{badge.name}</span>
+              <button
+                type="button"
+                aria-label={`${labels.RemovePrompt} ${badge.name}`}
+                onClick={() => {
+                  setPromptBadges((current) => current.filter((p) => p.id !== badge.id));
+                }}
+                className="hover:text-primary/70"
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <AttachmentChips
+        attachments={attachments}
+        labels={labels}
+        onRemove={(id) => {
+          setAttachments((current) => current.filter((a) => a.id !== id));
+        }}
+      />
+
+      <div className="relative">
+        {showSuggestions && trigger?.kind === '/' ? (
+          <ComposerSuggestions<PromptOption>
+            title={pickerLabels.Prompts}
+            items={promptMatches}
+            activeIndex={activeIndex}
+            loadingLabel={pickerLabels.Loading}
+            emptyLabel={pickerLabels.NoResults}
+            listboxId={listboxId}
+            getOptionId={getOptionId}
+            getKey={(item) => item.id}
+            onHover={setActiveIndex}
+            onSelect={selectPrompt}
+            renderItem={(item) => (
+              <div className="flex flex-col">
+                <span className="font-medium">{item.name}</span>
+                {item.shortDescription ? (
+                  <span className="text-muted-foreground text-xs">{item.shortDescription}</span>
+                ) : null}
+              </div>
+            )}
+          />
+        ) : null}
+
+        {showSuggestions && trigger?.kind === '@' ? (
+          <ComposerSuggestions<MentionOption>
+            title={pickerLabels.Mentions}
+            items={mentionResults}
+            activeIndex={activeIndex}
+            loading={mentionLoading}
+            loadingLabel={pickerLabels.Loading}
+            emptyLabel={pickerLabels.NoResults}
+            listboxId={listboxId}
+            getOptionId={getOptionId}
+            getKey={(item) => `${item.type}:${item.id}`}
+            onHover={setActiveIndex}
+            onSelect={selectMention}
+            renderItem={(item) => (
+              <div className="flex flex-col">
+                <span className="font-medium">{item.label}</span>
+                {item.description ? (
+                  <span className="text-muted-foreground text-xs">{item.description}</span>
+                ) : null}
+              </div>
+            )}
+          />
+        ) : null}
+
+        <textarea
+          ref={textareaRef}
+          data-slot="composer-input"
+          value={text}
+          disabled={disabled}
+          rows={2}
+          maxLength={SEND_MESSAGE_LIMITS.MESSAGE_MAX_LENGTH}
+          placeholder={labels.Placeholder}
+          aria-label={labels.Placeholder}
+          role="combobox"
+          aria-expanded={showSuggestions}
+          aria-controls={showSuggestions ? listboxId : undefined}
+          aria-activedescendant={
+            showSuggestions && suggestionItems.length > 0 ? getOptionId(activeIndex) : undefined
+          }
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          className="border-input bg-background w-full resize-none rounded-md border px-3 py-2 text-sm"
+        />
+      </div>
+
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          {workspaces && workspaces.length > 0 ? (
+            <select
+              data-slot="composer-workspace"
+              aria-label={labels.Workspace}
+              value={workspace ?? workspaces[0]}
+              disabled={disabled}
+              onChange={(event) => onWorkspaceChange?.(event.target.value)}
+              className="border-input bg-background rounded-md border px-2 py-1 text-xs"
+            >
+              {workspaces.map((ws) => (
+                <option key={ws} value={ws}>
+                  {ws}
+                </option>
+              ))}
+            </select>
+          ) : null}
+
+          {uploadAttachment ? (
+            <label
+              data-slot="composer-attach"
+              className="hover:bg-accent inline-flex cursor-pointer items-center rounded-md p-1.5"
+              title={labels.Attach}
+            >
+              <Paperclip className="size-4" aria-hidden />
+              <span className="sr-only">{labels.Attach}</span>
+              <input
+                type="file"
+                multiple
+                className="hidden"
+                disabled={disabled}
+                onChange={handleFiles}
+              />
+            </label>
+          ) : null}
+        </div>
+
+        {isStreaming ? (
+          <button
+            type="button"
+            data-slot="composer-stop"
+            onClick={onStop}
+            className="bg-muted text-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm"
+          >
+            <Square className="size-3.5" aria-hidden />
+            {labels.Stop}
+          </button>
+        ) : (
+          <button
+            type="button"
+            data-slot="composer-send"
+            disabled={!canSend}
+            onClick={submit}
+            className="bg-primary text-primary-foreground inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
+          >
+            <Send className="size-3.5" aria-hidden />
+            {labels.Send}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/chat-message.tsx
+++ b/packages/@granit/react-ai-chat/src/components/chat-message.tsx
@@ -1,0 +1,39 @@
+import { cn } from '@granit/utils';
+
+import type { ChatMessageRole } from '@granit/ai-chat';
+
+export interface ChatMessageProps {
+  readonly role: ChatMessageRole;
+  /**
+   * Message text. ⚠️ **Untrusted** for assistant messages — rendered here as a
+   * plain text node (React escapes it). Never replace this with an HTML sink.
+   */
+  readonly content: string;
+  /** Localised author label (e.g. "You" / "Assistant"). */
+  readonly authorLabel?: string;
+  readonly className?: string;
+}
+
+/** A single chat bubble. Aligns right for the user, left for the assistant. */
+export function ChatMessage({ role, content, authorLabel, className }: Readonly<ChatMessageProps>) {
+  const isUser = role === 'user';
+  return (
+    <div
+      data-slot="chat-message"
+      data-role={role}
+      className={cn('flex flex-col gap-1', isUser ? 'items-end' : 'items-start', className)}
+    >
+      {authorLabel ? (
+        <span className="text-muted-foreground text-xs font-medium">{authorLabel}</span>
+      ) : null}
+      <div
+        className={cn(
+          'max-w-[80%] rounded-lg px-3 py-2 text-sm whitespace-pre-wrap',
+          isUser ? 'bg-primary text-primary-foreground' : 'bg-muted text-foreground'
+        )}
+      >
+        {content}
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/clarification-prompt.tsx
+++ b/packages/@granit/react-ai-chat/src/components/clarification-prompt.tsx
@@ -1,0 +1,96 @@
+import { cn } from '@granit/utils';
+import { useState } from 'react';
+
+import { defaultChatLabels } from '../locales/index';
+
+import type { ChatTranslations } from '../locales/index';
+import type { ClarificationResponse } from '@granit/ai-chat';
+
+export interface ClarificationPromptProps {
+  readonly clarification: ClarificationResponse;
+  /**
+   * Invoked with the chosen answer. For a listed option this is
+   * `value ?? label`; for the free-text "other" field it is the typed string.
+   * The host sends it as the next `message`.
+   */
+  readonly onChoose: (answer: string) => void;
+  readonly labels?: ChatTranslations['Clarification'];
+  readonly disabled?: boolean;
+  readonly className?: string;
+}
+
+/**
+ * Renders a clarifying question that blocked the turn: the question plus
+ * clickable options, and — when `allowOther` — a free-text fallback. Choosing
+ * an option (or submitting the free text) emits `onChoose`.
+ */
+export function ClarificationPrompt({
+  clarification,
+  onChoose,
+  labels = defaultChatLabels.Clarification,
+  disabled = false,
+  className,
+}: Readonly<ClarificationPromptProps>) {
+  const [other, setOther] = useState('');
+  const trimmedOther = other.trim();
+
+  return (
+    <section
+      data-slot="clarification"
+      aria-label={clarification.question}
+      className={cn('border-border bg-card flex flex-col gap-3 rounded-lg border p-3', className)}
+    >
+      <p data-slot="clarification-question" className="text-sm font-medium">
+        {clarification.question}
+      </p>
+
+      <ul className="flex flex-wrap gap-2">
+        {clarification.options.map((option, index) => (
+          <li key={`${option.label}-${index}`}>
+            <button
+              type="button"
+              data-slot="clarification-option"
+              disabled={disabled}
+              onClick={() => {
+                onChoose(option.value ?? option.label);
+              }}
+              className="border-border bg-background hover:bg-accent rounded-md border px-2.5 py-1.5 text-sm transition-colors disabled:opacity-50"
+            >
+              {option.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      {clarification.allowOther ? (
+        <form
+          className="flex items-center gap-2"
+          onSubmit={(event) => {
+            event.preventDefault();
+            if (trimmedOther) onChoose(trimmedOther);
+          }}
+        >
+          <input
+            type="text"
+            data-slot="clarification-other"
+            value={other}
+            disabled={disabled}
+            placeholder={labels.OtherPlaceholder}
+            aria-label={labels.Other}
+            onChange={(event) => {
+              setOther(event.target.value);
+            }}
+            className="border-input bg-background flex-1 rounded-md border px-2.5 py-1.5 text-sm"
+          />
+          <button
+            type="submit"
+            disabled={disabled || trimmedOther === ''}
+            className="bg-primary text-primary-foreground rounded-md px-2.5 py-1.5 text-sm disabled:opacity-50"
+          >
+            {labels.Submit}
+          </button>
+        </form>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/composer-suggestions.tsx
+++ b/packages/@granit/react-ai-chat/src/components/composer-suggestions.tsx
@@ -1,0 +1,89 @@
+import { cn } from '@granit/utils';
+
+import type { ReactNode } from 'react';
+
+export interface ComposerSuggestionsProps<T> {
+  readonly title: string;
+  readonly items: readonly T[];
+  /** Index of the keyboard-highlighted item (owned by the composer). */
+  readonly activeIndex: number;
+  readonly getKey: (item: T, index: number) => string;
+  readonly renderItem: (item: T) => ReactNode;
+  readonly onSelect: (item: T) => void;
+  readonly onHover: (index: number) => void;
+  readonly emptyLabel: string;
+  readonly loading?: boolean;
+  readonly loadingLabel: string;
+  /** `id` of the listbox, referenced by the textarea's `aria-controls`. */
+  readonly listboxId: string;
+  readonly getOptionId: (index: number) => string;
+  readonly className?: string;
+}
+
+/**
+ * Controlled listbox of `/` or `@` suggestions. Keyboard navigation and the
+ * active index are owned by the composer (the textarea keeps focus); this
+ * component only renders the ARIA `listbox`/`option` structure and forwards
+ * pointer selection.
+ */
+export function ComposerSuggestions<T>({
+  title,
+  items,
+  activeIndex,
+  getKey,
+  renderItem,
+  onSelect,
+  onHover,
+  emptyLabel,
+  loading = false,
+  loadingLabel,
+  listboxId,
+  getOptionId,
+  className,
+}: Readonly<ComposerSuggestionsProps<T>>) {
+  return (
+    <div
+      data-slot="composer-suggestions"
+      className={cn(
+        'border-border bg-popover absolute bottom-full z-10 mb-1 max-h-60 w-full overflow-auto rounded-md border shadow-md',
+        className
+      )}
+    >
+      <p className="text-muted-foreground px-2 pt-2 pb-1 text-xs font-medium">{title}</p>
+      {loading ? (
+        <p data-slot="suggestions-loading" className="text-muted-foreground px-2 py-2 text-sm">
+          {loadingLabel}
+        </p>
+      ) : items.length === 0 ? (
+        <p data-slot="suggestions-empty" className="text-muted-foreground px-2 py-2 text-sm">
+          {emptyLabel}
+        </p>
+      ) : (
+        <ul role="listbox" id={listboxId} aria-label={title}>
+          {items.map((item, index) => (
+            <li
+              key={getKey(item, index)}
+              id={getOptionId(index)}
+              role="option"
+              aria-selected={index === activeIndex}
+              onMouseEnter={() => {
+                onHover(index);
+              }}
+              onMouseDown={(event) => {
+                // Keep textarea focus; select on mousedown before blur.
+                event.preventDefault();
+                onSelect(item);
+              }}
+              className={cn(
+                'cursor-pointer px-2 py-1.5 text-sm',
+                index === activeIndex ? 'bg-accent text-accent-foreground' : ''
+              )}
+            >
+              {renderItem(item)}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/composer-types.ts
+++ b/packages/@granit/react-ai-chat/src/components/composer-types.ts
@@ -1,0 +1,42 @@
+import type { MentionRequest, PromptId } from '@granit/ai-chat';
+
+/** A `/` prompt-badge option shown in the prompt picker. */
+export interface PromptOption {
+  readonly id: PromptId;
+  readonly name: string;
+  readonly shortDescription?: string | null;
+  /** Icon identifier owned by the host app's glyph set. */
+  readonly icon?: string | null;
+  readonly iconColor?: string | null;
+}
+
+/** An `@` mention option resolved by the app-specific `searchMentions` adapter. */
+export interface MentionOption {
+  readonly type: string;
+  readonly id: string;
+  readonly label: string;
+  readonly description?: string | null;
+}
+
+/** A mention staged in the composer (kept for the request's `mentions` array). */
+export interface StagedMention extends MentionRequest {
+  readonly label: string;
+}
+
+/**
+ * App-specific search for `@` mention candidates. There is no generic
+ * mention-search endpoint — the host implements this against its entity APIs.
+ */
+export type SearchMentions = (query: string) => Promise<readonly MentionOption[]>;
+
+/**
+ * App-specific attachment upload: push the file to the app's blob store and
+ * return the opaque reference the backend reads back. Reject to surface an
+ * error chip.
+ */
+export type UploadAttachment = (file: File) => Promise<{
+  readonly reference: string;
+  readonly fileName: string;
+  readonly contentType: string;
+  readonly sizeBytes: number | string;
+}>;

--- a/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
+++ b/packages/@granit/react-ai-chat/src/components/conversation-thread.tsx
@@ -1,0 +1,86 @@
+import { cn } from '@granit/utils';
+
+import { defaultChatLabels } from '../locales/index';
+
+import { ChatMessage } from './chat-message';
+
+import type { ChatTranslations } from '../locales/index';
+import type { MessageResponse } from '@granit/ai-chat';
+
+export interface ConversationThreadProps {
+  /** Persisted messages, oldest first. */
+  readonly messages: readonly MessageResponse[];
+  /**
+   * Live assistant text for the in-flight turn (from `useChatStream().content`).
+   * ⚠️ Untrusted — rendered as plain text.
+   */
+  readonly streamingContent?: string;
+  /** Whether a turn is currently streaming (drives the typing indicator). */
+  readonly isStreaming?: boolean;
+  readonly labels?: ChatTranslations['Thread'];
+  readonly className?: string;
+}
+
+/**
+ * Renders a conversation: the persisted messages plus the live streaming
+ * assistant bubble. The streaming region is an ARIA live region
+ * (`role="log"`, `aria-live="polite"`) so screen readers announce incremental
+ * text. The typing indicator honours `prefers-reduced-motion` (the framework's
+ * base stylesheet neutralises the animation).
+ */
+export function ConversationThread({
+  messages,
+  streamingContent,
+  isStreaming = false,
+  labels = defaultChatLabels.Thread,
+  className,
+}: Readonly<ConversationThreadProps>) {
+  const isEmpty = messages.length === 0 && !streamingContent && !isStreaming;
+
+  return (
+    <div
+      data-slot="conversation-thread"
+      role="log"
+      aria-live="polite"
+      aria-relevant="additions text"
+      className={cn('flex flex-col gap-3', className)}
+    >
+      {isEmpty ? (
+        <p data-slot="thread-empty" className="text-muted-foreground py-8 text-center text-sm">
+          {labels.Empty}
+        </p>
+      ) : null}
+
+      {messages.map((message) => (
+        <ChatMessage
+          key={message.id}
+          role={message.role}
+          content={message.content}
+          authorLabel={message.role === 'user' ? labels.You : labels.Assistant}
+        />
+      ))}
+
+      {streamingContent ? (
+        <ChatMessage role="assistant" content={streamingContent} authorLabel={labels.Assistant} />
+      ) : null}
+
+      {isStreaming && !streamingContent ? (
+        <div
+          data-slot="thread-typing"
+          className="text-muted-foreground flex items-center gap-1 text-sm"
+          aria-label={labels.AssistantTyping}
+        >
+          <span className="bg-muted-foreground size-1.5 animate-pulse rounded-full" aria-hidden />
+          <span
+            className="bg-muted-foreground size-1.5 animate-pulse rounded-full [animation-delay:150ms]"
+            aria-hidden
+          />
+          <span
+            className="bg-muted-foreground size-1.5 animate-pulse rounded-full [animation-delay:300ms]"
+            aria-hidden
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/components/detect-trigger.ts
+++ b/packages/@granit/react-ai-chat/src/components/detect-trigger.ts
@@ -1,0 +1,30 @@
+/** An active `/` (prompt) or `@` (mention) token ending at the caret. */
+export interface ActiveTrigger {
+  readonly kind: '/' | '@';
+  /** Text typed after the trigger char, up to the caret (no whitespace). */
+  readonly query: string;
+  /** Index of the trigger char in the text. */
+  readonly start: number;
+}
+
+const WHITESPACE = /\s/;
+
+/**
+ * Detect a `/` or `@` autocomplete token ending at `caret`. A trigger is active
+ * only at the start of the input or directly after whitespace, and its query
+ * may not contain whitespace (typing a space dismisses the picker).
+ */
+export function detectTrigger(text: string, caret: number): ActiveTrigger | null {
+  for (let i = caret - 1; i >= 0; i--) {
+    const ch = text[i]!;
+    if (ch === '/' || ch === '@') {
+      const prev = i > 0 ? text[i - 1] : undefined;
+      if (prev !== undefined && !WHITESPACE.test(prev)) return null;
+      const query = text.slice(i + 1, caret);
+      if (WHITESPACE.test(query)) return null;
+      return { kind: ch, query, start: i };
+    }
+    if (WHITESPACE.test(ch)) return null;
+  }
+  return null;
+}

--- a/packages/@granit/react-ai-chat/src/components/suggested-actions.tsx
+++ b/packages/@granit/react-ai-chat/src/components/suggested-actions.tsx
@@ -1,0 +1,61 @@
+import { cn } from '@granit/utils';
+import { ArrowUpRight } from 'lucide-react';
+
+import { defaultChatLabels } from '../locales/index';
+
+import type { ChatTranslations } from '../locales/index';
+import type { SuggestedActionResponse } from '@granit/ai-chat';
+
+export interface SuggestedActionsProps {
+  readonly actions: readonly SuggestedActionResponse[];
+  /**
+   * Invoked when the user clicks an action. The action's `deepLink` is an app
+   * route — the host app maps it to a navigation. **Never auto-invoked**: the
+   * agent only proposes; the user decides.
+   */
+  readonly onSelect: (action: SuggestedActionResponse) => void;
+  readonly labels?: ChatTranslations['Suggestions'];
+  readonly className?: string;
+}
+
+/**
+ * Renders streamed suggested actions as buttons. They emit `onSelect` instead
+ * of navigating directly, so deep-link routing stays an app concern and no
+ * action ever fires automatically.
+ */
+export function SuggestedActions({
+  actions,
+  onSelect,
+  labels = defaultChatLabels.Suggestions,
+  className,
+}: Readonly<SuggestedActionsProps>) {
+  if (actions.length === 0) return null;
+
+  return (
+    <section
+      data-slot="suggested-actions"
+      aria-label={labels.Title}
+      className={cn('flex flex-col gap-2', className)}
+    >
+      <h3 className="text-muted-foreground text-xs font-medium">{labels.Title}</h3>
+      <ul className="flex flex-wrap gap-2">
+        {actions.map((action, index) => (
+          <li key={`${action.deepLink}-${index}`}>
+            <button
+              type="button"
+              data-slot="suggested-action"
+              onClick={() => {
+                onSelect(action);
+              }}
+              title={action.description ?? undefined}
+              className="border-border bg-card hover:bg-accent inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-sm transition-colors"
+            >
+              <ArrowUpRight className="size-3.5" aria-hidden />
+              {action.label}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/@granit/react-ai-chat/src/constants.ts
+++ b/packages/@granit/react-ai-chat/src/constants.ts
@@ -1,0 +1,10 @@
+export const API_VERSION = 'v1';
+
+/** Route prefix served by the agentic chat endpoints (`MapGranitConversations`). */
+export const MODULE = 'conversations';
+
+/** Default base path for the chat endpoints. Apps override via the provider config. */
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+
+/** Default React Query key prefix for chat queries. */
+export const DEFAULT_QUERY_KEY_PREFIX = ['ai-chat'] as const;

--- a/packages/@granit/react-ai-chat/src/hooks/query-keys.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/query-keys.ts
@@ -1,0 +1,25 @@
+import type { ConversationId } from '@granit/ai-chat';
+
+/**
+ * Query-key factory for chat queries. All keys are namespaced under the
+ * provider's `queryKeyPrefix` so multiple chat instances stay isolated.
+ */
+export const conversationKeys = {
+  /** Root key for every chat query. */
+  all: (prefix: readonly string[]): readonly unknown[] => [...prefix],
+  /** The conversation list. */
+  list: (prefix: readonly string[]): readonly unknown[] => [...prefix, 'conversations', 'list'],
+  /** A single conversation and its messages. */
+  detail: (prefix: readonly string[], id: ConversationId): readonly unknown[] => [
+    ...prefix,
+    'conversations',
+    'detail',
+    id,
+  ],
+  /** The selectable default workspaces. */
+  workspaces: (prefix: readonly string[]): readonly unknown[] => [
+    ...prefix,
+    'conversations',
+    'workspaces',
+  ],
+} as const;

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-stream.ts
@@ -1,0 +1,198 @@
+import { CHAT_STREAM_EVENT_TYPES, streamConversationMessage } from '@granit/ai-chat';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useRef, useState } from 'react';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type {
+  ChatStreamEvent,
+  ClarificationResponse,
+  ConversationId,
+  SendMessageRequest,
+  SuggestedActionResponse,
+} from '@granit/ai-chat';
+
+/** Token usage reported near the end of a turn. */
+export interface ChatStreamUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+}
+
+export interface UseChatStreamReturn {
+  /**
+   * Accumulated assistant answer for the current turn (delta frames appended
+   * in order). Reset on each `send()`.
+   *
+   * ⚠️ **Untrusted** model output — steerable by prompt injection, poisoned
+   * RAG, or echoed tool results. Render it as plain text, or sanitize it (and
+   * scheme-allowlist any links) before rendering as HTML/markdown. Never pass
+   * it to `dangerouslySetInnerHTML` unsanitized.
+   */
+  readonly content: string;
+  /** The new/continued conversation id, once the first frame arrives. */
+  readonly conversationId: ConversationId | null;
+  /** Suggested deep-link actions streamed for this turn. Never auto-invoke. */
+  readonly suggestedActions: readonly SuggestedActionResponse[];
+  /**
+   * A clarifying question that blocked the turn, or `null`. When set, render
+   * its options; the chosen `value ?? label` becomes the next `send()` message.
+   */
+  readonly clarification: ClarificationResponse | null;
+  /** Token usage for the turn, or `null` until the `usage` frame arrives. */
+  readonly usage: ChatStreamUsage | null;
+  /** Whether a stream is currently active. */
+  readonly isStreaming: boolean;
+  /** Error from the last stream attempt, or `null`. */
+  readonly error: Error | null;
+  /** Start a new turn. Aborts any in-progress stream first. */
+  readonly send: (request: SendMessageRequest) => void;
+  /** Abort the current stream (stop button / unmount). */
+  readonly abort: () => void;
+}
+
+/**
+ * Streams an agentic chat turn over Server-Sent Events
+ * (`POST /conversations/messages`).
+ *
+ * Accumulates `delta` content into `content`, captures the conversation id,
+ * suggested actions, a clarification, and token usage as their frames arrive.
+ * Each `send()` resets per-turn state and cancels any in-progress stream. On
+ * successful completion the conversation list and the affected detail query are
+ * invalidated so the persisted messages refresh.
+ *
+ * @example
+ * ```tsx
+ * const { content, isStreaming, send } = useChatStream();
+ * send({ message: 'What changed on invoice 42?', promptRefs: [briefId] });
+ * <p aria-live="polite">{content}</p>
+ * ```
+ */
+export function useChatStream(): UseChatStreamReturn {
+  const config = useAIChatConfig();
+  const queryClient = useQueryClient();
+
+  const [content, setContent] = useState('');
+  const [conversationId, setConversationId] = useState<ConversationId | null>(null);
+  const [suggestedActions, setSuggestedActions] = useState<readonly SuggestedActionResponse[]>([]);
+  const [clarification, setClarification] = useState<ClarificationResponse | null>(null);
+  const [usage, setUsage] = useState<ChatStreamUsage | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const abortRef = useRef<AbortController | null>(null);
+
+  const abort = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+      abortRef.current = null;
+    }
+  }, []);
+
+  const send = useCallback(
+    (request: SendMessageRequest) => {
+      abort();
+      setContent('');
+      setConversationId(null);
+      setSuggestedActions([]);
+      setClarification(null);
+      setUsage(null);
+      setError(null);
+      setIsStreaming(true);
+
+      const controller = new AbortController();
+      abortRef.current = controller;
+
+      void (async () => {
+        let resolvedId: ConversationId | null = null;
+        try {
+          let accumulated = '';
+          for await (const event of streamConversationMessage(
+            config.client,
+            config.basePath,
+            request,
+            controller.signal
+          )) {
+            applyEvent(event, {
+              appendContent: (chunk) => {
+                accumulated += chunk;
+                setContent(accumulated);
+              },
+              setConversationId: (id) => {
+                resolvedId = id;
+                setConversationId(id);
+              },
+              setSuggestedActions,
+              setClarification,
+              setUsage,
+            });
+          }
+
+          queryClient
+            .invalidateQueries({ queryKey: conversationKeys.list(config.queryKeyPrefix) })
+            .catch(() => undefined);
+          if (resolvedId) {
+            queryClient
+              .invalidateQueries({
+                queryKey: conversationKeys.detail(config.queryKeyPrefix, resolvedId),
+              })
+              .catch(() => undefined);
+          }
+        } catch (err) {
+          if (err instanceof DOMException && err.name === 'AbortError') return;
+          setError(err instanceof Error ? err : new Error(String(err)));
+        } finally {
+          setIsStreaming(false);
+          abortRef.current = null;
+        }
+      })();
+    },
+    [abort, config, queryClient]
+  );
+
+  return {
+    content,
+    conversationId,
+    suggestedActions,
+    clarification,
+    usage,
+    isStreaming,
+    error,
+    send,
+    abort,
+  };
+}
+
+/** Per-frame state updaters, kept out of the hook body for readability. */
+interface EventSinks {
+  readonly appendContent: (chunk: string) => void;
+  readonly setConversationId: (id: ConversationId) => void;
+  readonly setSuggestedActions: (actions: readonly SuggestedActionResponse[]) => void;
+  readonly setClarification: (clarification: ClarificationResponse) => void;
+  readonly setUsage: (usage: ChatStreamUsage) => void;
+}
+
+/** Dispatch a single {@link ChatStreamEvent} to the matching state updater. */
+function applyEvent(event: ChatStreamEvent, sinks: EventSinks): void {
+  switch (event.type) {
+    case CHAT_STREAM_EVENT_TYPES.DELTA:
+      if (event.content) sinks.appendContent(event.content);
+      break;
+    case CHAT_STREAM_EVENT_TYPES.CONVERSATION:
+      if (event.conversationId) sinks.setConversationId(event.conversationId);
+      break;
+    case CHAT_STREAM_EVENT_TYPES.SUGGESTIONS:
+      if (event.suggestedActions) sinks.setSuggestedActions(event.suggestedActions);
+      break;
+    case CHAT_STREAM_EVENT_TYPES.CLARIFICATION:
+      if (event.clarification) sinks.setClarification(event.clarification);
+      break;
+    case CHAT_STREAM_EVENT_TYPES.USAGE:
+      sinks.setUsage({
+        inputTokens: event.inputTokens ?? 0,
+        outputTokens: event.outputTokens ?? 0,
+      });
+      break;
+  }
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-chat-workspaces.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-chat-workspaces.ts
@@ -1,0 +1,25 @@
+import { listChatWorkspaces } from '@granit/ai-chat';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type { ChatWorkspacesResponse } from '@granit/ai-chat';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List the workspaces a user may set as their default chat workspace
+ * (`Auto` first, then the chat-capable workspaces). Backs the workspace
+ * dropdown in the composer and the chat settings screen.
+ */
+export function useChatWorkspaces(options?: {
+  enabled?: boolean;
+}): UseQueryResult<ChatWorkspacesResponse> {
+  const config = useAIChatConfig();
+  return useQuery({
+    queryKey: conversationKeys.workspaces(config.queryKeyPrefix),
+    queryFn: () => listChatWorkspaces(config.client, config.basePath),
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-conversation.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-conversation.ts
@@ -1,0 +1,27 @@
+import { getConversation } from '@granit/ai-chat';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type { ConversationId, ConversationResponse } from '@granit/ai-chat';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetch one of the current user's conversations and its messages.
+ *
+ * @param id - the conversation id, or `null` to disable the query (e.g. before
+ *   the first turn of a brand-new conversation).
+ */
+export function useConversation(
+  id: ConversationId | null,
+  options?: { enabled?: boolean }
+): UseQueryResult<ConversationResponse> {
+  const config = useAIChatConfig();
+  return useQuery({
+    queryKey: conversationKeys.detail(config.queryKeyPrefix, id ?? ('' as ConversationId)),
+    queryFn: () => getConversation(config.client, config.basePath, id as ConversationId),
+    enabled: (options?.enabled ?? true) && id !== null,
+  });
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-conversations.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-conversations.ts
@@ -1,0 +1,29 @@
+import { listConversations } from '@granit/ai-chat';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type { ConversationSummaryResponse } from '@granit/ai-chat';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List the current user's conversations, newest first (owner-private).
+ *
+ * @example
+ * ```tsx
+ * const { data } = useConversations();
+ * data?.map((c) => <li key={c.id}>{c.title}</li>);
+ * ```
+ */
+export function useConversations(options?: {
+  enabled?: boolean;
+}): UseQueryResult<readonly ConversationSummaryResponse[]> {
+  const config = useAIChatConfig();
+  return useQuery({
+    queryKey: conversationKeys.list(config.queryKeyPrefix),
+    queryFn: () => listConversations(config.client, config.basePath),
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-create-conversation.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-create-conversation.ts
@@ -1,0 +1,49 @@
+import { createConversation } from '@granit/ai-chat';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type { ConversationResponse, CreateConversationRequest } from '@granit/ai-chat';
+
+export interface UseCreateConversationReturn {
+  readonly create: (request: CreateConversationRequest) => void;
+  readonly createAsync: (request: CreateConversationRequest) => Promise<ConversationResponse>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to create an empty conversation. Invalidates the conversation list
+ * on success. Requires `AIChat.Conversations.Manage`.
+ */
+export function useCreateConversation(): UseCreateConversationReturn {
+  const config = useAIChatConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (request: CreateConversationRequest) =>
+      createConversation(config.client, config.basePath, request),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: conversationKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+    },
+  });
+
+  const create = useCallback(
+    (request: CreateConversationRequest) => {
+      mutation.mutate(request);
+    },
+    [mutation]
+  );
+
+  const createAsync = useCallback(
+    async (request: CreateConversationRequest) => mutation.mutateAsync(request),
+    [mutation]
+  );
+
+  return { create, createAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-delete-conversation.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-delete-conversation.ts
@@ -1,0 +1,50 @@
+import { deleteConversation } from '@granit/ai-chat';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type { ConversationId } from '@granit/ai-chat';
+
+export interface UseDeleteConversationReturn {
+  readonly remove: (id: ConversationId) => void;
+  readonly removeAsync: (id: ConversationId) => Promise<void>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to delete a conversation. Invalidates the list on success.
+ * Requires `AIChat.Conversations.Delete`.
+ */
+export function useDeleteConversation(): UseDeleteConversationReturn {
+  const config = useAIChatConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (id: ConversationId) => deleteConversation(config.client, config.basePath, id),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: conversationKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+    },
+  });
+
+  const remove = useCallback(
+    (id: ConversationId) => {
+      mutation.mutate(id);
+    },
+    [mutation]
+  );
+
+  const removeAsync = useCallback(
+    async (id: ConversationId) => {
+      await mutation.mutateAsync(id);
+    },
+    [mutation]
+  );
+
+  return { remove, removeAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-chat/src/hooks/use-rename-conversation.ts
+++ b/packages/@granit/react-ai-chat/src/hooks/use-rename-conversation.ts
@@ -1,0 +1,59 @@
+import { renameConversation } from '@granit/ai-chat';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIChatConfig } from '../providers/ai-chat-provider';
+
+import { conversationKeys } from './query-keys';
+
+import type { ConversationId, RenameConversationRequest } from '@granit/ai-chat';
+
+export interface RenameConversationVariables {
+  readonly id: ConversationId;
+  readonly request: RenameConversationRequest;
+}
+
+export interface UseRenameConversationReturn {
+  readonly rename: (variables: RenameConversationVariables) => void;
+  readonly renameAsync: (variables: RenameConversationVariables) => Promise<void>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to rename a conversation. Invalidates the list and the affected
+ * detail on success. Requires `AIChat.Conversations.Manage`.
+ */
+export function useRenameConversation(): UseRenameConversationReturn {
+  const config = useAIChatConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: ({ id, request }: RenameConversationVariables) =>
+      renameConversation(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      queryClient
+        .invalidateQueries({ queryKey: conversationKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: conversationKeys.detail(config.queryKeyPrefix, id) })
+        .catch(() => undefined);
+    },
+  });
+
+  const rename = useCallback(
+    (variables: RenameConversationVariables) => {
+      mutation.mutate(variables);
+    },
+    [mutation]
+  );
+
+  const renameAsync = useCallback(
+    async (variables: RenameConversationVariables) => {
+      await mutation.mutateAsync(variables);
+    },
+    [mutation]
+  );
+
+  return { rename, renameAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -1,0 +1,28 @@
+// Provider
+export { AIChatProvider, useAIChatConfig } from './providers/ai-chat-provider';
+export type {
+  AIChatConfig,
+  AIChatProviderProps,
+  ResolvedAIChatConfig,
+} from './providers/ai-chat-provider';
+
+// Query keys
+export { conversationKeys } from './hooks/query-keys';
+
+// Hooks — conversations
+export { useConversations } from './hooks/use-conversations';
+export { useConversation } from './hooks/use-conversation';
+export { useChatWorkspaces } from './hooks/use-chat-workspaces';
+export { useCreateConversation } from './hooks/use-create-conversation';
+export type { UseCreateConversationReturn } from './hooks/use-create-conversation';
+export { useRenameConversation } from './hooks/use-rename-conversation';
+export type {
+  RenameConversationVariables,
+  UseRenameConversationReturn,
+} from './hooks/use-rename-conversation';
+export { useDeleteConversation } from './hooks/use-delete-conversation';
+export type { UseDeleteConversationReturn } from './hooks/use-delete-conversation';
+
+// Hooks — streaming
+export { useChatStream } from './hooks/use-chat-stream';
+export type { ChatStreamUsage, UseChatStreamReturn } from './hooks/use-chat-stream';

--- a/packages/@granit/react-ai-chat/src/index.ts
+++ b/packages/@granit/react-ai-chat/src/index.ts
@@ -26,3 +26,36 @@ export type { UseDeleteConversationReturn } from './hooks/use-delete-conversatio
 // Hooks — streaming
 export { useChatStream } from './hooks/use-chat-stream';
 export type { ChatStreamUsage, UseChatStreamReturn } from './hooks/use-chat-stream';
+
+// Components
+export { ChatMessage } from './components/chat-message';
+export type { ChatMessageProps } from './components/chat-message';
+export { ConversationThread } from './components/conversation-thread';
+export type { ConversationThreadProps } from './components/conversation-thread';
+export { SuggestedActions } from './components/suggested-actions';
+export type { SuggestedActionsProps } from './components/suggested-actions';
+export { ClarificationPrompt } from './components/clarification-prompt';
+export type { ClarificationPromptProps } from './components/clarification-prompt';
+export { AttachmentChips } from './components/attachment-chips';
+export type {
+  AttachmentChipsProps,
+  AttachmentStatus,
+  ComposerAttachment,
+} from './components/attachment-chips';
+export { ChatComposer } from './components/chat-composer';
+export type { ChatComposerProps } from './components/chat-composer';
+export { ComposerSuggestions } from './components/composer-suggestions';
+export type { ComposerSuggestionsProps } from './components/composer-suggestions';
+export { detectTrigger } from './components/detect-trigger';
+export type { ActiveTrigger } from './components/detect-trigger';
+export type {
+  MentionOption,
+  PromptOption,
+  SearchMentions,
+  StagedMention,
+  UploadAttachment,
+} from './components/composer-types';
+
+// i18n
+export { aiChatTranslationsEn, aiChatTranslationsFr, defaultChatLabels } from './locales/index';
+export type { ChatTranslations } from './locales/index';

--- a/packages/@granit/react-ai-chat/src/locales/en.ts
+++ b/packages/@granit/react-ai-chat/src/locales/en.ts
@@ -1,0 +1,64 @@
+/** Translation shape for the `aiChat` namespace. */
+export interface ChatTranslations {
+  readonly Thread: {
+    readonly Empty: string;
+    readonly You: string;
+    readonly Assistant: string;
+    readonly AssistantTyping: string;
+  };
+  readonly Composer: {
+    readonly Placeholder: string;
+    readonly Send: string;
+    readonly Stop: string;
+    readonly Attach: string;
+    readonly Workspace: string;
+    readonly RemoveAttachment: string;
+    readonly RemovePrompt: string;
+  };
+  readonly Suggestions: {
+    readonly Title: string;
+  };
+  readonly Clarification: {
+    readonly Other: string;
+    readonly OtherPlaceholder: string;
+    readonly Submit: string;
+  };
+  readonly Pickers: {
+    readonly Prompts: string;
+    readonly Mentions: string;
+    readonly NoResults: string;
+    readonly Loading: string;
+  };
+}
+
+export const aiChatTranslationsEn: ChatTranslations = {
+  Thread: {
+    Empty: 'Ask anything about your app.',
+    You: 'You',
+    Assistant: 'Assistant',
+    AssistantTyping: 'Assistant is typing…',
+  },
+  Composer: {
+    Placeholder: 'Ask your app… ( / for prompts, @ to mention )',
+    Send: 'Send',
+    Stop: 'Stop',
+    Attach: 'Attach a file',
+    Workspace: 'Workspace',
+    RemoveAttachment: 'Remove attachment',
+    RemovePrompt: 'Remove prompt',
+  },
+  Suggestions: {
+    Title: 'Suggested actions',
+  },
+  Clarification: {
+    Other: 'Something else…',
+    OtherPlaceholder: 'Type your answer',
+    Submit: 'Send',
+  },
+  Pickers: {
+    Prompts: 'Prompts',
+    Mentions: 'Mentions',
+    NoResults: 'No results',
+    Loading: 'Searching…',
+  },
+};

--- a/packages/@granit/react-ai-chat/src/locales/fr.ts
+++ b/packages/@granit/react-ai-chat/src/locales/fr.ts
@@ -1,0 +1,33 @@
+import type { ChatTranslations } from './en';
+
+export const aiChatTranslationsFr: ChatTranslations = {
+  Thread: {
+    Empty: 'Posez une question sur votre application.',
+    You: 'Vous',
+    Assistant: 'Assistant',
+    AssistantTyping: 'L’assistant écrit…',
+  },
+  Composer: {
+    Placeholder: 'Interrogez votre application… ( / pour les prompts, @ pour mentionner )',
+    Send: 'Envoyer',
+    Stop: 'Arrêter',
+    Attach: 'Joindre un fichier',
+    Workspace: 'Espace de travail',
+    RemoveAttachment: 'Supprimer la pièce jointe',
+    RemovePrompt: 'Supprimer le prompt',
+  },
+  Suggestions: {
+    Title: 'Actions suggérées',
+  },
+  Clarification: {
+    Other: 'Autre chose…',
+    OtherPlaceholder: 'Saisissez votre réponse',
+    Submit: 'Envoyer',
+  },
+  Pickers: {
+    Prompts: 'Prompts',
+    Mentions: 'Mentions',
+    NoResults: 'Aucun résultat',
+    Loading: 'Recherche…',
+  },
+};

--- a/packages/@granit/react-ai-chat/src/locales/index.ts
+++ b/packages/@granit/react-ai-chat/src/locales/index.ts
@@ -1,0 +1,10 @@
+export { aiChatTranslationsEn } from './en';
+export { aiChatTranslationsFr } from './fr';
+export type { ChatTranslations } from './en';
+
+/**
+ * English defaults used by components when no `labels` prop is provided, so
+ * they render standalone (and tests need no i18n bootstrap). Apps register the
+ * `aiChat*` bundles with i18next and pass translated labels down.
+ */
+export { aiChatTranslationsEn as defaultChatLabels } from './en';

--- a/packages/@granit/react-ai-chat/src/providers/ai-chat-provider.tsx
+++ b/packages/@granit/react-ai-chat/src/providers/ai-chat-provider.tsx
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------
+// AI chat context provider — supplies the Axios client and config to all
+// conversation hooks. Mirrors the @granit/react-ai provider pattern.
+// ---------------------------------------------------------------------------
+
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for {@link AIChatProvider}. */
+export interface AIChatConfig {
+  /** Axios client with auth, CSRF, and tenant interceptors. */
+  readonly client?: AxiosInstance;
+  /** Base path for the conversation endpoints (default: `/api/v1/conversations`). */
+  readonly basePath?: string;
+  /** React Query key prefix (default: `['ai-chat']`). */
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/** {@link AIChatConfig} after the provider has resolved `client` and defaults. */
+export interface ResolvedAIChatConfig extends AIChatConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
+}
+
+export interface AIChatProviderProps {
+  readonly config: AIChatConfig;
+  readonly children: ReactNode;
+}
+
+const AIChatConfigContext = createContext<ResolvedAIChatConfig | null>(null);
+
+/** Provides chat configuration to child components and hooks. */
+export function AIChatProvider({ config, children }: Readonly<AIChatProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedAIChatConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'AIChatProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      client,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+    };
+  }, [config, contextClient]);
+  return <AIChatConfigContext value={value}>{children}</AIChatConfigContext>;
+}
+
+/** Returns the chat configuration from the nearest {@link AIChatProvider}. */
+export function useAIChatConfig(): ResolvedAIChatConfig {
+  const ctx = useContext(AIChatConfigContext);
+  if (!ctx) {
+    throw new Error('useAIChatConfig must be used within an AIChatProvider');
+  }
+  return ctx;
+}

--- a/packages/@granit/react-ai-chat/src/testing/data.ts
+++ b/packages/@granit/react-ai-chat/src/testing/data.ts
@@ -1,0 +1,53 @@
+import { toEntityId, toISODateString } from '@granit/types';
+
+import type {
+  ConversationResponse,
+  ConversationSummaryResponse,
+  MessageResponse,
+} from '@granit/ai-chat';
+
+const OWNER = toEntityId<'User'>('b2222222-2222-2222-2222-222222222222');
+
+const CONVERSATION_ID = toEntityId<'Conversation'>('a1111111-1111-1111-1111-111111111111');
+
+/** A full conversation with two messages, returned by `GET /conversations/{id}`. */
+export const mockConversation: ConversationResponse = {
+  id: CONVERSATION_ID,
+  title: 'Invoice questions',
+  ownerId: OWNER,
+  createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
+  modifiedAt: toISODateString('2026-06-15T09:05:00.000Z'),
+  messages: [
+    {
+      id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333331'),
+      role: 'user',
+      content: 'What changed on invoice 42 last week?',
+      createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
+    },
+    {
+      id: toEntityId<'Message'>('c3333333-3333-3333-3333-333333333332'),
+      role: 'assistant',
+      content: 'The total was revised from €1,200 to €1,350 and the due date moved to June 30.',
+      createdAt: toISODateString('2026-06-15T09:00:08.000Z'),
+    },
+  ] satisfies MessageResponse[],
+};
+
+/** Conversation summaries returned by `GET /conversations`, newest first. */
+export const mockConversationSummaries: ConversationSummaryResponse[] = [
+  {
+    id: CONVERSATION_ID,
+    title: 'Invoice questions',
+    createdAt: toISODateString('2026-06-15T09:00:00.000Z'),
+    modifiedAt: toISODateString('2026-06-15T09:05:00.000Z'),
+  },
+  {
+    id: toEntityId<'Conversation'>('a1111111-1111-1111-1111-111111111112'),
+    title: 'Daily brief',
+    createdAt: toISODateString('2026-06-14T07:30:00.000Z'),
+    modifiedAt: null,
+  },
+];
+
+/** Selectable default workspaces returned by `GET /conversations/workspaces`. */
+export const mockChatWorkspaces: readonly string[] = ['Auto', 'default', 'support'];

--- a/packages/@granit/react-ai-chat/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-chat/src/testing/handlers.ts
@@ -1,0 +1,112 @@
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { mockChatWorkspaces, mockConversation, mockConversationSummaries } from './data';
+
+import type {
+  ConversationResponse,
+  ConversationSummaryResponse,
+  CreateConversationRequest,
+  RenameConversationRequest,
+} from '@granit/ai-chat';
+import type { Mutable } from '@granit/testing';
+
+/** One SSE frame line for the conversations stream (flat ChatStreamEvent JSON). */
+function frame(event: Record<string, unknown>): string {
+  return `data: ${JSON.stringify(event)}\n\n`;
+}
+
+/**
+ * Create stateful MSW handlers for the agentic chat endpoints. Create / rename /
+ * delete mutate an in-memory list reflected by subsequent GETs. The
+ * `POST /messages` handler streams flat `ChatStreamEvent` frames
+ * (conversation → delta → delta → usage) and closes — no `[DONE]` sentinel.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/conversations`).
+ */
+export function createAIChatHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  let summaries: Mutable<ConversationSummaryResponse>[] = [...mockConversationSummaries];
+
+  return [
+    // GET /conversations/workspaces — before /:id so it is not swallowed.
+    http.get(`${baseUrl}/workspaces`, () => HttpResponse.json({ workspaces: mockChatWorkspaces })),
+
+    // GET /conversations — list summaries, newest first.
+    http.get(baseUrl, () => HttpResponse.json(summaries)),
+
+    // GET /conversations/:id — full conversation.
+    http.get(`${baseUrl}/:id`, ({ params }) => {
+      const id = params.id as string;
+      const summary = summaries.find((c) => c.id === id);
+      if (!summary) return new HttpResponse(null, { status: 404 });
+      return HttpResponse.json<ConversationResponse>({
+        ...mockConversation,
+        id: summary.id,
+        title: summary.title,
+      });
+    }),
+
+    // POST /conversations — create.
+    http.post(baseUrl, async ({ request }) => {
+      const body = (await request.json()) as CreateConversationRequest;
+      const created: ConversationResponse = {
+        ...mockConversation,
+        id: mockConversation.id,
+        title: body.title,
+        messages: [],
+      };
+      summaries = [
+        {
+          id: created.id,
+          title: created.title,
+          createdAt: created.createdAt,
+          modifiedAt: created.modifiedAt,
+        },
+        ...summaries,
+      ];
+      return HttpResponse.json(created, { status: 201 });
+    }),
+
+    // PUT /conversations/:id/title — rename.
+    http.put(`${baseUrl}/:id/title`, async ({ params, request }) => {
+      const id = params.id as string;
+      const body = (await request.json()) as RenameConversationRequest;
+      const index = summaries.findIndex((c) => c.id === id);
+      if (index === -1) return new HttpResponse(null, { status: 404 });
+      summaries = summaries.map((c) => (c.id === id ? { ...c, title: body.title } : c));
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    // DELETE /conversations/:id — delete.
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const id = params.id as string;
+      const before = summaries.length;
+      summaries = summaries.filter((c) => c.id !== id);
+      if (summaries.length === before) return new HttpResponse(null, { status: 404 });
+      return new HttpResponse(null, { status: 204 });
+    }),
+
+    // POST /conversations/messages — SSE stream (no [DONE] sentinel).
+    http.post(`${baseUrl}/messages`, async ({ request }) => {
+      const body = (await request.json()) as { message: string; conversationId?: string | null };
+      const conversationId = body.conversationId ?? mockConversation.id;
+      const answer = `Mock answer to: "${body.message.slice(0, 50)}"`;
+
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(frame({ type: 'conversation', conversationId })));
+          controller.enqueue(encoder.encode(frame({ type: 'delta', content: answer })));
+          controller.enqueue(encoder.encode(frame({ type: 'delta', content: ' Done.' })));
+          controller.enqueue(
+            encoder.encode(frame({ type: 'usage', inputTokens: 12, outputTokens: 8 }))
+          );
+          controller.close();
+        },
+      });
+
+      return new HttpResponse(stream, { headers: { 'Content-Type': 'text/event-stream' } });
+    }),
+  ];
+}

--- a/packages/@granit/react-ai-chat/src/testing/index.ts
+++ b/packages/@granit/react-ai-chat/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-ai-chat/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockChatWorkspaces, mockConversation, mockConversationSummaries } from './data';
+export { createAIChatHandlers } from './handlers';

--- a/packages/@granit/react-ai-chat/tsconfig.json
+++ b/packages/@granit/react-ai-chat/tsconfig.json
@@ -6,9 +6,11 @@
       "@granit/api-client": ["../api-client/src/index.ts"],
       "@granit/react-api-client": ["../react-api-client/src/index.ts"],
       "@granit/types": ["../types/src/index.ts"],
+      "@granit/utils": ["../utils/src/index.ts"],
       "@granit/testing": ["../testing/src/index.ts"],
       "@granit/react-testing": ["../react-testing/src/index.ts"]
     }
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
 }

--- a/packages/@granit/react-ai-chat/tsconfig.json
+++ b/packages/@granit/react-ai-chat/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/ai-chat": ["../ai-chat/src/index.ts"],
+      "@granit/api-client": ["../api-client/src/index.ts"],
+      "@granit/react-api-client": ["../react-api-client/src/index.ts"],
+      "@granit/types": ["../types/src/index.ts"],
+      "@granit/testing": ["../testing/src/index.ts"],
+      "@granit/react-testing": ["../react-testing/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-ai-chat/tsup.config.ts
+++ b/packages/@granit/react-ai-chat/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -205,6 +205,19 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/ai-chat:
+    dependencies:
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/analytics:
     dependencies:
       '@granit/api-client':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -984,6 +984,37 @@ importers:
         specifier: workspace:*
         version: link:../types
 
+  packages/@granit/react-ai-chat:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.2)(typescript@6.0.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/ai-chat':
+        specifier: workspace:*
+        version: link:../ai-chat
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
   packages/@granit/react-analytics:
     dependencies:
       '@tanstack/react-query':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -989,6 +989,9 @@ importers:
       '@tanstack/react-query':
         specifier: 5.101.0
         version: 5.101.0(react@19.2.7)
+      lucide-react:
+        specifier: ^1.0.0
+        version: 1.17.0(react@19.2.7)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.2)(typescript@6.0.3)
@@ -1014,6 +1017,9 @@ importers:
       '@granit/types':
         specifier: workspace:*
         version: link:../types
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
 
   packages/@granit/react-analytics:
     dependencies:


### PR DESCRIPTION
## What

The **React surface for the agentic "Ask your app" chat** — the headline AI feature whose backend shipped in Epic **granit-dotnet#2626** (ADR-067). This is the **chat-first** half; the user-facing **prompt catalogue** (`@granit/ai-prompts` / `@granit/react-ai-prompts`) follows in a separate PR.

Two new packages, mirroring the existing `@granit/ai` ⁄ `@granit/react-ai` (low-level proxy) split — but targeting the **product** endpoint `POST /conversations/messages`, not the raw `/ai/chat/{workspace}` proxy.

### `@granit/ai-chat` (core, framework-agnostic)
- Hand-written DTOs mirroring `Granit.AI.Chat.Endpoints` (optionality from the OpenAPI `required` arrays; int64 `sizeBytes` as `number | string`).
- Conversation CRUD + `listChatWorkspaces` over the Axios client.
- `streamConversationMessage` — async generator over SSE via Axios `adapter: 'fetch'` (flows through CSRF/auth/tenant interceptors). Flat `ChatStreamEvent` frames (`conversation`/`delta`/`usage`/`suggestions`/`clarification`); **ends on connection close — no `[DONE]` sentinel**.
- `AIChatPermissions.Conversations.{Read,Send,Manage,Delete}`.
- Vendored `contracts/openapi/ai-chat.json` + wired into `@granit/contract-tests` (13 DTOs + route conformance diffed against the backend spec).

### `@granit/react-ai-chat` (React bindings + UI)
- `AIChatProvider`, `useChatStream` (accumulates deltas; captures conversationId, suggested actions, clarification, usage; abortable; invalidates queries on completion), conversation CRUD/workspace hooks with a namespaced query-key factory.
- Components: `ConversationThread` (ARIA live log, reduced-motion typing indicator, **untrusted content rendered as plain text**), `ChatComposer` (textarea with `/` prompt-badge + `@` mention autocomplete — keyboard nav, ARIA combobox/listbox — attachment chips, workspace selector, Send/Stop), `SuggestedActions` (buttons that **emit `onSelect`, never auto-navigate**), `ClarificationPrompt`, `AttachmentChips`.
- App seams injected as adapters (`searchMentions`, `uploadAttachment`); deep-link routing + prompt catalogue stay app concerns (wired in showcase / follow-up PR).
- en/fr i18n bundles + label-prop defaults; stateful MSW testing seam under `/testing`.

## Security / UX
- Server enforces ACLs; client only gates affordances. Conversations are owner-private.
- Streamed content treated as untrusted (plain-text render, no HTML sink). Suggested actions never auto-invoked.
- WCAG AA: keyboard nav for the `/` and `@` pickers, ARIA live region for streamed text, `prefers-reduced-motion` honoured.

## DoD
- `pnpm lint --max-warnings 0`, `tsc`, and Vitest **green** (48 new tests across both packages); contract conformance + arch-tests + `check:csp` pass.
- **Storybook**: granit-front has no Storybook harness (stories live in the showcase) — stories land with the showcase wiring (Part D), not here.

## Not in this PR (follow-ups)
- `@granit/ai-prompts` + `@granit/react-ai-prompts` (the `/` catalogue CRUD + picker + icon picker) — next PR.
- Showcase wiring (chat page, prompt catalogue page, chat settings, app-seam adapters, Storybook) — separate `granit-showcase-react` MR.
- Per-user chat settings UI (`Granit.AI.Chat.*` via the generic user-settings client).

Refs granit-dotnet#2626