### PR TITLE
fix(ai): align AI packages with framework conventions

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -78,6 +78,21 @@
       "description": "AI workspace management, chat completion, embedding generation, and usage tracking types and API functions — mirrors Granit.AI.Endpoints .NET",
       "exports": [
         {
+          "name": "AI_CAPABILITY_EXTENSIONS",
+          "kind": "const",
+          "signature": "const AI_CAPABILITY_EXTENSIONS"
+        },
+        {
+          "name": "AI_STREAM_DONE_MARKER",
+          "kind": "const",
+          "signature": "const AI_STREAM_DONE_MARKER"
+        },
+        {
+          "name": "AI_WORKSPACE_KINDS",
+          "kind": "const",
+          "signature": "const AI_WORKSPACE_KINDS"
+        },
+        {
           "name": "listAIProviderModels",
           "kind": "function",
           "signature": "async function listAIProviderModels( client: AxiosInstance, basePath: string, providerName: string ): Promise<readonly AIProviderModelResponse[]>"
@@ -2556,11 +2571,6 @@
           "signature": "function AIProvider("
         },
         {
-          "name": "buildAIQueryKey",
-          "kind": "function",
-          "signature": "function buildAIQueryKey( config: AIConfig, ...segments: readonly string[] ): readonly unknown[]"
-        },
-        {
           "name": "useAIConfig",
           "kind": "function",
           "signature": "function useAIConfig(): ResolvedAIConfig"
@@ -2576,6 +2586,17 @@
           "kind": "interface",
           "signature": "interface AIProviderProps",
           "members": []
+        },
+        {
+          "name": "ResolvedAIConfig",
+          "kind": "interface",
+          "signature": "interface ResolvedAIConfig extends AIConfig",
+          "members": []
+        },
+        {
+          "name": "aiKeys",
+          "kind": "const",
+          "signature": "const aiKeys"
         },
         {
           "name": "useAIProviderModels",

--- a/packages/@granit/ai/README.md
+++ b/packages/@granit/ai/README.md
@@ -14,18 +14,25 @@ pnpm add @granit/ai
 
 - `AIWorkspaceResponse`, `AIWorkspaceListResponse`, `AIWorkspaceCreateRequest`, `AIWorkspaceUpdateRequest`, `AIWorkspaceKind` -- workspaces
 - `AIChatRequest`, `AIChatResponse`, `AIChatMessageRequest`, `AIChatMessageRole`, `AIChatStreamChunk`, `AIChatStreamUsage`, `AIChatUsageResponse`, `ChatStreamEvent` -- chat
-- `AIEmbeddingRequest`, `AIEmbeddingResponse`, `AIEmbeddingDataResponse`, `AIEmbeddingUsageResponse`, `AIUsageRecord` -- embeddings
+- `AIEmbeddingRequest`, `AIEmbeddingResponse`, `AIEmbeddingDataResponse`, `AIEmbeddingUsageResponse` -- embeddings
+- `AIProviderResponse`, `AIProviderModelResponse`, `AIModelCapabilities` -- provider/model discovery
+- `AIUsageRecord`, `AIUsageRecordId` -- usage records (queried via `@granit/react-ai/usage`)
 
 ### Constants
 
 - `AI_WORKSPACE_KINDS` -- workspace kind values
-- `AI_PERMISSIONS` -- permission constants
+- `AI_CAPABILITY_EXTENSIONS` -- well-known capability extension identifiers
 - `AI_STREAM_DONE_MARKER` -- SSE stream terminator
+
+### Permissions
+
+- `AIPermissions` -- permission constants (`AIPermissions.Workspaces.Manage`, `AIPermissions.Chat.Execute`, ...)
 
 ### Functions
 
 - `listAIWorkspaces(...)`, `getAIWorkspace(...)`, `createAIWorkspace(...)`, `updateAIWorkspace(...)`, `deleteAIWorkspace(...)` -- workspace CRUD
-- `chatComplete(...)`, `chatStream(...)` -- chat completion
+- `listAIProviders(...)`, `listAIProviderModels(...)` -- provider/model discovery
+- `chatComplete(...)`, `chatStream(...)` -- chat completion (sync + SSE)
 - `generateEmbeddings(...)` -- embedding generation
 
 ## Usage
@@ -37,10 +44,9 @@ import type { AIChatRequest } from '@granit/ai';
 const workspaces = await listAIWorkspaces(client, basePath);
 
 const request: AIChatRequest = {
-  workspaceId: '...',
   messages: [{ role: 'user', content: 'Hello' }],
 };
-const response = await chatComplete(client, basePath, request);
+const response = await chatComplete(client, basePath, 'default', request);
 ```
 
 ## License

--- a/packages/@granit/ai/src/__tests__/ai-providers-api.test.ts
+++ b/packages/@granit/ai/src/__tests__/ai-providers-api.test.ts
@@ -1,0 +1,55 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import { listAIProviderModels, listAIProviders } from '../api/ai-providers-api';
+
+describe('ai-providers-api', () => {
+  describe('listAIProviders', () => {
+    it('should GET {basePath}/providers', async () => {
+      const client = createMockClient();
+      const data = [
+        { name: 'OpenAI', supportsChat: true, supportsEmbeddings: true },
+        { name: 'Anthropic', supportsChat: true, supportsEmbeddings: false },
+      ];
+      vi.mocked(client.get).mockResolvedValue({ data });
+
+      const result = await listAIProviders(client, '');
+
+      expect(client.get).toHaveBeenCalledWith('/providers');
+      expect(result).toEqual(data);
+    });
+
+    it('should prepend basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      await listAIProviders(client, '/api/v1/ai');
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/ai/providers');
+    });
+  });
+
+  describe('listAIProviderModels', () => {
+    it('should GET {basePath}/providers/{providerName}/models', async () => {
+      const client = createMockClient();
+      const data = [
+        { id: 'gpt-4o', displayName: 'GPT-4o', capabilities: {}, maxContextTokens: 128000 },
+      ];
+      vi.mocked(client.get).mockResolvedValue({ data });
+
+      const result = await listAIProviderModels(client, '', 'OpenAI');
+
+      expect(client.get).toHaveBeenCalledWith('/providers/OpenAI/models');
+      expect(result).toEqual(data);
+    });
+
+    it('should encode the provider name in the URL', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      await listAIProviderModels(client, '/api/v1/ai', 'Azure OpenAI');
+
+      expect(client.get).toHaveBeenCalledWith('/api/v1/ai/providers/Azure%20OpenAI/models');
+    });
+  });
+});

--- a/packages/@granit/ai/src/index.ts
+++ b/packages/@granit/ai/src/index.ts
@@ -23,12 +23,7 @@ export type {
   AIWorkspaceUpdateRequest,
   ChatStreamEvent,
 } from './types/index';
-export {
-  AI_CAPABILITY_EXTENSIONS,
-  AI_PERMISSIONS,
-  AI_STREAM_DONE_MARKER,
-  AI_WORKSPACE_KINDS,
-} from './types/index';
+export { AI_CAPABILITY_EXTENSIONS, AI_STREAM_DONE_MARKER, AI_WORKSPACE_KINDS } from './types/index';
 
 // API — Providers
 export { listAIProviderModels, listAIProviders } from './api/ai-providers-api';

--- a/packages/@granit/ai/src/types/index.ts
+++ b/packages/@granit/ai/src/types/index.ts
@@ -13,15 +13,6 @@ export const AI_WORKSPACE_KINDS = {
   DYNAMIC: 'Dynamic',
 } as const;
 
-/** AI permission strings. Mirrors `AIPermissions` in Granit.AI.Endpoints. */
-export const AI_PERMISSIONS = {
-  WORKSPACES_READ: 'AI.Workspaces.Read',
-  WORKSPACES_MANAGE: 'AI.Workspaces.Manage',
-  USAGE_READ: 'AI.Usage.Read',
-  CHAT_EXECUTE: 'AI.Chat.Execute',
-  EMBEDDINGS_EXECUTE: 'AI.Embeddings.Execute',
-} as const;
-
 /** Well-known capability extension identifiers. Mirrors `WellKnownAICapabilities`. */
 export const AI_CAPABILITY_EXTENSIONS = {
   WEB_SEARCH: 'web-search',

--- a/packages/@granit/react-ai-chat/package.json
+++ b/packages/@granit/react-ai-chat/package.json
@@ -18,6 +18,7 @@
     "@granit/ai-chat": "workspace:*",
     "@granit/api-client": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "lucide-react": "^1.0.0",

--- a/packages/@granit/react-ai-prompts/package.json
+++ b/packages/@granit/react-ai-prompts/package.json
@@ -18,6 +18,7 @@
     "@granit/ai-prompts": "workspace:*",
     "@granit/api-client": "workspace:*",
     "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
     "@granit/utils": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "lucide-react": "^1.0.0",

--- a/packages/@granit/react-ai/package.json
+++ b/packages/@granit/react-ai/package.json
@@ -21,6 +21,7 @@
     "@granit/query-engine": "workspace:*",
     "@granit/react-api-client": "workspace:*",
     "@granit/react-query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
     "@tanstack/react-query": "^5.0.0",
     "msw": "^2.12.0",
     "react": "^19.0.0"

--- a/packages/@granit/react-ai/src/constants.ts
+++ b/packages/@granit/react-ai/src/constants.ts
@@ -1,3 +1,6 @@
 export const API_VERSION = 'v1';
 export const MODULE = 'ai';
 export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;
+
+/** Default React Query key prefix for AI queries. */
+export const DEFAULT_QUERY_KEY_PREFIX = ['ai'] as const;

--- a/packages/@granit/react-ai/src/hooks/query-keys.ts
+++ b/packages/@granit/react-ai/src/hooks/query-keys.ts
@@ -1,0 +1,26 @@
+/**
+ * Query-key factory for AI queries, namespaced under the provider's
+ * `queryKeyPrefix` so multiple AI instances stay isolated. Mirrors the
+ * `@granit/react-ai-chat` / `@granit/react-ai-prompts` key-factory pattern.
+ */
+export const aiKeys = {
+  /** Root key for every AI query. */
+  all: (prefix: readonly string[]): readonly unknown[] => [...prefix],
+  /** The registered providers. */
+  providers: (prefix: readonly string[]): readonly unknown[] => [...prefix, 'providers'],
+  /** The models for a given provider. */
+  providerModels: (prefix: readonly string[], providerName: string): readonly unknown[] => [
+    ...prefix,
+    'providers',
+    providerName,
+    'models',
+  ],
+  /** The workspace list. */
+  workspaces: (prefix: readonly string[]): readonly unknown[] => [...prefix, 'workspaces'],
+  /** A single workspace by name. */
+  workspace: (prefix: readonly string[], name: string): readonly unknown[] => [
+    ...prefix,
+    'workspaces',
+    name,
+  ],
+} as const;

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat-stream.ts
@@ -81,7 +81,7 @@ export function useAIChatStream(): UseAIChatStreamReturn {
           let accumulated = '';
           for await (const event of chatStream(
             config.client,
-            config.basePath ?? '',
+            config.basePath,
             workspaceName,
             request,
             controller.signal

--- a/packages/@granit/react-ai/src/hooks/use-ai-chat.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-chat.ts
@@ -36,7 +36,7 @@ export function useAIChat(): UseAIChatReturn {
 
   const mutation = useMutation({
     mutationFn: ({ workspaceName, request }: { workspaceName: string; request: AIChatRequest }) =>
-      chatComplete(config.client, config.basePath ?? '', workspaceName, request),
+      chatComplete(config.client, config.basePath, workspaceName, request),
   });
 
   const send = useCallback(

--- a/packages/@granit/react-ai/src/hooks/use-ai-embeddings.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-embeddings.ts
@@ -37,7 +37,7 @@ export function useAIEmbeddings(): UseAIEmbeddingsReturn {
     }: {
       workspaceName: string;
       request: AIEmbeddingRequest;
-    }) => generateEmbeddings(config.client, config.basePath ?? '', workspaceName, request),
+    }) => generateEmbeddings(config.client, config.basePath, workspaceName, request),
   });
 
   const generate = useCallback(

--- a/packages/@granit/react-ai/src/hooks/use-ai-provider-models.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-provider-models.ts
@@ -1,7 +1,9 @@
 import { listAIProviderModels } from '@granit/ai';
 import { useQuery } from '@tanstack/react-query';
 
-import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider';
+import { useAIConfig } from '../providers/ai-provider';
+
+import { aiKeys } from './query-keys';
 
 import type { AIProviderModelResponse } from '@granit/ai';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -26,8 +28,8 @@ export function useAIProviderModels(
   const hasProvider = !!providerName;
 
   return useQuery({
-    queryKey: buildAIQueryKey(config, 'providers', providerName ?? '', 'models'),
-    queryFn: () => listAIProviderModels(config.client, config.basePath ?? '', providerName!),
+    queryKey: aiKeys.providerModels(config.queryKeyPrefix, providerName ?? ''),
+    queryFn: () => listAIProviderModels(config.client, config.basePath, providerName!),
     enabled: hasProvider && (options?.enabled ?? true),
   });
 }

--- a/packages/@granit/react-ai/src/hooks/use-ai-providers.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-providers.ts
@@ -1,7 +1,9 @@
 import { listAIProviders } from '@granit/ai';
 import { useQuery } from '@tanstack/react-query';
 
-import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider';
+import { useAIConfig } from '../providers/ai-provider';
+
+import { aiKeys } from './query-keys';
 
 import type { AIProviderResponse } from '@granit/ai';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -21,8 +23,8 @@ export function useAIProviders(options?: {
   const config = useAIConfig();
 
   return useQuery({
-    queryKey: buildAIQueryKey(config, 'providers'),
-    queryFn: () => listAIProviders(config.client, config.basePath ?? ''),
+    queryKey: aiKeys.providers(config.queryKeyPrefix),
+    queryFn: () => listAIProviders(config.client, config.basePath),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/@granit/react-ai/src/hooks/use-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-workspace.ts
@@ -1,7 +1,9 @@
 import { getAIWorkspace } from '@granit/ai';
 import { useQuery } from '@tanstack/react-query';
 
-import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider';
+import { useAIConfig } from '../providers/ai-provider';
+
+import { aiKeys } from './query-keys';
 
 import type { AIWorkspaceResponse } from '@granit/ai';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -22,8 +24,8 @@ export function useAIWorkspace(
   const config = useAIConfig();
 
   return useQuery({
-    queryKey: buildAIQueryKey(config, 'workspaces', name),
-    queryFn: () => getAIWorkspace(config.client, config.basePath ?? '', name),
+    queryKey: aiKeys.workspace(config.queryKeyPrefix, name),
+    queryFn: () => getAIWorkspace(config.client, config.basePath, name),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/@granit/react-ai/src/hooks/use-ai-workspaces.ts
+++ b/packages/@granit/react-ai/src/hooks/use-ai-workspaces.ts
@@ -1,7 +1,9 @@
 import { listAIWorkspaces } from '@granit/ai';
 import { useQuery } from '@tanstack/react-query';
 
-import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider';
+import { useAIConfig } from '../providers/ai-provider';
+
+import { aiKeys } from './query-keys';
 
 import type { AIWorkspaceListResponse } from '@granit/ai';
 import type { UseQueryResult } from '@tanstack/react-query';
@@ -21,8 +23,8 @@ export function useAIWorkspaces(options?: {
   const config = useAIConfig();
 
   return useQuery({
-    queryKey: buildAIQueryKey(config, 'workspaces'),
-    queryFn: () => listAIWorkspaces(config.client, config.basePath ?? ''),
+    queryKey: aiKeys.workspaces(config.queryKeyPrefix),
+    queryFn: () => listAIWorkspaces(config.client, config.basePath),
     enabled: options?.enabled ?? true,
   });
 }

--- a/packages/@granit/react-ai/src/hooks/use-create-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-create-ai-workspace.ts
@@ -2,7 +2,9 @@ import { createAIWorkspace } from '@granit/ai';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider';
+import { useAIConfig } from '../providers/ai-provider';
+
+import { aiKeys } from './query-keys';
 
 import type { AIWorkspaceCreateRequest, AIWorkspaceResponse } from '@granit/ai';
 
@@ -30,10 +32,10 @@ export function useCreateAIWorkspace(): UseCreateAIWorkspaceReturn {
 
   const mutation = useMutation({
     mutationFn: (request: AIWorkspaceCreateRequest) =>
-      createAIWorkspace(config.client, config.basePath ?? '', request),
+      createAIWorkspace(config.client, config.basePath, request),
     onSuccess: () => {
       queryClient
-        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces') })
+        .invalidateQueries({ queryKey: aiKeys.workspaces(config.queryKeyPrefix) })
         .catch(() => undefined);
     },
   });

--- a/packages/@granit/react-ai/src/hooks/use-delete-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-delete-ai-workspace.ts
@@ -2,7 +2,9 @@ import { deleteAIWorkspace } from '@granit/ai';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider';
+import { useAIConfig } from '../providers/ai-provider';
+
+import { aiKeys } from './query-keys';
 
 export interface UseDeleteAIWorkspaceReturn {
   readonly remove: (name: string) => void;
@@ -27,10 +29,10 @@ export function useDeleteAIWorkspace(): UseDeleteAIWorkspaceReturn {
   const queryClient = useQueryClient();
 
   const mutation = useMutation({
-    mutationFn: (name: string) => deleteAIWorkspace(config.client, config.basePath ?? '', name),
+    mutationFn: (name: string) => deleteAIWorkspace(config.client, config.basePath, name),
     onSuccess: () => {
       queryClient
-        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces') })
+        .invalidateQueries({ queryKey: aiKeys.workspaces(config.queryKeyPrefix) })
         .catch(() => undefined);
     },
   });

--- a/packages/@granit/react-ai/src/hooks/use-update-ai-workspace.ts
+++ b/packages/@granit/react-ai/src/hooks/use-update-ai-workspace.ts
@@ -2,7 +2,9 @@ import { updateAIWorkspace } from '@granit/ai';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 
-import { buildAIQueryKey, useAIConfig } from '../providers/ai-provider';
+import { useAIConfig } from '../providers/ai-provider';
+
+import { aiKeys } from './query-keys';
 
 import type { AIWorkspaceResponse, AIWorkspaceUpdateRequest } from '@granit/ai';
 
@@ -33,13 +35,13 @@ export function useUpdateAIWorkspace(): UseUpdateAIWorkspaceReturn {
 
   const mutation = useMutation({
     mutationFn: ({ name, request }: { name: string; request: AIWorkspaceUpdateRequest }) =>
-      updateAIWorkspace(config.client, config.basePath ?? '', name, request),
+      updateAIWorkspace(config.client, config.basePath, name, request),
     onSuccess: (_data, { name }) => {
       queryClient
-        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces') })
+        .invalidateQueries({ queryKey: aiKeys.workspaces(config.queryKeyPrefix) })
         .catch(() => undefined);
       queryClient
-        .invalidateQueries({ queryKey: buildAIQueryKey(config, 'workspaces', name) })
+        .invalidateQueries({ queryKey: aiKeys.workspace(config.queryKeyPrefix, name) })
         .catch(() => undefined);
     },
   });

--- a/packages/@granit/react-ai/src/index.ts
+++ b/packages/@granit/react-ai/src/index.ts
@@ -1,6 +1,9 @@
 // Provider
-export { AIProvider, buildAIQueryKey, useAIConfig } from './providers/ai-provider';
-export type { AIConfig, AIProviderProps } from './providers/ai-provider';
+export { AIProvider, useAIConfig } from './providers/ai-provider';
+export type { AIConfig, AIProviderProps, ResolvedAIConfig } from './providers/ai-provider';
+
+// Query keys
+export { aiKeys } from './hooks/query-keys';
 
 // Hooks — Providers
 export { useAIProviderModels } from './hooks/use-ai-provider-models';

--- a/packages/@granit/react-ai/src/providers/ai-provider.tsx
+++ b/packages/@granit/react-ai/src/providers/ai-provider.tsx
@@ -5,7 +5,7 @@
 import { useOptionalGranitClient } from '@granit/react-api-client';
 import { createContext, useContext, useMemo } from 'react';
 
-import { DEFAULT_BASE_PATH } from '../constants';
+import { DEFAULT_BASE_PATH, DEFAULT_QUERY_KEY_PREFIX } from '../constants';
 
 import type { AxiosInstance } from '@granit/api-client';
 import type { ReactNode } from 'react';
@@ -21,11 +21,14 @@ export interface AIConfig {
 }
 
 /**
- * AIConfig after the provider has resolved `client` from
- * `config.client` or the nearest `<GranitClientProvider>`.
+ * {@link AIConfig} after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>` and applied the
+ * `basePath` / `queryKeyPrefix` defaults.
  */
 export interface ResolvedAIConfig extends AIConfig {
   readonly client: AxiosInstance;
+  readonly basePath: string;
+  readonly queryKeyPrefix: readonly string[];
 }
 
 export interface AIProviderProps {
@@ -47,8 +50,9 @@ export function AIProvider({ config, children }: Readonly<AIProviderProps>) {
     }
     return {
       ...config,
-      basePath: config.basePath ?? DEFAULT_BASE_PATH,
       client,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      queryKeyPrefix: config.queryKeyPrefix ?? DEFAULT_QUERY_KEY_PREFIX,
     };
   }, [config, contextClient]);
   return <AIConfigContext value={value}>{children}</AIConfigContext>;
@@ -61,13 +65,4 @@ export function useAIConfig(): ResolvedAIConfig {
     throw new Error('useAIConfig must be used within an AIProvider');
   }
   return ctx;
-}
-
-/** Builds a consistent React Query key for AI operations. */
-export function buildAIQueryKey(
-  config: AIConfig,
-  ...segments: readonly string[]
-): readonly unknown[] {
-  const prefix = config.queryKeyPrefix ?? ['ai'];
-  return [...prefix, ...segments];
 }


