### PR TITLE
feat(react-notifications): add notification view registry

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -5605,6 +5605,26 @@
           "signature": "function useNotificationConfig(): NotificationContextValue"
         },
         {
+          "name": "registerNotificationView",
+          "kind": "function",
+          "signature": "function registerNotificationView<TData>(view: NotificationView<TData>): void"
+        },
+        {
+          "name": "getNotificationView",
+          "kind": "function",
+          "signature": "function getNotificationView(code: string): NotificationView | undefined"
+        },
+        {
+          "name": "resolveNotificationPresentation",
+          "kind": "function",
+          "signature": "function resolveNotificationPresentation( notification: PresentableNotification, ctx: NotificationPresentContext ): NotificationPresentation"
+        },
+        {
+          "name": "presentDefault",
+          "kind": "function",
+          "signature": "function presentDefault(notification: PresentableNotification): NotificationPresentation"
+        },
+        {
           "name": "useRealTimeNotifications",
           "kind": "function",
           "signature": "function useRealTimeNotifications(): UseRealTimeNotificationsReturn"

--- a/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
+++ b/packages/@granit/dashboards/src/types/__tests__/widget-bridge.test.ts
@@ -260,6 +260,52 @@ describe('widgetDefinitionToUpdateRequest', () => {
   });
 });
 
