### PR TITLE
feat(payments-sepa): integrate SEPA Direct Debit & SEPA Transfer modules

### DIFF
--- a/.mcp-front-index.json
+++ b/.mcp-front-index.json
@@ -2210,6 +2210,48 @@
       ]
     },
     {
+      "name": "@granit/payments-sepa-direct-debit",
+      "description": "SEPA Direct Debit — mandate lifecycle and per-tenant SEPA configuration types and API functions",
+      "exports": [
+        {
+          "name": "CollectionStatus",
+          "kind": "type",
+          "signature": "type CollectionStatus ="
+        },
+        {
+          "name": "ConsentSource",
+          "kind": "type",
+          "signature": "type ConsentSource = 'AdminConfirm' | 'ProviderWebhook' | 'CustomerSelfService'"
+        },
+        {
+          "name": "MandateStatus",
+          "kind": "type",
+          "signature": "type MandateStatus = 'Pending' | 'Active' | 'Suspended' | 'Cancelled' | 'Failed' | 'Expired'"
+        },
+        {
+          "name": "SddScheme",
+          "kind": "type",
+          "signature": "type SddScheme = 'Core' | 'B2B'"
+        },
+        {
+          "name": "SepaDirectDebitPermissions",
+          "kind": "const",
+          "signature": "const SepaDirectDebitPermissions"
+        }
+      ]
+    },
+    {
+      "name": "@granit/payments-sepa-transfer",
+      "description": "SEPA bank transfer — per-tenant beneficiary configuration types and API functions",
+      "exports": [
+        {
+          "name": "SepaTransferPermissions",
+          "kind": "const",
+          "signature": "const SepaTransferPermissions"
+        }
+      ]
+    },
+    {
       "name": "@granit/presence",
       "description": "User presence types and API — mirrors Granit.Presence .NET contract",
       "exports": [
@@ -6424,6 +6466,23 @@
           "members": []
         }
       ]
