### PR TITLE
feat(ai-prompts): prompt catalogue core + React surface (@granit/ai-prompts, @granit/react-ai-prompts)

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2850,6 +2850,92 @@
       ]
     },
     {
+      "name": "@granit/react-ai-prompts",
+      "description": "React bindings for @granit/ai-prompts — AIPromptsProvider, prompt catalogue CRUD + customise hooks, the / picker hook + popover, an icon picker, and the catalogue manager UI",
+      "exports": [
+        {
+          "name": "AIPromptsProvider",
+          "kind": "function",
+          "signature": "function AIPromptsProvider("
+        },
+        {
+          "name": "useAIPromptsConfig",
+          "kind": "function",
+          "signature": "function useAIPromptsConfig(): ResolvedAIPromptsConfig"
+        },
+        {
+          "name": "promptKeys",
+          "kind": "const",
+          "signature": "const promptKeys"
+        },
+        {
+          "name": "usePrompts",
+          "kind": "function",
+          "signature": "function usePrompts(options?:"
+        },
+        {
+          "name": "usePrompt",
+          "kind": "function",
+          "signature": "function usePrompt( id: PromptId | null, options?:"
+        },
+        {
+          "name": "usePromptPicker",
+          "kind": "function",
+          "signature": "function usePromptPicker(options?:"
+        },
+        {
+          "name": "useCreatePrompt",
+          "kind": "function",
+          "signature": "function useCreatePrompt(): UseCreatePromptReturn"
+        },
+        {
+          "name": "UseCreatePromptReturn",
+          "kind": "interface",
+          "signature": "interface UseCreatePromptReturn",
+          "members": []
+        },
+        {
+          "name": "useUpdatePrompt",
+          "kind": "function",
+          "signature": "function useUpdatePrompt(): UseUpdatePromptReturn"
+        },
+        {
+          "name": "UpdatePromptVariables",
+          "kind": "interface",
+          "signature": "interface UpdatePromptVariables",
+          "members": []
+        },
+        {
+          "name": "UseUpdatePromptReturn",
+          "kind": "interface",
+          "signature": "interface UseUpdatePromptReturn",
+          "members": []
+        },
+        {
+          "name": "useDeletePrompt",
+          "kind": "function",
+          "signature": "function useDeletePrompt(): UseDeletePromptReturn"
+        },
+        {
+          "name": "UseDeletePromptReturn",
+          "kind": "interface",
+          "signature": "interface UseDeletePromptReturn",
+          "members": []
+        },
+        {
+          "name": "useCustomisePrompt",
+          "kind": "function",
+          "signature": "function useCustomisePrompt(): UseCustomisePromptReturn"
+        },
+        {
+          "name": "UseCustomisePromptReturn",
+          "kind": "interface",
+          "signature": "interface UseCustomisePromptReturn",
+          "members": []
+        }
+      ]
+    },
+    {
       "name": "@granit/react-analytics",
       "description": "React hooks and renderers for @granit/analytics — useMetric hook plus KpiTile widget renderer registered into the @granit/dashboards widget registry",
       "exports": [

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -116,6 +116,32 @@
       ]
     },
     {
+      "name": "@granit/ai-prompts",
+      "description": "AI prompt catalogue — prompt CRUD, the chat picker, and copy-on-customise types and API functions. Mirrors Granit.AI.Prompts.Endpoints .NET",
+      "exports": [
+        {
+          "name": "GENERAL_CATEGORY_NAME",
+          "kind": "const",
+          "signature": "const GENERAL_CATEGORY_NAME"
+        },
+        {
+          "name": "ICON_COLOR_PATTERN",
+          "kind": "const",
+          "signature": "const ICON_COLOR_PATTERN"
+        },
+        {
+          "name": "PROMPT_LIMITS",
+          "kind": "const",
+          "signature": "const PROMPT_LIMITS"
+        },
+        {
+          "name": "AIPromptsPermissions",
+          "kind": "const",
+          "signature": "const AIPromptsPermissions"
+        }
+      ]
+    },
+    {
       "name": "@granit/analytics",
       "description": "Framework-agnostic types for Granit.Analytics — MetricResponse runtime envelopes plus KPI / Chart / Table / Pivot widget definitions consumed by @granit/dashboards",
       "exports": [

--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2932,6 +2932,67 @@
           "kind": "interface",
           "signature": "interface UseCustomisePromptReturn",
           "members": []
+        },
+        {
+          "name": "PromptIcon",
+          "kind": "function",
+          "signature": "function PromptIcon("
+        },
+        {
+          "name": "PromptIconProps",
+          "kind": "interface",
+          "signature": "interface PromptIconProps",
+          "members": []
+        },
+        {
+          "name": "IconPicker",
+          "kind": "function",
+          "signature": "function IconPicker("
+        },
+        {
+          "name": "IconPickerProps",
+          "kind": "interface",
+          "signature": "interface IconPickerProps",
+          "members": []
+        },
+        {
+          "name": "PromptForm",
+          "kind": "function",
+          "signature": "function PromptForm("
+        },
+        {
+          "name": "PromptFormProps",
+          "kind": "interface",
+          "signature": "interface PromptFormProps",
+          "members": []
+        },
+        {
+          "name": "PromptFormValues",
+          "kind": "interface",
+          "signature": "interface PromptFormValues",
+          "members": []
+        },
+        {
+          "name": "PromptCatalogue",
+          "kind": "function",
+          "signature": "function PromptCatalogue("
+        },
+        {
+          "name": "PromptCatalogueProps",
+          "kind": "interface",
+          "signature": "interface PromptCatalogueProps",
+          "members": []
+        },
+        {
+          "name": "PromptPicker",
+          "kind": "function",
+          "signature": "function PromptPicker("
+        },
+        {
+          "name": "PromptPickerProps",
+          "kind": "interface",
+          "signature": "interface PromptPickerProps",
+          "members": []
         }
       ]
     },

