### PR TITLE
feat(bank-accounts): add @granit/bank-accounts + react bindings

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -974,6 +974,17 @@
       ]
     },
     {
+      "name": "@granit/bank-accounts",
+      "description": "Centralized bank account referential — types and API functions (create, read, list per party, verify, archive)",
+      "exports": [
+        {
+          "name": "BankAccountsPermissions",
+          "kind": "const",
+          "signature": "const BankAccountsPermissions"
+        }
+      ]
+    },
+    {
       "name": "@granit/bff",
       "description": "BFF authentication types and CSRF manager — TypeScript mirror of Granit.Bff .NET",
       "exports": []
@@ -3593,6 +3604,11 @@
     {
       "name": "@granit/react-background-jobs",
       "description": "React hooks for background job monitoring — useBackgroundJobs, usePauseJob, useResumeJob, useTriggerJob",
+      "exports": []
+    },
+    {
+      "name": "@granit/react-bank-accounts",
+      "description": "React bindings for @granit/bank-accounts — BankAccountsProvider and hooks",
       "exports": []
     },
     {

--- a/contracts/openapi/bank-accounts.json
+++ b/contracts/openapi/bank-accounts.json
@@ -1,0 +1,1325 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "bank-accounts",
+    "version": "1"
+  },
+  "paths": {
+    "/bank-accounts": {
+      "post": {
+        "tags": ["Bank Accounts"],
+        "summary": "Registers a bank account for a party.",
+        "description": "Creates a bank account in the centralized referential, attached to a party. The account identifier (IBAN or domestic number) is encrypted at rest and never returned in clear; routing code and BIC are stored as public bank identifiers. Returns 400 when the scheme and routing code are incoherent. Requires the BankAccounts.Accounts.Manage permission.",
+        "operationId": "CreateBankAccount",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBankAccountRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BankAccountResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["Bank Accounts"],
+        "summary": "Returns a filtered, sorted, and paginated list of BankAccount entries.",
+        "description": "Executes a dynamic query against BankAccount using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryBankAccount",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfBankAccount"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfBankAccount"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bank-accounts/{id}": {
+      "get": {
+        "tags": ["Bank Accounts"],
+        "summary": "Returns a bank account by id.",
+        "description": "Fetches a single bank account, with the account identifier masked (e.g. **** 7034). Scoped to the current tenant. Returns 404 when the account does not exist. Requires the BankAccounts.Accounts.Read permission.",
+        "operationId": "GetBankAccount",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BankAccountResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Bank Accounts"],
+        "summary": "Archives (soft-deletes) a bank account.",
+        "description": "Archives the account so it no longer appears in a party's active list; the record is retained (audit / regulatory). Idempotent. Returns 404 when the account does not exist. Requires the BankAccounts.Accounts.Manage permission.",
+        "operationId": "ArchiveBankAccount",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bank-accounts/by-party/{partyId}": {
+      "get": {
+        "tags": ["Bank Accounts"],
+        "summary": "Lists the non-archived bank accounts of a party.",
+        "description": "Returns the active bank accounts owned by the given party, with masked account identifiers — the app-facing per-party view (the cross-tenant admin grid is the bare GET /). Requires the BankAccounts.Accounts.Read permission.",
+        "operationId": "ListBankAccountsByParty",
+        "parameters": [
+          {
+            "name": "partyId",
+            "in": "path",
+            "description": "Unique identifier of the party.",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/BankAccountResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bank-accounts/{id}/verify": {
+      "post": {
+        "tags": ["Bank Accounts"],
+        "summary": "Marks a bank account as verified.",
+        "description": "Records proof of account ownership. Idempotent: re-verifying an already-verified account succeeds without raising a new event. Returns 404 when the account does not exist. Requires the BankAccounts.Accounts.Verify permission.",
+        "operationId": "VerifyBankAccount",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BankAccountResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/bank-accounts/meta": {
+      "get": {
+        "tags": ["Bank Accounts"],
+        "summary": "Returns query metadata for BankAccount (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for BankAccount: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetBankAccountMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "BankAccount": {
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "scheme": {
+            "$ref": "#/components/schemas/BankAccountScheme"
+          },
+          "accountIdentifier": {
+            "type": "string"
+          },
+          "routingCode": {
+            "type": ["null", "string"]
+          },
+          "bic": {
+            "type": ["null", "string"]
+          },
+          "holderName": {
+            "type": "string"
+          },
+          "countryCode": {
+            "type": "string"
+          },
+          "accountType": {
+            "$ref": "#/components/schemas/BankAccountType"
+          },
+          "bankName": {
+            "type": ["null", "string"]
+          },
+          "bankAddress": {
+            "type": ["null", "string"]
+          },
+          "intermediaryBic": {
+            "type": ["null", "string"]
+          },
+          "internalNote": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "$ref": "#/components/schemas/BankAccountStatus"
+          },
+          "verified": {
+            "type": "boolean"
+          },
+          "trusted": {
+            "type": "boolean"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "BankAccountResponse": {
+        "required": [
+          "id",
+          "partyId",
+          "scheme",
+          "accountType",
+          "accountIdentifierMasked",
+          "routingCode",
+          "bic",
+          "holderName",
+          "countryCode",
+          "bankName",
+          "bankAddress",
+          "intermediaryBic",
+          "status",
+          "verified",
+          "trusted",
+          "tenantId"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "scheme": {
+            "$ref": "#/components/schemas/BankAccountScheme"
+          },
+          "accountType": {
+            "$ref": "#/components/schemas/BankAccountType"
+          },
+          "accountIdentifierMasked": {
+            "type": "string"
+          },
+          "routingCode": {
+            "type": ["null", "string"]
+          },
+          "bic": {
+            "type": ["null", "string"]
+          },
+          "holderName": {
+            "type": "string"
+          },
+          "countryCode": {
+            "type": "string"
+          },
+          "bankName": {
+            "type": ["null", "string"]
+          },
+          "bankAddress": {
+            "type": ["null", "string"]
+          },
+          "intermediaryBic": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "$ref": "#/components/schemas/BankAccountStatus"
+          },
+          "verified": {
+            "type": "boolean"
+          },
+          "trusted": {
+            "type": "boolean"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          }
+        }
+      },
+      "BankAccountScheme": {
+        "enum": ["Iban", "UsAch", "CaEft", "AuBsb", "InIfsc", "Other"]
+      },
+      "BankAccountStatus": {
+        "enum": ["Active", "Archived"]
+      },
+      "BankAccountType": {
+        "enum": ["Unknown", "Checking", "Savings"]
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "CreateBankAccountRequest": {
+        "required": ["partyId", "scheme", "accountIdentifier", "holderName", "countryCode"],
+        "type": "object",
+        "properties": {
+          "partyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "scheme": {
+            "$ref": "#/components/schemas/BankAccountScheme"
+          },
+          "accountIdentifier": {
+            "maxLength": 64,
+            "type": "string",
+            "x-granit-validator": "Validation:Format:Iban"
+          },
+          "holderName": {
+            "maxLength": 140,
+            "type": "string"
+          },
+          "countryCode": {
+            "type": "string",
+            "x-granit-validator": "Validation:Format:Iso3166Alpha2"
+          },
+          "routingCode": {
+            "maxLength": 34,
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:Ifsc"
+          },
+          "bic": {
+            "maxLength": 11,
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:BicSwift"
+          },
+          "accountType": {
+            "$ref": "#/components/schemas/BankAccountType"
+          },
+          "trusted": {
+            "type": "boolean",
+            "default": false
+          },
+          "bankName": {
+            "maxLength": 140,
+            "type": ["null", "string"]
+          },
+          "bankAddress": {
+            "maxLength": 200,
+            "type": ["null", "string"]
+          },
+          "intermediaryBic": {
+            "maxLength": 11,
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:BicSwift"
+          },
+          "internalNote": {
+            "maxLength": 1000,
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfBankAccount": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfBankAccount"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfBankAccount": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/BankAccount"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "PagedResultOfBankAccount": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "partyId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "scheme": {
+                  "enum": ["Iban", "UsAch", "CaEft", "AuBsb", "InIfsc", "Other"]
+                },
+                "accountIdentifier": {
+                  "type": "string"
+                },
+                "routingCode": {
+                  "type": ["null", "string"]
+                },
+                "bic": {
+                  "type": ["null", "string"]
+                },
+                "holderName": {
+                  "type": "string"
+                },
+                "countryCode": {
+                  "type": "string"
+                },
+                "accountType": {
+                  "enum": ["Unknown", "Checking", "Savings"]
+                },
+                "bankName": {
+                  "type": ["null", "string"]
+                },
+                "bankAddress": {
+                  "type": ["null", "string"]
+                },
+                "intermediaryBic": {
+                  "type": ["null", "string"]
+                },
+                "internalNote": {
+                  "type": ["null", "string"]
+                },
+                "status": {
+                  "enum": ["Active", "Archived"]
+                },
+                "verified": {
+                  "type": "boolean"
+                },
+                "trusted": {
+                  "type": "boolean"
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Bank Accounts"
+    }
+  ]
+}

--- a/packages/@granit/bank-accounts/README.md
+++ b/packages/@granit/bank-accounts/README.md
@@ -1,0 +1,3 @@
+# @granit/bank-accounts
+
+Centralized bank account referential — types and API functions

--- a/packages/@granit/bank-accounts/package.json
+++ b/packages/@granit/bank-accounts/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@granit/bank-accounts",
+  "description": "Centralized bank account referential — types and API functions (create, read, list per party, verify, archive)",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/types": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/bank-accounts/src/__tests__/bank-accounts-api.test.ts
+++ b/packages/@granit/bank-accounts/src/__tests__/bank-accounts-api.test.ts
@@ -1,0 +1,225 @@
+import { createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  archiveBankAccount,
+  createBankAccount,
+  getBankAccount,
+  getBankAccountsQueryMeta,
+  listBankAccounts,
+  listBankAccountsByParty,
+  verifyBankAccount,
+} from '../api/bank-accounts-api';
+
+import type { BankAccount, BankAccountResponse, CreateBankAccountRequest } from '../types/index';
+import type { QueryMetadata } from '@granit/query-engine';
+import type { ISODateString, TenantId } from '@granit/types';
+
+const basePath = '/bank-accounts';
+
+const sampleAccount: BankAccountResponse = {
+  id: 'acc-1',
+  partyId: 'party-1',
+  scheme: 'Iban',
+  accountType: 'Checking',
+  accountIdentifierMasked: '**** 7034',
+  routingCode: null,
+  bic: 'GEBABEBB',
+  holderName: 'Alice Doe',
+  countryCode: 'BE',
+  bankName: 'BNP Paribas Fortis',
+  bankAddress: null,
+  intermediaryBic: null,
+  status: 'Active',
+  verified: false,
+  trusted: false,
+  tenantId: 'tenant-1' as TenantId,
+};
+
+describe('bank-accounts-api', () => {
+  describe('createBankAccount', () => {
+    it('should POST {basePath} with the request body', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleAccount });
+
+      const request: CreateBankAccountRequest = {
+        partyId: 'party-1',
+        scheme: 'Iban',
+        accountIdentifier: 'BE68539007547034',
+        holderName: 'Alice Doe',
+        countryCode: 'BE',
+      };
+
+      const result = await createBankAccount(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith('/bank-accounts', request);
+      expect(result).toEqual(sampleAccount);
+    });
+  });
+
+  describe('getBankAccount', () => {
+    it('should GET {basePath}/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleAccount });
+
+      const result = await getBankAccount(client, basePath, 'acc-1');
+
+      expect(client.get).toHaveBeenCalledWith('/bank-accounts/acc-1');
+      expect(result).toEqual(sampleAccount);
+    });
+
+    it('should encode the id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleAccount });
+
+      await getBankAccount(client, basePath, 'acc/special');
+
+      expect(client.get).toHaveBeenCalledWith('/bank-accounts/acc%2Fspecial');
+    });
+  });
+
+  describe('listBankAccountsByParty', () => {
+    it('should GET {basePath}/by-party/{partyId} and return the array', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleAccount] });
+
+      const result = await listBankAccountsByParty(client, basePath, 'party-1');
+
+      expect(client.get).toHaveBeenCalledWith('/bank-accounts/by-party/party-1');
+      expect(result).toEqual([sampleAccount]);
+    });
+
+    it('should encode the partyId', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [] });
+
+      await listBankAccountsByParty(client, basePath, 'party/special');
+
+      expect(client.get).toHaveBeenCalledWith('/bank-accounts/by-party/party%2Fspecial');
+    });
+  });
+
+  describe('verifyBankAccount', () => {
+    it('should POST {basePath}/{id}/verify', async () => {
+      const client = createMockClient();
+      const verified = { ...sampleAccount, verified: true };
+      vi.mocked(client.post).mockResolvedValue({ data: verified });
+
+      const result = await verifyBankAccount(client, basePath, 'acc-1');
+
+      expect(client.post).toHaveBeenCalledWith('/bank-accounts/acc-1/verify');
+      expect(result).toEqual(verified);
+    });
+
+    it('should encode the id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleAccount });
+
+      await verifyBankAccount(client, basePath, 'acc/special');
+
+      expect(client.post).toHaveBeenCalledWith('/bank-accounts/acc%2Fspecial/verify');
+    });
+  });
+
+  describe('archiveBankAccount', () => {
+    it('should DELETE {basePath}/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      await archiveBankAccount(client, basePath, 'acc-1');
+
+      expect(client.delete).toHaveBeenCalledWith('/bank-accounts/acc-1');
+    });
+
+    it('should encode the id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      await archiveBankAccount(client, basePath, 'acc/special');
+
+      expect(client.delete).toHaveBeenCalledWith('/bank-accounts/acc%2Fspecial');
+    });
+  });
+
+  it('should work with a custom basePath', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockResolvedValue({ data: [sampleAccount] });
+
+    await listBankAccountsByParty(client, '/custom/bank-accounts', 'party-1');
+
+    expect(client.get).toHaveBeenCalledWith('/custom/bank-accounts/by-party/party-1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// QueryEngine wrappers
+// ---------------------------------------------------------------------------
+
+const sampleEntity: BankAccount = {
+  id: 'acc-1',
+  tenantId: 'tenant-1' as TenantId,
+  partyId: 'party-1',
+  scheme: 'Iban',
+  accountIdentifier: '',
+  routingCode: null,
+  bic: 'GEBABEBB',
+  holderName: 'Alice Doe',
+  countryCode: 'BE',
+  accountType: 'Checking',
+  bankName: 'BNP Paribas Fortis',
+  bankAddress: null,
+  intermediaryBic: null,
+  internalNote: null,
+  status: 'Active',
+  verified: true,
+  trusted: false,
+  createdAt: '2026-04-01T00:00:00Z' as ISODateString,
+  createdBy: 'user-1',
+  modifiedAt: null,
+  modifiedBy: null,
+};
+
+const sampleMeta: QueryMetadata = {
+  columns: [],
+  filterableFields: [],
+} as unknown as QueryMetadata;
+
+describe('bank-accounts-api / QueryEngine', () => {
+  describe('listBankAccounts', () => {
+    it('should GET {basePath} with serialized params', async () => {
+      const client = createMockClient();
+      const page = { items: [sampleEntity], totalCount: 1 };
+      vi.mocked(client.get).mockResolvedValue({ data: page });
+
+      const result = await listBankAccounts(client, basePath, { page: 1, pageSize: 25 });
+
+      expect(client.get).toHaveBeenCalledTimes(1);
+      const url = vi.mocked(client.get).mock.calls[0]?.[0] as string;
+      expect(url).toContain('/bank-accounts');
+      expect(url).toContain('page=1');
+      expect(url).toContain('pageSize=25');
+      expect(result).toEqual(page);
+    });
+
+    it('should GET {basePath} with no query string when params omitted', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: { items: [], totalCount: 0 } });
+
+      await listBankAccounts(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith('/bank-accounts', undefined);
+    });
+  });
+
+  describe('getBankAccountsQueryMeta', () => {
+    it('should GET {basePath}/meta', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleMeta });
+
+      const result = await getBankAccountsQueryMeta(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith('/bank-accounts/meta', undefined);
+      expect(result).toEqual(sampleMeta);
+    });
+  });
+});