+    },
+    {
+      "name": "@granit/react-payments-sepa-direct-debit",
+      "description": "React bindings for @granit/payments-sepa-direct-debit — SepaDirectDebitProvider and hooks",
+      "exports": [
+        {
+          "name": "ConfirmMandateArgs",
+          "kind": "interface",
+          "signature": "interface ConfirmMandateArgs",
+          "members": []
+        }
+      ]
+    },
+    {
+      "name": "@granit/react-payments-sepa-transfer",
+      "description": "React bindings for @granit/payments-sepa-transfer — SepaTransferProvider and hooks",
+      "exports": []
     },
     {
       "name": "@granit/react-presence",

--- a/contracts/openapi/sepa-direct-debit.json
+++ b/contracts/openapi/sepa-direct-debit.json
@@ -1,0 +1,1769 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "sepa-direct-debit",
+    "version": "1"
+  },
+  "paths": {
+    "/sepa-direct-debit/mandates": {
+      "post": {
+        "tags": ["SEPA Direct Debit - Mandates"],
+        "summary": "Sets up a SEPA Direct Debit mandate for the current tenant.",
+        "description": "Resolves the configured provider, stamps the tenant's Creditor Identifier, and persists a new mandate in Pending status. Returns the mandate together with any provider-hosted signature URL. Returns 409 when the tenant has no active SEPA configuration. Requires the SepaDirectDebit.Mandates.Create permission.",
+        "operationId": "CreateSepaMandate",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateMandateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MandateSetupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "get": {
+        "tags": ["SEPA Direct Debit - Mandates"],
+        "summary": "Returns a filtered, sorted, and paginated list of Mandate entries.",
+        "description": "Executes a dynamic query against Mandate using the Granit query engine. Accepts filter expressions, sort directives, column selection, pagination, and free-text search via query parameters. Returns a PagedResult by default. When the groupBy query parameter is specified, returns a GroupedResult instead (same status code, different shape).",
+        "operationId": "QueryMandate",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "1-based page index. Ignored when cursor is supplied.",
+            "schema": {
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Number of items per page (1-500). Server-side cap applies.",
+            "schema": {
+              "maximum": 500,
+              "minimum": 1,
+              "type": ["null", "integer"],
+              "format": "int32"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor for keyset pagination. When supplied, overrides page.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "search",
+            "in": "query",
+            "description": "Free-text search across searchable columns declared in the query definition.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Comma-separated sort directives. Prefix a field with '-' for descending (e.g. '-createdAt,lastName').",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "groupBy",
+            "in": "query",
+            "description": "Field to group results by. When set, the response shape becomes GroupedResult instead of PagedResult.",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "quickFilters",
+            "in": "query",
+            "description": "Comma-separated quick-filter names (declared in the query definition).",
+            "schema": {
+              "type": ["null", "string"]
+            }
+          },
+          {
+            "name": "skipTotalCount",
+            "in": "query",
+            "description": "Skip the total row count for faster pagination when the client doesn't need it.",
+            "schema": {
+              "type": ["null", "boolean"]
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "description": "Bracketed filter expressions: 'filter[field.op]=value'. Example: 'filter[name.contains]=alice&filter[age.gt]=18'.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "presets",
+            "in": "query",
+            "description": "Bracketed preset selectors: 'presets[group]=name'. Applies preset filter groups declared in the query definition.",
+            "style": "deepObject",
+            "explode": true,
+            "schema": {
+              "type": ["null", "object"],
+              "additionalProperties": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/PagedResultOfMandate"
+                    },
+                    {
+                      "$ref": "#/components/schemas/GroupedResultOfMandate"
+                    }
+                  ],
+                  "description": "PagedResult when groupBy is absent; GroupedResult otherwise."
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sepa-direct-debit/mandates/{id}/confirm": {
+      "post": {
+        "tags": ["SEPA Direct Debit - Mandates"],
+        "summary": "Confirms (activates) a pending mandate after the customer signature.",
+        "description": "Activates a Pending or Suspended mandate, recording verifiable consent evidence (the required signature time, masked source IP, actor) and raising the mandate-activated integration event. Returns 404 when the mandate does not exist, 409 when it cannot transition to active, and 403 when confirming a provider-backed mandate without the SepaDirectDebit.Mandates.ConfirmOverride permission (such mandates activate via the provider's verified flow). Requires the SepaDirectDebit.Mandates.Confirm permission.",
+        "operationId": "ConfirmSepaMandate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ConfirmMandateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MandateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sepa-direct-debit/mandates/{id}/cancel": {
+      "post": {
+        "tags": ["SEPA Direct Debit - Mandates"],
+        "summary": "Cancels (revokes) a mandate.",
+        "description": "Cancels the mandate and notifies the provider when a provider mandate id is present. Returns 404 when the mandate does not exist and 409 when it is already in a terminal status. Requires the SepaDirectDebit.Mandates.Cancel permission.",
+        "operationId": "CancelSepaMandate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MandateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sepa-direct-debit/mandates/{id}": {
+      "get": {
+        "tags": ["SEPA Direct Debit - Mandates"],
+        "summary": "Returns a mandate by id.",
+        "description": "Fetches a single mandate, with the debtor IBAN masked. Scoped to the current tenant. Returns 404 when the mandate does not exist. Requires the SepaDirectDebit.Mandates.Read permission.",
+        "operationId": "GetSepaMandate",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Resource identifier (UUID).",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MandateResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sepa-direct-debit/mandates/meta": {
+      "get": {
+        "tags": ["SEPA Direct Debit - Mandates"],
+        "summary": "Returns query metadata for Mandate (columns, filters, sorts, presets).",
+        "description": "Returns the query definition metadata for Mandate: available columns with display labels and data types, supported filter operators, default sort order, presets, and quick filters. Use this to dynamically build query UIs without hardcoding column definitions.",
+        "operationId": "GetMandateMeta",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/QueryMetadata"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sepa-direct-debit/configuration": {
+      "get": {
+        "tags": ["SEPA Direct Debit - Configuration"],
+        "summary": "Returns the current tenant's SEPA Direct Debit configuration.",
+        "description": "Fetches the tenant's Creditor Identifier (SCI), scheme and provider defaults, and active flag. Returns 404 when SEPA has not been configured for the tenant. Requires the SepaDirectDebit.Configuration.Manage permission.",
+        "operationId": "GetSepaConfiguration",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SepaConfigurationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["SEPA Direct Debit - Configuration"],
+        "summary": "Creates or updates the current tenant's SEPA Direct Debit configuration.",
+        "description": "Upserts the tenant's SEPA configuration (one per tenant). The Creditor Identifier (SCI) is locked once the tenant has mandates: changing it then returns 409, as it requires a SEPA mandate migration rather than an in-place edit. Requires the SepaDirectDebit.Configuration.Manage permission.",
+        "operationId": "UpsertSepaConfiguration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SepaConfigurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SepaConfigurationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "CollectionStatus": {
+        "enum": ["Pending", "Submitted", "Processing", "Succeeded", "Failed", "Refunded"]
+      },
+      "ColumnDefinition": {
+        "required": [
+          "name",
+          "label",
+          "type",
+          "order",
+          "isSortable",
+          "isFilterable",
+          "isVisible",
+          "format"
+        ],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "isSortable": {
+            "type": "boolean"
+          },
+          "isFilterable": {
+            "type": "boolean"
+          },
+          "isVisible": {
+            "type": "boolean"
+          },
+          "format": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "ConfirmMandateRequest": {
+        "required": ["signedAt"],
+        "type": "object",
+        "properties": {
+          "signedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "documentReference": {
+            "maxLength": 128,
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "ConsentEvidence": {
+        "type": "object",
+        "properties": {
+          "signedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "source": {
+            "$ref": "#/components/schemas/ConsentSource"
+          },
+          "sourceIpMasked": {
+            "type": ["null", "string"]
+          },
+          "actor": {
+            "type": ["null", "string"]
+          },
+          "actorKind": {
+            "type": ["null", "string"]
+          },
+          "documentReference": {
+            "type": ["null", "string"]
+          },
+          "userAgent": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "ConsentSource": {
+        "enum": ["AdminConfirm", "ProviderWebhook", "CustomerSelfService"]
+      },
+      "CreateMandateRequest": {
+        "required": ["debtorPartyId", "debtorName", "debtorIban"],
+        "type": "object",
+        "properties": {
+          "debtorPartyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "debtorName": {
+            "maxLength": 70,
+            "type": "string"
+          },
+          "debtorIban": {
+            "type": "string",
+            "x-granit-validator": "Validation:Format:Iban"
+          },
+          "debtorBic": {
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:BicSwift"
+          },
+          "scheme": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SddScheme"
+              }
+            ]
+          },
+          "providerName": {
+            "maxLength": 64,
+            "type": ["null", "string"]
+          },
+          "redirectUrl": {
+            "maxLength": 2048,
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:UrlHttps"
+          }
+        }
+      },
+      "DateFilterMeta": {
+        "required": ["name", "defaultPeriod", "availablePeriods"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "defaultPeriod": {
+            "$ref": "#/components/schemas/DatePeriod"
+          },
+          "availablePeriods": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DatePeriod"
+            }
+          }
+        }
+      },
+      "DatePeriod": {
+        "enum": ["Today", "ThisWeek", "ThisMonth", "LastMonth", "ThisQuarter", "ThisYear", "Custom"]
+      },
+      "DirectDebitPayment": {
+        "type": "object",
+        "properties": {
+          "invoiceId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "amount": {
+            "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+            "type": ["number", "string"],
+            "format": "double"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/CollectionStatus"
+          },
+          "scheduledDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "submittedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "settledAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "failureCode": {
+            "type": ["null", "string"]
+          },
+          "failureReason": {
+            "type": ["null", "string"]
+          },
+          "providerCollectionId": {
+            "type": ["null", "string"]
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "FilterableField": {
+        "required": ["name", "type", "operators"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "operators": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterOperator"
+            }
+          },
+          "enumValues": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          },
+          "lookup": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/LookupDescriptor"
+              }
+            ]
+          }
+        }
+      },
+      "FilterGroupMeta": {
+        "required": ["name", "label", "presets"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "presets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PresetMeta"
+            }
+          }
+        }
+      },
+      "FilterOperator": {
+        "enum": [
+          "Eq",
+          "Contains",
+          "StartsWith",
+          "EndsWith",
+          "Gt",
+          "Gte",
+          "Lt",
+          "Lte",
+          "In",
+          "Between"
+        ]
+      },
+      "GroupByField": {
+        "required": ["name", "type"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "GroupedResultOfMandate": {
+        "required": ["groups", "totalCount"],
+        "type": "object",
+        "properties": {
+          "groups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupEntryOfMandate"
+            }
+          },
+          "totalCount": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "GroupEntryOfMandate": {
+        "required": ["field", "value", "label", "count"],
+        "type": "object",
+        "properties": {
+          "field": {
+            "type": "string"
+          },
+          "value": {},
+          "label": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "aggregates": {
+            "type": ["null", "object"]
+          },
+          "items": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/Mandate"
+            }
+          }
+        }
+      },
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "IDomainEvent": {
+        "type": "object",
+        "description": "Marker interface for domain events."
+      },
+      "IIntegrationEvent": {
+        "type": "object",
+        "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+      },
+      "LookupDescriptor": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": ["null", "string"]
+          },
+          "endpoint": {
+            "type": ["null", "string"]
+          },
+          "kind": {
+            "$ref": "#/components/schemas/LookupKind"
+          },
+          "requiredPermission": {
+            "type": ["null", "string"]
+          },
+          "searchParam": {
+            "type": ["null", "string"],
+            "default": "search"
+          },
+          "scopeKeys": {
+            "type": ["null", "array"],
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "LookupKind": {
+        "enum": ["QueryEngine", "Simple", "ReferenceData", "Enum"],
+        "default": "QueryEngine"
+      },
+      "Mandate": {
+        "type": "object",
+        "properties": {
+          "mandateReference": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MandateStatus"
+          },
+          "scheme": {
+            "$ref": "#/components/schemas/SddScheme"
+          },
+          "debtorName": {
+            "type": "string"
+          },
+          "debtorIban": {
+            "type": "string"
+          },
+          "debtorBic": {
+            "type": ["null", "string"]
+          },
+          "creditorId": {
+            "type": "string"
+          },
+          "debtorPartyId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "debtorBankAccountId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "signedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "activatedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cancelledAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "lastCollectionAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "providerName": {
+            "type": ["null", "string"]
+          },
+          "providerMandateId": {
+            "type": ["null", "string"]
+          },
+          "consent": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ConsentEvidence"
+              }
+            ]
+          },
+          "activationSource": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ConsentSource"
+              }
+            ]
+          },
+          "collections": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/DirectDebitPayment"
+            }
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "concurrencyStamp": {
+            "type": "string"
+          },
+          "modifiedAt": {
+            "type": ["null", "string"],
+            "description": "Last modification timestamp (UTC).",
+            "format": "date-time"
+          },
+          "modifiedBy": {
+            "type": ["null", "string"],
+            "description": "Identifier of the user who last modified the entity."
+          },
+          "domainEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IDomainEvent"
+            }
+          },
+          "integrationEvents": {
+            "type": ["null", "array"],
+            "items": {
+              "$ref": "#/components/schemas/IIntegrationEvent"
+            }
+          },
+          "createdAt": {
+            "type": "string",
+            "description": "Creation timestamp (UTC).",
+            "format": "date-time"
+          },
+          "createdBy": {
+            "type": "string",
+            "description": "Identifier of the user who created the entity."
+          },
+          "id": {
+            "type": "string",
+            "description": "Unique identifier of the entity.",
+            "format": "uuid"
+          }
+        }
+      },
+      "MandateResponse": {
+        "required": [
+          "id",
+          "mandateReference",
+          "status",
+          "scheme",
+          "debtorName",
+          "debtorIbanMasked",
+          "creditorId",
+          "providerName",
+          "providerMandateId",
+          "signedAt",
+          "activatedAt",
+          "cancelledAt",
+          "tenantId",
+          "concurrencyStamp"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "mandateReference": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MandateStatus"
+          },
+          "scheme": {
+            "$ref": "#/components/schemas/SddScheme"
+          },
+          "debtorName": {
+            "type": "string"
+          },
+          "debtorIbanMasked": {
+            "type": "string"
+          },
+          "creditorId": {
+            "type": "string"
+          },
+          "providerName": {
+            "type": ["null", "string"]
+          },
+          "providerMandateId": {
+            "type": ["null", "string"]
+          },
+          "signedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "activatedAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "cancelledAt": {
+            "type": ["null", "string"],
+            "format": "date-time"
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "concurrencyStamp": {
+            "type": "string"
+          }
+        }
+      },
+      "MandateSetupResponse": {
+        "required": ["id", "mandateReference", "status", "redirectUrl"],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "mandateReference": {
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/MandateStatus"
+          },
+          "redirectUrl": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "MandateStatus": {
+        "enum": ["Pending", "Active", "Suspended", "Cancelled", "Failed", "Expired"]
+      },
+      "PagedResultOfMandate": {
+        "required": ["items", "totalCount", "hasMore"],
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "mandateReference": {
+                  "type": "string"
+                },
+                "status": {
+                  "enum": ["Pending", "Active", "Suspended", "Cancelled", "Failed", "Expired"]
+                },
+                "scheme": {
+                  "enum": ["Core", "B2B"]
+                },
+                "debtorName": {
+                  "type": "string"
+                },
+                "debtorIban": {
+                  "type": "string"
+                },
+                "debtorBic": {
+                  "type": ["null", "string"]
+                },
+                "creditorId": {
+                  "type": "string"
+                },
+                "debtorPartyId": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "debtorBankAccountId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "signedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "activatedAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "cancelledAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "lastCollectionAt": {
+                  "type": ["null", "string"],
+                  "format": "date-time"
+                },
+                "providerName": {
+                  "type": ["null", "string"]
+                },
+                "providerMandateId": {
+                  "type": ["null", "string"]
+                },
+                "consent": {
+                  "type": "object",
+                  "properties": {
+                    "signedAt": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "source": {
+                      "enum": ["AdminConfirm", "ProviderWebhook", "CustomerSelfService"]
+                    },
+                    "sourceIpMasked": {
+                      "type": ["null", "string"]
+                    },
+                    "actor": {
+                      "type": ["null", "string"]
+                    },
+                    "actorKind": {
+                      "type": ["null", "string"]
+                    },
+                    "documentReference": {
+                      "type": ["null", "string"]
+                    },
+                    "userAgent": {
+                      "type": ["null", "string"]
+                    }
+                  }
+                },
+                "activationSource": {
+                  "enum": ["AdminConfirm", "ProviderWebhook", "CustomerSelfService", null]
+                },
+                "collections": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "invoiceId": {
+                        "type": "string",
+                        "format": "uuid"
+                      },
+                      "amount": {
+                        "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
+                        "type": ["number", "string"],
+                        "format": "double"
+                      },
+                      "currency": {
+                        "type": "string"
+                      },
+                      "status": {
+                        "enum": [
+                          "Pending",
+                          "Submitted",
+                          "Processing",
+                          "Succeeded",
+                          "Failed",
+                          "Refunded"
+                        ]
+                      },
+                      "scheduledDate": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "submittedAt": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "settledAt": {
+                        "type": ["null", "string"],
+                        "format": "date-time"
+                      },
+                      "failureCode": {
+                        "type": ["null", "string"]
+                      },
+                      "failureReason": {
+                        "type": ["null", "string"]
+                      },
+                      "providerCollectionId": {
+                        "type": ["null", "string"]
+                      },
+                      "id": {
+                        "type": "string",
+                        "description": "Unique identifier of the entity.",
+                        "format": "uuid"
+                      }
+                    }
+                  }
+                },
+                "tenantId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
+                "concurrencyStamp": {
+                  "type": "string"
+                },
+                "modifiedAt": {
+                  "type": ["null", "string"],
+                  "description": "Last modification timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "modifiedBy": {
+                  "type": ["null", "string"],
+                  "description": "Identifier of the user who last modified the entity."
+                },
+                "domainEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for domain events."
+                  }
+                },
+                "integrationEvents": {
+                  "type": ["null", "array"],
+                  "items": {
+                    "type": "object",
+                    "description": "Marker interface for integration events (ETO — Event Transfer Object)."
+                  }
+                },
+                "createdAt": {
+                  "type": "string",
+                  "description": "Creation timestamp (UTC).",
+                  "format": "date-time"
+                },
+                "createdBy": {
+                  "type": "string",
+                  "description": "Identifier of the user who created the entity."
+                },
+                "id": {
+                  "type": "string",
+                  "description": "Unique identifier of the entity.",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "totalCount": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "hasMore": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "PaginationMeta": {
+        "required": ["defaultPageSize", "maxPageSize", "maxStreamSize", "supportsCursor"],
+        "type": "object",
+        "properties": {
+          "defaultPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxPageSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "maxStreamSize": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "supportsCursor": {
+            "type": "boolean"
+          }
+        }
+      },
+      "PresetMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "QueryMetadata": {
+        "required": [
+          "columns",
+          "filterableFields",
+          "sortableFields",
+          "presetFilterGroups",
+          "quickFilters",
+          "dateFilters",
+          "groupByFields",
+          "pagination"
+        ],
+        "type": "object",
+        "properties": {
+          "columns": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ColumnDefinition"
+            }
+          },
+          "filterableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterableField"
+            }
+          },
+          "sortableFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SortableField"
+            }
+          },
+          "presetFilterGroups": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FilterGroupMeta"
+            }
+          },
+          "quickFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/QuickFilterMeta"
+            }
+          },
+          "dateFilters": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DateFilterMeta"
+            }
+          },
+          "groupByFields": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroupByField"
+            }
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "defaultSort": {
+            "type": ["null", "string"]
+          }
+        }
+      },
+      "QuickFilterMeta": {
+        "required": ["name", "label", "isDefault"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "isDefault": {
+            "type": "boolean"
+          }
+        }
+      },
+      "SddScheme": {
+        "enum": ["Core", "B2B", null]
+      },
+      "SepaConfigurationRequest": {
+        "required": ["creditorId", "defaultScheme"],
+        "type": "object",
+        "properties": {
+          "creditorId": {
+            "maxLength": 35,
+            "type": "string",
+            "x-granit-validator": "Validation:Format:SepaCreditorIdentifier"
+          },
+          "defaultScheme": {
+            "$ref": "#/components/schemas/SddScheme"
+          },
+          "creditorName": {
+            "maxLength": 70,
+            "type": ["null", "string"]
+          },
+          "defaultProviderName": {
+            "maxLength": 64,
+            "type": ["null", "string"]
+          },
+          "isActive": {
+            "type": "boolean",
+            "default": true
+          },
+          "companyPartyId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "creditorIban": {
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:Iban"
+          },
+          "creditorBic": {
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:BicSwift"
+          }
+        }
+      },
+      "SepaConfigurationResponse": {
+        "required": [
+          "creditorId",
+          "creditorName",
+          "defaultScheme",
+          "defaultProviderName",
+          "isActive",
+          "companyPartyId",
+          "creditorIbanMasked",
+          "creditorBic",
+          "tenantId",
+          "concurrencyStamp"
+        ],
+        "type": "object",
+        "properties": {
+          "creditorId": {
+            "type": "string"
+          },
+          "creditorName": {
+            "type": ["null", "string"]
+          },
+          "defaultScheme": {
+            "$ref": "#/components/schemas/SddScheme"
+          },
+          "defaultProviderName": {
+            "type": ["null", "string"]
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "companyPartyId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "creditorIbanMasked": {
+            "type": ["null", "string"]
+          },
+          "creditorBic": {
+            "type": ["null", "string"]
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "concurrencyStamp": {
+            "type": "string"
+          }
+        }
+      },
+      "SortableField": {
+        "required": ["name"],
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "SEPA Direct Debit - Configuration"
+    },
+    {
+      "name": "SEPA Direct Debit - Mandates"
+    }
+  ]
+}

