### PR TITLE
fix(payments): re-sync OpenAPI snapshot & align DTOs with backend

### DIFF
--- a/contracts/openapi/payments.json
+++ b/contracts/openapi/payments.json
@@ -1217,6 +1217,16 @@
               }
             }
           },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
           "403": {
             "description": "Forbidden",
             "content": {
@@ -1674,7 +1684,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+                  "$ref": "#/components/schemas/PaymentMethodConfigurationItemResponse"
                 }
               }
             }
@@ -1764,7 +1774,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+                  "$ref": "#/components/schemas/PaymentMethodConfigurationItemResponse"
                 }
               }
             }
@@ -1854,7 +1864,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+                  "$ref": "#/components/schemas/PaymentMethodConfigurationItemResponse"
                 }
               }
             }
@@ -2565,6 +2575,10 @@
                   "type": ["null", "string"],
                   "format": "uuid"
                 },
+                "mandateId": {
+                  "type": ["null", "string"],
+                  "format": "uuid"
+                },
                 "actionUrl": {
                   "type": ["null", "string"]
                 },
@@ -2660,6 +2674,9 @@
                       }
                     }
                   }
+                },
+                "metadataJson": {
+                  "type": ["null", "string"]
                 },
                 "tenantId": {
                   "type": ["null", "string"],
@@ -2797,12 +2814,15 @@
         "type": "object",
         "properties": {
           "providerName": {
+            "maxLength": 50,
             "type": "string"
           },
           "type": {
+            "maxLength": 50,
             "type": "string"
           },
           "token": {
+            "maxLength": 500,
             "type": "string"
           }
         }
@@ -2875,17 +2895,22 @@
             "format": "uuid"
           },
           "amount": {
+            "maximum": 999999999.99,
+            "exclusiveMinimum": 0,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
             "type": ["number", "string"],
             "format": "double"
           },
           "currency": {
+            "pattern": "^[A-Z]{3}$",
             "type": "string"
           },
           "methodType": {
+            "maxLength": 50,
             "type": "string"
           },
           "providerName": {
+            "maxLength": 50,
             "type": ["null", "string"]
           }
         }
@@ -2906,23 +2931,32 @@
             "format": "uuid"
           },
           "amount": {
+            "maximum": 999999999.99,
+            "exclusiveMinimum": 0,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
             "type": ["number", "string"],
             "format": "double"
           },
           "currency": {
+            "pattern": "^[A-Z]{3}$",
             "type": "string"
           },
           "methodType": {
+            "maxLength": 50,
             "type": "string"
           },
           "successUrl": {
-            "type": "string"
+            "maxLength": 2048,
+            "type": "string",
+            "x-granit-validator": "Validation:Format:UrlHttps"
           },
           "cancelUrl": {
-            "type": "string"
+            "maxLength": 2048,
+            "type": "string",
+            "x-granit-validator": "Validation:Format:UrlHttps"
           },
           "providerName": {
+            "maxLength": 50,
             "type": ["null", "string"]
           }
         }
@@ -3116,7 +3150,7 @@
           "PointOfSale"
         ]
       },
-      "PaymentMethodConfigurationItem": {
+      "PaymentMethodConfigurationItemResponse": {
         "required": ["methodType", "displayLabel", "category", "activated", "capabilitySnapshot"],
         "type": "object",
         "properties": {
@@ -3211,13 +3245,13 @@
           "methods": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/PaymentMethodConfigurationItem"
+              "$ref": "#/components/schemas/PaymentMethodConfigurationItemResponse"
             }
           }
         }
       },
       "PaymentRefundRequest": {
-        "required": ["transactionId", "amount", "reason"],
+        "required": ["transactionId", "amount"],
         "type": "object",
         "properties": {
           "transactionId": {
@@ -3225,11 +3259,14 @@
             "format": "uuid"
           },
           "amount": {
+            "maximum": 999999999.99,
+            "exclusiveMinimum": 0,
             "pattern": "^-?(?:0|[1-9]\\d*)(?:\\.\\d+)?$",
             "type": ["number", "string"],
             "format": "double"
           },
           "reason": {
+            "maxLength": 500,
             "type": ["null", "string"]
           }
         }
@@ -3312,6 +3349,10 @@
             "type": ["null", "string"],
             "format": "uuid"
           },