--- a/packages/@granit/bank-accounts/src/api/bank-accounts-api.ts
+++ b/packages/@granit/bank-accounts/src/api/bank-accounts-api.ts
@@ -1,0 +1,125 @@
+import { getPage, getQueryMeta } from '@granit/query-engine';
+
+import type {
+  BankAccount,
+  BankAccountListParams,
+  BankAccountPage,
+  BankAccountResponse,
+  CreateBankAccountRequest,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+import type { QueryMetadata } from '@granit/query-engine';
+
+// ---------------------------------------------------------------------------
+// CRUD + lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a bank account for a party. The account identifier is encrypted at
+ * rest; the response masks it. Requires `BankAccounts.Accounts.Manage`.
+ *
+ * `POST {basePath}`
+ */
+export async function createBankAccount(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreateBankAccountRequest
+): Promise<BankAccountResponse> {
+  const response = await client.post<BankAccountResponse>(basePath, request);
+  return response.data;
+}
+
+/**
+ * Get a single bank account by ID, with the account identifier masked. Scoped
+ * to the current tenant. Requires `BankAccounts.Accounts.Read`.
+ *
+ * `GET {basePath}/{id}`
+ */
+export async function getBankAccount(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<BankAccountResponse> {
+  const response = await client.get<BankAccountResponse>(`${basePath}/${encodeURIComponent(id)}`);
+  return response.data;
+}
+
+/**
+ * List the non-archived bank accounts of a party (the app-facing per-party
+ * view). Requires `BankAccounts.Accounts.Read`.
+ *
+ * `GET {basePath}/by-party/{partyId}`
+ */
+export async function listBankAccountsByParty(
+  client: AxiosInstance,
+  basePath: string,
+  partyId: string
+): Promise<readonly BankAccountResponse[]> {
+  const response = await client.get<readonly BankAccountResponse[]>(
+    `${basePath}/by-party/${encodeURIComponent(partyId)}`
+  );
+  return response.data;
+}
+
+/**
+ * Mark a bank account as verified (proof of ownership). Idempotent: re-verifying
+ * an already-verified account succeeds. Requires `BankAccounts.Accounts.Verify`.
+ *
+ * `POST {basePath}/{id}/verify`
+ */
+export async function verifyBankAccount(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<BankAccountResponse> {
+  const response = await client.post<BankAccountResponse>(
+    `${basePath}/${encodeURIComponent(id)}/verify`
+  );
+  return response.data;
+}
+
+/**
+ * Archive (soft-delete) a bank account so it no longer appears in a party's
+ * active list; the record is retained for audit/regulatory purposes.
+ * Idempotent. Requires `BankAccounts.Accounts.Manage`.
+ *
+ * `DELETE {basePath}/{id}`
+ */
+export async function archiveBankAccount(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<void> {
+  await client.delete(`${basePath}/${encodeURIComponent(id)}`);
+}
+
+// ---------------------------------------------------------------------------
+// QueryEngine — cross-tenant admin grid (GET {basePath} + /meta)
+// ---------------------------------------------------------------------------
+
+/**
+ * List bank accounts via the QueryEngine admin grid (paginated, filterable,
+ * cross-tenant). Requires `BankAccounts.Accounts.Read`.
+ *
+ * `GET {basePath}`
+ */
+export async function listBankAccounts(
+  client: AxiosInstance,
+  basePath: string,
+  params?: BankAccountListParams
+): Promise<BankAccountPage> {
+  return getPage<BankAccount>(client, basePath, params ?? {});
+}
+
+/**
+ * Get the QueryEngine metadata (columns, filterable fields, presets) for the
+ * bank account grid.
+ *
+ * `GET {basePath}/meta`
+ */
+export async function getBankAccountsQueryMeta(
+  client: AxiosInstance,
+  basePath: string
+): Promise<QueryMetadata> {
+  return getQueryMeta(client, basePath);
+}

--- a/packages/@granit/bank-accounts/src/index.ts
+++ b/packages/@granit/bank-accounts/src/index.ts
@@ -1,0 +1,25 @@
+// Types
+export type {
+  BankAccount,
+  BankAccountListParams,
+  BankAccountPage,
+  BankAccountResponse,
+  BankAccountScheme,
+  BankAccountStatus,
+  BankAccountType,
+  CreateBankAccountRequest,
+} from './types/index';
+
+// Permissions
+export { BankAccountsPermissions } from './permissions';
+
+// API
+export {
+  archiveBankAccount,
+  createBankAccount,
+  getBankAccount,
+  getBankAccountsQueryMeta,
+  listBankAccounts,
+  listBankAccountsByParty,
+  verifyBankAccount,
+} from './api/bank-accounts-api';

--- a/packages/@granit/bank-accounts/src/permissions.ts
+++ b/packages/@granit/bank-accounts/src/permissions.ts
@@ -1,0 +1,18 @@
+/**
+ * Permission constants for the bank account referential. Mirrors
+ * `Granit.BankAccounts.Endpoints.Permissions.BankAccountsPermissions`.
+ *
+ * `Verify` is split from `Manage` on purpose: verification (proof of ownership)
+ * is a control step a payout/treasury operator may hold without the right to
+ * create or archive accounts (ISO 27001 A.9.4 least privilege).
+ */
+export const BankAccountsPermissions = {
+  Accounts: {
+    /** Read bank accounts. */
+    Read: 'BankAccounts.Accounts.Read',
+    /** Create and archive bank accounts. */
+    Manage: 'BankAccounts.Accounts.Manage',
+    /** Verify a bank account (mark proof of ownership). */
+    Verify: 'BankAccounts.Accounts.Verify',
+  },
+} as const;

--- a/packages/@granit/bank-accounts/src/types/index.ts
+++ b/packages/@granit/bank-accounts/src/types/index.ts
@@ -1,0 +1,113 @@
+import type { PagedResult, QueryRequest } from '@granit/query-engine';
+import type { ISODateString, TenantId } from '@granit/types';
+
+/**
+ * Routing scheme of a bank account. Mirrors
+ * `Granit.BankAccounts.Domain.BankAccountScheme` (serialized to its string name).
+ *
+ * `Iban` is self-contained (ISO 13616, no routing code); the domestic schemes
+ * each carry their own routing code (`UsAch` → ABA, `CaEft` → transit,
+ * `AuBsb` → BSB, `InIfsc` → IFSC). `Other` is the open-ended fallback.
+ */
+export type BankAccountScheme = 'Iban' | 'UsAch' | 'CaEft' | 'AuBsb' | 'InIfsc' | 'Other';
+
+/** Lifecycle status of a bank account. `Archived` is a soft-delete (record retained). */
+export type BankAccountStatus = 'Active' | 'Archived';
+
+/** Account type. `Unknown` is the default when the caller does not classify the account. */
+export type BankAccountType = 'Unknown' | 'Checking' | 'Savings';
+
+/**
+ * Registers a bank account for a party.
+ *
+ * Account-identifier and routing-code rules are scheme-aware (enforced
+ * server-side): an `Iban` forbids a routing code, while each domestic scheme
+ * requires its own. The `accountIdentifier` is encrypted at rest and never
+ * returned in clear — responses expose {@link BankAccountResponse.accountIdentifierMasked}.
+ */
+export interface CreateBankAccountRequest {
+  readonly partyId: string;
+  readonly scheme: BankAccountScheme;
+  /** IBAN or domestic account number (max 64 chars). Encrypted at rest. */
+  readonly accountIdentifier: string;
+  /** Account holder name (max 140 chars). */
+  readonly holderName: string;
+  /** ISO 3166-1 alpha-2 country code. */
+  readonly countryCode: string;
+  /** Domestic routing code (max 34 chars). Required for domestic schemes, forbidden for `Iban`. */
+  readonly routingCode?: string | null;
+  /** Bank/SWIFT BIC (max 11 chars). */
+  readonly bic?: string | null;
+  readonly accountType?: BankAccountType;
+  /** Marks the account as trusted at creation. Defaults to `false`. */
+  readonly trusted?: boolean;
+  readonly bankName?: string | null;
+  readonly bankAddress?: string | null;
+  /** Intermediary/correspondent bank BIC (max 11 chars). */
+  readonly intermediaryBic?: string | null;
+  /** Free-text internal note (max 1000 chars). Never returned in responses. */
+  readonly internalNote?: string | null;
+}
+
+/**
+ * A bank account as returned by the CRUD endpoints, with the account identifier
+ * masked (e.g. `**** 7034`). The clear identifier and the internal note are
+ * never projected here.
+ */
+export interface BankAccountResponse {
+  readonly id: string;
+  readonly partyId: string;
+  readonly scheme: BankAccountScheme;
+  readonly accountType: BankAccountType;
+  /** Masked account identifier (e.g. `**** 7034`). */
+  readonly accountIdentifierMasked: string;
+  readonly routingCode: string | null;
+  readonly bic: string | null;
+  readonly holderName: string;
+  readonly countryCode: string;
+  readonly bankName: string | null;
+  readonly bankAddress: string | null;
+  readonly intermediaryBic: string | null;
+  readonly status: BankAccountStatus;
+  readonly verified: boolean;
+  readonly trusted: boolean;
+  readonly tenantId: TenantId | null;
+}
+
+/**
+ * Bank account entity as returned by the QueryEngine admin grid (`GET {basePath}`).
+ *
+ * Distinct from {@link BankAccountResponse}: the query endpoint returns the raw
+ * audited entity including `tenantId` and audit columns. The encrypted
+ * `accountIdentifier` is excluded from the query projection server-side, so it
+ * is effectively never populated through this surface.
+ */
+export interface BankAccount {
+  readonly id: string;
+  readonly tenantId: TenantId | null;
+  readonly partyId: string;
+  readonly scheme: BankAccountScheme;
+  readonly accountIdentifier: string;
+  readonly routingCode: string | null;
+  readonly bic: string | null;
+  readonly holderName: string;
+  readonly countryCode: string;
+  readonly accountType: BankAccountType;
+  readonly bankName: string | null;
+  readonly bankAddress: string | null;
+  readonly intermediaryBic: string | null;
+  readonly internalNote: string | null;
+  readonly status: BankAccountStatus;
+  readonly verified: boolean;
+  readonly trusted: boolean;
+  readonly createdAt: ISODateString;
+  readonly createdBy: string;
+  readonly modifiedAt: ISODateString | null;
+  readonly modifiedBy: string | null;
+}
+
+/** Paginated page of {@link BankAccount} entities (QueryEngine admin grid). */
+export type BankAccountPage = PagedResult<BankAccount>;
+
+/** Query parameters accepted by the bank account QueryEngine grid (`GET {basePath}`). */
+export type BankAccountListParams = QueryRequest;

--- a/packages/@granit/bank-accounts/tsconfig.json
+++ b/packages/@granit/bank-accounts/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/bank-accounts/tsup.config.ts
+++ b/packages/@granit/bank-accounts/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-bank-accounts/README.md
+++ b/packages/@granit/react-bank-accounts/README.md
@@ -1,0 +1,3 @@
+# @granit/react-bank-accounts
+
+React bindings for @granit/bank-accounts — BankAccountsProvider and hooks

--- a/packages/@granit/react-bank-accounts/package.json
+++ b/packages/@granit/react-bank-accounts/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@granit/react-bank-accounts",
+  "description": "React bindings for @granit/bank-accounts — BankAccountsProvider and hooks",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/bank-accounts": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
+    "msw": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  }
+}

--- a/packages/@granit/react-bank-accounts/src/__tests__/bank-accounts-provider.test.tsx
+++ b/packages/@granit/react-bank-accounts/src/__tests__/bank-accounts-provider.test.tsx
@@ -1,0 +1,70 @@
+import { renderHook } from '@testing-library/react';
+import * as React from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+import {
+  BankAccountsProvider,
+  buildBankAccountsQueryKey,
+  useBankAccountsConfig,
+} from '../providers/bank-accounts-provider';
+
+import type { BankAccountsConfig } from '../providers/bank-accounts-provider';
+import type { AxiosInstance } from 'axios';
+
+const mockConfig: BankAccountsConfig = {
+  client: {} as AxiosInstance,
+  basePath: DEFAULT_BASE_PATH,
+};
+
+function createWrapper(config: BankAccountsConfig) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <BankAccountsProvider config={config}>{children}</BankAccountsProvider>;
+  };
+}
+
+describe('BankAccountsProvider', () => {
+  it('should provide config via useBankAccountsConfig', () => {
+    const { result } = renderHook(() => useBankAccountsConfig(), {
+      wrapper: createWrapper(mockConfig),
+    });
+
+    expect(result.current.client).toBe(mockConfig.client);
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
+  });
+
+  it('should default the basePath when omitted', () => {
+    const { result } = renderHook(() => useBankAccountsConfig(), {
+      wrapper: createWrapper({ client: {} as AxiosInstance }),
+    });
+
+    expect(result.current.basePath).toBe(DEFAULT_BASE_PATH);
+  });
+
+  it('should throw when used outside provider', () => {
+    expect(() => {
+      renderHook(() => useBankAccountsConfig());
+    }).toThrow('useBankAccountsConfig must be used within a BankAccountsProvider');
+  });
+
+  it('should throw when no client is available', () => {
+    expect(() => {
+      renderHook(() => useBankAccountsConfig(), {
+        wrapper: createWrapper({} as BankAccountsConfig),
+      });
+    }).toThrow('BankAccountsProvider requires an Axios client');
+  });
+});
+
+describe('buildBankAccountsQueryKey', () => {
+  it('should build key with default prefix', () => {
+    const key = buildBankAccountsQueryKey(mockConfig, 'detail', 'acc-1');
+    expect(key).toEqual(['bank-accounts', 'detail', 'acc-1']);
+  });
+
+  it('should build key with custom prefix', () => {
+    const config: BankAccountsConfig = { ...mockConfig, queryKeyPrefix: ['custom'] };
+    const key = buildBankAccountsQueryKey(config, 'by-party', 'party-1');
+    expect(key).toEqual(['custom', 'by-party', 'party-1']);
+  });
+});