--- a/contracts/openapi/sepa-transfer.json
+++ b/contracts/openapi/sepa-transfer.json
@@ -1,0 +1,263 @@
+{
+  "openapi": "3.1.1",
+  "info": {
+    "title": "sepa-transfer",
+    "version": "1"
+  },
+  "paths": {
+    "/sepa-transfer/configuration": {
+      "get": {
+        "tags": ["SEPA Transfer"],
+        "summary": "Returns the current tenant's SEPA bank transfer configuration.",
+        "description": "Fetches the tenant's beneficiary account (masked IBAN), beneficiary name and active flag. Returns 404 when SEPA transfer has not been configured for the tenant. Requires the SepaTransfer.Configuration.Manage permission.",
+        "operationId": "GetSepaTransferConfiguration",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SepaTransferConfigurationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["SEPA Transfer"],
+        "summary": "Creates or updates the current tenant's SEPA bank transfer configuration.",
+        "description": "Upserts the tenant's SEPA transfer configuration (one per tenant). When a beneficiary IBAN is supplied, the account is provisioned into the BankAccounts referential on the company Party and stamped onto the configuration. Requires the SepaTransfer.Configuration.Manage permission.",
+        "operationId": "UpsertSepaTransferConfiguration",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SepaTransferConfigurationRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SepaTransferConfigurationResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HttpValidationProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "HttpValidationProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": ["null", "string"]
+          },
+          "title": {
+            "type": ["null", "string"]
+          },
+          "status": {
+            "type": ["null", "integer"],
+            "format": "int32"
+          },
+          "detail": {
+            "type": ["null", "string"]
+          },
+          "instance": {
+            "type": ["null", "string"]
+          },
+          "errors": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ProblemDetails": {
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "description": "A URI reference that identifies the problem type."
+          },
+          "title": {
+            "type": "string",
+            "description": "A short, human-readable summary of the problem type."
+          },
+          "status": {
+            "type": "integer",
+            "description": "The HTTP status code."
+          },
+          "detail": {
+            "type": "string",
+            "description": "A human-readable explanation specific to this occurrence."
+          },
+          "instance": {
+            "type": "string",
+            "description": "A URI reference that identifies the specific occurrence."
+          }
+        }
+      },
+      "SepaTransferConfigurationRequest": {
+        "type": "object",
+        "properties": {
+          "beneficiaryName": {
+            "maxLength": 70,
+            "type": ["null", "string"]
+          },
+          "isActive": {
+            "type": "boolean",
+            "default": true
+          },
+          "companyPartyId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "beneficiaryIban": {
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:Iban"
+          },
+          "beneficiaryBic": {
+            "type": ["null", "string"],
+            "x-granit-validator": "Validation:Format:BicSwift"
+          }
+        }
+      },
+      "SepaTransferConfigurationResponse": {
+        "required": [
+          "beneficiaryName",
+          "isActive",
+          "companyPartyId",
+          "beneficiaryIbanMasked",
+          "beneficiaryBic",
+          "tenantId",
+          "concurrencyStamp"
+        ],
+        "type": "object",
+        "properties": {
+          "beneficiaryName": {
+            "type": ["null", "string"]
+          },
+          "isActive": {
+            "type": "boolean"
+          },
+          "companyPartyId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "beneficiaryIbanMasked": {
+            "type": ["null", "string"]
+          },
+          "beneficiaryBic": {
+            "type": ["null", "string"]
+          },
+          "tenantId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
+          "concurrencyStamp": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "SEPA Transfer"
+    }
+  ]
+}

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -267,4 +267,28 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'SiteHostnameCreateRequest',
     ],
   },
+  {
+    slug: 'sepa-transfer',
+    package: 'payments-sepa-transfer',
+    types: ['SepaTransferConfigurationRequest', 'SepaTransferConfigurationResponse'],
+    checkEndpoints: true,
+  },
+  {
+    // The mandate admin grid (GET /mandates + /mandates/meta) is served by the
+    // query-engine generic surface, not by an api/ function — ignore those
+    // routes (POST /mandates create shares the route, so it is unchecked here
+    // but covered by the package's own unit tests).
+    slug: 'sepa-direct-debit',
+    package: 'payments-sepa-direct-debit',
+    types: [
+      'CreateMandateRequest',
+      'ConfirmMandateRequest',
+      'MandateSetupResponse',
+      'MandateResponse',
+      'SepaConfigurationRequest',
+      'SepaConfigurationResponse',
+    ],
+    checkEndpoints: true,
+    endpointIgnore: ['/mandates', '/mandates/meta'],
+  },
 ];

--- a/packages/@granit/payments-sepa-direct-debit/README.md
+++ b/packages/@granit/payments-sepa-direct-debit/README.md
@@ -1,0 +1,3 @@
+# @granit/payments-sepa-direct-debit
+
+SEPA Direct Debit types and API functions — mandate lifecycle (setup, confirm, cancel, read) and per-tenant SEPA configuration (Creditor Identifier and scheme defaults).

--- a/packages/@granit/payments-sepa-direct-debit/package.json
+++ b/packages/@granit/payments-sepa-direct-debit/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/payments-sepa-direct-debit",
+  "description": "SEPA Direct Debit — mandate lifecycle and per-tenant SEPA configuration types and API functions",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/payments-sepa-direct-debit/src/__tests__/sepa-direct-debit-api.test.ts
+++ b/packages/@granit/payments-sepa-direct-debit/src/__tests__/sepa-direct-debit-api.test.ts
@@ -1,0 +1,160 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  cancelMandate,
+  confirmMandate,
+  createMandate,
+  getMandate,
+  getSepaConfiguration,
+  upsertSepaConfiguration,
+} from '../api/sepa-direct-debit-api';
+
+import type {
+  ConfirmMandateRequest,
+  CreateMandateRequest,
+  MandateResponse,
+  MandateSetupResponse,
+  SepaConfigurationRequest,
+  SepaConfigurationResponse,
+} from '../types/index';
+
+const basePath = '/sepa-direct-debit';
+
+const sampleMandate: MandateResponse = {
+  id: 'mdt-1',
+  mandateReference: 'RUM-0001',
+  status: 'Active',
+  scheme: 'Core',
+  debtorName: 'Alice Martin',
+  debtorIbanMasked: 'BE** **** **** 1234',
+  creditorId: 'BE68ZZZ0123456789',
+  providerName: 'GoCardless',
+  providerMandateId: 'MD0001',
+  signedAt: '2026-05-01T10:00:00Z',
+  activatedAt: '2026-05-01T10:05:00Z',
+  cancelledAt: null,
+  tenantId: null,
+  concurrencyStamp: 'stamp-1',
+};
+
+const sampleSetup: MandateSetupResponse = {
+  id: 'mdt-1',
+  mandateReference: 'RUM-0001',
+  status: 'Pending',
+  redirectUrl: 'https://pay.gocardless.com/flow/abc',
+};
+
+const sampleConfiguration: SepaConfigurationResponse = {
+  creditorId: 'BE68ZZZ0123456789',
+  creditorName: 'Acme NV',
+  defaultScheme: 'Core',
+  defaultProviderName: 'GoCardless',
+  isActive: true,
+  companyPartyId: null,
+  creditorIbanMasked: 'BE** **** **** 9999',
+  creditorBic: 'GEBABEBB',
+  tenantId: null,
+  concurrencyStamp: 'stamp-cfg',
+};
+
+describe('sepa-direct-debit-api', () => {
+  describe('createMandate', () => {
+    it('should POST {basePath}/mandates and return the setup response', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleSetup));
+      const request: CreateMandateRequest = {
+        debtorPartyId: 'party-1',
+        debtorName: 'Alice Martin',
+        debtorIban: 'BE68539007547034',
+      };
+
+      const result = await createMandate(client, basePath, request);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/mandates`, request);
+      expect(result).toEqual(sampleSetup);
+    });
+  });
+
+  describe('getMandate', () => {
+    it('should GET {basePath}/mandates/{id}', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleMandate));
+
+      const result = await getMandate(client, basePath, 'mdt-1');
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/mandates/mdt-1`);
+      expect(result).toEqual(sampleMandate);
+    });
+
+    it('should encode id with special characters', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleMandate));
+
+      await getMandate(client, basePath, 'mdt/special@id');
+
+      expect(client.get).toHaveBeenCalledWith(
+        `${basePath}/mandates/${encodeURIComponent('mdt/special@id')}`
+      );
+    });
+  });
+
+  describe('confirmMandate', () => {
+    it('should POST {basePath}/mandates/{id}/confirm with the signature payload', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(axiosResponse(sampleMandate));
+      const request: ConfirmMandateRequest = { signedAt: '2026-05-01T10:00:00Z' };
+
+      const result = await confirmMandate(client, basePath, 'mdt-1', request);
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/mandates/mdt-1/confirm`, request);
+      expect(result).toEqual(sampleMandate);
+    });
+  });
+
+  describe('cancelMandate', () => {
+    it('should POST {basePath}/mandates/{id}/cancel', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue(
+        axiosResponse({
+          ...sampleMandate,
+          status: 'Cancelled',
+          cancelledAt: '2026-06-01T00:00:00Z',
+        })
+      );
+
+      const result = await cancelMandate(client, basePath, 'mdt-1');
+
+      expect(client.post).toHaveBeenCalledWith(`${basePath}/mandates/mdt-1/cancel`);
+      expect(result.status).toBe('Cancelled');
+    });
+  });
+
+  describe('getSepaConfiguration', () => {
+    it('should GET {basePath}/configuration', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleConfiguration));
+
+      const result = await getSepaConfiguration(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/configuration`);
+      expect(result).toEqual(sampleConfiguration);
+    });
+  });
+
+  describe('upsertSepaConfiguration', () => {
+    it('should PUT {basePath}/configuration', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleConfiguration));
+      const request: SepaConfigurationRequest = {
+        creditorId: 'BE68ZZZ0123456789',
+        defaultScheme: 'Core',
+      };
+
+      const result = await upsertSepaConfiguration(client, basePath, request);
+
+      expect(client.put).toHaveBeenCalledWith(`${basePath}/configuration`, request);
+      expect(result).toEqual(sampleConfiguration);
+    });
+  });
+});