### PR DESCRIPTION
## Summary

Framework-conformity fixes from a `/audit` of the `ai*` / `react-ai*` packages. No behavioural changes to runtime data flow; type mirroring, endpoint coverage, and SSE handling were already correct.

## Changes

- **`refactor(ai)!`** — remove the duplicate flat `AI_PERMISSIONS` constant; the nested `AIPermissions` (`permissions.ts`) is now the single source of truth, matching `@granit/ai-chat` / `@granit/ai-prompts` and the CLAUDE.md core convention. Fix the README usage example (wrong `chatComplete` signature + non-existent `workspaceId`) and document the providers/capabilities surface.
- **`refactor(react-ai)!`** — replace the `buildAIQueryKey` provider helper with a dedicated `hooks/query-keys.ts` `aiKeys` factory (mirrors `conversationKeys` / `promptKeys`); resolve `queryKeyPrefix` in the provider and narrow `ResolvedAIConfig.basePath` / `queryKeyPrefix` to required, dropping the dead `config.basePath ?? ''` from every hook.
- **`fix(react-ai)`** — declare `@granit/types` as a `peerDependency` in `react-ai` / `react-ai-chat` / `react-ai-prompts` (it's a runtime value import in the published `./testing` entry).
- **`test(ai)`** — add the missing `ai-providers-api` test.

## Breaking changes

- `@granit/ai` no longer exports `AI_PERMISSIONS` → use `AIPermissions`.
- `@granit/react-ai` no longer exports `buildAIQueryKey` → use `aiKeys`.

Only consumer is showcase-admin-react; the matching migration ships as a **separate GitLab MR** (drafted until this lands — merge **this PR first**).

## Verification

- `tsc` ✅ (6/6 packages) · `eslint` ✅ · `vitest` ✅ 123 tests · `markdownlint` ✅