--- a/packages/@granit/react-bank-accounts/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-bank-accounts/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,79 @@
+import { createMswServer } from '@granit/testing/msw-server';
+import { describe, expect, it } from 'vitest';
+
+import { bankAccountQueryMetadata, createBankAccountsHandlers } from '../testing/index';
+
+const BASE = 'http://api.test/api/v1/bank-accounts';
+const server = createMswServer();
+
+describe('createBankAccountsHandlers', () => {
+  it('responds with bankAccountQueryMetadata at /meta', async () => {
+    server.use(...createBankAccountsHandlers(BASE));
+    const response = await fetch(`${BASE}/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(bankAccountQueryMetadata);
+  });
+
+  it('serves the QueryEngine admin grid (paged) at the base path', async () => {
+    server.use(...createBankAccountsHandlers(BASE));
+    const response = await fetch(BASE);
+    expect(response.status).toBe(200);
+    const page = (await response.json()) as { items: unknown[]; totalCount: number };
+    expect(page.totalCount).toBe(page.items.length);
+    expect(page.items.length).toBeGreaterThan(0);
+  });
+
+  it('lists only active accounts of a party at /by-party/:partyId', async () => {
+    server.use(...createBankAccountsHandlers(BASE));
+    const response = await fetch(`${BASE}/by-party/pty_001`);
+    expect(response.status).toBe(200);
+    const accounts = (await response.json()) as { partyId: string; status: string }[];
+    expect(accounts.length).toBeGreaterThan(0);
+    expect(accounts.every((a) => a.partyId === 'pty_001' && a.status === 'Active')).toBe(true);
+  });
+
+  it('registers a new account at POST / (masked identifier, starts unverified)', async () => {
+    server.use(...createBankAccountsHandlers(BASE));
+    const response = await fetch(BASE, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        partyId: 'pty_001',
+        scheme: 'Iban',
+        accountIdentifier: 'BE68539007547034',
+        holderName: 'Bob Roe',
+        countryCode: 'BE',
+      }),
+    });
+    expect(response.status).toBe(201);
+    const created = (await response.json()) as {
+      accountIdentifierMasked: string;
+      verified: boolean;
+    };
+    expect(created.accountIdentifierMasked).toBe('**** 7034');
+    expect(created.verified).toBe(false);
+  });
+
+  it('verifies an account at POST /:id/verify (idempotent)', async () => {
+    server.use(...createBankAccountsHandlers(BASE));
+    const verify = await fetch(`${BASE}/ba_002/verify`, { method: 'POST' });
+    expect(verify.status).toBe(200);
+    const verified = (await verify.json()) as { verified: boolean };
+    expect(verified.verified).toBe(true);
+  });
+
+  it('archives an account at DELETE /:id and removes it from the party list', async () => {
+    server.use(...createBankAccountsHandlers(BASE));
+    const archive = await fetch(`${BASE}/ba_001`, { method: 'DELETE' });
+    expect(archive.status).toBe(204);
+
+    const after = (await (await fetch(`${BASE}/by-party/pty_001`)).json()) as { id: string }[];
+    expect(after.some((a) => a.id === 'ba_001')).toBe(false);
+  });
+
+  it('returns 404 verifying an unknown account', async () => {
+    server.use(...createBankAccountsHandlers(BASE));
+    const response = await fetch(`${BASE}/missing/verify`, { method: 'POST' });
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/@granit/react-bank-accounts/src/__tests__/use-bank-accounts.test.tsx
+++ b/packages/@granit/react-bank-accounts/src/__tests__/use-bank-accounts.test.tsx
@@ -1,0 +1,176 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useArchiveBankAccount,
+  useBankAccount,
+  useBankAccountsByParty,
+  useCreateBankAccount,
+  useVerifyBankAccount,
+} from '../hooks/use-bank-accounts';
+import { BankAccountsProvider } from '../providers/bank-accounts-provider';
+
+import type { BankAccountsConfig } from '../providers/bank-accounts-provider';
+import type { BankAccountResponse } from '@granit/bank-accounts';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: BankAccountsConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <BankAccountsProvider config={config}>{children}</BankAccountsProvider>
+    );
+  };
+}
+
+const sampleAccount: BankAccountResponse = {
+  id: 'acc-1',
+  partyId: 'party-1',
+  scheme: 'Iban',
+  accountType: 'Checking',
+  accountIdentifierMasked: '**** 7034',
+  routingCode: null,
+  bic: 'GEBABEBB',
+  holderName: 'Alice Doe',
+  countryCode: 'BE',
+  bankName: 'BNP Paribas Fortis',
+  bankAddress: null,
+  intermediaryBic: null,
+  status: 'Active',
+  verified: false,
+  trusted: false,
+  tenantId: null,
+};
+
+describe('use-bank-accounts', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useBankAccount', () => {
+    it('fetches an account by ID with the default basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleAccount });
+
+      const { result } = renderHook(() => useBankAccount('acc-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/api/v1/bank-accounts/acc-1');
+      expect(result.current.data).toEqual(sampleAccount);
+    });
+
+    it('is disabled when id is empty', () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useBankAccount(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useBankAccountsByParty', () => {
+    it('fetches the accounts of a party', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: [sampleAccount] });
+
+      const { result } = renderHook(() => useBankAccountsByParty('party-1'), {
+        wrapper: createWrapper(client, '/custom/bank-accounts'),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/custom/bank-accounts/by-party/party-1');
+      expect(result.current.data).toEqual([sampleAccount]);
+    });
+
+    it('is disabled when partyId is empty', () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useBankAccountsByParty(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useCreateBankAccount', () => {
+    it('registers an account via POST', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleAccount });
+
+      const { result } = renderHook(() => useCreateBankAccount(), {
+        wrapper: createWrapper(client),
+      });
+
+      const request = {
+        partyId: 'party-1',
+        scheme: 'Iban' as const,
+        accountIdentifier: 'BE68539007547034',
+        holderName: 'Alice Doe',
+        countryCode: 'BE',
+      };
+      result.current.mutate(request);
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/bank-accounts', request);
+    });
+  });
+
+  describe('useVerifyBankAccount', () => {
+    it('verifies an account via POST', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: { ...sampleAccount, verified: true } });
+
+      const { result } = renderHook(() => useVerifyBankAccount(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('acc-1');
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.post).toHaveBeenCalledWith('/api/v1/bank-accounts/acc-1/verify');
+    });
+  });
+
+  describe('useArchiveBankAccount', () => {
+    it('archives an account via DELETE', async () => {
+      const client = createMockClient();
+      vi.mocked(client.delete).mockResolvedValue({ data: undefined });
+
+      const { result } = renderHook(() => useArchiveBankAccount(), {
+        wrapper: createWrapper(client),
+      });
+
+      result.current.mutate('acc-1');
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.delete).toHaveBeenCalledWith('/api/v1/bank-accounts/acc-1');
+    });
+  });
+
+  it('exposes error state on failure', async () => {
+    const client = createMockClient();
+    vi.mocked(client.get).mockRejectedValue(new Error('Network error'));
+
+    const { result } = renderHook(() => useBankAccount('acc-1'), {
+      wrapper: createWrapper(client),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Network error');
+  });
+});

--- a/packages/@granit/react-bank-accounts/src/constants.ts
+++ b/packages/@granit/react-bank-accounts/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'bank-accounts';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-bank-accounts/src/hooks/use-bank-accounts.ts
+++ b/packages/@granit/react-bank-accounts/src/hooks/use-bank-accounts.ts
@@ -1,0 +1,137 @@
+import {
+  archiveBankAccount,
+  createBankAccount,
+  getBankAccount,
+  listBankAccountsByParty,
+  verifyBankAccount,
+} from '@granit/bank-accounts';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  buildBankAccountsQueryKey,
+  useBankAccountsConfig,
+} from '../providers/bank-accounts-provider';
+
+import type { BankAccountResponse, CreateBankAccountRequest } from '@granit/bank-accounts';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Get a single bank account by ID (account identifier masked).
+ *
+ * The query is automatically disabled when `id` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: account } = useBankAccount(selectedId);
+ * ```
+ */
+export function useBankAccount(id: string): UseQueryResult<BankAccountResponse> {
+  const config = useBankAccountsConfig();
+
+  return useQuery({
+    queryKey: buildBankAccountsQueryKey(config, 'detail', id),
+    queryFn: () => getBankAccount(config.client, config.basePath, id),
+    enabled: id.length > 0,
+  });
+}
+
+/**
+ * List the non-archived bank accounts of a party (per-party view).
+ *
+ * The query is automatically disabled when `partyId` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: accounts } = useBankAccountsByParty(partyId);
+ * ```
+ */
+export function useBankAccountsByParty(
+  partyId: string
+): UseQueryResult<readonly BankAccountResponse[]> {
+  const config = useBankAccountsConfig();
+
+  return useQuery({
+    queryKey: buildBankAccountsQueryKey(config, 'by-party', partyId),
+    queryFn: () => listBankAccountsByParty(config.client, config.basePath, partyId),
+    enabled: partyId.length > 0,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Register a bank account for a party.
+ * Invalidates bank account queries on success.
+ *
+ * @example
+ * ```tsx
+ * const create = useCreateBankAccount();
+ * await create.mutateAsync({ partyId, scheme: 'Iban', accountIdentifier, holderName, countryCode });
+ * ```
+ */
+export function useCreateBankAccount(): UseMutationResult<
+  BankAccountResponse,
+  Error,
+  CreateBankAccountRequest
+> {
+  const config = useBankAccountsConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateBankAccountRequest) =>
+      createBankAccount(config.client, config.basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildBankAccountsQueryKey(config) });
+    },
+  });
+}
+
+/**
+ * Mark a bank account as verified (proof of ownership). Idempotent.
+ * Invalidates bank account queries on success.
+ *
+ * @example
+ * ```tsx
+ * const verify = useVerifyBankAccount();
+ * await verify.mutateAsync('acc-1');
+ * ```
+ */
+export function useVerifyBankAccount(): UseMutationResult<BankAccountResponse, Error, string> {
+  const config = useBankAccountsConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => verifyBankAccount(config.client, config.basePath, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildBankAccountsQueryKey(config) });
+    },
+  });
+}
+
+/**
+ * Archive (soft-delete) a bank account. Idempotent.
+ * Invalidates bank account queries on success.
+ *
+ * @example
+ * ```tsx
+ * const archive = useArchiveBankAccount();
+ * await archive.mutateAsync('acc-1');
+ * ```
+ */
+export function useArchiveBankAccount(): UseMutationResult<void, Error, string> {
+  const config = useBankAccountsConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => archiveBankAccount(config.client, config.basePath, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: buildBankAccountsQueryKey(config) });
+    },
+  });
+}