--- a/packages/@granit/payments-sepa-direct-debit/src/api/sepa-direct-debit-api.ts
+++ b/packages/@granit/payments-sepa-direct-debit/src/api/sepa-direct-debit-api.ts
@@ -1,0 +1,117 @@
+import type {
+  ConfirmMandateRequest,
+  CreateMandateRequest,
+  MandateResponse,
+  MandateSetupResponse,
+  SepaConfigurationRequest,
+  SepaConfigurationResponse,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Set up a SEPA Direct Debit mandate for the current tenant.
+ *
+ * `POST {basePath}/mandates` → 201 Created
+ *
+ * Returns the new mandate (Pending) together with any provider-hosted signature
+ * URL. The backend returns 409 when the tenant has no active SEPA configuration.
+ */
+export async function createMandate(
+  client: AxiosInstance,
+  basePath: string,
+  request: CreateMandateRequest
+): Promise<MandateSetupResponse> {
+  const response = await client.post<MandateSetupResponse>(`${basePath}/mandates`, request);
+  return response.data;
+}
+
+/**
+ * Get a single mandate by ID. The debtor IBAN is masked.
+ *
+ * `GET {basePath}/mandates/{id}`
+ */
+export async function getMandate(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<MandateResponse> {
+  const response = await client.get<MandateResponse>(
+    `${basePath}/mandates/${encodeURIComponent(id)}`
+  );
+  return response.data;
+}
+
+/**
+ * Confirm (activate) a pending mandate after the debtor's signature.
+ *
+ * `POST {basePath}/mandates/{id}/confirm`
+ *
+ * Confirming a provider-backed mandate requires the
+ * `SepaDirectDebit.Mandates.ConfirmOverride` permission (such mandates normally
+ * activate via the provider's verified flow); the backend returns 403 otherwise.
+ */
+export async function confirmMandate(
+  client: AxiosInstance,
+  basePath: string,
+  id: string,
+  request: ConfirmMandateRequest
+): Promise<MandateResponse> {
+  const response = await client.post<MandateResponse>(
+    `${basePath}/mandates/${encodeURIComponent(id)}/confirm`,
+    request
+  );
+  return response.data;
+}
+
+/**
+ * Cancel (revoke) a mandate.
+ *
+ * `POST {basePath}/mandates/{id}/cancel`
+ *
+ * The backend returns 409 when the mandate is already in a terminal status.
+ */
+export async function cancelMandate(
+  client: AxiosInstance,
+  basePath: string,
+  id: string
+): Promise<MandateResponse> {
+  const response = await client.post<MandateResponse>(
+    `${basePath}/mandates/${encodeURIComponent(id)}/cancel`
+  );
+  return response.data;
+}
+
+/**
+ * Get the current tenant's SEPA Direct Debit configuration.
+ *
+ * `GET {basePath}/configuration`
+ *
+ * The backend returns 404 when SEPA has not been configured for the tenant.
+ */
+export async function getSepaConfiguration(
+  client: AxiosInstance,
+  basePath: string
+): Promise<SepaConfigurationResponse> {
+  const response = await client.get<SepaConfigurationResponse>(`${basePath}/configuration`);
+  return response.data;
+}
+
+/**
+ * Create or update the current tenant's SEPA Direct Debit configuration.
+ *
+ * `PUT {basePath}/configuration`
+ *
+ * The Creditor Identifier (SCI) is locked once the tenant has mandates: changing
+ * it then returns 409 (it requires a SEPA mandate migration, not an in-place edit).
+ */
+export async function upsertSepaConfiguration(
+  client: AxiosInstance,
+  basePath: string,
+  request: SepaConfigurationRequest
+): Promise<SepaConfigurationResponse> {
+  const response = await client.put<SepaConfigurationResponse>(
+    `${basePath}/configuration`,
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/payments-sepa-direct-debit/src/index.ts
+++ b/packages/@granit/payments-sepa-direct-debit/src/index.ts
@@ -1,0 +1,26 @@
+// Types
+export type {
+  ConfirmMandateRequest,
+  ConsentEvidence,
+  CreateMandateRequest,
+  DirectDebitPayment,
+  Mandate,
+  MandateResponse,
+  MandateSetupResponse,
+  SepaConfigurationRequest,
+  SepaConfigurationResponse,
+} from './types/index';
+export type { CollectionStatus, ConsentSource, MandateStatus, SddScheme } from './types/index';
+
+// Permissions
+export { SepaDirectDebitPermissions } from './permissions';
+
+// API
+export {
+  cancelMandate,
+  confirmMandate,
+  createMandate,
+  getMandate,
+  getSepaConfiguration,
+  upsertSepaConfiguration,
+} from './api/sepa-direct-debit-api';

--- a/packages/@granit/payments-sepa-direct-debit/src/permissions.ts
+++ b/packages/@granit/payments-sepa-direct-debit/src/permissions.ts
@@ -1,0 +1,20 @@
+/**
+ * SEPA Direct Debit permissions. A dedicated group (distinct from `Payments`):
+ * SEPA Direct Debit legally engages the company, so the SEPA / treasury
+ * administrator role is commonly separate from the generic payments administrator.
+ *
+ * Mirrors the backend `SepaDirectDebitPermissions`.
+ */
+export const SepaDirectDebitPermissions = {
+  Mandates: {
+    Read: 'SepaDirectDebit.Mandates.Read',
+    Create: 'SepaDirectDebit.Mandates.Create',
+    Confirm: 'SepaDirectDebit.Mandates.Confirm',
+    /** Override a provider-backed mandate's activation by hand (audited). */
+    ConfirmOverride: 'SepaDirectDebit.Mandates.ConfirmOverride',
+    Cancel: 'SepaDirectDebit.Mandates.Cancel',
+  },
+  Configuration: {
+    Manage: 'SepaDirectDebit.Configuration.Manage',
+  },
+} as const;

--- a/packages/@granit/payments-sepa-direct-debit/src/types/index.ts
+++ b/packages/@granit/payments-sepa-direct-debit/src/types/index.ts
@@ -1,0 +1,157 @@
+/** Lifecycle status of a SEPA Direct Debit mandate. */
+export type MandateStatus = 'Pending' | 'Active' | 'Suspended' | 'Cancelled' | 'Failed' | 'Expired';
+
+/** SEPA Direct Debit scheme. `Core` for consumers, `B2B` for businesses. */
+export type SddScheme = 'Core' | 'B2B';
+
+/** How a mandate's consent was captured. */
+export type ConsentSource = 'AdminConfirm' | 'ProviderWebhook' | 'CustomerSelfService';
+
+/** Settlement status of a single direct-debit collection. */
+export type CollectionStatus =
+  | 'Pending'
+  | 'Submitted'
+  | 'Processing'
+  | 'Succeeded'
+  | 'Failed'
+  | 'Refunded';
+
+/**
+ * Set up a new mandate for a debtor. The debtor IBAN is validated server-side
+ * and never echoed back unmasked.
+ */
+export interface CreateMandateRequest {
+  readonly debtorPartyId: string;
+  readonly debtorName: string;
+  readonly debtorIban: string;
+  readonly debtorBic?: string | null;
+  /** Override the tenant's default scheme for this mandate. */
+  readonly scheme?: SddScheme | null;
+  /** Override the tenant's default provider for this mandate. */
+  readonly providerName?: string | null;
+  /** Where the provider redirects after a hosted signature flow. */
+  readonly redirectUrl?: string | null;
+}
+
+/** Confirm (activate) a pending mandate after the debtor's signature. */
+export interface ConfirmMandateRequest {
+  /** When the debtor signed (ISO 8601). */
+  readonly signedAt: string;
+  /** Reference to the stored signed document, when activation is overridden. */
+  readonly documentReference?: string | null;
+}
+
+/**
+ * Result of {@link CreateMandateRequest}. `redirectUrl` is present when the
+ * provider hosts the signature flow; `null` for in-house confirmation.
+ */
+export interface MandateSetupResponse {
+  readonly id: string;
+  readonly mandateReference: string;
+  readonly status: MandateStatus;
+  readonly redirectUrl: string | null;
+}
+
+/** A mandate, with the debtor IBAN masked. */
+export interface MandateResponse {
+  readonly id: string;
+  readonly mandateReference: string;
+  readonly status: MandateStatus;
+  readonly scheme: SddScheme;
+  readonly debtorName: string;
+  readonly debtorIbanMasked: string;
+  readonly creditorId: string;
+  readonly providerName: string | null;
+  readonly providerMandateId: string | null;
+  readonly signedAt: string | null;
+  readonly activatedAt: string | null;
+  readonly cancelledAt: string | null;
+  readonly tenantId: string | null;
+  readonly concurrencyStamp: string;
+}
+
+/** Create or update the tenant's SEPA Direct Debit configuration. */
+export interface SepaConfigurationRequest {
+  /** Creditor Identifier (SCI). Locked once the tenant has mandates. */
+  readonly creditorId: string;
+  readonly defaultScheme: SddScheme;
+  readonly creditorName?: string | null;
+  readonly defaultProviderName?: string | null;
+  readonly isActive?: boolean;
+  readonly companyPartyId?: string | null;
+  readonly creditorIban?: string | null;
+  readonly creditorBic?: string | null;
+}
+
+/** The tenant's SEPA Direct Debit configuration, with the creditor IBAN masked. */
+export interface SepaConfigurationResponse {
+  readonly creditorId: string;
+  readonly creditorName: string | null;
+  readonly defaultScheme: SddScheme;
+  readonly defaultProviderName: string | null;
+  readonly isActive: boolean;
+  readonly companyPartyId: string | null;
+  readonly creditorIbanMasked: string | null;
+  readonly creditorBic: string | null;
+  readonly tenantId: string | null;
+  readonly concurrencyStamp: string;
+}
+
+/** Verifiable consent evidence captured when a mandate is activated. */
+export interface ConsentEvidence {
+  readonly signedAt?: string;
+  readonly source?: ConsentSource;
+  readonly sourceIpMasked?: string | null;
+  readonly actor?: string | null;
+  readonly actorKind?: string | null;
+  readonly documentReference?: string | null;
+  readonly userAgent?: string | null;
+}
+
+/** A single collection (debit) executed against a mandate. */
+export interface DirectDebitPayment {
+  readonly id?: string;
+  readonly invoiceId?: string;
+  readonly amount?: number;
+  readonly currency?: string;
+  readonly status?: CollectionStatus;
+  readonly scheduledDate?: string;
+  readonly submittedAt?: string | null;
+  readonly settledAt?: string | null;
+  readonly failureCode?: string | null;
+  readonly failureReason?: string | null;
+  readonly providerCollectionId?: string | null;
+}
+
+/**
+ * Mandate row as returned by the query-engine admin grid
+ * (`GET /sepa-direct-debit/mandates`). Richer than {@link MandateResponse}:
+ * carries consent evidence, activation source, and the collection history.
+ */
+export interface Mandate {
+  readonly id?: string;
+  readonly mandateReference?: string;
+  readonly status?: MandateStatus;
+  readonly scheme?: SddScheme;
+  readonly debtorName?: string;
+  readonly debtorIban?: string;
+  readonly debtorBic?: string | null;
+  readonly creditorId?: string;
+  readonly debtorPartyId?: string;
+  readonly debtorBankAccountId?: string | null;
+  readonly signedAt?: string | null;
+  readonly activatedAt?: string | null;
+  readonly cancelledAt?: string | null;
+  readonly lastCollectionAt?: string | null;
+  readonly providerName?: string | null;
+  readonly providerMandateId?: string | null;
+  readonly consent?: ConsentEvidence | null;
+  readonly activationSource?: ConsentSource | null;
+  readonly collections?: readonly DirectDebitPayment[] | null;
+  readonly tenantId?: string | null;
+  readonly concurrencyStamp?: string;
+  readonly modifiedAt?: string | null;
+  readonly modifiedBy?: string | null;
+  readonly createdAt?: string;
+  readonly createdBy?: string;
+}

--- a/packages/@granit/payments-sepa-direct-debit/tsconfig.json
+++ b/packages/@granit/payments-sepa-direct-debit/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/payments-sepa-direct-debit/tsup.config.ts
+++ b/packages/@granit/payments-sepa-direct-debit/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/payments-sepa-transfer/README.md
+++ b/packages/@granit/payments-sepa-transfer/README.md
@@ -1,0 +1,3 @@
+# @granit/payments-sepa-transfer
+
+SEPA bank transfer types and API functions — per-tenant beneficiary configuration (masked IBAN/BIC upsert).

--- a/packages/@granit/payments-sepa-transfer/package.json
+++ b/packages/@granit/payments-sepa-transfer/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@granit/payments-sepa-transfer",
+  "description": "SEPA bank transfer — per-tenant beneficiary configuration types and API functions",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/testing": "workspace:*"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  }
+}

--- a/packages/@granit/payments-sepa-transfer/src/__tests__/sepa-transfer-api.test.ts
+++ b/packages/@granit/payments-sepa-transfer/src/__tests__/sepa-transfer-api.test.ts
@@ -1,0 +1,54 @@
+import { axiosResponse, createMockClient } from '@granit/testing';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  getSepaTransferConfiguration,
+  upsertSepaTransferConfiguration,
+} from '../api/sepa-transfer-api';
+
+import type {
+  SepaTransferConfigurationRequest,
+  SepaTransferConfigurationResponse,
+} from '../types/index';
+
+const basePath = '/sepa-transfer';
+
+const sampleConfiguration: SepaTransferConfigurationResponse = {
+  beneficiaryName: 'Acme NV',
+  isActive: true,
+  companyPartyId: 'party-1',
+  beneficiaryIbanMasked: 'BE** **** **** 9999',
+  beneficiaryBic: 'GEBABEBB',
+  tenantId: null,
+  concurrencyStamp: 'stamp-1',
+};
+
+describe('sepa-transfer-api', () => {
+  describe('getSepaTransferConfiguration', () => {
+    it('should GET {basePath}/configuration', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue(axiosResponse(sampleConfiguration));
+
+      const result = await getSepaTransferConfiguration(client, basePath);
+
+      expect(client.get).toHaveBeenCalledWith(`${basePath}/configuration`);
+      expect(result).toEqual(sampleConfiguration);
+    });
+  });
+
+  describe('upsertSepaTransferConfiguration', () => {
+    it('should PUT {basePath}/configuration', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue(axiosResponse(sampleConfiguration));
+      const request: SepaTransferConfigurationRequest = {
+        beneficiaryName: 'Acme NV',
+        beneficiaryIban: 'BE68539007547034',
+      };
+
+      const result = await upsertSepaTransferConfiguration(client, basePath, request);
+
+      expect(client.put).toHaveBeenCalledWith(`${basePath}/configuration`, request);
+      expect(result).toEqual(sampleConfiguration);
+    });
+  });
+});

--- a/packages/@granit/payments-sepa-transfer/src/api/sepa-transfer-api.ts
+++ b/packages/@granit/payments-sepa-transfer/src/api/sepa-transfer-api.ts
@@ -1,0 +1,40 @@
+import type {
+  SepaTransferConfigurationRequest,
+  SepaTransferConfigurationResponse,
+} from '../types/index';
+import type { AxiosInstance } from '@granit/api-client';
+
+/**
+ * Get the current tenant's SEPA bank transfer configuration.
+ *
+ * `GET {basePath}/configuration`
+ *
+ * The backend returns 404 when SEPA transfer has not been configured for the tenant.
+ */
+export async function getSepaTransferConfiguration(
+  client: AxiosInstance,
+  basePath: string
+): Promise<SepaTransferConfigurationResponse> {
+  const response = await client.get<SepaTransferConfigurationResponse>(`${basePath}/configuration`);
+  return response.data;
+}
+
+/**
+ * Create or update the current tenant's SEPA bank transfer configuration.
+ *
+ * `PUT {basePath}/configuration`
+ *
+ * When a `beneficiaryIban` is supplied, the account is provisioned into the
+ * company's `BankAccounts` referential and stamped onto the configuration.
+ */
+export async function upsertSepaTransferConfiguration(
+  client: AxiosInstance,
+  basePath: string,
+  request: SepaTransferConfigurationRequest
+): Promise<SepaTransferConfigurationResponse> {
+  const response = await client.put<SepaTransferConfigurationResponse>(
+    `${basePath}/configuration`,
+    request
+  );
+  return response.data;
+}

