### PR TITLE
fix(deps): sync pnpm-lock.yaml after @granit/types peer add (#653 follow-up)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1007,7 +1007,7 @@ importers:
         version: 1.17.0(react@19.2.7)
       msw:
         specifier: ^2.14.6
-        version: 2.14.6(@types/node@25.9.2)(typescript@6.0.3)
+        version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7
@@ -1044,7 +1044,7 @@ importers:
         version: 1.17.0(react@19.2.7)
       msw:
         specifier: ^2.14.6
-        version: 2.14.6(@types/node@25.9.2)(typescript@6.0.3)
+        version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
       react:
         specifier: 19.2.7
         version: 19.2.7


### PR DESCRIPTION
## Problem

CI on PR #653 failed `pnpm install --frozen-lockfile`:

```
ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY  Broken lockfile: no entry for
'msw@2.14.6(@types/node@25.9.2)(typescript@6.0.3)' in pnpm-lock.yaml
```

#653 promoted `@granit/types` to a `peerDependency` of `react-ai`, `react-ai-chat`, and `react-ai-prompts`. That shifted the peer-resolution context for those importers, so `msw` should resolve under `@types/node@25.9.3` — but the `react-ai-chat` / `react-ai-prompts` importer entries still pinned the stale `@types/node@25.9.2` variant, for which no snapshot exists. `pnpm install --lockfile-only` doesn't detect this (peer-only manifest change); a full `--no-frozen-lockfile` resolution does.

## Fix

Recompute the two stale importer entries to `@types/node@25.9.3` (2 lines). No version bumps. `pnpm install --frozen-lockfile` now passes locally (pnpm 10.34.3, matching the pinned `packageManager`).