+describe('KPI configJson bridge (bare-Datasource contract)', () => {
+  // The backend treats a KPI's `configJson` as the bare polymorphic
+  // `Datasource` (`JsonSerializer.Serialize<Datasource>`): a top-level
+  // `{ kind, metricName }`, NOT a `{ datasource: { … } }` wrapper. The bridge
+  // must lift it under `datasource` on read and re-emit it bare on write.
+  const BARE_DATASOURCE = {
+    kind: 'metric',
+    metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
+  };
+
+  it('lifts a bare-datasource configJson under `widget.datasource` (regression: KpiTile crash)', () => {
+    const instance: WidgetInstanceResponse = {
+      id: WIDGET_ID,
+      widgetType: 'Kpi',
+      position: 2,
+      width: 3,
+      height: 2,
+      titleLocalizationKey: `Widget:${DASHBOARD_NAME}.UnpaidCount`,
+      metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
+      queryName: null,
+      configJson: JSON.stringify(BARE_DATASOURCE),
+      requiredPermission: null,
+    };
+    const widget = widgetInstanceToDefinition(instance, DASHBOARD_NAME) as KpiWidgetStub;
+    // The crash was `isMetricDatasource(undefined)` — assert the binding is
+    // present and correctly shaped, not spread flat onto the widget.
+    expect(widget.datasource).toBeDefined();
+    expect(widget.datasource).toEqual(BARE_DATASOURCE);
+    expect((widget as unknown as Record<string, unknown>)['kind']).toBeUndefined();
+    expect((widget as unknown as Record<string, unknown>)['metricName']).toBeUndefined();
+  });
+
+  it('re-emits the bare datasource (not a wrapper) on write', () => {
+    const widget: KpiWidgetStub = {
+      slug: 'UnpaidCount',
+      type: 'kpi',
+      position: 2,
+      size: { width: 3, height: 2 },
+      datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+    };
+    const request = widgetDefinitionToAddRequest(widget, DASHBOARD_NAME);
+    expect(JSON.parse(request.configJson)).toEqual(BARE_DATASOURCE);
+    expect(JSON.parse(request.configJson)).not.toHaveProperty('datasource');
+  });
+});
+
 describe('round-trip: instance → definition → addRequest → instance-shaped fields', () => {
   it('preserves every widget field across the bridge', () => {
     const original: WidgetInstanceResponse = {
@@ -271,8 +317,10 @@ describe('round-trip: instance → definition → addRequest → instance-shaped
       titleLocalizationKey: `Widget:${DASHBOARD_NAME}.UnpaidCount`,
       metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
       queryName: null,
+      // Bare polymorphic Datasource — exactly what the backend persists.
       configJson: JSON.stringify({
-        datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+        kind: 'metric',
+        metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric',
       }),
       requiredPermission: null,
     };
@@ -283,6 +331,7 @@ describe('round-trip: instance → definition → addRequest → instance-shaped
     expect(addRequest.width).toBe(original.width);
     expect(addRequest.height).toBe(original.height);
     expect(addRequest.titleLocalizationKey).toBe(original.titleLocalizationKey);
+    // `metricName` is denormalized off the datasource, reproducing the column.
     expect(addRequest.metricName).toBe(original.metricName);
     expect(addRequest.queryName).toBe(original.queryName);
     expect(JSON.parse(addRequest.configJson)).toEqual(JSON.parse(original.configJson));

--- a/packages/@granit/dashboards/src/types/widget-bridge.ts
+++ b/packages/@granit/dashboards/src/types/widget-bridge.ts
@@ -107,8 +107,19 @@ function denormalizeReferences(widget: WidgetDefinitionBase): {
  * Strips the structural fields from a widget definition and serializes
  * the remainder to JSON. Round-trip-safe: `configJsonToWidgetFields`
  * undoes this exactly when paired with the same structural fields.
+ *
+ * KPI is special-cased: its `configJson` is the *bare* polymorphic
+ * {@link Datasource} (matching the backend's `JsonSerializer.Serialize<Datasource>`),
+ * not the generic strip-structural-fields blob. KPI `actions` are intentionally
+ * not persisted — there's no server-side Actions column for KPI and the bare
+ * datasource has no room for them, so they don't round-trip. If KPI action
+ * persistence is wanted, that's a separate story.
  */
 function widgetFieldsToConfigJson(widget: WidgetDefinitionBase): string {
+  if (widget.type === 'kpi') {
+    const datasource = (widget as unknown as { datasource?: unknown }).datasource;
+    return JSON.stringify(datasource ?? null);
+  }
   const config: Record<string, unknown> = {};
   const w = widget as unknown as Readonly<Record<string, unknown>>;
   for (const key of Object.keys(w)) {
@@ -152,7 +163,16 @@ export function widgetInstanceToDefinition(
   dashboardName: string
 ): WidgetDefinition {
   const slug = extractSlugFromTitleKey(instance.titleLocalizationKey, dashboardName);
-  const fields = configJsonToWidgetFields(instance.configJson) ?? {};
+  const parsed = configJsonToWidgetFields(instance.configJson) ?? {};
+  // A KPI persists its `configJson` as the *bare* polymorphic `Datasource`
+  // (backend: `JsonSerializer.Serialize<Datasource>(k.Datasource)` →
+  // `{"kind":"metric","metricName":"…"}`), not a strip-structural-fields blob.
+  // Lift it under the `datasource` key the editor's `KpiWidgetDefinition`
+  // expects instead of spreading it flat — a flat spread leaves
+  // `widget.datasource` undefined and crashes `<KpiTile>`. KPI `actions` are
+  // not part of `configJson` (no server-side Actions column for KPI), so they
+  // don't round-trip through detail/edit — consistent with the backend.
+  const fields = instance.widgetType === 'Kpi' ? { datasource: parsed } : parsed;
   const widget: WidgetDefinitionBase & Readonly<Record<string, unknown>> = {
     ...fields,
     slug,

--- a/packages/@granit/react-analytics/src/__tests__/kpi-tile.test.tsx
+++ b/packages/@granit/react-analytics/src/__tests__/kpi-tile.test.tsx
@@ -1,0 +1,84 @@
+import { createApiClient } from '@granit/api-client';
+import { GranitClientProvider } from '@granit/react-api-client';
+import { createQueryWrapper } from '@granit/react-testing';
+import { render, screen } from '@testing-library/react';
+import i18n from 'i18next';
+import { I18nextProvider, initReactI18next } from 'react-i18next';
+import { describe, expect, it } from 'vitest';
+
+import { KpiTile } from '../components/kpi-tile';
+
+import type { KpiWidgetDefinition } from '@granit/analytics';
+import type { ReactNode } from 'react';
+
+const testI18n = i18n.createInstance();
+void testI18n.use(initReactI18next).init({
+  lng: 'en',
+  fallbackLng: 'en',
+  nsSeparator: false,
+  keySeparator: false,
+  resources: { en: { translation: {} } },
+  interpolation: { escapeValue: false },
+});
+
+const QueryWrapper = createQueryWrapper();
+const apiClient = createApiClient({ baseURL: '/api' });
+
+function renderTile(node: ReactNode) {
+  return render(
+    <QueryWrapper>
+      <GranitClientProvider client={apiClient}>
+        <I18nextProvider i18n={testI18n}>{node}</I18nextProvider>
+      </GranitClientProvider>
+    </QueryWrapper>
+  );
+}
+
+const baseKpi = {
+  slug: 'UnpaidCount',
+  type: 'kpi',
+  position: 0,
+  size: { width: 3, height: 2 },
+} as const;
+
+describe('KpiTile (smart) — datasource guards', () => {
+  it('renders the unsupported tile (no crash) when `datasource` is undefined', () => {
+    // Regression: a persisted KPI whose `configJson` failed to parse — or a
+    // pre-fix flat-spread instance — reaches the renderer with no datasource.
+    // The guard must treat it like the "unsupported" branch, not crash on
+    // `isMetricDatasource(undefined)` / `datasource.kind`.
+    const widget = { ...baseKpi, datasource: undefined } as unknown as KpiWidgetDefinition;
+    const { container } = renderTile(<KpiTile widget={widget} />);
+    const tile = container.querySelector('[data-slot="kpi-tile"]');
+    expect(tile).toBeInTheDocument();
+    expect(tile?.getAttribute('data-datasource-kind')).toBe('none');
+  });
+
+  it('renders the unsupported tile for a non-metric datasource kind', () => {
+    const widget = {
+      ...baseKpi,
+      datasource: {
+        kind: 'iot-telemetry',
+        entityAlias: 'sensor',
+        telemetryKey: 'temp',
+        aggregation: 'Last',
+        keyFormats: null,
+      },
+    } as unknown as KpiWidgetDefinition;
+    const { container } = renderTile(<KpiTile widget={widget} />);
+    expect(
+      container.querySelector('[data-slot="kpi-tile"]')?.getAttribute('data-datasource-kind')
+    ).toBe('iot-telemetry');
+  });
+
+  it('binds a metric datasource and renders the value tile', () => {
+    const widget = {
+      ...baseKpi,
+      datasource: { kind: 'metric', metricName: 'Granit.Invoicing.UnpaidInvoiceCountMetric' },
+    } as KpiWidgetDefinition;
+    renderTile(<KpiTile widget={widget} />);
+    // Metric branch mounts <KpiTileView> (loading skeleton while the disabled/
+    // pending query settles) — not the unsupported text node.
+    expect(screen.queryByText(/not supported/i)).toBeNull();
+  });
+});

--- a/packages/@granit/react-analytics/src/components/kpi-tile.tsx
+++ b/packages/@granit/react-analytics/src/components/kpi-tile.tsx
@@ -36,7 +36,11 @@ export function KpiTile({ widget }: KpiTileProps) {
   const { t, i18n } = useTranslation();
   const { datasource } = widget;
 
-  const metricName = isMetricDatasource(datasource) ? datasource.metricName : '';
+  // `datasource` can be undefined when a persisted KPI's `configJson` failed to
+  // parse (or pre-fix data lifted the bare datasource flat) — guard before
+  // narrowing so a malformed binding renders the "unsupported" tile instead of
+  // crashing on `datasource.kind`.
+  const metricName = datasource && isMetricDatasource(datasource) ? datasource.metricName : '';
 
   const query = useMetric(metricName, DEFAULT_PERIOD, { enabled: metricName !== '' });
 
@@ -46,15 +50,16 @@ export function KpiTile({ widget }: KpiTileProps) {
   const onClick = useWidgetTriggerHandler('Click', widget.actions);
   const handleClick = onClick ? () => onClick() : undefined;
 
-  if (!isMetricDatasource(datasource)) {
+  if (!datasource || !isMetricDatasource(datasource)) {
+    const kind = datasource?.kind ?? 'none';
     const message = t('Analytics.UnsupportedDatasource', {
       defaultValue: 'Datasource not supported yet ({{kind}})',
-      kind: datasource.kind,
+      kind,
     });
     return (
       <div
         data-slot="kpi-tile"
-        data-datasource-kind={datasource.kind}
+        data-datasource-kind={kind}
         className="flex h-full items-center text-xs text-muted-foreground"
       >
         {message}

--- a/packages/@granit/react-dashboards/src/testing/data.ts
+++ b/packages/@granit/react-dashboards/src/testing/data.ts
@@ -15,7 +15,7 @@
 //
 // Mock data typed against `@granit/dashboards` wire contracts.
 
-import { Datasource, WIDGET_SIZE } from '@granit/dashboards';
+import { Datasource, WIDGET_SIZE, widgetDefinitionToAddRequest } from '@granit/dashboards';
 
 import type {
   DashboardCatalogEntryResponse,
@@ -411,8 +411,10 @@ const sampleFinanceDashboard: DashboardDefinition = {
       ],
     },
     // `kpi` widgets are declared by `@granit/analytics`; the testing module
-    // serialises them as plain data (no analytics dependency), so the
-    // persisted `configJson` matches the real import byte-for-byte.
+    // serialises them as plain data (no analytics dependency). The persisted
+    // `configJson` is produced by the write-direction bridge helper (see
+    // `seedStoredDashboard`), which emits the bare `Datasource` for KPI so the
+    // mock stays byte-compatible with the backend and the read-direction bridge.
   ] as DashboardDefinition['widgets'],
 };
 
@@ -474,18 +476,26 @@ function seedStoredDashboard(
     sourceDefinitionVersion: definition.version,
     layoutColumns: definition.layout.columns,
     layoutRowHeight: definition.layout.rowHeight,
-    widgets: definition.widgets.map((widget, index) => ({
-      id: `${id.slice(0, -3)}${(widgetIdBase + index).toString(16).padStart(3, '0')}`,
-      widgetType: widget.type.charAt(0).toUpperCase() + widget.type.slice(1),
-      position: widget.position,
-      width: widget.size.width,
-      height: widget.size.height,
-      titleLocalizationKey: `Widget:${definition.name}.${widget.slug}`,
-      metricName: null,
-      queryName: null,
-      configJson: JSON.stringify(widget),
-      requiredPermission: null,
-    })),
+    widgets: definition.widgets.map((widget, index) => {
+      // Derive the persisted shape through the write-direction bridge so the
+      // mock's `configJson` / `metricName` / `queryName` are byte-compatible
+      // with what the backend persists (and what the read-direction bridge
+      // expects) per widget kind — KPI emits a bare `Datasource`, not a
+      // wrapped or whole-widget blob.
+      const request = widgetDefinitionToAddRequest(widget, definition.name);
+      return {
+        id: `${id.slice(0, -3)}${(widgetIdBase + index).toString(16).padStart(3, '0')}`,
+        widgetType: widget.type.charAt(0).toUpperCase() + widget.type.slice(1),
+        position: widget.position,
+        width: widget.size.width,
+        height: widget.size.height,
+        titleLocalizationKey: `Widget:${definition.name}.${widget.slug}`,
+        metricName: request.metricName ?? null,
+        queryName: request.queryName ?? null,
+        configJson: request.configJson,
+        requiredPermission: null,
+      };
+    }),
   };
 }
 

--- a/packages/@granit/react-notifications/src/__tests__/notification-rendering.test.ts
+++ b/packages/@granit/react-notifications/src/__tests__/notification-rendering.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import { presentDefault } from '../rendering/default-view';
+import { registerNotificationView } from '../rendering/registry';
+import { resolveNotificationPresentation } from '../rendering/resolve';
+
+import type { NotificationPresentContext, PresentableNotification } from '../rendering/types';
+
+const ctx: NotificationPresentContext = { t: (key, options) => options?.defaultValue ?? key };
+
+function notification(overrides: Partial<PresentableNotification>): PresentableNotification {
+  return {
+    notificationTypeName: 'Unknown.Type',
+    severity: 'Info',
+    data: {},
+    relatedEntityType: null,
+    relatedEntityId: null,
+    ...overrides,
+  };
+}
+
+describe('notification rendering', () => {
+  describe('presentDefault', () => {
+    it('should read title/body from the payload', () => {
+      const result = presentDefault(notification({ data: { title: 'Hi', body: 'There' } }));
+      expect(result).toMatchObject({ title: 'Hi', body: 'There' });
+    });
+
+    it('should degrade to the type name when title is missing or non-string', () => {
+      expect(presentDefault(notification({ notificationTypeName: 'A.B', data: {} })).title).toBe(
+        'A.B'
+      );
+      expect(
+        presentDefault(notification({ notificationTypeName: 'A.B', data: { title: 42 } })).title
+      ).toBe('A.B');
+    });
+  });
+
+  describe('resolveNotificationPresentation', () => {
+    it('should fall back to the default view for an unregistered type', () => {
+      const result = resolveNotificationPresentation(
+        notification({ notificationTypeName: 'Not.Registered', data: { title: 'X' } }),
+        ctx
+      );
+      expect(result.title).toBe('X');
+      expect(result.action).toBeUndefined();
+    });
+
+    it('should use a registered view and pass it through the translate context', () => {
+      registerNotificationView<{ name: string }>({
+        code: 'Test.Registered',
+        parse: (data) => {
+          const d = data as { name?: unknown };
+          return typeof d.name === 'string' ? { name: d.name } : null;
+        },
+        present: (data, _n, c) => ({
+          title: data.name,
+          action: { label: c.t('Generic.Open', { defaultValue: 'Open' }), to: '/somewhere' },
+        }),
+      });
+
+      const result = resolveNotificationPresentation(
+        notification({ notificationTypeName: 'Test.Registered', data: { name: 'Widget' } }),
+        ctx
+      );
+
+      expect(result.title).toBe('Widget');
+      expect(result.action).toEqual({ label: 'Open', to: '/somewhere' });
+    });
+
+    it('should fall back to the default view when a registered payload fails validation', () => {
+      registerNotificationView<{ name: string }>({
+        code: 'Test.Strict',
+        parse: (data) => {
+          const d = data as { name?: unknown };
+          return typeof d.name === 'string' ? { name: d.name } : null;
+        },
+        present: (data) => ({ title: data.name }),
+      });
+
+      const result = resolveNotificationPresentation(
+        notification({
+          notificationTypeName: 'Test.Strict',
+          data: { name: 123, body: 'fallback body' },
+        }),
+        ctx
+      );
+
+      expect(result.title).toBe('Test.Strict');
+      expect(result.body).toBe('fallback body');
+    });
+  });
+});

--- a/packages/@granit/react-notifications/src/index.ts
+++ b/packages/@granit/react-notifications/src/index.ts
@@ -1,6 +1,19 @@
 // Provider
 export { NotificationProvider, useNotificationConfig } from './providers/notification-provider';
 
+// Rendering — view registry, resolution, default view
+export { registerNotificationView, getNotificationView } from './rendering/registry';
+export { resolveNotificationPresentation } from './rendering/resolve';
+export { presentDefault } from './rendering/default-view';
+export type {
+  NotificationActionLink,
+  NotificationPresentation,
+  NotificationPresentContext,
+  NotificationView,
+  PresentableNotification,
+  TranslateFn,
+} from './rendering/types';
+
 // Hooks
 export { useRealTimeNotifications } from './hooks/use-real-time-notifications';
 export type { UseRealTimeNotificationsReturn } from './hooks/use-real-time-notifications';

--- a/packages/@granit/react-notifications/src/rendering/default-view.ts
+++ b/packages/@granit/react-notifications/src/rendering/default-view.ts
@@ -1,0 +1,23 @@
+import type { NotificationPresentation, PresentableNotification } from './types';
+
+interface DefaultNotificationData {
+  readonly title?: string;
+  readonly body?: string;
+}
+
+/**
+ * Fallback presentation used when no view is registered for a type, or when a
+ * view's data validation fails. Reads the conventional `title` / `body` fields
+ * and degrades to the type name so a notification is never rendered blank.
+ */
+export function presentDefault(notification: PresentableNotification): NotificationPresentation {
+  const data = (notification.data ?? {}) as DefaultNotificationData;
+  const title =
+    typeof data.title === 'string' && data.title.length > 0
+      ? data.title
+      : notification.notificationTypeName;
+  return {
+    title,
+    body: typeof data.body === 'string' ? data.body : undefined,
+  };
+}

--- a/packages/@granit/react-notifications/src/rendering/registry.ts
+++ b/packages/@granit/react-notifications/src/rendering/registry.ts
@@ -1,0 +1,18 @@
+import type { NotificationView } from './types';
+
+/**
+ * Process-wide registry mapping `notificationTypeName` → view. Apps and feature
+ * packages populate it at load time via {@link registerNotificationView};
+ * lookups are idempotent and order-independent.
+ */
+const registry = new Map<string, NotificationView>();
+
+/** Registers (or replaces) the view for a notification type code. */
+export function registerNotificationView<TData>(view: NotificationView<TData>): void {
+  registry.set(view.code, view as NotificationView);
+}
+
+/** Returns the view registered for a type code, or `undefined` when none exists. */
+export function getNotificationView(code: string): NotificationView | undefined {
+  return registry.get(code);
+}

--- a/packages/@granit/react-notifications/src/rendering/resolve.ts
+++ b/packages/@granit/react-notifications/src/rendering/resolve.ts
@@ -1,0 +1,31 @@
+import { presentDefault } from './default-view';
+import { getNotificationView } from './registry';
+
+import type {
+  NotificationPresentContext,
+  NotificationPresentation,
+  PresentableNotification,
+} from './types';
+
+/**
+ * Resolves the rendering descriptor for a notification: looks up its view by
+ * `notificationTypeName`, validates the payload, and falls back to the default
+ * view when no view matches or validation fails (defensive — a malformed
+ * payload must never crash the inbox).
+ */
+export function resolveNotificationPresentation(
+  notification: PresentableNotification,
+  ctx: NotificationPresentContext
+): NotificationPresentation {
+  const view = getNotificationView(notification.notificationTypeName);
+  if (!view) {
+    return presentDefault(notification);
+  }
+
+  const data = view.parse(notification.data);
+  if (data === null) {
+    return presentDefault(notification);
+  }
+
+  return view.present(data, notification, ctx);
+}

--- a/packages/@granit/react-notifications/src/rendering/types.ts
+++ b/packages/@granit/react-notifications/src/rendering/types.ts
@@ -1,0 +1,72 @@
+import type { NotificationSeverity, UserNotification } from '@granit/notifications';
+import type { ComponentType } from 'react';
+
+/**
+ * Translate function shape the rendering layer relies on. Kept structural
+ * (rather than importing i18next's `TFunction`) so views and the consuming app
+ * stay decoupled from the i18n backend.
+ */
+export type TranslateFn = (
+  key: string,
+  options?: Record<string, unknown> & { defaultValue?: string }
+) => string;
+
+/** A click-through link produced by a notification view. */
+export interface NotificationActionLink {
+  readonly label: string;
+  /**
+   * Where the action points. Resolution is the host's concern: relative paths
+   * are typically routed in-app, absolute (`http(s)://`) URLs opened externally.
+   * Internal routes should be derived by the view from the notification's
+   * semantic fields — the backend never emits frontend routes.
+   */
+  readonly to: string;
+}
+
+/**
+ * Normalized rendering descriptor for a single notification. A view turns the
+ * raw `data` payload into this shape; the host renders the chrome uniformly so
+ * every notification respects the design system.
+ */
+export interface NotificationPresentation {
+  readonly title: string;
+  readonly body?: string;
+  readonly icon?: ComponentType<{ className?: string }>;
+  readonly iconClassName?: string;
+  /** Overrides the severity badge; defaults to the notification's own severity. */
+  readonly severity?: NotificationSeverity;
+  /** Extra outline badge (e.g. a notification subtype). */
+  readonly typeBadge?: string;
+  readonly action?: NotificationActionLink;
+}
+
+/**
+ * Subset of notification fields a view may rely on — the intersection of the
+ * REST shape (`UserNotification`) and the SSE transport shape, so the same view
+ * works for both live and persisted notifications.
+ */
+export type PresentableNotification = Pick<
+  UserNotification,
+  'notificationTypeName' | 'severity' | 'data' | 'relatedEntityType' | 'relatedEntityId'
+>;
+
+/** Ambient context handed to every view at render time. */
+export interface NotificationPresentContext {
+  readonly t: TranslateFn;
+}
+
+/**
+ * A registered renderer for one notification type, keyed by
+ * `notificationTypeName` (the backend-emitted "code").
+ */
+export interface NotificationView<TData = unknown> {
+  /** Matches `UserNotification.notificationTypeName`. */
+  readonly code: string;
+  /** Validates/narrows `data`; return `null` to fall back to the default view. */
+  readonly parse: (data: unknown) => TData | null;
+  readonly present: (
+    data: TData,
+    notification: PresentableNotification,
+    ctx: NotificationPresentContext
+  ) => NotificationPresentation;
+}


### PR DESCRIPTION
## Why

The notification view registry (originally PR #645) was accidentally merged into `fix/kpi-configjson-contract` instead of `develop`. That base branch had already merged to develop via #644 (~2h earlier), so this feature never reached `develop`.

Verified absent from develop: `packages/@granit/react-notifications/src/rendering/{registry,resolve,types,default-view}.ts` (~250 lines) plus `index.ts` re-exports and `__tests__/notification-rendering.test.ts`.

This PR re-targets the same work (branch tip `28f5cb04`, unchanged) onto `develop`.

## What

- Notification view registry + resolver (`rendering/`)
- Default view fallback
- Public exports via `src/index.ts`
- Co-located rendering tests

Re-lands #645 against the correct base. Closes the develop gap left by the stacked-PR mis-merge.