--- a/packages/@granit/payments-sepa-transfer/src/index.ts
+++ b/packages/@granit/payments-sepa-transfer/src/index.ts
@@ -1,0 +1,14 @@
+// Types
+export type {
+  SepaTransferConfigurationRequest,
+  SepaTransferConfigurationResponse,
+} from './types/index';
+
+// Permissions
+export { SepaTransferPermissions } from './permissions';
+
+// API
+export {
+  getSepaTransferConfiguration,
+  upsertSepaTransferConfiguration,
+} from './api/sepa-transfer-api';

--- a/packages/@granit/payments-sepa-transfer/src/permissions.ts
+++ b/packages/@granit/payments-sepa-transfer/src/permissions.ts
@@ -1,0 +1,8 @@
+/**
+ * SEPA bank transfer permissions. Mirrors the backend `SepaTransferPermissions`.
+ */
+export const SepaTransferPermissions = {
+  Configuration: {
+    Manage: 'SepaTransfer.Configuration.Manage',
+  },
+} as const;

--- a/packages/@granit/payments-sepa-transfer/src/types/index.ts
+++ b/packages/@granit/payments-sepa-transfer/src/types/index.ts
@@ -1,0 +1,24 @@
+/**
+ * Create or update the tenant's SEPA bank transfer configuration. When a
+ * `beneficiaryIban` is supplied it is provisioned into the company's
+ * `BankAccounts` referential and stamped onto the configuration; it is never
+ * echoed back unmasked.
+ */
+export interface SepaTransferConfigurationRequest {
+  readonly beneficiaryName?: string | null;
+  readonly isActive?: boolean;
+  readonly companyPartyId?: string | null;
+  readonly beneficiaryIban?: string | null;
+  readonly beneficiaryBic?: string | null;
+}
+
+/** The tenant's SEPA bank transfer configuration, with the beneficiary IBAN masked. */
+export interface SepaTransferConfigurationResponse {
+  readonly beneficiaryName: string | null;
+  readonly isActive: boolean;
+  readonly companyPartyId: string | null;
+  readonly beneficiaryIbanMasked: string | null;
+  readonly beneficiaryBic: string | null;
+  readonly tenantId: string | null;
+  readonly concurrencyStamp: string;
+}

--- a/packages/@granit/payments-sepa-transfer/tsconfig.json
+++ b/packages/@granit/payments-sepa-transfer/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "include": ["src/**/*.ts"]
+}

--- a/packages/@granit/payments-sepa-transfer/tsup.config.ts
+++ b/packages/@granit/payments-sepa-transfer/tsup.config.ts
@@ -1,0 +1,3 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig();

--- a/packages/@granit/react-payments-sepa-direct-debit/README.md
+++ b/packages/@granit/react-payments-sepa-direct-debit/README.md
@@ -1,0 +1,3 @@
+# @granit/react-payments-sepa-direct-debit
+
+React bindings for `@granit/payments-sepa-direct-debit` — `SepaDirectDebitProvider`, mandate + configuration hooks, and MSW testing handlers.

--- a/packages/@granit/react-payments-sepa-direct-debit/package.json
+++ b/packages/@granit/react-payments-sepa-direct-debit/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "@granit/react-payments-sepa-direct-debit",
+  "description": "React bindings for @granit/payments-sepa-direct-debit — SepaDirectDebitProvider and hooks",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/payments-sepa-direct-debit": "workspace:*",
+    "@granit/query-engine": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-query-engine": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@granit/query-engine": {
+      "optional": true
+    },
+    "@granit/react-query-engine": {
+      "optional": true
+    },
+    "msw": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  }
+}

--- a/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,60 @@
+import { createMswServer } from '@granit/testing/msw-server';
+import { describe, expect, it } from 'vitest';
+
+import { createSepaDirectDebitHandlers, mandateQueryMetadata } from '../testing/index';
+
+const BASE = 'http://api.test/api/v1/sepa-direct-debit';
+const server = createMswServer();
+
+describe('createSepaDirectDebitHandlers', () => {
+  it('responds with mandateQueryMetadata at /mandates/meta', async () => {
+    server.use(...createSepaDirectDebitHandlers(BASE));
+    const response = await fetch(`${BASE}/mandates/meta`);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(mandateQueryMetadata);
+  });
+
+  it('returns the tenant configuration at /configuration', async () => {
+    server.use(...createSepaDirectDebitHandlers(BASE));
+    const response = await fetch(`${BASE}/configuration`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { creditorId: string };
+    expect(body.creditorId).toBe('BE68ZZZ0123456789');
+  });
+
+  it('creates a mandate (201) carrying the requested redirect URL', async () => {
+    server.use(...createSepaDirectDebitHandlers(BASE));
+    const response = await fetch(`${BASE}/mandates`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        debtorPartyId: 'party-1',
+        debtorName: 'Alice',
+        debtorIban: 'BE68539007547034',
+        redirectUrl: 'https://app.test/return',
+      }),
+    });
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as { status: string; redirectUrl: string | null };
+    expect(body.status).toBe('Pending');
+    expect(body.redirectUrl).toBe('https://app.test/return');
+  });
+
+  it('confirms a known mandate to Active', async () => {
+    server.use(...createSepaDirectDebitHandlers(BASE));
+    const response = await fetch(`${BASE}/mandates/mdt_01/confirm`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ signedAt: '2026-06-01T00:00:00Z' }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { status: string };
+    expect(body.status).toBe('Active');
+  });
+
+  it('returns 404 for an unknown mandate', async () => {
+    server.use(...createSepaDirectDebitHandlers(BASE));
+    const response = await fetch(`${BASE}/mandates/does-not-exist`);
+    expect(response.status).toBe(404);
+  });
+});

--- a/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/use-sepa-direct-debit.test.tsx
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/__tests__/use-sepa-direct-debit.test.tsx
@@ -1,0 +1,203 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useCancelMandate,
+  useConfirmMandate,
+  useCreateMandate,
+  useMandate,
+  useSepaConfiguration,
+  useUpsertSepaConfiguration,
+} from '../hooks/use-sepa-direct-debit';
+import { SepaDirectDebitProvider } from '../providers/sepa-direct-debit-provider';
+
+import type { SepaDirectDebitConfig } from '../providers/sepa-direct-debit-provider';
+import type {
+  MandateResponse,
+  MandateSetupResponse,
+  SepaConfigurationResponse,
+} from '@granit/payments-sepa-direct-debit';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const sampleMandate: MandateResponse = {
+  id: 'mdt-1',
+  mandateReference: 'RUM-0001',
+  status: 'Active',
+  scheme: 'Core',
+  debtorName: 'Alice Martin',
+  debtorIbanMasked: 'BE** **** **** 1234',
+  creditorId: 'BE68ZZZ0123456789',
+  providerName: 'GoCardless',
+  providerMandateId: 'MD0001',
+  signedAt: '2026-05-01T10:00:00Z',
+  activatedAt: '2026-05-01T10:05:00Z',
+  cancelledAt: null,
+  tenantId: null,
+  concurrencyStamp: 'stamp-1',
+};
+
+const sampleSetup: MandateSetupResponse = {
+  id: 'mdt-1',
+  mandateReference: 'RUM-0001',
+  status: 'Pending',
+  redirectUrl: null,
+};
+
+const sampleConfiguration: SepaConfigurationResponse = {
+  creditorId: 'BE68ZZZ0123456789',
+  creditorName: 'Acme NV',
+  defaultScheme: 'Core',
+  defaultProviderName: 'GoCardless',
+  isActive: true,
+  companyPartyId: null,
+  creditorIbanMasked: 'BE** **** **** 9999',
+  creditorBic: 'GEBABEBB',
+  tenantId: null,
+  concurrencyStamp: 'stamp-cfg',
+};
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: SepaDirectDebitConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <SepaDirectDebitProvider config={config}>{children}</SepaDirectDebitProvider>
+    );
+  };
+}
+
+describe('use-sepa-direct-debit', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useMandate', () => {
+    it('fetches a mandate by id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleMandate });
+
+      const { result } = renderHook(() => useMandate('mdt-1'), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/api/v1/sepa-direct-debit/mandates/mdt-1');
+      expect(result.current.data).toEqual(sampleMandate);
+    });
+
+    it('is disabled for an empty id', () => {
+      const client = createMockClient();
+
+      const { result } = renderHook(() => useMandate(''), {
+        wrapper: createWrapper(client),
+      });
+
+      expect(result.current.fetchStatus).toBe('idle');
+      expect(client.get).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('useSepaConfiguration', () => {
+    it('fetches the tenant configuration with a custom basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleConfiguration });
+
+      const { result } = renderHook(() => useSepaConfiguration(), {
+        wrapper: createWrapper(client, '/custom/sdd'),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/custom/sdd/configuration');
+      expect(result.current.data).toEqual(sampleConfiguration);
+    });
+  });
+
+  describe('useCreateMandate', () => {
+    it('creates a mandate and returns the setup response', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleSetup });
+
+      const { result } = renderHook(() => useCreateMandate(), {
+        wrapper: createWrapper(client),
+      });
+
+      await result.current.mutateAsync({
+        debtorPartyId: 'party-1',
+        debtorName: 'Alice Martin',
+        debtorIban: 'BE68539007547034',
+      });
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/sepa-direct-debit/mandates', {
+        debtorPartyId: 'party-1',
+        debtorName: 'Alice Martin',
+        debtorIban: 'BE68539007547034',
+      });
+    });
+  });
+
+  describe('useConfirmMandate', () => {
+    it('confirms a mandate with the signature payload', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({ data: sampleMandate });
+
+      const { result } = renderHook(() => useConfirmMandate(), {
+        wrapper: createWrapper(client),
+      });
+
+      await result.current.mutateAsync({
+        id: 'mdt-1',
+        request: { signedAt: '2026-05-01T10:00:00Z' },
+      });
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/sepa-direct-debit/mandates/mdt-1/confirm', {
+        signedAt: '2026-05-01T10:00:00Z',
+      });
+    });
+  });
+
+  describe('useCancelMandate', () => {
+    it('cancels a mandate by id', async () => {
+      const client = createMockClient();
+      vi.mocked(client.post).mockResolvedValue({
+        data: { ...sampleMandate, status: 'Cancelled' },
+      });
+
+      const { result } = renderHook(() => useCancelMandate(), {
+        wrapper: createWrapper(client),
+      });
+
+      const mandate = await result.current.mutateAsync('mdt-1');
+
+      expect(client.post).toHaveBeenCalledWith('/api/v1/sepa-direct-debit/mandates/mdt-1/cancel');
+      expect(mandate.status).toBe('Cancelled');
+    });
+  });
+
+  describe('useUpsertSepaConfiguration', () => {
+    it('upserts the tenant configuration', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleConfiguration });
+
+      const { result } = renderHook(() => useUpsertSepaConfiguration(), {
+        wrapper: createWrapper(client),
+      });
+
+      await result.current.mutateAsync({
+        creditorId: 'BE68ZZZ0123456789',
+        defaultScheme: 'Core',
+      });
+
+      expect(client.put).toHaveBeenCalledWith('/api/v1/sepa-direct-debit/configuration', {
+        creditorId: 'BE68ZZZ0123456789',
+        defaultScheme: 'Core',
+      });
+    });
+  });
+});