--- a/contracts/openapi/ai-prompts.json
+++ b/contracts/openapi/ai-prompts.json
@@ -1,0 +1,797 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "ai-prompts",
+    "version": "1"
+  },
+  "paths": {
+    "/prompts": {
+      "get": {
+        "tags": ["AI - Prompts"],
+        "summary": "Lists the caller's prompt catalogue.",
+        "description": "Returns the framework-seeded system prompts plus the caller's own prompts, system prompts first then by name, without their instruction text.",
+        "operationId": "ListPrompts",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PromptSummaryResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["AI - Prompts"],
+        "summary": "Creates a prompt owned by the caller.",
+        "description": "Creates a private prompt with the given content, decoration, and categories, owned by the caller.",
+        "operationId": "CreatePrompt",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prompts/picker": {
+      "get": {
+        "tags": ["AI - Prompts"],
+        "summary": "Returns the catalogue grouped by category for the chat picker.",
+        "description": "Returns the caller's catalogue grouped by category, each prompt carrying its icon, colour, and short description. Uncategorised prompts fall under the \"General\" group.",
+        "operationId": "GetPromptPicker",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptPickerResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prompts/{id}": {
+      "get": {
+        "tags": ["AI - Prompts"],
+        "summary": "Returns one prompt from the caller's catalogue by ID.",
+        "description": "Returns the prompt with its instruction text. Scoped to the caller: another user's private prompt is reported as not found.",
+        "operationId": "GetPrompt",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["AI - Prompts"],
+        "summary": "Updates one of the caller's own prompts.",
+        "description": "Updates the prompt and bumps its version. System prompts are read-only and reported as not found; customise one to get an editable copy.",
+        "operationId": "UpdatePrompt",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePromptRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["AI - Prompts"],
+        "summary": "Deletes one of the caller's own prompts.",
+        "description": "Deletes the prompt. System prompts cannot be deleted; another user's prompt is reported as not found.",
+        "operationId": "DeletePrompt",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/prompts/{id}/customise": {
+      "post": {
+        "tags": ["AI - Prompts"],
+        "summary": "Creates a private editable copy of a system prompt.",
+        "description": "Copies a system prompt into a new prompt owned by the caller (resolving its display text and categories); the original is untouched.",
+        "operationId": "CustomisePrompt",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PromptResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CreatePromptRequest": {
+        "required": ["name", "content"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "content": {
+            "maxLength": 20000,
+            "type": "string"
+          },
+          "shortDescription": {
+            "maxLength": 500,
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "maxLength": 100,
+            "type": ["null", "string"]
+          },
+          "iconColor": {
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:ColorHex"
+          },
+          "categoryIds": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "PromptPickerCategoryResponse": {
+        "required": ["categoryId", "categoryName", "prompts"],
+        "type": "object",
+        "properties": {
+          "categoryId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "categoryName": {
+            "type": "string"
+          },
+          "prompts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PromptPickerItemResponse"
+            }
+          }
+        }
+      },
+      "PromptPickerItemResponse": {
+        "required": ["id", "name", "shortDescription", "icon", "iconColor", "isSystem"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortDescription": {
+            "type": "string"
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "iconColor": {
+            "type": ["null", "string"]
+          },
+          "isSystem": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PromptPickerResponse": {
+        "required": ["categories"],
+        "type": "object",
+        "properties": {
+          "categories": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PromptPickerCategoryResponse"
+            }
+          }
+        }
+      },
+      "PromptResponse": {
+        "required": [
+          "id",
+          "name",
+          "shortDescription",
+          "content",
+          "icon",
+          "iconColor",
+          "version",
+          "isSystem",
+          "ownerId",
+          "categoryIds",
+          "createdAt",
+          "modifiedAt"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortDescription": {
+            "type": "string"
+          },
+          "content": {
+            "type": "string"
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "iconColor": {
+            "type": ["null", "string"]
+          },
+          "version": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSystem": {
+            "type": "boolean"
+          },
+          "ownerId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "categoryIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          }
+        }
+      },
+      "PromptSummaryResponse": {
+        "required": [
+          "id",
+          "name",
+          "shortDescription",
+          "icon",
+          "iconColor",
+          "isSystem",
+          "categoryIds"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "shortDescription": {
+            "type": "string"
+          },
+          "icon": {
+            "type": ["null", "string"]
+          },
+          "iconColor": {
+            "type": ["null", "string"]
+          },
+          "isSystem": {
+            "type": "boolean"
+          },
+          "categoryIds": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      },
+      "UpdatePromptRequest": {
+        "required": ["name", "content"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "content": {
+            "maxLength": 20000,
+            "type": "string"
+          },
+          "shortDescription": {
+            "maxLength": 500,
+            "type": ["null", "string"]
+          },
+          "icon": {
+            "maxLength": 100,
+            "type": ["null", "string"]
+          },
+          "iconColor": {
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:ColorHex"
+          },
+          "categoryIds": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "AI - Prompts"
+    }
+  ]
+}

--- a/packages/@granit/ai-prompts/README.md
+++ b/packages/@granit/ai-prompts/README.md
@@ -1,0 +1,47 @@
+# @granit/ai-prompts
+
+Framework-agnostic types and API functions for the AI prompt catalogue. Mirrors
+the `Granit.AI.Prompts.Endpoints` .NET contract (prefix `/prompts`).
+
+This is the core, headless layer: DTOs, prompt CRUD, the `/` picker payload,
+and copy-on-customise. React bindings (hooks, picker popover, catalogue
+manager, icon picker) live in `@granit/react-ai-prompts`.
+
+## Installation
+
+```bash
+pnpm add @granit/ai-prompts
+```
+
+## API
+
+### Types
+
+- `PromptSummaryResponse`, `PromptResponse` — catalogue read models (`isSystem`
+  marks read-only framework prompts; user prompts are owner-private).
+- `PromptPickerResponse`, `PromptPickerCategoryResponse`, `PromptPickerItemResponse`
+  — the `/` picker grouped by category (`categoryId: null` ⇒ "General").
+- `CreatePromptRequest`, `UpdatePromptRequest` — write bodies.
+- `PromptId`, `CategoryId` — branded identifiers.
+
+> `icon` is an identifier string — the front owns the glyph set. `iconColor` is a
+> hex string `#RRGGBB` / `#RRGGBBAA` (see `ICON_COLOR_PATTERN`). System prompts'
+> `name` / `shortDescription` arrive already localized.
+
+### Constants
+
+- `PROMPT_LIMITS`, `ICON_COLOR_PATTERN`, `GENERAL_CATEGORY_NAME`.
+
+### Functions
+
+- `listPrompts`, `getPromptPicker`, `getPrompt`, `createPrompt`, `updatePrompt`,
+  `deletePrompt` — JSON CRUD over the Axios client.
+- `customisePrompt` — clones a **system** prompt into a private editable copy
+  (`POST /prompts/{id}/customise`); a non-system target returns 409. System
+  prompts are read-only: `PUT` / `DELETE` on one returns 404, so the UI offers
+  **Customise** instead of Edit/Delete when `isSystem` is `true`.
+
+### Permissions
+
+`AIPromptsPermissions.Templates.{Read,Manage,Delete}` — the server enforces
+them; the client only gates affordances.

--- a/packages/@granit/ai-prompts/package.json
+++ b/packages/@granit/ai-prompts/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@granit/ai-prompts",
+  "description": "AI prompt catalogue — prompt CRUD, the chat picker, and copy-on-customise types and API functions. Mirrors Granit.AI.Prompts.Endpoints .NET",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/ai-prompts/src/__tests__/prompts-api.test.ts
+++ b/packages/@granit/ai-prompts/src/__tests__/prompts-api.test.ts
@@ -1,0 +1,93 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  createPrompt,
+  customisePrompt,
+  deletePrompt,
+  getPrompt,
+  getPromptPicker,
+  listPrompts,
+  updatePrompt,
+} from '../api/prompts-api';
+
+import type { PromptId, PromptResponse } from '../types/index';
+
+const BASE = '/api/v1/prompts';
+const ID = 'p1111111-1111-1111-1111-111111111111' as PromptId;
+
+const PROMPT: PromptResponse = {
+  id: ID,
+  name: 'Summarize',
+  shortDescription: 'Summarize the current record',
+  content: 'Summarize {{record}} in three bullet points.',
+  icon: 'sparkles',
+  iconColor: '#3366FF',
+  version: 1,
+  isSystem: false,
+  ownerId: 'b2222222-2222-2222-2222-222222222222' as PromptResponse['ownerId'],
+  categoryIds: [],
+  createdAt: '2026-06-15T10:00:00Z' as PromptResponse['createdAt'],
+  modifiedAt: null,
+};
+
+describe('prompts-api', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('listPrompts GETs the base path', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse([]));
+    await listPrompts(client, BASE);
+    expect(client.get).toHaveBeenCalledWith(BASE);
+  });
+
+  it('getPromptPicker GETs {basePath}/picker', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse({ categories: [] }));
+    await getPromptPicker(client, BASE);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/picker`);
+  });
+
+  it('getPrompt GETs {basePath}/{id}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(PROMPT));
+    const result = await getPrompt(client, BASE, ID);
+    expect(client.get).toHaveBeenCalledWith(`${BASE}/${ID}`);
+    expect(result).toEqual(PROMPT);
+  });
+
+  it('createPrompt POSTs the body to the base path', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(PROMPT));
+    await createPrompt(client, BASE, { name: 'Summarize', content: 'Do it' });
+    expect(client.post).toHaveBeenCalledWith(BASE, { name: 'Summarize', content: 'Do it' });
+  });
+
+  it('updatePrompt PUTs to {basePath}/{id}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.put).mockResolvedValue(axiosResponse(PROMPT));
+    await updatePrompt(client, BASE, ID, { name: 'Summarize', content: 'Updated' });
+    expect(client.put).toHaveBeenCalledWith(`${BASE}/${ID}`, {
+      name: 'Summarize',
+      content: 'Updated',
+    });
+  });
+
+  it('deletePrompt DELETEs {basePath}/{id}', async () => {
+    const client = createMockClient();
+    vi.mocked(client.delete).mockResolvedValue(axiosResponse(undefined));
+    await deletePrompt(client, BASE, ID);
+    expect(client.delete).toHaveBeenCalledWith(`${BASE}/${ID}`);
+  });
+
+  it('customisePrompt POSTs to {basePath}/{id}/customise and returns the clone', async () => {
+    const client = createMockClient();
+    const clone = { ...PROMPT, isSystem: false };
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(clone));
+    const result = await customisePrompt(client, BASE, ID);
+    expect(client.post).toHaveBeenCalledWith(`${BASE}/${ID}/customise`);
+    expect(result.isSystem).toBe(false);
+  });
+});

--- a/packages/@granit/ai-prompts/src/api/prompts-api.ts
+++ b/packages/@granit/ai-prompts/src/api/prompts-api.ts
@@ -1,0 +1,120 @@
+// ---------------------------------------------------------------------------
+// Prompt catalogue API functions.
+// Mirrors Granit.AI.Prompts.Endpoints — CRUD, the `/` picker, and
+// copy-on-customise. Routes are relative to `basePath` (the `/prompts` prefix).
+// ---------------------------------------------------------------------------
+
+import type {
+  CreatePromptRequest,
+  PromptId,
+  PromptPickerResponse,
+  PromptResponse,
+  PromptSummaryResponse,
+  UpdatePromptRequest,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * List the caller's catalogue (system prompts first, then own by name),
+ * without instruction text.
+ *
+ * `GET {basePath}`
+ */
+export async function listPrompts(
+  client: AxiosInstance,
+  basePath: string
+): Promise<readonly PromptSummaryResponse[]> {
+  const response = await client.get<readonly PromptSummaryResponse[]>(basePath);
+  return response.data;
+}
+
+/**
+ * Get the catalogue grouped by category for the chat `/` picker.
+ *
+ * `GET {basePath}/picker`
+ */
+export async function getPromptPicker(
+  client: AxiosInstance,
+  basePath: string
+): Promise<PromptPickerResponse> {
+  const response = await client.get<PromptPickerResponse>(`${basePath}/picker`);
+  return response.data;
+}
+
+/**
+ * Get one prompt with its instruction text.
+ *
+ * `GET {basePath}/{id}`
+ */
+export async function getPrompt(
+  client: AxiosInstance,
+  basePath: string,
+  id: PromptId
+): Promise<PromptResponse> {
+  const response = await client.get<PromptResponse>(`${basePath}/${encodeURIComponent(id)}`);
+  return response.data;
+}
+
+/**
+ * Create a private prompt owned by the caller.
+ *
+ * `POST {basePath}`
+ */
+export async function createPrompt(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreatePromptRequest
+): Promise<PromptResponse> {
+  const response = await client.post<PromptResponse>(basePath, request);
+  return response.data;
+}
+
+/**
+ * Update one of the caller's own prompts (bumps its version). System prompts
+ * are read-only — the backend reports them as not found (404).
+ *
+ * `PUT {basePath}/{id}`
+ */
+export async function updatePrompt(
+  client: AxiosInstance,
+  basePath: string,
+  id: PromptId,
+  request: UpdatePromptRequest
+): Promise<PromptResponse> {
+  const response = await client.put<PromptResponse>(
+    `${basePath}/${encodeURIComponent(id)}`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Delete one of the caller's own prompts. System prompts cannot be deleted
+ * (404).
+ *
+ * `DELETE {basePath}/{id}`
+ */
+export async function deletePrompt(
+  client: AxiosInstance,
+  basePath: string,
+  id: PromptId
+): Promise<void> {
+  await client.delete(`${basePath}/${encodeURIComponent(id)}`);
+}
+
+/**
+ * Clone a **system** prompt into a private, editable copy owned by the caller;
+ * the original is untouched. A non-system target returns 409.
+ *
+ * `POST {basePath}/{id}/customise`
+ */
+export async function customisePrompt(
+  client: AxiosInstance,
+  basePath: string,
+  id: PromptId
+): Promise<PromptResponse> {
+  const response = await client.post<PromptResponse>(
+    `${basePath}/${encodeURIComponent(id)}/customise`
+  );
+  return response.data;
+}

--- a/packages/@granit/ai-prompts/src/index.ts
+++ b/packages/@granit/ai-prompts/src/index.ts
@@ -1,0 +1,29 @@
+// Types
+export type {
+  CategoryId,
+  CreatePromptRequest,
+  PromptId,
+  PromptPickerCategoryResponse,
+  PromptPickerItemResponse,
+  PromptPickerResponse,
+  PromptResponse,
+  PromptSummaryResponse,
+  UpdatePromptRequest,
+} from './types/index';
+
+// Constants
+export { GENERAL_CATEGORY_NAME, ICON_COLOR_PATTERN, PROMPT_LIMITS } from './types/index';
+
+// API
+export {
+  createPrompt,
+  customisePrompt,
+  deletePrompt,
+  getPrompt,
+  getPromptPicker,
+  listPrompts,
+  updatePrompt,
+} from './api/prompts-api';
+
+// Permissions
+export { AIPromptsPermissions } from './permissions';

--- a/packages/@granit/ai-prompts/src/permissions.ts
+++ b/packages/@granit/ai-prompts/src/permissions.ts
@@ -1,0 +1,17 @@
+/**
+ * Permission constants for the AI prompt catalogue.
+ * Mirrors `Granit.AI.Prompts.Endpoints.Permissions.AIPromptsPermissions`.
+ *
+ * The server enforces these; the client only gates affordances. User prompts
+ * are owner-private — never build cross-user views.
+ */
+export const AIPromptsPermissions = {
+  Templates: {
+    /** List/read prompts (system + the caller's own) and the picker. */
+    Read: 'AIPrompts.Templates.Read',
+    /** Create, update, and customise prompts. */
+    Manage: 'AIPrompts.Templates.Manage',
+    /** Delete the caller's own prompts. */
+    Delete: 'AIPrompts.Templates.Delete',
+  },
+} as const;

--- a/packages/@granit/ai-prompts/src/types/index.ts
+++ b/packages/@granit/ai-prompts/src/types/index.ts
@@ -1,0 +1,115 @@
+import type { EntityId, ISODateString, UserId } from '@granit/types';
+
+// ---------------------------------------------------------------------------
+// Types mirroring Granit.AI.Prompts and Granit.AI.Prompts.Endpoints .NET
+// contracts. Property names match the camelCase JSON from the backend.
+// Optionality follows the OpenAPI `required` array, not C# nullability:
+// `icon` / `iconColor` are required keys with nullable values (`T | null`).
+// ---------------------------------------------------------------------------
+
+// -- Branded identifiers -----------------------------------------------------
+
+/** Prompt-template identifier (UUID). */
+export type PromptId = EntityId<'Prompt'>;
+
+/** Taxonomy category identifier (UUID). */
+export type CategoryId = EntityId<'Category'>;
+
+// -- Constants ---------------------------------------------------------------
+
+/** Server-enforced limits for prompt create/update requests. */
+export const PROMPT_LIMITS = {
+  /** `name` maximum length. */
+  NAME_MAX_LENGTH: 200,
+  /** `content` (instruction text) maximum length. */
+  CONTENT_MAX_LENGTH: 20_000,
+  /** `shortDescription` maximum length. */
+  SHORT_DESCRIPTION_MAX_LENGTH: 500,
+  /** `icon` identifier maximum length. */
+  ICON_MAX_LENGTH: 100,
+} as const;
+
+/**
+ * Validates `iconColor`: a hex string `#RRGGBB` or `#RRGGBBAA`. Mirrors the
+ * backend `Validation:Format:ColorHex` rule.
+ */
+export const ICON_COLOR_PATTERN = /^#(?:[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+
+/** Group name for uncategorised prompts in the picker. */
+export const GENERAL_CATEGORY_NAME = 'General';
+
+// -- Read models -------------------------------------------------------------
+
+/** A catalogue list item, without its instruction text. */
+export interface PromptSummaryResponse {
+  readonly id: PromptId;
+  readonly name: string;
+  readonly shortDescription: string;
+  /** Icon identifier — the front owns the glyph set. */
+  readonly icon: string | null;
+  /** Hex colour `#RRGGBB` / `#RRGGBBAA`. */
+  readonly iconColor: string | null;
+  /** System prompts are read-only — offer Customise instead of Edit/Delete. */
+  readonly isSystem: boolean;
+  readonly categoryIds: readonly CategoryId[];
+}
+
+/** A full prompt with its instruction text. */
+export interface PromptResponse {
+  readonly id: PromptId;
+  readonly name: string;
+  readonly shortDescription: string;
+  readonly content: string;
+  readonly icon: string | null;
+  readonly iconColor: string | null;
+  readonly version: number;
+  readonly isSystem: boolean;
+  readonly ownerId: UserId;
+  readonly categoryIds: readonly CategoryId[];
+  readonly createdAt: ISODateString;
+  readonly modifiedAt: ISODateString | null;
+}
+
+/** One prompt entry in the `/` picker (no instruction text). */
+export interface PromptPickerItemResponse {
+  readonly id: PromptId;
+  readonly name: string;
+  readonly shortDescription: string;
+  readonly icon: string | null;
+  readonly iconColor: string | null;
+  readonly isSystem: boolean;
+}
+
+/** A picker group. `categoryId` is null for the "General" group. */
+export interface PromptPickerCategoryResponse {
+  readonly categoryId: CategoryId | null;
+  readonly categoryName: string;
+  readonly prompts: readonly PromptPickerItemResponse[];
+}
+
+/** The `/` picker payload — the catalogue grouped by category. */
+export interface PromptPickerResponse {
+  readonly categories: readonly PromptPickerCategoryResponse[];
+}
+
+// -- Write models ------------------------------------------------------------
+
+/** Body of `POST /prompts`. */
+export interface CreatePromptRequest {
+  readonly name: string;
+  readonly content: string;
+  readonly shortDescription?: string | null;
+  readonly icon?: string | null;
+  readonly iconColor?: string | null;
+  readonly categoryIds?: readonly CategoryId[] | null;
+}
+
+/** Body of `PUT /prompts/{id}`. Same shape as create. */
+export interface UpdatePromptRequest {
+  readonly name: string;
+  readonly content: string;
+  readonly shortDescription?: string | null;
+  readonly icon?: string | null;
+  readonly iconColor?: string | null;
+  readonly categoryIds?: readonly CategoryId[] | null;
+}