--- a/packages/@granit/react-bank-accounts/src/index.ts
+++ b/packages/@granit/react-bank-accounts/src/index.ts
@@ -1,0 +1,20 @@
+// Provider
+export {
+  BankAccountsProvider,
+  buildBankAccountsQueryKey,
+  useBankAccountsConfig,
+} from './providers/bank-accounts-provider';
+export type {
+  BankAccountsConfig,
+  BankAccountsProviderProps,
+  ResolvedBankAccountsConfig,
+} from './providers/bank-accounts-provider';
+
+// Hooks
+export {
+  useArchiveBankAccount,
+  useBankAccount,
+  useBankAccountsByParty,
+  useCreateBankAccount,
+  useVerifyBankAccount,
+} from './hooks/use-bank-accounts';

--- a/packages/@granit/react-bank-accounts/src/providers/bank-accounts-provider.tsx
+++ b/packages/@granit/react-bank-accounts/src/providers/bank-accounts-provider.tsx
@@ -1,0 +1,70 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for the bank accounts provider. */
+export interface BankAccountsConfig {
+  readonly client?: AxiosInstance;
+  /** Base path for bank account endpoints (default: `/api/v1/bank-accounts`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * BankAccountsConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>` and defaulted
+ * `basePath`. Both are guaranteed present, so hooks read them without a
+ * non-null assertion.
+ */
+export interface ResolvedBankAccountsConfig extends BankAccountsConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+}
+
+export interface BankAccountsProviderProps {
+  readonly config: BankAccountsConfig;
+  readonly children: ReactNode;
+}
+
+const BankAccountsConfigContext = createContext<ResolvedBankAccountsConfig | null>(null);
+
+/** Provides bank accounts configuration to child components and hooks. */
+export function BankAccountsProvider({ config, children }: Readonly<BankAccountsProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedBankAccountsConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'BankAccountsProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
+  return <BankAccountsConfigContext value={value}>{children}</BankAccountsConfigContext>;
+}
+
+/** Returns the bank accounts configuration from the nearest `BankAccountsProvider`. */
+export function useBankAccountsConfig(): ResolvedBankAccountsConfig {
+  const ctx = useContext(BankAccountsConfigContext);
+  if (!ctx) {
+    throw new Error('useBankAccountsConfig must be used within a BankAccountsProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for bank account operations. */
+export function buildBankAccountsQueryKey(
+  config: BankAccountsConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? ['bank-accounts'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-bank-accounts/src/testing/data.ts
+++ b/packages/@granit/react-bank-accounts/src/testing/data.ts
@@ -1,0 +1,73 @@
+import { toEntityId, toISODateString } from '@granit/types';
+
+import type { BankAccount, BankAccountResponse } from '@granit/bank-accounts';
+import type { Mutable } from '@granit/testing';
+import type { TenantId } from '@granit/types';
+
+const TENANT_ID = toEntityId<'Tenant'>('tnt_001') as unknown as TenantId;
+const PARTY_ID = toEntityId<'Party'>('pty_001');
+
+export const sampleBankAccounts: Mutable<BankAccountResponse>[] = [
+  {
+    id: toEntityId<'BankAccount'>('ba_001'),
+    partyId: PARTY_ID,
+    scheme: 'Iban',
+    accountType: 'Checking',
+    accountIdentifierMasked: '**** 7034',
+    routingCode: null,
+    bic: 'GEBABEBB',
+    holderName: 'Alice Doe',
+    countryCode: 'BE',
+    bankName: 'BNP Paribas Fortis',
+    bankAddress: null,
+    intermediaryBic: null,
+    status: 'Active',
+    verified: true,
+    trusted: true,
+    tenantId: TENANT_ID,
+  },
+  {
+    id: toEntityId<'BankAccount'>('ba_002'),
+    partyId: PARTY_ID,
+    scheme: 'UsAch',
+    accountType: 'Savings',
+    accountIdentifierMasked: '**** 6789',
+    routingCode: '021000021',
+    bic: null,
+    holderName: 'Alice Doe',
+    countryCode: 'US',
+    bankName: 'JPMorgan Chase',
+    bankAddress: null,
+    intermediaryBic: null,
+    status: 'Active',
+    verified: false,
+    trusted: false,
+    tenantId: TENANT_ID,
+  },
+];
+
+/** QueryEngine entity rows for the bank account admin grid (`GET {basePath}`). */
+export const sampleBankAccountEntities: Mutable<BankAccount>[] = sampleBankAccounts.map((a) => ({
+  id: a.id,
+  tenantId: TENANT_ID,
+  partyId: a.partyId,
+  scheme: a.scheme,
+  // The encrypted account identifier is excluded from the query projection.
+  accountIdentifier: '',
+  routingCode: a.routingCode,
+  bic: a.bic,
+  holderName: a.holderName,
+  countryCode: a.countryCode,
+  accountType: a.accountType,
+  bankName: a.bankName,
+  bankAddress: a.bankAddress,
+  intermediaryBic: a.intermediaryBic,
+  internalNote: null,
+  status: a.status,
+  verified: a.verified,
+  trusted: a.trusted,
+  createdAt: toISODateString('2026-04-01T00:00:00Z'),
+  createdBy: 'usr_seed',
+  modifiedAt: null,
+  modifiedBy: null,
+}));

--- a/packages/@granit/react-bank-accounts/src/testing/handlers.ts
+++ b/packages/@granit/react-bank-accounts/src/testing/handlers.ts
@@ -1,0 +1,247 @@
+import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
+import { noContent, notFound } from '@granit/testing/msw';
+import { toEntityId } from '@granit/types';
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { sampleBankAccountEntities, sampleBankAccounts } from './data';
+
+import type { BankAccountResponse, CreateBankAccountRequest } from '@granit/bank-accounts';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const SCHEMES = ['Iban', 'UsAch', 'CaEft', 'AuBsb', 'InIfsc', 'Other'];
+const STATUSES = ['Active', 'Archived'];
+const ACCOUNT_TYPES = ['Unknown', 'Checking', 'Savings'];
+
+/** Mock /meta payload for the bank account admin grid (`GET {basePath}`). */
+export const bankAccountQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'partyId',
+      label: 'Party',
+      type: 'Guid',
+      order: 1,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'holderName',
+      label: 'Holder',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'scheme',
+      label: 'Scheme',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'countryCode',
+      label: 'Country',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'accountType',
+      label: 'Type',
+      type: 'String',
+      order: 5,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'verified',
+      label: 'Verified',
+      type: 'Boolean',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'trusted',
+      label: 'Trusted',
+      type: 'Boolean',
+      order: 8,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'tenantId',
+      label: 'Tenant',
+      type: 'Guid',
+      order: 9,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'createdAt',
+      label: 'Created at',
+      type: 'DateTime',
+      order: 10,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+  ],
+  filterableFields: [
+    { name: 'partyId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'holderName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'scheme', type: 'String', operators: ENUM_OPERATORS, enumValues: SCHEMES },
+    { name: 'countryCode', type: 'String', operators: STRING_OPERATORS },
+    {
+      name: 'accountType',
+      type: 'String',
+      operators: ENUM_OPERATORS,
+      enumValues: ACCOUNT_TYPES,
+    },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: STATUSES },
+    { name: 'tenantId', type: 'Guid', operators: ENUM_OPERATORS },
+    { name: 'createdAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'holderName' },
+    { name: 'scheme' },
+    { name: 'countryCode' },
+    { name: 'accountType' },
+    { name: 'status' },
+    { name: 'verified' },
+    { name: 'trusted' },
+    { name: 'createdAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active', isDefault: true },
+    { name: 'archived', label: 'Archived', isDefault: false },
+    { name: 'unverified', label: 'Unverified', isDefault: false },
+  ],
+  dateFilters: [],
+  groupByFields: [
+    { name: 'scheme', type: 'String' },
+    { name: 'status', type: 'String' },
+    { name: 'countryCode', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 10_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-createdAt',
+};
+
+/**
+ * Create stateful MSW handlers for bank account endpoints. Create / verify /
+ * archive mutations persist in the in-memory list.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/bank-accounts`)
+ */
+export function createBankAccountsHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  let accounts = [...sampleBankAccounts];
+
+  return [
+    // GET {basePath}/meta — QueryEngine metadata (registered before /:id)
+    createQueryMetaHandler(baseUrl, bankAccountQueryMetadata),
+
+    // GET {basePath}/by-party/:partyId — active accounts of a party (plain array)
+    http.get(`${baseUrl}/by-party/:partyId`, ({ params }) => {
+      const partyId = params.partyId as string;
+      const owned = accounts.filter((a) => a.partyId === partyId && a.status === 'Active');
+      return HttpResponse.json(owned);
+    }),
+
+    // GET {basePath} — QueryEngine admin grid (paged)
+    http.get(baseUrl, () => {
+      return HttpResponse.json({
+        items: sampleBankAccountEntities,
+        totalCount: sampleBankAccountEntities.length,
+      });
+    }),
+
+    // POST {basePath} — register a bank account
+    http.post(baseUrl, async ({ request }) => {
+      const body = (await request.json()) as CreateBankAccountRequest;
+      const tail = body.accountIdentifier.slice(-4).padStart(4, '0');
+      const newAccount: BankAccountResponse = {
+        id: toEntityId<'BankAccount'>(`ba_${String(accounts.length + 1).padStart(3, '0')}`),
+        partyId: body.partyId,
+        scheme: body.scheme,
+        accountType: body.accountType ?? 'Unknown',
+        accountIdentifierMasked: `**** ${tail}`,
+        routingCode: body.routingCode ?? null,
+        bic: body.bic ?? null,
+        holderName: body.holderName,
+        countryCode: body.countryCode,
+        bankName: body.bankName ?? null,
+        bankAddress: body.bankAddress ?? null,
+        intermediaryBic: body.intermediaryBic ?? null,
+        status: 'Active',
+        verified: false,
+        trusted: body.trusted ?? false,
+        tenantId: sampleBankAccounts[0]?.tenantId ?? null,
+      };
+      accounts = [...accounts, newAccount];
+      return HttpResponse.json(newAccount, { status: 201 });
+    }),
+
+    // POST {basePath}/:id/verify — mark verified (idempotent)
+    http.post(`${baseUrl}/:id/verify`, ({ params }) => {
+      const id = params.id as string;
+      const existing = accounts.find((a) => a.id === id);
+      if (!existing) return notFound();
+      const updated: BankAccountResponse = { ...existing, verified: true };
+      accounts = accounts.map((a) => (a.id === id ? updated : a));
+      return HttpResponse.json(updated);
+    }),
+
+    // GET {basePath}/:id — single account
+    http.get(`${baseUrl}/:id`, ({ params }) => {
+      const account = accounts.find((a) => a.id === params.id);
+      if (!account) return notFound();
+      return HttpResponse.json(account);
+    }),
+
+    // DELETE {basePath}/:id — archive (soft-delete, idempotent)
+    http.delete(`${baseUrl}/:id`, ({ params }) => {
+      const id = params.id as string;
+      const existing = accounts.find((a) => a.id === id);
+      if (!existing) return notFound();
+      accounts = accounts.map((a) => (a.id === id ? { ...a, status: 'Archived' } : a));
+      return noContent();
+    }),
+  ];
+}

--- a/packages/@granit/react-bank-accounts/src/testing/index.ts
+++ b/packages/@granit/react-bank-accounts/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-bank-accounts/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { sampleBankAccountEntities, sampleBankAccounts } from './data';
+export { bankAccountQueryMetadata, createBankAccountsHandlers } from './handlers';

--- a/packages/@granit/react-bank-accounts/tsconfig.json
+++ b/packages/@granit/react-bank-accounts/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/bank-accounts": ["../bank-accounts/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-bank-accounts/tsup.config.ts
+++ b/packages/@granit/react-bank-accounts/tsup.config.ts
@@ -1,0 +1,6 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  external: [/^@granit\//, 'msw'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -389,6 +389,21 @@ importers:
         specifier: workspace:*
         version: link:../types
 
+  packages/@granit/bank-accounts:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
   packages/@granit/bff:
     devDependencies:
       '@granit/logger':
@@ -1374,6 +1389,43 @@ importers:
       '@granit/query-engine':
         specifier: workspace:*
         version: link:../query-engine
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
+  packages/@granit/react-bank-accounts:
+    dependencies:
+      '@granit/bank-accounts':
+        specifier: workspace:*
+        version: link:../bank-accounts
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
       '@tanstack/react-query':
         specifier: 5.101.0
         version: 5.101.0(react@19.2.7)


### PR DESCRIPTION
## Summary

Front module mirroring the backend `Granit.BankAccounts.Endpoints` (granit-business): a centralized bank account referential. Built from the module's OpenAPI spec, following the `metering` query-engine module template.

### Packages
- **`@granit/bank-accounts`** (core, framework-agnostic)
  - `types/` — `BankAccountScheme` / `BankAccountStatus` / `BankAccountType`, `CreateBankAccountRequest`, `BankAccountResponse` (masked), `BankAccount` QE entity, `BankAccountPage`, `BankAccountListParams`. Optionality derived strictly from the spec `required` arrays.
  - `api/` — `createBankAccount`, `getBankAccount`, `listBankAccountsByParty`, `verifyBankAccount`, `archiveBankAccount`, plus QE `listBankAccounts` / `getBankAccountsQueryMeta`.
  - `permissions.ts` — `BankAccounts.Accounts.{Read,Manage,Verify}`.
- **`@granit/react-bank-accounts`** (React bindings)
  - `BankAccountsProvider` + `useBankAccountsConfig` + `buildBankAccountsQueryKey`.
  - Hooks: `useBankAccount`, `useBankAccountsByParty`, `useCreateBankAccount`, `useVerifyBankAccount`, `useArchiveBankAccount`.
  - `./testing` subpath — stateful MSW handlers + `bankAccountQueryMetadata` + fixtures.
- Vendored `contracts/openapi/bank-accounts.json`.

### Contract notes
- QueryEngine admin grid is mounted at the **base path** (`GET /` + `/meta`), not a subpath — so the wrappers pass `basePath` directly to `getPage` / `getQueryMeta`.
- `accountIdentifier` is encrypted/masked: responses expose `accountIdentifierMasked` only; `internalNote` is never returned.
- `verify` is a dedicated action (`POST /{id}/verify`, idempotent); archive is a soft-delete (`DELETE /{id}`).

## Test plan
- [x] `tsc --noEmit` clean (both packages)
- [x] `eslint --max-warnings 0` clean
- [x] Vitest: 34 passed, 100% coverage on new code
- [x] `@granit/arch-tests`: 2234 passed (import boundaries respected)
- [x] `pnpm install --frozen-lockfile` passes

> Not registered in `@granit/contract-tests` (matches the metering/webhooks precedent); the spec is vendored so adding a manifest entry later is a one-liner.