--- a/packages/@granit/react-payments-sepa-direct-debit/src/constants.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'sepa-direct-debit';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-payments-sepa-direct-debit/src/hooks/use-sepa-direct-debit.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/hooks/use-sepa-direct-debit.ts
@@ -1,0 +1,190 @@
+import {
+  cancelMandate,
+  confirmMandate,
+  createMandate,
+  getMandate,
+  getSepaConfiguration,
+  upsertSepaConfiguration,
+} from '@granit/payments-sepa-direct-debit';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  buildSepaDirectDebitQueryKey,
+  useSepaDirectDebitConfig,
+} from '../providers/sepa-direct-debit-provider';
+
+import type {
+  ConfirmMandateRequest,
+  CreateMandateRequest,
+  MandateResponse,
+  MandateSetupResponse,
+  SepaConfigurationRequest,
+  SepaConfigurationResponse,
+} from '@granit/payments-sepa-direct-debit';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+/**
+ * Get a single mandate by ID. The query is disabled when `id` is empty.
+ *
+ * @example
+ * ```tsx
+ * const { data: mandate } = useMandate(selectedId);
+ * ```
+ */
+export function useMandate(id: string): UseQueryResult<MandateResponse> {
+  const config = useSepaDirectDebitConfig();
+
+  return useQuery({
+    queryKey: buildSepaDirectDebitQueryKey(config, 'mandates', id),
+    queryFn: () => getMandate(config.client, config.basePath, id),
+    enabled: id.length > 0,
+  });
+}
+
+/**
+ * Get the current tenant's SEPA Direct Debit configuration.
+ *
+ * @example
+ * ```tsx
+ * const { data: config } = useSepaConfiguration();
+ * ```
+ */
+export function useSepaConfiguration(): UseQueryResult<SepaConfigurationResponse> {
+  const config = useSepaDirectDebitConfig();
+
+  return useQuery({
+    queryKey: buildSepaDirectDebitQueryKey(config, 'configuration'),
+    queryFn: () => getSepaConfiguration(config.client, config.basePath),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Set up a SEPA Direct Debit mandate. Invalidates the package's mandate keys on
+ * success.
+ *
+ * Note: the cross-tenant mandate admin grid is fetched by
+ * `@granit/react-query-engine` under its own `QueryProvider` — a different query
+ * key namespace this provider cannot reach. To refresh that grid after a
+ * mutation, invalidate the query-engine endpoint prefix **without** the params
+ * object so every cached page flushes, e.g.
+ * `queryClient.invalidateQueries({ queryKey: [...queryKeyPrefix, 'list'] })`
+ * (and `'grouped'`).
+ *
+ * @example
+ * ```tsx
+ * const create = useCreateMandate();
+ * const setup = await create.mutateAsync({ debtorPartyId, debtorName, debtorIban });
+ * if (setup.redirectUrl) window.location.href = setup.redirectUrl;
+ * ```
+ */
+export function useCreateMandate(): UseMutationResult<
+  MandateSetupResponse,
+  Error,
+  CreateMandateRequest
+> {
+  const config = useSepaDirectDebitConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateMandateRequest) =>
+      createMandate(config.client, config.basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildSepaDirectDebitQueryKey(config, 'mandates'),
+      });
+    },
+  });
+}
+
+/** Arguments for a mandate mutation that targets a specific mandate. */
+export interface ConfirmMandateArgs {
+  readonly id: string;
+  readonly request: ConfirmMandateRequest;
+}
+
+/**
+ * Confirm (activate) a pending mandate after the debtor's signature. Invalidates
+ * the package's mandate keys on success (see {@link useCreateMandate} for the
+ * cross-provider QE grid invalidation note).
+ *
+ * @example
+ * ```tsx
+ * const confirm = useConfirmMandate();
+ * await confirm.mutateAsync({ id, request: { signedAt: new Date().toISOString() } });
+ * ```
+ */
+export function useConfirmMandate(): UseMutationResult<MandateResponse, Error, ConfirmMandateArgs> {
+  const config = useSepaDirectDebitConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, request }: ConfirmMandateArgs) =>
+      confirmMandate(config.client, config.basePath, id, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildSepaDirectDebitQueryKey(config, 'mandates'),
+      });
+    },
+  });
+}
+
+/**
+ * Cancel (revoke) a mandate by ID. Invalidates the package's mandate keys on
+ * success (see {@link useCreateMandate} for the cross-provider QE grid note).
+ *
+ * @example
+ * ```tsx
+ * const cancel = useCancelMandate();
+ * await cancel.mutateAsync(mandateId);
+ * ```
+ */
+export function useCancelMandate(): UseMutationResult<MandateResponse, Error, string> {
+  const config = useSepaDirectDebitConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => cancelMandate(config.client, config.basePath, id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildSepaDirectDebitQueryKey(config, 'mandates'),
+      });
+    },
+  });
+}
+
+/**
+ * Create or update the tenant's SEPA Direct Debit configuration. Invalidates the
+ * configuration query on success.
+ *
+ * @example
+ * ```tsx
+ * const upsert = useUpsertSepaConfiguration();
+ * await upsert.mutateAsync({ creditorId, defaultScheme: 'Core' });
+ * ```
+ */
+export function useUpsertSepaConfiguration(): UseMutationResult<
+  SepaConfigurationResponse,
+  Error,
+  SepaConfigurationRequest
+> {
+  const config = useSepaDirectDebitConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: SepaConfigurationRequest) =>
+      upsertSepaConfiguration(config.client, config.basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildSepaDirectDebitQueryKey(config, 'configuration'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-payments-sepa-direct-debit/src/index.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/index.ts
@@ -1,0 +1,22 @@
+// Provider
+export {
+  SepaDirectDebitProvider,
+  buildSepaDirectDebitQueryKey,
+  useSepaDirectDebitConfig,
+} from './providers/sepa-direct-debit-provider';
+export type {
+  SepaDirectDebitConfig,
+  SepaDirectDebitProviderProps,
+  ResolvedSepaDirectDebitConfig,
+} from './providers/sepa-direct-debit-provider';
+
+// Hooks
+export {
+  useCancelMandate,
+  useConfirmMandate,
+  useCreateMandate,
+  useMandate,
+  useSepaConfiguration,
+  useUpsertSepaConfiguration,
+} from './hooks/use-sepa-direct-debit';
+export type { ConfirmMandateArgs } from './hooks/use-sepa-direct-debit';

--- a/packages/@granit/react-payments-sepa-direct-debit/src/providers/sepa-direct-debit-provider.tsx
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/providers/sepa-direct-debit-provider.tsx
@@ -1,0 +1,73 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for the SEPA Direct Debit provider. */
+export interface SepaDirectDebitConfig {
+  readonly client?: AxiosInstance;
+  /** Base path for SEPA Direct Debit endpoints (default: `/api/v1/sepa-direct-debit`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * SepaDirectDebitConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>` and defaulted
+ * `basePath`. Both are guaranteed present, so hooks read them without a
+ * non-null assertion.
+ */
+export interface ResolvedSepaDirectDebitConfig extends SepaDirectDebitConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+}
+
+export interface SepaDirectDebitProviderProps {
+  readonly config: SepaDirectDebitConfig;
+  readonly children: ReactNode;
+}
+
+const SepaDirectDebitConfigContext = createContext<ResolvedSepaDirectDebitConfig | null>(null);
+
+/** Provides SEPA Direct Debit configuration to child components and hooks. */
+export function SepaDirectDebitProvider({
+  config,
+  children,
+}: Readonly<SepaDirectDebitProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedSepaDirectDebitConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'SepaDirectDebitProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
+  return <SepaDirectDebitConfigContext value={value}>{children}</SepaDirectDebitConfigContext>;
+}
+
+/** Returns the SEPA Direct Debit configuration from the nearest `SepaDirectDebitProvider`. */
+export function useSepaDirectDebitConfig(): ResolvedSepaDirectDebitConfig {
+  const ctx = useContext(SepaDirectDebitConfigContext);
+  if (!ctx) {
+    throw new Error('useSepaDirectDebitConfig must be used within a SepaDirectDebitProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for SEPA Direct Debit operations. */
+export function buildSepaDirectDebitQueryKey(
+  config: SepaDirectDebitConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? ['sepa-direct-debit'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-payments-sepa-direct-debit/src/testing/data.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/testing/data.ts
@@ -1,0 +1,52 @@
+import type {
+  MandateResponse,
+  SepaConfigurationResponse,
+} from '@granit/payments-sepa-direct-debit';
+
+export const sampleMandates: MandateResponse[] = [
+  {
+    id: 'mdt_01',
+    mandateReference: 'RUM-0000001',
+    status: 'Active',
+    scheme: 'Core',
+    debtorName: 'Alice Martin',
+    debtorIbanMasked: 'BE** **** **** 1234',
+    creditorId: 'BE68ZZZ0123456789',
+    providerName: 'GoCardless',
+    providerMandateId: 'MD0000001',
+    signedAt: '2026-05-01T10:00:00Z',
+    activatedAt: '2026-05-01T10:05:00Z',
+    cancelledAt: null,
+    tenantId: 'tenant_01',
+    concurrencyStamp: 'stamp_01',
+  },
+  {
+    id: 'mdt_02',
+    mandateReference: 'RUM-0000002',
+    status: 'Pending',
+    scheme: 'B2B',
+    debtorName: 'Bravo Logistics BV',
+    debtorIbanMasked: 'NL** **** **** 5678',
+    creditorId: 'BE68ZZZ0123456789',
+    providerName: null,
+    providerMandateId: null,
+    signedAt: null,
+    activatedAt: null,
+    cancelledAt: null,
+    tenantId: 'tenant_01',
+    concurrencyStamp: 'stamp_02',
+  },
+];
+
+export const sampleConfiguration: SepaConfigurationResponse = {
+  creditorId: 'BE68ZZZ0123456789',
+  creditorName: 'Acme NV',
+  defaultScheme: 'Core',
+  defaultProviderName: 'GoCardless',
+  isActive: true,
+  companyPartyId: 'party_company_01',
+  creditorIbanMasked: 'BE** **** **** 9999',
+  creditorBic: 'GEBABEBB',
+  tenantId: 'tenant_01',
+  concurrencyStamp: 'stamp_cfg',
+};

--- a/packages/@granit/react-payments-sepa-direct-debit/src/testing/handlers.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/testing/handlers.ts
@@ -1,0 +1,212 @@
+import { DATE_OPERATORS, ENUM_OPERATORS, STRING_OPERATORS } from '@granit/query-engine';
+import { createQueryMetaHandler } from '@granit/react-query-engine/testing';
+import { created, notFound } from '@granit/testing/msw';
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { sampleConfiguration, sampleMandates } from './data';
+
+import type {
+  ConfirmMandateRequest,
+  CreateMandateRequest,
+  MandateSetupResponse,
+} from '@granit/payments-sepa-direct-debit';
+import type { QueryMetadata } from '@granit/query-engine';
+
+const MANDATE_STATUSES = ['Pending', 'Active', 'Suspended', 'Cancelled', 'Failed', 'Expired'];
+const MANDATE_SCHEMES = ['Core', 'B2B'];
+
+/** Mock `/meta` payload for the mandate query-engine grid. */
+export const mandateQueryMetadata: QueryMetadata = {
+  columns: [
+    {
+      name: 'id',
+      label: 'ID',
+      type: 'Guid',
+      order: 0,
+      isSortable: false,
+      isFilterable: false,
+      isVisible: false,
+    },
+    {
+      name: 'mandateReference',
+      label: 'Reference',
+      type: 'String',
+      order: 1,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'status',
+      label: 'Status',
+      type: 'String',
+      order: 2,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'scheme',
+      label: 'Scheme',
+      type: 'String',
+      order: 3,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'debtorName',
+      label: 'Debtor',
+      type: 'String',
+      order: 4,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'creditorId',
+      label: 'Creditor ID',
+      type: 'String',
+      order: 5,
+      isSortable: false,
+      isFilterable: true,
+      isVisible: false,
+    },
+    {
+      name: 'signedAt',
+      label: 'Signed at',
+      type: 'DateTime',
+      order: 6,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: true,
+    },
+    {
+      name: 'activatedAt',
+      label: 'Activated at',
+      type: 'DateTime',
+      order: 7,
+      isSortable: true,
+      isFilterable: true,
+      isVisible: false,
+    },
+  ],
+  filterableFields: [
+    { name: 'mandateReference', type: 'String', operators: STRING_OPERATORS },
+    { name: 'status', type: 'String', operators: ENUM_OPERATORS, enumValues: MANDATE_STATUSES },
+    { name: 'scheme', type: 'String', operators: ENUM_OPERATORS, enumValues: MANDATE_SCHEMES },
+    { name: 'debtorName', type: 'String', operators: STRING_OPERATORS },
+    { name: 'creditorId', type: 'String', operators: STRING_OPERATORS },
+    { name: 'signedAt', type: 'DateTime', operators: DATE_OPERATORS },
+    { name: 'activatedAt', type: 'DateTime', operators: DATE_OPERATORS },
+  ],
+  sortableFields: [
+    { name: 'mandateReference' },
+    { name: 'status' },
+    { name: 'scheme' },
+    { name: 'debtorName' },
+    { name: 'signedAt' },
+    { name: 'activatedAt' },
+  ],
+  presetFilterGroups: [],
+  quickFilters: [
+    { name: 'active', label: 'Active', isDefault: false },
+    { name: 'pending', label: 'Pending', isDefault: false },
+  ],
+  dateFilters: [
+    {
+      name: 'signedAt',
+      defaultPeriod: 'ThisYear',
+      availablePeriods: [
+        'Today',
+        'ThisWeek',
+        'ThisMonth',
+        'LastMonth',
+        'ThisQuarter',
+        'ThisYear',
+        'Custom',
+      ],
+    },
+  ],
+  groupByFields: [
+    { name: 'status', type: 'String' },
+    { name: 'scheme', type: 'String' },
+  ],
+  pagination: {
+    defaultPageSize: 25,
+    maxPageSize: 100,
+    maxStreamSize: 50_000,
+    supportsCursor: false,
+  },
+  defaultSort: '-signedAt',
+};
+
+/**
+ * Create stateful MSW handlers for SEPA Direct Debit endpoints: the mandate
+ * query-engine grid (`/mandates/meta`), single-mandate read, mandate lifecycle
+ * (create / confirm / cancel), and the per-tenant configuration.
+ *
+ * @param baseUrl - API base path (default: `/api/v1/sepa-direct-debit`)
+ */
+export function createSepaDirectDebitHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  return [
+    // GET /mandates/meta — query metadata for the admin grid
+    createQueryMetaHandler(`${baseUrl}/mandates`, mandateQueryMetadata),
+
+    // GET single mandate by ID
+    http.get(`${baseUrl}/mandates/:id`, ({ params }) => {
+      const mandate = sampleMandates.find((m) => m.id === params.id);
+      if (!mandate) return notFound();
+      return HttpResponse.json(mandate);
+    }),
+
+    // POST /mandates — set up a mandate → 201 Created
+    http.post(`${baseUrl}/mandates`, async ({ request }) => {
+      const body = (await request.json()) as CreateMandateRequest;
+      const setup: MandateSetupResponse = {
+        id: `mdt_mock_${String(sampleMandates.length + 1).padStart(2, '0')}`,
+        mandateReference: `RUM-MOCK-${String(sampleMandates.length + 1).padStart(7, '0')}`,
+        status: 'Pending',
+        redirectUrl: body.redirectUrl ?? null,
+      };
+      return created(setup);
+    }),
+
+    // POST /mandates/:id/confirm — activate a pending mandate
+    http.post(`${baseUrl}/mandates/:id/confirm`, async ({ params, request }) => {
+      const mandate = sampleMandates.find((m) => m.id === params.id);
+      if (!mandate) return notFound();
+      const body = (await request.json()) as ConfirmMandateRequest;
+      return HttpResponse.json({
+        ...mandate,
+        status: 'Active',
+        signedAt: body.signedAt,
+        activatedAt: body.signedAt,
+      });
+    }),
+
+    // POST /mandates/:id/cancel — revoke a mandate
+    http.post(`${baseUrl}/mandates/:id/cancel`, ({ params }) => {
+      const mandate = sampleMandates.find((m) => m.id === params.id);
+      if (!mandate) return notFound();
+      return HttpResponse.json({
+        ...mandate,
+        status: 'Cancelled',
+        cancelledAt: '2026-06-15T00:00:00Z',
+      });
+    }),
+
+    // GET /configuration — tenant SEPA configuration
+    http.get(`${baseUrl}/configuration`, () => {
+      return HttpResponse.json(sampleConfiguration);
+    }),
+
+    // PUT /configuration — upsert tenant SEPA configuration
+    http.put(`${baseUrl}/configuration`, async ({ request }) => {
+      const body = (await request.json()) as Record<string, unknown>;
+      return HttpResponse.json({ ...sampleConfiguration, ...body });
+    }),
+  ];
+}

--- a/packages/@granit/react-payments-sepa-direct-debit/src/testing/index.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-payments-sepa-direct-debit/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { sampleConfiguration, sampleMandates } from './data';
+export { createSepaDirectDebitHandlers, mandateQueryMetadata } from './handlers';

--- a/packages/@granit/react-payments-sepa-direct-debit/tsconfig.json
+++ b/packages/@granit/react-payments-sepa-direct-debit/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/payments-sepa-direct-debit": ["../payments-sepa-direct-debit/src/index.ts"],
+      "@granit/query-engine": ["../query-engine/src/index.ts"],
+      "@granit/react-query-engine/testing": ["../react-query-engine/src/testing/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-payments-sepa-direct-debit/tsup.config.ts
+++ b/packages/@granit/react-payments-sepa-direct-debit/tsup.config.ts
@@ -1,0 +1,6 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  external: [/^@granit\//, 'msw'],
+});

--- a/packages/@granit/react-payments-sepa-transfer/README.md
+++ b/packages/@granit/react-payments-sepa-transfer/README.md
@@ -1,0 +1,3 @@
+# @granit/react-payments-sepa-transfer
+
+React bindings for `@granit/payments-sepa-transfer` — `SepaTransferProvider`, configuration hooks, and MSW testing handlers.

--- a/packages/@granit/react-payments-sepa-transfer/package.json
+++ b/packages/@granit/react-payments-sepa-transfer/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@granit/react-payments-sepa-transfer",
+  "description": "React bindings for @granit/payments-sepa-transfer — SepaTransferProvider and hooks",
+  "version": "0.1.0",
+  "license": "Apache-2.0",
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts",
+    "./testing": "./src/testing/index.ts"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup"
+  },
+  "peerDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/payments-sepa-transfer": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/types": "workspace:*",
+    "@tanstack/react-query": "^5.0.0",
+    "msw": "^2.12.0",
+    "react": "^19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "msw": {
+      "optional": true
+    }
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      },
+      "./testing": {
+        "types": "./dist/testing/index.d.ts",
+        "import": "./dist/testing/index.js"
+      }
+    },
+    "registry": "https://npm.pkg.github.com"
+  },
+  "devDependencies": {
+    "@granit/api-client": "workspace:*",
+    "@granit/react-api-client": "workspace:*",
+    "@granit/react-testing": "workspace:*",
+    "@granit/testing": "workspace:*",
+    "@granit/types": "workspace:*"
+  }
+}