+          "mandateId": {
+            "type": ["null", "string"],
+            "format": "uuid"
+          },
           "actionUrl": {
             "type": ["null", "string"]
           },
@@ -3343,6 +3384,9 @@
             "items": {
               "$ref": "#/components/schemas/Dispute"
             }
+          },
+          "metadataJson": {
+            "type": ["null", "string"]
           },
           "tenantId": {
             "type": ["null", "string"],

--- a/packages/@granit/contract-tests/src/manifest.ts
+++ b/packages/@granit/contract-tests/src/manifest.ts
@@ -267,6 +267,36 @@ export const CONTRACTS: readonly ModuleContract[] = [
       'SiteHostnameCreateRequest',
     ],
   },
+  // ─── Business payments (granit-business / Granit.Payments.Endpoints) ────────
+  // Object DTOs only. The list/grid surfaces (GET /transactions, /methods,
+  // /configuration) are served by the query-engine generic helper, so route
+  // conformance is left off here. Standalone string-union enums (PaymentStatus,
+  // RefundStatus, DisputeStatus, PaymentMethodCategory, PaymentMethodSequenceTypeName
+  // — the last also name-shifted from the spec's `PaymentMethodSequenceType`) are
+  // verified indirectly via the fields that reference them, per the field-by-field
+  // oracle, not listed here.
+  {
+    slug: 'payments',
+    package: 'payments',
+    types: [
+      'PaymentChargeRequest',
+      'PaymentRefundRequest',
+      'PaymentCheckoutRequest',
+      'PaymentAttachMethodRequest',
+      'PaymentTransactionResponse',
+      'PaymentRefundResponse',
+      'PaymentDisputeResponse',
+      'PaymentCheckoutSessionResponse',
+      'PaymentMethodResponse',
+      'PaymentAvailableMethodResponse',
+      'PaymentMethodCapabilityResponse',
+      'PaymentMethodAmountBoundResponse',
+      'PaymentMethodConfigurationItemResponse',
+      'PaymentProviderConfigurationResponse',
+      'PaymentCatalogMethod',
+      'PaymentProviderCatalogResponse',
+    ],
+  },
   {
     slug: 'sepa-transfer',
     package: 'payments-sepa-transfer',

--- a/packages/@granit/payments/src/__tests__/payments-api.test.ts
+++ b/packages/@granit/payments/src/__tests__/payments-api.test.ts
@@ -25,7 +25,7 @@ import type {
   PaymentCheckoutRequest,
   PaymentCheckoutSessionResponse,
   PaymentMethodCapabilityResponse,
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
   PaymentProviderConfigurationResponse,
@@ -86,7 +86,7 @@ const sampleAvailableMethod: PaymentAvailableMethodResponse = {
   capability: sampleCapability,
 };
 
-const sampleConfigurationItem: PaymentMethodConfigurationItem = {
+const sampleConfigurationItem: PaymentMethodConfigurationItemResponse = {
   methodType: 'bancontact',
   displayLabel: 'Bancontact',
   category: 'BankRedirect',
@@ -332,7 +332,7 @@ describe('payments-api', () => {
   describe('deactivatePaymentMethod', () => {
     it('should POST {basePath}/configuration/{provider}/{method}/deactivate', async () => {
       const client = createMockClient();
-      const deactivated: PaymentMethodConfigurationItem = {
+      const deactivated: PaymentMethodConfigurationItemResponse = {
         ...sampleConfigurationItem,
         activated: false,
       };

--- a/packages/@granit/payments/src/api/payments-api.ts
+++ b/packages/@granit/payments/src/api/payments-api.ts
@@ -5,7 +5,7 @@ import type {
   PaymentChargeRequest,
   PaymentCheckoutRequest,
   PaymentCheckoutSessionResponse,
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
   PaymentProviderConfigurationResponse,
@@ -200,8 +200,8 @@ export async function activatePaymentMethod(
   basePath: string,
   providerName: string,
   methodType: string
-): Promise<PaymentMethodConfigurationItem> {
-  const response = await client.post<PaymentMethodConfigurationItem>(
+): Promise<PaymentMethodConfigurationItemResponse> {
+  const response = await client.post<PaymentMethodConfigurationItemResponse>(
     `${basePath}/configuration/${encodeURIComponent(providerName)}/${encodeURIComponent(methodType)}/activate`
   );
   return response.data;
@@ -217,8 +217,8 @@ export async function deactivatePaymentMethod(
   basePath: string,
   providerName: string,
   methodType: string
-): Promise<PaymentMethodConfigurationItem> {
-  const response = await client.post<PaymentMethodConfigurationItem>(
+): Promise<PaymentMethodConfigurationItemResponse> {
+  const response = await client.post<PaymentMethodConfigurationItemResponse>(
     `${basePath}/configuration/${encodeURIComponent(providerName)}/${encodeURIComponent(methodType)}/deactivate`
   );
   return response.data;
@@ -255,8 +255,8 @@ export async function resyncPaymentMethodConfiguration(
   basePath: string,
   providerName: string,
   methodType: string
-): Promise<PaymentMethodConfigurationItem> {
-  const response = await client.post<PaymentMethodConfigurationItem>(
+): Promise<PaymentMethodConfigurationItemResponse> {
+  const response = await client.post<PaymentMethodConfigurationItemResponse>(
     `${basePath}/configuration/${encodeURIComponent(providerName)}/${encodeURIComponent(methodType)}/resync`
   );
   return response.data;

--- a/packages/@granit/payments/src/index.ts
+++ b/packages/@granit/payments/src/index.ts
@@ -10,7 +10,7 @@ export type {
   PaymentDisputeResponse,
   PaymentMethodAmountBoundResponse,
   PaymentMethodCapabilityResponse,
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   PaymentMethodResponse,
   PaymentMethodSequenceTypeName,
   PaymentProviderCatalogResponse,

--- a/packages/@granit/payments/src/types/index.ts
+++ b/packages/@granit/payments/src/types/index.ts
@@ -154,7 +154,7 @@ export interface PaymentMethodCapabilityResponse {
 }
 
 /** A single payment method declared by a provider with its activation state. */
-export interface PaymentMethodConfigurationItem {
+export interface PaymentMethodConfigurationItemResponse {
   readonly methodType: string;
   readonly displayLabel: string;
   readonly category: PaymentMethodCategory;
@@ -170,12 +170,12 @@ export interface PaymentMethodConfigurationItem {
 /** All methods declared by a single provider, with activation state. */
 export interface PaymentProviderConfigurationResponse {
   readonly providerName: string;
-  readonly methods: readonly PaymentMethodConfigurationItem[];
+  readonly methods: readonly PaymentMethodConfigurationItemResponse[];
 }
 
 /**
  * A method entry in the live provider catalog (fetched on-demand from the
- * provider via `GET /configuration/catalog`). Unlike `PaymentMethodConfigurationItem`,
+ * provider via `GET /configuration/catalog`). Unlike `PaymentMethodConfigurationItemResponse`,
  * `capability` is always present — the catalog is a live read from the provider,
  * not a stored snapshot.
  */

--- a/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
+++ b/packages/@granit/react-payments/src/__tests__/use-payments.test.tsx
@@ -28,7 +28,7 @@ import type {
   PaymentAvailableMethodResponse,
   PaymentCheckoutSessionResponse,
   PaymentMethodCapabilityResponse,
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
   PaymentProviderConfigurationResponse,
@@ -104,7 +104,7 @@ const sampleAvailableMethod: PaymentAvailableMethodResponse = {
   capability: sampleCapability,
 };
 
-const sampleConfigurationItem: PaymentMethodConfigurationItem = {
+const sampleConfigurationItem: PaymentMethodConfigurationItemResponse = {
   methodType: 'bancontact',
   displayLabel: 'Bancontact',
   category: 'BankRedirect',
@@ -432,7 +432,7 @@ describe('use-payments', () => {
   describe('useDeactivatePaymentMethod', () => {
     it('posts to the deactivate endpoint and returns the refreshed config item', async () => {
       const client = createMockClient();
-      const deactivated: PaymentMethodConfigurationItem = {
+      const deactivated: PaymentMethodConfigurationItemResponse = {
         ...sampleConfigurationItem,
         activated: false,
       };

--- a/packages/@granit/react-payments/src/hooks/use-payments.ts
+++ b/packages/@granit/react-payments/src/hooks/use-payments.ts
@@ -25,7 +25,7 @@ import type {
   PaymentChargeRequest,
   PaymentCheckoutRequest,
   PaymentCheckoutSessionResponse,
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   PaymentMethodResponse,
   PaymentProviderCatalogResponse,
   PaymentProviderConfigurationResponse,
@@ -295,7 +295,7 @@ export function usePaymentMethodConfigurations(): UseQueryResult<
  * ```
  */
 export function useActivatePaymentMethod(): UseMutationResult<
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   Error,
   PaymentMethodToggleArgs
 > {
@@ -332,7 +332,7 @@ export function useActivatePaymentMethod(): UseMutationResult<
  * ```
  */
 export function useDeactivatePaymentMethod(): UseMutationResult<
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   Error,
   PaymentMethodToggleArgs
 > {
@@ -392,7 +392,7 @@ export function useProviderCatalog(
  * ```
  */
 export function useResyncPaymentMethod(): UseMutationResult<
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   Error,
   PaymentMethodToggleArgs
 > {

--- a/packages/@granit/react-payments/src/testing/configuration.ts
+++ b/packages/@granit/react-payments/src/testing/configuration.ts
@@ -14,7 +14,7 @@ import type {
   PaymentCatalogMethod,
   PaymentMethodCapabilityResponse,
   PaymentMethodCategory,
-  PaymentMethodConfigurationItem,
+  PaymentMethodConfigurationItemResponse,
   PaymentProviderCatalogResponse,
   PaymentProviderConfigurationResponse,
 } from '@granit/payments';
@@ -130,7 +130,7 @@ export function createPaymentsConfigurationHandlers(baseUrl = DEFAULT_BASE_PATH)
   activated.set(key('mollie', 'ideal'), null);
 
   function buildConfiguration(provider: MockProvider): PaymentProviderConfigurationResponse {
-    const items: PaymentMethodConfigurationItem[] = provider.methods.map((m) => {
+    const items: PaymentMethodConfigurationItemResponse[] = provider.methods.map((m) => {
       const k = key(provider.providerName, m.methodType);
       const isActive = activated.has(k);
       return {
@@ -165,7 +165,7 @@ export function createPaymentsConfigurationHandlers(baseUrl = DEFAULT_BASE_PATH)
     provider: string | readonly string[] | undefined,
     method: string | readonly string[] | undefined,
     capability: PaymentMethodCapabilityResponse | null
-  ): PaymentMethodConfigurationItem | null {
+  ): PaymentMethodConfigurationItemResponse | null {
     const found = mockPaymentProviders.find((p) => p.providerName === provider);
     const m = found?.methods.find((x) => x.methodType === method);
     if (!found || !m) return null;


### PR DESCRIPTION
## Context
Drift audit against `granit-business/.../Granit.Business.OpenApi.Generator/generated`. The `payments` contract snapshot was stale (backend was bulk-regenerated; front had only re-synced the SEPA specs).

## Changes
- **Re-vendor** `contracts/openapi/payments.json` via `scripts/sync-openapi-contracts.mjs` — now byte-in-sync with the generated spec (added validation constraints, `mandateId`/`metadataJson` on the `PaymentTransaction` query-engine entity).
- **Rename** `PaymentMethodConfigurationItem` → `PaymentMethodConfigurationItemResponse` across `@granit/payments` + `@granit/react-payments`, tracking the backend schema rename and the front `*Response` naming convention. Hard rename (no deprecated alias — still pre-release).
- **Register `payments`** in the `@granit/contract-tests` manifest (object DTOs only) so this class of drift is caught by the conformance oracle going forward.

## Verification
- Conformance: 179 passed (16 new payments DTO checks).
- `tsc --noEmit`, ESLint (`--max-warnings 0`), package tests (84) all green.

## ⚠️ Cross-repo follow-up
`granit-showcase-react` references the old `PaymentMethodConfigurationItem` name in `features/payments/.../payment-configuration-section.test.tsx`. A coordinated showcase MR follows (merge this first).