--- a/packages/@granit/ai-prompts/tsconfig.json
+++ b/packages/@granit/ai-prompts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/ai-prompts/tsup.config.ts
+++ b/packages/@granit/ai-prompts/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -122,6 +122,20 @@ export const CONTRACTS: readonly ModuleContract[] = [
     checkEndpoints: true,
   },
   {
+    slug: 'ai-prompts',
+    package: 'ai-prompts',
+    types: [
+      'PromptSummaryResponse',
+      'PromptResponse',
+      'PromptPickerResponse',
+      'PromptPickerCategoryResponse',
+      'PromptPickerItemResponse',
+      'CreatePromptRequest',
+      'UpdatePromptRequest',
+    ],
+    checkEndpoints: true,
+  },
+  {
     slug: 'auditing',
     package: 'auditing',
     types: [

--- a/packages/@granit/react-ai-prompts/README.md
+++ b/packages/@granit/react-ai-prompts/README.md
@@ -1,0 +1,39 @@
+# @granit/react-ai-prompts
+
+React bindings for [`@granit/ai-prompts`](../ai-prompts) — the AI prompt
+catalogue. Provides the `AIPromptsProvider`, catalogue CRUD + customise hooks,
+the `/` picker hook, and (on top of these) the picker popover, an icon picker,
+and the catalogue manager UI.
+
+## Installation
+
+```bash
+pnpm add @granit/react-ai-prompts
+```
+
+## Usage
+
+```tsx
+import { AIPromptsProvider } from '@granit/react-ai-prompts';
+
+<AIPromptsProvider config={{ client }}>{children}</AIPromptsProvider>;
+```
+
+### Hooks
+
+- `usePrompts()` — the flat catalogue (system first), for the manager.
+- `usePromptPicker()` — the catalogue grouped by category for the chat `/`
+  picker. Flatten its items into `@granit/react-ai-chat`'s `<ChatComposer prompts>`.
+- `usePrompt(id)` — one prompt with its instruction text (edit form).
+- `useCreatePrompt()` / `useUpdatePrompt()` / `useDeletePrompt()` — mutations
+  that invalidate the list, picker, and affected detail.
+- `useCustomisePrompt()` — clones a **system** prompt into a private editable
+  copy (system prompts are read-only — offer Customise instead of Edit/Delete).
+- `promptKeys` — the query-key factory.
+
+## Testing
+
+`@granit/react-ai-prompts/testing` exports `createAIPromptsHandlers(baseUrl)`
+(stateful MSW handlers enforcing the system-prompt read-only / customise / 409
+semantics) plus `mockPromptSummaries`, `mockPromptPicker`, `mockSystemPrompt`,
+and `mockUserPrompt`.

--- a/packages/@granit/react-ai-prompts/package.json
+++ b/packages/@granit/react-ai-prompts/package.json
@@ -1,0 +1,54 @@
+{
+  "name": "@granit/react-ai-prompts",
+  "description": "React bindings for @granit/ai-prompts — AIPromptsProvider, prompt catalogue CRUD + customise hooks, the / picker hook + popover, an icon picker, and the catalogue manager UI",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/ai-prompts": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/utils": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "lucide-react": "^1.0.0",
+    "msw": "^2.12.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/ai-prompts": "workspace:*",
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@granit/utils": "workspace:*"
+  }
+}

--- a/packages/@granit/react-ai-prompts/src/__tests__/components.test.tsx
+++ b/packages/@granit/react-ai-prompts/src/__tests__/components.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { IconPicker } from '../components/icon-picker';
+import { PromptCatalogue } from '../components/prompt-catalogue';
+import { PromptForm } from '../components/prompt-form';
+import { PromptPicker } from '../components/prompt-picker';
+import { mockPromptPicker, mockPromptSummaries } from '../testing/data';
+
+import type { CreatePromptRequest } from '@granit/ai-prompts';
+
+describe('PromptCatalogue', () => {
+  it('offers Customise for system prompts and Edit/Delete for own (when permitted)', () => {
+    render(
+      <PromptCatalogue
+        prompts={mockPromptSummaries}
+        canManage
+        canDelete
+        onEdit={vi.fn()}
+        onDelete={vi.fn()}
+        onCustomise={vi.fn()}
+      />
+    );
+    // System prompt → Customise, no Edit/Delete.
+    expect(screen.getByRole('button', { name: /customise summarize/i })).toBeInTheDocument();
+    // User prompt → Edit + Delete.
+    expect(screen.getByRole('button', { name: /edit daily brief/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete daily brief/i })).toBeInTheDocument();
+  });
+
+  it('hides management affordances without permission', () => {
+    render(<PromptCatalogue prompts={mockPromptSummaries} onEdit={vi.fn()} onDelete={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /edit/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /delete/i })).toBeNull();
+  });
+
+  it('emits onCustomise with the system prompt id', async () => {
+    const onCustomise = vi.fn();
+    render(<PromptCatalogue prompts={mockPromptSummaries} canManage onCustomise={onCustomise} />);
+    await userEvent.click(screen.getByRole('button', { name: /customise summarize/i }));
+    expect(onCustomise).toHaveBeenCalledWith(mockPromptSummaries[0]!.id);
+  });
+});
+
+describe('PromptForm', () => {
+  it('blocks submit until name and instruction are filled', async () => {
+    const onSubmit = vi.fn<(r: CreatePromptRequest) => void>();
+    render(<PromptForm onSubmit={onSubmit} />);
+
+    const save = screen.getByRole('button', { name: /save/i });
+    expect(save).toBeDisabled();
+
+    await userEvent.type(screen.getByLabelText(/name/i, { selector: 'input' }), 'Summarize');
+    await userEvent.type(screen.getByLabelText(/instruction/i), 'Do the thing');
+    expect(save).toBeEnabled();
+
+    await userEvent.click(save);
+    const request = onSubmit.mock.calls[0]![0];
+    expect(request).toMatchObject({ name: 'Summarize', content: 'Do the thing' });
+  });
+
+  it('flags an invalid hex colour', async () => {
+    render(<PromptForm onSubmit={vi.fn()} />);
+    await userEvent.type(screen.getByLabelText(/icon colour hex/i), 'not-a-color');
+    expect(screen.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+});
+
+describe('IconPicker', () => {
+  it('selects an icon and edits the colour', async () => {
+    const onIconChange = vi.fn();
+    const onColorChange = vi.fn();
+    render(
+      <IconPicker
+        icon="sparkles"
+        iconColor="#3366FF"
+        onIconChange={onIconChange}
+        onColorChange={onColorChange}
+      />
+    );
+    await userEvent.click(screen.getByRole('radio', { name: 'calendar' }));
+    expect(onIconChange).toHaveBeenCalledWith('calendar');
+  });
+});
+
+describe('PromptPicker', () => {
+  it('renders grouped categories and selects on click', async () => {
+    const onSelect = vi.fn();
+    render(<PromptPicker categories={mockPromptPicker.categories} onSelect={onSelect} />);
+
+    expect(screen.getByRole('group', { name: 'Records' })).toBeInTheDocument();
+    expect(screen.getByRole('group', { name: 'General' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Summarize'));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'Summarize', isSystem: true })
+    );
+  });
+
+  it('filters by the search query', async () => {
+    render(<PromptPicker categories={mockPromptPicker.categories} onSelect={vi.fn()} />);
+    await userEvent.type(screen.getByRole('combobox'), 'daily');
+    expect(screen.getByText('Daily brief')).toBeInTheDocument();
+    expect(screen.queryByText('Summarize')).toBeNull();
+  });
+});

--- a/packages/@granit/react-ai-prompts/src/__tests__/test-utils.tsx
+++ b/packages/@granit/react-ai-prompts/src/__tests__/test-utils.tsx
@@ -1,0 +1,24 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import * as React from 'react';
+
+import { AIPromptsProvider } from '../providers/ai-prompts-provider';
+
+import type { AIPromptsConfig } from '../providers/ai-prompts-provider';
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+export const TEST_BASE_PATH = '/api/v1/prompts';
+
+/** Wraps hooks in a fresh QueryClient + AIPromptsProvider bound to `client`. */
+export function createWrapper(client: AxiosInstance, basePath = TEST_BASE_PATH) {
+  return function Wrapper({ children }: { readonly children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: AIPromptsConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <AIPromptsProvider config={config}>{children}</AIPromptsProvider>
+    );
+  };
+}

--- a/packages/@granit/react-ai-prompts/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-ai-prompts/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,52 @@
+import { createMswServer } from '@granit/testing/msw-server';
+import { describe, expect, it } from 'vitest';
+
+import { mockSystemPrompt, mockUserPrompt } from '../testing/data';
+import { createAIPromptsHandlers } from '../testing/index';
+
+import type { PromptResponse } from '@granit/ai-prompts';
+
+const BASE = 'http://api.test/api/v1/prompts';
+const server = createMswServer();
+
+describe('createAIPromptsHandlers', () => {
+  it('serves the grouped picker (not swallowed by /:id)', async () => {
+    server.use(...createAIPromptsHandlers(BASE));
+    const response = await fetch(`${BASE}/picker`);
+    const body = (await response.json()) as { categories: unknown[] };
+    expect(body.categories).toHaveLength(2);
+  });
+
+  it('rejects PUT on a system prompt with 404 (read-only)', async () => {
+    server.use(...createAIPromptsHandlers(BASE));
+    const response = await fetch(`${BASE}/${mockSystemPrompt.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hack', content: 'nope' }),
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it('customises a system prompt into a private editable copy', async () => {
+    server.use(...createAIPromptsHandlers(BASE));
+    const response = await fetch(`${BASE}/${mockSystemPrompt.id}/customise`, { method: 'POST' });
+    expect(response.status).toBe(201);
+    const clone = (await response.json()) as PromptResponse;
+    expect(clone.isSystem).toBe(false);
+    expect(clone.id).not.toBe(mockSystemPrompt.id);
+  });
+
+  it('returns 409 when customising a non-system prompt', async () => {
+    server.use(...createAIPromptsHandlers(BASE));
+    const response = await fetch(`${BASE}/${mockUserPrompt.id}/customise`, { method: 'POST' });
+    expect(response.status).toBe(409);
+  });
+
+  it('deletes a user prompt and reflects it in the list', async () => {
+    server.use(...createAIPromptsHandlers(BASE));
+    const del = await fetch(`${BASE}/${mockUserPrompt.id}`, { method: 'DELETE' });
+    expect(del.status).toBe(204);
+    const list = (await (await fetch(BASE)).json()) as PromptResponse[];
+    expect(list.some((p) => p.id === mockUserPrompt.id)).toBe(false);
+  });
+});

--- a/packages/@granit/react-ai-prompts/src/__tests__/use-prompts.test.tsx
+++ b/packages/@granit/react-ai-prompts/src/__tests__/use-prompts.test.tsx
@@ -1,0 +1,66 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useCreatePrompt } from '../hooks/use-create-prompt';
+import { useCustomisePrompt } from '../hooks/use-customise-prompt';
+import { usePromptPicker } from '../hooks/use-prompt-picker';
+import { usePrompts } from '../hooks/use-prompts';
+import { mockPromptPicker, mockPromptSummaries, mockSystemPrompt } from '../testing/data';
+
+import { createWrapper, TEST_BASE_PATH } from './test-utils';
+
+import type { PromptId } from '@granit/ai-prompts';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('prompt catalogue hooks', () => {
+  it('usePrompts returns the catalogue, system first', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(mockPromptSummaries));
+
+    const { result } = renderHook(() => usePrompts(), { wrapper: createWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]?.isSystem).toBe(true);
+    expect(client.get).toHaveBeenCalledWith(TEST_BASE_PATH);
+  });
+
+  it('usePromptPicker returns the grouped picker with a null-category General group', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue(axiosResponse(mockPromptPicker));
+
+    const { result } = renderHook(() => usePromptPicker(), { wrapper: createWrapper(client) });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.get).toHaveBeenCalledWith(`${TEST_BASE_PATH}/picker`);
+    expect(result.current.data?.categories.some((c) => c.categoryId === null)).toBe(true);
+  });
+
+  it('useCreatePrompt POSTs the body and resolves the new prompt', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(mockSystemPrompt));
+
+    const { result } = renderHook(() => useCreatePrompt(), { wrapper: createWrapper(client) });
+    await act(async () => {
+      await result.current.createAsync({ name: 'X', content: 'Y' });
+    });
+
+    expect(client.post).toHaveBeenCalledWith(TEST_BASE_PATH, { name: 'X', content: 'Y' });
+  });
+
+  it('useCustomisePrompt POSTs to {id}/customise', async () => {
+    const client = createMockClient();
+    vi.mocked(client.post).mockResolvedValue(axiosResponse(mockSystemPrompt));
+
+    const { result } = renderHook(() => useCustomisePrompt(), { wrapper: createWrapper(client) });
+    const id = mockSystemPrompt.id as PromptId;
+    await act(async () => {
+      await result.current.customiseAsync(id);
+    });
+
+    expect(client.post).toHaveBeenCalledWith(`${TEST_BASE_PATH}/${id}/customise`);
+  });
+});

--- a/packages/@granit/react-ai-prompts/src/components/icon-picker.tsx
+++ b/packages/@granit/react-ai-prompts/src/components/icon-picker.tsx
@@ -1,0 +1,105 @@
+import { ICON_COLOR_PATTERN } from '@granit/ai-prompts';
+import { cn } from '@granit/utils';
+
+import { defaultPromptLabels } from '../locales/index';
+
+import { getPromptIcon, PROMPT_ICON_IDS } from './icon-registry';
+
+import type { PromptTranslations } from '../locales/index';
+
+export interface IconPickerProps {
+  readonly icon: string | null;
+  readonly iconColor: string | null;
+  readonly onIconChange: (icon: string) => void;
+  readonly onColorChange: (color: string) => void;
+  readonly labels?: PromptTranslations['IconPicker'];
+  readonly className?: string;
+}
+
+/** Truncate a color to the 6-digit hex a native `<input type=color>` accepts. */
+function toColorInput(color: string | null): string {
+  if (color && /^#[0-9a-fA-F]{6}/.test(color)) return color.slice(0, 7);
+  return '#3366ff';
+}
+
+/**
+ * Selects a prompt glyph from the front-owned icon set plus its hex colour.
+ * The grid is a `radiogroup`; the colour is editable both as a swatch and as a
+ * hex string (so `#RRGGBBAA` alpha is reachable).
+ */
+export function IconPicker({
+  icon,
+  iconColor,
+  onIconChange,
+  onColorChange,
+  labels = defaultPromptLabels.IconPicker,
+  className,
+}: Readonly<IconPickerProps>) {
+  const colorValid = iconColor === null || iconColor === '' || ICON_COLOR_PATTERN.test(iconColor);
+
+  return (
+    <div data-slot="icon-picker" className={cn('flex flex-col gap-2', className)}>
+      <div role="radiogroup" aria-label={labels.IconLabel} className="flex flex-wrap gap-1">
+        {PROMPT_ICON_IDS.map((id) => {
+          const Glyph = getPromptIcon(id);
+          const selected = id === icon;
+          return (
+            <button
+              key={id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              aria-label={id}
+              data-slot="icon-option"
+              onClick={() => {
+                onIconChange(id);
+              }}
+              className={cn(
+                'rounded-md border p-1.5',
+                selected ? 'border-primary bg-primary/10' : 'border-border hover:bg-accent'
+              )}
+            >
+              <Glyph
+                className="size-4"
+                aria-hidden
+                style={iconColor ? { color: iconColor } : undefined}
+              />
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <input
+          type="color"
+          aria-label={labels.ColorLabel}
+          value={toColorInput(iconColor)}
+          onChange={(event) => {
+            onColorChange(event.target.value);
+          }}
+          className="size-7 cursor-pointer rounded border-0 bg-transparent p-0"
+        />
+        <input
+          type="text"
+          data-slot="icon-color-hex"
+          aria-label={labels.ColorHexLabel}
+          value={iconColor ?? ''}
+          placeholder="#RRGGBB"
+          aria-invalid={!colorValid}
+          onChange={(event) => {
+            onColorChange(event.target.value);
+          }}
+          className={cn(
+            'w-28 rounded-md border px-2 py-1 text-sm',
+            colorValid ? 'border-input' : 'border-destructive'
+          )}
+        />
+        {!colorValid ? (
+          <span data-slot="icon-color-error" className="text-destructive text-xs">
+            {labels.ColorInvalid}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-prompts/src/components/icon-registry.ts
+++ b/packages/@granit/react-ai-prompts/src/components/icon-registry.ts
@@ -1,0 +1,55 @@
+import {
+  Bell,
+  BookOpen,
+  Bot,
+  Brain,
+  Calendar,
+  FileText,
+  Lightbulb,
+  ListChecks,
+  Mail,
+  MessageSquare,
+  PenLine,
+  Search,
+  Sparkles,
+  Star,
+  Tag,
+  Zap,
+} from 'lucide-react';
+
+import type { LucideIcon } from 'lucide-react';
+
+/**
+ * The front owns the prompt glyph set: the catalogue stores an icon
+ * *identifier* string; this registry maps it to a rendered glyph. Extend it as
+ * the showcase / apps need more icons — backend never sends a component.
+ */
+export const PROMPT_ICONS: Record<string, LucideIcon> = {
+  sparkles: Sparkles,
+  calendar: Calendar,
+  'file-text': FileText,
+  'message-square': MessageSquare,
+  search: Search,
+  lightbulb: Lightbulb,
+  'list-checks': ListChecks,
+  mail: Mail,
+  bell: Bell,
+  star: Star,
+  tag: Tag,
+  zap: Zap,
+  bot: Bot,
+  'book-open': BookOpen,
+  'pen-line': PenLine,
+  brain: Brain,
+};
+
+/** The icon identifier used when a prompt has no icon or an unknown one. */
+export const DEFAULT_PROMPT_ICON = 'sparkles';
+
+/** Selectable icon identifiers, for the icon picker grid. */
+export const PROMPT_ICON_IDS: readonly string[] = Object.keys(PROMPT_ICONS);
+
+/** Resolve an icon identifier to a glyph, falling back to the default. */
+export function getPromptIcon(icon: string | null | undefined): LucideIcon {
+  return (icon ? PROMPT_ICONS[icon] : undefined) ?? PROMPT_ICONS[DEFAULT_PROMPT_ICON]!;
+}

--- a/packages/@granit/react-ai-prompts/src/components/prompt-catalogue.tsx
+++ b/packages/@granit/react-ai-prompts/src/components/prompt-catalogue.tsx
@@ -1,0 +1,140 @@
+import { cn } from '@granit/utils';
+import { Copy, Pencil, Plus, Trash2 } from 'lucide-react';
+
+import { defaultPromptLabels } from '../locales/index';
+
+import { PromptIcon } from './prompt-icon';
+
+import type { PromptTranslations } from '../locales/index';
+import type { PromptId, PromptSummaryResponse } from '@granit/ai-prompts';
+
+export interface PromptCatalogueProps {
+  readonly prompts: readonly PromptSummaryResponse[];
+  readonly onNew?: () => void;
+  readonly onEdit?: (id: PromptId) => void;
+  readonly onDelete?: (id: PromptId) => void;
+  readonly onCustomise?: (id: PromptId) => void;
+  /** Gates Edit/Customise/New (server still enforces `AIPrompts.Templates.Manage`). */
+  readonly canManage?: boolean;
+  /** Gates Delete (server still enforces `AIPrompts.Templates.Delete`). */
+  readonly canDelete?: boolean;
+  readonly labels?: PromptTranslations['Catalogue'];
+  readonly className?: string;
+}
+
+/**
+ * Lists the prompt catalogue with management affordances. System prompts are
+ * read-only — they offer **Customise** instead of Edit/Delete. Affordances are
+ * gated by `canManage` / `canDelete`; the server re-checks regardless.
+ */
+export function PromptCatalogue({
+  prompts,
+  onNew,
+  onEdit,
+  onDelete,
+  onCustomise,
+  canManage = false,
+  canDelete = false,
+  labels = defaultPromptLabels.Catalogue,
+  className,
+}: Readonly<PromptCatalogueProps>) {
+  return (
+    <div data-slot="prompt-catalogue" className={cn('flex flex-col gap-2', className)}>
+      {canManage && onNew ? (
+        <div className="flex justify-end">
+          <button
+            type="button"
+            data-slot="prompt-new"
+            onClick={onNew}
+            className="bg-primary text-primary-foreground inline-flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm"
+          >
+            <Plus className="size-3.5" aria-hidden />
+            {labels.New}
+          </button>
+        </div>
+      ) : null}
+
+      {prompts.length === 0 ? (
+        <p data-slot="catalogue-empty" className="text-muted-foreground py-6 text-center text-sm">
+          {labels.Empty}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {prompts.map((prompt) => (
+            <li
+              key={prompt.id}
+              data-slot="catalogue-item"
+              data-system={prompt.isSystem}
+              className="border-border flex items-center gap-3 rounded-md border p-2"
+            >
+              <PromptIcon
+                icon={prompt.icon}
+                iconColor={prompt.iconColor}
+                className="size-5 shrink-0"
+              />
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium">{prompt.name}</span>
+                  {prompt.isSystem ? (
+                    <span className="bg-muted text-muted-foreground rounded px-1.5 py-0.5 text-[10px] font-medium">
+                      {labels.System}
+                    </span>
+                  ) : null}
+                </div>
+                <p className="text-muted-foreground truncate text-xs">{prompt.shortDescription}</p>
+              </div>
+
+              <div className="flex shrink-0 items-center gap-1">
+                {prompt.isSystem ? (
+                  canManage && onCustomise ? (
+                    <button
+                      type="button"
+                      data-slot="prompt-customise"
+                      aria-label={`${labels.Customise} ${prompt.name}`}
+                      onClick={() => {
+                        onCustomise(prompt.id);
+                      }}
+                      className="hover:bg-accent inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs"
+                    >
+                      <Copy className="size-3.5" aria-hidden />
+                      {labels.Customise}
+                    </button>
+                  ) : null
+                ) : (
+                  <>
+                    {canManage && onEdit ? (
+                      <button
+                        type="button"
+                        data-slot="prompt-edit"
+                        aria-label={`${labels.Edit} ${prompt.name}`}
+                        onClick={() => {
+                          onEdit(prompt.id);
+                        }}
+                        className="hover:bg-accent rounded-md p-1.5"
+                      >
+                        <Pencil className="size-3.5" aria-hidden />
+                      </button>
+                    ) : null}
+                    {canDelete && onDelete ? (
+                      <button
+                        type="button"
+                        data-slot="prompt-delete"
+                        aria-label={`${labels.Delete} ${prompt.name}`}
+                        onClick={() => {
+                          onDelete(prompt.id);
+                        }}
+                        className="hover:bg-accent text-destructive rounded-md p-1.5"
+                      >
+                        <Trash2 className="size-3.5" aria-hidden />
+                      </button>
+                    ) : null}
+                  </>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-prompts/src/components/prompt-form.tsx
+++ b/packages/@granit/react-ai-prompts/src/components/prompt-form.tsx
@@ -1,0 +1,159 @@
+import { ICON_COLOR_PATTERN, PROMPT_LIMITS } from '@granit/ai-prompts';
+import { cn } from '@granit/utils';
+import { useState } from 'react';
+
+import { defaultPromptLabels } from '../locales/index';
+
+import { IconPicker } from './icon-picker';
+
+import type { PromptTranslations } from '../locales/index';
+import type { CategoryId, CreatePromptRequest } from '@granit/ai-prompts';
+
+/** Editable prompt fields. */
+export interface PromptFormValues {
+  readonly name: string;
+  readonly shortDescription: string;
+  readonly content: string;
+  readonly icon: string | null;
+  readonly iconColor: string | null;
+}
+
+export interface PromptFormProps {
+  /** Initial values (for the edit form). Category ids are passed through unchanged. */
+  readonly initial?: Partial<PromptFormValues> & { readonly categoryIds?: readonly CategoryId[] };
+  readonly onSubmit: (request: CreatePromptRequest) => void;
+  readonly onCancel?: () => void;
+  readonly submitting?: boolean;
+  readonly labels?: PromptTranslations['Form'];
+  readonly iconLabels?: PromptTranslations['IconPicker'];
+  readonly className?: string;
+}
+
+/**
+ * Create/edit form for a prompt. Validates the required name and instruction
+ * and the hex `iconColor` at the edge before emitting a `CreatePromptRequest`
+ * (also valid as an `UpdatePromptRequest` — same shape).
+ */
+export function PromptForm({
+  initial,
+  onSubmit,
+  onCancel,
+  submitting = false,
+  labels = defaultPromptLabels.Form,
+  iconLabels,
+  className,
+}: Readonly<PromptFormProps>) {
+  const [name, setName] = useState(initial?.name ?? '');
+  const [shortDescription, setShortDescription] = useState(initial?.shortDescription ?? '');
+  const [content, setContent] = useState(initial?.content ?? '');
+  const [icon, setIcon] = useState<string | null>(initial?.icon ?? null);
+  const [iconColor, setIconColor] = useState<string | null>(initial?.iconColor ?? null);
+
+  const nameValid = name.trim().length > 0;
+  const contentValid = content.trim().length > 0;
+  const colorValid = !iconColor || ICON_COLOR_PATTERN.test(iconColor);
+  const canSubmit = nameValid && contentValid && colorValid && !submitting;
+
+  return (
+    <form
+      data-slot="prompt-form"
+      className={cn('flex flex-col gap-3', className)}
+      onSubmit={(event) => {
+        event.preventDefault();
+        if (!canSubmit) return;
+        onSubmit({
+          name: name.trim(),
+          content: content.trim(),
+          shortDescription: shortDescription.trim() || null,
+          icon,
+          iconColor: iconColor || null,
+          ...(initial?.categoryIds ? { categoryIds: initial.categoryIds } : {}),
+        });
+      }}
+    >
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">{labels.Name}</span>
+        <input
+          type="text"
+          data-slot="prompt-name"
+          value={name}
+          maxLength={PROMPT_LIMITS.NAME_MAX_LENGTH}
+          placeholder={labels.NamePlaceholder}
+          aria-invalid={!nameValid}
+          onChange={(event) => {
+            setName(event.target.value);
+          }}
+          className="border-input rounded-md border px-2.5 py-1.5"
+        />
+        {!nameValid ? (
+          <span className="text-destructive text-xs">{labels.NameRequired}</span>
+        ) : null}
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">{labels.ShortDescription}</span>
+        <input
+          type="text"
+          data-slot="prompt-short-description"
+          value={shortDescription}
+          maxLength={PROMPT_LIMITS.SHORT_DESCRIPTION_MAX_LENGTH}
+          onChange={(event) => {
+            setShortDescription(event.target.value);
+          }}
+          className="border-input rounded-md border px-2.5 py-1.5"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        <span className="font-medium">{labels.Content}</span>
+        <textarea
+          data-slot="prompt-content"
+          value={content}
+          rows={5}
+          maxLength={PROMPT_LIMITS.CONTENT_MAX_LENGTH}
+          placeholder={labels.ContentPlaceholder}
+          aria-invalid={!contentValid}
+          onChange={(event) => {
+            setContent(event.target.value);
+          }}
+          className="border-input resize-y rounded-md border px-2.5 py-1.5"
+        />
+        {!contentValid ? (
+          <span className="text-destructive text-xs">{labels.ContentRequired}</span>
+        ) : null}
+      </label>
+
+      <fieldset className="flex flex-col gap-1 text-sm">
+        <legend className="font-medium">{labels.Icon}</legend>
+        <IconPicker
+          icon={icon}
+          iconColor={iconColor}
+          labels={iconLabels}
+          onIconChange={setIcon}
+          onColorChange={setIconColor}
+        />
+      </fieldset>
+
+      <div className="flex items-center justify-end gap-2">
+        {onCancel ? (
+          <button
+            type="button"
+            data-slot="prompt-cancel"
+            onClick={onCancel}
+            className="rounded-md px-3 py-1.5 text-sm"
+          >
+            {labels.Cancel}
+          </button>
+        ) : null}
+        <button
+          type="submit"
+          data-slot="prompt-save"
+          disabled={!canSubmit}
+          className="bg-primary text-primary-foreground rounded-md px-3 py-1.5 text-sm disabled:opacity-50"
+        >
+          {labels.Save}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/packages/@granit/react-ai-prompts/src/components/prompt-icon.tsx
+++ b/packages/@granit/react-ai-prompts/src/components/prompt-icon.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@granit/utils';
+
+import { getPromptIcon } from './icon-registry';
+
+export interface PromptIconProps {
+  /** Icon identifier from the catalogue (mapped via the glyph registry). */
+  readonly icon: string | null | undefined;
+  /** Hex colour `#RRGGBB` / `#RRGGBBAA` applied to the glyph. */
+  readonly iconColor?: string | null;
+  readonly className?: string;
+}
+
+/** Renders a prompt's glyph in its configured colour. */
+export function PromptIcon({ icon, iconColor, className }: Readonly<PromptIconProps>) {
+  const Glyph = getPromptIcon(icon);
+  return (
+    <Glyph
+      data-slot="prompt-icon"
+      aria-hidden
+      className={cn('size-4', className)}
+      style={iconColor ? { color: iconColor } : undefined}
+    />
+  );
+}

--- a/packages/@granit/react-ai-prompts/src/components/prompt-picker.tsx
+++ b/packages/@granit/react-ai-prompts/src/components/prompt-picker.tsx
@@ -1,0 +1,160 @@
+import { cn } from '@granit/utils';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+
+import { defaultPromptLabels } from '../locales/index';
+
+import { PromptIcon } from './prompt-icon';
+
+import type { PromptTranslations } from '../locales/index';
+import type { PromptPickerCategoryResponse, PromptPickerItemResponse } from '@granit/ai-prompts';
+import type { KeyboardEvent } from 'react';
+
+export interface PromptPickerProps {
+  readonly categories: readonly PromptPickerCategoryResponse[];
+  readonly onSelect: (item: PromptPickerItemResponse) => void;
+  readonly autoFocus?: boolean;
+  readonly labels?: PromptTranslations['Picker'];
+  readonly className?: string;
+}
+
+/**
+ * A standalone, searchable `/` prompt picker grouped by category. The search
+ * box is an ARIA `combobox`; arrow keys move a single active index across the
+ * flattened result, Enter selects. (Inside the chat composer, the inline picker
+ * in `@granit/react-ai-chat` is used instead.)
+ */
+export function PromptPicker({
+  categories,
+  onSelect,
+  autoFocus = false,
+  labels = defaultPromptLabels.Picker,
+  className,
+}: Readonly<PromptPickerProps>) {
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const baseId = useId();
+  const listboxId = `${baseId}-listbox`;
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return categories
+      .map((category) => ({
+        category,
+        prompts: q
+          ? category.prompts.filter(
+              (p) =>
+                p.name.toLowerCase().includes(q) || p.shortDescription.toLowerCase().includes(q)
+            )
+          : category.prompts,
+      }))
+      .filter((group) => group.prompts.length > 0);
+  }, [categories, query]);
+
+  const flat = useMemo(() => filtered.flatMap((group) => group.prompts), [filtered]);
+
+  const onKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (flat.length === 0) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      setActiveIndex((i) => (i + 1) % flat.length);
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      setActiveIndex((i) => (i - 1 + flat.length) % flat.length);
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      const item = flat[activeIndex];
+      if (item) onSelect(item);
+    }
+  };
+
+  let runningIndex = -1;
+
+  return (
+    <div
+      data-slot="prompt-picker"
+      className={cn('border-border bg-popover w-full rounded-md border', className)}
+    >
+      <input
+        ref={inputRef}
+        type="text"
+        role="combobox"
+        aria-expanded
+        aria-controls={listboxId}
+        aria-label={labels.Title}
+        value={query}
+        placeholder={labels.Title}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          setActiveIndex(0);
+        }}
+        onKeyDown={onKeyDown}
+        className="border-border w-full border-b px-2.5 py-2 text-sm outline-none"
+      />
+
+      {flat.length === 0 ? (
+        <p data-slot="picker-empty" className="text-muted-foreground px-2.5 py-2 text-sm">
+          {labels.NoResults}
+        </p>
+      ) : (
+        <ul
+          role="listbox"
+          id={listboxId}
+          aria-label={labels.Title}
+          className="max-h-72 overflow-auto py-1"
+        >
+          {filtered.map((group) => (
+            <li
+              key={group.category.categoryId ?? group.category.categoryName}
+              role="group"
+              aria-label={group.category.categoryName}
+            >
+              <p className="text-muted-foreground px-2.5 pt-2 pb-1 text-xs font-medium">
+                {group.category.categoryName}
+              </p>
+              <ul>
+                {group.prompts.map((item) => {
+                  runningIndex++;
+                  const index = runningIndex;
+                  return (
+                    <li
+                      key={item.id}
+                      role="option"
+                      aria-selected={index === activeIndex}
+                      data-slot="picker-item"
+                      onMouseEnter={() => {
+                        setActiveIndex(index);
+                      }}
+                      onMouseDown={(event) => {
+                        event.preventDefault();
+                        onSelect(item);
+                      }}
+                      className={cn(
+                        'flex cursor-pointer items-center gap-2 px-2.5 py-1.5 text-sm',
+                        index === activeIndex ? 'bg-accent text-accent-foreground' : ''
+                      )}
+                    >
+                      <PromptIcon
+                        icon={item.icon}
+                        iconColor={item.iconColor}
+                        className="size-4 shrink-0"
+                      />
+                      <span className="flex-1 truncate">{item.name}</span>
+                      {item.isSystem ? (
+                        <span className="text-muted-foreground text-[10px]">{labels.System}</span>
+                      ) : null}
+                    </li>
+                  );
+                })}
+              </ul>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/packages/@granit/react-ai-prompts/src/constants.ts
+++ b/packages/@granit/react-ai-prompts/src/constants.ts
@@ -1,0 +1,10 @@
+export const API_VERSION = 'v1';
+
+/** Route prefix served by the prompt-catalogue endpoints (`MapGranitPrompts`). */
+export const MODULE = 'prompts';
+
+/** Default base path for the catalogue endpoints. Apps override via the provider. */
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+
+/** Default React Query key prefix for catalogue queries. */
+export const DEFAULT_QUERY_KEY_PREFIX = ['ai-prompts'] as const;

--- a/packages/@granit/react-ai-prompts/src/hooks/query-keys.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/query-keys.ts
@@ -1,0 +1,21 @@
+import type { PromptId } from '@granit/ai-prompts';
+
+/**
+ * Query-key factory for catalogue queries, namespaced under the provider's
+ * `queryKeyPrefix`.
+ */
+export const promptKeys = {
+  /** Root key for every catalogue query. */
+  all: (prefix: readonly string[]): readonly unknown[] => [...prefix],
+  /** The flat catalogue list. */
+  list: (prefix: readonly string[]): readonly unknown[] => [...prefix, 'prompts', 'list'],
+  /** The catalogue grouped for the `/` picker. */
+  picker: (prefix: readonly string[]): readonly unknown[] => [...prefix, 'prompts', 'picker'],
+  /** A single prompt with its instruction text. */
+  detail: (prefix: readonly string[], id: PromptId): readonly unknown[] => [
+    ...prefix,
+    'prompts',
+    'detail',
+    id,
+  ],
+} as const;

--- a/packages/@granit/react-ai-prompts/src/hooks/use-create-prompt.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/use-create-prompt.ts
@@ -1,0 +1,52 @@
+import { createPrompt } from '@granit/ai-prompts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIPromptsConfig } from '../providers/ai-prompts-provider';
+
+import { promptKeys } from './query-keys';
+
+import type { CreatePromptRequest, PromptResponse } from '@granit/ai-prompts';
+
+export interface UseCreatePromptReturn {
+  readonly create: (request: CreatePromptRequest) => void;
+  readonly createAsync: (request: CreatePromptRequest) => Promise<PromptResponse>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to create a private prompt. Invalidates the list and picker on
+ * success. Requires `AIPrompts.Templates.Manage`.
+ */
+export function useCreatePrompt(): UseCreatePromptReturn {
+  const config = useAIPromptsConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (request: CreatePromptRequest) =>
+      createPrompt(config.client, config.basePath, request),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.picker(config.queryKeyPrefix) })
+        .catch(() => undefined);
+    },
+  });
+
+  const create = useCallback(
+    (request: CreatePromptRequest) => {
+      mutation.mutate(request);
+    },
+    [mutation]
+  );
+
+  const createAsync = useCallback(
+    async (request: CreatePromptRequest) => mutation.mutateAsync(request),
+    [mutation]
+  );
+
+  return { create, createAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-prompts/src/hooks/use-customise-prompt.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/use-customise-prompt.ts
@@ -1,0 +1,49 @@
+import { customisePrompt } from '@granit/ai-prompts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIPromptsConfig } from '../providers/ai-prompts-provider';
+
+import { promptKeys } from './query-keys';
+
+import type { PromptId, PromptResponse } from '@granit/ai-prompts';
+
+export interface UseCustomisePromptReturn {
+  readonly customise: (id: PromptId) => void;
+  readonly customiseAsync: (id: PromptId) => Promise<PromptResponse>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to clone a **system** prompt into a private editable copy. Returns
+ * the new prompt and invalidates the list and picker. A non-system target
+ * returns 409. Requires `AIPrompts.Templates.Manage`.
+ */
+export function useCustomisePrompt(): UseCustomisePromptReturn {
+  const config = useAIPromptsConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (id: PromptId) => customisePrompt(config.client, config.basePath, id),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.picker(config.queryKeyPrefix) })
+        .catch(() => undefined);
+    },
+  });
+
+  const customise = useCallback(
+    (id: PromptId) => {
+      mutation.mutate(id);
+    },
+    [mutation]
+  );
+
+  const customiseAsync = useCallback(async (id: PromptId) => mutation.mutateAsync(id), [mutation]);
+
+  return { customise, customiseAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-prompts/src/hooks/use-delete-prompt.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/use-delete-prompt.ts
@@ -1,0 +1,53 @@
+import { deletePrompt } from '@granit/ai-prompts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIPromptsConfig } from '../providers/ai-prompts-provider';
+
+import { promptKeys } from './query-keys';
+
+import type { PromptId } from '@granit/ai-prompts';
+
+export interface UseDeletePromptReturn {
+  readonly remove: (id: PromptId) => void;
+  readonly removeAsync: (id: PromptId) => Promise<void>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to delete one of the caller's own prompts. Invalidates the list and
+ * picker on success. Requires `AIPrompts.Templates.Delete`.
+ */
+export function useDeletePrompt(): UseDeletePromptReturn {
+  const config = useAIPromptsConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: (id: PromptId) => deletePrompt(config.client, config.basePath, id),
+    onSuccess: () => {
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.picker(config.queryKeyPrefix) })
+        .catch(() => undefined);
+    },
+  });
+
+  const remove = useCallback(
+    (id: PromptId) => {
+      mutation.mutate(id);
+    },
+    [mutation]
+  );
+
+  const removeAsync = useCallback(
+    async (id: PromptId) => {
+      await mutation.mutateAsync(id);
+    },
+    [mutation]
+  );
+
+  return { remove, removeAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-prompts/src/hooks/use-prompt-picker.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/use-prompt-picker.ts
@@ -1,0 +1,24 @@
+import { getPromptPicker } from '@granit/ai-prompts';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAIPromptsConfig } from '../providers/ai-prompts-provider';
+
+import { promptKeys } from './query-keys';
+
+import type { PromptPickerResponse } from '@granit/ai-prompts';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetch the catalogue grouped by category for the chat `/` picker. Feed the
+ * flattened items to `@granit/react-ai-chat`'s `<ChatComposer prompts>`.
+ */
+export function usePromptPicker(options?: {
+  enabled?: boolean;
+}): UseQueryResult<PromptPickerResponse> {
+  const config = useAIPromptsConfig();
+  return useQuery({
+    queryKey: promptKeys.picker(config.queryKeyPrefix),
+    queryFn: () => getPromptPicker(config.client, config.basePath),
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/packages/@granit/react-ai-prompts/src/hooks/use-prompt.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/use-prompt.ts
@@ -1,0 +1,26 @@
+import { getPrompt } from '@granit/ai-prompts';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAIPromptsConfig } from '../providers/ai-prompts-provider';
+
+import { promptKeys } from './query-keys';
+
+import type { PromptId, PromptResponse } from '@granit/ai-prompts';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Fetch one prompt with its instruction text (e.g. to populate the edit form).
+ *
+ * @param id - the prompt id, or `null` to disable the query.
+ */
+export function usePrompt(
+  id: PromptId | null,
+  options?: { enabled?: boolean }
+): UseQueryResult<PromptResponse> {
+  const config = useAIPromptsConfig();
+  return useQuery({
+    queryKey: promptKeys.detail(config.queryKeyPrefix, id ?? ('' as PromptId)),
+    queryFn: () => getPrompt(config.client, config.basePath, id as PromptId),
+    enabled: (options?.enabled ?? true) && id !== null,
+  });
+}

--- a/packages/@granit/react-ai-prompts/src/hooks/use-prompts.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/use-prompts.ts
@@ -1,0 +1,24 @@
+import { listPrompts } from '@granit/ai-prompts';
+import { useQuery } from '@tanstack/react-query';
+
+import { useAIPromptsConfig } from '../providers/ai-prompts-provider';
+
+import { promptKeys } from './query-keys';
+
+import type { PromptSummaryResponse } from '@granit/ai-prompts';
+import type { UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * List the caller's catalogue (system prompts first, then own), without
+ * instruction text. Backs the catalogue manager.
+ */
+export function usePrompts(options?: {
+  enabled?: boolean;
+}): UseQueryResult<readonly PromptSummaryResponse[]> {
+  const config = useAIPromptsConfig();
+  return useQuery({
+    queryKey: promptKeys.list(config.queryKeyPrefix),
+    queryFn: () => listPrompts(config.client, config.basePath),
+    enabled: options?.enabled ?? true,
+  });
+}

--- a/packages/@granit/react-ai-prompts/src/hooks/use-update-prompt.ts
+++ b/packages/@granit/react-ai-prompts/src/hooks/use-update-prompt.ts
@@ -1,0 +1,61 @@
+import { updatePrompt } from '@granit/ai-prompts';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+import { useAIPromptsConfig } from '../providers/ai-prompts-provider';
+
+import { promptKeys } from './query-keys';
+
+import type { PromptId, PromptResponse, UpdatePromptRequest } from '@granit/ai-prompts';
+
+export interface UpdatePromptVariables {
+  readonly id: PromptId;
+  readonly request: UpdatePromptRequest;
+}
+
+export interface UseUpdatePromptReturn {
+  readonly update: (variables: UpdatePromptVariables) => void;
+  readonly updateAsync: (variables: UpdatePromptVariables) => Promise<PromptResponse>;
+  readonly isPending: boolean;
+  readonly error: Error | null;
+}
+
+/**
+ * Mutation to update one of the caller's own prompts. Invalidates the list,
+ * picker, and the affected detail on success. System prompts are read-only
+ * (the backend returns 404 — offer Customise instead).
+ */
+export function useUpdatePrompt(): UseUpdatePromptReturn {
+  const config = useAIPromptsConfig();
+  const queryClient = useQueryClient();
+
+  const mutation = useMutation({
+    mutationFn: ({ id, request }: UpdatePromptVariables) =>
+      updatePrompt(config.client, config.basePath, id, request),
+    onSuccess: (_data, { id }) => {
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.list(config.queryKeyPrefix) })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.picker(config.queryKeyPrefix) })
+        .catch(() => undefined);
+      queryClient
+        .invalidateQueries({ queryKey: promptKeys.detail(config.queryKeyPrefix, id) })
+        .catch(() => undefined);
+    },
+  });
+
+  const update = useCallback(
+    (variables: UpdatePromptVariables) => {
+      mutation.mutate(variables);
+    },
+    [mutation]
+  );
+
+  const updateAsync = useCallback(
+    async (variables: UpdatePromptVariables) => mutation.mutateAsync(variables),
+    [mutation]
+  );
+
+  return { update, updateAsync, isPending: mutation.isPending, error: mutation.error };
+}

--- a/packages/@granit/react-ai-prompts/src/index.ts
+++ b/packages/@granit/react-ai-prompts/src/index.ts
@@ -23,3 +23,29 @@ export { useDeletePrompt } from './hooks/use-delete-prompt';
 export type { UseDeletePromptReturn } from './hooks/use-delete-prompt';
 export { useCustomisePrompt } from './hooks/use-customise-prompt';
 export type { UseCustomisePromptReturn } from './hooks/use-customise-prompt';
+
+// Components
+export { PromptIcon } from './components/prompt-icon';
+export type { PromptIconProps } from './components/prompt-icon';
+export { IconPicker } from './components/icon-picker';
+export type { IconPickerProps } from './components/icon-picker';
+export { PromptForm } from './components/prompt-form';
+export type { PromptFormProps, PromptFormValues } from './components/prompt-form';
+export { PromptCatalogue } from './components/prompt-catalogue';
+export type { PromptCatalogueProps } from './components/prompt-catalogue';
+export { PromptPicker } from './components/prompt-picker';
+export type { PromptPickerProps } from './components/prompt-picker';
+export {
+  DEFAULT_PROMPT_ICON,
+  getPromptIcon,
+  PROMPT_ICON_IDS,
+  PROMPT_ICONS,
+} from './components/icon-registry';
+
+// i18n
+export {
+  aiPromptsTranslationsEn,
+  aiPromptsTranslationsFr,
+  defaultPromptLabels,
+} from './locales/index';
+export type { PromptTranslations } from './locales/index';

--- a/packages/@granit/react-ai-prompts/src/index.ts
+++ b/packages/@granit/react-ai-prompts/src/index.ts
@@ -1,0 +1,25 @@
+// Provider
+export { AIPromptsProvider, useAIPromptsConfig } from './providers/ai-prompts-provider';
+export type {
+  AIPromptsConfig,
+  AIPromptsProviderProps,
+  ResolvedAIPromptsConfig,
+} from './providers/ai-prompts-provider';
+
+// Query keys
+export { promptKeys } from './hooks/query-keys';
+
+// Hooks — queries
+export { usePrompts } from './hooks/use-prompts';
+export { usePrompt } from './hooks/use-prompt';
+export { usePromptPicker } from './hooks/use-prompt-picker';
+
+// Hooks — mutations
+export { useCreatePrompt } from './hooks/use-create-prompt';
+export type { UseCreatePromptReturn } from './hooks/use-create-prompt';
+export { useUpdatePrompt } from './hooks/use-update-prompt';
+export type { UpdatePromptVariables, UseUpdatePromptReturn } from './hooks/use-update-prompt';
+export { useDeletePrompt } from './hooks/use-delete-prompt';
+export type { UseDeletePromptReturn } from './hooks/use-delete-prompt';
+export { useCustomisePrompt } from './hooks/use-customise-prompt';
+export type { UseCustomisePromptReturn } from './hooks/use-customise-prompt';

--- a/packages/@granit/react-ai-prompts/src/locales/en.ts
+++ b/packages/@granit/react-ai-prompts/src/locales/en.ts
@@ -1,0 +1,70 @@
+/** Translation shape for the `aiPrompts` namespace. */
+export interface PromptTranslations {
+  readonly Picker: {
+    readonly Title: string;
+    readonly NoResults: string;
+    readonly System: string;
+  };
+  readonly Catalogue: {
+    readonly Empty: string;
+    readonly New: string;
+    readonly Edit: string;
+    readonly Delete: string;
+    readonly Customise: string;
+    readonly System: string;
+    readonly DeleteConfirm: string;
+  };
+  readonly Form: {
+    readonly Name: string;
+    readonly NamePlaceholder: string;
+    readonly ShortDescription: string;
+    readonly Content: string;
+    readonly ContentPlaceholder: string;
+    readonly Icon: string;
+    readonly Save: string;
+    readonly Cancel: string;
+    readonly NameRequired: string;
+    readonly ContentRequired: string;
+  };
+  readonly IconPicker: {
+    readonly IconLabel: string;
+    readonly ColorLabel: string;
+    readonly ColorHexLabel: string;
+    readonly ColorInvalid: string;
+  };
+}
+
+export const aiPromptsTranslationsEn: PromptTranslations = {
+  Picker: {
+    Title: 'Prompts',
+    NoResults: 'No prompts',
+    System: 'System',
+  },
+  Catalogue: {
+    Empty: 'No prompts yet.',
+    New: 'New prompt',
+    Edit: 'Edit',
+    Delete: 'Delete',
+    Customise: 'Customise',
+    System: 'System',
+    DeleteConfirm: 'Delete this prompt?',
+  },
+  Form: {
+    Name: 'Name',
+    NamePlaceholder: 'e.g. Summarize',
+    ShortDescription: 'Short description',
+    Content: 'Instruction',
+    ContentPlaceholder: 'What should the assistant do?',
+    Icon: 'Icon',
+    Save: 'Save',
+    Cancel: 'Cancel',
+    NameRequired: 'A name is required.',
+    ContentRequired: 'An instruction is required.',
+  },
+  IconPicker: {
+    IconLabel: 'Icon',
+    ColorLabel: 'Icon colour',
+    ColorHexLabel: 'Icon colour hex',
+    ColorInvalid: 'Use #RRGGBB or #RRGGBBAA.',
+  },
+};

--- a/packages/@granit/react-ai-prompts/src/locales/fr.ts
+++ b/packages/@granit/react-ai-prompts/src/locales/fr.ts
@@ -1,0 +1,36 @@
+import type { PromptTranslations } from './en';
+
+export const aiPromptsTranslationsFr: PromptTranslations = {
+  Picker: {
+    Title: 'Prompts',
+    NoResults: 'Aucun prompt',
+    System: 'Système',
+  },
+  Catalogue: {
+    Empty: 'Aucun prompt pour l’instant.',
+    New: 'Nouveau prompt',
+    Edit: 'Modifier',
+    Delete: 'Supprimer',
+    Customise: 'Personnaliser',
+    System: 'Système',
+    DeleteConfirm: 'Supprimer ce prompt ?',
+  },
+  Form: {
+    Name: 'Nom',
+    NamePlaceholder: 'ex. Résumer',
+    ShortDescription: 'Description courte',
+    Content: 'Instruction',
+    ContentPlaceholder: 'Que doit faire l’assistant ?',
+    Icon: 'Icône',
+    Save: 'Enregistrer',
+    Cancel: 'Annuler',
+    NameRequired: 'Un nom est requis.',
+    ContentRequired: 'Une instruction est requise.',
+  },
+  IconPicker: {
+    IconLabel: 'Icône',
+    ColorLabel: 'Couleur de l’icône',
+    ColorHexLabel: 'Couleur de l’icône (hex)',
+    ColorInvalid: 'Utilisez #RRGGBB ou #RRGGBBAA.',
+  },
+};

--- a/packages/@granit/react-ai-prompts/src/locales/index.ts
+++ b/packages/@granit/react-ai-prompts/src/locales/index.ts
@@ -1,0 +1,10 @@
+export { aiPromptsTranslationsEn } from './en';
+export { aiPromptsTranslationsFr } from './fr';
+export type { PromptTranslations } from './en';
+
+/**
+ * English defaults used by components when no `labels` prop is provided, so
+ * they render standalone (and tests need no i18n bootstrap). Apps register the
+ * `aiPrompts*` bundles with i18next and pass translated labels down.
+ */
+export { aiPromptsTranslationsEn as defaultPromptLabels } from './en';

--- a/packages/@granit/react-ai-prompts/src/providers/ai-prompts-provider.tsx
+++ b/packages/@granit/react-ai-prompts/src/providers/ai-prompts-provider.tsx
@@ -1,0 +1,65 @@
+// ---------------------------------------------------------------------------
+// AI prompts context provider — supplies the Axios client and config to all
+// catalogue hooks. Mirrors the @granit/react-ai-chat provider pattern.
+// ---------------------------------------------------------------------------
+
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for {@link AIPromptsProvider}. */
+export interface AIPromptsConfig {
+  /** Axios client with auth, CSRF, and tenant interceptors. */
+  readonly client?: AxiosInstance;
+  /** Base path for the catalogue endpoints (default: `/api/v1/prompts`). */
+  readonly basePath?: string;
+  /** React Query key prefix (default: `['ai-prompts']`). */
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/** {@link AIPromptsConfig} after the provider has resolved `client` and defaults. */
+export interface ResolvedAIPromptsConfig extends AIPromptsConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
+}
+
+export interface AIPromptsProviderProps {
+  readonly config: AIPromptsConfig;
+  readonly children: ReactNode;
+}
+
+const AIPromptsConfigContext = createContext<ResolvedAIPromptsConfig | null>(null);
+
+/** Provides catalogue configuration to child components and hooks. */
+export function AIPromptsProvider({ config, children }: Readonly<AIPromptsProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedAIPromptsConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'AIPromptsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      client,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
+    };
+  }, [config, contextClient]);
+  return <AIPromptsConfigContext value={value}>{children}</AIPromptsConfigContext>;
+}
+
+/** Returns the catalogue configuration from the nearest {@link AIPromptsProvider}. */
+export function useAIPromptsConfig(): ResolvedAIPromptsConfig {
+  const ctx = useContext(AIPromptsConfigContext);
+  if (!ctx) {
+    throw new Error('useAIPromptsConfig must be used within an AIPromptsProvider');
+  }
+  return ctx;
+}

--- a/packages/@granit/react-ai-prompts/src/testing/data.ts
+++ b/packages/@granit/react-ai-prompts/src/testing/data.ts
@@ -1,0 +1,102 @@
+import { toEntityId, toISODateString } from '@granit/types';
+
+import type {
+  PromptPickerResponse,
+  PromptResponse,
+  PromptSummaryResponse,
+} from '@granit/ai-prompts';
+
+const OWNER = toEntityId<'User'>('b2222222-2222-2222-2222-222222222222');
+const SYSTEM_OWNER = toEntityId<'User'>('00000000-0000-0000-0000-000000000000');
+
+const SYSTEM_ID = toEntityId<'Prompt'>('51111111-1111-1111-1111-111111111111');
+const USER_ID = toEntityId<'Prompt'>('52222222-2222-2222-2222-222222222222');
+const CATEGORY_ID = toEntityId<'Category'>('c3333333-3333-3333-3333-333333333333');
+
+/** A read-only, framework-seeded system prompt. */
+export const mockSystemPrompt: PromptResponse = {
+  id: SYSTEM_ID,
+  name: 'Summarize',
+  shortDescription: 'Summarize the current record',
+  content: 'Summarize {{record}} in three concise bullet points.',
+  icon: 'sparkles',
+  iconColor: '#3366FF',
+  version: 1,
+  isSystem: true,
+  ownerId: SYSTEM_OWNER,
+  categoryIds: [CATEGORY_ID],
+  createdAt: toISODateString('2026-01-01T00:00:00.000Z'),
+  modifiedAt: null,
+};
+
+/** A private prompt owned by the caller. */
+export const mockUserPrompt: PromptResponse = {
+  id: USER_ID,
+  name: 'Daily brief',
+  shortDescription: 'My morning summary',
+  content: 'Give me a brief of what changed since yesterday.',
+  icon: 'calendar',
+  iconColor: '#10B981',
+  version: 2,
+  isSystem: false,
+  ownerId: OWNER,
+  categoryIds: [],
+  createdAt: toISODateString('2026-06-10T08:00:00.000Z'),
+  modifiedAt: toISODateString('2026-06-12T08:00:00.000Z'),
+};
+
+/** Catalogue summaries returned by `GET /prompts` (system first). */
+export const mockPromptSummaries: PromptSummaryResponse[] = [
+  {
+    id: SYSTEM_ID,
+    name: mockSystemPrompt.name,
+    shortDescription: mockSystemPrompt.shortDescription,
+    icon: mockSystemPrompt.icon,
+    iconColor: mockSystemPrompt.iconColor,
+    isSystem: true,
+    categoryIds: mockSystemPrompt.categoryIds,
+  },
+  {
+    id: USER_ID,
+    name: mockUserPrompt.name,
+    shortDescription: mockUserPrompt.shortDescription,
+    icon: mockUserPrompt.icon,
+    iconColor: mockUserPrompt.iconColor,
+    isSystem: false,
+    categoryIds: [],
+  },
+];
+
+/** The `/` picker payload returned by `GET /prompts/picker`. */
+export const mockPromptPicker: PromptPickerResponse = {
+  categories: [
+    {
+      categoryId: CATEGORY_ID,
+      categoryName: 'Records',
+      prompts: [
+        {
+          id: SYSTEM_ID,
+          name: mockSystemPrompt.name,
+          shortDescription: mockSystemPrompt.shortDescription,
+          icon: mockSystemPrompt.icon,
+          iconColor: mockSystemPrompt.iconColor,
+          isSystem: true,
+        },
+      ],
+    },
+    {
+      categoryId: null,
+      categoryName: 'General',
+      prompts: [
+        {
+          id: USER_ID,
+          name: mockUserPrompt.name,
+          shortDescription: mockUserPrompt.shortDescription,
+          icon: mockUserPrompt.icon,
+          iconColor: mockUserPrompt.iconColor,
+          isSystem: false,
+        },
+      ],
+    },
+  ],
+};

--- a/packages/@granit/react-ai-prompts/src/testing/handlers.ts
+++ b/packages/@granit/react-ai-prompts/src/testing/handlers.ts
@@ -1,0 +1,150 @@
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { mockPromptPicker, mockPromptSummaries, mockSystemPrompt, mockUserPrompt } from './data';
+
+import type {
+  CreatePromptRequest,
+  PromptResponse,
+  PromptSummaryResponse,
+  UpdatePromptRequest,
+} from '@granit/ai-prompts';
+import type { Mutable } from '@granit/testing';
+
+const PROMPTS: Record<string, PromptResponse> = {
+  [mockSystemPrompt.id]: mockSystemPrompt,
+  [mockUserPrompt.id]: mockUserPrompt,
+};
+
+/**
+ * Create stateful MSW handlers for the prompt-catalogue endpoints. Create /
+ * update / delete / customise mutate an in-memory list reflected by subsequent
+ * GETs. System prompts are read-only: PUT / DELETE return 404; customising a
+ * non-system prompt returns 409.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/prompts`).
+ */
+export function createAIPromptsHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  let summaries: Mutable<PromptSummaryResponse>[] = [...mockPromptSummaries];
+  const details: Record<string, PromptResponse> = { ...PROMPTS };
+  let created = 0;
+
+  return [
+    // GET /prompts/picker — before /:id so it is not swallowed.
+    http.get(`${baseUrl}/picker`, () => HttpResponse.json(mockPromptPicker)),
+
+    // GET /prompts — summaries (system first).
+    http.get(baseUrl, () => HttpResponse.json(summaries)),
+
+    // GET /prompts/:id — full prompt.
+    http.get(`${baseUrl}/:id`, ({ params }) => {
+      const prompt = details[params.id as string];
+      if (!prompt) return new HttpResponse(null, { status: 404 });
+      return HttpResponse.json(prompt);
+    }),
+
+    // POST /prompts — create.
+    http.post(baseUrl, async ({ request }) => {
+      const body = (await request.json()) as CreatePromptRequest;
+      created++;
+      const id = `5aaaaaaa-0000-0000-0000-${String(created).padStart(12, '0')}`;
+      const prompt: PromptResponse = {
+        id: id as PromptResponse['id'],
+        name: body.name,
+        shortDescription: body.shortDescription ?? '',
+        content: body.content,
+        icon: body.icon ?? null,
+        iconColor: body.iconColor ?? null,
+        version: 1,
+        isSystem: false,
+        ownerId: mockUserPrompt.ownerId,
+        categoryIds: body.categoryIds ?? [],
+        createdAt: mockUserPrompt.createdAt,
+        modifiedAt: null,
+      };
+      details[id] = prompt;
+      summaries = [
+        ...summaries,
+        {
+          id: prompt.id,
+          name: prompt.name,
+          shortDescription: prompt.shortDescription,
+          icon: prompt.icon,
+          iconColor: prompt.iconColor,
+          isSystem: false,
+          categoryIds: prompt.categoryIds,
+        },
+      ];
+      return HttpResponse.json(prompt, { status: 201 });
+    }),
+
+    // POST /prompts/:id/customise — clone a system prompt.
+    http.post(`${baseUrl}/:id/customise`, ({ params }) => {
+      const source = details[params.id as string];
+      if (!source) return new HttpResponse(null, { status: 404 });
+      if (!source.isSystem) {
+        return HttpResponse.json(
+          { title: 'Conflict', status: 409, detail: 'Only system prompts can be customised.' },
+          { status: 409 }
+        );
+      }
+      created++;
+      const id = `5bbbbbbb-0000-0000-0000-${String(created).padStart(12, '0')}`;
+      const clone: PromptResponse = {
+        ...source,
+        id: id as PromptResponse['id'],
+        isSystem: false,
+        ownerId: mockUserPrompt.ownerId,
+        version: 1,
+      };
+      details[id] = clone;
+      summaries = [
+        ...summaries,
+        {
+          id: clone.id,
+          name: clone.name,
+          shortDescription: clone.shortDescription,
+          icon: clone.icon,
+          iconColor: clone.iconColor,
+          isSystem: false,
+          categoryIds: clone.categoryIds,
+        },
+      ];
+      return HttpResponse.json(clone, { status: 201 });
+    }),
+
+    // PUT /prompts/:id — update (system prompts are read-only → 404).
+    http.put(`${baseUrl}/:id`, async ({ params, request }) => {
+      const existing = details[params.id as string];
+      if (!existing || existing.isSystem) return new HttpResponse(null, { status: 404 });
+      const body = (await request.json()) as UpdatePromptRequest;
+      const updated: PromptResponse = {
+        ...existing,
+        name: body.name,
+        content: body.content,
+        shortDescription: body.shortDescription ?? '',
+        icon: body.icon ?? null,
+        iconColor: body.iconColor ?? null,
+        categoryIds: body.categoryIds ?? [],
+        version: existing.version + 1,
+      };
+      details[existing.id] = updated;
+      summaries = summaries.map((s) =>
+        s.id === existing.id
+          ? { ...s, name: updated.name, shortDescription: updated.shortDescription }
+          : s
+      );
+      return HttpResponse.json(updated);
+    }),
+
+    // DELETE /prompts/:id — delete (system prompts → 404).
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const existing = details[params.id as string];
+      if (!existing || existing.isSystem) return new HttpResponse(null, { status: 404 });
+      delete details[existing.id];
+      summaries = summaries.filter((s) => s.id !== existing.id);
+      return new HttpResponse(null, { status: 204 });
+    }),
+  ];
+}

--- a/packages/@granit/react-ai-prompts/src/testing/index.ts
+++ b/packages/@granit/react-ai-prompts/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-ai-prompts/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { mockPromptPicker, mockPromptSummaries, mockSystemPrompt, mockUserPrompt } from './data';
+export { createAIPromptsHandlers } from './handlers';

--- a/packages/@granit/react-ai-prompts/tsconfig.json
+++ b/packages/@granit/react-ai-prompts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/ai-prompts": ["../ai-prompts/src/index.ts"],
+      "@granit/api-client": ["../api-client/src/index.ts"],
+      "@granit/react-api-client": ["../react-api-client/src/index.ts"],
+      "@granit/types": ["../types/src/index.ts"],
+      "@granit/utils": ["../utils/src/index.ts"],
+      "@granit/testing": ["../testing/src/index.ts"],
+      "@granit/react-testing": ["../react-testing/src/index.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "exclude": ["src/__tests__/**"]
+}

--- a/packages/@granit/react-ai-prompts/tsup.config.ts
+++ b/packages/@granit/react-ai-prompts/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,19 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/ai-prompts:
+    dependencies:
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/analytics:
     dependencies:
       '@granit/api-client':
@@ -5405,11 +5418,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  acorn@8.17.0:
-    resolution: {integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
     engines: {node: '>= 6.0.0'}
@@ -5487,8 +5495,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.37:
-    resolution: {integrity: sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==}
+  baseline-browser-mapping@2.10.34:
+    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -5533,8 +5541,8 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  caniuse-lite@1.0.30001799:
-    resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+  caniuse-lite@1.0.30001797:
+    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
 
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
@@ -5753,8 +5761,8 @@ packages:
   echarts@6.1.0:
     resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
-  electron-to-chromium@1.5.372:
-    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+  electron-to-chromium@1.5.368:
+    resolution: {integrity: sha512-7RckJJK4uESJF9PxvfMWd3TGqIiieUTG4HxnKaKuIpGbcr+r2ZEB3g2gAhCP3Fqm42vJSzLfgab9eva/C4/XVw==}
 
   emoji-regex@10.6.0:
     resolution: {integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==}
@@ -5864,16 +5872,6 @@ packages:
   eslint-visitor-keys@5.0.1:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-
-  eslint@10.5.0:
-    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
-    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
-    hasBin: true
-    peerDependencies:
-      jiti: '*'
-    peerDependenciesMeta:
-      jiti:
-        optional: true
 
   eslint@10.5.0:
     resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
@@ -8103,11 +8101,6 @@ snapshots:
       eslint: 10.5.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.6.1))':
-    dependencies:
-      eslint: 10.5.0(jiti@2.6.1)
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/regexpp@4.12.2': {}
 
   '@eslint/config-array@0.23.5':
@@ -9786,17 +9779,11 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  acorn-import-attributes@1.9.5(acorn@8.17.0):
+  acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
-      acorn: 8.17.0
-
-  acorn-jsx@5.3.2(acorn@8.17.0):
-    dependencies:
-      acorn: 8.17.0
+      acorn: 8.16.0
 
   acorn@8.16.0: {}
-
-  acorn@8.17.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -9884,7 +9871,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.37: {}
+  baseline-browser-mapping@2.10.34: {}
 
   bidi-js@1.0.3:
     dependencies:
@@ -9900,9 +9887,9 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.37
-      caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.372
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
+      electron-to-chromium: 1.5.368
       node-releases: 2.0.47
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
@@ -9930,7 +9917,7 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  caniuse-lite@1.0.30001799: {}
+  caniuse-lite@1.0.30001797: {}
 
   chai@6.2.2: {}
 
@@ -10124,7 +10111,7 @@ snapshots:
       tslib: 2.3.0
       zrender: 6.1.0
 
-  electron-to-chromium@1.5.372: {}
+  electron-to-chromium@1.5.368: {}
 
   emoji-regex@10.6.0: {}
 
@@ -10286,47 +10273,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint@10.5.0(jiti@2.6.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.6.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
-      '@eslint/config-helpers': 0.6.0
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.2
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.6.1
-    transitivePeerDependencies:
-      - supports-color
-
   espree@11.2.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       eslint-visitor-keys: 5.0.1
 
   esquery@1.7.0:
@@ -10621,8 +10571,8 @@ snapshots:
 
   import-in-the-middle@2.0.6:
     dependencies:
-      acorn: 8.17.0
-      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
       cjs-module-lexer: 2.2.0
       module-details-from-path: 1.0.4
 
@@ -11169,7 +11119,7 @@ snapshots:
 
   mlly@1.8.2:
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.16.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1034,6 +1034,43 @@ importers:
         specifier: workspace:*
         version: link:../utils
 
+  packages/@granit/react-ai-prompts:
+    dependencies:
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      lucide-react:
+        specifier: ^1.0.0
+        version: 1.17.0(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.2)(typescript@6.0.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/ai-prompts':
+        specifier: workspace:*
+        version: link:../ai-prompts
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+      '@granit/utils':
+        specifier: workspace:*
+        version: link:../utils
+
   packages/@granit/react-analytics:
     dependencies:
       '@tanstack/react-query':


### PR DESCRIPTION
## What

The **user-facing prompt catalogue** — the `/` prompt-badge templates powering the agentic chat composer. Second of the two front PRs for Epic **granit-dotnet#2626** (ADR-067); the chat surface landed in the first (`@granit/ai-chat` / `@granit/react-ai-chat`).

> Scope note: this is the **catalogue** (the user-facing `/` picker), not the invisible code-first guardrails — the front builds UI only for the catalogue.

### `@granit/ai-prompts` (core, framework-agnostic)
- Hand-written DTOs mirroring `Granit.AI.Prompts.Endpoints` — `icon` / `iconColor` are required-but-nullable; picker `categoryId` is nullable (the "General" group).
- Prompt CRUD, the `/` picker payload, and `customisePrompt` (`POST /prompts/{id}/customise`).
- `AIPromptsPermissions.Templates.{Read,Manage,Delete}`.
- Vendored `contracts/openapi/ai-prompts.json` + wired into `@granit/contract-tests` (7 DTOs + route conformance).

### `@granit/react-ai-prompts` (React bindings + UI)
- `AIPromptsProvider`; `usePrompts`, `usePromptPicker`, `usePrompt`; mutations `useCreatePrompt` / `useUpdatePrompt` / `useDeletePrompt` / `useCustomisePrompt` with a namespaced query-key factory.
- Components: `PromptCatalogue` (manager — **Customise** for read-only system prompts, Edit/Delete for own, affordances gated by `canManage` / `canDelete`), `PromptForm` (create/edit with name/instruction validation + the icon picker), `IconPicker` + `PromptIcon` + a front-owned lucide glyph registry keyed by identifier with hex colour editing, `PromptPicker` (standalone searchable `/` popover grouped by category, keyboard nav, ARIA combobox/listbox).
- en/fr i18n bundles + label-prop defaults; stateful MSW testing seam enforcing the read-only / customise / 409 semantics.

## Key contract behaviours honoured
- **System prompts are read-only**: `PUT` / `DELETE` → 404; the UI offers **Customise** instead of Edit/Delete when `isSystem` is `true`. Customising a non-system prompt → 409.
- User prompts are owner-private. `icon` is an identifier (front owns the glyph set); `iconColor` is hex `#RRGGBB` / `#RRGGBBAA` (validated client-side at the edge).
- Client gates affordances by permission; the server re-checks regardless.

## DoD
- `pnpm lint --max-warnings 0`, `tsc`, Vitest **green** (33 new tests); contract conformance + arch-tests + `check:csp` pass.
- Storybook: granit-front has no Storybook harness (stories live in the showcase) — out of scope here, lands with the showcase wiring.

## Wiring (separate showcase MR)
The showcase flattens `usePromptPicker()` into `@granit/react-ai-chat`'s `<ChatComposer prompts>`, mounts `<PromptCatalogue>` on a management page, and registers the i18n bundles. Tracked in the `granit-showcase-react` MR.

Refs granit-dotnet#2626