--- a/packages/@granit/react-payments-sepa-transfer/src/__tests__/testing-handlers.test.ts
+++ b/packages/@granit/react-payments-sepa-transfer/src/__tests__/testing-handlers.test.ts
@@ -1,0 +1,31 @@
+import { createMswServer } from '@granit/testing/msw-server';
+import { describe, expect, it } from 'vitest';
+
+import { createSepaTransferHandlers } from '../testing/index';
+
+const BASE = 'http://api.test/api/v1/sepa-transfer';
+const server = createMswServer();
+
+describe('createSepaTransferHandlers', () => {
+  it('returns the tenant configuration at /configuration', async () => {
+    server.use(...createSepaTransferHandlers(BASE));
+    const response = await fetch(`${BASE}/configuration`);
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as { beneficiaryIbanMasked: string };
+    expect(body.beneficiaryIbanMasked).toBe('BE** **** **** 9999');
+  });
+
+  it('upserts and echoes the beneficiary name without leaking the raw IBAN', async () => {
+    server.use(...createSepaTransferHandlers(BASE));
+    const response = await fetch(`${BASE}/configuration`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ beneficiaryName: 'Bravo BV', beneficiaryIban: 'BE68539007547034' }),
+    });
+    expect(response.status).toBe(200);
+    const body = (await response.json()) as Record<string, unknown>;
+    expect(body.beneficiaryName).toBe('Bravo BV');
+    expect(body).not.toHaveProperty('beneficiaryIban');
+    expect(body.beneficiaryIbanMasked).toBe('BE** **** **** 9999');
+  });
+});

--- a/packages/@granit/react-payments-sepa-transfer/src/__tests__/use-sepa-transfer.test.tsx
+++ b/packages/@granit/react-payments-sepa-transfer/src/__tests__/use-sepa-transfer.test.tsx
@@ -1,0 +1,93 @@
+import { createTestQueryClient } from '@granit/react-testing';
+import { createMockClient } from '@granit/testing';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  useSepaTransferConfiguration,
+  useUpsertSepaTransferConfiguration,
+} from '../hooks/use-sepa-transfer';
+import { SepaTransferProvider } from '../providers/sepa-transfer-provider';
+
+import type { SepaTransferConfig } from '../providers/sepa-transfer-provider';
+import type { SepaTransferConfigurationResponse } from '@granit/payments-sepa-transfer';
+import type { AxiosInstance } from 'axios';
+import type { ReactNode } from 'react';
+
+const sampleConfiguration: SepaTransferConfigurationResponse = {
+  beneficiaryName: 'Acme NV',
+  isActive: true,
+  companyPartyId: 'party-1',
+  beneficiaryIbanMasked: 'BE** **** **** 9999',
+  beneficiaryBic: 'GEBABEBB',
+  tenantId: null,
+  concurrencyStamp: 'stamp-1',
+};
+
+function createWrapper(client: AxiosInstance, basePath?: string) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    const queryClient = createTestQueryClient();
+    const config: SepaTransferConfig = { client, basePath };
+    return React.createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      <SepaTransferProvider config={config}>{children}</SepaTransferProvider>
+    );
+  };
+}
+
+describe('use-sepa-transfer', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('useSepaTransferConfiguration', () => {
+    it('fetches the tenant configuration', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleConfiguration });
+
+      const { result } = renderHook(() => useSepaTransferConfiguration(), {
+        wrapper: createWrapper(client),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/api/v1/sepa-transfer/configuration');
+      expect(result.current.data).toEqual(sampleConfiguration);
+    });
+
+    it('uses a custom basePath', async () => {
+      const client = createMockClient();
+      vi.mocked(client.get).mockResolvedValue({ data: sampleConfiguration });
+
+      const { result } = renderHook(() => useSepaTransferConfiguration(), {
+        wrapper: createWrapper(client, '/custom/transfer'),
+      });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(client.get).toHaveBeenCalledWith('/custom/transfer/configuration');
+    });
+  });
+
+  describe('useUpsertSepaTransferConfiguration', () => {
+    it('upserts the tenant configuration', async () => {
+      const client = createMockClient();
+      vi.mocked(client.put).mockResolvedValue({ data: sampleConfiguration });
+
+      const { result } = renderHook(() => useUpsertSepaTransferConfiguration(), {
+        wrapper: createWrapper(client),
+      });
+
+      await result.current.mutateAsync({
+        beneficiaryName: 'Acme NV',
+        beneficiaryIban: 'BE68539007547034',
+      });
+
+      expect(client.put).toHaveBeenCalledWith('/api/v1/sepa-transfer/configuration', {
+        beneficiaryName: 'Acme NV',
+        beneficiaryIban: 'BE68539007547034',
+      });
+    });
+  });
+});

--- a/packages/@granit/react-payments-sepa-transfer/src/constants.ts
+++ b/packages/@granit/react-payments-sepa-transfer/src/constants.ts
@@ -1,0 +1,3 @@
+export const API_VERSION = 'v1';
+export const MODULE = 'sepa-transfer';
+export const DEFAULT_BASE_PATH = `/api/${API_VERSION}/${MODULE}`;

--- a/packages/@granit/react-payments-sepa-transfer/src/hooks/use-sepa-transfer.ts
+++ b/packages/@granit/react-payments-sepa-transfer/src/hooks/use-sepa-transfer.ts
@@ -1,0 +1,62 @@
+import {
+  getSepaTransferConfiguration,
+  upsertSepaTransferConfiguration,
+} from '@granit/payments-sepa-transfer';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  buildSepaTransferQueryKey,
+  useSepaTransferConfig,
+} from '../providers/sepa-transfer-provider';
+
+import type {
+  SepaTransferConfigurationRequest,
+  SepaTransferConfigurationResponse,
+} from '@granit/payments-sepa-transfer';
+import type { UseMutationResult, UseQueryResult } from '@tanstack/react-query';
+
+/**
+ * Get the current tenant's SEPA bank transfer configuration.
+ *
+ * @example
+ * ```tsx
+ * const { data: config } = useSepaTransferConfiguration();
+ * ```
+ */
+export function useSepaTransferConfiguration(): UseQueryResult<SepaTransferConfigurationResponse> {
+  const config = useSepaTransferConfig();
+
+  return useQuery({
+    queryKey: buildSepaTransferQueryKey(config, 'configuration'),
+    queryFn: () => getSepaTransferConfiguration(config.client, config.basePath),
+  });
+}
+
+/**
+ * Create or update the tenant's SEPA bank transfer configuration. Invalidates
+ * the configuration query on success.
+ *
+ * @example
+ * ```tsx
+ * const upsert = useUpsertSepaTransferConfiguration();
+ * await upsert.mutateAsync({ beneficiaryName: 'Acme NV', beneficiaryIban: 'BE68…' });
+ * ```
+ */
+export function useUpsertSepaTransferConfiguration(): UseMutationResult<
+  SepaTransferConfigurationResponse,
+  Error,
+  SepaTransferConfigurationRequest
+> {
+  const config = useSepaTransferConfig();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: SepaTransferConfigurationRequest) =>
+      upsertSepaTransferConfiguration(config.client, config.basePath, request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: buildSepaTransferQueryKey(config, 'configuration'),
+      });
+    },
+  });
+}

--- a/packages/@granit/react-payments-sepa-transfer/src/index.ts
+++ b/packages/@granit/react-payments-sepa-transfer/src/index.ts
@@ -1,0 +1,17 @@
+// Provider
+export {
+  SepaTransferProvider,
+  buildSepaTransferQueryKey,
+  useSepaTransferConfig,
+} from './providers/sepa-transfer-provider';
+export type {
+  SepaTransferConfig,
+  SepaTransferProviderProps,
+  ResolvedSepaTransferConfig,
+} from './providers/sepa-transfer-provider';
+
+// Hooks
+export {
+  useSepaTransferConfiguration,
+  useUpsertSepaTransferConfiguration,
+} from './hooks/use-sepa-transfer';

--- a/packages/@granit/react-payments-sepa-transfer/src/providers/sepa-transfer-provider.tsx
+++ b/packages/@granit/react-payments-sepa-transfer/src/providers/sepa-transfer-provider.tsx
@@ -1,0 +1,70 @@
+import { useOptionalGranitClient } from '@granit/react-api-client';
+import { createContext, useContext, useMemo } from 'react';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import type { AxiosInstance } from '@granit/api-client';
+import type { ReactNode } from 'react';
+
+/** Configuration for the SEPA transfer provider. */
+export interface SepaTransferConfig {
+  readonly client?: AxiosInstance;
+  /** Base path for SEPA transfer endpoints (default: `/api/v1/sepa-transfer`). */
+  readonly basePath?: string;
+  readonly queryKeyPrefix?: readonly string[];
+}
+
+/**
+ * SepaTransferConfig after the provider has resolved `client` from
+ * `config.client` or the nearest `<GranitClientProvider>` and defaulted
+ * `basePath`. Both are guaranteed present, so hooks read them without a
+ * non-null assertion.
+ */
+export interface ResolvedSepaTransferConfig extends SepaTransferConfig {
+  readonly client: AxiosInstance;
+  readonly basePath: string;
+}
+
+export interface SepaTransferProviderProps {
+  readonly config: SepaTransferConfig;
+  readonly children: ReactNode;
+}
+
+const SepaTransferConfigContext = createContext<ResolvedSepaTransferConfig | null>(null);
+
+/** Provides SEPA transfer configuration to child components and hooks. */
+export function SepaTransferProvider({ config, children }: Readonly<SepaTransferProviderProps>) {
+  const contextClient = useOptionalGranitClient();
+  const value = useMemo<ResolvedSepaTransferConfig>(() => {
+    const client = config.client ?? contextClient;
+    if (!client) {
+      throw new Error(
+        'SepaTransferProvider requires an Axios client. Provide it via config.client or wrap your app in a <GranitClientProvider>.'
+      );
+    }
+    return {
+      ...config,
+      basePath: config.basePath ?? DEFAULT_BASE_PATH,
+      client,
+    };
+  }, [config, contextClient]);
+  return <SepaTransferConfigContext value={value}>{children}</SepaTransferConfigContext>;
+}
+
+/** Returns the SEPA transfer configuration from the nearest `SepaTransferProvider`. */
+export function useSepaTransferConfig(): ResolvedSepaTransferConfig {
+  const ctx = useContext(SepaTransferConfigContext);
+  if (!ctx) {
+    throw new Error('useSepaTransferConfig must be used within a SepaTransferProvider');
+  }
+  return ctx;
+}
+
+/** Builds a consistent React Query key for SEPA transfer operations. */
+export function buildSepaTransferQueryKey(
+  config: SepaTransferConfig,
+  ...segments: readonly string[]
+): readonly unknown[] {
+  const prefix = config.queryKeyPrefix ?? ['sepa-transfer'];
+  return [...prefix, ...segments];
+}

--- a/packages/@granit/react-payments-sepa-transfer/src/testing/data.ts
+++ b/packages/@granit/react-payments-sepa-transfer/src/testing/data.ts
@@ -1,0 +1,11 @@
+import type { SepaTransferConfigurationResponse } from '@granit/payments-sepa-transfer';
+
+export const sampleConfiguration: SepaTransferConfigurationResponse = {
+  beneficiaryName: 'Acme NV',
+  isActive: true,
+  companyPartyId: 'party_company_01',
+  beneficiaryIbanMasked: 'BE** **** **** 9999',
+  beneficiaryBic: 'GEBABEBB',
+  tenantId: 'tenant_01',
+  concurrencyStamp: 'stamp_cfg',
+};

--- a/packages/@granit/react-payments-sepa-transfer/src/testing/handlers.ts
+++ b/packages/@granit/react-payments-sepa-transfer/src/testing/handlers.ts
@@ -1,0 +1,34 @@
+import { http, HttpResponse } from 'msw';
+
+import { DEFAULT_BASE_PATH } from '../constants';
+
+import { sampleConfiguration } from './data';
+
+import type { SepaTransferConfigurationRequest } from '@granit/payments-sepa-transfer';
+
+/**
+ * Create MSW handlers for the SEPA bank transfer endpoints: the per-tenant
+ * beneficiary configuration (read + upsert).
+ *
+ * @param baseUrl - API base path (default: `/api/v1/sepa-transfer`)
+ */
+export function createSepaTransferHandlers(baseUrl = DEFAULT_BASE_PATH) {
+  return [
+    // GET /configuration — tenant SEPA transfer configuration
+    http.get(`${baseUrl}/configuration`, () => {
+      return HttpResponse.json(sampleConfiguration);
+    }),
+
+    // PUT /configuration — upsert tenant SEPA transfer configuration.
+    // The raw IBAN is never echoed back; the response carries only the masked form.
+    http.put(`${baseUrl}/configuration`, async ({ request }) => {
+      const body = (await request.json()) as SepaTransferConfigurationRequest;
+      return HttpResponse.json({
+        ...sampleConfiguration,
+        beneficiaryName: body.beneficiaryName ?? sampleConfiguration.beneficiaryName,
+        isActive: body.isActive ?? sampleConfiguration.isActive,
+        beneficiaryBic: body.beneficiaryBic ?? sampleConfiguration.beneficiaryBic,
+      });
+    }),
+  ];
+}

--- a/packages/@granit/react-payments-sepa-transfer/src/testing/index.ts
+++ b/packages/@granit/react-payments-sepa-transfer/src/testing/index.ts
@@ -1,0 +1,6 @@
+// ---------------------------------------------------------------------------
+// @granit/react-payments-sepa-transfer/testing — Mock data & MSW handlers
+// ---------------------------------------------------------------------------
+
+export { sampleConfiguration } from './data';
+export { createSepaTransferHandlers } from './handlers';

--- a/packages/@granit/react-payments-sepa-transfer/tsconfig.json
+++ b/packages/@granit/react-payments-sepa-transfer/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": {
+    "paths": {
+      "@granit/payments-sepa-transfer": ["../payments-sepa-transfer/src/index.ts"],
+      "@granit/testing/msw": ["../testing/src/msw.ts"]
+    }
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/@granit/react-payments-sepa-transfer/tsup.config.ts
+++ b/packages/@granit/react-payments-sepa-transfer/tsup.config.ts
@@ -1,0 +1,6 @@
+import { createTsupConfig } from '../../../tsup.preset';
+
+export default createTsupConfig({
+  entry: ['src/index.ts', 'src/testing/index.ts'],
+  external: [/^@granit\//, 'msw'],
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -856,6 +856,24 @@ importers:
         specifier: workspace:*
         version: link:../testing
 
+  packages/@granit/payments-sepa-direct-debit:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
+  packages/@granit/payments-sepa-transfer:
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+
   packages/@granit/presence:
     devDependencies:
       '@granit/api-client':
@@ -2512,6 +2530,74 @@ importers:
       lucide-react:
         specifier: ^1.0.0
         version: 1.17.0(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
+  packages/@granit/react-payments-sepa-direct-debit:
+    dependencies:
+      '@granit/payments-sepa-direct-debit':
+        specifier: workspace:*
+        version: link:../payments-sepa-direct-debit
+      '@granit/query-engine':
+        specifier: workspace:*
+        version: link:../query-engine
+      '@granit/react-query-engine':
+        specifier: workspace:*
+        version: link:../react-query-engine
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
+      msw:
+        specifier: ^2.14.6
+        version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
+      react:
+        specifier: 19.2.7
+        version: 19.2.7
+    devDependencies:
+      '@granit/api-client':
+        specifier: workspace:*
+        version: link:../api-client
+      '@granit/react-api-client':
+        specifier: workspace:*
+        version: link:../react-api-client
+      '@granit/react-testing':
+        specifier: workspace:*
+        version: link:../react-testing
+      '@granit/testing':
+        specifier: workspace:*
+        version: link:../testing
+      '@granit/types':
+        specifier: workspace:*
+        version: link:../types
+
+  packages/@granit/react-payments-sepa-transfer:
+    dependencies:
+      '@granit/payments-sepa-transfer':
+        specifier: workspace:*
+        version: link:../payments-sepa-transfer
+      '@tanstack/react-query':
+        specifier: 5.101.0
+        version: 5.101.0(react@19.2.7)
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)


### PR DESCRIPTION
## Context

Two new `granit-business` bounded contexts shipped — `Granit.Payments.SepaDirectDebit.Endpoints` and `Granit.Payments.SepaTransfer.Endpoints`. This adds the matching front TypeScript surface so consumers (e.g. `showcase-admin-react`) can call them with the same ergonomics as `@granit/payments`.

## Packages (mirroring the `@granit/payments` family)

| Package | Contents |
|---|---|
| `@granit/payments-sepa-direct-debit` | DTOs, Axios API (createMandate, getMandate, confirm, cancel, get/upsert config), permissions |
| `@granit/react-payments-sepa-direct-debit` | `SepaDirectDebitProvider`, React Query hooks, MSW handlers (+ mandate QE grid meta) |
| `@granit/payments-sepa-transfer` | DTOs, Axios API (get/upsert config), permissions |
| `@granit/react-payments-sepa-transfer` | `SepaTransferProvider`, hooks, MSW handlers |

All four are **Published** packages (tsup + `publishConfig`), versions `0.1.0`.

## Key decisions

- **Typing**: optionality derived from the OpenAPI `required` array (`T | null` for required+nullable, `?: T | null` otherwise), not from nullability alone. Money decimals as `number` per repo convention.
- **Mandate grid**: served by `@granit/react-query-engine` (`MapGranitQuery`), not a hand-written list hook — same pattern as payment transactions. The package contributes the `Mandate` row type + a QE meta MSW handler.
- **React Query invalidation**: mutation hooks invalidate the package's own keys at **prefix level**. The cross-tenant mandate grid lives under the app's separate `QueryProvider`, so a JSDoc note documents that apps must invalidate the QE endpoint prefix (`[...queryKeyPrefix, 'list'/'grouped']`, **without** `params`) to flush every cached page.
- **Contract conformance**: both specs vendored into `contracts/openapi/` and registered in the `@granit/contract-tests` manifest (`checkEndpoints` on; the QE grid routes ignored as they are served generically).

## Verification

- `tsc --noEmit` — 5 packages clean
- Tests — **26 passed** (API + hooks + MSW handlers)
- Conformance oracle — **163 passed** (incl. the two new slugs)
- `eslint --max-warnings 0`, `pnpm check:csp`, `tsup` build — all green
- Lockfile synced in-commit; `.mcp-front-index.json` regenerated by the pre-commit hook

## Out of scope

- No UI grid/component (apps wire the mandate grid via `@granit/react-query-engine`)
- No `showcase-admin-react` changes (separate repo / MR if/when consumed)